### PR TITLE
:construction_worker: Allow both ASan and UBSan to work together

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,12 +262,14 @@ if(ASAN)
         monad PUBLIC "-fsanitize=address" "-fno-omit-frame-pointer"
     )
     target_link_options(monad PUBLIC "-fsanitize=address")
-elseif(UBSAN)
+endif()
+if(UBSAN)
     message("Undefined Behavior Sanitizer: On")
     target_compile_options(
-        monad PUBLIC "-fsanitize=undefined" "-fno-omit-frame-pointer"
+        monad PUBLIC "-fsanitize=undefined" "-fno-omit-frame-pointer" "-fPIC"
     )
     target_link_options(monad PUBLIC "-fsanitize=undefined")
-else()
+endif()
+if(NOT UBSAN AND NOT ASAN)
     target_link_options(monad PRIVATE LINKER:-z,defs)
 endif()


### PR DESCRIPTION
Problem:
- Both ASan and UBSan can work together, but the current cmake does not allow it
- There is no reason not to allow it

Solution:
- Let both of the sanitizers be configured if desired.

@rgarc - this addresses the issue that came up during the compatibility integration