### PR TITLE
:sparkles: Add state_history client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ dmypy.json
 
 # vcpkg
 vcpkg_installed/
+
+# rust
+Cargo.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ add_subdirectory(third_party/evmone)
 add_subdirectory(third_party/intx)
 add_subdirectory(third_party/silkpre)
 
+add_subdirectory(state_history)
+
 function(monad_compile_options target)
     set_property(TARGET ${target} PROPERTY C_STANDARD 11)
     set_property(TARGET ${target} PROPERTY C_STANDARD_REQUIRED ON)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM fedora:38
 
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
 RUN yum -y install \
   dnf-plugins-core
 

--- a/scripts/cargo/clean_build_and_run.sh
+++ b/scripts/cargo/clean_build_and_run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+source "$HOME/.cargo/env"
+
+cargo clean
+cargo build
+cargo run

--- a/state_history/CMakeLists.txt
+++ b/state_history/CMakeLists.txt
@@ -1,0 +1,20 @@
+configure_file("build.rs.in" "${CMAKE_CURRENT_BINARY_DIR}/build.rs")
+
+add_custom_target(
+    copy_state_history_crate ALL
+    COMMENT "Copy state_history"
+    COMMAND cp -r "${PROJECT_SOURCE_DIR}/state_history"
+            "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ln -sf "${CMAKE_CURRENT_BINARY_DIR}/build.rs"
+            "${CMAKE_CURRENT_BINARY_DIR}/state_history/build.rs"
+    USES_TERMINAL VERBATIM
+)
+
+add_custom_target(
+    state_history_crate ALL
+    COMMENT "Building and running state_history"
+    COMMAND "${PROJECT_SOURCE_DIR}/scripts/cargo/clean_build_and_run.sh"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/state_history"
+    USES_TERMINAL VERBATIM
+)
+add_dependencies(state_history_crate copy_state_history_crate)

--- a/state_history/Cargo.toml
+++ b/state_history/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "state_history"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"

--- a/state_history/build.rs.in
+++ b/state_history/build.rs.in
@@ -1,0 +1,10 @@
+fn main() {
+    cxx_build::bridge("@PROJECT_SOURCE_DIR@/state_history/src/lib.rs")
+        .compiler("clang++")
+        .flag("-std=c++2a")
+        .include("@PROJECT_SOURCE_DIR@/include")
+        .include("@PROJECT_SOURCE_DIR@/third_party/evmone/evmc/include")
+        .include("@PROJECT_SOURCE_DIR@/third_party/intx/include")
+        .file("@PROJECT_SOURCE_DIR@/state_history/include/client.hpp")
+        .compile("state_history");
+}

--- a/state_history/include/account.hpp
+++ b/state_history/include/account.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "bytes.hpp"
+
+#include <monad/core/account.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace monad::state_history
+{
+    struct Account
+    {
+        using Balance = std::array<uint8_t, monad::uint256_t::num_bits / 8>;
+
+        monad::Account account;
+
+        [[nodiscard]] constexpr Balance get_balance() const noexcept
+        {
+            // TODO
+            return {};
+        }
+
+        [[nodiscard]] constexpr uint64_t get_nonce() const noexcept
+        {
+            // TODO
+            return 0;
+        }
+
+        [[nodiscard]] Bytes32 get_code_hash() const noexcept
+        {
+            // TODO
+            return {};
+        }
+    };
+}

--- a/state_history/include/bytes.hpp
+++ b/state_history/include/bytes.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <monad/core/bytes.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace monad::state_history
+{
+    using Bytes32 = std::array<uint8_t, sizeof(monad::bytes32_t)>;
+}

--- a/state_history/include/client.hpp
+++ b/state_history/include/client.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "account.hpp"
+#include "bytes.hpp"
+
+#include <monad/core/address.hpp>
+#include <monad/core/assert.h>
+#include <monad/core/bytes.hpp>
+#include <monad/core/int.hpp>
+
+#include <array>
+#include <filesystem>
+#include <memory>
+
+namespace monad::state_history
+{
+    struct Client
+    {
+        using Address = std::array<uint8_t, sizeof(monad::address_t)>;
+
+        std::filesystem::path const root;
+        uint64_t const block_number;
+        std::string buf;
+
+        Client(std::filesystem::path root, uint64_t block_number)
+            : root(root)
+            , block_number(block_number)
+        {
+        }
+
+        [[nodiscard]] std::unique_ptr<Account> get_account(Address) const
+        {
+            // TODO
+            return std::make_unique<Account>();
+        }
+
+        [[nodiscard]] constexpr std::string const &get_code(Address) const
+        {
+            // TODO
+            return buf;
+        }
+
+        [[nodiscard]] constexpr Bytes32 get_storage_hash(Address) const
+        {
+            // TODO
+            return {};
+        }
+
+        [[nodiscard]] constexpr std::string const &
+        get_account_proof(Address) const
+        {
+            // TODO
+            return buf;
+        }
+
+        [[nodiscard]] constexpr std::string const &
+        get_storage_proof(Address, Bytes32) const
+        {
+            // TODO
+            return buf;
+        }
+    };
+
+    inline std::unique_ptr<Client>
+    make_client_at_block_number(std::string const &root, uint64_t block_number)
+    {
+        return std::make_unique<Client>(root, block_number);
+    }
+
+    inline std::unique_ptr<Client> make_client(std::string const &root)
+    {
+        // TODO:
+        return make_client_at_block_number(root, 0);
+    }
+}

--- a/state_history/src/lib.rs
+++ b/state_history/src/lib.rs
@@ -1,0 +1,27 @@
+#[cxx::bridge(namespace = "monad::state_history")]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("state_history/include/client.hpp");
+
+        type Account;
+
+        fn get_balance(self: &Account) -> [u8; 32];
+        fn get_nonce(self: &Account) -> u64;
+        fn get_code_hash(self: &Account) -> [u8; 32];
+
+        type Client;
+
+        fn make_client(root: &CxxString) -> Result<UniquePtr<Client>>;
+        fn make_client_at_block_number(
+            root: &CxxString,
+            block_number: u64,
+        ) -> Result<UniquePtr<Client>>;
+
+        fn get_account(self: &Client, address: [u8; 20]) -> Result<UniquePtr<Account>>;
+        fn get_code(self: &Client, address: [u8; 20]) -> Result<&CxxString>;
+        fn get_storage_hash(self: &Client, address: [u8; 20]) -> Result<[u8; 32]>;
+        fn get_account_proof(self: &Client, address: [u8; 20]) -> Result<&CxxString>;
+        fn get_storage_proof(self: &Client, address: [u8; 20], key: [u8; 32])
+            -> Result<&CxxString>;
+    }
+}

--- a/state_history/src/main.rs
+++ b/state_history/src/main.rs
@@ -1,0 +1,13 @@
+use cxx::let_cxx_string;
+
+// Example of how to use state_history
+fn main() {
+    let_cxx_string!(root = "/path/to/database/root");
+    let client = state_history::ffi::make_client(&root);
+    assert!(client.is_ok());
+    let account = client
+        .unwrap()
+        .get_account([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert!(account.is_ok());
+    assert!(account.unwrap().get_nonce() == 0);
+}


### PR DESCRIPTION
Problem:
- Rpc server needs to query the database when servicing requests to its various endpoints

Solution:
- Create an interface which the rpc server may use to interact with the database from a separate process

This is by no means a complete interface, but should start to shape how the RPC server interacts with execution's persistent store.

Implementations and corresponding unit tests to arrive shortly.