### PR TITLE
:fire: Program state to ignore the burn address

### DIFF
--- a/include/monad/execution/block_processor.hpp
+++ b/include/monad/execution/block_processor.hpp
@@ -51,9 +51,7 @@ struct AllTxnBlockProcessor
             r.push_back(d.get_receipt());
         }
 
-        if (b.header.number != 0u) {
-            TTraits::apply_block_award(s, b);
-        }
+        TTraits::apply_block_award(s, b);
 
         auto const finished_time = std::chrono::steady_clock::now();
         auto const elapsed_ms =

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -699,3 +699,18 @@ TYPED_TEST(AccountStateTest, can_commit_multiple)
     EXPECT_EQ(db.at(c).nonce, 1);
     EXPECT_FALSE(db.contains(d));
 }
+
+TYPED_TEST(AccountStateTest, burn_address)
+{
+    TypeParam db{};
+    AccountState t{db};
+
+    auto s = typename decltype(t)::WorkingCopy{t};
+
+    EXPECT_TRUE(s.account_exists(decltype(s)::BURN_ADDRESS));
+    s.create_account(decltype(s)::BURN_ADDRESS);
+    EXPECT_EQ(s.get_balance(decltype(s)::BURN_ADDRESS), bytes32_t{0});
+    s.set_balance(decltype(s)::BURN_ADDRESS, uint256_t{1'000});
+    EXPECT_EQ(s.get_code_hash(decltype(s)::BURN_ADDRESS), NULL_HASH);
+    EXPECT_EQ(s.access_account(decltype(s)::BURN_ADDRESS), EVMC_ACCESS_COLD);
+}


### PR DESCRIPTION
Problem:
- Anything sent to address 0x00..00 is supposed to be burned.
- There is no code at that address, and it is not part of the trie
- As a beneficiary, the reward should be burnt as well.

Solution:
- Program all account state functions that are accessed as a 'to' in the
  transaction to ignore anything coming for the burn address.
