### PR TITLE
✅ Turn off ethash unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
 
 set(BUILD_SHARED_LIBS OFF)
+set(ETHASH_BUILD_TESTS OFF)
 
 add_subdirectory(third_party/ethash)
 add_subdirectory(third_party/evmone)


### PR DESCRIPTION
ethash unit tests take a while to run and we shouldn't need to run them in monad

resolves #6 partially (although I do not see other third party unit tests being run)