### PR TITLE
Refactor block_db tests to be able to run from anywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,14 @@ add_library(monad STATIC
 
 target_include_directories(monad
     PUBLIC ${PROJECT_SOURCE_DIR}/include
+    PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
     PRIVATE ${Boost_INCLUDE_DIRS}
 )
+
+set(TEST_DATA_DIR "${PROJECT_SOURCE_DIR}/test")
+
+configure_file(cmake/test_resource_data.h.in test/test_resource_data.h @ONLY)
+
 target_link_libraries(monad
     PRIVATE Boost::fiber
     PRIVATE Boost::log

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <monad/config.hpp>
+
+#include <filesystem>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace test_resource
+{
+
+    std::filesystem::__cxx11::path const test_data_dir = "@TEST_DATA_DIR@";
+
+    auto const correct_block_data_dir =
+        test_data_dir / "common" / "blocks" / "compressed_blocks";
+    auto const bad_decompress_block_data_dir =
+        test_data_dir / "common" / "blocks" / "bad_decompress_blocks";
+    auto const bad_decode_block_data_dir =
+        test_data_dir / "common" / "blocks" / "bad_decode_blocks";
+}
+
+MONAD_NAMESPACE_END

--- a/src/monad/db/test/block_db.cpp
+++ b/src/monad/db/test/block_db.cpp
@@ -2,43 +2,15 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
+#include <test_resource_data.h>
 
 using namespace monad;
 using namespace db;
 
-// DATA_DIR needs to be the full path (/space/ssd....)
-std::filesystem::__cxx11::path get_dir_path(int error_type = 0)
-{
-    auto env_path = std::getenv("DATA_DIR");
-    if (env_path) {
-        return std::filesystem::__cxx11::path(env_path);
-    }
-    else {
-        auto monad_path = std::filesystem::current_path()
-                              .parent_path()
-                              .parent_path()
-                              .parent_path()
-                              .parent_path()
-                              .parent_path();
-
-        auto dir_path =
-            monad_path / "test" / "common" / "blocks" / "compressed_blocks";
-        if (error_type == 1) {
-            dir_path = dir_path.parent_path() / "bad_decompress_blocks";
-        }
-        else if (error_type == 2) {
-            dir_path = dir_path.parent_path() / "bad_decode_blocks";
-        }
-
-        return dir_path;
-    }
-}
-
 TEST(BlockDb, ReadNonExistingBlock)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto const res = block_db.get(1u, block);
     EXPECT_EQ(res, BlockDb::Status::NO_BLOCK_FOUND);
 }
@@ -46,7 +18,7 @@ TEST(BlockDb, ReadNonExistingBlock)
 TEST(BlockDb, ReadNonDecompressableBlock)
 {
     Block block{};
-    BlockDb block_db(get_dir_path(1));
+    BlockDb block_db(test_resource::bad_decompress_block_data_dir);
     auto const res = block_db.get(46'402u, block);
     EXPECT_EQ(res, BlockDb::Status::DECOMPRESS_ERROR);
 }
@@ -54,7 +26,7 @@ TEST(BlockDb, ReadNonDecompressableBlock)
 TEST(BlockDb, ReadNonDecodeableBlock)
 {
     Block block{};
-    BlockDb block_db(get_dir_path(2));
+    BlockDb block_db(test_resource::bad_decode_block_data_dir);
     auto const res = block_db.get(46'402u, block);
     EXPECT_EQ(res, BlockDb::Status::DECODE_ERROR);
 }
@@ -62,7 +34,7 @@ TEST(BlockDb, ReadNonDecodeableBlock)
 TEST(BlockDb, ReadBlock46402)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto const res = block_db.get(46'402u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }
@@ -70,7 +42,7 @@ TEST(BlockDb, ReadBlock46402)
 TEST(BlockDb, ReadBlock2730000)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto res = block_db.get(2'730'000u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }
@@ -78,7 +50,7 @@ TEST(BlockDb, ReadBlock2730000)
 TEST(BlockDb, ReadBlock2730001)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto res = block_db.get(2'730'001u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }
@@ -86,7 +58,7 @@ TEST(BlockDb, ReadBlock2730001)
 TEST(BlockDb, ReadBlock2730002)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto res = block_db.get(2'730'002u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }
@@ -94,7 +66,7 @@ TEST(BlockDb, ReadBlock2730002)
 TEST(BlockDb, ReadBlock2730009)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto res = block_db.get(2'730'009u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }
@@ -102,7 +74,7 @@ TEST(BlockDb, ReadBlock2730009)
 TEST(BlockDb, ReadBlock14000000)
 {
     Block block{};
-    BlockDb block_db(get_dir_path());
+    BlockDb block_db(test_resource::correct_block_data_dir);
     auto res = block_db.get(14'000'000u, block);
     EXPECT_EQ(res, BlockDb::Status::SUCCESS);
 }


### PR DESCRIPTION
- CMake configure an absolute path for monad-dbtests (Previously was using environmental)
- Now monad-dbtests should be able to run from any dir

Issue #87 