### PR TITLE
:bug: Let rocksdb recipe set USE_RTTI in release and debug mode

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -16,4 +16,3 @@ rocksdb:with_zstd=False
 rocksdb:with_tbb=False  # TODO
 rocksdb:with_jemalloc=False  # TODO
 rocksdb:enable_sse=sse42
-rocksdb:use_rtti=False


### PR DESCRIPTION
Rocksdb recipe defaults this to false in release and true in debug mode. Hard coding `use_rtti` to false results in debug build failing because `dynamic_cast` is used in `assert` statements. This PR fixes that.

https://conan.io/center/rocksdb?tab=recipe