### PR TITLE
:recycle: Rename create_contract to create_account

### DIFF
--- a/include/monad/execution/evm.hpp
+++ b/include/monad/execution/evm.hpp
@@ -126,7 +126,7 @@ struct Evm
                     unexpected_t({.status_code = EVMC_INVALID_INSTRUCTION}));
             }
 
-            s.create_contract(new_address);
+            s.create_account(new_address);
 
             return result_t({m});
         };

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -45,7 +45,7 @@ namespace fake
 
             unsigned int txn_id() const noexcept { return _txn_id; }
 
-            void create_contract(address_t const &) noexcept {}
+            void create_account(address_t const &) noexcept {}
 
             // EVMC Host Interface
             [[nodiscard]] bool account_exists(address_t const &a)

--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -141,7 +141,7 @@ struct AccountState<TAccountDB>::WorkingCopy : public AccountState<TAccountDB>
         return AccountState::account_exists(a);
     }
 
-    void create_contract(address_t const &a)
+    void create_account(address_t const &a)
     {
         auto const [_, inserted] =
             changed_.emplace(a, diff_t{get_committed_storage(a), Account{}});

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -37,9 +37,9 @@ struct State
         }
 
         unsigned int txn_id() const noexcept { return txn_id_; }
-        void create_contract(address_t const &a) noexcept
+        void create_account(address_t const &a) noexcept
         {
-            accounts_.create_contract(a);
+            accounts_.create_account(a);
         }
 
         // EVMC Host Interface

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -207,7 +207,7 @@ TYPED_TEST(AccountStateTest, create_account_working_copy)
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
-    bs.create_contract(a);
+    bs.create_account(a);
     bs.set_balance(a, 38'000);
     bs.set_nonce(a, 2);
 
@@ -260,7 +260,7 @@ TYPED_TEST(AccountStateTest, destruct_touched_dead_working_copy)
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
-    bs.create_contract(a);
+    bs.create_account(a);
     bs.set_balance(a, 38'000);
     bs.destruct_touched_dead();
     bs.destruct_suicides();
@@ -289,7 +289,7 @@ TYPED_TEST(AccountStateTest, revert_touched_working_copy)
 
     bs.access_account(a);
     bs.set_balance(a, 15'000);
-    bs.create_contract(b);
+    bs.create_account(b);
     bs.revert();
     EXPECT_FALSE(s.account_exists(b));
 
@@ -311,7 +311,7 @@ TYPED_TEST(AccountStateTest, can_merge_fresh)
 
     s.access_account(b);
     s.access_account(c);
-    s.create_contract(a);
+    s.create_account(a);
     s.set_nonce(a, 1);
     s.set_balance(a, 38'000);
     s.set_balance(b, 42'000);
@@ -340,7 +340,7 @@ TYPED_TEST(AccountStateTest, can_merge_onto_merged)
 
     s.access_account(a);
     s.access_account(b);
-    s.create_contract(c);
+    s.create_account(c);
     s.set_nonce(c, 1);
     s.set_balance(c, 38'000);
     s.set_balance(b, 42'000);
@@ -400,7 +400,7 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_adds)
 
     auto s = typename decltype(t)::WorkingCopy{t};
 
-    s.create_contract(a);
+    s.create_account(a);
     s.set_nonce(a, 1);
     s.set_balance(a, 80'000);
 
@@ -465,7 +465,7 @@ TYPED_TEST(AccountStateTest, merge_multiple_changes)
 
         s.access_account(b);
         s.access_account(c);
-        s.create_contract(a);
+        s.create_account(a);
         s.set_nonce(a, 1);
         s.set_balance(a, 38'000);
         s.set_balance(b, 42'000);
@@ -483,7 +483,7 @@ TYPED_TEST(AccountStateTest, merge_multiple_changes)
         auto s = typename decltype(t)::WorkingCopy{t};
 
         s.access_account(b);
-        s.create_contract(c);
+        s.create_account(c);
         s.set_balance(c, 22'000);
         s.set_nonce(c, 1);
         s.set_balance(b, 48'000);
@@ -590,7 +590,7 @@ TYPED_TEST(AccountStateTest, can_commit_multiple)
 
         s.access_account(b);
         s.access_account(c);
-        s.create_contract(a);
+        s.create_account(a);
         s.set_nonce(a, 1);
         s.set_balance(a, 38'000);
         s.set_balance(b, 42'000);
@@ -607,7 +607,7 @@ TYPED_TEST(AccountStateTest, can_commit_multiple)
         s.access_account(a);
         s.access_account(b);
         s.access_account(d);
-        s.create_contract(c);
+        s.create_account(c);
         s.set_balance(c, 22'000);
         s.set_nonce(c, 1);
         s.set_balance(b, 48'000);

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -118,7 +118,7 @@ TYPED_TEST(StateTest, can_merge_fresh)
 
     auto s = t.get_working_copy(0);
 
-    s.create_contract(a);
+    s.create_account(a);
     s.set_nonce(a, 1);
     s.set_balance(a, 38'000);
     s.set_code(a, c1);


### PR DESCRIPTION
Problem:
- While integrating, the call create_contract offered confusing semantics
- The call is used to create both EOA and contract accounts.

Solution:
- Change the naming to create_account to better reflect both use cases.

Note: This is a naming change only.  No functionality change.

@rgarc - this is feedback from our integration of the compatibility test.