### PR TITLE
:recycle: Replace contains-at access pattern with a db query

### DIFF
--- a/include/monad/db/account_store.hpp
+++ b/include/monad/db/account_store.hpp
@@ -31,31 +31,13 @@ struct AccountStore
     {
     }
 
-    [[nodiscard]] bool
-    committed_storage_contains(address_t const &a) const noexcept
-    {
-        if (merged_.contains(a)) {
-            if (merged_.at(a).updated.has_value()) {
-                return true;
-            }
-            return false;
-        }
-        if (db_.contains(a)) {
-            return true;
-        }
-        return false;
-    }
-
     [[nodiscard]] std::optional<Account>
     get_committed_storage(address_t const &a) const
     {
         if (merged_.contains(a)) {
             return merged_.at(a).updated;
         }
-        if (db_.contains(a)) {
-            return {db_.at(a)};
-        }
-        return std::nullopt;
+        return db_.query(a);
     }
 
     // EVMC Host Interface


### PR DESCRIPTION
Problem:
- There are many instances where we follow a contains incantation with a subsequent at. While the double call may be optimized away by compilers for STL backends, they will likely not optimize away for a real database backend. Moreover, the contains and at call is (currently) not fiber aware whereas query is.

Solution:
- Replace pattern with a call to query, which will asynchronously fetch the value and yield the current fiber

Related to https://github.com/monad-crypto/monad/issues/96