### PR TITLE
:bug: Don't apply gas award to ommers

### DIFF
--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -80,12 +80,12 @@ namespace fork_traits
     {
         // reward block beneficiary, YP Eqn. 172
         uint256_t const miner_reward = reward + ommer_reward * b.ommers.size();
-        s.apply_reward(b.header.beneficiary, miner_reward);
+        s.apply_block_reward(b.header.beneficiary, miner_reward);
 
         // reward ommers, YP Eqn. 175
         for (auto &i : b.ommers) {
             auto const subtrahend = ((b.header.number - i.number) * reward) / 8;
-            s.apply_reward(i.beneficiary, reward - subtrahend);
+            s.apply_ommer_reward(i.beneficiary, reward - subtrahend);
         }
     }
 

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -190,7 +190,12 @@ namespace fake
 
         std::unordered_map<address_t, uint256_t> _block_reward{};
 
-        void apply_reward(address_t const &a, uint256_t const &r)
+        void apply_block_reward(address_t const &a, uint256_t const &r)
+        {
+            _block_reward.insert({a, r});
+        }
+
+        void apply_ommer_reward(address_t const &a, uint256_t const &r)
         {
             _block_reward.insert({a, r});
         }

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -194,9 +194,14 @@ struct State
     {
     }
 
-    void apply_reward(address_t const &a, uint256_t const &reward)
+    void apply_block_reward(address_t const &a, uint256_t const &reward)
     {
         accounts_.apply_reward(a, reward + gas_award_);
+    }
+
+    void apply_ommer_reward(address_t const &a, uint256_t const &reward)
+    {
+        accounts_.apply_reward(a, reward);
     }
 
     unsigned int current_txn() const { return current_txn_; }

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -98,7 +98,7 @@ TYPED_TEST(StateTest, apply_award)
 
    as.merge_changes(bs);
    as.merge_changes(cs);
-   as.apply_reward(a, 100);
+   as.apply_block_reward(a, 100);
    as.commit();
 
    auto ds = as.get_working_copy(2);
@@ -488,7 +488,7 @@ TYPED_TEST(StateTest, commit_twice)
     }
 }
 
-TYPED_TEST(StateTest, commit_twice_apply_block_award)
+TYPED_TEST(StateTest, commit_twice_apply_block_reward)
 {
     auto db = test::make_db<TypeParam>();
     AccountState accounts{db};
@@ -504,7 +504,7 @@ TYPED_TEST(StateTest, commit_twice_apply_block_award)
         EXPECT_EQ(
             t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
         t.merge_changes(bs);
-        t.apply_reward(a, 100);
+        t.apply_block_reward(a, 100);
         t.commit();
     }
     {
@@ -514,11 +514,14 @@ TYPED_TEST(StateTest, commit_twice_apply_block_award)
         EXPECT_EQ(
             t.can_merge_changes(bs), decltype(t)::MergeStatus::WILL_SUCCEED);
         t.merge_changes(bs);
-        t.apply_reward(a, 100);
+        t.apply_ommer_reward(b, 300);
+        t.apply_block_reward(a, 100);
         t.commit();
     }
 
     auto ds = t.get_working_copy(0);
     ds.access_account(a);
+    ds.access_account(b);
     EXPECT_EQ(ds.get_balance(a), bytes32_t{220});
+    EXPECT_EQ(ds.get_balance(b), bytes32_t{300});
 }

--- a/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
+++ b/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
@@ -31,6 +31,7 @@ using namespace monad;
 static constexpr auto from = 0x5353535353535353535353535353535353535353_address;
 static constexpr auto to = 0xbebebebebebebebebebebebebebebebebebebebe_address;
 static constexpr auto a = 0xa5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5_address;
+static constexpr auto o = 0xb5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5_address;
 
 using code_db_t = std::unordered_map<address_t, byte_string>;
 using account_store_db_t = db::InMemoryDB;
@@ -94,4 +95,65 @@ TEST(TxnProcEvmInterpStateHost, account_transfer)
     EXPECT_EQ(t.type, Transaction::Type::eip155);
     EXPECT_EQ(working_state.get_balance(from), bytes32_t{8'790'000});
     EXPECT_EQ(working_state.get_balance(to), bytes32_t{1'000'000});
+}
+
+TEST(TxnProcEvmInterpStateHost, block_gas_award_not_to_ommer)
+{
+    db::BlockDb blocks{test_resource::correct_block_data_dir};
+    account_store_db_t db{};
+    state::AccountState accounts{db};
+    state::ValueState values{db};
+    code_db_t code_db{};
+    state::CodeState codes{code_db};
+    state::State s{accounts, values, codes, blocks};
+
+    db.commit(state::StateChanges{
+        .account_changes =
+            {{a, Account{}},
+             {to, Account{}},
+             {from, Account{.balance = 10'000'000}}},
+        .storage_changes = {}});
+
+    BlockHeader const bh{.number = 2, .beneficiary = a};
+    BlockHeader const ommer{.number = 1, .beneficiary = o};
+    Transaction const t{
+        .nonce = 0,
+        .gas_price = 10,
+        .gas_limit = 25'000,
+        .amount = 1'000'000,
+        .to = to,
+        .from = from,
+        .type = Transaction::Type::eip155};
+    Block b{.header = bh, .transactions = {t}, .ommers = {ommer}};
+
+    auto working_state = s.get_working_copy(0u);
+
+    using state_t = decltype(working_state);
+    using fork_t = monad::fork_traits::byzantium;
+    using tp_t = execution::TransactionProcessor<state_t, fork_t>;
+
+    tp_t tp{};
+    evm_host_t<state_t, fork_t> h{bh, t, working_state};
+
+    EXPECT_EQ(tp.validate(working_state, t, 0), tp_t::Status::SUCCESS);
+
+    auto r = tp.execute(working_state, h, t, 0);
+    EXPECT_EQ(r.status, Receipt::Status::SUCCESS);
+    EXPECT_EQ(r.gas_used, 21'000);
+    EXPECT_EQ(t.type, Transaction::Type::eip155);
+    EXPECT_EQ(working_state.get_balance(from), bytes32_t{8'790'000});
+    EXPECT_EQ(working_state.get_balance(to), bytes32_t{1'000'000});
+
+    EXPECT_EQ(
+        s.can_merge_changes(working_state),
+        decltype(s)::MergeStatus::WILL_SUCCEED);
+    s.merge_changes(working_state);
+
+    fork_t::apply_block_award(s, b);
+
+    auto ws = s.get_working_copy(1u);
+    ws.access_account(a);
+    ws.access_account(o);
+    EXPECT_EQ(ws.get_balance(a), bytes32_t{3'093'750'000'000'210'000});
+    EXPECT_EQ(ws.get_balance(o), bytes32_t{2'625'000'000'000'000'000});
 }


### PR DESCRIPTION
Problem:
- The award accumulator is currently being applied to the ommers account, but that is incorrect.

Solution:
- Only apply the gas award to the block beneficiary.