### PR TITLE
:rotating_light: suppress clangtidy warning on sizeof usage in log macros

### DIFF
--- a/include/monad/logging/fake_log_macros.hpp
+++ b/include/monad/logging/fake_log_macros.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#define MONAD_LOG_HELPER(...) (void)(sizeof(__VA_ARGS__))
+// clang-format off
+#define MONAD_LOG_HELPER(...) (void)(sizeof(__VA_ARGS__)) /* NOLINT: suppressing bugprone-sizeof-expression*/
+// clang-format on
 
 #define MONAD_LOG_TRACE_L3(logger, fmt, ...)                                   \
     do {                                                                       \


### PR DESCRIPTION
Problem:
- clangtidy warns on sizeof usage in our logging macros even though it is known that the enclosed expression compiles away in debug

Solution:
- Suppress the warning for that line, similar to the assert macro