### PR TITLE
:art: Refactor out member functions of dumb Transaction structure

### DIFF
--- a/include/monad/core/transaction.hpp
+++ b/include/monad/core/transaction.hpp
@@ -41,17 +41,6 @@ struct Transaction
     Type type;
     AccessList access_list{};
     uint64_t priority_fee{};
-
-    // EIP-1559
-    inline uint64_t per_gas_priority_fee(uint64_t const base_fee_per_gas) const
-    {
-        return std::min(priority_fee, gas_price - base_fee_per_gas);
-    }
-
-    inline uint64_t per_gas_cost(uint64_t const base_fee_per_gas) const
-    {
-        return per_gas_priority_fee(base_fee_per_gas) + base_fee_per_gas;
-    }
 };
 
 static_assert(sizeof(Transaction::AccessEntry) == 48);
@@ -62,5 +51,18 @@ static_assert(alignof(Transaction::AccessList) == 8);
 
 static_assert(sizeof(Transaction) == 248);
 static_assert(alignof(Transaction) == 8);
+
+// EIP-1559
+inline uint64_t per_gas_priority_fee(
+    Transaction const &t, uint64_t const base_fee_per_gas)
+{
+    return std::min(t.priority_fee, t.gas_price - base_fee_per_gas);
+}
+
+inline uint64_t
+per_gas_cost(Transaction const &t, uint64_t const base_fee_per_gas)
+{
+    return per_gas_priority_fee(t, base_fee_per_gas) + base_fee_per_gas;
+}
 
 MONAD_NAMESPACE_END

--- a/include/monad/execution/evmc_host.hpp
+++ b/include/monad/execution/evmc_host.hpp
@@ -173,7 +173,7 @@ struct EvmcHost : public evmc::HostInterface
             .block_timestamp = static_cast<int64_t>(block_header_.timestamp),
             .block_gas_limit = static_cast<int64_t>(block_header_.gas_limit)};
 
-        const uint256_t gas_cost = transaction_.per_gas_cost(
+        const uint256_t gas_cost = per_gas_cost(transaction_,
             block_header_.base_fee_per_gas.value_or(0));
         intx::be::store(result.tx_gas_price.bytes, gas_cost);
 

--- a/include/monad/execution/transaction_processor.hpp
+++ b/include/monad/execution/transaction_processor.hpp
@@ -60,18 +60,18 @@ struct TransactionProcessor
     {
         // refund and priority, Eqn. 73-76
         auto const gas_remaining = g_star(s, t, gas_leftover);
-        auto const per_gas_cost =
-            t.per_gas_cost(b.base_fee_per_gas.value_or(0));
+        auto const gas_cost =
+            per_gas_cost(t, b.base_fee_per_gas.value_or(0));
         auto const bene_balance =
             intx::be::load<uint256_t>(s.get_balance(b.beneficiary));
 
         s.set_balance(
             b.beneficiary,
-            bene_balance + (per_gas_cost * (t.gas_limit - gas_remaining)));
+            bene_balance + (gas_cost * (t.gas_limit - gas_remaining)));
         const auto sender_balance =
             intx::be::load<uint256_t>(s.get_balance(*t.from));
 
-        s.set_balance(*t.from, sender_balance + (per_gas_cost * gas_remaining));
+        s.set_balance(*t.from, sender_balance + (gas_cost * gas_remaining));
         return gas_remaining;
     }
 
@@ -109,7 +109,7 @@ struct TransactionProcessor
         TState const &state, Transaction const &t, uint64_t base_fee_per_gas)
     {
         upfront_cost_ =
-            intx::umul(t.gas_limit, t.per_gas_cost(base_fee_per_gas));
+            intx::umul(t.gas_limit, per_gas_cost(t, base_fee_per_gas));
 
         // Yellow paper, Eq. 62
         // g0 <= Tg

--- a/src/monad/execution/test/evmc_host.cpp
+++ b/src/monad/execution/test/evmc_host.cpp
@@ -63,7 +63,7 @@ TEST(EvmcHost, get_tx_context)
     fake::State s{};
     fake::Evm e{};
 
-    const static uint256_t gas_cost = t.per_gas_cost(37'000'000'000);
+    const static uint256_t gas_cost = per_gas_cost(t, 37'000'000'000);
     const static uint256_t chain_id{1};
     const static uint256_t base_fee_per_gas{37'000'000'000};
 


### PR DESCRIPTION
- Currently all members are suffixed with underscore for class types.
- dumb structures aren't suffixed, so refactor out the member function `per_gas_cost()` to just be a free function.

@jhunsaker - making sure I don't lose track of your feedback.