### PR TITLE
:new: Add database restart support for replay_ethereum

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -9,10 +9,8 @@ MONAD_NAMESPACE_BEGIN
 namespace test_resource
 {
 
-    inline std::filesystem::__cxx11::path const test_data_dir =
-        "@TEST_DATA_DIR@";
-    inline std::filesystem::__cxx11::path const build_dir =
-        "@CMAKE_BINARY_DIR@";
+    inline std::filesystem::path const test_data_dir = "@TEST_DATA_DIR@";
+    inline std::filesystem::path const build_dir = "@CMAKE_BINARY_DIR@";
 
     // blocks
     inline auto const correct_block_data_dir =


### PR DESCRIPTION
- Add DB restart code
- Currently the DB state is stored under build/. So don't ever remove build/ if you don't want to lose all DB state.