### PR TITLE
🚚  Rename working copy of state to ChangeSet

### DIFF
--- a/include/monad/execution/replay_block_db.hpp
+++ b/include/monad/execution/replay_block_db.hpp
@@ -46,7 +46,7 @@ public:
         block_num_t block_number;
     };
 
-    template <concepts::fork_traits<typename TState::WorkingCopy> TTraits>
+    template <concepts::fork_traits<typename TState::ChangeSet> TTraits>
     [[nodiscard]] constexpr block_num_t
     loop_until(std::optional<block_num_t> until_block_number)
     {
@@ -90,7 +90,7 @@ public:
     }
 
     template <
-        concepts::fork_traits<typename TState::WorkingCopy> TTraits,
+        concepts::fork_traits<typename TState::ChangeSet> TTraits,
         template <typename, typename> class TTxnProcessor,
         template <typename, typename, typename, typename> class TEvm,
         template <typename, typename, typename> class TStaticPrecompiles,
@@ -137,15 +137,15 @@ public:
                     TTraits,
                     TFiberData<
                         TState,
-                        TTxnProcessor<typename TState::WorkingCopy, TTraits>,
+                        TTxnProcessor<typename TState::ChangeSet, TTraits>,
                         TEvmHost<
-                            typename TState::WorkingCopy,
+                            typename TState::ChangeSet,
                             TTraits,
                             TEvm<
-                                typename TState::WorkingCopy,
+                                typename TState::ChangeSet,
                                 TTraits,
                                 TStaticPrecompiles<
-                                    typename TState::WorkingCopy,
+                                    typename TState::ChangeSet,
                                     TTraits,
                                     TPrecompiles>,
                                 TInterpreter>>,
@@ -199,7 +199,7 @@ public:
     }
 
     template <
-        concepts::fork_traits<typename TState::WorkingCopy> TTraits,
+        concepts::fork_traits<typename TState::ChangeSet> TTraits,
         template <typename, typename> class TTxnProcessor,
         template <typename, typename, typename, typename> class TEvm,
         template <typename, typename, typename> class TStaticPrecompiles,

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -43,7 +43,7 @@ namespace fake
 
     struct State
     {
-        struct WorkingCopy
+        struct ChangeSet
         {
             std::unordered_map<address_t, Account> _accounts{};
             std::unordered_map<address_t, byte_string> _code{};
@@ -55,9 +55,9 @@ namespace fake
             uint64_t _suicides{};
             uint256_t _reward{};
 
-            WorkingCopy() = default;
+            ChangeSet() = default;
 
-            WorkingCopy(unsigned int id)
+            ChangeSet(unsigned int id)
                 : _txn_id{id}
             {
             }
@@ -215,17 +215,17 @@ namespace fake
 
         unsigned int current_txn() { return _current_txn; }
 
-        WorkingCopy get_working_copy(unsigned int id)
+        ChangeSet get_new_changeset(unsigned int id)
         {
-            return WorkingCopy(id);
+            return ChangeSet(id);
         }
 
-        MergeStatus can_merge_changes(WorkingCopy const &)
+        MergeStatus can_merge_changes(ChangeSet const &)
         {
             return _merge_status;
         }
 
-        void merge_changes(WorkingCopy &) { return; }
+        void merge_changes(ChangeSet &) { return; }
 
         void commit() const noexcept { return; }
 

--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -22,7 +22,7 @@ struct AccountState
     using diff_t = diff<std::optional<Account>>;
     using change_set_t = std::unordered_map<address_t, diff_t>;
 
-    struct WorkingCopy;
+    struct ChangeSet;
 
     // TODO Irrevocable change separated out to avoid reversion
     TAccountDB &db_;
@@ -92,14 +92,14 @@ struct AccountState
         return get_committed_storage(a).value_or(Account{}).code_hash;
     }
 
-    [[nodiscard]] bool can_merge(WorkingCopy const &diffs) const noexcept
+    [[nodiscard]] bool can_merge(ChangeSet const &diffs) const noexcept
     {
         return std::ranges::all_of(diffs.changed_, [&](auto const &p) {
             return get_committed_storage(p.first) == p.second.orig;
         });
     }
 
-    void merge_changes(WorkingCopy &diffs)
+    void merge_changes(ChangeSet &diffs)
     {
         assert(can_merge(diffs));
 
@@ -141,7 +141,7 @@ struct AccountState
 };
 
 template <typename TAccountDB>
-struct AccountState<TAccountDB>::WorkingCopy : public AccountState<TAccountDB>
+struct AccountState<TAccountDB>::ChangeSet : public AccountState<TAccountDB>
 {
     change_set_t changed_{};
     uint64_t total_selfdestructs_{};

--- a/include/monad/state/code_state.hpp
+++ b/include/monad/state/code_state.hpp
@@ -21,7 +21,7 @@ struct CodeState
 {
     using map_t = std::unordered_map<address_t, byte_string>;
 
-    struct WorkingCopy;
+    struct ChangeSet;
 
     TCodeDB &db_;
     map_t merged_{};
@@ -43,14 +43,14 @@ struct CodeState
         return {empty};
     }
 
-    [[nodiscard]] bool can_merge(WorkingCopy const &w) const
+    [[nodiscard]] bool can_merge(ChangeSet const &w) const
     {
         return std::ranges::none_of(w.code_, [&](auto const &a) {
             return merged_.contains(a.first) || db_.contains(a.first);
         });
     }
 
-    void merge_changes(WorkingCopy &w)
+    void merge_changes(ChangeSet &w)
     {
         assert(can_merge(w));
 
@@ -79,11 +79,11 @@ struct CodeState
 };
 
 template <typename TCodeDB>
-struct CodeState<TCodeDB>::WorkingCopy : public CodeState<TCodeDB>
+struct CodeState<TCodeDB>::ChangeSet : public CodeState<TCodeDB>
 {
     map_t code_{};
 
-    explicit WorkingCopy(CodeState const &c)
+    explicit ChangeSet(CodeState const &c)
         : CodeState(c)
     {
     }

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -21,20 +21,20 @@ template <
     class TDatabase>
 struct State
 {
-    struct WorkingCopy
+    struct ChangeSet
     {
         uint256_t gas_award_{};
-        typename TAccountState::WorkingCopy accounts_;
-        typename TValueState::WorkingCopy storage_;
-        typename TCodeState::WorkingCopy code_;
+        typename TAccountState::ChangeSet accounts_;
+        typename TValueState::ChangeSet storage_;
+        typename TCodeState::ChangeSet code_;
         std::vector<Receipt::Log> logs_{};
         TBlockCache &block_cache_{};
         unsigned int txn_id_{};
 
-        WorkingCopy(
-            unsigned int i, typename TAccountState::WorkingCopy &&a,
-            typename TValueState::WorkingCopy &&s,
-            typename TCodeState::WorkingCopy &&c, TBlockCache &b)
+        ChangeSet(
+            unsigned int i, typename TAccountState::ChangeSet &&a,
+            typename TValueState::ChangeSet &&s,
+            typename TCodeState::ChangeSet &&c, TBlockCache &b)
             : accounts_{std::move(a)}
             , storage_{std::move(s)}
             , code_{std::move(c)}
@@ -212,17 +212,17 @@ struct State
 
     unsigned int current_txn() const { return current_txn_; }
 
-    WorkingCopy get_working_copy(unsigned int id) const
+    ChangeSet get_new_changeset(unsigned int id) const
     {
-        return WorkingCopy(
+        return ChangeSet(
             id,
-            typename TAccountState::WorkingCopy{accounts_},
-            typename TValueState::WorkingCopy{storage_},
-            typename TCodeState::WorkingCopy{code_},
+            typename TAccountState::ChangeSet{accounts_},
+            typename TValueState::ChangeSet{storage_},
+            typename TCodeState::ChangeSet{code_},
             block_cache_);
     }
 
-    MergeStatus can_merge_changes(WorkingCopy const &c) const
+    MergeStatus can_merge_changes(ChangeSet const &c) const
     {
         if (current_txn() != c.txn_id()) {
             return MergeStatus::TRY_LATER;
@@ -235,7 +235,7 @@ struct State
         return MergeStatus::COLLISION_DETECTED;
     }
 
-    void merge_changes(WorkingCopy &c)
+    void merge_changes(ChangeSet &c)
     {
         accounts_.merge_changes(c.accounts_);
         storage_.merge_touched(c.storage_);

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -33,7 +33,7 @@ struct ValueState
         void clear() { storage_.clear(); }
     };
 
-    struct WorkingCopy;
+    struct ChangeSet;
 
     ValueState(TValueDB &store)
         : db_{store}
@@ -84,7 +84,7 @@ struct ValueState
 
     void clear_changes() { merged_.clear(); }
 
-    bool can_merge(WorkingCopy const &diffs) const noexcept
+    bool can_merge(ChangeSet const &diffs) const noexcept
     {
         for (auto const &[a, keys] : diffs.touched_.storage_) {
             for (auto const &[k, v] : keys) {
@@ -96,7 +96,7 @@ struct ValueState
         return true;
     }
 
-    void merge_touched(WorkingCopy &diffs)
+    void merge_touched(ChangeSet &diffs)
     {
         MONAD_DEBUG_ASSERT(can_merge(diffs));
 
@@ -114,7 +114,7 @@ struct ValueState
 };
 
 template <typename TValueDB>
-struct ValueState<TValueDB>::WorkingCopy : public ValueState<TValueDB>
+struct ValueState<TValueDB>::ChangeSet : public ValueState<TValueDB>
 {
     InnerStorage touched_{};
     std::unordered_map<address_t, std::unordered_set<bytes32_t>>

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
         monad::execution::EvmcHost,
         monad::execution::TransactionProcessorFiberData,
         monad::execution::EVMOneBaselineInterpreter<
-            state_t::WorkingCopy,
+            state_t::ChangeSet,
             monad::eth_start_fork>,
         monad::eth_start_fork::static_precompiles_t>(
         state,

--- a/src/monad/execution/ethereum/test/fork_traits.cpp
+++ b/src/monad/execution/ethereum/test/fork_traits.cpp
@@ -9,7 +9,7 @@
 using namespace monad;
 using namespace monad::fork_traits;
 
-using state_t = execution::fake::State::WorkingCopy;
+using state_t = execution::fake::State::ChangeSet;
 
 auto constexpr a{0xbebebebebebebebebebebebebebebebebebebebe_address};
 auto constexpr b{0x5353535353535353535353535353535353535353_address};
@@ -30,7 +30,7 @@ TEST(fork_traits, frontier)
     EXPECT_EQ(f.intrinsic_gas(t), 21'072);
     EXPECT_EQ(f.starting_nonce(), 0);
 
-    execution::fake::State::WorkingCopy s{};
+    execution::fake::State::ChangeSet s{};
     s._selfdestructs = 10;
 
     EXPECT_EQ(f.get_selfdestruct_refund(s), 240'000);
@@ -121,7 +121,7 @@ TEST(fork_traits, homestead)
     EXPECT_EQ(h.intrinsic_gas(t), 21'000);
     EXPECT_EQ(h.starting_nonce(), 0);
 
-    execution::fake::State::WorkingCopy s{};
+    execution::fake::State::ChangeSet s{};
     byte_string const code{0x00, 0x00, 0x00, 0x00, 0x00};
     { // Successfully deploy code
         int64_t gas = 10'000;
@@ -164,7 +164,7 @@ TEST(fork_traits, spurious_dragon)
     EXPECT_EQ(sd.intrinsic_gas(t), 21'000);
     EXPECT_EQ(sd.starting_nonce(), 1);
 
-    execution::fake::State::WorkingCopy s{};
+    execution::fake::State::ChangeSet s{};
     s._touched_dead = 10;
     sd.destruct_touched_dead(s);
     EXPECT_EQ(s._touched_dead, 0);
@@ -199,7 +199,7 @@ TEST(fork_traits, byzantium)
     EXPECT_EQ(byz.intrinsic_gas(t), 21'000);
     EXPECT_EQ(byz.starting_nonce(), 1);
 
-    execution::fake::State::WorkingCopy s{};
+    execution::fake::State::ChangeSet s{};
     s._touched_dead = 10;
     byz.destruct_touched_dead(s);
     EXPECT_EQ(s._touched_dead, 0);
@@ -276,7 +276,7 @@ static_assert(concepts::fork_traits<fork_traits::london, state_t>);
 TEST(fork_traits, london)
 {
     fork_traits::london l{};
-    execution::fake::State::WorkingCopy s{};
+    execution::fake::State::ChangeSet s{};
     s._selfdestructs = 10;
 
     EXPECT_EQ(l.get_selfdestruct_refund(s), 0);

--- a/src/monad/execution/ethereum/test/replay_eth_block_db.cpp
+++ b/src/monad/execution/ethereum/test/replay_eth_block_db.cpp
@@ -131,7 +131,7 @@ struct fakeReceiptFiberData
     inline void operator()()
     {
         TTxnProcessor p{};
-        typename TState::WorkingCopy s{};
+        typename TState::ChangeSet s{};
         TEvmHost h{};
         BlockHeader bh{};
         Transaction t{};

--- a/src/monad/execution/test/evm.cpp
+++ b/src/monad/execution/test/evm.cpp
@@ -14,22 +14,22 @@ using namespace monad::execution;
 
 constexpr static auto null{0x0000000000000000000000000000000000000000_address};
 
-using traits_t = fake::traits::alpha<fake::State::WorkingCopy>;
+using traits_t = fake::traits::alpha<fake::State::ChangeSet>;
 
-template <concepts::fork_traits<fake::State::WorkingCopy> TTraits>
+template <concepts::fork_traits<fake::State::ChangeSet> TTraits>
 using traits_templated_static_precompiles_t = StaticPrecompiles<
-    fake::State::WorkingCopy, TTraits, typename TTraits::static_precompiles_t>;
+    fake::State::ChangeSet, TTraits, typename TTraits::static_precompiles_t>;
 
-template <concepts::fork_traits<fake::State::WorkingCopy> TTraits>
+template <concepts::fork_traits<fake::State::ChangeSet> TTraits>
 using traits_templated_evm_t =
-    Evm<fake::State::WorkingCopy, fake::traits::alpha<fake::State::WorkingCopy>,
+    Evm<fake::State::ChangeSet, fake::traits::alpha<fake::State::ChangeSet>,
         traits_templated_static_precompiles_t<TTraits>, fake::Interpreter>;
 
 using evm_t = traits_templated_evm_t<traits_t>;
 using evm_host_t = fake::EvmHost<
-    fake::State::WorkingCopy, traits_t,
+    fake::State::ChangeSet, traits_t,
     fake::Evm<
-        fake::State::WorkingCopy, traits_t,
+        fake::State::ChangeSet, traits_t,
         fake::static_precompiles::OneHundredGas, fake::Interpreter>>;
 
 TEST(Evm, make_account_address)
@@ -38,7 +38,7 @@ TEST(Evm, make_account_address)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 6;
 
@@ -67,7 +67,7 @@ TEST(Evm, make_account_address_create2)
     static constexpr auto cafebabe_salt{
         0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32};
     static const uint8_t deadbeef[4]{0xde, 0xad, 0xbe, 0xef};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 5;
 
@@ -94,7 +94,7 @@ TEST(Evm, create_with_insufficient)
 {
     constexpr static auto from{
         0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
 
     evmc_message m{
@@ -115,7 +115,7 @@ TEST(Evm, create_nonce_out_of_range)
 {
     constexpr static auto from{
         0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = std::numeric_limits<uint64_t>::max();
 
@@ -139,7 +139,7 @@ TEST(Evm, eip684_existing_nonce)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 6;
     s._accounts[to].nonce = 5; // existing
@@ -166,7 +166,7 @@ TEST(Evm, eip684_existing_code)
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
     constexpr static auto code_hash{
         0x6b8cebdc2590b486457bbb286e96011bdd50ccc1d8580c1ffb3c89e828462283_bytes32};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 6;
     s._accounts[to].code_hash = code_hash; // existing
@@ -191,7 +191,7 @@ TEST(Evm, transfer_call_balances)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 6;
     s._accounts[to].balance = 0;
@@ -217,7 +217,7 @@ TEST(Evm, transfer_call_balances_to_self)
     constexpr static auto from{
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to = from;
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 6;
 
@@ -242,7 +242,7 @@ TEST(Evm, dont_transfer_on_delegatecall)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 5;
     s._accounts[to].balance = 0;
@@ -269,7 +269,7 @@ TEST(Evm, dont_transfer_on_staticcall)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     constexpr static auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    static fake::State::WorkingCopy s{};
+    static fake::State::ChangeSet s{};
     s._accounts[from].balance = 10'000'000'000;
     s._accounts[from].nonce = 5;
     s._accounts[to].balance = 0;
@@ -297,7 +297,7 @@ TEST(Evm, create_contract_account)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto new_addr{
         0x58f3f9ebd5dbdf751f12d747b02d00324837077d_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
 
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 50'000u, .nonce = 1});
@@ -330,7 +330,7 @@ TEST(Evm, create2_contract_account)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto new_addr2{
         0xe0e05f8f41129e2087ec0a3759810fdced46edd4_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
 
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 50'000u, .nonce = 1});
@@ -362,7 +362,7 @@ TEST(Evm, oog_create_account)
 {
     constexpr static auto from{
         0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 10'000, .nonce = 1});
     traits_t::_store_contract_result.status_code = EVMC_OUT_OF_GAS;
@@ -385,7 +385,7 @@ TEST(Evm, revert_create_account)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto null{
         0x0000000000000000000000000000000000000000_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 10'000});
     traits_t::_store_contract_result.status_code = EVMC_SUCCESS;
@@ -410,7 +410,7 @@ TEST(Evm, call_evm)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto to{
         0xf8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 50'000u});
     s._accounts.emplace(to, Account{.balance = 50'000u});
@@ -431,7 +431,7 @@ TEST(Evm, call_evm)
 
 TEST(Evm, static_precompile_execution)
 {
-    using beta_traits_t = fake::traits::beta<fake::State::WorkingCopy>;
+    using beta_traits_t = fake::traits::beta<fake::State::ChangeSet>;
     using alpha_evm_t = evm_t;
     using beta_evm_t = traits_templated_evm_t<beta_traits_t>;
 
@@ -439,7 +439,7 @@ TEST(Evm, static_precompile_execution)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000001_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 15'000});
     s._accounts.emplace(code_address, Account{.nonce = 4});
@@ -480,7 +480,7 @@ TEST(Evm, out_of_gas_static_precompile_execution)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000001_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 15'000});
     s._accounts.emplace(code_address, Account{.nonce = 6});
@@ -509,7 +509,7 @@ TEST(Evm, revert_call_evm)
         0x5353535353535353535353535353535353535353_address};
     constexpr static auto code_address{
         0x0000000000000000000000000000000000000003_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts.emplace(from, Account{.balance = 15'000});
     s._accounts.emplace(code_address, Account{.nonce = 10});

--- a/src/monad/execution/test/evmc_host.cpp
+++ b/src/monad/execution/test/evmc_host.cpp
@@ -11,13 +11,13 @@
 using namespace monad;
 using namespace execution;
 
-using traits_t = fake::traits::alpha<fake::State::WorkingCopy>;
+using traits_t = fake::traits::alpha<fake::State::ChangeSet>;
 
-template <concepts::fork_traits<fake::State::WorkingCopy> TTraits>
+template <concepts::fork_traits<fake::State::ChangeSet> TTraits>
 using traits_templated_evmc_host_t = EvmcHost<
-    fake::State::WorkingCopy, TTraits,
+    fake::State::ChangeSet, TTraits,
     fake::Evm<
-        fake::State::WorkingCopy, TTraits, fake::static_precompiles::OneHundredGas,
+        fake::State::ChangeSet, TTraits, fake::static_precompiles::OneHundredGas,
         fake::Interpreter>>;
 
 using evmc_host_t = traits_templated_evmc_host_t<traits_t>;
@@ -68,7 +68,7 @@ TEST(EvmcHost, get_tx_context)
         .base_fee_per_gas = 37'000'000'000,
     };
     Transaction const t{.sc = {.chain_id = 1}, .from = from};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
 
     const static uint256_t gas_cost = 37'000'000'000;
     const static uint256_t chain_id{1};
@@ -109,7 +109,7 @@ TEST(EvmcHost, emit_log)
     static const byte_string data = {0x00, 0x01, 0x02, 0x03, 0x04};
     BlockHeader const b{};
     Transaction const t{};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
 
     evmc_host_t host{b, t, s};
 

--- a/src/monad/execution/test/evmone_baseline_interpreter.cpp
+++ b/src/monad/execution/test/evmone_baseline_interpreter.cpp
@@ -11,20 +11,20 @@ using namespace monad;
 using namespace monad::execution;
 
 using interpreter_t = EVMOneBaselineInterpreter<
-    fake::State::WorkingCopy, fake::traits::alpha<fake::State::WorkingCopy>>;
+    fake::State::ChangeSet, fake::traits::alpha<fake::State::ChangeSet>>;
 
-using traits_t = fake::traits::alpha<fake::State::WorkingCopy>;
+using traits_t = fake::traits::alpha<fake::State::ChangeSet>;
 
 using evm_host_t = fake::EvmHost<
-    fake::State::WorkingCopy, traits_t,
+    fake::State::ChangeSet, traits_t,
     fake::Evm<
-        fake::State::WorkingCopy, traits_t,
+        fake::State::ChangeSet, traits_t,
         fake::static_precompiles::OneHundredGas, fake::Interpreter>>;
 
 TEST(Evm1BaselineInterpreter, execute_empty)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
 
     evm_host_t h{};
     s._code.emplace(a, byte_string{});
@@ -40,7 +40,7 @@ TEST(Evm1BaselineInterpreter, execute_empty)
 TEST(Evm1BaselineInterpreter, execute_simple)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     byte_string code = {
         0x60, // PUSH1, 3 gas
@@ -63,7 +63,7 @@ TEST(Evm1BaselineInterpreter, execute_simple)
 TEST(Evm1BaselineInterpreter, execute_invalid)
 {
     constexpr address_t a{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     byte_string code = {
         0x60, // PUSH1, 3 gas

--- a/src/monad/execution/test/replay_block_db.cpp
+++ b/src/monad/execution/test/replay_block_db.cpp
@@ -150,7 +150,7 @@ struct fakeEmptyFiberData
 };
 
 using state_t = execution::fake::State;
-using traits_t = execution::fake::traits::alpha<state_t::WorkingCopy>;
+using traits_t = execution::fake::traits::alpha<state_t::ChangeSet>;
 using receipt_collector_t = std::vector<std::vector<Receipt>>;
 
 using replay_t = ReplayFromBlockDb<

--- a/src/monad/execution/test/transaction_processor.cpp
+++ b/src/monad/execution/test/transaction_processor.cpp
@@ -8,18 +8,18 @@
 using namespace monad;
 using namespace monad::execution;
 
-using traits_t = fake::traits::alpha<fake::State::WorkingCopy>;
-using processor_t = TransactionProcessor<fake::State::WorkingCopy, traits_t>;
+using traits_t = fake::traits::alpha<fake::State::ChangeSet>;
+using processor_t = TransactionProcessor<fake::State::ChangeSet, traits_t>;
 
 using evm_host_t = fake::EvmHost<
-    fake::State::WorkingCopy, traits_t,
+    fake::State::ChangeSet, traits_t,
     fake::Evm<
-        fake::State::WorkingCopy, traits_t,
+        fake::State::ChangeSet, traits_t,
         fake::static_precompiles::OneHundredGas, fake::Interpreter>>;
 
 TEST(TransactionProcessor, g_star)
 {
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     traits_t::_sd_refund = 10'000;
     traits_t::_max_refund_quotient = 2;
 
@@ -39,7 +39,7 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
 {
     constexpr static auto from{
         0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
-    fake::State::WorkingCopy s{};
+    fake::State::ChangeSet s{};
     evm_host_t h{};
     s._accounts[from] = {.balance = 56'000'000'000'000'000, .nonce = 25};
     h._result = {.status_code = EVMC_SUCCESS, .gas_left = 15'000};

--- a/src/monad/execution/test/transaction_processor_data_fail_apply_state.cpp
+++ b/src/monad/execution/test/transaction_processor_data_fail_apply_state.cpp
@@ -16,10 +16,10 @@ template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
     state_t, TTxnProc,
     fake::EvmHost<
-        fake::State::WorkingCopy, fake::traits::alpha<fake::State::WorkingCopy>,
+        fake::State::ChangeSet, fake::traits::alpha<fake::State::ChangeSet>,
         fake::Evm<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>,
             fake::static_precompiles::OneHundredGas, fake::Interpreter>>,
     TExecution>;
 
@@ -69,8 +69,8 @@ TEST(TransactionProcessorFiberData, fail_apply_state_first_time)
 
     data_t<
         fakeEmptyTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeApplyStateAfterYieldEM>
         d{global_state, t, b, 0};
     d();

--- a/src/monad/execution/test/transaction_processor_data_fail_validation.cpp
+++ b/src/monad/execution/test/transaction_processor_data_fail_validation.cpp
@@ -16,10 +16,10 @@ template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
     state_t, TTxnProc,
     fake::EvmHost<
-        fake::State::WorkingCopy, fake::traits::alpha<fake::State::WorkingCopy>,
+        fake::State::ChangeSet, fake::traits::alpha<fake::State::ChangeSet>,
         fake::Evm<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>,
             fake::static_precompiles::OneHundredGas, fake::Interpreter>>,
     TExecution>;
 
@@ -84,8 +84,8 @@ TEST(
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 10};
     d();
@@ -106,8 +106,8 @@ TEST(TransactionProcessorFiberData, validation_insufficient_balance_optimistic)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeSuccessAfterYieldEM>
         d{s, t, b, 10};
     d();
@@ -128,8 +128,8 @@ TEST(TransactionProcessorFiberData, validation_later_nonce_current_txn_id)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 10};
     d();
@@ -150,8 +150,8 @@ TEST(TransactionProcessorFiberData, validation_later_nonce_optimistic)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeSuccessAfterYieldEM>
         d{s, t, b, 10};
     d();
@@ -171,8 +171,8 @@ TEST(TransactionProcessorFiberData, validation_invalid_gas_limit_current_txn_id)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 10};
     d();
@@ -193,8 +193,8 @@ TEST(TransactionProcessorFiberData, validation_invalid_gas_limit_optimistic)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeSuccessAfterYieldEM>
         d{s, t, b, 10};
     d();
@@ -215,8 +215,8 @@ TEST(TransactionProcessorFiberData, validation_bad_nonce_current_txn_id)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 10};
     d();
@@ -237,8 +237,8 @@ TEST(TransactionProcessorFiberData, validation_bad_nonce_optimistic)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeSuccessAfterYieldEM>
         d{s, t, b, 10};
     d();
@@ -259,8 +259,8 @@ TEST(TransactionProcessorFiberData, validation_deployed_code_current_txn_id)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 10};
     d();
@@ -281,8 +281,8 @@ TEST(TransactionProcessorFiberData, validation_deployed_code_optimistic)
 
     data_t<
         fakeGlobalStatusTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         fakeSuccessAfterYieldEM>
         d{s, t, b, 10};
     d();

--- a/src/monad/execution/test/transaction_processor_data_succeed.cpp
+++ b/src/monad/execution/test/transaction_processor_data_succeed.cpp
@@ -16,10 +16,10 @@ template <class TTxnProc, class TExecution>
 using data_t = TransactionProcessorFiberData<
     state_t, TTxnProc,
     fake::EvmHost<
-        fake::State::WorkingCopy, fake::traits::alpha<fake::State::WorkingCopy>,
+        fake::State::ChangeSet, fake::traits::alpha<fake::State::ChangeSet>,
         fake::Evm<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>,
             fake::static_precompiles::OneHundredGas, fake::Interpreter>>,
     TExecution>;
 
@@ -60,8 +60,8 @@ TEST(TransactionProcessorFiberData, invoke_successfully_first_time)
 
     data_t<
         fakeSuccessfulTP<
-            fake::State::WorkingCopy,
-            fake::traits::alpha<fake::State::WorkingCopy>>,
+            fake::State::ChangeSet,
+            fake::traits::alpha<fake::State::ChangeSet>>,
         BoostFiberExecution>
         d{s, t, b, 0};
     d();

--- a/src/monad/execution/test/validation.cpp
+++ b/src/monad/execution/test/validation.cpp
@@ -8,8 +8,8 @@
 using namespace monad;
 using namespace monad::execution;
 
-using traits_t = fake::traits::alpha<fake::State::WorkingCopy>;
-using processor_t = TransactionProcessor<fake::State::WorkingCopy, traits_t>;
+using traits_t = fake::traits::alpha<fake::State::ChangeSet>;
+using processor_t = TransactionProcessor<fake::State::ChangeSet, traits_t>;
 
 TEST(Execution, static_validate_no_sender)
 {
@@ -30,7 +30,7 @@ TEST(Execution, validate_enough_gas)
         .amount = 1,
         .from = a};
 
-    fake::State::WorkingCopy state{0};
+    fake::State::ChangeSet state{0};
     
     state._accounts[a] = {.balance = 55'939'568'773'815'811};
     traits_t::_intrinsic_gas = 53'000;
@@ -45,7 +45,7 @@ TEST(Execution, validate_deployed_code)
     constexpr static auto a{0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
     constexpr static auto some_non_null_hash{
         0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {56'939'568'773'815'811, some_non_null_hash, 24};
     traits_t::_intrinsic_gas = 27'500;
 
@@ -67,7 +67,7 @@ TEST(Execution, validate_nonce)
         .amount = 55'939'568'773'815'811,
         .from = a};
 
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 56'939'568'773'815'811, .nonce = 24};
     auto status = p.validate(state, t, 0);
     EXPECT_EQ(status, processor_t::Status::BAD_NONCE);
@@ -85,7 +85,7 @@ TEST(Execution, validate_nonce_optimistically)
         .amount = 55'939'568'773'815'811,
         .from = a};
 
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 56'939'568'773'815'811, .nonce = 24};
     auto status = p.validate(state, t, 0);
     EXPECT_EQ(status, processor_t::Status::LATER_NONCE);
@@ -106,7 +106,7 @@ TEST(Execution, validate_enough_balance)
         .priority_fee = 100'000'000,
     };
 
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 55'939'568'773'815'811};
     traits_t::_intrinsic_gas = 21'000;
 
@@ -120,7 +120,7 @@ TEST(Execution, successful_validation)
 {
     constexpr static auto a{0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
     constexpr static auto b{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 56'939'568'773'815'811, .nonce = 25};
     traits_t::_intrinsic_gas = 21'000;
 
@@ -142,7 +142,7 @@ TEST(Execution, insufficient_balance_higher_base_fee)
 {
     constexpr static auto a{0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
     constexpr static auto b{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 56'939'568'773'815'811, .nonce = 25};
     traits_t::_intrinsic_gas = 21'000;
 
@@ -165,7 +165,7 @@ TEST(Execution, successful_validation_higher_base_fee)
 {
     constexpr static auto a{0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
     constexpr static auto b{0x5353535353535353535353535353535353535353_address};
-    fake::State::WorkingCopy state{};
+    fake::State::ChangeSet state{};
     state._accounts[a] = {.balance = 50'000'000'000'000'000, .nonce = 25};
     traits_t::_intrinsic_gas = 21'000;
 

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -32,24 +32,24 @@ TEST(CodeState, code_at)
     EXPECT_EQ(code, c1);
 }
 
-TEST(CodeState, working_copy)
+TEST(CodeState, changeset)
 {
     db_t db{};
     db.insert({a, c1});
     CodeState s{db};
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
     auto const code_1 = t.code_at(a);
     EXPECT_EQ(code_1, c1);
 }
 
-TEST(CodeStateWorkingCopy, set_code)
+TEST(CodeStateChangeSet, set_code)
 {
     db_t db{};
     db.insert({a, c1});
     CodeState s{db};
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
     t.set_code(b, c2);
     t.set_code(c, byte_string{});
 
@@ -61,19 +61,19 @@ TEST(CodeStateWorkingCopy, set_code)
     EXPECT_EQ(code_3, byte_string{});
 }
 
-TEST(CodeStateWorkingCopy, get_code_size)
+TEST(CodeStateChangeSet, get_code_size)
 {
     db_t db{};
     db.insert({a, c1});
     CodeState s{db};
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
     auto const size = t.get_code_size(a);
 
     EXPECT_EQ(size, c1.size());
 }
 
-TEST(CodeStateWorkingCopy, copy_code)
+TEST(CodeStateChangeSet, copy_code)
 {
     db_t db{};
     db.insert({a, c1});
@@ -82,7 +82,7 @@ TEST(CodeStateWorkingCopy, copy_code)
     static constexpr unsigned size{8};
     uint8_t buffer[size];
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
 
     { // underflow
         auto const total = t.copy_code(a, 0u, buffer, size);
@@ -115,7 +115,7 @@ TEST(CodeState, can_merge)
     db.insert({a, c1});
     CodeState s{db};
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
     t.set_code(b, c2);
     EXPECT_TRUE(s.can_merge(t));
 }
@@ -127,7 +127,7 @@ TEST(CodeState, merge_changes)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(b, c2);
         EXPECT_TRUE(s.can_merge(t));
         s.merge_changes(t);
@@ -142,7 +142,7 @@ TEST(CodeState, revert)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(b, c2);
         EXPECT_TRUE(s.can_merge(t));
         t.revert();
@@ -157,13 +157,13 @@ TEST(CodeState, cant_merge_colliding_merge)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(a, c1);
         EXPECT_TRUE(s.can_merge(t));
         s.merge_changes(t);
     }
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(a, c2);
         EXPECT_FALSE(s.can_merge(t));
     }
@@ -175,7 +175,7 @@ TEST(CodeState, cant_merge_colliding_store)
     db.insert({a, c1});
     CodeState s{db};
 
-    auto t = decltype(s)::WorkingCopy{s};
+    auto t = decltype(s)::ChangeSet{s};
     t.set_code(a, c2);
     EXPECT_FALSE(s.can_merge(t));
 }
@@ -186,13 +186,13 @@ TEST(CodeState, merge_multiple_changes)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(a, c1);
         EXPECT_TRUE(s.can_merge(t));
         s.merge_changes(t);
     }
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(b, c2);
         EXPECT_TRUE(s.can_merge(t));
         s.merge_changes(t);
@@ -208,7 +208,7 @@ TEST(CodeState, can_commit)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(a, c1);
         t.set_code(b, c2);
         EXPECT_TRUE(s.can_merge(t));
@@ -223,7 +223,7 @@ TEST(CodeState, can_commit_multiple)
     CodeState s{db};
 
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(a, c1);
         t.set_code(b, c2);
         EXPECT_TRUE(s.can_merge(t));
@@ -232,7 +232,7 @@ TEST(CodeState, can_commit_multiple)
     EXPECT_TRUE(s.can_commit());
     s.commit_all_merged();
     {
-        auto t = decltype(s)::WorkingCopy{s};
+        auto t = decltype(s)::ChangeSet{s};
         t.set_code(c, c3);
         EXPECT_TRUE(s.can_merge(t));
         s.merge_changes(t);

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -91,20 +91,20 @@ TEST(EvmInterpStateHost, return_existing_storage)
         .sender = from,
         .code_address = a};
 
-    // Get working copy
-    auto working_state = s.get_working_copy(0u);
+    // Get new changeset
+    auto changeset = s.get_new_changeset(0u);
 
     using fork_t = monad::fork_traits::byzantium;
-    using state_t = decltype(working_state);
+    using state_t = decltype(changeset);
 
     // Prep per transaction processor
-    working_state.access_account(to);
-    working_state.access_account(from);
+    changeset.access_account(to);
+    changeset.access_account(from);
 
     evm_t<state_t, fork_t> e{};
-    evm_host_t<state_t, fork_t> h{b, t, working_state};
+    evm_host_t<state_t, fork_t> h{b, t, changeset};
 
-    auto status = e.call_evm(&h, working_state, m);
+    auto status = e.call_evm(&h, changeset, m);
 
     EXPECT_EQ(status.status_code, EVMC_SUCCESS);
     EXPECT_EQ(status.output_size, 1u);
@@ -158,20 +158,20 @@ TEST(EvmInterpStateHost, store_then_return_storage)
         .sender = from,
         .code_address = a};
 
-    // Get working copy
-    auto working_state = s.get_working_copy(0u);
+    // Get new changeset
+    auto changeset = s.get_new_changeset(0u);
 
     using fork_t = monad::fork_traits::byzantium;
-    using state_t = decltype(working_state);
+    using state_t = decltype(changeset);
 
     // Prep per transaction processor
-    working_state.access_account(to);
-    working_state.access_account(from);
+    changeset.access_account(to);
+    changeset.access_account(from);
 
     evm_t<state_t, fork_t> e{};
-    evm_host_t<state_t, fork_t> h{b, t, working_state};
+    evm_host_t<state_t, fork_t> h{b, t, changeset};
 
-    auto status = e.call_evm(&h, working_state, m);
+    auto status = e.call_evm(&h, changeset, m);
 
     EXPECT_EQ(status.status_code, EVMC_SUCCESS);
     EXPECT_EQ(status.output_size, 1u);


### PR DESCRIPTION
Problem:
- The Working Copy of the state is not just a working copy, but it
  really represents a revertable change set.

Solution:
- Change the name.

Note: This is peeling off just the name change separate from re-working the state to be hierarchical and revertible.  I think it is too much to review with those changes included, and will also cause it to linger.
