### PR TITLE
:sparkles: Add get_code member to state

### DIFF
--- a/include/monad/db/state.hpp
+++ b/include/monad/db/state.hpp
@@ -133,6 +133,11 @@ struct State
             return code_.copy_code(a, offset, buffer, size);
         }
 
+        [[nodiscard]] byte_string_view get_code(address_t const &a) const noexcept
+        {
+            return code_.code_at(a);
+        }
+
         void revert() noexcept
         {
             accounts_.revert();

--- a/src/monad/db/test/state.cpp
+++ b/src/monad/db/test/state.cpp
@@ -67,6 +67,27 @@ TYPED_TEST(StateTest, get_working_copy)
     EXPECT_EQ(cs.get_balance(a), bytes32_t{30'000});
 }
 
+TYPED_TEST(StateTest, get_code)
+{
+    TypeParam db;
+    AccountStore accounts{db};
+    ValueStore values{db};
+    code_db_t code_db{};
+    CodeStore code{code_db};
+    State as{accounts, values, code};
+    byte_string const contract{0x60, 0x34, 0x00};
+    db.create(a, {.balance = 10'000});
+    code_db.emplace(a, contract);
+    db.commit();
+
+    [[maybe_unused]] auto bs = as.get_working_copy(0);
+
+    bs.access_account(a);
+    auto const c = bs.get_code(a);
+
+    EXPECT_EQ(c, contract);
+}
+
 TYPED_TEST(StateTest, can_merge_fresh)
 {
     TypeParam db;


### PR DESCRIPTION
Super small PR - just something I noticed when building the interpreter.