### PR TITLE
:bug: Clear the accumulated gas reward after committing

### DIFF
--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -248,6 +248,7 @@ struct State
         accounts_.commit_all_merged();
         code_.commit_all_merged();
         current_txn_ = 0;
+        gas_award_ = 0;
     }
 
     [[nodiscard]] bytes32_t get_state_hash() const


### PR DESCRIPTION
Problem:
- The current gas award is not cleared after committing, so subsequent awards will accumulate.

Solution:
- Clear it after committing.