### PR TITLE
:construction_worker: Add and fix -Wconversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ function(monad_compile_options target)
     set_property(TARGET ${target} PROPERTY C_STANDARD_REQUIRED ON)
     set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
     set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Werror)
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Werror -Wconversion -Wpedantic)
 endfunction()
 
 

--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -16,19 +16,19 @@ namespace fork_traits
         static constexpr auto block_number = 0u;
 
         // YP, Eqn. 60, first summation
-        [[nodiscard]] static constexpr inline auto
+        [[nodiscard]] static constexpr inline uint64_t
         g_data(Transaction const &t) noexcept
         {
-            const unsigned zeros = std::count_if(
+            const auto zeros = std::count_if(
                 std::cbegin(t.data), std::cend(t.data), [](unsigned char c) {
                     return c == 0x00;
                 });
-            const auto nonzeros = t.data.size() - zeros;
-            return zeros * 4 + nonzeros * 68;
+            const auto nonzeros = t.data.size() - static_cast<uint64_t>(zeros);
+            return static_cast<uint64_t>(zeros) * 4u + nonzeros * 68u;
         }
 
         // YP, section 6.2, Eqn. 60
-        [[nodiscard]] static constexpr inline unsigned
+        [[nodiscard]] static constexpr inline uint64_t
         intrinsic_gas(Transaction const &t) noexcept
         {
             return 21'000 + g_data(t);
@@ -36,7 +36,7 @@ namespace fork_traits
 
         [[nodiscard]] static constexpr inline auto starting_nonce() noexcept
         {
-            return 0;
+            return 0u;
         }
 
         template <class TState>
@@ -61,8 +61,8 @@ namespace fork_traits
         static constexpr inline bool enough_gas_to_store_code(
             TState &s, address_t const &a, evmc_result &r) noexcept
         {
-            int const deploy_cost = r.output_size * 200;
-            if (r.gas_left >= deploy_cost) {
+            auto const deploy_cost = r.output_size * 200u;
+            if (static_cast<uint64_t>(r.gas_left) >= deploy_cost) {
                 s.set_code(a, {r.output_data, r.output_size});
                 r.gas_left -= deploy_cost;
                 r.create_address = a;
@@ -133,7 +133,7 @@ namespace fork_traits
         // https://eips.ethereum.org/EIPS/eip-161
         [[nodiscard]] static constexpr inline auto starting_nonce() noexcept
         {
-            return 1;
+            return 1u;
         }
 
         template <class TState>
@@ -201,15 +201,15 @@ namespace fork_traits
         static constexpr auto block_number = 9'069'000u;
 
         // https://eips.ethereum.org/EIPS/eip-2028
-        [[nodiscard]] static constexpr inline unsigned
+        [[nodiscard]] static constexpr inline uint64_t
         g_data(Transaction const &t) noexcept
         {
-            const unsigned zeros = std::count_if(
+            const auto zeros = std::count_if(
                 std::cbegin(t.data), std::cend(t.data), [](unsigned char c) {
                     return c == 0x00;
                 });
-            const auto nonzeros = t.data.size() - zeros;
-            return zeros * 4u + nonzeros * 16u;
+            const auto nonzeros = t.data.size() - static_cast<uint64_t>(zeros);
+            return static_cast<uint64_t>(zeros) * 4u + nonzeros * 16u;
         }
 
         [[nodiscard]] static constexpr inline auto

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -188,7 +188,7 @@ namespace fake
         {
             return _intrinsic_gas;
         }
-        static inline auto starting_nonce() { return 1; }
+        static inline auto starting_nonce() { return 1u; }
         static inline auto max_refund_quotient()
         {
             return _max_refund_quotient;

--- a/include/monad/execution/transaction_processor.hpp
+++ b/include/monad/execution/transaction_processor.hpp
@@ -77,7 +77,8 @@ struct TransactionProcessor
 
     template <class TEvmHost>
     Receipt execute(
-        TState &s, TEvmHost &h, BlockHeader const &b, Transaction const &t) const
+        TState &s, TEvmHost &h, BlockHeader const &b,
+        Transaction const &t) const
     {
         irrevocable_change(s, t);
 
@@ -95,7 +96,9 @@ struct TransactionProcessor
         auto m = TEvmHost::make_msg_from_txn(t);
         auto result = h.call(m);
 
-        auto const gas_remaining = award_fee_and_refund(s, b, t, result.gas_left);
+		MONAD_ASSERT(result.gas_left >= 0);
+        auto const gas_remaining = award_fee_and_refund(
+            s, b, t, static_cast<uint64_t>(result.gas_left));
 
         // finalize state, Eqn. 77-79
         s.destruct_suicides();

--- a/include/monad/rlp/encode.hpp
+++ b/include/monad/rlp/encode.hpp
@@ -12,18 +12,19 @@ MONAD_RLP_NAMESPACE_BEGIN
 inline byte_string encode_string(byte_string_view const str)
 {
     byte_string result;
-    uint32_t const size = str.size();
+    uint32_t const size = static_cast<uint32_t>(str.size());
     if (size == 1 && str[0] <= 0x7f) {
         result = str;
     }
     else if (size > 55) {
         auto const size_str = to_big_compact(size);
-        result.push_back(0xb7 + size_str.size());
+		MONAD_ASSERT(size_str.size() <= 8u);
+        result.push_back(0xb7 + static_cast<unsigned char>(size_str.size()));
         result += size_str;
         result += str;
     }
     else {
-        result.push_back(0x80 + size);
+        result.push_back(0x80 + static_cast<unsigned char>(size));
         result += str;
     }
     return result;
@@ -37,11 +38,12 @@ inline byte_string encode_list(Args const &...args)
     byte_string result;
     if (size > 55) {
         auto const size_str = to_big_compact(size);
-        result += (0xf7 + size_str.size());
+		MONAD_ASSERT(size_str.size() <= 8u);
+        result += (0xf7 + static_cast<unsigned char>(size_str.size()));
         result += size_str;
     }
     else {
-        result += (0xc0 + size);
+        result += (0xc0 + static_cast<unsigned char>(size));
     }
     ([&] { result += args; }(), ...);
     return result;

--- a/src/monad/core/receipt.cpp
+++ b/src/monad/core/receipt.cpp
@@ -16,9 +16,9 @@ void set_3_bits(Receipt::Bloom &bloom, byte_string_view const bytes)
         const uint16_t bit =
             intx::to_big_endian(
                 reinterpret_cast<uint16_t const *>(h.bytes)[i]) &
-            2047;
-        const auto byte = 255 - bit / 8;
-        bloom[byte] |= 1 << (bit & 7);
+            2047u;
+        const auto byte = 255u - bit / 8u;
+        bloom[byte] |= 1u << (bit & 7u);
     }
 }
 

--- a/src/monad/core/signature.cpp
+++ b/src/monad/core/signature.cpp
@@ -4,18 +4,18 @@ MONAD_NAMESPACE_BEGIN
 
 void SignatureAndChain::from_v(uint64_t const &v)
 {
-    if (v == 28) {
+    if (v == 28u) {
         odd_y_parity = true;
     }
-    else if (v == 27) {
+    else if (v == 27u) {
         odd_y_parity = false;
     }
     else // chain_id has value
     {
         auto tmp = v - 35;
-        if (tmp & 1) {
+        if (tmp & 1u) {
             odd_y_parity = true;
-            tmp ^= 1;
+            tmp ^= 1u;
         }
         chain_id = tmp >> 1;
     }
@@ -24,9 +24,9 @@ void SignatureAndChain::from_v(uint64_t const &v)
 uint64_t get_v(SignatureAndChain const &sc) noexcept
 {
     if (sc.chain_id.has_value()) {
-        return (*sc.chain_id * 2) + 35 + (int)sc.odd_y_parity;
+        return (*sc.chain_id * 2u) + 35u + sc.odd_y_parity;
     }
-    return sc.odd_y_parity ? 28 : 27;
+    return sc.odd_y_parity ? 28u : 27u;
 }
 
 MONAD_NAMESPACE_END

--- a/src/monad/rlp/test/decode_block.cpp
+++ b/src/monad/rlp/test/decode_block.cpp
@@ -33,7 +33,7 @@ inline byte_string read_block_asset(uint32_t block_num)
     if (input) {
         while (input) {
             input.get(c);
-            output += c;
+            output += static_cast<unsigned char>(c);
         }
         output = output.substr(0, output.length() - 1);
     }


### PR DESCRIPTION
Using unsigned values can yield some subtle overflow bugs.  Turn on `-Wconversion` so that we aren't accidentally relying on implicit conversions