### PR TITLE
:truck: make tests output database files to build directory

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -11,6 +11,8 @@ namespace test_resource
 
     inline std::filesystem::__cxx11::path const test_data_dir =
         "@TEST_DATA_DIR@";
+    inline std::filesystem::__cxx11::path const build_dir =
+        "@CMAKE_BINARY_DIR@";
 
     // blocks
     inline auto const correct_block_data_dir =

--- a/include/monad/db/rocks_trie_db.hpp
+++ b/include/monad/db/rocks_trie_db.hpp
@@ -66,7 +66,6 @@ struct RocksTrieDB : TrieDBInterface<RocksTrieDB>
         }
     };
 
-    std::filesystem::path const name;
     rocksdb::Options options;
     trie::PathComparator accounts_comparator;
     trie::PrefixPathComparator storage_comparator;
@@ -77,10 +76,8 @@ struct RocksTrieDB : TrieDBInterface<RocksTrieDB>
     Trie accounts_trie;
     Trie storage_trie;
 
-    RocksTrieDB(
-        std::filesystem::path name = std::filesystem::absolute("rocks_trie_db"))
-        : name(name)
-        , options([]() {
+    explicit RocksTrieDB(std::filesystem::path name)
+        : options([]() {
             rocksdb::Options ret;
             ret.IncreaseParallelism(2);
             ret.OptimizeLevelStyleCompaction();
@@ -105,21 +102,10 @@ struct RocksTrieDB : TrieDBInterface<RocksTrieDB>
         }())
         , cfs()
         , db([&]() {
-            if (std::filesystem::exists(name)) {
-                MONAD_ASSERT(std::filesystem::is_directory(name));
-            }
-            else {
-                std::filesystem::create_directory(name);
-            }
-
             rocksdb::DB *db = nullptr;
 
-            rocksdb::Status const s = rocksdb::DB::Open(
-                options,
-                name / fmt::format("{}", std::chrono::system_clock::now()),
-                cfds,
-                &cfs,
-                &db);
+            rocksdb::Status const s =
+                rocksdb::DB::Open(options, name, cfds, &cfs, &db);
 
             MONAD_ROCKS_ASSERT(s);
             MONAD_ASSERT(cfds.size() == cfs.size());

--- a/src/monad/db/test/db.cpp
+++ b/src/monad/db/test/db.cpp
@@ -6,6 +6,7 @@
 #include <monad/db/rocks_trie_db.hpp>
 #include <monad/logging/formatter.hpp>
 #include <monad/state/state_changes.hpp>
+#include <monad/test/make_db.hpp>
 
 using namespace monad;
 using namespace monad::db;
@@ -40,7 +41,7 @@ TYPED_TEST_SUITE(TrieDBTest, TrieDBTypes);
 
 TYPED_TEST(DBTest, storage_creation)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
     db.commit(state::StateChanges{
         .account_changes = {{a, acct}},
@@ -61,7 +62,7 @@ TYPED_TEST(DBTest, storage_creation)
 
 TEST(InMemoryTrieDB, account_creation)
 {
-    InMemoryTrieDB db;
+    auto db = test::make_db<InMemoryTrieDB>();
     Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
     db.commit(state::StateChanges{
         .account_changes = {{a, acct}}, .storage_changes = {}});
@@ -75,7 +76,7 @@ TEST(InMemoryTrieDB, account_creation)
 
 TYPED_TEST(DBTest, query)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
     db.commit(state::StateChanges{
         .account_changes = {{a, acct}},
@@ -89,7 +90,7 @@ TYPED_TEST(DBTest, query)
 
 TEST(InMemoryTrieDB, erase)
 {
-    InMemoryTrieDB db;
+    auto db = test::make_db<InMemoryTrieDB>();
     Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
     db.commit(state::StateChanges{
         .account_changes = {{a, acct}},
@@ -120,7 +121,7 @@ TEST(InMemoryTrieDB, erase)
 
 TYPED_TEST(TrieDBTest, ModifyStorageOfAccount)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
     db.commit(state::StateChanges{
         .account_changes = {{a, acct}},

--- a/src/monad/execution/ethereum/test/genesis.cpp
+++ b/src/monad/execution/ethereum/test/genesis.cpp
@@ -5,6 +5,8 @@
 #include <monad/db/rocks_db.hpp>
 #include <monad/db/rocks_trie_db.hpp>
 
+#include <monad/test/make_db.hpp>
+
 #include <monad/execution/ethereum/genesis.hpp>
 
 #include <gtest/gtest.h>
@@ -71,7 +73,7 @@ TYPED_TEST(GenesisStateTest, read_ethereum_mainnet_genesis_state)
 
     auto const genesis_file_path =
         test_resource::ethereum_genesis_dir / "mainnet.json";
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
 
     std::ifstream ifile(genesis_file_path.c_str());
     auto const genesis_json = nlohmann::json::parse(ifile);
@@ -94,7 +96,7 @@ TYPED_TEST(GenesisStateRootTest, ethereum_mainnet_genesis_state_root)
 {
     auto const genesis_file_path =
         test_resource::ethereum_genesis_dir / "mainnet.json";
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
 
     auto const block_header = read_genesis(genesis_file_path, db);
 

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -9,6 +9,8 @@
 #include <monad/state/account_state.hpp>
 #include <monad/state/state_changes.hpp>
 
+#include <monad/test/make_db.hpp>
+
 #include <gtest/gtest.h>
 
 #include <unordered_map>
@@ -40,7 +42,7 @@ using diff_t = AccountState<std::unordered_map<address_t, Account>>::diff_t;
 // AccountState
 TYPED_TEST(AccountStateTest, account_exists)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {d, Account{}}},
@@ -58,7 +60,7 @@ TYPED_TEST(AccountStateTest, account_exists)
 
 TYPED_TEST(AccountStateTest, get_balance)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 20'000}}},
         .storage_changes = {}});
@@ -72,7 +74,7 @@ TYPED_TEST(AccountStateTest, get_balance)
 
 TYPED_TEST(AccountStateTest, apply_reward)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
@@ -94,7 +96,7 @@ TYPED_TEST(AccountStateTest, apply_reward)
 
 TYPED_TEST(AccountStateTest, get_code_hash)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.code_hash = hash1}}},
         .storage_changes = {}});
@@ -108,7 +110,7 @@ TYPED_TEST(AccountStateTest, get_code_hash)
 
 TYPED_TEST(AccountStateTest, working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 10'000}}},
         .storage_changes = {}});
@@ -131,7 +133,7 @@ TYPED_TEST(AccountStateTest, working_copy)
 // AccountStateWorkingCopy
 TYPED_TEST(AccountStateTest, account_exists_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {d, Account{}}},
@@ -156,7 +158,7 @@ TYPED_TEST(AccountStateTest, account_exists_working_copy)
 
 TYPED_TEST(AccountStateTest, access_account_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
@@ -172,7 +174,7 @@ TYPED_TEST(AccountStateTest, access_account_working_copy)
 
 TYPED_TEST(AccountStateTest, get_balance_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 20'000}}},
         .storage_changes = {}});
@@ -192,7 +194,7 @@ TYPED_TEST(AccountStateTest, get_balance_working_copy)
 
 TYPED_TEST(AccountStateTest, get_nonce_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.nonce = 2}}}, .storage_changes = {}});
 
@@ -210,7 +212,7 @@ TYPED_TEST(AccountStateTest, get_nonce_working_copy)
 
 TYPED_TEST(AccountStateTest, get_code_hash_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.code_hash = hash1}}},
         .storage_changes = {}});
@@ -230,7 +232,7 @@ TYPED_TEST(AccountStateTest, get_code_hash_working_copy)
 
 TYPED_TEST(AccountStateTest, create_account_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
 
     auto bs = typename decltype(s)::WorkingCopy{s};
@@ -245,7 +247,7 @@ TYPED_TEST(AccountStateTest, create_account_working_copy)
 
 TYPED_TEST(AccountStateTest, set_code_hash_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState s{db};
     db.commit(StateChanges{
         .account_changes = {{b, Account{}}}, .storage_changes = {}});
@@ -264,7 +266,7 @@ TYPED_TEST(AccountStateTest, set_code_hash_working_copy)
 
 TYPED_TEST(AccountStateTest, selfdestruct_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{a, Account{.balance = 18'000}}, {c, Account{.balance = 38'000}}},
@@ -299,7 +301,7 @@ TYPED_TEST(AccountStateTest, selfdestruct_working_copy)
 
 TYPED_TEST(AccountStateTest, destruct_touched_dead_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 10'000}}, {b, Account{}}},
         .storage_changes = {}});
@@ -327,7 +329,7 @@ TYPED_TEST(AccountStateTest, destruct_touched_dead_working_copy)
 
 TYPED_TEST(AccountStateTest, revert_touched_working_copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 10'000, .nonce = 2}}},
         .storage_changes = {}});
@@ -349,7 +351,7 @@ TYPED_TEST(AccountStateTest, revert_touched_working_copy)
 
 TYPED_TEST(AccountStateTest, can_merge_fresh)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 40'000u}},
@@ -375,7 +377,7 @@ TYPED_TEST(AccountStateTest, can_merge_fresh)
 
 TYPED_TEST(AccountStateTest, can_merge_onto_merged)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 40'000u}},
@@ -406,7 +408,7 @@ TYPED_TEST(AccountStateTest, can_merge_onto_merged)
 
 TYPED_TEST(AccountStateTest, cant_merge_colliding_merge)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes = {}});
@@ -427,7 +429,7 @@ TYPED_TEST(AccountStateTest, cant_merge_colliding_merge)
 
 TYPED_TEST(AccountStateTest, cant_merge_deleted_merge)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes{}});
@@ -449,7 +451,7 @@ TYPED_TEST(AccountStateTest, cant_merge_deleted_merge)
 
 TYPED_TEST(AccountStateTest, cant_merge_conflicting_adds)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     AccountState t{db};
     diff_t r{std::nullopt, Account{.balance = 10'000, .nonce = 1}};
 
@@ -466,7 +468,7 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_adds)
 
 TYPED_TEST(AccountStateTest, cant_merge_conflicting_modifies)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes{}});
@@ -487,7 +489,7 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_modifies)
 
 TYPED_TEST(AccountStateTest, cant_merge_conflicting_deleted)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 10'000u, .nonce = 1}},
@@ -511,7 +513,7 @@ TYPED_TEST(AccountStateTest, cant_merge_conflicting_deleted)
 
 TYPED_TEST(AccountStateTest, merge_multiple_changes)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 40'000u}},
@@ -559,7 +561,7 @@ TYPED_TEST(AccountStateTest, merge_multiple_changes)
 
 TYPED_TEST(AccountStateTest, can_commit)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 40'000u}},
@@ -578,7 +580,7 @@ TYPED_TEST(AccountStateTest, can_commit)
 
 TYPED_TEST(AccountStateTest, cant_commit_merged_new_different_than_stored)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes = {}});
@@ -590,7 +592,7 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_new_different_than_stored)
 
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_balance)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes = {}});
@@ -603,7 +605,7 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_balance)
 
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_nonce)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.balance = 40'000u}}},
         .storage_changes = {}});
@@ -619,7 +621,7 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_nonce)
 
 TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_code_hash)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{.code_hash = hash1}}},
         .storage_changes = {}});
@@ -631,7 +633,7 @@ TYPED_TEST(AccountStateTest, cant_commit_merged_different_than_stored_code_hash)
 
 TYPED_TEST(AccountStateTest, cant_commit_deleted_isnt_stored)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}}, .storage_changes = {}});
     AccountState t{db};
@@ -644,7 +646,7 @@ TYPED_TEST(AccountStateTest, cant_commit_deleted_isnt_stored)
 
 TYPED_TEST(AccountStateTest, can_commit_multiple)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes =
             {{b, Account{.balance = 40'000u}},

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -10,6 +10,7 @@
 #include <monad/state/state.hpp>
 #include <monad/state/state_changes.hpp>
 #include <monad/state/value_state.hpp>
+#include <monad/test/make_db.hpp>
 
 #include <gtest/gtest.h>
 
@@ -53,179 +54,177 @@ struct fakeBlockCache {
 
 TYPED_TEST(StateTest, get_working_copy)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State as{accounts, values, code, block_cache};
-    db.commit(StateChanges{
-        .account_changes = {{a, Account{.balance = 10'000}}},
-        .storage_changes = {}});
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State as{accounts, values, code, block_cache};
+   db.commit(StateChanges{
+       .account_changes = {{a, Account{.balance = 10'000}}},
+       .storage_changes = {}});
 
-    [[maybe_unused]] auto bs = as.get_working_copy(0);
-    [[maybe_unused]] auto cs = as.get_working_copy(1);
+   [[maybe_unused]] auto bs = as.get_working_copy(0);
+   [[maybe_unused]] auto cs = as.get_working_copy(1);
 
-    bs.access_account(a);
-    bs.set_balance(a, 20'000);
+   bs.access_account(a);
+   bs.set_balance(a, 20'000);
 
-    cs.access_account(a);
-    cs.set_balance(a, 30'000);
+   cs.access_account(a);
+   cs.set_balance(a, 30'000);
 
-    EXPECT_TRUE(bs.account_exists(a));
-    EXPECT_FALSE(bs.account_exists(b));
-    EXPECT_TRUE(cs.account_exists(a));
-    EXPECT_FALSE(cs.account_exists(b));
-    EXPECT_EQ(bs.get_balance(a), bytes32_t{20'000});
-    EXPECT_EQ(cs.get_balance(a), bytes32_t{30'000});
+   EXPECT_TRUE(bs.account_exists(a));
+   EXPECT_FALSE(bs.account_exists(b));
+   EXPECT_TRUE(cs.account_exists(a));
+   EXPECT_FALSE(cs.account_exists(b));
+   EXPECT_EQ(bs.get_balance(a), bytes32_t{20'000});
+   EXPECT_EQ(cs.get_balance(a), bytes32_t{30'000});
 }
 
 TYPED_TEST(StateTest, apply_award)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State as{accounts, values, code, block_cache};
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State as{accounts, values, code, block_cache};
 
-    auto bs = as.get_working_copy(0);
-    auto cs = as.get_working_copy(1);
+   auto bs = as.get_working_copy(0);
+   auto cs = as.get_working_copy(1);
 
-    bs.add_txn_award(10'000);
-    cs.add_txn_award(20'000);
+   bs.add_txn_award(10'000);
+   cs.add_txn_award(20'000);
 
-    as.merge_changes(bs);
-    as.merge_changes(cs);
-    as.apply_reward(a, 100);
-    as.commit();
+   as.merge_changes(bs);
+   as.merge_changes(cs);
+   as.apply_reward(a, 100);
+   as.commit();
 
-    auto ds = as.get_working_copy(2);
-    ds.access_account(a);
-    EXPECT_EQ(ds.get_balance(a), bytes32_t{30'100});
+   auto ds = as.get_working_copy(2);
+   ds.access_account(a);
+   EXPECT_EQ(ds.get_balance(a), bytes32_t{30'100});
 }
 
 TYPED_TEST(StateTest, get_code)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State as{accounts, values, code, block_cache};
-    byte_string const contract{0x60, 0x34, 0x00};
-    code_db.emplace(a, contract);
-    db.commit(StateChanges{
-        .account_changes = {{a, Account{.balance = 10'000}}},
-        .storage_changes = {}});
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State as{accounts, values, code, block_cache};
+   byte_string const contract{0x60, 0x34, 0x00};
+   code_db.emplace(a, contract);
+   db.commit(StateChanges{
+       .account_changes = {{a, Account{.balance = 10'000}}},
+       .storage_changes = {}});
 
-    [[maybe_unused]] auto bs = as.get_working_copy(0);
+   [[maybe_unused]] auto bs = as.get_working_copy(0);
 
-    bs.access_account(a);
-    auto const c = bs.get_code(a);
+   bs.access_account(a);
+   auto const c = bs.get_code(a);
 
-    EXPECT_EQ(c, contract);
+   EXPECT_EQ(c, contract);
 }
 
 TYPED_TEST(StateTest, can_merge_fresh)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State t{accounts, values, code, block_cache};
 
-    db.commit(StateChanges{
-        .account_changes =
-            {{b, Account{.balance = 40'000u}},
-             {c, Account{.balance = 50'000u}}},
-        .storage_changes = {
-            {b, {{key1, value1}, {key2, value2}}},
-            {c, {{key1, value1}, {key2, value2}}}}});
+   db.commit(StateChanges{
+       .account_changes =
+           {{b, Account{.balance = 40'000u}}, {c, Account{.balance = 50'000u}}},
+       .storage_changes = {
+           {b, {{key1, value1}, {key2, value2}}},
+           {c, {{key1, value1}, {key2, value2}}}}});
 
-    auto s = t.get_working_copy(0);
+   auto s = t.get_working_copy(0);
 
-    s.create_account(a);
-    s.set_nonce(a, 1);
-    s.set_balance(a, 38'000);
-    s.set_code(a, c1);
-    EXPECT_EQ(s.set_storage(a, key2, value1), EVMC_STORAGE_ADDED);
-    EXPECT_EQ(s.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
-    EXPECT_EQ(s.get_code_size(a), c1.size());
+   s.create_account(a);
+   s.set_nonce(a, 1);
+   s.set_balance(a, 38'000);
+   s.set_code(a, c1);
+   EXPECT_EQ(s.set_storage(a, key2, value1), EVMC_STORAGE_ADDED);
+   EXPECT_EQ(s.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
+   EXPECT_EQ(s.get_code_size(a), c1.size());
 
-    s.access_account(b);
-    s.set_balance(b, 42'000);
-    s.set_nonce(b, 3);
-    EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-    EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
-    EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
+   s.access_account(b);
+   s.set_balance(b, 42'000);
+   s.set_nonce(b, 3);
+   EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+   EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+   EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
 
-    s.access_account(c);
-    EXPECT_EQ(s.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
-    EXPECT_EQ(s.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
-    EXPECT_TRUE(s.selfdestruct(c, b));
-    s.destruct_suicides();
+   s.access_account(c);
+   EXPECT_EQ(s.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
+   EXPECT_EQ(s.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
+   EXPECT_TRUE(s.selfdestruct(c, b));
+   s.destruct_suicides();
 
-    EXPECT_EQ(t.can_merge_changes(s), decltype(t)::MergeStatus::WILL_SUCCEED);
+   EXPECT_EQ(t.can_merge_changes(s), decltype(t)::MergeStatus::WILL_SUCCEED);
 }
 
 TYPED_TEST(StateTest, can_merge_same_account_different_storage)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State t{accounts, values, code, block_cache};
 
-    db.commit(StateChanges{
-        .account_changes =
-            {{b, Account{.balance = 40'000u}},
-             {c, Account{.balance = 50'000u}}},
-        .storage_changes = {
-            {b, {{key1, value1}, {key2, value2}}},
-            {c, {{key1, value1}, {key2, value2}}}}});
+   db.commit(StateChanges{
+       .account_changes =
+           {{b, Account{.balance = 40'000u}}, {c, Account{.balance = 50'000u}}},
+       .storage_changes = {
+           {b, {{key1, value1}, {key2, value2}}},
+           {c, {{key1, value1}, {key2, value2}}}}});
 
-    auto bs = t.get_working_copy(0);
-    auto cs = t.get_working_copy(1);
+   auto bs = t.get_working_copy(0);
+   auto cs = t.get_working_copy(1);
 
-    bs.access_account(b);
-    EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+   bs.access_account(b);
+   EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
 
-    EXPECT_EQ(t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
-    t.merge_changes(bs);
+   EXPECT_EQ(t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
+   t.merge_changes(bs);
 
-    cs.access_account(b);
-    EXPECT_EQ(cs.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+   cs.access_account(b);
+   EXPECT_EQ(cs.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
 
-    EXPECT_EQ(t.can_merge_changes(cs), decltype(t)::MergeStatus::WILL_SUCCEED);
-    t.merge_changes(cs);
+   EXPECT_EQ(t.can_merge_changes(cs), decltype(t)::MergeStatus::WILL_SUCCEED);
+   t.merge_changes(cs);
 }
 
 TYPED_TEST(StateTest, cant_merge_colliding_storage)
 {
-    TypeParam db;
-    AccountState accounts{db};
-    ValueState values{db};
-    code_db_t code_db{};
-    CodeState code{code_db};
-    State t{accounts, values, code, block_cache};
+   auto db = test::make_db<TypeParam>();
+   AccountState accounts{db};
+   ValueState values{db};
+   code_db_t code_db{};
+   CodeState code{code_db};
+   State t{accounts, values, code, block_cache};
 
-    db.commit(StateChanges{
-        .account_changes = {{b, Account{.balance = 40'000u}}},
-        .storage_changes = {{b, {{key1, value1}}}}});
+   db.commit(StateChanges{
+       .account_changes = {{b, Account{.balance = 40'000u}}},
+       .storage_changes = {{b, {{key1, value1}}}}});
 
-    auto bs = t.get_working_copy(0);
-    auto cs = t.get_working_copy(1);
+   auto bs = t.get_working_copy(0);
+   auto cs = t.get_working_copy(1);
 
-    {
-        bs.access_account(b);
-        EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+   {
+       bs.access_account(b);
+       EXPECT_EQ(bs.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
 
-        EXPECT_EQ(
-            t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
-        t.merge_changes(bs);
+       EXPECT_EQ(
+           t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
+       t.merge_changes(bs);
     }
     {
         cs.access_account(b);
@@ -248,7 +247,7 @@ TYPED_TEST(StateTest, cant_merge_colliding_storage)
 
 TYPED_TEST(StateTest, merge_txn0_and_txn1)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
     ValueState values{db};
     code_db_t code_db{};
@@ -290,7 +289,7 @@ TYPED_TEST(StateTest, merge_txn0_and_txn1)
 
 TYPED_TEST(StateTest, cant_merge_txn1_collision_need_to_rerun)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
     ValueState values{db};
     code_db_t code_db{};
@@ -344,7 +343,7 @@ TYPED_TEST(StateTest, cant_merge_txn1_collision_need_to_rerun)
 
 TYPED_TEST(StateTest, merge_txn1_try_again_merge_txn0_then_txn1)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
     ValueState values{db};
     code_db_t code_db{};
@@ -391,7 +390,7 @@ TYPED_TEST(StateTest, merge_txn1_try_again_merge_txn0_then_txn1)
 
 TYPED_TEST(StateTest, can_commit)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
     ValueState values{db};
     code_db_t code_db{};
@@ -440,7 +439,7 @@ TYPED_TEST(StateTest, can_commit)
 
 TYPED_TEST(StateTest, commit_twice)
 {
-    TypeParam db;
+    auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
     ValueState values{db};
     code_db_t code_db{};

--- a/src/monad/state/test/value_state.cpp
+++ b/src/monad/state/test/value_state.cpp
@@ -5,11 +5,14 @@
 
 #include <monad/state/value_state.hpp>
 
+#include <monad/state/state_changes.hpp>
+
 #include <monad/db/in_memory_db.hpp>
 #include <monad/db/in_memory_trie_db.hpp>
 #include <monad/db/rocks_db.hpp>
 #include <monad/db/rocks_trie_db.hpp>
-#include <monad/state/state_changes.hpp>
+
+#include <monad/test/make_db.hpp>
 
 #include <gtest/gtest.h>
 
@@ -44,7 +47,7 @@ TYPED_TEST_SUITE(ValueStateTest, DBTypes);
 
 TYPED_TEST(ValueStateTest, access_storage)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState t{db};
 
     auto s = typename decltype(t)::WorkingCopy{t};
@@ -61,7 +64,7 @@ TYPED_TEST(ValueStateTest, access_storage)
 
 TYPED_TEST(ValueStateTest, copy)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {c, Account{}}},
         .storage_changes = {
@@ -87,7 +90,7 @@ TYPED_TEST(ValueStateTest, get_storage)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {
@@ -107,7 +110,7 @@ TYPED_TEST(ValueStateTest, get_storage)
 
 TYPED_TEST(ValueStateTest, set_add_delete_touched)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState t{db};
 
     auto s = typename decltype(t)::WorkingCopy{t};
@@ -121,7 +124,7 @@ TYPED_TEST(ValueStateTest, set_add_delete_touched)
 
 TYPED_TEST(ValueStateTest, set_modify_delete_storage)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState t{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
@@ -147,7 +150,7 @@ TYPED_TEST(ValueStateTest, set_modify_delete_merged)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}, {key2, value2}}}}});
@@ -174,7 +177,7 @@ TYPED_TEST(ValueStateTest, set_modify_delete_merged)
 
 TYPED_TEST(ValueStateTest, multiple_get_and_set_from_storage)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState t{db};
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}, {c, Account{}}},
@@ -216,7 +219,7 @@ TYPED_TEST(ValueStateTest, multiple_get_and_set_from_merged)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {c, Account{}}},
         .storage_changes = {
@@ -259,7 +262,7 @@ TYPED_TEST(ValueStateTest, multiple_get_and_set_from_merged)
 
 TYPED_TEST(ValueStateTest, revert)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState t{db};
 
     auto s = typename decltype(t)::WorkingCopy{t};
@@ -281,7 +284,7 @@ TYPED_TEST(ValueStateTest, revert)
 
 TYPED_TEST(ValueStateTest, can_merge)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {
@@ -306,7 +309,7 @@ TYPED_TEST(ValueStateTest, can_merge)
 
 TYPED_TEST(ValueStateTest, can_merge_added)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState s{db};
 
     auto t = typename decltype(s)::WorkingCopy{s};
@@ -317,7 +320,7 @@ TYPED_TEST(ValueStateTest, can_merge_added)
 
 TYPED_TEST(ValueStateTest, can_merge_deleted)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key2, value2}}}}});
@@ -331,7 +334,7 @@ TYPED_TEST(ValueStateTest, can_merge_deleted)
 
 TYPED_TEST(ValueStateTest, can_merge_modified)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -345,7 +348,7 @@ TYPED_TEST(ValueStateTest, can_merge_modified)
 
 TYPED_TEST(ValueStateTest, can_merge_modify_merged_added)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState s{db};
 
     {
@@ -365,7 +368,7 @@ TYPED_TEST(ValueStateTest, can_merge_modify_merged_added)
 
 TYPED_TEST(ValueStateTest, can_merge_delete_merged_added)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState s{db};
 
     {
@@ -384,7 +387,7 @@ TYPED_TEST(ValueStateTest, can_merge_delete_merged_added)
 
 TYPED_TEST(ValueStateTest, can_merge_add_on_merged_deleted)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key2, value2}}}}});
@@ -406,7 +409,7 @@ TYPED_TEST(ValueStateTest, can_merge_add_on_merged_deleted)
 
 TYPED_TEST(ValueStateTest, can_merge_delete_merged_modified)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -434,7 +437,7 @@ TYPED_TEST(ValueStateTest, cant_merge_colliding_merge)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -451,7 +454,7 @@ TYPED_TEST(ValueStateTest, cant_merge_colliding_merge)
 
 TYPED_TEST(ValueStateTest, cant_merge_deleted_merge)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -470,7 +473,7 @@ TYPED_TEST(ValueStateTest, cant_merge_conflicting_adds)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     ValueState s{db};
 
     auto t = typename decltype(s)::WorkingCopy{s};
@@ -486,7 +489,7 @@ TYPED_TEST(ValueStateTest, cant_merge_conflicting_modifies)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value3}}}}});
@@ -503,7 +506,7 @@ TYPED_TEST(ValueStateTest, cant_merge_conflicting_modifies)
 
 TYPED_TEST(ValueStateTest, cant_merge_conflicting_deleted)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -522,7 +525,7 @@ TYPED_TEST(ValueStateTest, cant_merge_delete_conflicts_with_modify)
 {
     using diff_t = typename ValueState<TypeParam>::diff_t;
 
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}}});
@@ -539,7 +542,7 @@ TYPED_TEST(ValueStateTest, cant_merge_delete_conflicts_with_modify)
 
 TYPED_TEST(ValueStateTest, merge_touched_multiple)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}, {b, {{key1, value1}}}}});
@@ -570,7 +573,7 @@ TYPED_TEST(ValueStateTest, merge_touched_multiple)
 
 TYPED_TEST(ValueStateTest, can_commit)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}, {b, {{key1, value1}}}}});
@@ -603,7 +606,7 @@ TYPED_TEST(ValueStateTest, can_commit)
 
 TYPED_TEST(ValueStateTest, can_commit_restored)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}, {b, {{key1, value1}}}}});
@@ -644,7 +647,7 @@ TYPED_TEST(ValueStateTest, can_commit_restored)
 
 TYPED_TEST(ValueStateTest, commit_all_merged)
 {
-    TypeParam db{};
+    auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
         .storage_changes = {{a, {{key1, value1}}}, {b, {{key1, value1}}}}});

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/environment.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/trie_fixture.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/one_hundred_updates.hpp
+    ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/make_db.hpp
 )
 
 target_include_directories(

--- a/test/unit/common/include/monad/test/make_db.hpp
+++ b/test/unit/common/include/monad/test/make_db.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "config.hpp"
+#include <monad/core/assert.h>
+#include <monad/db/config.hpp>
+#include <test_resource_data.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+MONAD_DB_NAMESPACE_BEGIN
+
+struct InMemoryDB;
+struct InMemoryTrieDB;
+struct RocksDB;
+struct RocksTrieDB;
+
+MONAD_DB_NAMESPACE_END
+
+MONAD_TEST_NAMESPACE_BEGIN
+
+inline std::filesystem::path make_db_name(testing::TestInfo const &info)
+{
+    auto const test_suite_name = [&]() {
+        std::string name = info.test_suite_name();
+        std::ranges::replace(name, '/', '_');
+        return name;
+    }();
+
+    auto const dir = monad::test_resource::build_dir / "rocksdb" /
+                     test_suite_name / info.name();
+    std::filesystem::create_directories(dir);
+    return dir / fmt::format(
+                     "{}", std::chrono::system_clock::now().time_since_epoch());
+}
+
+template <typename TDatabase>
+    requires std::same_as<TDatabase, db::InMemoryDB> ||
+             std::same_as<TDatabase, db::InMemoryTrieDB> ||
+             std::same_as<TDatabase, db::RocksDB> ||
+             std::same_as<TDatabase, db::RocksTrieDB>
+inline TDatabase make_db()
+{
+    auto const *info = testing::UnitTest::GetInstance()->current_test_info();
+    MONAD_ASSERT(info);
+    if constexpr (
+        std::same_as<TDatabase, db::InMemoryDB> ||
+        std::same_as<TDatabase, db::InMemoryTrieDB>) {
+        return TDatabase{};
+    }
+    else {
+        return TDatabase{make_db_name(*info)};
+    }
+}
+
+MONAD_TEST_NAMESPACE_END


### PR DESCRIPTION
Problem:
- currently tests emit database files in whatever directory the command is ran from, which leads to messiness
- it is hard to tell which database files belong to which tests

Solution:
- make unit tests output to the build directory with a descriptive directory structure

Related to https://github.com/monad-crypto/monad/issues/104