### PR TITLE
:bug: Properly clean up deleted branch nodes after all siblings are deleted

### DIFF
--- a/src/monad/trie/test/single_trie.cpp
+++ b/src/monad/trie/test/single_trie.cpp
@@ -552,3 +552,31 @@ TYPED_TEST(BasicTrieTest, KeyOfUpdatedNodeChanges)
         0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
         byte_string({0xde, 0xad, 0xbe, 0xef}))});
 }
+
+TYPED_TEST(BasicTrieTest, BranchDeletedAfterSiblingGetsDeleted)
+{
+    this->process_updates({
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000110_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000111_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000120_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+    });
+
+    this->process_updates(
+        {test::make_upsert(
+             0x0000000000000000000000000000000000000000000000000000000000000111_bytes32,
+             byte_string({0xde, 0xad, 0xbe, 0xef})),
+         test::make_del(
+             0x0000000000000000000000000000000000000000000000000000000000000120_bytes32)});
+
+    this->process_updates({
+        test::make_upsert(
+            0x0000000000000000000000000000000000000000000000000000000000000130_bytes32,
+            byte_string({0xde, 0xad, 0xbe, 0xef})),
+    });
+}


### PR DESCRIPTION
Problem:
- A branch node does not get properly removed from state when all of its siblings are deleted. This eventually causes an assertion error later when a node incorrectly determines that the old node is its parent.

Solution:
- Delete all prefixes of an updated node