### PR TITLE
👷  Don't build state_db until absl<->vcpkg is fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,10 +150,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/include/monad/db/block_db.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/config.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/file_db.hpp
-    ${PROJECT_SOURCE_DIR}/include/monad/db/state_db.hpp
     ${PROJECT_SOURCE_DIR}/src/monad/db/block_db.cpp
     ${PROJECT_SOURCE_DIR}/src/monad/db/file_db.cpp
-    ${PROJECT_SOURCE_DIR}/src/monad/db/state_db.cpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/db_interface.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/trie_db_interface.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/rocks_db.hpp


### PR DESCRIPTION
Problem:
- StateDb uses abseil library, and building with sanitizers fails to link correctly.
- vcpkg can't install absl correctly with this repo's configuration, and requires the same FetchContent hack to work around.
- The FetchContent hack for absl is untenable.

Solution:
- For now, don't build state_db.{hpp,cpp} into the monad library