### PR TITLE
:zap: Improve the performance of the InMemoryWriter

### DIFF
--- a/test/unit/common/include/monad/test/trie_fixture.hpp
+++ b/test/unit/common/include/monad/test/trie_fixture.hpp
@@ -153,9 +153,10 @@ struct in_memory_fixture : public ::testing::Test
     using cursor_t = monad::trie::InMemoryCursor<TComparator>;
     using writer_t = monad::trie::InMemoryWriter<TComparator>;
     using trie_t = monad::trie::Trie<cursor_t, writer_t>;
+    using storage_t = std::map<byte_string, byte_string, TComparator>;
 
-    std::vector<std::pair<byte_string, byte_string>> leaves_storage_;
-    std::vector<std::pair<byte_string, byte_string>> trie_storage_;
+    storage_t leaves_storage_;
+    storage_t trie_storage_;
     cursor_t leaves_cursor_;
     cursor_t trie_cursor_;
     writer_t leaves_writer_;


### PR DESCRIPTION
Problem:
- Performance when executing with InMemoryTrieDB is unacceptably slow

Solution:
- Do some low-hanging-fruit optimizatons to make more tenable

## Benchmarking (replay first 100 blocks):

Before
```
real    0m26.051s
user    0m30.111s
sys     0m0.108s
```
After
```
real    0m6.214s
user    0m7.479s
sys     0m0.216s
```