### PR TITLE
:bug: Remove incorrect asserts in `TrieDBInterface::commit`

### DIFF
--- a/include/monad/db/trie_db_interface.hpp
+++ b/include/monad/db/trie_db_interface.hpp
@@ -213,7 +213,8 @@ struct TrieDBInterface
 
         for (auto const &[addr, storage_root] : updated_storage_roots) {
             auto const account = query(addr);
-            MONAD_DEBUG_ASSERT(account.has_value());
+            if (!account)
+                continue;
 
             auto const ak = trie::Nibbles{std::bit_cast<bytes32_t>(
                 ethash::keccak256(addr.bytes, sizeof(addr.bytes)))};
@@ -235,17 +236,10 @@ struct TrieDBInterface
             accounts().leaves_writer.write();
             accounts().trie_writer.write();
 
-            // Note: there should never be an instance where we have storage
-            // updates but no account updates. The assertions in the else
-            // statement enforce this
             storage().leaves_writer.write();
             storage().trie_writer.write();
 
             take_snapshot();
-        }
-        else {
-            MONAD_DEBUG_ASSERT(obj.storage_changes.empty());
-            MONAD_DEBUG_ASSERT(obj.account_changes.empty());
         }
     }
 


### PR DESCRIPTION
Problem:
- As part of 178695af474f15821e1968eb1551746506c6face, a lot of DB commit functionality was consolidated into a single function.
- This function had assertions to protect against calling it when there are storage updates but no account updates.
- However, as can be seen at https://github.com/monad-crypto/monad/blob/aa911ab8160dc16ebe129f3df8e38ae8ce18af17/include/monad/state/value_state.hpp#L117-L136, this will always be the case (there are only storage updates and no account updates).

Solution:
- Remove these assertions.


NOTE: There is likely a good reason for these assertions to previously exist, so I will wait for @zander-xyz to approve. 