### PR TITLE
:bug: Fix db to execute with executor

### DIFF
--- a/include/monad/db/create_and_prune_block_history.hpp
+++ b/include/monad/db/create_and_prune_block_history.hpp
@@ -2,7 +2,6 @@
 
 #include <monad/db/config.hpp>
 #include <monad/db/util.hpp>
-#include <monad/execution/config.hpp>
 
 #include <fmt/format.h>
 #include <fmt/std.h>
@@ -14,21 +13,9 @@
 #include <iostream>
 #include <memory>
 
-MONAD_EXECUTION_NAMESPACE_BEGIN
-struct BoostFiberExecution;
-MONAD_EXECUTION_NAMESPACE_END
-
 MONAD_DB_NAMESPACE_BEGIN
 
-namespace detail
-{
-    template <typename TExecution>
-    struct RocksTrieDB;
-};
-using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
-
 template <typename TDB>
-    requires std::same_as<TDB, db::RocksTrieDB>
 [[nodiscard]] inline tl::expected<void, std::string>
 create_and_prune_block_history(TDB const &db, uint64_t block_number)
 {

--- a/include/monad/db/db_interface.hpp
+++ b/include/monad/db/db_interface.hpp
@@ -34,12 +34,14 @@ struct DBInterface
 
     [[nodiscard]] constexpr std::optional<Account> try_find(address_t const &a)
     {
-        return TExecutor::execute([=, this]() { return self().try_find(a); });
+        return TExecutor::execute(
+            [=, this]() { return self().try_find_impl(a); });
     }
 
     [[nodiscard]] constexpr bool contains(address_t const &a)
     {
-        return TExecutor::execute([=, this]() { return self().contains(a); });
+        return TExecutor::execute(
+            [=, this]() { return self().contains_impl(a); });
     }
 
     [[nodiscard]] constexpr Account at(address_t const &a)
@@ -53,14 +55,14 @@ struct DBInterface
     try_find(address_t const &a, bytes32_t const &k)
     {
         return TExecutor::execute(
-            [=, this]() { return self().try_find(a, k); });
+            [=, this]() { return self().try_find_impl(a, k); });
     }
 
     [[nodiscard]] constexpr bool
     contains(address_t const &a, bytes32_t const &k)
     {
         return TExecutor::execute(
-            [=, this]() { return self().contains(a, k); });
+            [=, this]() { return self().contains_impl(a, k); });
     }
 
     [[nodiscard]] constexpr bytes32_t at(address_t const &a, bytes32_t const &k)

--- a/include/monad/db/in_memory_db.hpp
+++ b/include/monad/db/in_memory_db.hpp
@@ -6,79 +6,84 @@
 
 MONAD_DB_NAMESPACE_BEGIN
 
-// Database impl without trie root generating logic, backed by stl
-struct InMemoryDB
-    : public DBInterface<InMemoryDB, monad::execution::SerialExecution>
+namespace detail
 {
-    using DBInterface<InMemoryDB, monad::execution::SerialExecution>::updates;
-
-    std::unordered_map<address_t, Account> accounts;
-    std::unordered_map<address_t, std::unordered_map<bytes32_t, bytes32_t>>
-        storage;
-
-    ////////////////////////////////////////////////////////////////////
-    // DBInterface implementations
-    ////////////////////////////////////////////////////////////////////
-
-    [[nodiscard]] bool contains(address_t const &a) const
+    // Database impl without trie root generating logic, backed by stl
+    template <typename TExecutor>
+    struct InMemoryDB : public DBInterface<InMemoryDB<TExecutor>, TExecutor>
     {
-        return accounts.contains(a);
-    }
+        using base_t = DBInterface<InMemoryDB<TExecutor>, TExecutor>;
 
-    [[nodiscard]] bool contains(address_t const &a, bytes32_t const &k) const
-    {
-        return storage.contains(a) && storage.at(a).contains(k);
-    }
+        std::unordered_map<address_t, Account> accounts;
+        std::unordered_map<address_t, std::unordered_map<bytes32_t, bytes32_t>>
+            storage;
 
-    [[nodiscard]] std::optional<Account> try_find(address_t const &a) const
-    {
-        if (accounts.contains(a)) {
-            return accounts.at(a);
+        ////////////////////////////////////////////////////////////////////
+        // DBInterface implementations
+        ////////////////////////////////////////////////////////////////////
+
+        [[nodiscard]] bool contains_impl(address_t const &a)
+        {
+            return accounts.contains(a);
         }
-        return std::nullopt;
-    }
 
-    [[nodiscard]] std::optional<bytes32_t>
-    try_find(address_t const &a, bytes32_t const &k) const
-    {
-        if (!contains(a, k)) {
+        [[nodiscard]] bool contains_impl(address_t const &a, bytes32_t const &k)
+        {
+            return storage.contains(a) && storage.at(a).contains(k);
+        }
+
+        [[nodiscard]] std::optional<Account> try_find_impl(address_t const &a)
+        {
+            if (accounts.contains(a)) {
+                return accounts.at(a);
+            }
             return std::nullopt;
         }
-        return storage.at(a).at(k);
-    }
 
-    void commit(state::changeset auto const &obj)
-    {
-        for (auto const &[a, updates] : obj.storage_changes) {
-            for (auto const &[k, v] : updates) {
-                if (v != bytes32_t{}) {
-                    storage[a][k] = v;
+        [[nodiscard]] std::optional<bytes32_t>
+        try_find_impl(address_t const &a, bytes32_t const &k)
+        {
+            if (!base_t::contains(a, k)) {
+                return std::nullopt;
+            }
+            return storage.at(a).at(k);
+        }
+
+        void commit(state::changeset auto const &obj)
+        {
+            for (auto const &[a, updates] : obj.storage_changes) {
+                for (auto const &[k, v] : updates) {
+                    if (v != bytes32_t{}) {
+                        storage[a][k] = v;
+                    }
+                    else {
+                        auto const n = storage[a].erase(k);
+                        MONAD_DEBUG_ASSERT(n == 1);
+                    }
+                }
+                if (storage[a].empty()) {
+                    storage.erase(a);
+                }
+            }
+
+            for (auto const &[a, acct] : obj.account_changes) {
+                if (acct.has_value()) {
+                    accounts[a] = acct.value();
                 }
                 else {
-                    auto const n = storage[a].erase(k);
+                    auto const n = accounts.erase(a);
                     MONAD_DEBUG_ASSERT(n == 1);
                 }
             }
-            if (storage[a].empty()) {
-                storage.erase(a);
-            }
         }
 
-        for (auto const &[a, acct] : obj.account_changes) {
-            if (acct.has_value()) {
-                accounts[a] = acct.value();
-            }
-            else {
-                auto const n = accounts.erase(a);
-                MONAD_DEBUG_ASSERT(n == 1);
-            }
+        constexpr void
+        create_and_prune_block_history(uint64_t /* block_number */) const
+        {
         }
-    }
+    };
+}
 
-    constexpr void
-    create_and_prune_block_history(uint64_t /* block_number */) const
-    {
-    }
-};
+using InMemoryDB = detail::InMemoryDB<monad::execution::SerialExecution>;
 
 MONAD_DB_NAMESPACE_END

--- a/include/monad/db/in_memory_trie_db.hpp
+++ b/include/monad/db/in_memory_trie_db.hpp
@@ -9,65 +9,72 @@
 
 MONAD_DB_NAMESPACE_BEGIN
 
-// Database impl with trie root generating logic, backed by stl
-struct InMemoryTrieDB
-    : public TrieDBInterface<InMemoryTrieDB, monad::execution::SerialExecution>
+namespace detail
 {
-    template <typename TComparator>
-    struct Trie
+    // Database impl with trie root generating logic, backed by stl
+    template <typename TExecutor>
+    struct InMemoryTrieDB
+        : public TrieDBInterface<InMemoryTrieDB<TExecutor>, TExecutor>
     {
-        using cursor_t = trie::InMemoryCursor<TComparator>;
-        using writer_t = trie::InMemoryWriter<TComparator>;
-        using storage_t = typename cursor_t::storage_t;
-        storage_t leaves_storage;
-        cursor_t leaves_cursor;
-        writer_t leaves_writer;
-        storage_t trie_storage;
-        cursor_t trie_cursor;
-        writer_t trie_writer;
-        trie::Trie<cursor_t, writer_t> trie;
+        template <typename TComparator>
+        struct Trie
+        {
+            using cursor_t = trie::InMemoryCursor<TComparator>;
+            using writer_t = trie::InMemoryWriter<TComparator>;
+            using storage_t = typename cursor_t::storage_t;
+            storage_t leaves_storage;
+            cursor_t leaves_cursor;
+            writer_t leaves_writer;
+            storage_t trie_storage;
+            cursor_t trie_cursor;
+            writer_t trie_writer;
+            trie::Trie<cursor_t, writer_t> trie;
 
-        Trie()
-            : leaves_storage{}
-            , leaves_cursor{leaves_storage}
-            , leaves_writer{leaves_storage}
-            , trie_storage{}
-            , trie_cursor{trie_storage}
-            , trie_writer{trie_storage}
-            , trie{leaves_cursor, trie_cursor, leaves_writer, trie_writer}
+            Trie()
+                : leaves_storage{}
+                , leaves_cursor{leaves_storage}
+                , leaves_writer{leaves_storage}
+                , trie_storage{}
+                , trie_cursor{trie_storage}
+                , trie_writer{trie_storage}
+                , trie{leaves_cursor, trie_cursor, leaves_writer, trie_writer}
+            {
+            }
+
+            [[nodiscard]] cursor_t make_leaf_cursor() const
+            {
+                return cursor_t{leaves_storage};
+            }
+
+            [[nodiscard]] cursor_t make_trie_cursor() const
+            {
+                return cursor_t{trie_storage};
+            }
+        };
+
+        Trie<trie::InMemoryPathComparator> accounts_trie;
+        Trie<trie::InMemoryPrefixPathComparator> storage_trie;
+
+        ////////////////////////////////////////////////////////////////////
+        // DBInterface implementations
+        ////////////////////////////////////////////////////////////////////
+        constexpr void
+        create_and_prune_block_history(uint64_t /* block_number */) const
         {
         }
 
-        [[nodiscard]] cursor_t make_leaf_cursor() const
-        {
-            return cursor_t{leaves_storage};
-        }
+        ////////////////////////////////////////////////////////////////////
+        // TrieDBInterface implementations
+        ////////////////////////////////////////////////////////////////////
 
-        [[nodiscard]] cursor_t make_trie_cursor() const
-        {
-            return cursor_t{trie_storage};
-        }
+        auto &accounts() { return accounts_trie; }
+        auto &storage() { return storage_trie; }
+        auto const &accounts() const { return accounts_trie; }
+        auto const &storage() const { return storage_trie; }
     };
+}
 
-    Trie<trie::InMemoryPathComparator> accounts_trie;
-    Trie<trie::InMemoryPrefixPathComparator> storage_trie;
-
-    ////////////////////////////////////////////////////////////////////
-    // DBInterface implementations
-    ////////////////////////////////////////////////////////////////////
-    constexpr void
-    create_and_prune_block_history(uint64_t /* block_number */) const
-    {
-    }
-
-    ////////////////////////////////////////////////////////////////////
-    // TrieDBInterface implementations
-    ////////////////////////////////////////////////////////////////////
-
-    auto &accounts() { return accounts_trie; }
-    auto &storage() { return storage_trie; }
-    auto const &accounts() const { return accounts_trie; }
-    auto const &storage() const { return storage_trie; }
-};
+using InMemoryTrieDB =
+    detail::InMemoryTrieDB<monad::execution::SerialExecution>;
 
 MONAD_DB_NAMESPACE_END

--- a/include/monad/db/prepare_state.hpp
+++ b/include/monad/db/prepare_state.hpp
@@ -2,7 +2,6 @@
 
 #include <monad/db/config.hpp>
 #include <monad/db/util.hpp>
-#include <monad/execution/config.hpp>
 
 #include <fmt/format.h>
 #include <tl/expected.hpp>
@@ -10,23 +9,11 @@
 #include <concepts>
 #include <filesystem>
 
-MONAD_EXECUTION_NAMESPACE_BEGIN
-struct BoostFiberExecution;
-MONAD_EXECUTION_NAMESPACE_END
-
 MONAD_DB_NAMESPACE_BEGIN
-
-namespace detail
-{
-    template <typename TExecution>
-    struct RocksTrieDB;
-};
-using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 // Preparing initial db state and return the path for opening. If preparation
 // fails, return a string explanation
 template <typename TDB>
-    requires std::same_as<TDB, db::RocksTrieDB>
 [[nodiscard]] inline tl::expected<std::filesystem::path, std::string>
 prepare_state(TDB const &db, uint64_t block_number)
 {

--- a/include/monad/db/rocks_db.hpp
+++ b/include/monad/db/rocks_db.hpp
@@ -103,7 +103,7 @@ namespace detail
         // DBInterface implementations
         ////////////////////////////////////////////////////////////////////
 
-        [[nodiscard]] bool contains(address_t const &a)
+        [[nodiscard]] bool contains_impl(address_t const &a)
         {
             rocksdb::PinnableSlice value;
             auto const res = db->Get(
@@ -112,7 +112,7 @@ namespace detail
             return res.ok();
         }
 
-        [[nodiscard]] bool contains(address_t const &a, bytes32_t const &k)
+        [[nodiscard]] bool contains_impl(address_t const &a, bytes32_t const &k)
         {
             auto const key = detail::make_basic_storage_key(a, k);
             rocksdb::PinnableSlice value;
@@ -122,7 +122,7 @@ namespace detail
             return res.ok();
         }
 
-        [[nodiscard]] std::optional<Account> try_find(address_t const &a)
+        [[nodiscard]] std::optional<Account> try_find_impl(address_t const &a)
         {
             rocksdb::PinnableSlice value;
             auto const res = db->Get(
@@ -145,7 +145,7 @@ namespace detail
         }
 
         [[nodiscard]] std::optional<bytes32_t>
-        try_find(address_t const &a, bytes32_t const &k)
+        try_find_impl(address_t const &a, bytes32_t const &k)
         {
             auto const key = detail::make_basic_storage_key(a, k);
             rocksdb::PinnableSlice value;

--- a/include/monad/db/trie_db_interface.hpp
+++ b/include/monad/db/trie_db_interface.hpp
@@ -58,18 +58,19 @@ struct TrieDBInterface
     // DBInterface accessor implementations
     ////////////////////////////////////////////////////////////////////
 
-    [[nodiscard]] constexpr bool contains(address_t const &a) const
+    [[nodiscard]] constexpr bool contains_impl(address_t const &a)
     {
         return find(a).has_value();
     }
 
     [[nodiscard]] constexpr bool
-    contains(address_t const &a, bytes32_t const &k) const
+    contains_impl(address_t const &a, bytes32_t const &k)
     {
         return find(a, k).has_value();
+        ;
     }
 
-    [[nodiscard]] std::optional<Account> try_find(address_t const &a) const
+    [[nodiscard]] std::optional<Account> try_find_impl(address_t const &a)
     {
         auto const c = find(a);
         if (!c.has_value()) {
@@ -95,7 +96,7 @@ struct TrieDBInterface
     }
 
     [[nodiscard]] std::optional<bytes32_t>
-    try_find(address_t const &a, bytes32_t const &k) const
+    try_find_impl(address_t const &a, bytes32_t const &k)
     {
         auto const c = find(a, k);
         if (!c.has_value()) {

--- a/include/monad/db/util.hpp
+++ b/include/monad/db/util.hpp
@@ -20,7 +20,6 @@ namespace detail
 using RocksTrieDB = detail::RocksTrieDB<monad::execution::BoostFiberExecution>;
 
 template <typename TDB>
-    requires std::same_as<TDB, db::RocksTrieDB>
 [[nodiscard]] constexpr std::string_view as_string() noexcept
 {
     using namespace std::literals::string_view_literals;

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
     monad_unit_test_common STATIC
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/config.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/environment.hpp
+    ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/hijacked_db.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/trie_fixture.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/one_hundred_updates.hpp
     ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/make_db.hpp

--- a/test/unit/common/include/monad/test/hijacked_db.hpp
+++ b/test/unit/common/include/monad/test/hijacked_db.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <monad/db/config.hpp>
+#include <monad/db/in_memory_db.hpp>
+#include <monad/db/in_memory_trie_db.hpp>
+#include <monad/db/rocks_db.hpp>
+#include <monad/db/rocks_trie_db.hpp>
+#include <monad/test/config.hpp>
+
+MONAD_TEST_NAMESPACE_BEGIN
+
+namespace hijacked
+{
+    struct Executor
+    {
+        inline static bool EXECUTED = false;
+        [[nodiscard]] constexpr static auto execute(std::invocable auto &&f)
+        {
+            EXECUTED = true;
+            return std::invoke(std::forward<decltype(f)>(f));
+        }
+    };
+
+    using InMemoryDB = monad::db::detail::InMemoryDB<Executor>;
+    using RocksDB = monad::db::detail::RocksDB<Executor>;
+    using InMemoryTrieDB = monad::db::detail::InMemoryTrieDB<Executor>;
+    using RocksTrieDB = monad::db::detail::RocksTrieDB<Executor>;
+}
+
+MONAD_TEST_NAMESPACE_END
+
+MONAD_DB_NAMESPACE_BEGIN
+
+template <>
+[[nodiscard]] constexpr std::string_view
+as_string<test::hijacked::RocksTrieDB>() noexcept
+{
+    return "hijackedrockstriedb";
+}
+
+MONAD_DB_NAMESPACE_END

--- a/test/unit/common/include/monad/test/make_db.hpp
+++ b/test/unit/common/include/monad/test/make_db.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "config.hpp"
 #include <monad/core/assert.h>
 #include <monad/db/in_memory_db.hpp>
 #include <monad/db/in_memory_trie_db.hpp>
 #include <monad/db/rocks_db.hpp>
 #include <monad/db/rocks_trie_db.hpp>
+#include <monad/test/config.hpp>
+#include <monad/test/hijacked_db.hpp>
 #include <test_resource_data.h>
 
 #include <algorithm>
@@ -35,19 +36,27 @@ inline std::filesystem::path make_db_root(testing::TestInfo const &info)
 
 template <typename TDatabase>
     requires std::same_as<TDatabase, db::InMemoryDB> ||
+             std::same_as<TDatabase, hijacked::InMemoryDB> ||
              std::same_as<TDatabase, db::InMemoryTrieDB> ||
+             std::same_as<TDatabase, hijacked::InMemoryTrieDB> ||
              std::same_as<TDatabase, db::RocksDB> ||
-             std::same_as<TDatabase, db::RocksTrieDB>
+             std::same_as<TDatabase, hijacked::RocksDB> ||
+             std::same_as<TDatabase, db::RocksTrieDB> ||
+             std::same_as<TDatabase, hijacked::RocksTrieDB>
 inline TDatabase make_db()
 {
     auto const *info = testing::UnitTest::GetInstance()->current_test_info();
     MONAD_ASSERT(info);
     if constexpr (
         std::same_as<TDatabase, db::InMemoryDB> ||
-        std::same_as<TDatabase, db::InMemoryTrieDB>) {
+        std::same_as<TDatabase, hijacked::InMemoryDB> ||
+        std::same_as<TDatabase, db::InMemoryTrieDB> ||
+        std::same_as<TDatabase, hijacked::InMemoryTrieDB>) {
         return TDatabase{};
     }
-    else if constexpr (std::same_as<TDatabase, db::RocksDB>) {
+    else if constexpr (
+        std::same_as<TDatabase, db::RocksDB> ||
+        std::same_as<TDatabase, hijacked::RocksDB>) {
         return TDatabase{make_db_root(*info)};
     }
     else {


### PR DESCRIPTION
Problem:
- Previously the executor was never invoked unless the base class implementation was explicitly invoked

Solution:
- Always execute queries using the executor, and enforce this via unit tests