### PR TITLE
♻️ consolidate all modifiers in DBInterface into commit() 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/monad/state/code_state.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/state/state.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/state/value_state.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/state/state_changes.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/state/concepts.hpp
     # trie
     ${PROJECT_SOURCE_DIR}/include/monad/trie/compact_encode.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/trie/nibbles.hpp

--- a/include/monad/db/db_interface.hpp
+++ b/include/monad/db/db_interface.hpp
@@ -5,6 +5,7 @@
 #include <monad/core/assert.h>
 #include <monad/core/bytes.hpp>
 #include <monad/db/config.hpp>
+#include <monad/state/concepts.hpp>
 
 MONAD_DB_NAMESPACE_BEGIN
 
@@ -78,75 +79,7 @@ struct DBInterface
     // modifiers
     ////////////////////////////////////////////////////////////////////
 
-    void create(address_t const &a, Account const &acct)
-    {
-        MONAD_DEBUG_ASSERT(!contains(a));
-        auto const [_, inserted] = updates.accounts.try_emplace(a, acct);
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void create(address_t const &a, bytes32_t const &k, bytes32_t const &v)
-    {
-        MONAD_DEBUG_ASSERT(v != bytes32_t{});
-        MONAD_DEBUG_ASSERT(!contains(a, k));
-        auto const [_, inserted] = updates.storage[a].try_emplace(k, v);
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void update(address_t const &a, Account const &acct)
-    {
-        MONAD_DEBUG_ASSERT(contains(a));
-        auto const [_, inserted] = updates.accounts.try_emplace(a, acct);
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void update(address_t const &a, bytes32_t const &k, bytes32_t const &v)
-    {
-        MONAD_DEBUG_ASSERT(v != bytes32_t{});
-        MONAD_DEBUG_ASSERT(contains(a));
-        MONAD_DEBUG_ASSERT(contains(a, k));
-        auto const [_, inserted] = updates.storage[a].try_emplace(k, v);
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void erase(address_t const &a)
-    {
-        MONAD_DEBUG_ASSERT(contains(a));
-        auto const [_, inserted] =
-            updates.accounts.try_emplace(a, std::nullopt);
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void erase(address_t const &a, bytes32_t const &k)
-    {
-        MONAD_DEBUG_ASSERT(contains(a));
-        MONAD_DEBUG_ASSERT(contains(a, k));
-        auto const [_, inserted] =
-            updates.storage[a].try_emplace(k, bytes32_t{});
-        MONAD_DEBUG_ASSERT(inserted);
-    }
-
-    void commit_storage_impl() { self().commit_storage_impl(); }
-
-    void commit_accounts_impl() { self().commit_accounts_impl(); }
-
-    void commit_storage()
-    {
-        commit_storage_impl();
-        updates.storage.clear();
-    }
-
-    void commit_accounts()
-    {
-        commit_accounts_impl();
-        updates.accounts.clear();
-    }
-
-    void commit()
-    {
-        commit_storage();
-        commit_accounts();
-    }
+    void commit(state::changeset auto const &obj) { self().commit(obj); }
 };
 
 MONAD_DB_NAMESPACE_END

--- a/include/monad/db/in_memory_db.hpp
+++ b/include/monad/db/in_memory_db.hpp
@@ -48,9 +48,9 @@ struct InMemoryDB
         return storage.at(a).at(k);
     }
 
-    void commit_storage_impl()
+    void commit(state::changeset auto const &obj)
     {
-        for (auto const &[a, updates] : updates.storage) {
+        for (auto const &[a, updates] : obj.storage_changes) {
             for (auto const &[k, v] : updates) {
                 if (v != bytes32_t{}) {
                     storage[a][k] = v;
@@ -64,11 +64,8 @@ struct InMemoryDB
                 storage.erase(a);
             }
         }
-    }
 
-    void commit_accounts_impl()
-    {
-        for (auto const &[a, acct] : updates.accounts) {
+        for (auto const &[a, acct] : obj.account_changes) {
             if (acct.has_value()) {
                 accounts[a] = acct.value();
             }

--- a/include/monad/db/rocks_db.hpp
+++ b/include/monad/db/rocks_db.hpp
@@ -175,9 +175,9 @@ struct RocksDB
         return result;
     }
 
-    void commit_storage_impl()
+    void commit(state::changeset auto const &obj)
     {
-        for (auto const &[a, updates] : updates.storage) {
+        for (auto const &[a, updates] : obj.storage_changes) {
             for (auto const &[k, v] : updates) {
                 auto const key = detail::make_basic_storage_key(a, k);
                 if (v != bytes32_t{}) {
@@ -191,12 +191,8 @@ struct RocksDB
                 }
             }
         }
-        commit_db();
-    }
 
-    void commit_accounts_impl()
-    {
-        for (auto const &[a, acct] : updates.accounts) {
+        for (auto const &[a, acct] : obj.account_changes) {
             if (acct.has_value()) {
                 // Note: no storage root calculations in this mode
                 auto const res = batch.Put(
@@ -210,6 +206,7 @@ struct RocksDB
                 MONAD_ROCKS_ASSERT(res);
             }
         }
+
         commit_db();
     }
 };

--- a/include/monad/execution/ethereum/genesis.hpp
+++ b/include/monad/execution/ethereum/genesis.hpp
@@ -8,6 +8,7 @@
 #include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
+#include <monad/state/state_changes.hpp>
 
 #include <evmc/hex.hpp>
 
@@ -69,6 +70,7 @@ read_genesis_blockheader(nlohmann::json const &genesis_json)
 template <typename TStateDB>
 inline void read_genesis_state(nlohmann::json const &genesis_json, TStateDB &db)
 {
+    state::StateChanges sc;
     for (auto const &account_info : genesis_json["alloc"].items()) {
         address_t address{};
         auto const address_byte_string =
@@ -84,10 +86,10 @@ inline void read_genesis_state(nlohmann::json const &genesis_json, TStateDB &db)
             account_info.value()["wei_balance"].get<std::string>();
         account.balance = intx::from_string<uint256_t>(balance_byte_string);
         account.nonce = 0u;
-
-        db.create(address, account);
+        
+        sc.account_changes.emplace_back(address, account);
     }
-    db.commit();
+    db.commit(sc);
 }
 
 template <typename TStateDB>

--- a/include/monad/state/concepts.hpp
+++ b/include/monad/state/concepts.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <monad/core/account.hpp>
+#include <monad/core/address.hpp>
+#include <monad/state/config.hpp>
+
+#include <concepts>
+#include <optional>
+#include <span>
+
+MONAD_STATE_NAMESPACE_BEGIN
+
+// clang-format off
+
+template <typename T>
+concept account_changes = requires(T obj) {
+    { obj.account_changes } -> std::ranges::range;
+    { *obj.account_changes.begin() } -> std::convertible_to<std::pair<address_t, std::optional<Account>>>;
+    { obj.account_changes.empty() } -> std::same_as<bool>;
+};
+
+template <typename T>
+concept storage_changes = requires(T obj) {
+    { obj.storage_changes } -> std::ranges::range;
+    { obj.storage_changes.begin()->first } -> std::convertible_to<address_t>;
+    { obj.storage_changes.begin()->second } -> std::ranges::range;
+    { *obj.storage_changes.begin()->second.begin() } -> std::convertible_to<std::pair<bytes32_t, bytes32_t>>;
+    { obj.storage_changes.empty() } -> std::same_as<bool>;
+};
+
+template <typename T>
+concept changeset = account_changes<T> && storage_changes<T>;
+
+// clang-format on
+
+MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/state_changes.hpp
+++ b/include/monad/state/state_changes.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <monad/core/account.hpp>
+#include <monad/core/address.hpp>
+#include <monad/core/bytes.hpp>
+#include <monad/state/config.hpp>
+
+#include <optional>
+#include <vector>
+
+MONAD_STATE_NAMESPACE_BEGIN
+
+struct StateChanges
+{
+    std::vector<std::pair<address_t, std::optional<Account>>> account_changes;
+    std::unordered_map<address_t, std::vector<std::pair<bytes32_t, bytes32_t>>>
+        storage_changes;
+};
+
+MONAD_STATE_NAMESPACE_END

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -7,6 +7,7 @@
 #include <monad/db/rocks_trie_db.hpp>
 
 #include <monad/state/account_state.hpp>
+#include <monad/state/state_changes.hpp>
 
 #include <gtest/gtest.h>
 
@@ -41,9 +42,9 @@ TYPED_TEST(AccountStateTest, account_exists)
 {
     TypeParam db{};
     AccountState s{db};
-    db.create(a, {});
-    db.create(d, {});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{}}, {d, Account{}}},
+        .storage_changes = {}});
 
     s.merged_.emplace(b, Account{});
     s.merged_.emplace(d, diff_t{Account{}, std::nullopt});
@@ -58,8 +59,9 @@ TYPED_TEST(AccountStateTest, account_exists)
 TYPED_TEST(AccountStateTest, get_balance)
 {
     TypeParam db{};
-    db.create(a, {.balance = 20'000});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 20'000}}},
+        .storage_changes = {}});
     AccountState s{db};
     s.merged_.emplace(
         b, diff_t{std::nullopt, Account{.balance = 10'000}});
@@ -71,8 +73,9 @@ TYPED_TEST(AccountStateTest, get_balance)
 TYPED_TEST(AccountStateTest, get_code_hash)
 {
     TypeParam db{};
-    db.create(a, {.code_hash = hash1});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.code_hash = hash1}}},
+        .storage_changes = {}});
     AccountState s{db};
     s.merged_.emplace(
         b, diff_t{std::nullopt, Account{.code_hash = hash2}});
@@ -84,8 +87,9 @@ TYPED_TEST(AccountStateTest, get_code_hash)
 TYPED_TEST(AccountStateTest, working_copy)
 {
     TypeParam db{};
-    db.create(a, {.balance = 10'000});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 10'000}}},
+        .storage_changes = {}});
     AccountState as{db};
 
     auto bs = typename decltype(as)::WorkingCopy{as};
@@ -107,9 +111,9 @@ TYPED_TEST(AccountStateTest, account_exists_working_copy)
 {
     TypeParam db{};
     AccountState s{db};
-    db.create(a, {});
-    db.create(d, {});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{}}, {d, Account{}}},
+        .storage_changes = {}});
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
@@ -132,9 +136,9 @@ TYPED_TEST(AccountStateTest, access_account_working_copy)
 {
     TypeParam db{};
     AccountState s{db};
-    db.create(a, {});
-    db.create(b, {});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{}}, {b, Account{}}},
+        .storage_changes = {}});
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
@@ -147,8 +151,9 @@ TYPED_TEST(AccountStateTest, access_account_working_copy)
 TYPED_TEST(AccountStateTest, get_balance_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.balance = 20'000});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 20'000}}},
+        .storage_changes = {}});
 
     AccountState s{db};
     s.merged_.emplace(
@@ -166,8 +171,8 @@ TYPED_TEST(AccountStateTest, get_balance_working_copy)
 TYPED_TEST(AccountStateTest, get_nonce_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.nonce = 2});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.nonce = 2}}}, .storage_changes = {}});
 
     AccountState s{db};
     s.merged_.emplace(b, diff_t{std::nullopt, Account{.nonce = 1}});
@@ -184,8 +189,9 @@ TYPED_TEST(AccountStateTest, get_nonce_working_copy)
 TYPED_TEST(AccountStateTest, get_code_hash_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.code_hash = hash1});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.code_hash = hash1}}},
+        .storage_changes = {}});
 
     AccountState s{db};
     s.merged_.emplace(
@@ -218,9 +224,10 @@ TYPED_TEST(AccountStateTest, create_account_working_copy)
 TYPED_TEST(AccountStateTest, selfdestruct_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.balance = 18'000});
-    db.create(c, {.balance = 38'000});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{a, Account{.balance = 18'000}}, {c, Account{.balance = 38'000}}},
+        .storage_changes = {}});
 
     AccountState s{db};
     s.merged_.emplace(
@@ -252,9 +259,9 @@ TYPED_TEST(AccountStateTest, selfdestruct_working_copy)
 TYPED_TEST(AccountStateTest, destruct_touched_dead_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.balance = 10'000});
-    db.create(b, {});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 10'000}}, {b, Account{}}},
+        .storage_changes = {}});
 
     AccountState s{db};
 
@@ -280,8 +287,9 @@ TYPED_TEST(AccountStateTest, destruct_touched_dead_working_copy)
 TYPED_TEST(AccountStateTest, revert_touched_working_copy)
 {
     TypeParam db{};
-    db.create(a, {.balance = 10'000, .nonce = 2});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 10'000, .nonce = 2}}},
+        .storage_changes = {}});
 
     AccountState s{db};
 
@@ -301,9 +309,11 @@ TYPED_TEST(AccountStateTest, revert_touched_working_copy)
 TYPED_TEST(AccountStateTest, can_merge_fresh)
 {
     TypeParam db{};
-    db.create(b, {.balance = 40'000u});
-    db.create(c, {.balance = 50'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {}});
 
     AccountState t{db};
 
@@ -325,9 +335,11 @@ TYPED_TEST(AccountStateTest, can_merge_fresh)
 TYPED_TEST(AccountStateTest, can_merge_onto_merged)
 {
     TypeParam db{};
-    db.create(b, {.balance = 40'000u});
-    db.create(c, {.balance = 50'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {}});
 
     AccountState t{db};
     t.merged_.emplace(a, diff_t{Account{.balance = 30'000}});
@@ -354,8 +366,9 @@ TYPED_TEST(AccountStateTest, can_merge_onto_merged)
 TYPED_TEST(AccountStateTest, cant_merge_colliding_merge)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes = {}});
 
     AccountState t{db};
     diff_t r{db.at(a), db.at(a)};
@@ -374,8 +387,9 @@ TYPED_TEST(AccountStateTest, cant_merge_colliding_merge)
 TYPED_TEST(AccountStateTest, cant_merge_deleted_merge)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes{}});
 
     AccountState t{db};
     diff_t r{db.at(a), db.at(a)};
@@ -412,8 +426,9 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_adds)
 TYPED_TEST(AccountStateTest, cant_merge_conflicting_modifies)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes{}});
 
     AccountState t{db};
     diff_t r{db.at(a), db.at(a)};
@@ -432,9 +447,11 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_modifies)
 TYPED_TEST(AccountStateTest, cant_merge_conflicting_deleted)
 {
     TypeParam db{};
-    db.create(b, {.balance = 10'000u, .nonce = 1});
-    db.create(c, {.balance = 40'000u, .nonce = 2});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 10'000u, .nonce = 1}},
+             {c, Account{.balance = 40'000u, .nonce = 2}}},
+        .storage_changes = {}});
 
     AccountState t{db};
     diff_t r{db.at(c), db.at(c)};
@@ -454,9 +471,11 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_deleted)
 TYPED_TEST(AccountStateTest, merge_multiple_changes)
 {
     TypeParam db{};
-    db.create(b, {.balance = 40'000u});
-    db.create(c, {.balance = 50'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {}});
 
     AccountState t{db};
 
@@ -500,9 +519,11 @@ TYPED_TEST(AccountStateTest, merge_multiple_changes)
 TYPED_TEST(AccountStateTest, can_commit)
 {
     TypeParam db{};
-    db.create(b, {.balance = 40'000u});
-    db.create(c, {.balance = 50'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {}});
     AccountState t{db};
     diff_t r{db.at(c), db.at(c)};
     r.updated.reset();
@@ -517,8 +538,9 @@ TYPED_TEST(AccountStateTest, can_commit)
 TYPED_TEST(AccountStateTest, cant_commit_merged_new_different_than_stored)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes = {}});
     AccountState t{db};
     t.merged_.emplace(a, diff_t{Account{.balance = 30'000}});
 
@@ -528,8 +550,9 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_new_different_than_stored)
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_balance)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes = {}});
     AccountState t{db};
     t.merged_.emplace(
         a, diff_t{Account{.balance = 30'000}, Account{.balance = 30'000}});
@@ -540,8 +563,9 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_balance)
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_nonce)
 {
     TypeParam db{};
-    db.create(a, {.balance = 40'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 40'000u}}},
+        .storage_changes = {}});
     AccountState t{db};
     t.merged_.emplace(
         a,
@@ -555,8 +579,9 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_nonce)
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_code_hash)
 {
     TypeParam db{};
-    db.create(a, {.code_hash = hash1});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.code_hash = hash1}}},
+        .storage_changes = {}});
     AccountState t{db};
     t.merged_.emplace(a, diff_t{Account{.code_hash = hash2}, Account{}});
 
@@ -566,8 +591,8 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_code_hash)
 TYPED_TEST(AccountStateTest, cant_commit_deleted_isnt_stored)
 {
     TypeParam db{};
-    db.create(a, {});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{}}}, .storage_changes = {}});
     AccountState t{db};
     diff_t r{Account{.balance = 10'000}, std::nullopt};
     r.updated.reset();
@@ -579,10 +604,12 @@ TYPED_TEST(AccountStateTest, cant_commit_deleted_isnt_stored)
 TYPED_TEST(AccountStateTest, can_commit_multiple)
 {
     TypeParam db{};
-    db.create(b, {.balance = 40'000u});
-    db.create(c, {.balance = 50'000u});
-    db.create(d, {.balance = 60'000u});
-    db.commit();
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}},
+             {d, Account{.balance = 60'000u}}},
+        .storage_changes = {}});
     AccountState t{db};
 
     {

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -14,6 +14,7 @@
 #include <monad/state/account_state.hpp>
 #include <monad/state/code_state.hpp>
 #include <monad/state/state.hpp>
+#include <monad/state/state_changes.hpp>
 #include <monad/state/value_state.hpp>
 
 #include <evmc/evmc.hpp>
@@ -75,11 +76,11 @@ TEST(EvmInterpStateHost, return_existing_storage)
         0xf3}; // RETURN
     code_db.emplace(a, code);
     Account A{};
-    db.create(a, A);
-    db.create(to, Account{});
-    db.create(from, Account{.balance = 10'000'000});
-    db.create(to, location, value1);
-    db.commit();
+
+    db.commit(state::StateChanges{
+        .account_changes =
+            {{a, A}, {to, Account{}}, {from, Account{.balance = 10'000'000}}},
+        .storage_changes = {{to, {{location, value1}}}}});
 
     BlockHeader const b{}; // Required for the host interface, but not used
     Transaction const t{};
@@ -142,10 +143,11 @@ TEST(EvmInterpStateHost, store_then_return_storage)
         0xf3}; // RETURN
     code_db.emplace(a, code);
     Account A{};
-    db.create(a, A);
-    db.create(to, Account{});
-    db.create(from, Account{.balance = 10'000'000});
-    db.commit();
+
+    db.commit(state::StateChanges{
+        .account_changes =
+            {{a, A}, {to, Account{}}, {from, Account{.balance = 10'000'000}}},
+        .storage_changes = {}});
 
     BlockHeader const b{}; // Required for the host interface, but not used
     Transaction const t{};


### PR DESCRIPTION
Problem:
- The DBInterface API is bloated with modifiers that complicates the
  interface

Solution:
- Consolidate all modifiers into a single commit function

On top of https://github.com/monad-crypto/monad/pull/165