### PR TITLE
:truck: Move state management functions to `state::` namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/execution/ethereum)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/execution/ethereum/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/execution/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/rlp/test)
+add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/state/test)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/monad/trie/test)
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/test/integration)
@@ -179,6 +180,11 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/monad/rlp/util.hpp
     ${PROJECT_SOURCE_DIR}/src/monad/rlp/decode_helpers.cpp
     ${PROJECT_SOURCE_DIR}/src/monad/rlp/encode_helpers.cpp
+    # state
+    ${PROJECT_SOURCE_DIR}/include/monad/state/account_state.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/state/code_state.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/state/state.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/state/value_state.hpp
     # trie
     ${PROJECT_SOURCE_DIR}/include/monad/trie/compact_encode.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/trie/nibbles.hpp

--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -5,17 +5,17 @@
 #include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
 
-#include <monad/db/config.hpp>
-#include <monad/db/datum.hpp>
+#include <monad/state/config.hpp>
+#include <monad/state/datum.hpp>
 
 #include <algorithm>
 #include <cassert>
 #include <unordered_map>
 
-MONAD_DB_NAMESPACE_BEGIN
+MONAD_STATE_NAMESPACE_BEGIN
 
 template <class TAccountDB>
-struct AccountStore
+struct AccountState
 {
     using diff_t = diff<std::optional<Account>>;
     using change_set_t = std::unordered_map<address_t, diff_t>;
@@ -26,7 +26,7 @@ struct AccountStore
     TAccountDB &db_;
     change_set_t merged_{};
 
-    AccountStore(TAccountDB &a)
+    AccountState(TAccountDB &a)
         : db_{a}
     {
     }
@@ -124,7 +124,7 @@ struct AccountStore
 };
 
 template <typename TAccountDB>
-struct AccountStore<TAccountDB>::WorkingCopy : public AccountStore<TAccountDB>
+struct AccountState<TAccountDB>::WorkingCopy : public AccountState<TAccountDB>
 {
     change_set_t changed_{};
     uint64_t total_selfdestructs_{};
@@ -138,7 +138,7 @@ struct AccountStore<TAccountDB>::WorkingCopy : public AccountStore<TAccountDB>
             }
             return false;
         }
-        return AccountStore::account_exists(a);
+        return AccountState::account_exists(a);
     }
 
     void create_contract(address_t const &a)
@@ -220,4 +220,4 @@ struct AccountStore<TAccountDB>::WorkingCopy : public AccountStore<TAccountDB>
     void revert() noexcept { changed_.clear(); }
 };
 
-MONAD_DB_NAMESPACE_END
+MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/code_state.hpp
+++ b/include/monad/state/code_state.hpp
@@ -5,19 +5,19 @@
 #include <monad/core/assert.h>
 #include <monad/core/byte_string.hpp>
 
-#include <monad/db/config.hpp>
-#include <monad/db/datum.hpp>
+#include <monad/state/config.hpp>
+#include <monad/state/datum.hpp>
 
 #include <algorithm>
 #include <unordered_map>
 
-MONAD_DB_NAMESPACE_BEGIN
+MONAD_STATE_NAMESPACE_BEGIN
 
 template <typename TError>
 class error;
 
 template <class TCodeDB>
-struct CodeStore
+struct CodeState
 {
     using map_t = std::unordered_map<address_t, byte_string>;
 
@@ -27,7 +27,7 @@ struct CodeStore
     map_t merged_{};
     static inline byte_string const empty{};
 
-    CodeStore(TCodeDB &s)
+    CodeState(TCodeDB &s)
         : db_{s}
     {
     }
@@ -79,12 +79,12 @@ struct CodeStore
 };
 
 template <typename TCodeDB>
-struct CodeStore<TCodeDB>::WorkingCopy : public CodeStore<TCodeDB>
+struct CodeState<TCodeDB>::WorkingCopy : public CodeState<TCodeDB>
 {
     map_t code_{};
 
-    explicit WorkingCopy(CodeStore const &c)
-        : CodeStore(c)
+    explicit WorkingCopy(CodeState const &c)
+        : CodeState(c)
     {
     }
 
@@ -93,7 +93,7 @@ struct CodeStore<TCodeDB>::WorkingCopy : public CodeStore<TCodeDB>
     {
         if (code_.contains(a))
             return {code_.at(a)};
-        return CodeStore::code_at(a);
+        return CodeState::code_at(a);
     }
 
     void set_code(address_t const &a, byte_string const &code)
@@ -126,4 +126,4 @@ struct CodeStore<TCodeDB>::WorkingCopy : public CodeStore<TCodeDB>
     void revert() { code_.clear(); }
 };
 
-MONAD_DB_NAMESPACE_END
+MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/config.hpp
+++ b/include/monad/state/config.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <monad/config.hpp>
+
+#define MONAD_STATE_NAMESPACE_BEGIN                                            \
+    MONAD_NAMESPACE_BEGIN namespace state                                      \
+    {
+
+#define MONAD_STATE_NAMESPACE_END                                              \
+    }                                                                          \
+    MONAD_NAMESPACE_END

--- a/include/monad/state/datum.hpp
+++ b/include/monad/state/datum.hpp
@@ -2,11 +2,11 @@
 
 #include <monad/core/address.hpp>
 #include <monad/core/bytes.hpp>
-#include <monad/db/config.hpp>
+#include <monad/state/config.hpp>
 
 #include <optional>
 
-MONAD_DB_NAMESPACE_BEGIN
+MONAD_STATE_NAMESPACE_BEGIN
 
 namespace fnv1a
 {
@@ -114,4 +114,4 @@ inline bool operator==(deleted_key const &a, bytes32_t const &b) noexcept
     return a.key == b;
 }
 
-MONAD_DB_NAMESPACE_END
+MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -5,29 +5,29 @@
 #include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
 
-#include <monad/db/config.hpp>
+#include <monad/state/config.hpp>
 
 #include <vector>
 
-MONAD_DB_NAMESPACE_BEGIN
+MONAD_STATE_NAMESPACE_BEGIN
 
 template <
-    class TAccountStore, class TValueStore, class TCodeStore, class TBlockCache>
+    class TAccountState, class TValueState, class TCodeState, class TBlockCache>
 struct State
 {
     struct WorkingCopy
     {
-        typename TAccountStore::WorkingCopy accounts_;
-        typename TValueStore::WorkingCopy storage_;
-        typename TCodeStore::WorkingCopy code_;
+        typename TAccountState::WorkingCopy accounts_;
+        typename TValueState::WorkingCopy storage_;
+        typename TCodeState::WorkingCopy code_;
         std::vector<Receipt::Log> logs_{};
         TBlockCache &block_cache_{};
         unsigned int txn_id_{};
 
         WorkingCopy(
-            unsigned int i, typename TAccountStore::WorkingCopy &&a,
-            typename TValueStore::WorkingCopy &&s,
-            typename TCodeStore::WorkingCopy &&c, TBlockCache &b)
+            unsigned int i, typename TAccountState::WorkingCopy &&a,
+            typename TValueState::WorkingCopy &&s,
+            typename TCodeState::WorkingCopy &&c, TBlockCache &b)
             : accounts_{std::move(a)}
             , storage_{std::move(s)}
             , code_{std::move(c)}
@@ -169,13 +169,13 @@ struct State
         COLLISION_DETECTED,
     };
 
-    TAccountStore &accounts_;
-    TValueStore &storage_;
-    TCodeStore &code_;
+    TAccountState &accounts_;
+    TValueState &storage_;
+    TCodeState &code_;
     TBlockCache &block_cache_{};
     unsigned int current_txn_{};
 
-    State(TAccountStore &a, TValueStore &s, TCodeStore &c, TBlockCache &bc)
+    State(TAccountState &a, TValueState &s, TCodeState &c, TBlockCache &bc)
         : accounts_{a}
         , storage_{s}
         , code_{c}
@@ -189,9 +189,9 @@ struct State
     {
         return WorkingCopy(
             id,
-            typename TAccountStore::WorkingCopy{accounts_},
-            typename TValueStore::WorkingCopy{storage_},
-            typename TCodeStore::WorkingCopy{code_},
+            typename TAccountState::WorkingCopy{accounts_},
+            typename TValueState::WorkingCopy{storage_},
+            typename TCodeState::WorkingCopy{code_},
             block_cache_);
     }
 
@@ -234,4 +234,4 @@ struct State
     }
 };
 
-MONAD_DB_NAMESPACE_END
+MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -4,16 +4,16 @@
 #include <monad/core/assert.h>
 #include <monad/core/bytes.hpp>
 
-#include <monad/db/config.hpp>
-#include <monad/db/datum.hpp>
+#include <monad/state/config.hpp>
+#include <monad/state/datum.hpp>
 
 #include <unordered_map>
 #include <unordered_set>
 
-MONAD_DB_NAMESPACE_BEGIN
+MONAD_STATE_NAMESPACE_BEGIN
 
 template <class TValueDB>
-struct ValueStore
+struct ValueState
 {
     using diff_t = diff<bytes32_t>;
     using key_value_map_t = std::unordered_map<bytes32_t, diff_t>;
@@ -49,7 +49,7 @@ struct ValueStore
 
     struct WorkingCopy;
 
-    ValueStore(TValueDB &store)
+    ValueState(TValueDB &store)
         : db_{store}
     {
     }
@@ -189,7 +189,7 @@ struct ValueStore
 };
 
 template <typename TValueDB>
-struct ValueStore<TValueDB>::WorkingCopy : public ValueStore<TValueDB>
+struct ValueState<TValueDB>::WorkingCopy : public ValueState<TValueDB>
 {
     InnerStorage touched_{};
     std::unordered_map<address_t, std::unordered_set<bytes32_t>>
@@ -323,4 +323,4 @@ struct ValueStore<TValueDB>::WorkingCopy : public ValueStore<TValueDB>
     }
 };
 
-MONAD_DB_NAMESPACE_END
+MONAD_STATE_NAMESPACE_END

--- a/src/monad/db/test/CMakeLists.txt
+++ b/src/monad/db/test/CMakeLists.txt
@@ -3,12 +3,7 @@ add_unit_test(
     TARGET
     monad-dbtests
     SOURCES
-    account_store.cpp
     block_db.cpp
-    code_store.cpp
-    datum.cpp
-    state.cpp
-    value_store.cpp
     trie_db.cpp
     LIBRARIES
     monad

--- a/src/monad/state/test/CMakeLists.txt
+++ b/src/monad/state/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_unit_test(
+    # ENABLE_LOGGING
+    TARGET
+    monad-statetests
+    SOURCES
+    account_state.cpp
+    code_state.cpp
+    datum.cpp
+    state.cpp
+    value_state.cpp
+    LIBRARIES
+    monad
+)

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -1,14 +1,14 @@
 #include <monad/core/address.hpp>
 #include <monad/core/byte_string.hpp>
 
-#include <monad/db/code_store.hpp>
+#include <monad/state/code_state.hpp>
 
 #include <gtest/gtest.h>
 
 #include <unordered_map>
 
 using namespace monad;
-using namespace monad::db;
+using namespace monad::state;
 
 static constexpr auto a = 0x5353535353535353535353535353535353535353_address;
 static constexpr auto b = 0xbebebebebebebebebebebebebebebebebebebebe_address;
@@ -22,32 +22,32 @@ static constexpr auto c3 =
 
 using db_t = std::unordered_map<address_t, byte_string>;
 
-TEST(CodeStore, code_at)
+TEST(CodeState, code_at)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto const code = s.code_at(a);
     EXPECT_EQ(code, c1);
 }
 
-TEST(CodeStore, working_copy)
+TEST(CodeState, working_copy)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto t = decltype(s)::WorkingCopy{s};
     auto const code_1 = t.code_at(a);
     EXPECT_EQ(code_1, c1);
 }
 
-TEST(CodeStoreWorkingCopy, set_code)
+TEST(CodeStateWorkingCopy, set_code)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto t = decltype(s)::WorkingCopy{s};
     t.set_code(b, c2);
@@ -61,11 +61,11 @@ TEST(CodeStoreWorkingCopy, set_code)
     EXPECT_EQ(code_3, byte_string{});
 }
 
-TEST(CodeStoreWorkingCopy, get_code_size)
+TEST(CodeStateWorkingCopy, get_code_size)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto t = decltype(s)::WorkingCopy{s};
     auto const size = t.get_code_size(a);
@@ -73,12 +73,12 @@ TEST(CodeStoreWorkingCopy, get_code_size)
     EXPECT_EQ(size, c1.size());
 }
 
-TEST(CodeStoreWorkingCopy, copy_code)
+TEST(CodeStateWorkingCopy, copy_code)
 {
     db_t db{};
     db.insert({a, c1});
     db.insert({b, c2});
-    CodeStore s{db};
+    CodeState s{db};
     static constexpr unsigned size{8};
     uint8_t buffer[size];
 
@@ -109,22 +109,22 @@ TEST(CodeStoreWorkingCopy, copy_code)
     }
 }
 
-TEST(CodeStore, can_merge)
+TEST(CodeState, can_merge)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto t = decltype(s)::WorkingCopy{s};
     t.set_code(b, c2);
     EXPECT_TRUE(s.can_merge(t));
 }
 
-TEST(CodeStore, merge_changes)
+TEST(CodeState, merge_changes)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};
@@ -135,11 +135,11 @@ TEST(CodeStore, merge_changes)
     EXPECT_EQ(s.code_at(b), c2);
 }
 
-TEST(CodeStore, revert)
+TEST(CodeState, revert)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};
@@ -151,10 +151,10 @@ TEST(CodeStore, revert)
     EXPECT_EQ(0, s.code_at(b).size());
 }
 
-TEST(CodeStore, cant_merge_colliding_merge)
+TEST(CodeState, cant_merge_colliding_merge)
 {
     db_t db{};
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};
@@ -169,21 +169,21 @@ TEST(CodeStore, cant_merge_colliding_merge)
     }
 }
 
-TEST(CodeStore, cant_merge_colliding_store)
+TEST(CodeState, cant_merge_colliding_store)
 {
     db_t db{};
     db.insert({a, c1});
-    CodeStore s{db};
+    CodeState s{db};
 
     auto t = decltype(s)::WorkingCopy{s};
     t.set_code(a, c2);
     EXPECT_FALSE(s.can_merge(t));
 }
 
-TEST(CodeStore, merge_multiple_changes)
+TEST(CodeState, merge_multiple_changes)
 {
     db_t db{};
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};
@@ -201,11 +201,11 @@ TEST(CodeStore, merge_multiple_changes)
     EXPECT_EQ(s.code_at(b), c2);
 }
 
-TEST(CodeStore, can_commit)
+TEST(CodeState, can_commit)
 {
     db_t db{};
     db.insert({c, c3});
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};
@@ -217,10 +217,10 @@ TEST(CodeStore, can_commit)
     EXPECT_TRUE(s.can_commit());
 }
 
-TEST(CodeStore, can_commit_multiple)
+TEST(CodeState, can_commit_multiple)
 {
     db_t db{};
-    CodeStore s{db};
+    CodeState s{db};
 
     {
         auto t = decltype(s)::WorkingCopy{s};

--- a/src/monad/state/test/datum.cpp
+++ b/src/monad/state/test/datum.cpp
@@ -2,7 +2,7 @@
 #include <monad/core/address.hpp>
 #include <monad/core/bytes.hpp>
 
-#include <monad/db/datum.hpp>
+#include <monad/state/datum.hpp>
 
 #include <gtest/gtest.h>
 
@@ -10,7 +10,7 @@
 #include <unordered_set>
 
 using namespace monad;
-using namespace monad::db;
+using namespace monad::state;
 
 TEST(diff, bytes32_unordered_map)
 {

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -1,11 +1,7 @@
 #include <monad/core/concepts.hpp>
 
-#include <monad/db/account_store.hpp>
 #include <monad/db/block_db.hpp>
-#include <monad/db/code_store.hpp>
-#include <monad/db/state.hpp>
 #include <monad/db/trie_db.hpp>
-#include <monad/db/value_store.hpp>
 
 #include <monad/execution/config.hpp>
 #include <monad/execution/ethereum/fork_traits.hpp>
@@ -14,6 +10,11 @@
 #include <monad/execution/evmone_baseline_interpreter.hpp>
 
 #include <monad/execution/test/fakes.hpp>
+
+#include <monad/state/account_state.hpp>
+#include <monad/state/code_state.hpp>
+#include <monad/state/state.hpp>
+#include <monad/state/value_state.hpp>
 
 #include <evmc/evmc.hpp>
 
@@ -52,11 +53,11 @@ TEST(EvmInterpStateHost, return_existing_storage)
 {
     db::BlockDb blocks{test_resource::correct_block_data_dir};
     account_store_db_t db{};
-    db::AccountStore accounts{db};
-    db::ValueStore values{db};
+    state::AccountState accounts{db};
+    state::ValueState values{db};
     code_db_t code_db{};
-    db::CodeStore codes{code_db};
-    db::State s{accounts, values, codes, blocks};
+    state::CodeState codes{code_db};
+    state::State s{accounts, values, codes, blocks};
 
     // Setup db - gas costs referenced here
     // https://www.evm.codes/?fork=byzantium
@@ -114,11 +115,11 @@ TEST(EvmInterpStateHost, store_then_return_storage)
 {
     db::BlockDb blocks{test_resource::correct_block_data_dir};
     account_store_db_t db{};
-    db::AccountStore accounts{db};
-    db::ValueStore values{db};
+    state::AccountState accounts{db};
+    state::ValueState values{db};
     code_db_t code_db{};
-    db::CodeStore codes{code_db};
-    db::State s{accounts, values, codes, blocks};
+    state::CodeState codes{code_db};
+    state::State s{accounts, values, codes, blocks};
 
     // Setup db - gas costs referenced here
     // https://www.evm.codes/?fork=byzantium


### PR DESCRIPTION
Problem:
- There is some confusion about what is state management vs. actual db code.

Solution:
- Move all state management functions to separate namespace and rename accordingly