### PR TITLE
:recycle: simplify db async interface

### DIFF
--- a/include/monad/db/create_and_prune_block_history.hpp
+++ b/include/monad/db/create_and_prune_block_history.hpp
@@ -2,6 +2,7 @@
 
 #include <monad/db/config.hpp>
 #include <monad/db/util.hpp>
+#include <monad/execution/config.hpp>
 
 #include <fmt/format.h>
 #include <fmt/std.h>
@@ -13,9 +14,18 @@
 #include <iostream>
 #include <memory>
 
+MONAD_EXECUTION_NAMESPACE_BEGIN
+struct BoostFiberExecution;
+MONAD_EXECUTION_NAMESPACE_END
+
 MONAD_DB_NAMESPACE_BEGIN
 
-struct RocksTrieDB;
+namespace detail
+{
+    template <typename TExecution>
+    struct RocksTrieDB;
+};
+using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 template <typename TDB>
     requires std::same_as<TDB, db::RocksTrieDB>

--- a/include/monad/db/in_memory_db.hpp
+++ b/include/monad/db/in_memory_db.hpp
@@ -8,10 +8,9 @@ MONAD_DB_NAMESPACE_BEGIN
 
 // Database impl without trie root generating logic, backed by stl
 struct InMemoryDB
-    : public DBInterface<InMemoryDB, monad::execution::BoostFiberExecution>
+    : public DBInterface<InMemoryDB, monad::execution::SerialExecution>
 {
-    using DBInterface<
-        InMemoryDB, monad::execution::BoostFiberExecution>::updates;
+    using DBInterface<InMemoryDB, monad::execution::SerialExecution>::updates;
 
     std::unordered_map<address_t, Account> accounts;
     std::unordered_map<address_t, std::unordered_map<bytes32_t, bytes32_t>>

--- a/include/monad/db/in_memory_trie_db.hpp
+++ b/include/monad/db/in_memory_trie_db.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <monad/db/trie_db_interface.hpp>
+#include <monad/execution/execution_model.hpp>
 #include <monad/trie/in_memory_comparator.hpp>
 #include <monad/trie/in_memory_cursor.hpp>
 #include <monad/trie/in_memory_writer.hpp>
@@ -9,7 +10,8 @@
 MONAD_DB_NAMESPACE_BEGIN
 
 // Database impl with trie root generating logic, backed by stl
-struct InMemoryTrieDB : public TrieDBInterface<InMemoryTrieDB>
+struct InMemoryTrieDB
+    : public TrieDBInterface<InMemoryTrieDB, monad::execution::SerialExecution>
 {
     template <typename TComparator>
     struct Trie

--- a/include/monad/db/prepare_state.hpp
+++ b/include/monad/db/prepare_state.hpp
@@ -2,6 +2,7 @@
 
 #include <monad/db/config.hpp>
 #include <monad/db/util.hpp>
+#include <monad/execution/config.hpp>
 
 #include <fmt/format.h>
 #include <tl/expected.hpp>
@@ -9,9 +10,18 @@
 #include <concepts>
 #include <filesystem>
 
+MONAD_EXECUTION_NAMESPACE_BEGIN
+struct BoostFiberExecution;
+MONAD_EXECUTION_NAMESPACE_END
+
 MONAD_DB_NAMESPACE_BEGIN
 
-struct RocksTrieDB;
+namespace detail
+{
+    template <typename TExecution>
+    struct RocksTrieDB;
+};
+using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 // Preparing initial db state and return the path for opening. If preparation
 // fails, return a string explanation

--- a/include/monad/db/rocks_db.hpp
+++ b/include/monad/db/rocks_db.hpp
@@ -28,180 +28,183 @@ namespace detail
         std::copy_n(k.bytes, sizeof(bytes32_t), &key[sizeof(address_t)]);
         return key;
     }
-}
 
-// Database impl without trie root generating logic, backed by rocksdb
-struct RocksDB
-    : public DBInterface<RocksDB, monad::execution::BoostFiberExecution>
-{
-    using DBInterface<RocksDB, monad::execution::BoostFiberExecution>::updates;
-
-    rocksdb::Options options;
-    std::vector<rocksdb::ColumnFamilyDescriptor> cfds;
-    std::vector<rocksdb::ColumnFamilyHandle *> cfs;
-    std::shared_ptr<rocksdb::DB> db;
-    rocksdb::WriteBatch batch;
-
-    explicit RocksDB(std::filesystem::path name)
-        : options([]() {
-            rocksdb::Options ret;
-            ret.IncreaseParallelism(2);
-            ret.OptimizeLevelStyleCompaction();
-            ret.create_if_missing = true;
-            ret.create_missing_column_families = true;
-            return ret;
-        }())
-        , cfds([&]() -> decltype(cfds) {
-            return {
-                {rocksdb::kDefaultColumnFamilyName, {}},
-                {"PlainAccounts", {}},
-                {"PlainStorage", {}}};
-        }())
-        , cfs()
-        , db([&]() {
-            rocksdb::DB *db = nullptr;
-
-            rocksdb::Status const s =
-                rocksdb::DB::Open(options, name, cfds, &cfs, &db);
-
-            MONAD_ROCKS_ASSERT(s);
-            MONAD_ASSERT(cfds.size() == cfs.size());
-
-            return db;
-        }())
-        , batch()
+    // Database impl without trie root generating logic, backed by rocksdb
+    template <typename TExecutor>
+    struct RocksDB : public DBInterface<RocksDB<TExecutor>, TExecutor>
     {
-    }
+        using DBInterface<RocksDB<TExecutor>, TExecutor>::updates;
 
-    ~RocksDB()
-    {
-        rocksdb::Status res;
-        for (auto *const cf : cfs) {
-            res = db->DestroyColumnFamilyHandle(cf);
+        rocksdb::Options options;
+        std::vector<rocksdb::ColumnFamilyDescriptor> cfds;
+        std::vector<rocksdb::ColumnFamilyHandle *> cfs;
+        std::shared_ptr<rocksdb::DB> db;
+        rocksdb::WriteBatch batch;
+
+        explicit RocksDB(std::filesystem::path name)
+            : options([]() {
+                rocksdb::Options ret;
+                ret.IncreaseParallelism(2);
+                ret.OptimizeLevelStyleCompaction();
+                ret.create_if_missing = true;
+                ret.create_missing_column_families = true;
+                return ret;
+            }())
+            , cfds([&]() -> decltype(cfds) {
+                return {
+                    {rocksdb::kDefaultColumnFamilyName, {}},
+                    {"PlainAccounts", {}},
+                    {"PlainStorage", {}}};
+            }())
+            , cfs()
+            , db([&]() {
+                rocksdb::DB *db = nullptr;
+
+                rocksdb::Status const s =
+                    rocksdb::DB::Open(options, name, cfds, &cfs, &db);
+
+                MONAD_ROCKS_ASSERT(s);
+                MONAD_ASSERT(cfds.size() == cfs.size());
+
+                return db;
+            }())
+            , batch()
+        {
+        }
+
+        ~RocksDB()
+        {
+            rocksdb::Status res;
+            for (auto *const cf : cfs) {
+                res = db->DestroyColumnFamilyHandle(cf);
+                MONAD_ASSERT(res.ok());
+            }
+
+            res = db->Close();
+            MONAD_ROCKS_ASSERT(res);
+        }
+
+        ////////////////////////////////////////////////////////////////////
+        // Helper functions
+        ////////////////////////////////////////////////////////////////////
+
+        [[nodiscard]] constexpr auto *accounts_cf() { return cfs[1]; }
+        [[nodiscard]] constexpr auto *storage_cf() { return cfs[2]; }
+
+        void commit_db()
+        {
+            rocksdb::WriteOptions options;
+            options.disableWAL = true;
+            db->Write(options, &batch);
+            batch.Clear();
+        }
+
+        ////////////////////////////////////////////////////////////////////
+        // DBInterface implementations
+        ////////////////////////////////////////////////////////////////////
+
+        [[nodiscard]] bool contains(address_t const &a)
+        {
+            rocksdb::PinnableSlice value;
+            auto const res = db->Get(
+                rocksdb::ReadOptions{}, accounts_cf(), to_slice(a), &value);
+            MONAD_ASSERT(res.ok() || res.IsNotFound());
+            return res.ok();
+        }
+
+        [[nodiscard]] bool contains(address_t const &a, bytes32_t const &k)
+        {
+            auto const key = detail::make_basic_storage_key(a, k);
+            rocksdb::PinnableSlice value;
+            auto const res = db->Get(
+                rocksdb::ReadOptions{}, storage_cf(), to_slice(key), &value);
+            MONAD_ASSERT(res.ok() || res.IsNotFound());
+            return res.ok();
+        }
+
+        [[nodiscard]] std::optional<Account> try_find(address_t const &a)
+        {
+            rocksdb::PinnableSlice value;
+            auto const res = db->Get(
+                rocksdb::ReadOptions{}, accounts_cf(), to_slice(a), &value);
+            if (res.IsNotFound()) {
+                return std::nullopt;
+            }
             MONAD_ASSERT(res.ok());
+
+            Account ret;
+            bytes32_t _;
+            auto const rest = rlp::decode_account(
+                ret,
+                _,
+                {reinterpret_cast<byte_string_view::value_type const *>(
+                     value.data()),
+                 value.size()});
+            MONAD_ASSERT(rest.empty());
+            return ret;
         }
 
-        res = db->Close();
-        MONAD_ROCKS_ASSERT(res);
-    }
-
-    ////////////////////////////////////////////////////////////////////
-    // Helper functions
-    ////////////////////////////////////////////////////////////////////
-
-    [[nodiscard]] constexpr auto *accounts_cf() { return cfs[1]; }
-    [[nodiscard]] constexpr auto *storage_cf() { return cfs[2]; }
-
-    void commit_db()
-    {
-        rocksdb::WriteOptions options;
-        options.disableWAL = true;
-        db->Write(options, &batch);
-        batch.Clear();
-    }
-
-    ////////////////////////////////////////////////////////////////////
-    // DBInterface implementations
-    ////////////////////////////////////////////////////////////////////
-
-    [[nodiscard]] bool contains(address_t const &a)
-    {
-        rocksdb::PinnableSlice value;
-        auto const res =
-            db->Get(rocksdb::ReadOptions{}, accounts_cf(), to_slice(a), &value);
-        MONAD_ASSERT(res.ok() || res.IsNotFound());
-        return res.ok();
-    }
-
-    [[nodiscard]] bool contains(address_t const &a, bytes32_t const &k)
-    {
-        auto const key = detail::make_basic_storage_key(a, k);
-        rocksdb::PinnableSlice value;
-        auto const res = db->Get(
-            rocksdb::ReadOptions{}, storage_cf(), to_slice(key), &value);
-        MONAD_ASSERT(res.ok() || res.IsNotFound());
-        return res.ok();
-    }
-
-    [[nodiscard]] std::optional<Account> try_find(address_t const &a)
-    {
-        rocksdb::PinnableSlice value;
-        auto const res =
-            db->Get(rocksdb::ReadOptions{}, accounts_cf(), to_slice(a), &value);
-        if (res.IsNotFound()) {
-            return std::nullopt;
+        [[nodiscard]] std::optional<bytes32_t>
+        try_find(address_t const &a, bytes32_t const &k)
+        {
+            auto const key = detail::make_basic_storage_key(a, k);
+            rocksdb::PinnableSlice value;
+            auto const res = db->Get(
+                rocksdb::ReadOptions{}, storage_cf(), to_slice(key), &value);
+            if (res.IsNotFound()) {
+                return std::nullopt;
+            }
+            MONAD_ROCKS_ASSERT(res);
+            MONAD_ASSERT(value.size() == sizeof(bytes32_t));
+            bytes32_t result;
+            std::copy_n(value.data(), sizeof(bytes32_t), result.bytes);
+            return result;
         }
-        MONAD_ASSERT(res.ok());
 
-        Account ret;
-        bytes32_t _;
-        auto const rest = rlp::decode_account(
-            ret,
-            _,
-            {reinterpret_cast<byte_string_view::value_type const *>(
-                 value.data()),
-             value.size()});
-        MONAD_ASSERT(rest.empty());
-        return ret;
-    }
+        void commit(state::changeset auto const &obj)
+        {
+            for (auto const &[a, updates] : obj.storage_changes) {
+                for (auto const &[k, v] : updates) {
+                    auto const key = detail::make_basic_storage_key(a, k);
+                    if (v != bytes32_t{}) {
+                        auto const res =
+                            batch.Put(storage_cf(), to_slice(key), to_slice(v));
+                        MONAD_ROCKS_ASSERT(res);
+                    }
+                    else {
+                        auto const res =
+                            batch.Delete(storage_cf(), to_slice(key));
+                        MONAD_ROCKS_ASSERT(res);
+                    }
+                }
+            }
 
-    [[nodiscard]] std::optional<bytes32_t>
-    try_find(address_t const &a, bytes32_t const &k)
-    {
-        auto const key = detail::make_basic_storage_key(a, k);
-        rocksdb::PinnableSlice value;
-        auto const res = db->Get(
-            rocksdb::ReadOptions{}, storage_cf(), to_slice(key), &value);
-        if (res.IsNotFound()) {
-            return std::nullopt;
-        }
-        MONAD_ROCKS_ASSERT(res);
-        MONAD_ASSERT(value.size() == sizeof(bytes32_t));
-        bytes32_t result;
-        std::copy_n(value.data(), sizeof(bytes32_t), result.bytes);
-        return result;
-    }
-
-    void commit(state::changeset auto const &obj)
-    {
-        for (auto const &[a, updates] : obj.storage_changes) {
-            for (auto const &[k, v] : updates) {
-                auto const key = detail::make_basic_storage_key(a, k);
-                if (v != bytes32_t{}) {
-                    auto const res =
-                        batch.Put(storage_cf(), to_slice(key), to_slice(v));
+            for (auto const &[a, acct] : obj.account_changes) {
+                if (acct.has_value()) {
+                    // Note: no storage root calculations in this mode
+                    auto const res = batch.Put(
+                        accounts_cf(),
+                        to_slice(a),
+                        to_slice(rlp::encode_account(acct.value(), NULL_ROOT)));
                     MONAD_ROCKS_ASSERT(res);
                 }
                 else {
-                    auto const res = batch.Delete(storage_cf(), to_slice(key));
+                    auto const res = batch.Delete(accounts_cf(), to_slice(a));
                     MONAD_ROCKS_ASSERT(res);
                 }
             }
+
+            commit_db();
         }
 
-        for (auto const &[a, acct] : obj.account_changes) {
-            if (acct.has_value()) {
-                // Note: no storage root calculations in this mode
-                auto const res = batch.Put(
-                    accounts_cf(),
-                    to_slice(a),
-                    to_slice(rlp::encode_account(acct.value(), NULL_ROOT)));
-                MONAD_ROCKS_ASSERT(res);
-            }
-            else {
-                auto const res = batch.Delete(accounts_cf(), to_slice(a));
-                MONAD_ROCKS_ASSERT(res);
-            }
+        constexpr void
+        create_and_prune_block_history(uint64_t /* block_number */) const
+        {
+            // implement this if support for block history is needed here
         }
+    };
+}
 
-        commit_db();
-    }
-
-    constexpr void
-    create_and_prune_block_history(uint64_t /* block_number */) const
-    {
-        // implement this if support for block history is needed here
-    }
-};
+using RocksDB = detail::RocksDB<monad::execution::BoostFiberExecution>;
 
 MONAD_DB_NAMESPACE_END

--- a/include/monad/db/rocks_trie_db.hpp
+++ b/include/monad/db/rocks_trie_db.hpp
@@ -4,6 +4,7 @@
 #include <monad/db/create_and_prune_block_history.hpp>
 #include <monad/db/prepare_state.hpp>
 #include <monad/db/trie_db_interface.hpp>
+#include <monad/execution/execution_model.hpp>
 #include <monad/trie/rocks_comparator.hpp>
 #include <monad/trie/rocks_cursor.hpp>
 #include <monad/trie/rocks_writer.hpp>
@@ -16,163 +17,172 @@
 
 MONAD_DB_NAMESPACE_BEGIN
 
-// Database impl with trie root generating logic, backed by rocksdb
-struct RocksTrieDB : public TrieDBInterface<RocksTrieDB>
+namespace detail
 {
-    using base_t = TrieDBInterface<RocksTrieDB>;
-
-    struct Trie
+    // Database impl with trie root generating logic, backed by rocksdb
+    template <typename TExecutor>
+    struct RocksTrieDB
+        : public TrieDBInterface<RocksTrieDB<TExecutor>, TExecutor>
     {
-        trie::RocksCursor leaves_cursor;
-        trie::RocksCursor trie_cursor;
-        trie::RocksWriter leaves_writer;
-        trie::RocksWriter trie_writer;
+        using base_t = TrieDBInterface<RocksTrieDB<TExecutor>, TExecutor>;
 
-        trie::Trie<trie::RocksCursor, trie::RocksWriter> trie;
-
-        Trie(
-            std::shared_ptr<rocksdb::DB> db, rocksdb::ColumnFamilyHandle *lc,
-            rocksdb::ColumnFamilyHandle *tc)
-            : leaves_cursor(db, lc)
-            , trie_cursor(db, tc)
-            , leaves_writer(trie::RocksWriter{
-                  .db = db, .batch = rocksdb::WriteBatch{}, .cf = lc})
-            , trie_writer(trie::RocksWriter{
-                  .db = db, .batch = rocksdb::WriteBatch{}, .cf = tc})
-            , trie(leaves_cursor, trie_cursor, leaves_writer, trie_writer)
+        struct Trie
         {
-        }
+            trie::RocksCursor leaves_cursor;
+            trie::RocksCursor trie_cursor;
+            trie::RocksWriter leaves_writer;
+            trie::RocksWriter trie_writer;
 
-        void reset_cursor()
-        {
-            leaves_cursor.reset();
-            trie_cursor.reset();
-        }
+            trie::Trie<trie::RocksCursor, trie::RocksWriter> trie;
 
-        [[nodiscard]] trie::RocksCursor make_leaf_cursor() const
-        {
-            return trie::RocksCursor{leaves_cursor.db_, leaves_cursor.cf_};
-        }
-
-        [[nodiscard]] trie::RocksCursor make_trie_cursor() const
-        {
-            return trie::RocksCursor{trie_cursor.db_, trie_cursor.cf_};
-        }
-    };
-
-    std::filesystem::path const root;
-    uint64_t const block_history_size;
-    rocksdb::Options options;
-    trie::PathComparator accounts_comparator;
-    trie::PrefixPathComparator storage_comparator;
-    std::vector<rocksdb::ColumnFamilyDescriptor> cfds;
-    std::vector<rocksdb::ColumnFamilyHandle *> cfs;
-    std::shared_ptr<rocksdb::DB> db;
-    Trie accounts_trie;
-    Trie storage_trie;
-
-    RocksTrieDB(
-        std::filesystem::path root, uint64_t block_number,
-        uint64_t block_history_size)
-        : root(root)
-        , block_history_size(block_history_size)
-        , options([]() {
-            rocksdb::Options ret;
-            ret.IncreaseParallelism(2);
-            ret.OptimizeLevelStyleCompaction();
-            ret.create_if_missing = true;
-            ret.create_missing_column_families = true;
-            return ret;
-        }())
-        , accounts_comparator()
-        , storage_comparator()
-        , cfds([&]() -> decltype(cfds) {
-            rocksdb::ColumnFamilyOptions accounts_opts;
-            rocksdb::ColumnFamilyOptions storage_opts;
-            accounts_opts.comparator = &accounts_comparator;
-            storage_opts.comparator = &storage_comparator;
-
-            return {
-                {rocksdb::kDefaultColumnFamilyName, {}},
-                {"AccountTrieLeaves", accounts_opts},
-                {"AccountTrieAll", accounts_opts},
-                {"StorageTrieLeaves", storage_opts},
-                {"StorageTrieAll", storage_opts}};
-        }())
-        , cfs()
-        , db([&]() {
-            rocksdb::DB *db = nullptr;
-
-            auto const path = prepare_state(*this, block_number);
-            if (!path.has_value()) {
-                throw std::runtime_error(path.error());
+            Trie(
+                std::shared_ptr<rocksdb::DB> db,
+                rocksdb::ColumnFamilyHandle *lc,
+                rocksdb::ColumnFamilyHandle *tc)
+                : leaves_cursor(db, lc)
+                , trie_cursor(db, tc)
+                , leaves_writer(trie::RocksWriter{
+                      .db = db, .batch = rocksdb::WriteBatch{}, .cf = lc})
+                , trie_writer(trie::RocksWriter{
+                      .db = db, .batch = rocksdb::WriteBatch{}, .cf = tc})
+                , trie(leaves_cursor, trie_cursor, leaves_writer, trie_writer)
+            {
             }
-            rocksdb::Status const s =
-                rocksdb::DB::Open(options, path.value(), cfds, &cfs, &db);
 
-            MONAD_ROCKS_ASSERT(s);
-            MONAD_ASSERT(cfds.size() == cfs.size());
+            void reset_cursor()
+            {
+                leaves_cursor.reset();
+                trie_cursor.reset();
+            }
 
-            return db;
-        }())
-        , accounts_trie(db, cfs[1], cfs[2])
-        , storage_trie(db, cfs[3], cfs[4])
-    {
-    }
+            [[nodiscard]] trie::RocksCursor make_leaf_cursor() const
+            {
+                return trie::RocksCursor{leaves_cursor.db_, leaves_cursor.cf_};
+            }
 
-    ~RocksTrieDB()
-    {
-        accounts_trie.reset_cursor();
-        storage_trie.reset_cursor();
+            [[nodiscard]] trie::RocksCursor make_trie_cursor() const
+            {
+                return trie::RocksCursor{trie_cursor.db_, trie_cursor.cf_};
+            }
+        };
 
-        rocksdb::Status res;
-        for (auto *const cf : cfs) {
-            res = db->DestroyColumnFamilyHandle(cf);
-            MONAD_ASSERT(res.ok());
+        std::filesystem::path const root;
+        uint64_t const block_history_size;
+        rocksdb::Options options;
+        trie::PathComparator accounts_comparator;
+        trie::PrefixPathComparator storage_comparator;
+        std::vector<rocksdb::ColumnFamilyDescriptor> cfds;
+        std::vector<rocksdb::ColumnFamilyHandle *> cfs;
+        std::shared_ptr<rocksdb::DB> db;
+        Trie accounts_trie;
+        Trie storage_trie;
+
+        RocksTrieDB(
+            std::filesystem::path root, uint64_t block_number,
+            uint64_t block_history_size)
+            : root(root)
+            , block_history_size(block_history_size)
+            , options([]() {
+                rocksdb::Options ret;
+                ret.IncreaseParallelism(2);
+                ret.OptimizeLevelStyleCompaction();
+                ret.create_if_missing = true;
+                ret.create_missing_column_families = true;
+                return ret;
+            }())
+            , accounts_comparator()
+            , storage_comparator()
+            , cfds([&]() -> decltype(cfds) {
+                rocksdb::ColumnFamilyOptions accounts_opts;
+                rocksdb::ColumnFamilyOptions storage_opts;
+                accounts_opts.comparator = &accounts_comparator;
+                storage_opts.comparator = &storage_comparator;
+
+                return {
+                    {rocksdb::kDefaultColumnFamilyName, {}},
+                    {"AccountTrieLeaves", accounts_opts},
+                    {"AccountTrieAll", accounts_opts},
+                    {"StorageTrieLeaves", storage_opts},
+                    {"StorageTrieAll", storage_opts}};
+            }())
+            , cfs()
+            , db([&]() {
+                rocksdb::DB *db = nullptr;
+
+                auto const path = prepare_state(*this, block_number);
+                if (!path.has_value()) {
+                    throw std::runtime_error(path.error());
+                }
+                rocksdb::Status const s =
+                    rocksdb::DB::Open(options, path.value(), cfds, &cfs, &db);
+
+                MONAD_ROCKS_ASSERT(s);
+                MONAD_ASSERT(cfds.size() == cfs.size());
+
+                return db;
+            }())
+            , accounts_trie(db, cfs[1], cfs[2])
+            , storage_trie(db, cfs[3], cfs[4])
+        {
         }
 
-        res = db->Close();
-        MONAD_ROCKS_ASSERT(res);
-    }
+        ~RocksTrieDB()
+        {
+            accounts_trie.reset_cursor();
+            storage_trie.reset_cursor();
 
-    ////////////////////////////////////////////////////////////////////
-    // DBInterface implementations
-    ////////////////////////////////////////////////////////////////////
+            rocksdb::Status res;
+            for (auto *const cf : cfs) {
+                res = db->DestroyColumnFamilyHandle(cf);
+                MONAD_ASSERT(res.ok());
+            }
 
-    void create_and_prune_block_history(uint64_t block_number)
-    {
-        auto const s =
-            ::monad::db::create_and_prune_block_history(*this, block_number);
-        if (!s.has_value()) {
-            // this is not a critical error in production, we can continue
-            // executing with the current database while someone investigates
-            MONAD_LOG_ERROR(
-                base_t::logger,
-                "Unable to save block_number {} for {} error={}",
-                block_number,
-                as_string<RocksTrieDB>(),
-                s.error());
+            res = db->Close();
+            MONAD_ROCKS_ASSERT(res);
         }
 
-        // kill in debug
-        MONAD_DEBUG_ASSERT(s.has_value());
-    }
+        ////////////////////////////////////////////////////////////////////
+        // DBInterface implementations
+        ////////////////////////////////////////////////////////////////////
 
-    void commit(state::changeset auto const &obj)
-    {
-        base_t::commit(obj);
-        accounts_trie.reset_cursor();
-        storage_trie.reset_cursor();
-    }
+        void create_and_prune_block_history(uint64_t block_number)
+        {
+            auto const s = ::monad::db::create_and_prune_block_history(
+                *this, block_number);
+            if (!s.has_value()) {
+                // this is not a critical error in production, we can continue
+                // executing with the current database while someone
+                // investigates
+                MONAD_LOG_ERROR(
+                    base_t::logger,
+                    "Unable to save block_number {} for {} error={}",
+                    block_number,
+                    as_string<RocksTrieDB>(),
+                    s.error());
+            }
 
-    ////////////////////////////////////////////////////////////////////
-    // TrieDBInterface implementations
-    ////////////////////////////////////////////////////////////////////
+            // kill in debug
+            MONAD_DEBUG_ASSERT(s.has_value());
+        }
 
-    auto &accounts() { return accounts_trie; }
-    auto &storage() { return storage_trie; }
-    auto const &accounts() const { return accounts_trie; }
-    auto const &storage() const { return storage_trie; }
+        void commit(state::changeset auto const &obj)
+        {
+            base_t::commit(obj);
+            accounts_trie.reset_cursor();
+            storage_trie.reset_cursor();
+        }
+
+        ////////////////////////////////////////////////////////////////////
+        // TrieDBInterface implementations
+        ////////////////////////////////////////////////////////////////////
+
+        auto &accounts() { return accounts_trie; }
+        auto &storage() { return storage_trie; }
+        auto const &accounts() const { return accounts_trie; }
+        auto const &storage() const { return storage_trie; }
+    };
 };
+
+using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 MONAD_DB_NAMESPACE_END

--- a/include/monad/db/util.hpp
+++ b/include/monad/db/util.hpp
@@ -2,12 +2,22 @@
 
 #include <monad/core/byte_string.hpp>
 #include <monad/db/config.hpp>
+#include <monad/execution/config.hpp>
 
 #include <rocksdb/slice.h>
 
+MONAD_EXECUTION_NAMESPACE_BEGIN
+struct BoostFiberExecution;
+MONAD_EXECUTION_NAMESPACE_END
+
 MONAD_DB_NAMESPACE_BEGIN
 
-struct RocksTrieDB;
+namespace detail
+{
+    template <typename TExecution>
+    struct RocksTrieDB;
+};
+using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 template <typename TDB>
     requires std::same_as<TDB, db::RocksTrieDB>

--- a/include/monad/execution/execution_model.hpp
+++ b/include/monad/execution/execution_model.hpp
@@ -4,6 +4,7 @@
 
 #include <boost/fiber/all.hpp>
 
+#include <concepts>
 #include <thread>
 
 MONAD_EXECUTION_NAMESPACE_BEGIN
@@ -13,15 +14,23 @@ struct BoostFiberExecution
     using fiber_t = boost::fibers::fiber;
     static void yield() noexcept { boost::this_fiber::yield(); }
 
-    [[nodiscard]] constexpr static auto get_executor() noexcept
+    [[nodiscard]] static auto execute(std::invocable auto &&f)
     {
-        return [](auto &&f) {
-            using result_t = decltype(std::declval<decltype(f)>()());
-            boost::fibers::promise<result_t> promise;
-            auto future = promise.get_future();
-            std::jthread thread{[&promise, f] { promise.set_value(f()); }};
-            return future.get();
-        };
+        using result_t = decltype(std::declval<decltype(f)>()());
+        boost::fibers::promise<result_t> promise;
+        auto future = promise.get_future();
+        std::jthread thread{[&promise, &f] {
+            promise.set_value(std::invoke(std::forward<decltype(f)>(f)));
+        }};
+        return future.get();
+    }
+};
+
+struct SerialExecution
+{
+    [[nodiscard]] constexpr static auto execute(std::invocable auto &&f)
+    {
+        return std::invoke(std::forward<decltype(f)>(f));
     }
 };
 

--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -61,7 +61,7 @@ struct AccountState
         if (merged_.contains(a)) {
             return merged_.at(a).updated;
         }
-        return db_.query(a);
+        return db_.try_find(a);
     }
 
     // EVMC Host Interface

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -87,7 +87,7 @@ struct ValueState
         if (merged_.contains_key(a, key)) {
             return merged_.storage_.at(a).at(key).updated;
         }
-        return db_.query(a, key).value_or(bytes32_t{});
+        return db_.try_find(a, key).value_or(bytes32_t{});
     }
 
     // Note: just for debug testing
@@ -95,7 +95,7 @@ struct ValueState
     {
         for (auto const &[a, key_set] : merged_.deleted_storage_) {
             for (auto const &[orig, key] : key_set) {
-                if (db_.query(a, key).value_or(bytes32_t{}) != orig) {
+                if (db_.try_find(a, key).value_or(bytes32_t{}) != orig) {
                     return false;
                 }
             }

--- a/src/monad/db/test/db.cpp
+++ b/src/monad/db/test/db.cpp
@@ -75,20 +75,6 @@ TEST(InMemoryTrieDB, account_creation)
     EXPECT_EQ(db.at(a), acct);
 }
 
-TYPED_TEST(DBTest, query)
-{
-    auto db = test::make_db<TypeParam>();
-    Account acct{.balance = 1'000'000, .code_hash = hash1, .nonce = 1337};
-    db.commit(state::StateChanges{
-        .account_changes = {{a, acct}},
-        .storage_changes = {{a, {{key1, value1}, {key2, value2}}}}});
-
-    EXPECT_EQ(db.query(a), acct);
-    EXPECT_FALSE(db.query(b).has_value());
-    EXPECT_EQ(db.query(a, key1), value1);
-    EXPECT_EQ(db.query(a, key2), value2);
-}
-
 TEST(InMemoryTrieDB, erase)
 {
     auto db = test::make_db<InMemoryTrieDB>();

--- a/test/unit/common/include/monad/test/make_db.hpp
+++ b/test/unit/common/include/monad/test/make_db.hpp
@@ -2,7 +2,10 @@
 
 #include "config.hpp"
 #include <monad/core/assert.h>
-#include <monad/db/config.hpp>
+#include <monad/db/in_memory_db.hpp>
+#include <monad/db/in_memory_trie_db.hpp>
+#include <monad/db/rocks_db.hpp>
+#include <monad/db/rocks_trie_db.hpp>
 #include <test_resource_data.h>
 
 #include <algorithm>
@@ -12,15 +15,6 @@
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
-
-MONAD_DB_NAMESPACE_BEGIN
-
-struct InMemoryDB;
-struct InMemoryTrieDB;
-struct RocksDB;
-struct RocksTrieDB;
-
-MONAD_DB_NAMESPACE_END
 
 MONAD_TEST_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Problem:
- db interface contains an extraneous function (query) which enables async operation
- some people have found this to bloat the API

Solution:
- wrap all interface functions with an executor to control asynchrony
- sunset query