### PR TITLE
Trie building on top of in memory storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ conan_cmake_install(
     SETTINGS ${settings}
 )
 
-
 ############
 ### deps
 ############
@@ -56,7 +55,6 @@ function(monad_compile_options target)
     target_compile_options(${target} PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>)
 endfunction()
 
-
 ############
 ### unit tests
 ############
@@ -66,6 +64,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/db/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/execution/ethereum/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/execution/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/rlp/test)
+add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/trie/test)
 
 
 ############
@@ -88,6 +87,7 @@ add_library(monad STATIC
     ${PROJECT_SOURCE_DIR}/include/monad/core/int.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/core/likely.h
     ${PROJECT_SOURCE_DIR}/include/monad/core/size_of.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/core/variant.hpp
     ${PROJECT_SOURCE_DIR}/src/monad/core/assert.c
     ${PROJECT_SOURCE_DIR}/src/monad/core/huge_mem.cpp
     ${PROJECT_SOURCE_DIR}/src/monad/core/int.cpp
@@ -129,7 +129,24 @@ add_library(monad STATIC
     ${PROJECT_SOURCE_DIR}/include/monad/rlp/util.hpp
     ${PROJECT_SOURCE_DIR}/src/monad/rlp/decode_helpers.cpp
     ${PROJECT_SOURCE_DIR}/src/monad/rlp/encode_helpers.cpp
+
+    # trie
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/compact_encode.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/nibbles.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/nibbles_view.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/node.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/trie.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/rocks_cursor.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/rocks_writer.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/util.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/assert.h
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/key_buffer.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/comparator.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/rocks_comparator.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/trie/process_transformation_list.hpp
+    ${PROJECT_SOURCE_DIR}/src/monad/trie/rocks_cursor.cpp
 )
+
 target_include_directories(monad
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PRIVATE ${Boost_INCLUDE_DIRS}

--- a/include/monad/core/byte_string.hpp
+++ b/include/monad/core/byte_string.hpp
@@ -38,4 +38,14 @@ inline byte_string_view to_byte_string_view(std::string const &s)
     return {reinterpret_cast<unsigned char const *>(&s[0]), s.size()};
 }
 
+struct byte_string_hasher
+{
+    size_t operator()(byte_string const &x) const
+    {
+        return std::hash<std::string>()(
+            {reinterpret_cast<std::string::value_type const *>(x.data()),
+             x.size()});
+    }
+};
+
 MONAD_NAMESPACE_END

--- a/include/monad/core/bytes.hpp
+++ b/include/monad/core/bytes.hpp
@@ -14,4 +14,7 @@ static_assert(alignof(bytes32_t) == 1);
 using namespace evmc::literals;
 inline constexpr bytes32_t NULL_HASH{0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32};
 
+// Root hash of an empty trie
+inline constexpr bytes32_t NULL_ROOT{0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32};
+
 MONAD_NAMESPACE_END

--- a/include/monad/core/variant.hpp
+++ b/include/monad/core/variant.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <monad/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// shamelessly stolen from cppreference
+
+// helper type for the visitor #4
+template <class... Ts>
+struct overloaded : Ts...
+{
+    using Ts::operator()...;
+};
+// explicit deduction guide (not needed as of C++20)
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+MONAD_NAMESPACE_END

--- a/include/monad/rlp/encode_helpers.hpp
+++ b/include/monad/rlp/encode_helpers.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ethash/keccak.hpp>
+
 #include <monad/rlp/config.hpp>
 #include <monad/rlp/encode.hpp>
 #include <monad/rlp/util.hpp>
@@ -11,13 +13,24 @@
 #include <monad/core/receipt.hpp>
 #include <monad/core/transaction.hpp>
 
+#include <monad/trie/config.hpp>
+
 MONAD_NAMESPACE_BEGIN
 
 struct Account;
 
 MONAD_NAMESPACE_END
 
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct Leaf;
+struct Branch;
+
+MONAD_TRIE_NAMESPACE_END
+
 MONAD_RLP_NAMESPACE_BEGIN
+
+inline byte_string const EMPTY_STRING = {0x80};
 
 inline byte_string encode_unsigned(unsigned_integral auto const &n)
 {
@@ -41,5 +54,9 @@ byte_string encode_topics(std::vector<bytes32_t> const &topics);
 byte_string encode_log(Receipt::Log const &log);
 byte_string encode_bloom(Receipt::Bloom const &b);
 byte_string encode_receipt(Receipt const &receipt);
+
+byte_string encode_leaf(trie::Leaf const&);
+byte_string encode_branch(trie::Branch const&);
+byte_string to_node_reference(byte_string_view rlp);
 
 MONAD_RLP_NAMESPACE_END

--- a/include/monad/trie/assert.h
+++ b/include/monad/trie/assert.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <iostream>
+#include <monad/core/assert.h>
+
+#define MONAD_ROCKS_ASSERT(res)                                                \
+    if (MONAD_UNLIKELY(!res.ok())) {                                           \
+        std::cerr << "Failed with " << res.ToString() << std::endl;            \
+        MONAD_ASSERT(res.ok());                                                \
+    }

--- a/include/monad/trie/compact_encode.hpp
+++ b/include/monad/trie/compact_encode.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles_view.hpp>
+
+#include <cassert>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// Transform the nibbles to its compact encoding
+// https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/
+[[nodiscard]] constexpr byte_string
+compact_encode(NibblesView const &nibbles, bool is_leaf)
+{
+    size_t i = 0;
+
+    byte_string bytes;
+
+    // Populate first byte with the encoded nibbles type and potentially
+    // also the first nibble if number of nibbles is odd
+    auto const first_byte = [&]() -> byte_string::value_type {
+        if (is_leaf) {
+            if (nibbles.size() % 2) {
+                auto const first_byte =
+                    static_cast<byte_string::value_type>(0x30 | nibbles[i]);
+                ++i;
+                return first_byte;
+            }
+            else {
+                return 0x20;
+            }
+        }
+        else {
+            if (nibbles.size() % 2) {
+                auto const first_byte =
+                    static_cast<byte_string::value_type>(0x10 | nibbles[i]);
+                ++i;
+                return first_byte;
+            }
+            else {
+                return 0x00;
+            }
+        }
+    }();
+
+    bytes.push_back(first_byte);
+
+    // should be an even number of hops away from the end
+    assert(((nibbles.size() - i) % 2) == 0);
+
+    for (; i < nibbles.size(); i += 2) {
+        bytes.push_back(static_cast<byte_string::value_type>(
+            (nibbles[i] << 4) | nibbles[i + 1]));
+    }
+
+    return bytes;
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/comparator.hpp
+++ b/include/monad/trie/comparator.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/config.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include <evmc/evmc.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+template <typename T>
+concept comparator = requires(T t, byte_string_view e, byte_string_view v) {
+    {
+        t(e, v)
+    } -> std::same_as<bool>;
+};
+
+struct poison_comparator
+{
+};
+
+template <typename...>
+inline auto injected_comparator = poison_comparator{};
+
+// compare number of nibbles first. if equal, compare lexicographically
+[[nodiscard]] inline int path_compare(byte_string_view s1, byte_string_view s2)
+{
+    assert(!s1.empty());
+    assert(!s2.empty());
+
+    auto const s1_size = static_cast<uint8_t>(s1[0]);
+    auto const s2_size = static_cast<uint8_t>(s2[0]);
+
+    auto rc = std::memcmp(&s1_size, &s2_size, 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    bool const odd = s1_size % 2;
+    assert(s1.size() == (1 + s1_size / 2 + odd));
+    assert(s2.size() == (1 + s1_size / 2 + odd));
+    rc = std::memcmp(s1.data(), s2.data(), s1.size() - odd);
+    if (rc != 0 || !odd) {
+        return rc;
+    }
+
+    uint8_t const b1 = s1[s1.size() - 1] & 0xF0;
+    uint8_t const b2 = s2[s2.size() - 1] & 0xF0;
+
+    return std::memcmp(&b1, &b2, 1);
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/config.hpp
+++ b/include/monad/trie/config.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <monad/config.hpp>
+
+#define MONAD_TRIE_NAMESPACE_BEGIN                                             \
+    MONAD_NAMESPACE_BEGIN namespace trie                                       \
+    {
+
+#define MONAD_TRIE_NAMESPACE_END                                               \
+    }                                                                          \
+    MONAD_NAMESPACE_END

--- a/include/monad/trie/in_memory_comparator.hpp
+++ b/include/monad/trie/in_memory_comparator.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <monad/core/address.hpp>
+#include <monad/trie/comparator.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct InMemoryPathComparator
+{
+    [[nodiscard]] inline bool
+    operator()(byte_string_view element, byte_string_view value) const
+    {
+        return path_compare(element, value) < 0;
+    }
+};
+
+struct InMemoryPrefixPathComparator
+{
+    [[nodiscard]] inline bool
+    operator()(byte_string_view element, byte_string_view value) const
+    {
+        assert(element.size() > sizeof(address_t));
+        assert(value.size() > sizeof(address_t));
+
+        auto const rc =
+            std::memcmp(element.data(), value.data(), sizeof(address_t));
+        if (rc != 0) {
+            return rc < 0;
+        }
+
+        element.remove_prefix(sizeof(address_t));
+        value.remove_prefix(sizeof(address_t));
+
+        return path_compare(element, value) < 0;
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/in_memory_cursor.hpp
+++ b/include/monad/trie/in_memory_cursor.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "evmc/evmc.hpp"
+
+#include <monad/core/address.hpp>
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/comparator.hpp>
+#include <monad/trie/config.hpp>
+#include <monad/trie/key_buffer.hpp>
+
+#include <tl/optional.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <unordered_map>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// Per-snapshot and prefix
+class InMemoryCursor
+{
+private:
+    using element_t = std::pair<byte_string, byte_string>;
+    using iterator_t = std::vector<element_t>::iterator;
+
+    std::vector<element_t> &storage_;
+    iterator_t it_;
+
+    mutable KeyBuffer buf_;
+
+public:
+    struct Key
+    {
+        bool has_prefix;
+        byte_string raw;
+
+        [[nodiscard]] constexpr bool operator==(Key const &) const = default;
+
+        [[nodiscard]] constexpr Nibbles path() const
+        {
+            assert(!has_prefix || raw.size() > sizeof(address_t));
+            return deserialize_nibbles(
+                       has_prefix ? raw.substr(sizeof(address_t)) : raw)
+                .first;
+        }
+
+        [[nodiscard]] constexpr bool path_empty() const
+        {
+            assert(!has_prefix || raw.size() > sizeof(address_t));
+            return (has_prefix ? raw[sizeof(address_t)] : raw[0]) == 0;
+        }
+    };
+
+    constexpr InMemoryCursor(std::vector<element_t> &storage)
+        : storage_(storage)
+        , it_(storage_.end())
+    {
+    }
+
+    [[nodiscard]] tl::optional<Key> key() const
+    {
+        return valid() ? tl::make_optional(
+                             Key{.has_prefix = (buf_.prefix_size > 0),
+                                 .raw = it_->first})
+                       : tl::nullopt;
+    }
+
+    [[nodiscard]] tl::optional<byte_string> value() const
+    {
+        return valid() ? tl::make_optional(it_->second) : tl::nullopt;
+    }
+
+    constexpr void prev()
+    {
+        if (it_ > storage_.begin()) {
+            std::advance(it_, -1);
+        }
+        else {
+            it_ = storage_.end();
+        }
+    }
+
+    constexpr void next()
+    {
+        if (it_ < storage_.end()) {
+            std::advance(it_, 1);
+        }
+        else {
+            it_ = storage_.begin();
+            MONAD_ASSERT(valid());
+        }
+    }
+
+    template <typename... DummyArgs>
+        requires(sizeof...(DummyArgs) == 0)
+    constexpr void lower_bound(
+        Nibbles const &key, tl::optional<Key> const & /*first*/ = tl::nullopt,
+        tl::optional<Key> const & /*last */ = tl::nullopt)
+    {
+        serialize_nibbles(buf_, key);
+        comparator auto const cmp = injected_comparator<DummyArgs...>;
+        it_ = std::ranges::lower_bound(
+            storage_, buf_.view(), cmp, &element_t::first);
+    }
+
+    [[nodiscard]] constexpr bool valid() const { return is_it_valid(it_); }
+
+    template <typename... DummyArgs>
+        requires(sizeof...(DummyArgs) == 0)
+    [[nodiscard]] constexpr bool empty() const
+    {
+        serialize_nibbles(buf_, Nibbles{});
+        comparator auto const cmp = injected_comparator<DummyArgs...>;
+        return !is_it_valid(std::ranges::lower_bound(
+            storage_, buf_.view(), cmp, &element_t::first));
+    }
+
+    constexpr void set_prefix(address_t const &address)
+    {
+        buf_.set_prefix(address);
+    }
+
+    constexpr void take_snapshot() const noexcept {};
+    constexpr void release_snapshots() const noexcept {};
+
+private:
+    [[nodiscard]] constexpr bool is_it_valid(iterator_t it) const
+    {
+        return it < storage_.end() && it->first.starts_with(buf_.prefix());
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/in_memory_writer.hpp
+++ b/include/monad/trie/in_memory_writer.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+#include <monad/trie/comparator.hpp>
+#include <monad/trie/config.hpp>
+#include <monad/trie/key_buffer.hpp>
+#include <monad/trie/writer.hpp>
+
+#include <monad/core/byte_string.hpp>
+#include <tl/optional.hpp>
+
+#include <iomanip>
+#include <ostream>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct InMemoryWriter
+{
+    using element_t = std::pair<byte_string, byte_string>;
+    using storage_t = std::vector<element_t>;
+    using changes_t = std::unordered_map<
+        byte_string, tl::optional<byte_string>, byte_string_hasher>;
+
+    std::unordered_map<WriterColumn, std::reference_wrapper<storage_t>>
+        storages_;
+    std::unordered_map<WriterColumn, changes_t> changes_;
+    std::unordered_map<WriterColumn, std::vector<byte_string>>
+        deleted_prefixes_;
+
+    constexpr void
+    put(WriterColumn col, KeyBuffer const &key, byte_string_view value)
+    {
+        changes_[col][byte_string{key.view()}] = value;
+    }
+
+    constexpr void del(WriterColumn col, KeyBuffer const &key)
+    {
+        changes_[col][byte_string{key.view()}] = tl::nullopt;
+    }
+
+    void del_prefix(WriterColumn col, byte_string_view prefix)
+    {
+        deleted_prefixes_[col].emplace_back(prefix);
+
+        if (auto it = changes_.find(col); it != changes_.end()) {
+            std::erase_if(it->second, [&](auto const &key) {
+                return key.first.starts_with(prefix);
+            });
+        }
+    }
+
+    template <typename... DummyArgs>
+        requires(sizeof...(DummyArgs) == 0)
+    void write()
+    {
+        // Delete the prefixes first
+        for (auto const &[col, prefixes] : deleted_prefixes_) {
+            for (auto const &prefix : prefixes) {
+                std::erase_if(storages_.at(col).get(), [&](auto const &key) {
+                    return key.first.starts_with(prefix);
+                });
+            }
+        }
+
+        // Apply changes second
+        for (auto const &[col, changes] : changes_) {
+            auto &storage = storages_.at(col).get();
+            for (auto const &change : changes) {
+                [[maybe_unused]] auto const num =
+                    std::erase_if(storage, [&](auto const &p) {
+                        return p.first == change.first;
+                    });
+
+                assert(num <= 1);
+
+                if (change.second) {
+                    storage.emplace_back(change.first, *change.second);
+                }
+            }
+
+            comparator auto const cmp = injected_comparator<DummyArgs...>;
+            std::ranges::sort(storage, cmp, &element_t::first);
+        }
+
+        changes_.clear();
+        deleted_prefixes_.clear();
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/key_buffer.hpp
+++ b/include/monad/trie/key_buffer.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <monad/trie/config.hpp>
+
+#include <monad/core/address.hpp>
+#include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/nibbles.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// A key is composed of a prefix and a path. This class helps facilitate
+// manipulation of a key.
+struct KeyBuffer
+{
+    constexpr static size_t MAX_PATH_SIZE = 1 + Nibbles::MAX_SIZE / 2;
+    constexpr static size_t MAX_SIZE = sizeof(address_t) + MAX_PATH_SIZE;
+
+    byte_string_fixed<MAX_SIZE> raw;
+    size_t buf_size = 0;
+    size_t prefix_size = 0;
+
+    [[nodiscard]] constexpr byte_string_view prefix() const
+    {
+        return {&raw[0], prefix_size};
+    }
+    [[nodiscard]] constexpr byte_string_view view() const
+    {
+        return {&raw[0], buf_size};
+    }
+
+    constexpr void set_prefix(address_t const &address)
+    {
+        prefix_size = sizeof(address_t);
+        buf_size = sizeof(address_t);
+        std::copy_n(&address.bytes[0], sizeof(address_t), &raw[0]);
+    }
+
+    constexpr void set_path(NibblesView const &nibbles)
+    {
+        assert(prefix_size == 0 || prefix_size == 20);
+
+        raw[prefix_size] = nibbles.size();
+
+        buf_size = prefix_size + 1;
+        if (nibbles.start % 2) {
+            for (size_t i = 0; i < nibbles.size(); i += 2) {
+                assert(nibbles[i] <= 0xF);
+
+                auto const left =
+                    static_cast<byte_string::value_type>(nibbles[i] << 4);
+                if (i == (nibbles.size() - 1)) {
+                    raw[buf_size] = left;
+                    ++buf_size;
+                    break;
+                }
+                raw[buf_size] = left | nibbles[i + 1];
+                ++buf_size;
+            }
+        }
+        else {
+            bool const is_odd = nibbles.size() % 2;
+            size_t const num_bytes = nibbles.size() / 2 + is_odd;
+
+            std::copy_n(
+                &nibbles.rep[nibbles.start / 2 + 1], num_bytes, &raw[buf_size]);
+
+            buf_size += num_bytes;
+
+            constexpr std::array<uint8_t, 2> masks = {0xFF, 0xF0};
+            raw[buf_size - 1] &= masks[is_odd];
+        }
+    }
+
+    constexpr void path_pop_back()
+    {
+        assert(buf_size <= MAX_SIZE);
+        assert(buf_size > prefix_size);
+        assert(raw[prefix_size]);
+
+        if (raw[prefix_size] % 2) {
+            --buf_size;
+        }
+        else {
+            raw[buf_size - 1] &= 0xF0;
+        }
+
+        --raw[prefix_size];
+    }
+
+    [[nodiscard]] constexpr bool path_empty() const
+    {
+        assert(buf_size > prefix_size);
+        return raw[prefix_size] == 0;
+    }
+};
+
+template <typename TNibbles>
+constexpr void serialize_nibbles(KeyBuffer &buffer, TNibbles &&nibbles)
+{
+    buffer.set_path(std::forward<TNibbles>(nibbles));
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/nibbles.hpp
+++ b/include/monad/trie/nibbles.hpp
@@ -1,0 +1,288 @@
+#pragma once
+
+#include <limits>
+#include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
+#include <monad/core/bytes.hpp>
+
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles_view.hpp>
+#include <monad/trie/util.hpp>
+
+#include <cassert>
+#include <cstring>
+#include <string>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+namespace impl
+{
+    template <typename TNibbles>
+    constexpr void copy_from_nibbles(byte_string &dest, TNibbles const &nibbles)
+    {
+        for (size_t i = 0; i < nibbles.size(); i += 2) {
+            assert(nibbles[i] <= 0xF);
+
+            auto const left =
+                static_cast<byte_string::value_type>(nibbles[i] << 4);
+            if (i == (nibbles.size() - 1)) {
+                dest.push_back(left);
+                break;
+            }
+            dest.push_back(left | nibbles[i + 1]);
+        }
+    }
+}
+
+struct Nibbles
+{
+    byte_string rep;
+
+    static constexpr uint8_t MAX_SIZE = 64;
+
+    constexpr Nibbles()
+        : rep(1, 0)
+    {
+    }
+    constexpr Nibbles(Nibbles const &) = default;
+    constexpr Nibbles(Nibbles &&) = default;
+    constexpr Nibbles &operator=(Nibbles const &) = default;
+
+    constexpr explicit Nibbles(byte_string_view nibbles)
+    {
+        assert(nibbles.size() <= MAX_SIZE);
+
+        rep.push_back(static_cast<byte_string::value_type>(nibbles.size()));
+
+        impl::copy_from_nibbles(rep, nibbles);
+    }
+
+    constexpr explicit Nibbles(bytes32_t const &b32)
+    {
+        static_assert(sizeof(bytes32_t) * 2 == MAX_SIZE);
+        rep.push_back(MAX_SIZE);
+        rep.append(b32.bytes, sizeof(bytes32_t));
+    }
+
+    constexpr explicit Nibbles(NibblesView const &nibbles)
+    {
+        rep.push_back(nibbles.size());
+
+        if (nibbles.start % 2) {
+            impl::copy_from_nibbles(rep, nibbles);
+        }
+        else {
+            bool const is_odd = nibbles.size() % 2;
+            rep.append(
+                &nibbles.rep[nibbles.start / 2 + 1],
+                nibbles.size() / 2 + is_odd);
+
+            constexpr std::array<uint8_t, 2> masks = {0xFF, 0xF0};
+            rep.back() &= masks[is_odd];
+        }
+    }
+
+    [[nodiscard]] constexpr byte_string::value_type operator[](uint8_t i) const
+    {
+        assert(i < size());
+        return get_nibble(rep, i);
+    }
+
+    [[nodiscard]] constexpr uint8_t size() const
+    {
+        assert(!rep.empty());
+        return rep.front();
+    }
+
+    [[nodiscard]] constexpr bool empty() const { return size() == 0; }
+
+    [[nodiscard]] constexpr NibblesView substr(uint8_t pos) const
+    {
+        assert(pos <= size());
+        return NibblesView{
+            rep, pos, static_cast<byte_string::value_type>(size() - pos)};
+    }
+
+    [[nodiscard]] constexpr NibblesView prefix(uint8_t n) const
+    {
+        assert(n <= size());
+        return {rep, 0, n};
+    }
+
+    constexpr void push_back(byte_string::value_type nibble)
+    {
+        assert(nibble <= 0xF);
+        assert(!rep.empty());
+
+        if (size() % 2) {
+            rep.back() |= nibble;
+        }
+        else {
+            rep.push_back(static_cast<byte_string::value_type>(nibble << 4));
+        }
+        ++rep[0];
+    }
+
+    constexpr void pop_back()
+    {
+        assert(!empty());
+
+        if (size() % 2) {
+            rep.pop_back();
+        }
+        else {
+            rep.back() &= 0xF0; // zero out last nibble
+        }
+
+        --rep[0];
+    }
+
+    [[nodiscard]] constexpr bool startswith(Nibbles const &prefix) const
+    {
+        if (prefix.size() > size()) {
+            return false;
+        }
+
+        size_t const i = prefix.size() / 2;
+        if (std::memcmp(&rep[1], &prefix.rep[1], i) != 0) {
+            return false;
+        }
+
+        if (prefix.size() % 2) {
+            return (rep[i + 1] & 0xF0) == (prefix.rep[i + 1] & 0xF0);
+        }
+
+        return true;
+    }
+
+    [[nodiscard]] constexpr operator NibblesView() const
+    {
+        return {rep, 0, size()};
+    }
+
+    [[nodiscard]] constexpr Nibbles operator+(Nibbles const &rhs) const
+    {
+        if (empty()) {
+            return rhs;
+        }
+
+        if (rhs.empty()) {
+            return *this;
+        }
+
+        Nibbles ret = *this;
+
+        if (ret.size() % 2) {
+            ret.rep.back() |= rhs.rep[1] >> 4;
+            impl::copy_from_nibbles(ret.rep, rhs.substr(1));
+        }
+        else {
+            ret.rep.append(&rhs.rep[1], rhs.rep.size() - 1);
+        }
+
+        ret.rep[0] += rhs.size();
+
+        return ret;
+    }
+
+    // lexicographic comparison
+    [[nodiscard]] constexpr int compare(Nibbles const &other) const
+    {
+        if (size() == other.size()) {
+            return std::memcmp(&rep[0], &other.rep[0], rep.size());
+        }
+
+        size_t const min_size = std::min(size(), other.size());
+
+        size_t const i = min_size / 2;
+        auto rc = std::memcmp(&rep[1], &other.rep[1], i);
+        if (rc != 0) {
+            return rc;
+        }
+
+        if (min_size % 2) {
+            uint8_t const b1 = rep[i + 1] & 0xF0;
+            uint8_t const b2 = other.rep[i + 1] & 0xF0;
+
+            rc = std::memcmp(&b1, &b2, 1);
+            if (rc != 0) {
+                return rc;
+            }
+        }
+
+        return size() - other.size();
+    }
+
+    [[nodiscard]] constexpr bool operator==(Nibbles const &) const = default;
+
+    [[nodiscard]] constexpr auto operator<=>(Nibbles const &rhs) const
+    {
+        return compare(rhs) <=> 0;
+    }
+
+    [[nodiscard]] constexpr bool operator==(NibblesView const &view) const
+    {
+        if (size() != view.size()) {
+            return false;
+        }
+
+        if (view.start % 2) {
+            for (uint8_t i = 0; i < size(); ++i) {
+                if ((*this)[i] != view[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        else {
+            size_t const i = size() / 2;
+            size_t const vs = view.start / 2 + 1;
+            auto const rc = std::memcmp(&rep[1], &view.rep[vs], i);
+            if (rc != 0 || (size() % 2) == 0) {
+                return rc == 0;
+            }
+
+            return (rep.back() & 0xF0) == (view.rep[vs + i] & 0xF0);
+        }
+    }
+};
+
+[[nodiscard]] constexpr std::pair<Nibbles, size_t>
+deserialize_nibbles(byte_string_view bytes)
+{
+    MONAD_ASSERT(!bytes.empty());
+
+    std::pair<Nibbles, size_t> ret;
+
+    auto &[nibbles, num_bytes] = ret;
+    num_bytes = 1 + bytes[0] / 2 + (bytes[0] % 2);
+
+    MONAD_ASSERT(bytes.size() >= num_bytes);
+
+    nibbles.rep = byte_string(bytes.data(), num_bytes);
+
+    return ret;
+}
+
+constexpr void serialize_nibbles(byte_string &buffer, Nibbles const &nibbles)
+{
+    buffer.append(nibbles.rep);
+}
+
+[[nodiscard]] constexpr uint8_t
+longest_common_prefix_size(Nibbles const &first, Nibbles const &second)
+{
+    auto const size =
+        static_cast<uint8_t>(std::min(first.size(), second.size()));
+    for (uint8_t i = 0; i < size; ++i) {
+        if (first[i] != second[i]) {
+            return i;
+        }
+    }
+    return size;
+}
+
+static_assert(sizeof(Nibbles) == 32);
+static_assert(alignof(Nibbles) == 8);
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/nibbles_view.hpp
+++ b/include/monad/trie/nibbles_view.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cassert>
+
+#include <monad/trie/config.hpp>
+#include <monad/trie/util.hpp>
+
+#include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct NibblesView
+{
+    byte_string_view rep;
+    uint8_t start; // starting nibble index
+    uint8_t len; // length of nibbles
+
+    constexpr NibblesView(byte_string_view rep, uint8_t start, uint8_t len)
+        : rep(rep)
+        , start(start)
+        , len(len)
+    {
+    }
+
+    [[nodiscard]] constexpr uint8_t size() const { return len; }
+
+    [[nodiscard]] constexpr bool empty() const { return size() == 0; }
+
+    [[nodiscard]] constexpr byte_string::value_type operator[](size_t i) const
+    {
+        assert(i < len);
+        return get_nibble(rep, i + start);
+    }
+
+    [[nodiscard]] constexpr bool operator==(NibblesView const &other) const
+    {
+        if (size() != other.size()) {
+            return false;
+        }
+
+        for (size_t i = 0; i < size(); ++i) {
+            if ((*this)[i] != other[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+static_assert(sizeof(NibblesView) == 24);
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/node.hpp
+++ b/include/monad/trie/node.hpp
@@ -1,0 +1,303 @@
+#pragma once
+
+#include <bit>
+#include <limits>
+
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles.hpp>
+
+#include <monad/core/assert.h>
+
+#include <monad/rlp/encode_helpers.hpp>
+
+#include <tl/optional.hpp>
+
+#include <cassert>
+#include <cstring>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct BaseNode
+{
+    enum class Type : uint8_t
+    {
+        DELETED = 0,
+        BRANCH = 1,
+        LEAF = 2
+    };
+
+    // parent + branch
+    tl::optional<uint8_t> key_size;
+    Nibbles path_to_node;
+    byte_string reference;
+
+    constexpr BaseNode() = default;
+
+    [[nodiscard]] constexpr NibblesView partial_path() const
+    {
+        assert(key_size);
+        return path_to_node.substr(*key_size);
+    }
+
+    [[nodiscard]] constexpr bool operator==(BaseNode const &) const = default;
+
+protected:
+    constexpr BaseNode(NibblesView const &path_to_node)
+        : path_to_node(path_to_node)
+    {
+    }
+};
+
+struct Branch : public BaseNode
+{
+    std::array<byte_string, 16> children = {
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+        rlp::EMPTY_STRING,
+    };
+
+    constexpr Branch() = default;
+    constexpr Branch(Branch &&) = default;
+    constexpr Branch(Branch const &) = default;
+
+    constexpr Branch(
+        NibblesView path_to_node, BaseNode const &first, BaseNode &&second)
+        : BaseNode(path_to_node)
+    {
+        auto const i = path_to_node.size();
+
+        assert(i < first.path_to_node.size());
+        assert(i < second.path_to_node.size());
+        assert(first.path_to_node[i] != second.path_to_node[i]);
+        assert(first.reference != rlp::EMPTY_STRING);
+        assert(second.reference != rlp::EMPTY_STRING);
+
+        children[first.path_to_node[i]] = std::move(first.reference);
+        children[second.path_to_node[i]] = std::move(second.reference);
+    }
+
+    [[nodiscard]] constexpr Nibbles first_child() const
+    {
+        auto const it = std::ranges::find_if_not(
+            children, [](auto const &ref) { return ref == rlp::EMPTY_STRING; });
+
+        assert(it != children.end());
+
+        auto ret = path_to_node;
+        ret.push_back(static_cast<byte_string::value_type>(
+            std::distance(children.begin(), it)));
+        return ret;
+    }
+
+    [[nodiscard]] constexpr byte_string::value_type last_branch() const
+    {
+        auto const it = std::ranges::find_if_not(
+            children.rbegin(), children.rend(), [](auto const &ref) {
+                return ref == rlp::EMPTY_STRING;
+            });
+        assert(it != children.rend());
+
+        return static_cast<byte_string::value_type>(
+            std::distance(children.begin(), it.base()) - 1);
+    }
+
+    constexpr void finalize(size_t s)
+    {
+        key_size = s;
+        reference = rlp::to_node_reference(rlp::encode_branch(*this));
+    }
+
+    constexpr void add_child(BaseNode &&child)
+    {
+        assert(child.path_to_node.size() > path_to_node.size());
+        assert(child.reference != rlp::EMPTY_STRING);
+
+        auto const branch = child.path_to_node[path_to_node.size()];
+
+        assert(branch <= 0xF);
+
+        children[branch] = std::move(child.reference);
+    }
+
+    [[nodiscard]] constexpr bool operator==(Branch const &) const = default;
+    [[nodiscard]] constexpr Branch &operator=(Branch &&) = default;
+};
+
+struct Leaf : public BaseNode
+{
+    byte_string value;
+
+    constexpr Leaf() = default;
+    constexpr Leaf(Leaf &&) = default;
+    constexpr Leaf(Leaf const &) = default;
+
+    constexpr Leaf(NibblesView const &path_to_node, byte_string_view value)
+        : BaseNode(path_to_node)
+        , value(value)
+    {
+    }
+
+    constexpr void finalize(size_t s)
+    {
+        key_size = s;
+        reference = rlp::to_node_reference(rlp::encode_leaf(*this));
+    }
+
+    [[nodiscard]] constexpr bool operator==(Leaf const &) const = default;
+    [[nodiscard]] constexpr Leaf &operator=(Leaf &&) = default;
+};
+
+using Node = std::variant<Leaf, Branch>;
+
+template <typename T>
+concept LeafOrBranch = std::same_as<T, Leaf> || std::same_as<T, Branch>;
+
+template <LeafOrBranch T>
+constexpr byte_string serialize_node(T const &node)
+{
+    byte_string buffer;
+
+    if constexpr (std::same_as<T, Leaf>) {
+        buffer.push_back(static_cast<uint8_t>(BaseNode::Type::LEAF));
+    }
+    else {
+        buffer.push_back(static_cast<uint8_t>(BaseNode::Type::BRANCH));
+    }
+
+    serialize_nibbles(buffer, Nibbles{node.partial_path()});
+
+    assert(node.reference.size() <= 33);
+    buffer.push_back(
+        static_cast<byte_string::value_type>(node.reference.size()));
+    buffer += node.reference;
+
+    if constexpr (std::same_as<T, Leaf>) {
+        buffer += node.value;
+    }
+    else {
+        for (auto const &child : node.children) {
+            assert(child.size() >= 1 && child.size() <= 33);
+            buffer += static_cast<byte_string::value_type>(child.size());
+            buffer += child;
+        }
+    }
+
+    return buffer;
+}
+
+namespace impl
+{
+    [[nodiscard]] constexpr size_t deserialize_base_node(
+        BaseNode &node, monad::trie::Nibbles const &key,
+        monad::byte_string_view bytes)
+    {
+        MONAD_ASSERT(!bytes.empty());
+
+        node.key_size = key.size();
+
+        auto const [partial_path, bytes_processed] =
+            monad::trie::deserialize_nibbles(bytes);
+        node.path_to_node = key + partial_path;
+
+        using diff_t = decltype(bytes)::difference_type;
+        assert(bytes_processed <= std::numeric_limits<diff_t>::max());
+
+        auto it =
+            std::next(bytes.begin(), static_cast<diff_t>(bytes_processed));
+        MONAD_ASSERT(it != bytes.end());
+        uint8_t const size = *it;
+
+        std::advance(it, 1);
+        MONAD_ASSERT(std::distance(it, bytes.end()) >= size);
+
+        auto const end = std::next(it, size);
+        node.reference = monad::byte_string_view(it, end);
+
+        assert(bytes.begin() < end);
+
+        return static_cast<size_t>(std::distance(bytes.begin(), end));
+    }
+}
+
+[[nodiscard]] constexpr Node
+deserialize_node(Nibbles const &key, byte_string_view value)
+{
+
+    MONAD_ASSERT(!value.empty());
+
+    auto it = value.begin();
+
+    if (static_cast<BaseNode::Type>(*it) == BaseNode::Type::BRANCH) {
+        Branch branch;
+
+        std::advance(it, 1);
+        auto const bytes_processed = impl::deserialize_base_node(
+            branch, key, byte_string_view(it, value.end()));
+        std::advance(it, bytes_processed);
+
+        for (size_t i = 0; i < branch.children.size(); ++i) {
+            MONAD_ASSERT(it != value.end());
+
+            uint8_t const size = *it;
+
+            auto const start = std::next(it);
+            MONAD_ASSERT(std::distance(start, value.end()) >= size);
+            auto const end = std::next(start, size);
+            branch.children[i] = byte_string_view(start, end);
+
+            it = end;
+        }
+
+        MONAD_ASSERT(it == value.end());
+
+        return branch;
+    }
+
+    MONAD_ASSERT(static_cast<BaseNode::Type>(*it) == BaseNode::Type::LEAF);
+
+    Leaf leaf;
+    std::advance(it, 1);
+    auto const bytes_processed = impl::deserialize_base_node(
+        leaf, key, byte_string_view(it, value.end()));
+    std::advance(it, bytes_processed);
+
+    leaf.value = byte_string_view(it, value.end());
+
+    return leaf;
+}
+
+[[nodiscard]] constexpr bytes32_t get_root_hash(Node const &var)
+{
+    return std::visit(
+        [&](auto const &node) {
+            if (node.reference.size() == (1 + sizeof(bytes32_t))) {
+                bytes32_t root_hash;
+                std::memcpy(
+                    root_hash.bytes, &node.reference[1], sizeof(bytes32_t));
+                return root_hash;
+            }
+
+            return std::bit_cast<bytes32_t>(ethash::keccak256(
+                node.reference.data(), node.reference.size()));
+        },
+        var);
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/process_transformation_list.hpp
+++ b/include/monad/trie/process_transformation_list.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <list>
+#include <monad/trie/config.hpp>
+#include <monad/trie/node.hpp>
+#include <monad/trie/transform.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+template <typename TFunc>
+[[nodiscard]] bytes32_t process_transformation_list_dead_simple(
+    std::list<Node> &&list, TFunc finalize_and_emit)
+{
+    if (list.empty()) {
+        return NULL_ROOT;
+    }
+
+    while (list.size() > 1) {
+        for (auto it = list.begin(); it != list.end();) {
+            if (std::next(it) == list.end()) {
+                break;
+            }
+
+            auto &second = *it;
+            auto &third = *std::next(it);
+
+            auto const action = transform(
+                it == list.begin()
+                    ? tl::nullopt
+                    : tl::make_optional<Nibbles const &>(
+                          std::visit(&BaseNode::path_to_node, *std::prev(it))),
+                std::visit(&BaseNode::path_to_node, second),
+                std::visit(&BaseNode::path_to_node, third),
+                std::next(it, 2) == list.end()
+                    ? tl::nullopt
+                    : tl::make_optional<Nibbles const &>(std::visit(
+                          &BaseNode::path_to_node, *std::next(it, 2))));
+
+            if (action == TransformAction::NONE) {
+                std::advance(it, 1);
+            }
+            else if (action == TransformAction::CONCATENATE_TO_BRANCH) {
+                MONAD_ASSERT(std::holds_alternative<Branch>(second));
+
+                auto &branch = *std::get_if<Branch>(&second);
+
+                std::visit(
+                    [&](auto &child) {
+                        // TODO: do not recalculate reference is parent doesnt
+                        // change
+                        finalize_and_emit(
+                            child, branch.path_to_node.size() + 1);
+                        branch.add_child(std::move(child));
+                    },
+                    third);
+
+                auto const next = std::next(it, 2);
+                list.erase(std::next(it));
+                it = next;
+            }
+            else if (action == TransformAction::NEW_BRANCH) {
+                std::visit(
+                    [&](auto &left, auto &right) {
+                        auto const parent_path =
+                            left.path_to_node.prefix(longest_common_prefix_size(
+                                left.path_to_node, right.path_to_node));
+
+                        finalize_and_emit(left, parent_path.size() + 1);
+                        finalize_and_emit(right, parent_path.size() + 1);
+
+                        second = Branch(
+                            parent_path, std::move(left), std::move(right));
+                    },
+                    second,
+                    third);
+                auto const next = std::next(it, 2);
+                list.erase(std::next(it));
+                it = next;
+            }
+        }
+    }
+
+    assert(list.size() == 1);
+    return std::visit(
+        [&finalize_and_emit](auto &node) {
+            finalize_and_emit(node, 0);
+            return get_root_hash(node);
+        },
+        list.front());
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/rocks_comparator.hpp
+++ b/include/monad/trie/rocks_comparator.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <monad/core/address.hpp>
+
+#include <monad/trie/comparator.hpp>
+#include <monad/trie/config.hpp>
+
+#include <rocksdb/comparator.h>
+#include <rocksdb/slice.h>
+
+#include <cassert>
+#include <cstring>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// IMPORTANT: changes to the comparator are NOT backwards compatible with
+// previous databases.
+class PathComparator : public rocksdb::Comparator
+{
+public:
+    virtual int
+    Compare(rocksdb::Slice const &s1, rocksdb::Slice const &s2) const override
+    {
+        assert(!s1.empty());
+        assert(!s2.empty());
+        return path_compare(
+            byte_string_view{
+                reinterpret_cast<byte_string_view::value_type const *>(
+                    s1.data()),
+                s1.size()},
+            byte_string_view{
+                reinterpret_cast<byte_string_view::value_type const *>(
+                    s2.data()),
+                s2.size()});
+    }
+
+    // Update this whenever the logic of this compartor is changed
+    virtual const char *Name() const override { return "PathComparator 0.0.1"; }
+
+    // TODO: implement these for potential optimizations? Figure out what they
+    // do
+    void FindShortestSeparator(
+        std::string *, rocksdb::Slice const &) const override final
+    {
+    }
+    void FindShortSuccessor(std::string *) const override final {}
+};
+
+class PrefixPathComparator : public rocksdb::Comparator
+{
+    int Compare(
+        rocksdb::Slice const &s1, rocksdb::Slice const &s2) const override final
+    {
+        assert(s1.size() > sizeof(address_t));
+        assert(s2.size() > sizeof(address_t));
+
+        auto const rc = std::memcmp(s1.data(), s2.data(), sizeof(address_t));
+        if (rc != 0) {
+            return rc;
+        }
+
+        auto bs1 = byte_string_view{
+            reinterpret_cast<byte_string_view::value_type const *>(s1.data()),
+            s1.size()};
+        auto bs2 = byte_string_view{
+            reinterpret_cast<byte_string_view::value_type const *>(s2.data()),
+            s2.size()};
+        bs1.remove_prefix(sizeof(address_t));
+        bs2.remove_prefix(sizeof(address_t));
+
+        return path_compare(bs1, bs2);
+    }
+
+    // Update this whenever the logic of this compartor is changed
+    const char *Name() const override final
+    {
+        return "PrefixPathComparator 0.0.1";
+    }
+
+    // TODO: implement these for potential optimizations? Figure out what they
+    // do
+    void FindShortestSeparator(
+        std::string *, rocksdb::Slice const &) const override final
+    {
+    }
+    void FindShortSuccessor(std::string *) const override final {}
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/rocks_cursor.hpp
+++ b/include/monad/trie/rocks_cursor.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "evmc/evmc.hpp"
+#include <bits/iterator_concepts.h>
+#include <cstring>
+#include <iterator>
+
+#include <monad/core/assert.h>
+#include <monad/core/variant.hpp>
+
+#include <monad/trie/assert.h>
+#include <monad/trie/key_buffer.hpp>
+#include <monad/trie/nibbles.hpp>
+#include <monad/trie/util.hpp>
+
+#include <rocksdb/comparator.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+
+#include <tl/optional.hpp>
+
+#include <filesystem>
+#include <type_traits>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// Per-snapshot and prefix
+class RocksCursor
+{
+private:
+    std::shared_ptr<rocksdb::DB> const db_;
+
+    byte_string lower_;
+    byte_string upper_;
+    rocksdb::Slice lower_slice_;
+    rocksdb::Slice upper_slice_;
+    std::unique_ptr<rocksdb::Iterator> it_;
+    rocksdb::ColumnFamilyHandle *cf_; // non-owning
+    rocksdb::ReadOptions read_opts_;
+    mutable KeyBuffer buf_;
+
+public:
+    struct Key
+    {
+        bool has_prefix;
+        byte_string raw;
+
+        [[nodiscard]] constexpr bool operator==(Key const &) const = default;
+
+        [[nodiscard]] constexpr Nibbles path() const
+        {
+            assert(!has_prefix || raw.size() > sizeof(address_t));
+            return deserialize_nibbles(
+                       has_prefix ? raw.substr(sizeof(address_t)) : raw)
+                .first;
+        }
+
+        [[nodiscard]] constexpr bool path_empty() const
+        {
+            assert(!has_prefix || raw.size() > sizeof(address_t));
+            return (has_prefix ? raw[sizeof(address_t)] : raw[0]) == 0;
+        }
+    };
+
+    RocksCursor(std::shared_ptr<rocksdb::DB>, rocksdb::ColumnFamilyHandle *);
+
+    tl::optional<Key> key() const;
+    tl::optional<byte_string> value() const;
+
+    void prev();
+    void next();
+    void lower_bound(
+        Nibbles const &key, tl::optional<Key> const &first = tl::nullopt,
+        tl::optional<Key> const &last = tl::nullopt);
+
+    [[nodiscard]] bool valid() const;
+    [[nodiscard]] bool empty();
+    void take_snapshot();
+    void set_prefix(address_t const &);
+    void release_snapshots();
+};
+
+Nibbles deserialize_nibbles(rocksdb::Slice);
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/rocks_writer.hpp
+++ b/include/monad/trie/rocks_writer.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "evmc/evmc.hpp"
+#include <monad/core/byte_string.hpp>
+
+#include <monad/trie/assert.h>
+#include <monad/trie/config.hpp>
+#include <monad/trie/key_buffer.hpp>
+#include <monad/trie/util.hpp>
+#include <monad/trie/writer.hpp>
+
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct RocksWriter
+{
+    std::shared_ptr<rocksdb::DB> const db;
+    rocksdb::WriteBatch batch;
+    std::array<rocksdb::ColumnFamilyHandle *, 4> const cfs;
+
+    void put(WriterColumn col, KeyBuffer const &key, byte_string_view value)
+    {
+        assert(
+            (col == WriterColumn::ACCOUNT_ALL ||
+             col == WriterColumn::ACCOUNT_LEAVES) ||
+            key.view().size() > sizeof(address_t));
+
+        auto *cf = cfs[static_cast<uint8_t>(col)];
+        assert(cf);
+        auto const res = batch.Put(cf, to_slice(key.view()), to_slice(value));
+        MONAD_ROCKS_ASSERT(res);
+    }
+
+    void del(WriterColumn col, KeyBuffer const &key)
+    {
+        assert(
+            (col == WriterColumn::ACCOUNT_ALL ||
+             col == WriterColumn::ACCOUNT_LEAVES) ||
+            key.view().size() > sizeof(address_t));
+
+        auto *cf = cfs[static_cast<uint8_t>(col)];
+        assert(cf);
+        auto res = batch.Delete(cf, to_slice(key.view()));
+        MONAD_ROCKS_ASSERT(res);
+    }
+
+    void write()
+    {
+        auto const res = db->Write(rocksdb::WriteOptions{}, &batch);
+        MONAD_ROCKS_ASSERT(res);
+        batch.Clear();
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/transform.hpp
+++ b/include/monad/trie/transform.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles.hpp>
+
+#include <tl/optional.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+enum class TransformAction
+{
+    NONE,
+    CONCATENATE_TO_BRANCH,
+    NEW_BRANCH
+};
+
+[[nodiscard]] constexpr TransformAction transform(
+    tl::optional<Nibbles const &> s_1, Nibbles const &s_2, Nibbles const &s_3,
+    tl::optional<Nibbles const &> s_4)
+{
+    auto const len = longest_common_prefix_size(s_2, s_3);
+    if ((!s_1 || len > longest_common_prefix_size(*s_1, s_2)) &&
+        (!s_4 || len >= longest_common_prefix_size(s_3, *s_4))) {
+        if (s_2.size() == len) {
+            return TransformAction::CONCATENATE_TO_BRANCH;
+        }
+        return TransformAction::NEW_BRANCH;
+    }
+
+    return TransformAction::NONE;
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/trie.hpp
+++ b/include/monad/trie/trie.hpp
@@ -1,0 +1,636 @@
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <iterator>
+#include <variant>
+#include <vector>
+
+#include <monad/trie/key_buffer.hpp>
+#include <monad/trie/nibbles.hpp>
+#include <monad/trie/node.hpp>
+#include <monad/trie/process_transformation_list.hpp>
+#include <monad/trie/writer.hpp>
+
+#include <monad/core/assert.h>
+#include <monad/core/likely.h>
+#include <monad/core/variant.hpp>
+
+#include <tl/optional.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+struct Upsert
+{
+    Nibbles key;
+    byte_string value;
+};
+
+struct Delete
+{
+    Nibbles key;
+};
+
+using Update = std::variant<Upsert, Delete>;
+
+[[nodiscard]] constexpr Nibbles const &get_update_key(Update const &u)
+{
+    return std::visit(
+        [](auto const &ud) -> Nibbles const & { return ud.key; }, u);
+}
+
+[[nodiscard]] constexpr bool is_deletion(Update const &u)
+{
+    return std::holds_alternative<Delete>(u);
+}
+
+[[nodiscard]] constexpr byte_string const &get_upsert_value(Update const &u)
+{
+    return std::get<Upsert>(u).value;
+}
+
+[[nodiscard]] constexpr bool
+are_parents_same(Nibbles const &k1, Nibbles const &k2)
+{
+    assert(!(k1.empty() && k2.empty()));
+
+    if (k1.empty() || k2.empty()) {
+        return false;
+    }
+
+    return k1.prefix(k1.size() - 1) == k2.prefix(k2.size() - 1);
+}
+
+template <typename TCursor, typename TWriter>
+class Trie
+{
+private:
+    using trie_key_t = typename TCursor::Key;
+
+    TCursor &leaves_cursor_;
+    TCursor &trie_cursor_;
+    TWriter &writer_;
+    WriterColumn const leaves_col_;
+    WriterColumn const trie_col_;
+    KeyBuffer buf_;
+
+public:
+    using update_iterator_t = typename std::vector<Update>::const_iterator;
+    using optional_iterator_t =
+        std::variant<std::monostate, trie_key_t, update_iterator_t>;
+
+    constexpr Trie(
+        TCursor &leaves, TCursor &all, TWriter &writer, WriterColumn leaves_col,
+        WriterColumn trie_cursor_col)
+        : leaves_cursor_(leaves)
+        , trie_cursor_(all)
+        , writer_(writer)
+        , leaves_col_(leaves_col)
+        , trie_col_(trie_cursor_col)
+    {
+    }
+
+    constexpr void clear()
+    {
+        writer_.del_prefix(leaves_col_, buf_.prefix());
+        writer_.del_prefix(trie_col_, buf_.prefix());
+    }
+
+    constexpr void take_snapshot()
+    {
+        leaves_cursor_.take_snapshot();
+        trie_cursor_.take_snapshot();
+    }
+
+    constexpr void set_trie_prefix(address_t const &prefix)
+    {
+        buf_.set_prefix(prefix);
+        leaves_cursor_.set_prefix(prefix);
+        trie_cursor_.set_prefix(prefix);
+    }
+
+    // Process updates and queue up writes to disk. returns root hash
+    // of trie after updates are processed
+    bytes32_t process_updates(std::vector<Update> const &updates)
+    {
+        // updates should come in sorted order
+        assert(std::ranges::is_sorted(
+            updates, std::ranges::less{}, get_update_key));
+
+        // there should be no duplicate updates
+        assert(
+            std::ranges::adjacent_find(
+                updates, std::equal_to<>{}, get_update_key) == updates.end());
+
+        assert(!updates.empty());
+
+        // all updates should be to leaves (approximate this by checking size)
+        assert(std::ranges::all_of(
+            updates,
+            [&updates](auto const &s) {
+                return s == get_update_key(updates.front()).size();
+            },
+            [](auto const &u) { return get_update_key(u).size(); }));
+
+        auto list = [&]() -> std::list<Node> {
+            if (leaves_cursor_.empty()) {
+                std::list<Node> ret;
+                std::ranges::transform(
+                    updates, std::back_inserter(ret), [](auto const &update) {
+                        assert(!is_deletion(update));
+                        return Leaf{
+                            get_update_key(update), get_upsert_value(update)};
+                    });
+                return ret;
+            }
+            return generate_transformation_list(updates);
+        }();
+
+        auto const finalize_and_emit = [&](LeafOrBranch auto &node,
+                                           size_t key_size) {
+            using DecayedNode = std::decay_t<decltype(node)>;
+
+            // if the key is changing, delete the old one
+            if (node.key_size && node.key_size != key_size) {
+                serialize_nibbles(
+                    buf_, node.path_to_node.prefix(*node.key_size));
+                writer_.del(trie_col_, buf_);
+            }
+
+            node.finalize(key_size);
+
+            auto const value = serialize_node(node);
+
+            serialize_nibbles(buf_, node.path_to_node.prefix(*node.key_size));
+            writer_.put(trie_col_, buf_, value);
+            if constexpr (std::same_as<DecayedNode, Leaf>) {
+                serialize_nibbles(buf_, node.path_to_node);
+                writer_.put(leaves_col_, buf_, {});
+            }
+        };
+
+        return process_transformation_list_dead_simple(
+            std::move(list), finalize_and_emit);
+    }
+
+    [[nodiscard]] std::list<Node>
+    generate_transformation_list(std::vector<Update> const &updates)
+    {
+        assert(!updates.empty());
+
+        // pre-process
+        std::vector<Nibbles> trie_keys;
+        trie_keys.reserve(updates.size());
+
+        for (auto it = updates.begin(); it < updates.end(); ++it) {
+            trie_keys.push_back(get_key(it));
+            if (is_deletion(*it)) {
+                // TODO: to optimize this, only delete nodes that we know
+                // exist and need to be deleted. Look at perf to see if we
+                // bottleneck here
+                // if this becomes a bottle neck, search for the
+                // key first and then delete starting from there.
+                // This will initiate less delete calls
+
+                serialize_nibbles(buf_, get_update_key(*it));
+                writer_.del(leaves_col_, buf_);
+
+                while (!buf_.path_empty()) {
+                    writer_.del(trie_col_, buf_);
+                    buf_.path_pop_back();
+                }
+            }
+        }
+
+        std::list<Node> ret;
+        bool found = move_to_previous(updates.begin(), trie_keys.at(0));
+
+        while (found) {
+            MONAD_ASSERT(trie_cursor_.valid());
+
+            // TODO: push back and then reverse for more optimized
+            ret.insert(
+                ret.begin(),
+                deserialize_node(
+                    trie_cursor_.key()->path(), *trie_cursor_.value()));
+            found = move_to_previous();
+            MONAD_ASSERT(trie_cursor_.valid());
+        }
+
+        NextResult result = FromUpdate{
+            .it = updates.begin(), .next_update = std::next(updates.begin())};
+
+        if (is_deletion(*updates.begin())) {
+            assert(std::holds_alternative<FromUpdate>(result));
+            result = next(std::get<FromUpdate>(result), updates, trie_keys);
+        }
+
+        while (!std::holds_alternative<None>(result)) {
+            std::visit(
+                overloaded{
+                    [](None) { assert(false); },
+                    [&](FromUpdate from) {
+                        assert(from.it != updates.end());
+                        assert(!is_deletion(*from.it));
+
+                        ret.push_back(Leaf{
+                            get_update_key(*from.it),
+                            get_upsert_value(*from.it)});
+                        result = next(from, updates, trie_keys);
+                    },
+                    [&](FromStorage from) {
+                        MONAD_ASSERT(trie_cursor_.valid());
+
+                        ret.push_back(deserialize_node(
+                            trie_cursor_.key()->path(), *trie_cursor_.value()));
+
+                        result = next(from, updates, trie_keys);
+                        MONAD_ASSERT(trie_cursor_.valid());
+                    }},
+                result);
+        }
+
+        return ret;
+    }
+
+    [[nodiscard]] constexpr bytes32_t root_hash() const
+    {
+        if (leaves_cursor_.empty()) {
+            return NULL_ROOT;
+        }
+        trie_cursor_.lower_bound({});
+        MONAD_ASSERT(trie_cursor_.valid());
+        return get_root_hash(deserialize_node(
+            trie_cursor_.key()->path(), *trie_cursor_.value()));
+    }
+
+private:
+    [[nodiscard]] constexpr bool at_root() const
+    {
+        MONAD_ASSERT(trie_cursor_.valid());
+        return trie_cursor_.key()->path_empty();
+    }
+
+    // Move the trie cursor to the node with the longest prefix
+    //
+    // Pre-condition: None
+    // Post-condition: trie cursor points to entry with longest prefix
+    constexpr void move_to_longest_prefix(
+        Nibbles const &start, tl::optional<trie_key_t> const &last) const
+    {
+        assert(!start.empty());
+        MONAD_ASSERT(!trie_cursor_.empty());
+
+        auto current = start;
+        current.pop_back();
+        trie_cursor_.lower_bound(current, tl::nullopt, last);
+        auto key = trie_cursor_.key();
+
+        while (!key || key->path() != current) {
+            assert(!current.empty());
+
+            current.pop_back();
+            trie_cursor_.lower_bound(current, tl::nullopt, key);
+            key = trie_cursor_.key();
+        }
+
+        assert(key && key->path() != start && start.startswith(key->path()));
+    }
+
+    constexpr void move_to_parent()
+    {
+        assert(!at_root());
+        MONAD_ASSERT(trie_cursor_.valid());
+
+        auto const curr = trie_cursor_.key();
+        auto const curr_path = curr->path();
+        move_to_longest_prefix(curr_path, curr);
+
+        MONAD_ASSERT(trie_cursor_.valid());
+
+        auto const parent =
+            deserialize_node(trie_cursor_.key()->path(), *trie_cursor_.value());
+        auto const parent_path = std::visit(&BaseNode::path_to_node, parent);
+
+        assert(std::holds_alternative<Branch>(parent));
+        assert(parent_path == curr_path.prefix(curr_path.size() - 1));
+    }
+
+    // return the key that the update would have if inserted into storage
+    // in isolation
+    [[nodiscard]] constexpr Nibbles get_key(update_iterator_t update)
+    {
+        assert(!leaves_cursor_.empty());
+
+        leaves_cursor_.lower_bound(get_update_key(*update));
+        auto const lb = leaves_cursor_.key();
+
+        leaves_cursor_.prev();
+        auto const prev = leaves_cursor_.key();
+
+        auto const left = leaves_cursor_.key().and_then(
+            [&](auto const &prev) -> tl::optional<uint8_t> {
+                return longest_common_prefix_size(
+                    prev.path(), get_update_key(*update));
+            });
+
+        auto const right =
+            lb.and_then([&](auto const &lb) -> tl::optional<uint8_t> {
+                if (lb.path() == get_update_key(*update)) {
+                    leaves_cursor_.next();
+                    MONAD_ASSERT(leaves_cursor_.key() == lb);
+
+                    leaves_cursor_.next();
+
+                    return leaves_cursor_.key().and_then(
+                        [&](auto const &next) -> tl::optional<uint8_t> {
+                            return longest_common_prefix_size(
+                                next.path(), get_update_key(*update));
+                        });
+                }
+                return longest_common_prefix_size(
+                    lb.path(), get_update_key(*update));
+            });
+
+        // Nothing to the left or right, we are updating the only
+        // leaf in the trie
+        if (!left && !right) {
+            return Nibbles{};
+        }
+
+        // key is parent path + branch (prefix of trie is invisible here)
+        return Nibbles{get_update_key(*update).prefix(
+            std::max(left.value_or(0), right.value_or(0)) + 1)};
+    }
+
+    // returns whether or not there is a previous
+    // if true, cursor will point at the prev element
+    [[nodiscard]] constexpr bool
+    move_to_previous(update_iterator_t from, Nibbles const &trie_key)
+    {
+        assert(!leaves_cursor_.empty());
+
+        trie_cursor_.lower_bound(trie_key);
+        auto const lb = trie_cursor_.key();
+        auto const lb_path = lb.map(&trie_key_t::path);
+
+        // node exists
+        if (lb_path && std::visit(
+                           &BaseNode::path_to_node,
+                           deserialize_node(*lb_path, *trie_cursor_.value())) ==
+                           get_update_key(*from)) {
+            return move_to_previous();
+        }
+
+        trie_cursor_.prev();
+
+        auto const prev = trie_cursor_.key().map(&trie_key_t::path);
+        MONAD_ASSERT(prev);
+
+        // node does not exist, but parent exists
+        if (are_parents_same(*prev, trie_key) ||
+            (lb_path && are_parents_same(*lb_path, trie_key))) {
+            // insertion at end of branch
+            if (!lb_path || !are_parents_same(*lb_path, trie_key)) {
+                move_to_parent();
+                return true;
+            }
+            trie_cursor_.next();
+            MONAD_ASSERT(trie_cursor_.key().map(&trie_key_t::path) == lb_path);
+            return move_to_previous();
+        }
+
+        // node does not exist, and parent does not exist
+        move_to_longest_prefix(trie_key, lb);
+
+        MONAD_ASSERT(trie_cursor_.valid());
+
+        if (std::visit(
+                &BaseNode::path_to_node,
+                deserialize_node(
+                    trie_cursor_.key()->path(), *trie_cursor_.value())) <
+            trie_key) {
+            return true;
+        }
+
+        return move_to_previous();
+    }
+
+    [[nodiscard]] constexpr bool move_to_previous()
+    {
+        // base cases for the root
+        if (at_root()) {
+            return false;
+        }
+
+        auto const curr = trie_cursor_.key().map(&trie_key_t::path);
+        MONAD_ASSERT(curr);
+        trie_cursor_.prev();
+        auto const prev = trie_cursor_.key().map(&trie_key_t::path);
+        MONAD_ASSERT(prev);
+
+        // first sibling in branch
+        if (!are_parents_same(*prev, *curr)) {
+            trie_cursor_.next();
+            MONAD_ASSERT(trie_cursor_.key().map(&trie_key_t::path) == curr);
+            move_to_parent();
+            return move_to_previous();
+        }
+
+        return true;
+    }
+
+    struct None
+    {
+    };
+    struct FromStorage
+    {
+        update_iterator_t next_update;
+    };
+    struct FromUpdate
+    {
+        update_iterator_t it;
+        update_iterator_t next_update;
+    };
+    using NextResult = std::variant<None, FromStorage, FromUpdate>;
+
+    template <typename T>
+        requires std::same_as<T, FromStorage> || std::same_as<T, FromUpdate>
+    [[nodiscard]] constexpr NextResult next(
+        T const &from, std::vector<Update> const &updates,
+        std::vector<Nibbles> const &trie_keys)
+    {
+        bool const from_storage = [&]() {
+            // Move cursor to next in storage
+            if constexpr (std::same_as<T, FromStorage>) {
+                return move_to_next();
+            }
+            else {
+                assert(from.it >= updates.begin());
+                return move_to_next(
+                    from.it,
+                    trie_keys.at(
+                        size_t(std::distance(updates.begin(), from.it))));
+            }
+        }();
+
+        auto const next_update = from.next_update;
+
+        // nothing from storage
+        if (!from_storage) {
+            if (next_update == updates.end()) {
+                return None{};
+            }
+
+            assert(!is_deletion(*next_update));
+
+            return FromUpdate{
+                .it = next_update, .next_update = std::next(next_update)};
+        }
+
+        MONAD_ASSERT(trie_cursor_.valid());
+
+        // no more updates to consider
+        if (next_update == updates.end()) {
+            return FromStorage{.next_update = updates.end()};
+        }
+
+        assert(next_update > updates.begin());
+        auto const update_key =
+            trie_keys.at(size_t(std::distance(updates.begin(), next_update)));
+
+        // Update is to the root
+        if (update_key.empty()) {
+            MONAD_ASSERT(trie_cursor_.key()->path().empty());
+            return FromUpdate{
+                .it = next_update, .next_update = std::next(next_update)};
+        }
+
+        auto const update_parent_path =
+            update_key.prefix(update_key.size() - 1);
+        auto node =
+            deserialize_node(trie_cursor_.key()->path(), *trie_cursor_.value());
+
+        // Find highest root that is not dirtied by the next update
+        while (std::holds_alternative<Branch>(node) &&
+               get_update_key(*next_update)
+                   .startswith(std::get<Branch>(node).path_to_node)) {
+
+            auto const &branch = std::get<Branch>(node);
+
+            // next update is insert at end of branch, return the branch itself
+            if (update_parent_path == branch.path_to_node &&
+                !is_deletion(*next_update) &&
+                branch.last_branch() <
+                    get_update_key(*next_update)[update_parent_path.size()]) {
+                return FromStorage{.next_update = next_update};
+            }
+
+            auto const curr = trie_cursor_.key();
+            MONAD_ASSERT(curr);
+            trie_cursor_.lower_bound(branch.first_child(), curr);
+            MONAD_ASSERT(trie_cursor_.valid());
+            node = deserialize_node(
+                trie_cursor_.key()->path(), *trie_cursor_.value());
+        }
+
+        if (std::visit(&BaseNode::path_to_node, node) <
+            get_update_key(*next_update)) {
+            return FromStorage{.next_update = next_update};
+        }
+
+        if (is_deletion(*next_update)) {
+            return next(
+                FromUpdate{
+                    .it = next_update, .next_update = std::next(next_update)},
+                updates,
+                trie_keys);
+        }
+
+        return FromUpdate{
+            .it = next_update, .next_update = std::next(next_update)};
+    }
+
+    [[nodiscard]] constexpr bool move_to_next()
+    {
+        if (MONAD_UNLIKELY(at_root())) {
+            return false;
+        }
+
+        auto const from_path = trie_cursor_.key()->path();
+        trie_cursor_.next();
+        auto const next = trie_cursor_.key().map(&trie_key_t::path);
+
+        // last sibling
+        if (!next || !are_parents_same(from_path, *next)) {
+            trie_cursor_.prev();
+            MONAD_ASSERT(
+                trie_cursor_.key().map(&trie_key_t::path) == from_path);
+            move_to_parent();
+            return move_to_next();
+        }
+
+        return true;
+    }
+
+    [[nodiscard]] constexpr bool
+    move_to_next(update_iterator_t update, Nibbles const &key)
+    {
+        assert(!leaves_cursor_.empty());
+
+        trie_cursor_.lower_bound(key);
+        auto const lb = trie_cursor_.key();
+        auto const lb_path = lb.map(&trie_key_t::path);
+        auto const lb_value = trie_cursor_.value();
+
+        // TODO: see if can get rid of all these path_to_node calls
+        // now that the key is guaranteed to be unique
+        //
+        // node exists
+        if (lb_path && std::visit(
+                           &BaseNode::path_to_node,
+                           deserialize_node(*lb_path, *trie_cursor_.value())) ==
+                           get_update_key(*update)) {
+            return move_to_next();
+        }
+
+        assert(!is_deletion(*update));
+
+        // if key is empty, then it is the root, which should not be
+        // possible if reaching this point
+        assert(!key.empty());
+
+        trie_cursor_.prev();
+        auto const prev = trie_cursor_.key().map(&trie_key_t::path);
+        MONAD_ASSERT(prev);
+
+        // node does not exist, but parent exists
+        if (are_parents_same(*prev, key) ||
+            (lb_path && are_parents_same(*lb_path, key))) {
+            // insertion at end of branch
+            if (!lb_path || !are_parents_same(*lb_path, key)) {
+                move_to_parent();
+                return move_to_next();
+            }
+            trie_cursor_.next();
+            MONAD_ASSERT(trie_cursor_.key().map(&trie_key_t::path) == lb_path);
+            return true;
+        }
+
+        // node does not exist, and parent does not exist
+        move_to_longest_prefix(key, lb);
+
+        MONAD_ASSERT(trie_cursor_.valid());
+
+        if (key < std::visit(
+                      &BaseNode::path_to_node,
+                      deserialize_node(
+                          trie_cursor_.key()->path(), *trie_cursor_.value()))) {
+            return true;
+        }
+
+        return move_to_next();
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/util.hpp
+++ b/include/monad/trie/util.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/config.hpp>
+
+#include <rocksdb/slice.h>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+[[nodiscard]] inline rocksdb::Slice to_slice(byte_string_view view)
+{
+    return {reinterpret_cast<const char *>(view.data()), view.size()};
+}
+
+[[nodiscard]] inline byte_string_view from_slice(rocksdb::Slice slice)
+{
+    return {
+        reinterpret_cast<byte_string_view::value_type const *>(slice.data()),
+        slice.size()};
+}
+
+constexpr byte_string_view::value_type
+get_nibble(byte_string_view rep, size_t i)
+{
+    return (i % 2) == 0 ? rep.at(i / 2 + 1) >> 4 : rep.at(i / 2 + 1) & 0x0F;
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/include/monad/trie/writer.hpp
+++ b/include/monad/trie/writer.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <monad/trie/config.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+// TODO: figure out how to do this better so that we dont have to specify
+// WriterColumn
+enum class WriterColumn : uint8_t
+{
+    ACCOUNT_LEAVES = 0,
+    STORAGE_LEAVES = 1,
+    ACCOUNT_ALL = 2,
+    STORAGE_ALL = 3
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/src/monad/rlp/encode_helpers.cpp
+++ b/src/monad/rlp/encode_helpers.cpp
@@ -6,6 +6,9 @@
 #include <monad/core/signature.hpp>
 #include <monad/core/transaction.hpp>
 
+#include <monad/trie/compact_encode.hpp>
+#include <monad/trie/node.hpp>
+
 #include <numeric>
 #include <string>
 
@@ -134,6 +137,54 @@ byte_string encode_receipt(Receipt const &r)
             static_cast<unsigned char>(r.type) + receipt_bytes);
     }
     return receipt_bytes;
+}
+
+byte_string encode_leaf(trie::Leaf const &leaf)
+{
+    return encode_list(
+        encode_string(trie::compact_encode(leaf.partial_path(), true)),
+        encode_string(leaf.value));
+}
+
+byte_string encode_branch(trie::Branch const &branch)
+{
+    auto const branch_rlp = encode_list(
+        branch.children[0],
+        branch.children[1],
+        branch.children[2],
+        branch.children[3],
+        branch.children[4],
+        branch.children[5],
+        branch.children[6],
+        branch.children[7],
+        branch.children[8],
+        branch.children[9],
+        branch.children[10],
+        branch.children[11],
+        branch.children[12],
+        branch.children[13],
+        branch.children[14],
+        branch.children[15],
+        encode_string(byte_string{}));
+
+    auto const partial_path = branch.partial_path();
+    if (partial_path.empty()) {
+        return branch_rlp;
+    }
+
+    return encode_list(
+        encode_string(trie::compact_encode(partial_path, false)),
+        to_node_reference(branch_rlp));
+}
+
+byte_string to_node_reference(byte_string_view rlp)
+{
+    if (rlp.size() < 32) {
+        return byte_string(rlp);
+    }
+
+    auto const hash = ethash::keccak256(rlp.data(), rlp.size());
+    return encode_string(to_byte_string_view(hash.bytes));
 }
 
 MONAD_RLP_NAMESPACE_END

--- a/src/monad/trie/rocks_cursor.cpp
+++ b/src/monad/trie/rocks_cursor.cpp
@@ -1,0 +1,151 @@
+#include <monad/trie/rocks_cursor.hpp>
+#include <tl/optional.hpp>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+RocksCursor::RocksCursor(
+    std::shared_ptr<rocksdb::DB> db, rocksdb::ColumnFamilyHandle *cf)
+    : db_(db)
+    , cf_(cf)
+{
+    read_opts_.snapshot = db_->GetSnapshot();
+
+    assert(cf);
+    assert(read_opts_.snapshot);
+}
+
+tl::optional<RocksCursor::Key> RocksCursor::key() const
+{
+    return valid() ? tl::make_optional(
+                         Key{.has_prefix = (buf_.prefix_size > 0),
+                             .raw = byte_string{from_slice(it_->key())}})
+                   : tl::nullopt;
+}
+
+tl::optional<byte_string> RocksCursor::value() const
+{
+    return valid() ? tl::make_optional(byte_string{from_slice(it_->value())})
+                   : tl::nullopt;
+}
+
+void RocksCursor::prev()
+{
+    if (it_->Valid()) {
+        it_->Prev();
+    }
+    else {
+        // Note: weird quirk here where we just seek to last if the
+        // iterator is not valid. This means that if we prev() from
+        // the very first node, and then prev() again, that will bring
+        // us to the very last element in the database. This is why we
+        // valid() to avoid running into this by accident
+        it_->SeekToLast();
+        MONAD_ASSERT(valid());
+    }
+
+    MONAD_ASSERT(it_->Valid() || it_->status().ok());
+}
+
+void RocksCursor::next()
+{
+    if (it_->Valid()) {
+        it_->Next();
+    }
+    else {
+        // Note: similar quirky behavior to prev()
+        it_->SeekToFirst();
+        MONAD_ASSERT(valid());
+    }
+
+    MONAD_ASSERT(it_->Valid() || it_->status().ok());
+}
+
+bool RocksCursor::valid() const
+{
+    return it_ && it_->Valid() &&
+           it_->key().starts_with(to_slice(buf_.prefix()));
+}
+
+void RocksCursor::lower_bound(
+    Nibbles const &key, tl::optional<Key> const &first,
+    tl::optional<Key> const &last)
+{
+    assert(read_opts_.snapshot);
+
+    bool new_iterator = !it_;
+
+    // set up the read options
+    if (first) {
+        if (read_opts_.iterate_lower_bound == nullptr ||
+            *read_opts_.iterate_lower_bound != to_slice(first->raw)) {
+            new_iterator = true;
+            lower_ = first->raw;
+            lower_slice_ =
+                rocksdb::Slice{(const char *)lower_.data(), lower_.size()};
+            read_opts_.iterate_lower_bound = &lower_slice_;
+        }
+    }
+    else if (read_opts_.iterate_lower_bound != nullptr) {
+        new_iterator = true;
+        read_opts_.iterate_lower_bound = nullptr;
+    }
+
+    if (last) {
+        if (read_opts_.iterate_upper_bound == nullptr ||
+            *read_opts_.iterate_upper_bound != to_slice(last->raw)) {
+            new_iterator = true;
+            upper_ = last->raw;
+            upper_slice_ =
+                rocksdb::Slice{(const char *)upper_.data(), upper_.size()};
+            read_opts_.iterate_upper_bound = &upper_slice_;
+        }
+    }
+    else if (read_opts_.iterate_upper_bound != nullptr) {
+        new_iterator = true;
+        read_opts_.iterate_upper_bound = nullptr;
+    }
+
+    // only create the new iterator if needed
+    if (new_iterator) {
+        it_.reset(db_->NewIterator(read_opts_, cf_));
+    }
+
+    serialize_nibbles(buf_, key);
+    it_->Seek(to_slice(buf_.view()));
+    MONAD_ASSERT(it_->Valid() || it_->status().ok());
+}
+
+bool RocksCursor::empty()
+{
+    lower_bound({});
+    return !valid();
+}
+
+void RocksCursor::take_snapshot()
+{
+    release_snapshots();
+    assert(!it_);
+    read_opts_.snapshot = db_->GetSnapshot();
+}
+
+void RocksCursor::release_snapshots()
+{
+    assert(read_opts_.snapshot);
+    db_->ReleaseSnapshot(read_opts_.snapshot);
+    it_.reset();
+}
+
+void RocksCursor::set_prefix(address_t const &address)
+{
+    buf_.set_prefix(address);
+}
+
+Nibbles deserialize_nibbles(rocksdb::Slice slice)
+{
+    auto [nibbles, size] = deserialize_nibbles(
+        {(byte_string_view::value_type *)slice.data(), slice.size()});
+    MONAD_ASSERT(size == slice.size());
+    return std::move(nibbles);
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/src/monad/trie/test/CMakeLists.txt
+++ b/src/monad/trie/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_unit_test(
+    TARGET
+    monad-trielibtests
+    SOURCES
+    nibbles.cpp
+    compact_encode.cpp
+    node.cpp
+    LIBRARIES
+    monad)
+
+add_unit_test(
+    TARGET
+    monad-singletrietests
+    SOURCES
+    single_trie.cpp
+    LIBRARIES
+    monad
+)
+
+add_unit_test(
+    TARGET
+    monad-multipletrietests
+    SOURCES
+    multiple_trie.cpp
+    LIBRARIES
+    monad
+)

--- a/src/monad/trie/test/compact_encode.cpp
+++ b/src/monad/trie/test/compact_encode.cpp
@@ -1,0 +1,34 @@
+#include <monad/trie/compact_encode.hpp>
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+using namespace monad::trie;
+
+TEST(CompactEncoding, Sanity)
+{
+    auto path = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+
+    EXPECT_EQ(compact_encode(path, false), byte_string({0x11, 0x23, 0x45}));
+    EXPECT_EQ(compact_encode(path, true), byte_string({0x31, 0x23, 0x45}));
+
+    path = Nibbles(byte_string{0x00, 0x01, 0x02, 0x03, 0x04, 0x05});
+
+    EXPECT_EQ(
+        compact_encode(path, false), byte_string({0x00, 0x01, 0x23, 0x45}));
+    EXPECT_EQ(
+        compact_encode(path, true), byte_string({0x20, 0x01, 0x23, 0x45}));
+
+    path = Nibbles(byte_string{0x00, 0x0f, 0x01, 0x0c, 0x0b, 0x08});
+
+    EXPECT_EQ(
+        compact_encode(path, false), byte_string({0x00, 0x0f, 0x1c, 0xb8}));
+    EXPECT_EQ(
+        compact_encode(path, true), byte_string({0x20, 0x0f, 0x1c, 0xb8}));
+
+    path = Nibbles(byte_string{0x0f, 0x01, 0x0c, 0x0b, 0x08});
+    EXPECT_EQ(compact_encode(path, false), byte_string({0x1f, 0x1c, 0xb8}));
+    EXPECT_EQ(compact_encode(path, true), byte_string({0x3f, 0x1c, 0xb8}));
+}

--- a/src/monad/trie/test/hard_updates.hpp
+++ b/src/monad/trie/test/hard_updates.hpp
@@ -1,0 +1,357 @@
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <monad/core/byte_string.hpp>
+#include <monad/trie/config.hpp>
+#include <monad/trie/nibbles.hpp>
+#include <monad/trie/trie.hpp>
+#include <vector>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+using namespace evmc::literals;
+
+constexpr std::array hard_updates = {
+    std::make_pair(
+        0x009d9ee6ae2a8d2d33a6152cbd20b53e8e846228d6f5c3ba6df1c81f16d3f127_bytes32,
+        0x41bc7c43173291670eb10f71ab33b6a34f3d6e579db35659d6f1feb95f74ed46_bytes32),
+    std::make_pair(
+        0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce_bytes32,
+        0xceb7bb5d7e6da5c57e30f0e5f9957c3d60257a504231acaab2188a8c6b075c73_bytes32),
+    std::make_pair(
+        0x04f4a4a9c6d36d0a720cbbc0369a0f0c50f10553d5bf85cdce61efddab992c3c_bytes32,
+        0x2ba70a242acb53c42948c21ac59f7d89dc88d11e6fe3aa494dc394b4a1c4499e_bytes32),
+    std::make_pair(
+        0x0f81fd306d0c0cddd0728a76e6bfb0dfa12891c89994d877f0445483563b380a_bytes32,
+        0x60e3d22c55b1915a6eb9fcd285b46f6cff8882d2f3ae2fd385a4e5572f5aa5f4_bytes32),
+    std::make_pair(
+        0x15fed0451499512d95f3ec5a41c878b9de55f21878b5b4e190d4667ec709b4cf_bytes32,
+        0xaf7281a4ee6398e7d7cea996b1154893081455d486bde0a063019c7a92076006_bytes32),
+    std::make_pair(
+        0x184125b2e3d1ded2ad3f82a383d9b09bd5bac4ccea4d41092f49523399598aca_bytes32,
+        0x26ddc3107bec749814c5e7d837dfc9bb4f0b22d6c868614e89672d04b1667e97_bytes32),
+    std::make_pair(
+        0x1d8453ab2f7716504a4457ebe9831dbf996267e350ad0b2029f654d0dce1e055_bytes32,
+        0x3290f093b62a83e1dba902596ead450f7b134025ed9989ec369095ddacbeda71_bytes32),
+    std::make_pair(
+        0x2039d7a642a51f16527f26c248d83d01f17bd6bb26f8f7a26a8ef0b25eba8fb5_bytes32,
+        0x49ef6c046b9034a7aa5853d67e5e386e1dc9a75613ba7ad5ff9d2aebd7a69d2d_bytes32),
+    std::make_pair(
+        0x276d032750f286c508d060efcddd1b7a9becbfdb64efb5dfcbee057f86722fef_bytes32,
+        0x4b7c90f99a32f7cd42939dde0f7ceb97abba1b04b7817964392f8a33dd45df56_bytes32),
+    std::make_pair(
+        0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563_bytes32,
+        0xd924bece74cfca1df3f35cf6770ad94b0489736f0934e9d9d94ddddbbe471d3f_bytes32),
+    std::make_pair(
+        0x2af357fc2ab2964b76482ec0fcac3b86f5aca1a8292676023c8b9ec392d821a0_bytes32,
+        0x777fc5eb0909658944a5d882594433ce895f6f5933bd9416b6f7bc654a3c7270_bytes32),
+    std::make_pair(
+        0x2b429e4eab6541b4beccc7b602371aa993f406b84ccf73c8867b6d83cb135f94_bytes32,
+        0x295d46a25bfa7d0e4985db9b32f0710fd18b74a59b5d013673821b8948d4be03_bytes32),
+    std::make_pair(
+        0x2ced9dd329f90a9efa5f4e1036cf7d16762391ac0cbe8efa32ce5639ae85fedc_bytes32,
+        0x5fe0ad29a9ca1a2be131d767d38e10cf4cbc99c0e60a9bf656b4dd770e9debf0_bytes32),
+    std::make_pair(
+        0x2e795758918d9c804da815b3be88b798e63d21d668c624228fbd697bff25ea3b_bytes32,
+        0xee7ddcb4ebe386781f741f9c96169d73fea0f9b88e59217192316cfc63cdaa9a_bytes32),
+    std::make_pair(
+        0x30e2bfdaad2f3c218a1a8cc54fa1c4e6182b6b7f3bca273390cf587b50b47311_bytes32,
+        0x5485e9da791cb91437f65126464669620b583691618d10f2a4ebc95f61eab7e9_bytes32),
+    std::make_pair(
+        0x3184fc86524b0495db56f434fba34e478911db355cbb44815e987625ab42e557_bytes32,
+        0x5718ef99f6395026120be81ca15ebbf6070088c64861ecc5e928bb1899790971_bytes32),
+    std::make_pair(
+        0x336c5ee8777d6ef07cafc1c552f7d0b579a7ae6e0af042e9d18981c5b78642d3_bytes32,
+        0x856f1a994bfd6fc3eeccc36d03d9e6135b106858e23c71c239ffe63172ccdd7d_bytes32),
+    std::make_pair(
+        0x39aebb35169c657d179f2c043aaa0f872996f17760662712f1dc6331fda57882_bytes32,
+        0xb6ddd6949b83c8b437eaae6bf1df332776486b83a2504aa427ddd4e345d064b2_bytes32),
+    std::make_pair(
+        0x3a709301f7eafe917c7a06e209b077a9f3942799fb24b913407674a4c1485893_bytes32,
+        0xb9c6c4378fb88d49cee1ff5a0ba8db11742704f8abe2f1e197a4413017c3569f_bytes32),
+    std::make_pair(
+        0x3cac317908c699fe873a7f6ee4e8cd63fbe9918b2315c97be91585590168e301_bytes32,
+        0xa530fec672450854e903f0e040018e09b2b0502c103b57d57cdb30e1be541b2d_bytes32),
+    std::make_pair(
+        0x3e327054f60b9c38a1c3fafb23d155d0f971a83a616685eb79c73127b3dfbcc5_bytes32,
+        0xb739475cf33502d6e8f9812f7c7a794d27d087f2d6f5add997eef20ac6af5365_bytes32),
+    std::make_pair(
+        0x3f6f363f9f5dc4d17b6302009df91c84926a6d7684d5200cf7564c162d14ee9e_bytes32,
+        0xe856ec919fb0c36dfb2983f919e2d5e8bd3e29cbcad5a4e6f577355cc248228f_bytes32),
+    std::make_pair(
+        0x40e863c4bf2d8368d2089be3cd3340ecb9c7be11c9c8f4588f2c50f607a3192f_bytes32,
+        0x49d1363f8bc1fce71d09133f0a75e6620b315d9d093e878ba9bea695d1ba7598_bytes32),
+    std::make_pair(
+        0x41414fecbcd48d24288f4cd69cdc4f11560667f16291c4c642082019a2c613a6_bytes32,
+        0xee7b15d99c5256e390760193f154d7309a7cd7857452c1ee50f14fcf97fd6690_bytes32),
+    std::make_pair(
+        0x44a25c9533b4c9e05472848068a6b5bcb693ce9e222f3f4ac82d2927a82a34ce_bytes32,
+        0x27e95048fd667877ca0bf0b185ad434bac70aa812d19d87fe775ed81601175e8_bytes32),
+    std::make_pair(
+        0x46700b4d40ac5c35af2c22dda2787a91eb567b06c924a8fb8ae9a05b20c08c21_bytes32,
+        0x0bbef1c0791779842aa77a6ddcb825e014947f82e0095c252a278ab62a1a310f_bytes32),
+    std::make_pair(
+        0x471ccdcb79bddea38175f8cc115b52365f2c864200fbce48e994511bb9c6006f_bytes32,
+        0x8aa1a7b2969b4f7578155e6c37601054558a47a66fb1088514a7d7e801d6fc85_bytes32),
+    std::make_pair(
+        0x496e418294117864002a95f894a01c9cc414c86e17325489a5ea2f0eef181967_bytes32,
+        0x3d2e63a91b2ecf2ed045c79f40b6f76bda5bcce6a8313c0c55a73b8d85b0652b_bytes32),
+    std::make_pair(
+        0x4d8a735acc38ab7f01310ca8e6026ed9f86de88141cd83996db741df5291fc0d_bytes32,
+        0xa3277ef3829bf16b18091531cfaecc91b5ac6792978fdffba6cb767020dc37ea_bytes32),
+    std::make_pair(
+        0x5037e1a5e02e081b1b850b130eca7ac17335fdf4c61cc5ff6ae765196fb0d5b3_bytes32,
+        0x5d6f7ffbc206483d9fd229f8b6c18c7090fc029dc1ec0f6022aa540bb0003b95_bytes32),
+    std::make_pair(
+        0x51980562e41978f15369c21f26920284ac6836d53b02cd89edf4fedc97e68215_bytes32,
+        0xa676bfdc8476e28ef0adff8750c1ae0676712a1391cf73661632accf171d0108_bytes32),
+    std::make_pair(
+        0x5380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a_bytes32,
+        0x1c97359531e581287f81fd6328c1adeb6f899ade3125ea7e56e060acf6e7bae4_bytes32),
+    std::make_pair(
+        0x53e7852638024f004d43a4be0eb8fee26a32a8372274843339b422448fd2576f_bytes32,
+        0xe9d657646f5721f860972318bfed8765866fb1f50fad2bd0ad0f4e1e920e2c3c_bytes32),
+    std::make_pair(
+        0x5429fdc28e48579bde709c0ca18c55d58f14c9438d5cd1829556be99fd68b97b_bytes32,
+        0xdb7ce7548ff79ce5b2b8c55121851c3e8df775143e2e03430bcbb372547ba067_bytes32),
+    std::make_pair(
+        0x54a8c0ab653c15bfb48b47fd011ba2b9617af01cb45cab344acd57c924d56798_bytes32,
+        0x57964a85b93f767d43ebe85377977a1330c8ff3f866fd0f312cfebf3e625dcbe_bytes32),
+    std::make_pair(
+        0x5562d44b8038c7ec81ac64c10e44ed3b5638aebd3a8cb9d4231533aa9cb3890e_bytes32,
+        0x6a8b239aed22f87fb4ee1110d33a932a9568487d32909eacb4032176be90e2e5_bytes32),
+    std::make_pair(
+        0x5706de766d5661c754fb7b4c89db363309a9f89fa2945c9d8c7a303b79943963_bytes32,
+        0x8e1b28f3926b2b3993c9ae0c0ec07a94910b3f2dac2c8219d217dda24deb8690_bytes32),
+    std::make_pair(
+        0x575b3e1ddd7d4ec1d0695cd1f4b1c0daa01cd98c8309e0d37422fa675d95c614_bytes32,
+        0x086fa79e1f55a679d1aa9a9be8e2993e61ae5388ac40664a72df2003be7b46aa_bytes32),
+    std::make_pair(
+        0x59642f809245ca2950deda7acf1d460ac419ef7a8d003ac6bb42f69b01891e5d_bytes32,
+        0x1cce20fe1fb6adcc6d962c7c7f24a92301736975626daedc392cbf6fe7474cc6_bytes32),
+    std::make_pair(
+        0x5a657105c493a1213c976c653e929218bb4a516bca307dce5861ec23fffa4e58_bytes32,
+        0x2aeecc3de2857fbce6967d86c57d05fe9fbe18e9efa58d45a8e82585f4508b7b_bytes32),
+    std::make_pair(
+        0x5b7d7eba22589dfe1bd7a5417faa2a79838f19c58fe7408d6f66be2327cc996d_bytes32,
+        0x9ed412a63f1e6af16cb430d296729f2c92fc0ac79532142d9805ea7a6674d9c5_bytes32),
+    std::make_pair(
+        0x5d8af3eccd090407b914616ecb273b9d6c3321c26358e846ccb87a888d338b27_bytes32,
+        0x1c6efa586cfffb53c830496f45274239e23d480178537b8b84326bb669262e0b_bytes32),
+    std::make_pair(
+        0x5e54bc0a1194513341483ee95706fa9d4a9831002cf6e153df784ce8a4122e31_bytes32,
+        0x56337628751dbff6354754ad54f9eb62664083b143eb993abb1bce188174a282_bytes32),
+    std::make_pair(
+        0x660b057b36925d4a0da5bf6588b4c64cff7f27ee34e9c90b052829bf8e2a3168_bytes32,
+        0xa03c98c3402151c5bd416af461d5e9d5e17ea2530d5bc8def80d330c66b55aa8_bytes32),
+    std::make_pair(
+        0x69a7b944221b2d0f646f2ce0d6fa665e124d14c473efc07ff1eb0c83454b4ae9_bytes32,
+        0x0b92d6081b191a66efc6a1a0aba4b77560bc237dcce2ddf3d66497b5103885b6_bytes32),
+    std::make_pair(
+        0x6a697d43a20a63e9c2fa5aab8419182ead1753af13004c66ad1b554bf6f4d618_bytes32,
+        0x1ed811a31fbc13c3881d6c794e9887199acbb393514ae9e7fc6d2d6693db3095_bytes32),
+    std::make_pair(
+        0x6ae96a95a7e84d959a072f5e21b3aab63a0aa74ddfcc855dd22efbd350b2b996_bytes32,
+        0xb1f780ceabd8aa55087d4ccf8fd8e5003228679339497942e2ee9ca2a730e2ee_bytes32),
+    std::make_pair(
+        0x6bd2dd6bd408cbee33429358bf24fdc64612fbf8b1b4db604518f40ffd34b607_bytes32,
+        0xfd110b28cfc998d73aa86b39b8bd43f8bfdcb1693714063d9ce87309098d2008_bytes32),
+    std::make_pair(
+        0x6f9c0300d90788e3eaa2560d9c84298b436854bda9b9a4a9e9e04faa2e5e88c4_bytes32,
+        0x2268217fa019194d3a5367d1af324f9b6e8a6ba8e2de7012ce6392886fce9cec_bytes32),
+    std::make_pair(
+        0x70464a66238eef9fe6d03af376d9ed5260552f234e748fae9663a0527ef34c5f_bytes32,
+        0xbb65555dc7a07caa57f90f12f9539823f396eb43e7e5d0400e32132d1c0d5517_bytes32),
+    std::make_pair(
+        0x72abee45b59e344af8a6e520241c4744aff26ed411f4c4b00f8af09adada43ba_bytes32,
+        0xbc4ee81ffd8672b14723a1627fb64111cdaebe0384bf7ca9d34b196fae7000bd_bytes32),
+    std::make_pair(
+        0x743fe1979ce56df143c677aee6cf53601258e834f8e5b1cbd7034b3dde6bc8de_bytes32,
+        0xf808591ba4e9326cb6e7c0b8e24688a3da18934f65bb27b985343b4ac41d9988_bytes32),
+    std::make_pair(
+        0x74723bc3efaf59d897623890ae3912b9be3c4c67ccee3ffcf10b36406c722c1b_bytes32,
+        0xdc292531a31361fc96fe90599536bb2e73366a1420d26a9708ffd4318b403f6d_bytes32),
+    std::make_pair(
+        0x767bfb6ead6760f170718f8074950b9439f9d58e73b64f2554c474039f0e3eb4_bytes32,
+        0xbce6e15314e2c5a6a0f674527511e912609d8dbddf5b83657c083d9c5654bd5f_bytes32),
+    std::make_pair(
+        0x7733ef1f65c467ebbbb75072ade6f3677cc49a146089f0a95abd1e4015c837b9_bytes32,
+        0xb6d6cc2bf4e5d304652aa0348b1d97203e1d094a7f088ff5a8ee16d2c4639833_bytes32),
+    std::make_pair(
+        0x7832a610e1da8a92556b75303c954e5e61fe6fa5c988b6cbe4bc820fca21f82c_bytes32,
+        0xb0f2c1db0555e406d674c65f119d2584b6c45aab9d6cc0b5b0cd951d8f3c527a_bytes32),
+    std::make_pair(
+        0x7cdb9d7f02ea58dfeb797ed6b4f7ea68846e4f2b0e30ed1535fc98b60c4ec809_bytes32,
+        0x95a4a365d8701653a28be599e46d6ba3c9d8e22b949bd0c5145e6128c5e70e1e_bytes32),
+    std::make_pair(
+        0x827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd_bytes32,
+        0xefce697da33fa6b3ada2712aa246088ffc1afc70a4354119494bfbf70bec56f9_bytes32),
+    std::make_pair(
+        0x8793e6836d0a81896acf9611001258236b1803cd63d84819ffc0c54e4f8bf055_bytes32,
+        0x895a15071f85acd65c8d140ef85789afff244ec52def78c46579a9fa6250882d_bytes32),
+    std::make_pair(
+        0x8c3a47de78197a12495b1b381467f70d10231a44907e73dacc7c548569326dc4_bytes32,
+        0x28151a9c7c0b9168ce54fbdf5f70c06186f80fdf54bce6cf7bbafaa68c352233_bytes32),
+    std::make_pair(
+        0x913b834257c793da6424db222da1ff2f6fd6170ac3094be0405cdcc5552e1a78_bytes32,
+        0x30f9b87636e2f8dc864863be69895cc0d909fbb1fa5dccd3c095bf859f16f4b8_bytes32),
+    std::make_pair(
+        0x9166c8d72e513a9e3b8389c11481ec071da93e37370fc62bf99c51a7b869a7dd_bytes32,
+        0x6ad0962ae65e60fbf606b5ce8f88e030ad119cf2192a43597042e86edecf71f8_bytes32),
+    std::make_pair(
+        0x94374ea151ea3e73d7dd2fb895cb7f0c645bb54bd2d9a388e6209a57af17a19f_bytes32,
+        0xcc6c269b3d0711cad8c44edd30516c588b61f5ff91150e2a26b5f8077fbc10b9_bytes32),
+    std::make_pair(
+        0x96e2012ae1835f1b97d8521c4558a877b98f5dbd5fbe082f6a7747eaa649fe09_bytes32,
+        0x6f002c350a6d7cfc47849318154e33affe35ecff131cfa4ec36c35e3e2f952f6_bytes32),
+    std::make_pair(
+        0x99ff0d9125e1fc9531a11262e15aeb2c60509a078c4cc4c64cefdfb06ff68647_bytes32,
+        0xef5b1eff5ee4745c1c0c680bc4159f6b838333dce523812329b36a9a28a2e65a_bytes32),
+    std::make_pair(
+        0x9fb46c079060b754f8d357eabb5846653dacf180a75e2fbf304b5f377689270e_bytes32,
+        0xc55dc336c09c892568dd484ebee442dc2bfcf8b05bd688d7599c3d6b050ba226_bytes32),
+    std::make_pair(
+        0xa2cb1106ca86af80134921e46c21e7552734ef973651d0bff2574d844f46f814_bytes32,
+        0x502bf37542db670363aa5227ffeb2c4712931d141eeddfe874c85f868326f84e_bytes32),
+    std::make_pair(
+        0xa533db48442c1c18882149f8a3b768b48288edf57aecf5122aa8b9170d52dcb2_bytes32,
+        0x2359f20ca3df81592f08be17ec42ea26c575d71b2d75b49b347a3e74e71c5dd5_bytes32),
+    std::make_pair(
+        0xa86d54e9aab41ae5e520ff0062ff1b4cbd0b2192bb01080a058bb170d84e6457_bytes32,
+        0x8bf962ca4e8d2fd1c0608cefcf4fa60dc4d04938936ced913a99b2bee467ea12_bytes32),
+    std::make_pair(
+        0xac5b832ce7527996a1c519945dbcd7564b88139d3ea3c59607b93459d99f841e_bytes32,
+        0x797c326b81eaaddf00d8158d381dccc21de5f50716dc1620f0f06501eb18891f_bytes32),
+    std::make_pair(
+        0xad315e209dd62516ab8c7d1c2d8c3c206525501ebef91d12c34431f9ea255371_bytes32,
+        0x97b99f6fde3650785875a310668c29a757d2a4956cc51e5375d514d845a27d80_bytes32),
+    std::make_pair(
+        0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5_bytes32,
+        0x91fb0b8ff5dd4783a9615975f3a963637005c031e41bd7180660d26e66af22a4_bytes32),
+    std::make_pair(
+        0xadaf372fcd93e6510620653a95d8b22c5e3c1ac0536d7b2362a5bbb3c7b49df1_bytes32,
+        0xc07139b17dad0894e2d8d50c25645b09fe95af9015faaf5d6eae17dc067167ef_bytes32),
+    std::make_pair(
+        0xae61b77b3e4cbac1353bfa4c59274e3ae531285c24e3cf57c11771ecbf72d9bf_bytes32,
+        0x22190e27be80950a03dda4ee386333dc9799fd2fb290daa3150e46a2d23aac30_bytes32),
+    std::make_pair(
+        0xb053beae235e330995e8af215e2c0fa8f3c3b702f86658a43c0f626cd06a9a33_bytes32,
+        0x6b4b1cbaeeb9200c66c3c15be5850f53f6b015a09b7ee379b1029afccca788c9_bytes32),
+    std::make_pair(
+        0xb696031ea0505df7c7b5cc290e50cea0402d2a396b0db1c5d08155bd219cc52e_bytes32,
+        0x41e34880ec5e32ec07537472efe0dd57523de9b94fca55420a7fdfe51032eac9_bytes32),
+    std::make_pair(
+        0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a_bytes32,
+        0x59d235d03a9ac57d77b8d6d205980b47c5f949a783b684cfefcd042939acce08_bytes32),
+    std::make_pair(
+        0xbf1039e9d8f458cb0631edfab4902ce135879eb69e38484e881a6574a68ba9c0_bytes32,
+        0x8033016a6d51137266e6d73ea13948ae2df652462048bd240647049edb6a9885_bytes32),
+    std::make_pair(
+        0xbf53adb76067fdab0d008aef3ad8b28bbb63c2ce4c2b63394ede73f01a70c865_bytes32,
+        0xa9874fc40d57d2fb37775ef6cbd1081bc8be37fb242714d1ca9715495f57a229_bytes32),
+    std::make_pair(
+        0xc0d41db1b6c5cd39e7205798b17f08eb6fc41ffc96eeaace0bef52fdf71aa9ab_bytes32,
+        0xafd2486a3eb43dd4c9960a09b4453cdfa67eb90060ab46700a2f118975f49f10_bytes32),
+    std::make_pair(
+        0xc41589e7559804ea4a2080dad19d876a024ccb05117835447d72ce08c1d020ec_bytes32,
+        0x5e9e94afff4b984db3c26ea95e87d25c0adb0a22cb42f974d00491c42c2e2cdc_bytes32),
+    std::make_pair(
+        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32,
+        0xd3704792b17e570850accb6d6c29897bb8cafd93270fcc0380dac23407ad6b76_bytes32),
+    std::make_pair(
+        0xc980e59163ce244bb4bb6211f48c7b46f88a4f40943e84eb99bdc41e129bd293_bytes32,
+        0xb76d25cb5c6e232b9a47f8f62928599a6c9c0afe6a366e6aa5e27cb8aaf37190_bytes32),
+    std::make_pair(
+        0xca1c89237bece40382b71cc333f0cf90b8d896352d5f336ce534d6875b926e2b_bytes32,
+        0xc13485abfe09327a9b802a242a7a695cf09e5a983f4e9266d59269ebc4fd6ec9_bytes32),
+    std::make_pair(
+        0xcbfc9f3ace1802ac45478ea2849968b5f2a6895f1c4beea8e29085ec84a2fe43_bytes32,
+        0x72a1696c1160977295b500aaf36552bee08c368e3cb16035045b11441cc4f798_bytes32),
+    std::make_pair(
+        0xcd2548c4fa14cb15667cd5e5667dafbd0970d09185c619eb3348f5d7dbf131ba_bytes32,
+        0x00d6f6111be0b3c562ae6b6c460310cc082aca16173fead2ccd9240e81d21659_bytes32),
+    std::make_pair(
+        0xd3f825fab1d4a425ed2702aa02ab5881c1d35fb3b8b952901dbea314309e2061_bytes32,
+        0x452749607759d3f5871fc60c3ad3fb9adf3c450da0c05d2a8cf49b4fc325d3f4_bytes32),
+    std::make_pair(
+        0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b_bytes32,
+        0x6070445d286cad1de38d94a0c24263c8f3848ba093befb01c0efa7355247836c_bytes32),
+    std::make_pair(
+        0xdafb08ad2e8051263f565108f38cabb76abdca652cbe1b7f859cc22e76f2f85c_bytes32,
+        0xd7e433419a84375cd5adf5740e7b966c920168c2d015913147c2fba0beb3dbbf_bytes32),
+    std::make_pair(
+        0xdcb42a70c54293e75a19dd1303d167822182d78b361dd7504758c35e516871b2_bytes32,
+        0xc458820dbb3ce7b3e8f55660338f039419e1877590a58c740af6f75535138d2f_bytes32),
+    std::make_pair(
+        0xdfcbe054725ea501056a95ff91530c2a83371e15ec9d05619f12c76baa92ee2f_bytes32,
+        0x07c20901e3d0533c01064c22ba75e8315086e5f063c6dae80f45884db4ea4d89_bytes32),
+    std::make_pair(
+        0xdff4c3682adc47c34a7d4e71e6d433ccc3cee8960cc8356979f56e9ca61a63c0_bytes32,
+        0xab7748a62c6f71d9ca7c36e477ae5c1974147858f8166ad5af453fe881889585_bytes32),
+    std::make_pair(
+        0xe168b55b543959bfc9a1ba0d6f846406e9c5078c9f20fb49488e72c3781df761_bytes32,
+        0xf541464883d3119b58a7b52f982ca83dd4ce242b8bf1c64e6b9f6f183b005d8e_bytes32),
+    std::make_pair(
+        0xe2b9f9f9430b05bfa9a3abd3bac9a181434d23a707ef1cde8bd25d30203538d8_bytes32,
+        0xb972b0667534c122caa6a16b0d25928aa04dbe95d62b67596b15e6896e304863_bytes32),
+    std::make_pair(
+        0xe540257305ba7ed8f0852280a8bb5fa439642e2bbe5efb8396023190d1d4efac_bytes32,
+        0x68298cb031cc308a3ef047b821e9f45debb014cdeae5d9b831eabe67be442fe9_bytes32),
+    std::make_pair(
+        0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c_bytes32,
+        0x09eeb06103f5d76b0f349b485f53acd30d7fcaacee792743ede2f2742c36b72c_bytes32),
+    std::make_pair(
+        0xe8fb33650faf37535ebd07826e66bdb5c39fb2091055617df310736132d8743c_bytes32,
+        0x32728b7bfcf2eee78f3a5f725a5270daca331d7a65ee5196cc78db7af7b57d15_bytes32),
+    std::make_pair(
+        0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3_bytes32,
+        0x9bbbdeb7664e104a76a180e31cc2cb166c1dd60b651ae5983dd5c0e98d7ef58c_bytes32),
+    std::make_pair(
+        0xf490de2920c8a35fabeb13208852aa28c76f9be9b03a4dd2b3c075f7a26923b4_bytes32,
+        0xc194af2d01f268ddc267961ec5e25b44380aab74c13a754d335d392a5e6511a9_bytes32),
+    std::make_pair(
+        0xf548e71c32522ed78c2588df2cfdc3acd5c04cf930953ecabcc86ee3532f317c_bytes32,
+        0x0b1f54273e2159bdb379c23cff2eb452c31f7e9e781b6c08138ae0af796b1132_bytes32),
+};
+
+[[nodiscard]] constexpr Update
+make_upsert(Nibbles const &key, byte_string const &value)
+{
+    return Upsert{
+        .key = key,
+        .value = value,
+    };
+}
+
+[[nodiscard]] constexpr Update
+make_upsert(evmc::bytes32 key, byte_string const &value)
+{
+    return make_upsert(Nibbles(key), value);
+}
+
+[[nodiscard]] constexpr Update make_del(Nibbles const &key)
+{
+    return Delete{
+        .key = key,
+    };
+}
+
+[[nodiscard]] constexpr Update make_del(evmc::bytes32 key)
+{
+    return make_del(Nibbles(key));
+}
+
+[[nodiscard]] constexpr std::vector<Update> make_hard_updates()
+{
+    std::vector<Update> ret;
+    for (auto const &[key, value] : hard_updates) {
+        ret.push_back(make_upsert(
+            key,
+            byte_string(
+                reinterpret_cast<byte_string::value_type const *>(&value.bytes),
+                sizeof(value.bytes))));
+    }
+    return ret;
+}
+
+MONAD_TRIE_NAMESPACE_END

--- a/src/monad/trie/test/helpers.hpp
+++ b/src/monad/trie/test/helpers.hpp
@@ -1,0 +1,263 @@
+#pragma once
+
+#include "hard_updates.hpp"
+
+#include <monad/trie/comparator.hpp>
+#include <monad/trie/in_memory_cursor.hpp>
+#include <monad/trie/in_memory_writer.hpp>
+#include <monad/trie/rocks_comparator.hpp>
+#include <monad/trie/rocks_cursor.hpp>
+#include <monad/trie/rocks_writer.hpp>
+#include <monad/trie/trie.hpp>
+
+#include <gtest/gtest.h>
+#include <rocksdb/db.h>
+
+MONAD_TRIE_NAMESPACE_BEGIN
+
+class rocks_fixture : public ::testing::Test
+{
+public:
+    std::filesystem::path const name_;
+    rocksdb::Options options_;
+    std::vector<rocksdb::ColumnFamilyDescriptor> cfds_;
+    std::vector<rocksdb::ColumnFamilyHandle *> cfs_;
+    PathComparator comparator_;
+    std::shared_ptr<rocksdb::DB> db_;
+    RocksCursor leaves_cursor_;
+    RocksCursor trie_cursor_;
+    RocksWriter writer_;
+
+    Trie<RocksCursor, RocksWriter> trie_;
+
+    rocks_fixture()
+        : name_(std::filesystem::absolute("rocksdb"))
+        , db_([&]() {
+            options_.IncreaseParallelism(2);
+            options_.OptimizeLevelStyleCompaction();
+            options_.create_if_missing = true;
+            options_.create_missing_column_families = true;
+
+            rocksdb::DB *db = nullptr;
+
+            rocksdb::ColumnFamilyOptions col_opts;
+            col_opts.comparator = &comparator_;
+
+            cfds_ = {
+                {rocksdb::kDefaultColumnFamilyName, col_opts},
+                {"AccountTrieLeaves", {}},
+                {"AccountTrieAll", col_opts}};
+
+            rocksdb::Status const s =
+                rocksdb::DB::Open(options_, name_, cfds_, &cfs_, &db);
+
+            if (!s.ok()) {
+                std::cerr << s.ToString() << std::endl;
+                MONAD_ASSERT(false);
+            }
+            MONAD_ASSERT(cfds_.size() == cfs_.size());
+
+            return db;
+        }())
+        , leaves_cursor_(db_, cfs_[1])
+        , trie_cursor_(db_, cfs_[2])
+        , writer_(RocksWriter{
+              .db = db_,
+              .batch = rocksdb::WriteBatch{},
+              .cfs = {cfs_[1], nullptr, cfs_[2], nullptr}})
+        , trie_(
+              leaves_cursor_, trie_cursor_, writer_,
+              WriterColumn::ACCOUNT_LEAVES, WriterColumn::ACCOUNT_ALL)
+    {
+        EXPECT_TRUE(leaves_cursor_.empty());
+        EXPECT_TRUE(trie_cursor_.empty());
+    }
+
+    ~rocks_fixture()
+    {
+        leaves_cursor_.release_snapshots();
+        trie_cursor_.release_snapshots();
+
+        rocksdb::Status res;
+        for (auto *const cf : cfs_) {
+            res = db_->DestroyColumnFamilyHandle(cf);
+            MONAD_ASSERT(res.ok());
+        }
+
+        res = db_->Close();
+        MONAD_ASSERT(res.ok());
+
+        res = rocksdb::DestroyDB(name_, options_, cfds_);
+        MONAD_ASSERT(res.ok());
+    }
+
+    void process_updates(std::vector<Update> const &updates)
+    {
+        trie_.process_updates(updates);
+
+        writer_.write();
+        leaves_cursor_.take_snapshot();
+        trie_cursor_.take_snapshot();
+    }
+};
+
+class rocks_prefix_fixture : public ::testing::Test
+{
+public:
+    std::filesystem::path const name_;
+    rocksdb::Options options_;
+    std::vector<rocksdb::ColumnFamilyDescriptor> cfds_;
+    std::vector<rocksdb::ColumnFamilyHandle *> cfs_;
+    PrefixPathComparator comparator_;
+    std::shared_ptr<rocksdb::DB> db_;
+    RocksCursor leaves_cursor_;
+    RocksCursor trie_cursor_;
+    RocksWriter writer_;
+
+    Trie<RocksCursor, RocksWriter> trie_;
+
+    std::vector<Update> const hard_updates_only_upserts_;
+
+    rocks_prefix_fixture()
+        : name_(std::filesystem::absolute("rocksdb"))
+        , db_([&]() {
+            options_.IncreaseParallelism(2);
+            options_.OptimizeLevelStyleCompaction();
+            options_.create_if_missing = true;
+            options_.create_missing_column_families = true;
+
+            rocksdb::DB *db = nullptr;
+
+            rocksdb::ColumnFamilyOptions col_opts;
+            col_opts.comparator = &comparator_;
+
+            cfds_ = {
+                {rocksdb::kDefaultColumnFamilyName, col_opts},
+                {"StorageTrieLeaves", col_opts},
+                {"StorageTrieAll", col_opts}};
+
+            rocksdb::Status const s =
+                rocksdb::DB::Open(options_, name_, cfds_, &cfs_, &db);
+
+            if (!s.ok()) {
+                std::cerr << s.ToString() << std::endl;
+                MONAD_ASSERT(false);
+            }
+            MONAD_ASSERT(cfds_.size() == cfs_.size());
+
+            return db;
+        }())
+        , leaves_cursor_(db_, cfs_[1])
+        , trie_cursor_(db_, cfs_[2])
+        , writer_(RocksWriter{
+              .db = db_,
+              .batch = rocksdb::WriteBatch{},
+              .cfs = {nullptr, cfs_[1], nullptr, cfs_[2]}})
+        , trie_(
+              leaves_cursor_, trie_cursor_, writer_,
+              WriterColumn::STORAGE_LEAVES, WriterColumn::STORAGE_ALL)
+    {
+        EXPECT_TRUE(leaves_cursor_.empty());
+        EXPECT_TRUE(trie_cursor_.empty());
+    }
+
+    ~rocks_prefix_fixture()
+    {
+        leaves_cursor_.release_snapshots();
+        trie_cursor_.release_snapshots();
+
+        rocksdb::Status res;
+        for (auto *const cf : cfs_) {
+            res = db_->DestroyColumnFamilyHandle(cf);
+            MONAD_ASSERT(res.ok());
+        }
+
+        res = db_->Close();
+        MONAD_ASSERT(res.ok());
+
+        res = rocksdb::DestroyDB(name_, options_, cfds_);
+        MONAD_ASSERT(res.ok());
+    }
+
+    void process_updates(std::vector<Update> const &updates)
+    {
+        trie_.process_updates(updates);
+
+        writer_.write();
+        leaves_cursor_.take_snapshot();
+        trie_cursor_.take_snapshot();
+    }
+};
+
+struct in_memory_fixture : public ::testing::Test
+{
+    using cursor_t = InMemoryCursor;
+    using writer_t = InMemoryWriter;
+    using trie_t = Trie<cursor_t, writer_t>;
+
+    std::vector<std::pair<byte_string, byte_string>> leaves_storage_;
+    std::vector<std::pair<byte_string, byte_string>> trie_storage_;
+    cursor_t leaves_cursor_;
+    cursor_t trie_cursor_;
+    writer_t writer_;
+    trie_t trie_;
+
+    in_memory_fixture()
+        : leaves_cursor_(leaves_storage_)
+        , trie_cursor_(trie_storage_)
+        , writer_([&]() {
+            writer_t writer;
+            writer.storages_.emplace(
+                WriterColumn::ACCOUNT_ALL, std::ref(trie_storage_));
+            writer.storages_.emplace(
+                WriterColumn::ACCOUNT_LEAVES, std::ref(leaves_storage_));
+            return writer;
+        }())
+        , trie_(
+              leaves_cursor_, trie_cursor_, writer_,
+              WriterColumn::ACCOUNT_LEAVES, WriterColumn::ACCOUNT_ALL)
+    {
+    }
+
+    void flush()
+    {
+        writer_.write();
+        leaves_cursor_.take_snapshot();
+        trie_cursor_.take_snapshot();
+    }
+
+    void process_updates(std::vector<Update> const &updates)
+    {
+        trie_.process_updates(updates);
+        flush();
+    }
+
+    void clear()
+    {
+        trie_.clear();
+        flush();
+    }
+
+    bool storage_empty() const
+    {
+        return leaves_storage_.empty() && trie_storage_.empty();
+    }
+
+    void print_trie_storage() const
+    {
+        auto const pretty = [](byte_string const &bytes) {
+            std::ostringstream oss;
+            oss << "0x";
+            for (auto b : bytes) {
+                oss << std::setw(2) << std::setfill('0') << std::hex << int(b);
+            }
+            return oss.str();
+        };
+
+        for (auto const &[key, val] : trie_storage_) {
+            std::cout << pretty(key) << " " << pretty(val) << std::endl;
+        }
+    }
+};
+
+MONAD_TRIE_NAMESPACE_END

--- a/src/monad/trie/test/multiple_trie.cpp
+++ b/src/monad/trie/test/multiple_trie.cpp
@@ -1,0 +1,187 @@
+#include "helpers.hpp"
+
+#include <gtest/gtest.h>
+
+#include <monad/trie/in_memory_comparator.hpp>
+#include <monad/trie/trie.hpp>
+
+using namespace monad;
+using namespace monad::trie;
+using namespace evmc::literals;
+
+template <>
+inline auto injected_comparator<> = InMemoryPrefixPathComparator{};
+
+TEST_F(in_memory_fixture, MultipleTrie)
+{
+    using namespace evmc::literals;
+
+    // Add first trie
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000001_address);
+    process_updates({
+        make_upsert(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        //               *
+        make_upsert(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe})),
+        //               *
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32,
+            byte_string({0xde, 0xad, 0xca, 0xfe})),
+        //                                                                      *
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xba, 0xbe})),
+    });
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3b71638660a388410706ca8b52d1008e979b47b1e938558004881b56a42c61c0_bytes32);
+
+    // Add a second trie
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000002_address);
+    process_updates(make_hard_updates());
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes32);
+
+    // switch back to other and check that old root remains the same
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000001_address);
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3b71638660a388410706ca8b52d1008e979b47b1e938558004881b56a42c61c0_bytes32);
+
+    // Remove from second trie
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000002_address);
+    std::vector updates = {
+        make_del(
+            0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce_bytes32),
+        make_del(
+            0x04f4a4a9c6d36d0a720cbbc0369a0f0c50f10553d5bf85cdce61efddab992c3c_bytes32),
+        make_del(
+            0x0f81fd306d0c0cddd0728a76e6bfb0dfa12891c89994d877f0445483563b380a_bytes32),
+        make_del(
+            0x184125b2e3d1ded2ad3f82a383d9b09bd5bac4ccea4d41092f49523399598aca_bytes32),
+        make_del(
+            0x1d8453ab2f7716504a4457ebe9831dbf996267e350ad0b2029f654d0dce1e055_bytes32),
+        make_del(
+            0x276d032750f286c508d060efcddd1b7a9becbfdb64efb5dfcbee057f86722fef_bytes32),
+        make_del(
+            0x2af357fc2ab2964b76482ec0fcac3b86f5aca1a8292676023c8b9ec392d821a0_bytes32),
+        make_del(
+            0x30e2bfdaad2f3c218a1a8cc54fa1c4e6182b6b7f3bca273390cf587b50b47311_bytes32),
+        make_del(
+            0x336c5ee8777d6ef07cafc1c552f7d0b579a7ae6e0af042e9d18981c5b78642d3_bytes32),
+        make_del(
+            0x39aebb35169c657d179f2c043aaa0f872996f17760662712f1dc6331fda57882_bytes32),
+        make_del(
+            0x3cac317908c699fe873a7f6ee4e8cd63fbe9918b2315c97be91585590168e301_bytes32),
+        make_del(
+            0x41414fecbcd48d24288f4cd69cdc4f11560667f16291c4c642082019a2c613a6_bytes32),
+        make_del(
+            0x44a25c9533b4c9e05472848068a6b5bcb693ce9e222f3f4ac82d2927a82a34ce_bytes32),
+        make_del(
+            0x46700b4d40ac5c35af2c22dda2787a91eb567b06c924a8fb8ae9a05b20c08c21_bytes32),
+        make_del(
+            0x5037e1a5e02e081b1b850b130eca7ac17335fdf4c61cc5ff6ae765196fb0d5b3_bytes32),
+        make_del(
+            0x5380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a_bytes32),
+        make_del(
+            0x5429fdc28e48579bde709c0ca18c55d58f14c9438d5cd1829556be99fd68b97b_bytes32),
+        make_del(
+            0x5706de766d5661c754fb7b4c89db363309a9f89fa2945c9d8c7a303b79943963_bytes32),
+        make_del(
+            0x575b3e1ddd7d4ec1d0695cd1f4b1c0daa01cd98c8309e0d37422fa675d95c614_bytes32),
+        make_del(
+            0x5a657105c493a1213c976c653e929218bb4a516bca307dce5861ec23fffa4e58_bytes32),
+        make_del(
+            0x69a7b944221b2d0f646f2ce0d6fa665e124d14c473efc07ff1eb0c83454b4ae9_bytes32),
+        make_del(
+            0x74723bc3efaf59d897623890ae3912b9be3c4c67ccee3ffcf10b36406c722c1b_bytes32),
+    };
+
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x0835cc0ded52cfc5c950bf8f9f7daece213b5a679118f921578e8b164ab5f757_bytes32);
+
+    // Remove first trie completely
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000001_address);
+
+    process_updates({
+        make_del(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32),
+        make_del(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32),
+    });
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32);
+
+    // Check that second remains the same
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000002_address);
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x0835cc0ded52cfc5c950bf8f9f7daece213b5a679118f921578e8b164ab5f757_bytes32);
+}
+
+TEST_F(in_memory_fixture, MultipleTrieClear)
+{
+    using namespace evmc::literals;
+
+    // Add first trie
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000001_address);
+    process_updates({
+        make_upsert(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        //               *
+        make_upsert(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe})),
+        //               *
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32,
+            byte_string({0xde, 0xad, 0xca, 0xfe})),
+        //                                                                      *
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xba, 0xbe})),
+    });
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3b71638660a388410706ca8b52d1008e979b47b1e938558004881b56a42c61c0_bytes32);
+
+    // Add a second trie
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000002_address);
+    process_updates(make_hard_updates());
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes32);
+
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000001_address);
+    clear();
+
+    EXPECT_EQ(trie_.root_hash(), NULL_ROOT);
+
+    // Check that second remains the same
+    trie_.set_trie_prefix(0xc9ea7ed000000000000000000000000000000002_address);
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes32);
+
+    clear();
+    EXPECT_EQ(trie_.root_hash(), NULL_ROOT);
+
+    EXPECT_TRUE(storage_empty());
+}

--- a/src/monad/trie/test/nibbles.cpp
+++ b/src/monad/trie/test/nibbles.cpp
@@ -1,0 +1,279 @@
+#include <gtest/gtest.h>
+
+#include <monad/trie/key_buffer.hpp>
+#include <monad/trie/nibbles.hpp>
+
+using namespace monad;
+using namespace monad::trie;
+
+TEST(Nibbles, SanityOdd)
+{
+    byte_string const nibble_array = {0x01, 0x02, 0x03, 0x04, 0x05};
+    auto const nibbles = Nibbles(nibble_array);
+    EXPECT_EQ(nibbles.rep, byte_string({5, 0x12, 0x34, 0x50}));
+    EXPECT_EQ(nibbles.size(), 5);
+
+    for (uint8_t i = 0; i < nibble_array.size(); ++i) {
+        EXPECT_EQ(nibbles[i], nibble_array[i]);
+    }
+}
+
+TEST(Nibbles, SanityEven)
+{
+    byte_string const nibble_array = {0x01, 0x02, 0x03, 0x04};
+    auto const nibbles = Nibbles(nibble_array);
+    EXPECT_EQ(nibbles.rep, byte_string({4, 0x12, 0x34}));
+    EXPECT_EQ(nibbles.size(), 4);
+
+    for (uint8_t i = 0; i < nibble_array.size(); ++i) {
+        EXPECT_EQ(nibbles[i], nibble_array[i]);
+    }
+}
+
+TEST(Nibbles, Comparison)
+{
+    auto const first = Nibbles(byte_string({0x01, 0x02, 0x03, 0x04}));
+    auto const second = Nibbles(byte_string({0x01, 0x02, 0x03, 0x04, 0x05}));
+
+    EXPECT_EQ(first, first);
+    EXPECT_NE(first, second);
+
+    EXPECT_TRUE(first < second);
+    EXPECT_TRUE(first <= second);
+    EXPECT_FALSE(first < first);
+    EXPECT_FALSE(second < first);
+    EXPECT_TRUE(second > first);
+    EXPECT_TRUE(first >= first);
+    EXPECT_TRUE(second >= first);
+
+    auto const third = Nibbles(byte_string({0x01, 0x02, 0x03, 0x01}));
+    EXPECT_TRUE(third < second);
+    EXPECT_TRUE(third < first);
+    EXPECT_TRUE(third <= second);
+    EXPECT_TRUE(third <= first);
+    EXPECT_FALSE(third > second);
+    EXPECT_FALSE(third > first);
+
+    auto view = third.substr(0);
+    EXPECT_EQ(view, third);
+
+    view = third.substr(2);
+    EXPECT_NE(view, third);
+
+    view = third.substr(3);
+    EXPECT_NE(view, third);
+
+    auto const fourth = Nibbles();
+    EXPECT_TRUE(fourth < third);
+    EXPECT_FALSE(fourth == third);
+    EXPECT_FALSE(fourth > third);
+
+    auto const fifth =
+        Nibbles(byte_string({0x00, 0x01, 0x01, 0x02, 0x03, 0x01}));
+    view = fifth.substr(2);
+    EXPECT_NE(view, first);
+    EXPECT_NE(view, second);
+    EXPECT_EQ(view, third);
+
+    auto another_view = third.substr(0);
+    EXPECT_EQ(view, another_view);
+}
+
+TEST(Nibbles, OneNibble)
+{
+    auto const first = Nibbles(byte_string({0x01}));
+    EXPECT_EQ(first.rep, byte_string({1, 0x10}));
+
+    auto const second = Nibbles(byte_string({0x02}));
+    EXPECT_EQ(second.rep, byte_string({1, 0x20}));
+
+    EXPECT_NE(first, second);
+    EXPECT_TRUE(first < second);
+
+    auto const third = Nibbles(byte_string({0x01, 0x02}));
+    EXPECT_EQ(third.rep, byte_string({2, 0x12}));
+
+    EXPECT_NE(first, third);
+    EXPECT_NE(second, third);
+
+    EXPECT_FALSE(third < first);
+    EXPECT_TRUE(third < second);
+}
+
+TEST(Nibbles, Addition)
+{
+    Nibbles const odd(byte_string({0x01, 0x02, 0x03}));
+    Nibbles const even(byte_string({0x01, 0x02}));
+
+    auto add = odd + even;
+    Nibbles expected;
+    expected.rep = byte_string({5, 0x12, 0x31, 0x20});
+    EXPECT_EQ(add, expected);
+
+    add = odd + odd;
+    expected.rep = byte_string({6, 0x12, 0x31, 0x23});
+    EXPECT_EQ(add, expected);
+
+    add = even + even;
+    expected.rep = byte_string({4, 0x12, 0x12});
+    EXPECT_EQ(add, expected);
+
+    Nibbles const first(
+        byte_string{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x3});
+    Nibbles const second(byte_string{
+        0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+        0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5,
+        0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3,
+        0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7});
+
+    EXPECT_EQ(
+        second.rep,
+        byte_string({54,   0x23, 0x45, 0x67, 0x81, 0x23, 0x45, 0x67, 0x81, 0x23,
+                     0x45, 0x67, 0x81, 0x23, 0x45, 0x67, 0x81, 0x23, 0x45, 0x67,
+                     0x81, 0x23, 0x45, 0x67, 0x81, 0x23, 0x45, 0x67}));
+
+    expected = Nibbles(byte_string{
+        0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x3, 0x2, 0x3, 0x4, 0x5,
+        0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2,
+        0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+        0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4,
+        0x5, 0x6, 0x7, 0x8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7});
+    add = first + second;
+    EXPECT_EQ(add, expected);
+}
+
+TEST(Nibbles, EmptyNibbles)
+{
+    Nibbles empty;
+    EXPECT_EQ(empty.size(), 0);
+    EXPECT_TRUE(empty.empty());
+
+    auto const one = Nibbles(byte_string({0x01}));
+    EXPECT_TRUE(empty < one);
+
+    auto add = empty + empty;
+    EXPECT_EQ(add, empty);
+
+    Nibbles non_empty(byte_string({0x01, 0x02}));
+    add = empty + non_empty;
+    EXPECT_EQ(add, non_empty);
+}
+
+TEST(Nibbles, LongestCommonPrefix)
+{
+    auto const first = Nibbles(byte_string({0x01, 0x02, 0x03, 0x04}));
+    auto const second = Nibbles(byte_string({0x01, 0x02, 0x03}));
+
+    EXPECT_EQ(longest_common_prefix_size(first, first), 4);
+    EXPECT_EQ(longest_common_prefix_size(first, second), 3);
+
+    auto const third = Nibbles(byte_string({0x02, 0x03, 0x04}));
+
+    EXPECT_EQ(longest_common_prefix_size(first, third), 0);
+}
+
+TEST(Nibbles, View)
+{
+    auto const nibbles = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+    auto view = NibblesView{nibbles};
+    EXPECT_EQ(view.size(), 5);
+    EXPECT_EQ(view.start, 0);
+    EXPECT_EQ(view.rep, nibbles.rep);
+
+    view = nibbles.substr(3);
+    EXPECT_EQ(view.size(), 2);
+    EXPECT_EQ(view.start, 3);
+    EXPECT_EQ(view.rep, nibbles.rep);
+
+    EXPECT_EQ(view[0], 0x04);
+    EXPECT_EQ(view[1], 0x05);
+}
+
+TEST(Nibbles, Serialize)
+{
+    auto const nibbles = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+    KeyBuffer buf;
+    serialize_nibbles(buf, nibbles);
+    EXPECT_EQ(buf.view(), byte_string({5, 0x12, 0x34, 0x50}));
+    auto view = NibblesView{nibbles};
+
+    serialize_nibbles(buf, view);
+    EXPECT_EQ(buf.view(), byte_string({5, 0x12, 0x34, 0x50}));
+
+    view = nibbles.substr(1);
+    serialize_nibbles(buf, view);
+    EXPECT_EQ(buf.view(), byte_string({4, 0x23, 0x45}));
+
+    view = nibbles.prefix(3);
+    serialize_nibbles(buf, view);
+    EXPECT_EQ(buf.view(), byte_string({3, 0x12, 0x30}));
+}
+
+TEST(Nibbles, DeserializeOdd)
+{
+    auto const nibbles = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+    KeyBuffer buf;
+    serialize_nibbles(buf, nibbles);
+
+    auto const [deserialized, size] = deserialize_nibbles(buf.view());
+    EXPECT_EQ(size, 4);
+    EXPECT_EQ(deserialized, nibbles);
+}
+
+TEST(Nibbles, DeserializeEven)
+{
+    auto const nibbles = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04});
+    KeyBuffer buf;
+    serialize_nibbles(buf, nibbles);
+
+    auto const [deserialized, size] = deserialize_nibbles(buf.view());
+    EXPECT_EQ(size, 3);
+    EXPECT_EQ(deserialized, nibbles);
+}
+
+TEST(Nibbles, StartsWith)
+{
+    auto const nibbles = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+
+    auto prefix = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+    EXPECT_TRUE(nibbles.startswith(prefix));
+
+    prefix = Nibbles();
+    EXPECT_TRUE(nibbles.startswith(prefix));
+
+    prefix = Nibbles(byte_string{0x01});
+    EXPECT_TRUE(nibbles.startswith(prefix));
+
+    prefix = Nibbles(byte_string{0x01, 0x02, 0x03});
+    EXPECT_TRUE(nibbles.startswith(prefix));
+
+    prefix = Nibbles(byte_string{0x01, 0x02, 0x02});
+    EXPECT_FALSE(nibbles.startswith(prefix));
+    prefix = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05, 0x06});
+    EXPECT_FALSE(nibbles.startswith(prefix));
+
+    prefix = Nibbles(byte_string{0x01, 0x02});
+    EXPECT_TRUE(nibbles.startswith(prefix));
+}
+
+TEST(Nibbles, PushAndPopBack)
+{
+    Nibbles nibbles;
+    nibbles.push_back(0x2);
+    EXPECT_EQ(nibbles, Nibbles(byte_string{0x2}));
+
+    nibbles.push_back(0x3);
+    EXPECT_EQ(nibbles, Nibbles(byte_string{0x2, 0x3}));
+
+    nibbles.push_back(0x4);
+    EXPECT_EQ(nibbles, Nibbles(byte_string{0x2, 0x3, 0x4}));
+
+    nibbles.pop_back();
+    EXPECT_EQ(nibbles, Nibbles(byte_string{0x2, 0x3}));
+
+    nibbles.pop_back();
+    nibbles.pop_back();
+
+    EXPECT_EQ(nibbles, Nibbles());
+    EXPECT_TRUE(nibbles.empty());
+}

--- a/src/monad/trie/test/node.cpp
+++ b/src/monad/trie/test/node.cpp
@@ -1,0 +1,32 @@
+#include "ethash/keccak.hpp"
+#include <monad/trie/node.hpp>
+
+#include <gtest/gtest.h>
+
+#include <ethash/keccak.hpp>
+#include <variant>
+
+using namespace monad;
+using namespace monad::trie;
+
+TEST(Node, Serialization)
+{
+    Leaf leaf;
+    leaf.path_to_node = Nibbles(byte_string({0x01, 0x02, 0x03, 0x04}));
+    leaf.reference = {0x01, 0x12, 0x34, 0x56, 0x78, 0x90};
+    leaf.value = {0xde, 0xad, 0xbe, 0xef};
+    leaf.finalize(0);
+    auto bytes = serialize_node(leaf);
+    auto node = deserialize_node({}, bytes);
+    EXPECT_TRUE(std::holds_alternative<Leaf>(node));
+    EXPECT_EQ(*std::get_if<Leaf>(&node), leaf);
+
+    Branch branch;
+    branch.path_to_node = Nibbles(byte_string({0x01, 0x02, 0x03, 0x04}));
+    branch.reference = {0x01, 0x12, 0x34, 0x56, 0x78, 0x90};
+    branch.finalize(0);
+    bytes = serialize_node(branch);
+    node = deserialize_node({}, bytes);
+    EXPECT_TRUE(std::holds_alternative<Branch>(node));
+    EXPECT_EQ(*std::get_if<Branch>(&node), branch);
+}

--- a/src/monad/trie/test/single_trie.cpp
+++ b/src/monad/trie/test/single_trie.cpp
@@ -1,0 +1,487 @@
+#include "helpers.hpp"
+
+#include <gtest/gtest.h>
+
+#include <monad/trie/in_memory_comparator.hpp>
+#include <monad/trie/trie.hpp>
+
+#include <tl/optional.hpp>
+
+#include <random>
+
+using namespace monad;
+using namespace monad::trie;
+using namespace evmc::literals;
+
+template <>
+inline auto injected_comparator<> = InMemoryPathComparator{};
+
+namespace
+{
+    template <typename T>
+    T basic_node(tl::optional<size_t> key_size, byte_string path_to_node)
+    {
+        T node;
+        node.key_size = key_size;
+        node.path_to_node = Nibbles(path_to_node);
+        return node;
+    }
+
+    bool validate_list(auto const &list, auto const &expected)
+    {
+        return std::ranges::equal(
+            list, expected, [](auto const &a, auto const &b) {
+                return std::visit(
+                    overloaded{
+                        [](Leaf na, Leaf nb) {
+                            return na.path_to_node == nb.path_to_node &&
+                                   na.key_size == nb.key_size;
+                        },
+                        [](Branch na, Branch nb) {
+                            return na.path_to_node == nb.path_to_node &&
+                                   na.key_size == nb.key_size;
+                        },
+                        [](auto, auto) { return false; }},
+                    a,
+                    b);
+            });
+    }
+}
+
+class GenerateTransformationListFixture : public in_memory_fixture
+{
+public:
+    GenerateTransformationListFixture()
+    {
+        process_updates({
+            make_upsert(Nibbles(byte_string{0x04, 0x02, 0x02, 0x01}), {}),
+            make_upsert(Nibbles(byte_string{0x04, 0x02, 0x03, 0x02}), {}),
+            make_upsert(Nibbles(byte_string{0x04, 0x02, 0x03, 0x06}), {}),
+            make_upsert(Nibbles(byte_string{0x04, 0x05, 0x02, 0x01}), {}),
+        });
+    }
+};
+
+class TrieUpdateFixture : public in_memory_fixture
+{
+public:
+    TrieUpdateFixture()
+    {
+        process_updates({
+            make_upsert(
+                0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+                byte_string({0xde, 0xad, 0xbe, 0xef})),
+            //               *
+            make_upsert(
+                0x1234567822345678123456781234567812345678123456781234567812345678_bytes32,
+                byte_string({0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe})),
+            //               *
+            make_upsert(
+                0x1234567832345678123456781234567812345678123456781234567812345671_bytes32,
+                byte_string({0xde, 0xad, 0xca, 0xfe})),
+            //                                                                      *
+            make_upsert(
+                0x1234567832345678123456781234567812345678123456781234567812345678_bytes32,
+                byte_string({0xde, 0xad, 0xba, 0xbe})),
+        });
+    }
+};
+
+TEST_F(in_memory_fixture, EmptyTrie)
+{
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32);
+}
+
+TEST_F(in_memory_fixture, OneElement)
+{
+    std::vector updates = {make_upsert(
+        0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+        byte_string({0xde, 0xad, 0xbe, 0xef}))};
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x9e586b00a955a1e3d24961ff0311d9cba844136213759880c08f77ecb1b70b7e_bytes32);
+
+    // update it again
+    updates = {make_upsert(
+        0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+        byte_string({0xde, 0xad}))};
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3622cef16d065ca02d848a6548f6dc4c2181d1bb1b9ad21eec3da906780ca709_bytes32);
+}
+
+TEST_F(in_memory_fixture, Simple)
+{
+    std::vector updates = {
+        make_upsert(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe})),
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32,
+            byte_string({0xde, 0xad, 0xca, 0xfe})),
+        make_upsert(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xba, 0xbe})),
+    };
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3b71638660a388410706ca8b52d1008e979b47b1e938558004881b56a42c61c0_bytes32);
+}
+
+TEST_F(in_memory_fixture, UnrelatedLeaves)
+{
+    std::vector updates = {
+        make_upsert(
+            0x0234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x2234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x3234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+    };
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xa17471d2db79edac8d01de8737cbf7d03ea962bafe3d759f61040fc0ded5fad9_bytes32);
+}
+
+TEST_F(TrieUpdateFixture, None)
+{
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3b71638660a388410706ca8b52d1008e979b47b1e938558004881b56a42c61c0_bytes32);
+}
+
+TEST_F(TrieUpdateFixture, RemoveEverything)
+{
+    process_updates({
+        make_del(
+            0x1234567812345678123456781234567812345678123456781234567812345678_bytes32),
+        make_del(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32),
+    });
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32);
+}
+
+TEST_F(TrieUpdateFixture, DeleteSingleBranch)
+{
+    process_updates({
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32),
+    });
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x3d32d5e1b401520d20cde4cc7db33b8a23f18d0c783bb9dd1462fa6dc753a48a_bytes32);
+}
+
+TEST_F(TrieUpdateFixture, Simple)
+{
+    process_updates({
+        make_upsert(
+            0x0234567812345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x1234567802345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        make_upsert(
+            0x1234567822345678123456781234567812345678123456781234567812345678_bytes32,
+            byte_string({0xef, 0xca, 0xfe, 0xba, 0xbe})),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345671_bytes32),
+        make_del(
+            0x1234567832345678123456781234567812345678123456781234567812345678_bytes32),
+    });
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x44227d20c84dd2c72431ecaef175e78b9a5539f55ddfe3bc9bae5331172d605c_bytes32);
+}
+
+TEST_F(GenerateTransformationListFixture, OneUpdate)
+{
+    // ----------------------------------------------------------------
+
+    std::vector updates = {
+        make_upsert(Nibbles(byte_string({0x05, 0x05, 0x05, 0x05})), {})};
+
+    std::list<Node> expected = {
+        basic_node<Branch>(0, {0x04}),
+        basic_node<Leaf>(tl::nullopt, {0x05, 0x05, 0x05, 0x05})};
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {make_upsert(Nibbles(byte_string({0x03, 0x03, 0x03, 0x03})), {})};
+
+    expected = std::list<Node>({
+        basic_node<Leaf>(tl::nullopt, {0x03, 0x03, 0x03, 0x03}),
+        basic_node<Branch>(0, {0x04}),
+    });
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {make_upsert(Nibbles(byte_string({0x04, 0x06, 0x02, 0x01})), {})};
+
+    expected = std::list<Node>(
+        {basic_node<Branch>(0, {0x04}),
+         basic_node<Leaf>(tl::nullopt, {0x04, 0x06, 0x02, 0x01})});
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {make_upsert(Nibbles(byte_string({0x04, 0x05, 0x02, 0x02})), {})};
+
+    expected = std::list<Node>(
+        {basic_node<Branch>(2, {0x04, 0x02}),
+         basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01}),
+         basic_node<Leaf>(tl::nullopt, {0x04, 0x05, 0x02, 0x02})});
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {make_upsert(Nibbles(byte_string({0x04, 0x02, 0x03, 0x04})), {})};
+
+    expected = std::list<Node>({
+        basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
+        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x02}),
+        basic_node<Leaf>(tl::nullopt, {0x04, 0x02, 0x03, 0x04}),
+        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x06}),
+        basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01}),
+    });
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+}
+
+TEST_F(GenerateTransformationListFixture, MultipleUpdates)
+{
+    // ----------------------------------------------------------------
+
+    std::vector updates = {
+        make_upsert(Nibbles(byte_string({0x04, 0x02, 0x02, 0x01})), {}),
+        make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x06})))};
+
+    std::vector<Node> expected = {
+        basic_node<Leaf>(tl::nullopt, {0x04, 0x02, 0x02, 0x01}),
+        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x02}),
+        basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01})};
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {
+        make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x02}))),
+        make_upsert(Nibbles(byte_string({0x04, 0x02, 0x03, 0x03})), {}),
+    };
+
+    expected = std::vector<Node>(
+        {basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
+         basic_node<Leaf>(tl::nullopt, {0x04, 0x02, 0x03, 0x03}),
+         basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x06}),
+         basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01})});
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {
+        make_del(Nibbles(byte_string({0x04, 0x02, 0x02, 0x01}))),
+        make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x02}))),
+        make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x06}))),
+        make_del(Nibbles(byte_string({0x04, 0x05, 0x02, 0x01}))),
+    };
+
+    expected.clear();
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+
+    // ----------------------------------------------------------------
+
+    updates = {
+        make_upsert(Nibbles(byte_string({0x04, 0x02, 0x02, 0x00})), {}),
+        make_upsert(Nibbles(byte_string({0x04, 0x02, 0x03, 0x07})), {}),
+        make_del(Nibbles(byte_string({0x04, 0x05, 0x02, 0x01}))),
+    };
+
+    expected = std::vector<Node>({
+        basic_node<Leaf>(tl::nullopt, {0x04, 0x02, 0x02, 0x00}),
+        basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
+        basic_node<Branch>(3, {0x04, 0x02, 0x03}),
+        basic_node<Leaf>(tl::nullopt, {0x04, 0x02, 0x03, 0x07}),
+    });
+
+    EXPECT_TRUE(
+        validate_list(trie_.generate_transformation_list(updates), expected));
+}
+
+TEST_F(in_memory_fixture, HardOnlyUpserts)
+{
+    auto const hard_updates = make_hard_updates();
+    auto it = hard_updates.begin();
+
+    std::vector<std::vector<Update>> updates;
+
+    // Batch updates into groups
+    while (it != hard_updates.end()) {
+        auto end = std::distance(it, hard_updates.end()) < 19
+                       ? hard_updates.end()
+                       : std::next(it, 19);
+        updates.push_back({it, end});
+        it = end;
+    }
+
+    // Randomize the updates
+    auto rng = std::default_random_engine{10};
+    std::shuffle(updates.begin(), updates.end(), rng);
+
+    for (auto const &update : updates) {
+        process_updates(update);
+    }
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes32);
+}
+
+TEST_F(in_memory_fixture, HardWithRemoval)
+{
+    process_updates(make_hard_updates());
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes32);
+
+    std::vector updates = {
+        make_del(
+            0x011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce_bytes32),
+        make_del(
+            0x04f4a4a9c6d36d0a720cbbc0369a0f0c50f10553d5bf85cdce61efddab992c3c_bytes32),
+        make_del(
+            0x0f81fd306d0c0cddd0728a76e6bfb0dfa12891c89994d877f0445483563b380a_bytes32),
+        make_del(
+            0x184125b2e3d1ded2ad3f82a383d9b09bd5bac4ccea4d41092f49523399598aca_bytes32),
+        make_del(
+            0x1d8453ab2f7716504a4457ebe9831dbf996267e350ad0b2029f654d0dce1e055_bytes32),
+        make_del(
+            0x276d032750f286c508d060efcddd1b7a9becbfdb64efb5dfcbee057f86722fef_bytes32),
+        make_del(
+            0x2af357fc2ab2964b76482ec0fcac3b86f5aca1a8292676023c8b9ec392d821a0_bytes32),
+        make_del(
+            0x30e2bfdaad2f3c218a1a8cc54fa1c4e6182b6b7f3bca273390cf587b50b47311_bytes32),
+        make_del(
+            0x336c5ee8777d6ef07cafc1c552f7d0b579a7ae6e0af042e9d18981c5b78642d3_bytes32),
+        make_del(
+            0x39aebb35169c657d179f2c043aaa0f872996f17760662712f1dc6331fda57882_bytes32),
+        make_del(
+            0x3cac317908c699fe873a7f6ee4e8cd63fbe9918b2315c97be91585590168e301_bytes32),
+        make_del(
+            0x41414fecbcd48d24288f4cd69cdc4f11560667f16291c4c642082019a2c613a6_bytes32),
+        make_del(
+            0x44a25c9533b4c9e05472848068a6b5bcb693ce9e222f3f4ac82d2927a82a34ce_bytes32),
+        make_del(
+            0x46700b4d40ac5c35af2c22dda2787a91eb567b06c924a8fb8ae9a05b20c08c21_bytes32),
+        make_del(
+            0x5037e1a5e02e081b1b850b130eca7ac17335fdf4c61cc5ff6ae765196fb0d5b3_bytes32),
+        make_del(
+            0x5380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a_bytes32),
+        make_del(
+            0x5429fdc28e48579bde709c0ca18c55d58f14c9438d5cd1829556be99fd68b97b_bytes32),
+        make_del(
+            0x5706de766d5661c754fb7b4c89db363309a9f89fa2945c9d8c7a303b79943963_bytes32),
+        make_del(
+            0x575b3e1ddd7d4ec1d0695cd1f4b1c0daa01cd98c8309e0d37422fa675d95c614_bytes32),
+        make_del(
+            0x5a657105c493a1213c976c653e929218bb4a516bca307dce5861ec23fffa4e58_bytes32),
+        make_del(
+            0x69a7b944221b2d0f646f2ce0d6fa665e124d14c473efc07ff1eb0c83454b4ae9_bytes32),
+        make_del(
+            0x74723bc3efaf59d897623890ae3912b9be3c4c67ccee3ffcf10b36406c722c1b_bytes32),
+    };
+
+    process_updates(updates);
+
+    EXPECT_EQ(
+        trie_.root_hash(),
+        0x0835cc0ded52cfc5c950bf8f9f7daece213b5a679118f921578e8b164ab5f757_bytes32);
+}
+
+TEST_F(in_memory_fixture, StateCleanup)
+{
+    auto const verify = [&](auto const &e) {
+        trie_cursor_.lower_bound({});
+        for (auto const &expected : e) {
+            EXPECT_TRUE(trie_cursor_.valid());
+            EXPECT_EQ(trie_cursor_.key()->path(), expected);
+            trie_cursor_.next();
+        }
+
+        // should be at the end now
+        EXPECT_FALSE(trie_cursor_.valid());
+    };
+
+    process_updates({
+        make_upsert(Nibbles(byte_string({0x01, 0x02, 0x0, 0x0})), {}),
+        make_upsert(Nibbles(byte_string({0x01, 0x02, 0x3, 0x4})), {}),
+        make_upsert(Nibbles(byte_string({0x01, 0x02, 0x3, 0x5})), {}),
+    });
+
+    std::vector expected_storage = {
+        Nibbles(),
+        Nibbles(byte_string{0x01, 0x02, 0x00}),
+        Nibbles(byte_string{0x01, 0x02, 0x03}),
+        Nibbles(byte_string{0x01, 0x02, 0x03, 0x04}),
+        Nibbles(byte_string{0x01, 0x02, 0x03, 0x05}),
+    };
+
+    verify(expected_storage);
+
+    process_updates({
+        make_del(Nibbles(byte_string{0x01, 0x02, 0x03, 0x04})),
+    });
+
+    expected_storage = {
+        Nibbles(),
+        Nibbles(byte_string{0x01, 0x02, 0x00}),
+        Nibbles(byte_string{0x01, 0x02, 0x03})};
+
+    verify(expected_storage);
+}


### PR DESCRIPTION
Here's the last working version I had of the trie building algorithm. The design isn't perfect and is a little rough around the edges, but I've chosen to present the code as-is in the interest of expedition. Happy to hear any and all opinions. 

Known items that are left:
- ~~noexcept cleanliness~~
- ~~clang format~~
- Squash

Unit tests pass on clang 16.0.2 in both debug and release mode with ASAN and UBSAN.