### PR TITLE
:bug: Allow accounts to spring into existence

### DIFF
--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -47,7 +47,8 @@ struct AccountState
 
         if (!account_before.has_value()) {
             merged_.emplace(a, diff_t{account_before, Account{}});
-        } else if (!merged_.contains(a)) {
+        }
+        else if (!merged_.contains(a)) {
             merged_.emplace(a, diff_t{account_before, account_before});
         }
 
@@ -167,12 +168,14 @@ struct AccountState<TAccountDB>::WorkingCopy : public AccountState<TAccountDB>
     // EVMC Host Interface
     evmc_access_status access_account(address_t const &a)
     {
-        MONAD_DEBUG_ASSERT(account_exists(a));
         if (changed_.contains(a)) {
             return EVMC_ACCESS_WARM;
         }
+        auto const account = get_committed_storage(a).has_value()
+                                 ? get_committed_storage(a)
+                                 : Account{};
         changed_.emplace(
-            a, diff_t{get_committed_storage(a), *get_committed_storage(a)});
+            a, diff_t{get_committed_storage(a), account});
         return EVMC_ACCESS_COLD;
     }
 

--- a/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
+++ b/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
@@ -61,7 +61,6 @@ TEST(TxnProcEvmInterpStateHost, account_transfer_miner_ommer_award)
     db.commit(state::StateChanges{
         .account_changes =
             {{a, Account{}},
-             {to, Account{}},
              {from, Account{.balance = 10'000'000}}},
         .storage_changes = {}});
 


### PR DESCRIPTION
Problem:
- In Ethereum, brand new accounts are allowed to spring into existence by being transferred to.

Solution:
- When accessing, no longer assert that they must exist, but create them if they being accessed and previously not existing.
