### PR TITLE
Add fiber aware async DB querying

### DIFF
--- a/include/monad/execution/execution_model.hpp
+++ b/include/monad/execution/execution_model.hpp
@@ -4,12 +4,25 @@
 
 #include <boost/fiber/all.hpp>
 
+#include <thread>
+
 MONAD_EXECUTION_NAMESPACE_BEGIN
 
 struct BoostFiberExecution
 {
     using fiber_t = boost::fibers::fiber;
-    static inline void yield() { boost::this_fiber::yield(); }
+    static void yield() noexcept { boost::this_fiber::yield(); }
+
+    [[nodiscard]] constexpr static auto get_executor() noexcept
+    {
+        return [](auto &&f) {
+            using result_t = decltype(std::declval<decltype(f)>()());
+            boost::fibers::promise<result_t> promise;
+            auto future = promise.get_future();
+            std::jthread thread{[&promise, f] { promise.set_value(f()); }};
+            return future.get();
+        };
+    }
 };
 
 MONAD_EXECUTION_NAMESPACE_END

--- a/src/monad/db/test/trie_db.cpp
+++ b/src/monad/db/test/trie_db.cpp
@@ -80,6 +80,21 @@ TEST(InMemoryTrieDB, account_creation)
     EXPECT_EQ(db.at(a), acct);
 }
 
+TYPED_TEST(DBTest, query)
+{
+    TypeParam db;
+    Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
+    db.create(a, acct);
+    db.create(a, key1, value1);
+    db.create(a, key2, value2);
+    db.commit();
+
+    EXPECT_EQ(db.query(a), acct);
+    EXPECT_FALSE(db.query(b).has_value());
+    EXPECT_EQ(db.query(a, key1), value1);
+    EXPECT_EQ(db.query(a, key2), value2);
+}
+
 TEST(InMemoryTrieDB, erase)
 {
     InMemoryTrieDB db;


### PR DESCRIPTION
This adds the capability to query the DB in an async fashion. Currently, behavior can be specialized using an executor. The inline executor invokes f with no arguments on the current thread whilst the single thread executor assigns f to be invoked on a different thread that it maintains. The executor model can be easily extended to support thread pools, if we ever need that.

The current unit tests I have are quite basic, so I'm open to any suggestions on how we might unit test this better.