### PR TITLE
:recycle: Refactor EvmHost instantiation

### DIFF
--- a/include/monad/execution/evmc_host.hpp
+++ b/include/monad/execution/evmc_host.hpp
@@ -22,16 +22,13 @@ struct EvmcHost : public evmc::Host
     BlockHeader const &block_header_;
     Transaction const &transaction_;
     TState &state_;
-    TEvm &evm_;
 
     using uint256be = evmc::uint256be;
 
-    EvmcHost(
-        BlockHeader const &b, Transaction const &t, TState &s, TEvm &e) noexcept
+    EvmcHost(BlockHeader const &b, Transaction const &t, TState &s) noexcept
         : block_header_{b}
         , transaction_{t}
         , state_{s}
-        , evm_{e}
     {
     }
     virtual ~EvmcHost() noexcept = default;
@@ -122,10 +119,10 @@ struct EvmcHost : public evmc::Host
     call(evmc_message const &m) noexcept override
     {
         if (m.kind == EVMC_CREATE || m.kind == EVMC_CREATE2) {
-            return evm_.create_contract_account(this, state_, m);
+            return TEvm::create_contract_account(this, state_, m);
         }
 
-        return evm_.call_evm(this, state_, m);
+        return TEvm::call_evm(this, state_, m);
     }
 
     virtual evmc_tx_context get_tx_context() const noexcept override

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -144,10 +144,15 @@ namespace fake
         State get_working_copy(unsigned int) { return State(*this); }
     };
 
+    template <class TState, concepts::fork_traits<TState> TTraits, class TEvm>
     struct EvmHost
     {
         evmc_result _result{};
         Receipt _receipt{};
+
+        EvmHost() = default;
+
+        EvmHost(BlockHeader const &, Transaction const &, TState &) noexcept {}
 
         [[nodiscard]] static constexpr inline evmc_message
         make_msg_from_txn(Transaction const &)
@@ -173,37 +178,38 @@ namespace fake
         }
     };
 
+    template <
+        class TState, concepts::fork_traits<TState> TTraits,
+        class TStaticPrecompiles, class TInterpreter>
     struct Evm
     {
         using new_address_t = tl::expected<address_t, evmc_result>;
         using unexpected_t = tl::unexpected<evmc_result>;
 
-        new_address_t _result{};
-        evmc_result _e_result{};
-
-        [[nodiscard]] tl::expected<address_t, evmc_result>
+        [[nodiscard]] static tl::expected<address_t, evmc_result>
         make_account_address(evmc_message const &) noexcept
         {
-            return _result;
+            return new_address_t{};
         }
 
-        [[nodiscard]] evmc_result transfer_call_balances(evmc_message const &)
+        [[nodiscard]] static evmc_result
+        transfer_call_balances(evmc_message const &)
         {
-            return _e_result;
+            return evmc_result{};
         }
 
-        template <class TState, class TEvmHost>
-        [[nodiscard]] evmc::Result
+        template <class TEvmHost>
+        [[nodiscard]] static evmc::Result
         call_evm(TEvmHost *, TState &, evmc_message const &) noexcept
         {
-            return evmc::Result{_e_result};
+            return evmc::Result{};
         }
 
-        template <class TState, class TEvmHost>
-        [[nodiscard]] evmc::Result create_contract_account(
+        template <class TEvmHost>
+        [[nodiscard]] static evmc::Result create_contract_account(
             TEvmHost *, TState &, evmc_message const &) noexcept
         {
-            return evmc::Result{_e_result};
+            return evmc::Result{};
         }
     };
 

--- a/include/monad/execution/transaction_processor_data.hpp
+++ b/include/monad/execution/transaction_processor_data.hpp
@@ -23,7 +23,7 @@ enum class TxnReadyStatus
 
 template <
     class TState, concepts::fork_traits<TState> TTraits, class TTxnProcessor,
-    class TEvm, class TExecution>
+    class TEvmHost, class TExecution>
 struct alignas(64) TransactionProcessorFiberData
 {
     using txn_processor_status_t = typename TTxnProcessor::Status;
@@ -95,9 +95,8 @@ struct alignas(64) TransactionProcessorFiberData
             }
 
             auto working_copy = s_.get_working_copy(id_);
-            TEvm
-                e{}; // e needs to be constructed with the working copy of state
-            result_ = p.execute(working_copy, e, bh_, txn_);
+            TEvmHost host{bh_, txn_, working_copy};
+            result_ = p.execute(working_copy, host, bh_, txn_);
 
             if (s_.can_merge_changes(working_copy) ==
                 TState::MergeStatus::WILL_SUCCEED) {

--- a/src/monad/execution/test/evm.cpp
+++ b/src/monad/execution/test/evm.cpp
@@ -24,6 +24,11 @@ using traits_templated_evm_t =
         traits_templated_static_precompiles_t<TTraits>, fake::Interpreter>;
 
 using evm_t = traits_templated_evm_t<traits_t>;
+using evm_host_t = fake::EvmHost<
+    fake::State, traits_t,
+    fake::Evm<
+        fake::State, traits_t, fake::static_precompiles::OneHundredGas,
+        fake::Interpreter>>;
 
 TEST(Evm, make_account_address)
 {
@@ -273,7 +278,7 @@ TEST(Evm, create_contract_account)
     constexpr static auto new_addr2{
         0x312c420ec31bc2760e2556911ccf7e5c7162909f_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 50'000u});
     traits_t::_gas_creation_cost = 5'000;
     traits_t::_success_store_contract = true;
@@ -302,7 +307,7 @@ TEST(Evm, revert_create_account)
     constexpr static auto null{
         0x0000000000000000000000000000000000000000_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 10'000});
     traits_t::_gas_creation_cost = 10'000;
     traits_t::_success_store_contract = false;
@@ -325,7 +330,7 @@ TEST(Evm, call_evm)
     constexpr static auto to{
         0xf8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 50'000u});
     s._map.emplace(to, Account{.balance = 50'000u});
     fake::Interpreter::_result = evmc::Result{
@@ -354,7 +359,7 @@ TEST(Evm, static_precompile_execution)
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000001_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 15'000});
     s._map.emplace(code_address, Account{.nonce = 4});
 
@@ -395,7 +400,7 @@ TEST(Evm, out_of_gas_static_precompile_execution)
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000001_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 15'000});
     s._map.emplace(code_address, Account{.nonce = 6});
 
@@ -424,7 +429,7 @@ TEST(Evm, revert_call_evm)
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000003_address};
     fake::State s{};
-    fake::EvmHost h{};
+    evm_host_t h{};
     s._map.emplace(from, Account{.balance = 15'000});
     s._map.emplace(code_address, Account{.nonce = 10});
     fake::Interpreter::_result = evmc::Result{

--- a/src/monad/execution/test/evmc_host.cpp
+++ b/src/monad/execution/test/evmc_host.cpp
@@ -14,7 +14,11 @@ using namespace execution;
 using traits_t = fake::traits::alpha<fake::State>;
 
 template <concepts::fork_traits<fake::State> TTraits>
-using traits_templated_evmc_host_t = EvmcHost<fake::State, TTraits, fake::Evm>;
+using traits_templated_evmc_host_t = EvmcHost<
+    fake::State, TTraits,
+    fake::Evm<
+        fake::State, TTraits, fake::static_precompiles::OneHundredGas,
+        fake::Interpreter>>;
 
 using evmc_host_t = traits_templated_evmc_host_t<traits_t>;
 
@@ -65,13 +69,12 @@ TEST(EvmcHost, get_tx_context)
     };
     Transaction const t{.sc = {.chain_id = 1}, .from = from};
     fake::State s{};
-    fake::Evm e{};
 
     const static uint256_t gas_cost = per_gas_cost(t, 37'000'000'000);
     const static uint256_t chain_id{1};
     const static uint256_t base_fee_per_gas{37'000'000'000};
 
-    evmc_host_t host{b, t, s, e};
+    evmc_host_t host{b, t, s};
 
     const auto result = host.get_tx_context();
     evmc_tx_context ctx{
@@ -107,9 +110,8 @@ TEST(EvmcHost, emit_log)
     BlockHeader const b{};
     Transaction const t{};
     fake::State s{};
-    fake::Evm e{};
 
-    evmc_host_t host{b, t, s, e};
+    evmc_host_t host{b, t, s};
 
     host.emit_log(
         from,

--- a/src/monad/execution/test/evmone_baseline_interpreter.cpp
+++ b/src/monad/execution/test/evmone_baseline_interpreter.cpp
@@ -13,11 +13,21 @@ using namespace monad::execution;
 using interpreter_t =
     EVMOneBaselineInterpreter<fake::State, fake::traits::alpha<fake::State>>;
 
+using traits_t = fake::traits::alpha<fake::State>;
+
 TEST(Evm1BaselineInterpreter, execute_empty)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
     fake::State s{};
-    fake::EvmHost h{};
+    fake::EvmHost<
+        fake::State,
+        traits_t,
+        fake::Evm<
+            fake::State,
+            traits_t,
+            fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>
+        h{};
     s._code.emplace(a, byte_string{});
 
     evmc_message m{.kind = EVMC_CALL, .gas = 10'000, .code_address = a};
@@ -32,7 +42,15 @@ TEST(Evm1BaselineInterpreter, execute_simple)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
     fake::State s{};
-    fake::EvmHost h{};
+    fake::EvmHost<
+        fake::State,
+        traits_t,
+        fake::Evm<
+            fake::State,
+            traits_t,
+            fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>
+        h{};
     byte_string code = {
         0x60, // PUSH1, 3 gas
         0x64, // 'd'
@@ -55,7 +73,15 @@ TEST(Evm1BaselineInterpreter, execute_invalid)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
     fake::State s{};
-    fake::EvmHost h{};
+    fake::EvmHost<
+        fake::State,
+        traits_t,
+        fake::Evm<
+            fake::State,
+            traits_t,
+            fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>
+        h{};
     byte_string code = {
         0x60, // PUSH1, 3 gas
         0x68, // 'h'

--- a/src/monad/execution/test/transaction_processor_data_fail_apply_state.cpp
+++ b/src/monad/execution/test/transaction_processor_data_fail_apply_state.cpp
@@ -14,7 +14,13 @@ using traits_t = fake::traits::alpha<state_t>;
 
 template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
-    state_t, traits_t, TTxnProc, fake::Evm, TExecution>;
+    state_t, traits_t, TTxnProc,
+    fake::EvmHost<
+        fake::State, traits_t,
+        fake::Evm<
+            fake::State, traits_t, fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>,
+    TExecution>;
 
 state_t global_state{};
 

--- a/src/monad/execution/test/transaction_processor_data_fail_validation.cpp
+++ b/src/monad/execution/test/transaction_processor_data_fail_validation.cpp
@@ -14,7 +14,13 @@ using traits_t = fake::traits::alpha<state_t>;
 
 template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
-    state_t, traits_t, TTxnProc, fake::Evm, TExecution>;
+    state_t, traits_t, TTxnProc,
+    fake::EvmHost<
+        fake::State, traits_t,
+        fake::Evm<
+            fake::State, traits_t, fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>,
+    TExecution>;
 
 enum class TestStatus
 {

--- a/src/monad/execution/test/transaction_processor_data_succeed.cpp
+++ b/src/monad/execution/test/transaction_processor_data_succeed.cpp
@@ -14,7 +14,13 @@ using traits_t = fake::traits::alpha<state_t>;
 
 template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
-    state_t, traits_t, TTxnProc, fake::Evm, TExecution>;
+    state_t, traits_t, TTxnProc,
+    fake::EvmHost<
+        fake::State, traits_t,
+        fake::Evm<
+            fake::State, traits_t, fake::static_precompiles::OneHundredGas,
+            fake::Interpreter>>,
+    TExecution>;
 
 template <class TState, concepts::fork_traits<TState> TTraits>
 struct fakeSuccessfulTP

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -101,7 +101,7 @@ TEST(EvmInterpStateHost, return_existing_storage)
     working_state.access_account(from);
 
     evm_t<state_t, fork_t> e{};
-    evm_host_t<state_t, fork_t> h{b, t, working_state, e};
+    evm_host_t<state_t, fork_t> h{b, t, working_state};
 
     auto status = e.call_evm(&h, working_state, m);
 
@@ -167,7 +167,7 @@ TEST(EvmInterpStateHost, store_then_return_storage)
     working_state.access_account(from);
 
     evm_t<state_t, fork_t> e{};
-    evm_host_t<state_t, fork_t> h{b, t, working_state, e};
+    evm_host_t<state_t, fork_t> h{b, t, working_state};
 
     auto status = e.call_evm(&h, working_state, m);
 
@@ -175,7 +175,6 @@ TEST(EvmInterpStateHost, store_then_return_storage)
     EXPECT_EQ(status.output_size, 1u);
     EXPECT_EQ(*(status.output_data), 0x4d);
     EXPECT_EQ(status.gas_left, 1);
-
 }
 
 // TODO


### PR DESCRIPTION
Problem:
- In TPFiberData, we instantiate a TEvmHost, but it takes in a reference to static Evm, which shouldn't be the case
- The current Evm and EvmHost fakes are not templated, causing a lot of inconsistentcy with real obj; Furthermore, all methods for Evm fake is not static

Solution:
- In the constructor for EvmHost, we delete the reference to Evm
- Rewrite the fakes to make them templated; Mark all functions in fake Evm as static