### PR TITLE
:recycle: Move recover_sender from FiberData to BP

### DIFF
--- a/include/monad/execution/block_processor.hpp
+++ b/include/monad/execution/block_processor.hpp
@@ -36,6 +36,7 @@ struct AllTxnBlockProcessor
 
         unsigned int i = 0;
         for (auto &txn : b.transactions) {
+            txn.from = recover_sender(txn);
             data.push_back({s, txn, b.header, i});
             fibers.emplace_back(data.back());
             ++i;

--- a/include/monad/execution/transaction_processor_data.hpp
+++ b/include/monad/execution/transaction_processor_data.hpp
@@ -27,7 +27,7 @@ struct alignas(64) TransactionProcessorFiberData
     using txn_processor_status_t = typename TTxnProcessor::Status;
 
     TState &s_;
-    Transaction &txn_;
+    Transaction const &txn_;
     BlockHeader const &bh_;
     unsigned int id_;
     Receipt result_{};
@@ -64,8 +64,6 @@ struct alignas(64) TransactionProcessorFiberData
         auto *txn_logger = log::logger_t::get_logger("txn_logger");
         auto const start_time = std::chrono::steady_clock::now();
 
-        txn_.from = recover_sender(txn_);
-
         MONAD_LOG_INFO(
             txn_logger,
             "Start executing Transaction {}, from = {}, to = {}",
@@ -95,7 +93,8 @@ struct alignas(64) TransactionProcessorFiberData
             }
 
             TEvmHost host{bh_, txn_, working_copy};
-            result_ = p.execute(working_copy, host, txn_, bh_.base_fee_per_gas.value_or(0));
+            result_ = p.execute(
+                working_copy, host, txn_, bh_.base_fee_per_gas.value_or(0));
 
             if (s_.can_merge_changes(working_copy) ==
                 TState::MergeStatus::WILL_SUCCEED) {

--- a/src/monad/core/transaction.cpp
+++ b/src/monad/core/transaction.cpp
@@ -25,10 +25,11 @@ std::optional<address_t> recover_sender(Transaction const &t)
     intx::be::unsafe::store(signature + sizeof(t.sc.r), t.sc.s);
 
     std::optional<address_t> res = evmc::address{};
-    std::unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
-        context(
-            secp256k1_context_create(SILKPRE_SECP256K1_CONTEXT_FLAGS),
-            &secp256k1_context_destroy);
+    static std::
+        unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
+            context(
+                secp256k1_context_create(SILKPRE_SECP256K1_CONTEXT_FLAGS),
+                &secp256k1_context_destroy);
     if (!silkpre_recover_address(
             res->bytes,
             txn_encoding_hash.bytes,


### PR DESCRIPTION
Problem:
- We currently call recover_sender from FiberData, which fails in parallel execution (maybe due to static secp library function)

Solution:
- Temporarily move this function to BlockProcessor
- Mark mem allocation part as static to avoid duplication

Future Work:
- Issue #188