### PR TITLE
Rlp uint128 numbers

### DIFF
--- a/include/monad/rlp/rlp.hpp
+++ b/include/monad/rlp/rlp.hpp
@@ -92,7 +92,8 @@ namespace rlp
     {
         template <class T>
         concept unsigned_integral =
-            std::unsigned_integral<T> || std::same_as<uint256_t, T>;
+            std::unsigned_integral<T> || std::same_as<uint128_t, T> ||
+            std::same_as<uint256_t, T>;
 
         // size of bytes if leading zeroes were stripped off
         constexpr size_t size_of_compacted_num(unsigned_integral auto num)

--- a/src/monad/rlp/test/test_rlp.cpp
+++ b/src/monad/rlp/test/test_rlp.cpp
@@ -86,6 +86,13 @@ TEST(Rlp, EncodeSanity)
 
     using namespace intx;
     encoding = encode(
+        0xbea34dd04b09ad3b6014251ee2457807_u128);
+    auto const sorta_big_num = monad::byte_string(
+        {0x90, 0xbe, 0xa3, 0x4d, 0xd0, 0x4b, 0x09, 0xad, 0x3b, 0x60, 0x14,
+         0x25, 0x1e, 0xe2, 0x45, 0x78, 0x07});
+    EXPECT_EQ(encoding.bytes, sorta_big_num);
+
+   encoding = encode(
         0xbea34dd04b09ad3b6014251ee24578074087ee60fda8c391cf466dfe5d687d7b_u256);
     auto const big_num = monad::byte_string(
         {0xa0, 0xbe, 0xa3, 0x4d, 0xd0, 0x4b, 0x09, 0xad, 0x3b, 0x60, 0x14,


### PR DESCRIPTION
rlp.hpp was never formatted correctly, so put that in its own commit to make review easier.