### PR TITLE
:bug: Fix fuzztest build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,6 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/test/integration)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # only include if fuzzing mode is turned on
     if(FUZZTEST_FUZZING_MODE)
-        # TODO: figure out why vcpkg is interferring with target names. Prior to
-        # introducing vcpkg, there were no conflicts in target names. Post
-        # vcpkg, we need the below workaround so that cmake is not adding
-        # multiple GTest::gtest targets. Our workaround is to ask all
-        # dependencies of fuzztest not to pull in and build their own gtest
-        set(FUZZTEST_USE_GTEST OFF)
-        set(FUZZTEST_TESTING OFF)
-        set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
         set(ANTLR_BUILD_CPP_TESTS OFF)
 
         add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/fuzztest)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,6 +1,19 @@
 enable_testing()
 
-find_package(GTest REQUIRED)
+# TODO: figure out why vcpkg is interferring with target names. Prior to
+# introducing vcpkg, there were no conflicts in target names. Post vcpkg, we
+# need the below workaround so that cmake is not adding multiple GTest::gtest
+# targets. our workaround is to ask all dependencies to invoke find_package
+# first before trying to build from source
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG b796f7d44681514f58a683a3a71ff17c94edb0c1 # v1.13.0
+    FIND_PACKAGE_ARGS NAMES GTest
+)
+FetchContent_MakeAvailable(googletest)
+
 include(GoogleTest)
 
 function(add_unit_test)
@@ -26,7 +39,7 @@ function(add_unit_test)
     endif()
 
     target_link_libraries(
-        ${ADD_UNIT_TEST_TARGET} PUBLIC GTest::GTest monad_unit_test_common
+        ${ADD_UNIT_TEST_TARGET} PUBLIC GTest::gtest monad_unit_test_common
                                        ${ADD_UNIT_TEST_LIBRARIES}
     )
     gtest_discover_tests(${ADD_UNIT_TEST_TARGET})


### PR DESCRIPTION
Problem:
- fuzztest.h was not being included if gtests were not also included. However, this poses a problem for our build system (circa vcpkg) where multiple dependencies trying to build GTest from source will conflict targets.

Solution:
- Use FetchContent to prefer pulling from find_package (when possible). Then all child dependencies will pull from the same target instead of trying to build and add their own.