### PR TITLE
:wrench: Introduce add_pytest which adds python tests to ctest

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -7,19 +7,30 @@ function(add_unit_test)
     set(OPTIONAL_ARGS ENABLE_LOGGING)
     set(ONE_VALUE_ARGS TARGET)
     set(MULTI_VALUE_ARGS SOURCES LIBRARIES)
-    cmake_parse_arguments(ADD_UNIT_TEST "${OPTIONAL_ARGS}" "${ONE_VALUE_ARGS}" "${MULTI_VALUE_ARGS}" ${ARGN})
+    cmake_parse_arguments(
+        ADD_UNIT_TEST "${OPTIONAL_ARGS}" "${ONE_VALUE_ARGS}"
+        "${MULTI_VALUE_ARGS}" ${ARGN}
+    )
 
     add_executable(${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_SOURCES})
     monad_compile_options(${ADD_UNIT_TEST_TARGET})
 
-    if ("${ADD_UNIT_TEST_ENABLE_LOGGING}" STREQUAL "FALSE")
-        target_compile_definitions(${ADD_UNIT_TEST_TARGET} PUBLIC DISABLE_LOGGING)
+    if("${ADD_UNIT_TEST_ENABLE_LOGGING}" STREQUAL "FALSE")
+        target_compile_definitions(
+            ${ADD_UNIT_TEST_TARGET} PUBLIC DISABLE_LOGGING
+        )
     endif()
 
-    target_link_libraries(${ADD_UNIT_TEST_TARGET}
-        GTest::GTest
-        monad_unit_test_common
+    target_link_libraries(
+        ${ADD_UNIT_TEST_TARGET} GTest::GTest monad_unit_test_common
         ${ADD_UNIT_TEST_LIBRARIES}
     )
     gtest_discover_tests(${ADD_UNIT_TEST_TARGET})
+endfunction()
+
+function(add_pytest)
+    set(ONE_VALUE_ARGS NAME EXECUTABLE)
+    cmake_parse_arguments(ADD_PYTEST "" "${ONE_VALUE_ARGS}" "" ${ARGN})
+    add_custom_target(${ADD_PYTEST_NAME} COMMAND pytest ${ADD_PYTEST_EXECUTABLE})
+    add_test(NAME ${ADD_PYTEST_NAME} COMMAND pytest ${ADD_PYTEST_EXECUTABLE})
 endfunction()


### PR DESCRIPTION
Problem:
- Python tests (if added) will not run alongside ctest

Solution:
- Introduce add_pytest which creates a custom target for the python test and adds it to ctest