### PR TITLE
:loud_sound: Enable VM tracing on debug mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(monad)
 option(ASAN "Turn on Address Sanitizer")
 option(UBSAN "Turn on Undefined Behavior Sanitizer")
 option(FUZZING "Enable fuzzing for clang" ON)
+option(EVMONE_TRACING "Enable instruction-level tracing for the evmone interpreter" OFF)
 
 include(cmake/test.cmake)
 
@@ -80,6 +81,9 @@ function(monad_compile_options target)
         ${target}
         PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>
     )
+    if (EVMONE_TRACING)
+        target_compile_definitions(${target} PRIVATE EVMONE_TRACING=1)
+    endif()
 endfunction()
 
 # ##############################################################################

--- a/include/monad/execution/evmone_baseline_interpreter.hpp
+++ b/include/monad/execution/evmone_baseline_interpreter.hpp
@@ -4,6 +4,7 @@
 #include <monad/core/concepts.hpp>
 
 #include <monad/execution/config.hpp>
+#include <monad/logging/monad_log.hpp>
 
 #include <evmone/baseline.hpp>
 
@@ -18,6 +19,11 @@
 
 #include <evmone/vm.hpp>
 
+#ifdef EVMONE_TRACING
+    #include <evmone/tracing.hpp>
+    #include <sstream>
+#endif
+
 MONAD_EXECUTION_NAMESPACE_BEGIN
 
 template <class TState, concepts::fork_traits<TState> TTraits>
@@ -27,23 +33,32 @@ struct EVMOneBaselineInterpreter
     static evmc::Result
     execute(TEvmHost *h, TState const &s, evmc_message const &m)
     {
-        evmc::Result result{evmc_result{.status_code = EVMC_SUCCESS, .gas_left = m.gas}};
+        [[maybe_unused]] decltype(monad::log::logger_t::get_logger()) logger =
+            monad::log::logger_t::get_logger(
+                "evmone_baseline_interpreter_logger");
+        evmc::Result result{
+            evmc_result{.status_code = EVMC_SUCCESS, .gas_left = m.gas}};
         auto const code = s.get_code(m.code_address);
         if (code.empty()) {
             return result;
         }
 
         evmone::VM v{};
+#ifdef EVMONE_TRACING
+        std::ostringstream instruction_trace_string_stream;
+        v.add_tracer(
+            evmone::create_instruction_tracer(instruction_trace_string_stream));
+#endif
+
         evmone::ExecutionState es{
-            m,
-            TTraits::rev,
-            h->get_interface(),
-            h->to_context(),
-            code,
-            {}};
+            m, TTraits::rev, h->get_interface(), h->to_context(), code, {}};
         evmone::baseline::CodeAnalysis ca{
             evmone::baseline::analyze(TTraits::rev, code)};
         result = evmc::Result{evmone::baseline::execute(v, m.gas, es, ca)};
+
+#ifdef EVMONE_TRACING
+        MONAD_LOG_DEBUG(logger, "{}", instruction_trace_string_stream.str());
+#endif
         return result;
     }
 };


### PR DESCRIPTION
Problem:
- The evmone interpreter ships with instruction-level tracing that is disabled by default (presumably for performance reasons).
- Having this tracing facilitates debugging the execution of transactions.

Solution:
- Enable VM tracing by calling `add_tracing` with an instruction tracer conditioned on whether or not the program was compiled in debug mode.

Note:
- See [evmone instruction tracer implementation](https://github.com/ethereum/evmone/blob/eda0bebe6b054ea575d0716caa1e2906bcf38068/lib/evmone/tracing.cpp#L69-L152)  