### PR TITLE
:fire: Remove incarnation from account structure

### DIFF
--- a/include/monad/core/account.hpp
+++ b/include/monad/core/account.hpp
@@ -11,10 +11,9 @@ struct Account
     uint256_t balance{0};
     bytes32_t code_hash{NULL_HASH};
     uint64_t nonce{0};
-    uint64_t incarnation{0};
 };
 
-static_assert(sizeof(Account) == 80);
+static_assert(sizeof(Account) == 72);
 static_assert(alignof(Account) == 8);
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
Problem:
- Incarnations are a way to deal with DoS attacks by keeping a history of storage by account reincarnated account/contract.
- We don't need this just yet.

Solution:
- Remove incarnation for now.  We'll bring it back when/if we need it.