### PR TITLE
:bug: Commit storage and account changes together.

### DIFF
--- a/include/monad/state/state_changes.hpp
+++ b/include/monad/state/state_changes.hpp
@@ -12,9 +12,12 @@ MONAD_STATE_NAMESPACE_BEGIN
 
 struct StateChanges
 {
-    std::vector<std::pair<address_t, std::optional<Account>>> account_changes;
-    std::unordered_map<address_t, std::vector<std::pair<bytes32_t, bytes32_t>>>
-        storage_changes;
+    using AccountChanges =
+        std::vector<std::pair<address_t, std::optional<Account>>>;
+    using StorageChanges = std::unordered_map<
+        address_t, std::vector<std::pair<bytes32_t, bytes32_t>>>;
+    AccountChanges account_changes;
+    StorageChanges storage_changes;
 };
 
 MONAD_STATE_NAMESPACE_END

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -114,26 +114,26 @@ struct ValueState
         return true;
     }
 
-    void commit_all_merged()
+    StateChanges::StorageChanges gather_changes() const
     {
         assert(can_commit());
-
-        StateChanges sc;
+        StateChanges::StorageChanges storage_changes;
 
         for (auto const &[addr, key_set] : merged_.deleted_storage_) {
             for (auto const &key : key_set) {
-                sc.storage_changes[addr].emplace_back(key.key, bytes32_t{});
+                storage_changes[addr].emplace_back(key.key, bytes32_t{});
             }
         }
         for (auto const &[addr, acct_storage] : merged_.storage_) {
             for (auto const &[key, value] : acct_storage) {
                 assert(value.updated != bytes32_t{});
-                sc.storage_changes[addr].emplace_back(key, value.updated);
+                storage_changes[addr].emplace_back(key, value.updated);
             }
         }
-        merged_.clear();
-        db_.commit(sc);
+        return storage_changes;
     }
+
+    void clear_changes() { merged_.clear(); }
 
     bool can_merge(WorkingCopy const &diffs) const noexcept
     {

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -108,7 +108,8 @@ int main(int argc, char *argv[])
         monad::state::AccountState<db_t>,
         monad::state::ValueState<db_t>,
         monad::state::CodeState<code_db_t>,
-        monad::db::BlockDb>;
+        monad::db::BlockDb,
+        db_t>;
     using execution_t = monad::execution::BoostFiberExecution;
 
     // Fakes
@@ -135,7 +136,7 @@ int main(int argc, char *argv[])
     monad::state::AccountState accounts{db};
     monad::state::ValueState values{db};
     monad::state::CodeState code{code_db};
-    state_t state{accounts, values, code, block_db};
+    state_t state{accounts, values, code, block_db, db};
 
     receipt_collector_t receipt_collector;
 

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -33,8 +33,8 @@ template <typename TDB>
 struct AccountStateTest : public testing::Test
 {
 };
-using DBTypes =
-    ::testing::Types<db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
+using DBTypes = ::testing::Types<
+    db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
 TYPED_TEST_SUITE(AccountStateTest, DBTypes);
 
 using diff_t = AccountState<std::unordered_map<address_t, Account>>::diff_t;
@@ -65,8 +65,7 @@ TYPED_TEST(AccountStateTest, get_balance)
         .account_changes = {{a, Account{.balance = 20'000}}},
         .storage_changes = {}});
     AccountState s{db};
-    s.merged_.emplace(
-        b, diff_t{std::nullopt, Account{.balance = 10'000}});
+    s.merged_.emplace(b, diff_t{std::nullopt, Account{.balance = 10'000}});
 
     EXPECT_EQ(s.get_balance(a), bytes32_t{20'000});
     EXPECT_EQ(s.get_balance(b), bytes32_t{10'000});
@@ -77,8 +76,7 @@ TYPED_TEST(AccountStateTest, apply_reward)
     auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
-        .account_changes = {{a, Account{}}},
-        .storage_changes = {}});
+        .account_changes = {{a, Account{}}}, .storage_changes = {}});
 
     s.merged_.emplace(b, Account{});
     s.merged_.emplace(c, diff_t{Account{}, Account{.balance = 10}});
@@ -101,8 +99,7 @@ TYPED_TEST(AccountStateTest, get_code_hash)
         .account_changes = {{a, Account{.code_hash = hash1}}},
         .storage_changes = {}});
     AccountState s{db};
-    s.merged_.emplace(
-        b, diff_t{std::nullopt, Account{.code_hash = hash2}});
+    s.merged_.emplace(b, diff_t{std::nullopt, Account{.code_hash = hash2}});
 
     EXPECT_EQ(s.get_code_hash(a), hash1);
     EXPECT_EQ(s.get_code_hash(b), hash2);
@@ -180,8 +177,7 @@ TYPED_TEST(AccountStateTest, get_balance_working_copy)
         .storage_changes = {}});
 
     AccountState s{db};
-    s.merged_.emplace(
-        b, diff_t{std::nullopt, Account{.balance = 10'000}});
+    s.merged_.emplace(b, diff_t{std::nullopt, Account{.balance = 10'000}});
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
@@ -218,8 +214,7 @@ TYPED_TEST(AccountStateTest, get_code_hash_working_copy)
         .storage_changes = {}});
 
     AccountState s{db};
-    s.merged_.emplace(
-        b, diff_t{std::nullopt, Account{.code_hash = hash2}});
+    s.merged_.emplace(b, diff_t{std::nullopt, Account{.code_hash = hash2}});
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
@@ -273,8 +268,7 @@ TYPED_TEST(AccountStateTest, selfdestruct_working_copy)
         .storage_changes = {}});
 
     AccountState s{db};
-    s.merged_.emplace(
-        b, diff_t{std::nullopt, Account{.balance = 28'000}});
+    s.merged_.emplace(b, diff_t{std::nullopt, Account{.balance = 28'000}});
 
     auto bs = typename decltype(s)::WorkingCopy{s};
 
@@ -387,8 +381,7 @@ TYPED_TEST(AccountStateTest, can_merge_onto_merged)
     AccountState t{db};
     t.merged_.emplace(a, diff_t{Account{.balance = 30'000}});
     t.merged_.emplace(b, diff_t{db.at(b), db.at(b)});
-    t.merged_.emplace(
-        c, diff_t{Account{.balance = 50'000}, std::nullopt});
+    t.merged_.emplace(c, diff_t{Account{.balance = 50'000}, std::nullopt});
     t.merged_[c].updated.reset();
 
     auto s = typename decltype(t)::WorkingCopy{t};
@@ -690,7 +683,8 @@ TYPED_TEST(AccountStateTest, can_commit_multiple)
     }
 
     EXPECT_TRUE(t.can_commit());
-    t.commit_all_merged();
+    StateChanges sc{.account_changes = t.gather_changes()};
+    db.commit(sc);
 
     EXPECT_TRUE(db.contains(a));
     EXPECT_EQ(db.at(a).balance, 98'000);

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -39,192 +39,195 @@ template <typename TDB>
 struct StateTest : public testing::Test
 {
 };
-using DBTypes =
-    ::testing::Types<db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
+using DBTypes = ::testing::Types<
+    db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
 TYPED_TEST_SUITE(StateTest, DBTypes);
 
 using code_db_t = std::unordered_map<address_t, byte_string>;
 
-struct fakeBlockCache {
-   [[nodiscard]] bytes32_t get_block_hash(int64_t) const noexcept
-   {
-       return bytes32_t{};
-   } 
+struct fakeBlockCache
+{
+    [[nodiscard]] bytes32_t get_block_hash(int64_t) const noexcept
+    {
+        return bytes32_t{};
+    }
 } block_cache;
 
 TYPED_TEST(StateTest, get_working_copy)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State as{accounts, values, code, block_cache};
-   db.commit(StateChanges{
-       .account_changes = {{a, Account{.balance = 10'000}}},
-       .storage_changes = {}});
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State as{accounts, values, code, block_cache, db};
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 10'000}}},
+        .storage_changes = {}});
 
-   [[maybe_unused]] auto bs = as.get_working_copy(0);
-   [[maybe_unused]] auto cs = as.get_working_copy(1);
+    [[maybe_unused]] auto bs = as.get_working_copy(0);
+    [[maybe_unused]] auto cs = as.get_working_copy(1);
 
-   bs.access_account(a);
-   bs.set_balance(a, 20'000);
+    bs.access_account(a);
+    bs.set_balance(a, 20'000);
 
-   cs.access_account(a);
-   cs.set_balance(a, 30'000);
+    cs.access_account(a);
+    cs.set_balance(a, 30'000);
 
-   EXPECT_TRUE(bs.account_exists(a));
-   EXPECT_FALSE(bs.account_exists(b));
-   EXPECT_TRUE(cs.account_exists(a));
-   EXPECT_FALSE(cs.account_exists(b));
-   EXPECT_EQ(bs.get_balance(a), bytes32_t{20'000});
-   EXPECT_EQ(cs.get_balance(a), bytes32_t{30'000});
+    EXPECT_TRUE(bs.account_exists(a));
+    EXPECT_FALSE(bs.account_exists(b));
+    EXPECT_TRUE(cs.account_exists(a));
+    EXPECT_FALSE(cs.account_exists(b));
+    EXPECT_EQ(bs.get_balance(a), bytes32_t{20'000});
+    EXPECT_EQ(cs.get_balance(a), bytes32_t{30'000});
 }
 
 TYPED_TEST(StateTest, apply_award)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State as{accounts, values, code, block_cache};
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State as{accounts, values, code, block_cache, db};
 
-   auto bs = as.get_working_copy(0);
-   auto cs = as.get_working_copy(1);
+    auto bs = as.get_working_copy(0);
+    auto cs = as.get_working_copy(1);
 
-   bs.add_txn_award(10'000);
-   cs.add_txn_award(20'000);
+    bs.add_txn_award(10'000);
+    cs.add_txn_award(20'000);
 
-   as.merge_changes(bs);
-   as.merge_changes(cs);
-   as.apply_block_reward(a, 100);
-   as.commit();
+    as.merge_changes(bs);
+    as.merge_changes(cs);
+    as.apply_block_reward(a, 100);
+    as.commit();
 
-   auto ds = as.get_working_copy(2);
-   ds.access_account(a);
-   EXPECT_EQ(ds.get_balance(a), bytes32_t{30'100});
+    auto ds = as.get_working_copy(2);
+    ds.access_account(a);
+    EXPECT_EQ(ds.get_balance(a), bytes32_t{30'100});
 }
 
 TYPED_TEST(StateTest, get_code)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State as{accounts, values, code, block_cache};
-   byte_string const contract{0x60, 0x34, 0x00};
-   code_db.emplace(a, contract);
-   db.commit(StateChanges{
-       .account_changes = {{a, Account{.balance = 10'000}}},
-       .storage_changes = {}});
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State as{accounts, values, code, block_cache, db};
+    byte_string const contract{0x60, 0x34, 0x00};
+    code_db.emplace(a, contract);
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.balance = 10'000}}},
+        .storage_changes = {}});
 
-   [[maybe_unused]] auto bs = as.get_working_copy(0);
+    [[maybe_unused]] auto bs = as.get_working_copy(0);
 
-   bs.access_account(a);
-   auto const c = bs.get_code(a);
+    bs.access_account(a);
+    auto const c = bs.get_code(a);
 
-   EXPECT_EQ(c, contract);
+    EXPECT_EQ(c, contract);
 }
 
 TYPED_TEST(StateTest, can_merge_fresh)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State t{accounts, values, code, block_cache};
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State t{accounts, values, code, block_cache, db};
 
-   db.commit(StateChanges{
-       .account_changes =
-           {{b, Account{.balance = 40'000u}}, {c, Account{.balance = 50'000u}}},
-       .storage_changes = {
-           {b, {{key1, value1}, {key2, value2}}},
-           {c, {{key1, value1}, {key2, value2}}}}});
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {
+            {b, {{key1, value1}, {key2, value2}}},
+            {c, {{key1, value1}, {key2, value2}}}}});
 
-   auto s = t.get_working_copy(0);
+    auto s = t.get_working_copy(0);
 
-   s.create_account(a);
-   s.set_nonce(a, 1);
-   s.set_balance(a, 38'000);
-   s.set_code(a, c1);
-   EXPECT_EQ(s.set_storage(a, key2, value1), EVMC_STORAGE_ADDED);
-   EXPECT_EQ(s.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
-   EXPECT_EQ(s.get_code_size(a), c1.size());
+    s.create_account(a);
+    s.set_nonce(a, 1);
+    s.set_balance(a, 38'000);
+    s.set_code(a, c1);
+    EXPECT_EQ(s.set_storage(a, key2, value1), EVMC_STORAGE_ADDED);
+    EXPECT_EQ(s.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
+    EXPECT_EQ(s.get_code_size(a), c1.size());
 
-   s.access_account(b);
-   s.set_balance(b, 42'000);
-   s.set_nonce(b, 3);
-   EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-   EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
-   EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
+    s.access_account(b);
+    s.set_balance(b, 42'000);
+    s.set_nonce(b, 3);
+    EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
 
-   s.access_account(c);
-   EXPECT_EQ(s.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
-   EXPECT_EQ(s.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
-   EXPECT_TRUE(s.selfdestruct(c, b));
-   s.destruct_suicides();
+    s.access_account(c);
+    EXPECT_EQ(s.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(s.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
+    EXPECT_TRUE(s.selfdestruct(c, b));
+    s.destruct_suicides();
 
-   EXPECT_EQ(t.can_merge_changes(s), decltype(t)::MergeStatus::WILL_SUCCEED);
+    EXPECT_EQ(t.can_merge_changes(s), decltype(t)::MergeStatus::WILL_SUCCEED);
 }
 
 TYPED_TEST(StateTest, can_merge_same_account_different_storage)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State t{accounts, values, code, block_cache};
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State t{accounts, values, code, block_cache, db};
 
-   db.commit(StateChanges{
-       .account_changes =
-           {{b, Account{.balance = 40'000u}}, {c, Account{.balance = 50'000u}}},
-       .storage_changes = {
-           {b, {{key1, value1}, {key2, value2}}},
-           {c, {{key1, value1}, {key2, value2}}}}});
+    db.commit(StateChanges{
+        .account_changes =
+            {{b, Account{.balance = 40'000u}},
+             {c, Account{.balance = 50'000u}}},
+        .storage_changes = {
+            {b, {{key1, value1}, {key2, value2}}},
+            {c, {{key1, value1}, {key2, value2}}}}});
 
-   auto bs = t.get_working_copy(0);
-   auto cs = t.get_working_copy(1);
+    auto bs = t.get_working_copy(0);
+    auto cs = t.get_working_copy(1);
 
-   bs.access_account(b);
-   EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+    bs.access_account(b);
+    EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
 
-   EXPECT_EQ(t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
-   t.merge_changes(bs);
+    EXPECT_EQ(t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
+    t.merge_changes(bs);
 
-   cs.access_account(b);
-   EXPECT_EQ(cs.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+    cs.access_account(b);
+    EXPECT_EQ(cs.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
 
-   EXPECT_EQ(t.can_merge_changes(cs), decltype(t)::MergeStatus::WILL_SUCCEED);
-   t.merge_changes(cs);
+    EXPECT_EQ(t.can_merge_changes(cs), decltype(t)::MergeStatus::WILL_SUCCEED);
+    t.merge_changes(cs);
 }
 
 TYPED_TEST(StateTest, cant_merge_colliding_storage)
 {
-   auto db = test::make_db<TypeParam>();
-   AccountState accounts{db};
-   ValueState values{db};
-   code_db_t code_db{};
-   CodeState code{code_db};
-   State t{accounts, values, code, block_cache};
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    code_db_t code_db{};
+    CodeState code{code_db};
+    State t{accounts, values, code, block_cache, db};
 
-   db.commit(StateChanges{
-       .account_changes = {{b, Account{.balance = 40'000u}}},
-       .storage_changes = {{b, {{key1, value1}}}}});
+    db.commit(StateChanges{
+        .account_changes = {{b, Account{.balance = 40'000u}}},
+        .storage_changes = {{b, {{key1, value1}}}}});
 
-   auto bs = t.get_working_copy(0);
-   auto cs = t.get_working_copy(1);
+    auto bs = t.get_working_copy(0);
+    auto cs = t.get_working_copy(1);
 
-   {
-       bs.access_account(b);
-       EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+    {
+        bs.access_account(b);
+        EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
 
-       EXPECT_EQ(
-           t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
-       t.merge_changes(bs);
+        EXPECT_EQ(
+            t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
+        t.merge_changes(bs);
     }
     {
         cs.access_account(b);
@@ -252,7 +255,7 @@ TYPED_TEST(StateTest, merge_txn0_and_txn1)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     db.commit(StateChanges{
         .account_changes =
@@ -294,7 +297,7 @@ TYPED_TEST(StateTest, cant_merge_txn1_collision_need_to_rerun)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     db.commit(StateChanges{
         .account_changes =
@@ -348,7 +351,7 @@ TYPED_TEST(StateTest, merge_txn1_try_again_merge_txn0_then_txn1)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     db.commit(StateChanges{
         .account_changes =
@@ -395,7 +398,7 @@ TYPED_TEST(StateTest, can_commit)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     db.commit(StateChanges{
         .account_changes =
@@ -451,7 +454,7 @@ TYPED_TEST(TrieDBTest, commit_storage_and_account_together_regression)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     auto working_copy = t.get_working_copy(0u);
 
@@ -470,7 +473,7 @@ TYPED_TEST(StateTest, commit_twice)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     db.commit(StateChanges{
         .account_changes =
@@ -521,7 +524,7 @@ TYPED_TEST(StateTest, commit_twice_apply_block_reward)
     ValueState values{db};
     code_db_t code_db{};
     CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+    State t{accounts, values, code, block_cache, db};
 
     {
         // Block 0, Txn 0

--- a/src/monad/state/test/value_state.cpp
+++ b/src/monad/state/test/value_state.cpp
@@ -41,8 +41,8 @@ template <typename TDB>
 struct ValueStateTest : public testing::Test
 {
 };
-using DBTypes =
-    ::testing::Types<db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
+using DBTypes = ::testing::Types<
+    db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
 TYPED_TEST_SUITE(ValueStateTest, DBTypes);
 
 TYPED_TEST(ValueStateTest, access_storage)
@@ -685,5 +685,5 @@ TYPED_TEST(ValueStateTest, commit_all_merged)
         EXPECT_TRUE(s.can_commit());
     }
 
-    s.commit_all_merged();
+    auto _ = s.gather_changes();
 }

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -58,7 +58,7 @@ TEST(EvmInterpStateHost, return_existing_storage)
     state::ValueState values{db};
     code_db_t code_db{};
     state::CodeState codes{code_db};
-    state::State s{accounts, values, codes, blocks};
+    state::State s{accounts, values, codes, blocks, db};
 
     // Setup db - gas costs referenced here
     // https://www.evm.codes/?fork=byzantium
@@ -120,7 +120,7 @@ TEST(EvmInterpStateHost, store_then_return_storage)
     state::ValueState values{db};
     code_db_t code_db{};
     state::CodeState codes{code_db};
-    state::State s{accounts, values, codes, blocks};
+    state::State s{accounts, values, codes, blocks, db};
 
     // Setup db - gas costs referenced here
     // https://www.evm.codes/?fork=byzantium

--- a/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
+++ b/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
@@ -56,12 +56,11 @@ TEST(TxnProcEvmInterpStateHost, account_transfer_miner_ommer_award)
     state::ValueState values{db};
     code_db_t code_db{};
     state::CodeState codes{code_db};
-    state::State s{accounts, values, codes, blocks};
+    state::State s{accounts, values, codes, blocks, db};
 
     db.commit(state::StateChanges{
         .account_changes =
-            {{a, Account{}},
-             {from, Account{.balance = 10'000'000}}},
+            {{a, Account{}}, {from, Account{.balance = 10'000'000}}},
         .storage_changes = {}});
 
     BlockHeader const bh{.number = 2, .beneficiary = a};


### PR DESCRIPTION
Problem:
- On the current main branch, assertions in [`TrieDBInterface::commit`]
  always fail because [`ValueState::commit_all_merged`] always calls
  into [`TrieDBInterface::commit`] with an empty list of account
  changes.

Solution:
- Collect the account and storage changes into the same `StateChanges`
  struct and commit them together so that the aforementioned assertions
  no longer fail.

Note:
- This PR directly contradicts [this comment], so this PR needs to be
  scrapped or the comment should be updated.

[`TrieDBInterface::commit`]: https://github.com/monad-crypto/monad/blob/e6c159c5e5ef834b241e5fa36d39ce487a3a0748/include/monad/db/trie_db_interface.hpp#L149-L250
[`ValueState::commit_all_merged`]: https://github.com/monad-crypto/monad/blob/e6c159c5e5ef834b241e5fa36d39ce487a3a0748/include/monad/state/value_state.hpp#L117-L136
[this comment]: https://github.com/monad-crypto/monad/blob/e6c159c5e5ef834b241e5fa36d39ce487a3a0748/include/monad/state/state.hpp#L238-L240