### PR TITLE
🐛 Fix bug in trie when an updated leaf's key changes 

### DIFF
--- a/include/monad/trie/trie.hpp
+++ b/include/monad/trie/trie.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <monad/core/assert.h>
+#include <monad/core/likely.h>
+#include <monad/core/variant.hpp>
 #include <monad/trie/key_buffer.hpp>
 #include <monad/trie/nibbles.hpp>
 #include <monad/trie/node.hpp>
 #include <monad/trie/process_transformation_list.hpp>
 #include <monad/trie/update.hpp>
-#include <monad/core/assert.h>
-#include <monad/core/likely.h>
-#include <monad/core/variant.hpp>
 
 #include <tl/optional.hpp>
 
@@ -184,6 +184,13 @@ struct Trie
                 }
 
                 // and make sure to delete the root too
+                trie_writer_.del(buf_);
+            }
+            else {
+                // indiscriminately delete the update key in case the
+                // corresponding leaf nodes path changes as a result of this
+                // batch of updates
+                serialize_nibbles(buf_, trie_keys.back());
                 trie_writer_.del(buf_);
             }
         }

--- a/src/monad/trie/test/single_trie.cpp
+++ b/src/monad/trie/test/single_trie.cpp
@@ -528,3 +528,27 @@ TYPED_TEST(BasicTrieTest, StateCleanup)
 
     verify(expected_storage);
 }
+
+TYPED_TEST(BasicTrieTest, KeyOfUpdatedNodeChanges)
+{
+    this->process_updates({
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000001_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+    });
+
+    this->process_updates({
+        test::make_del(
+            0x0000000000000000000000000000000000000000000000000000000000000000_bytes32),
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000001_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+    });
+
+    this->process_updates({test::make_upsert(
+        0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
+        byte_string({0xde, 0xad, 0xbe, 0xef}))});
+}


### PR DESCRIPTION
Problem:
- When a leaf is simulatneously updated and its key is changed (ie. via
  leaf deletions resulting in the parent perishing), the old leaf is not
  cleaned up. This causes future upserts of leaves with the same key
  prefix to assert at the move_to_parent function.

Solution:
- Clean up the old leaf and add a unit test to assure that the
  assertions pass.

On top of https://github.com/monad-crypto/monad/pull/133