### PR TITLE
:recycle: Upgrade InnerStorage out from subclass

### DIFF
--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -14,24 +14,27 @@
 
 MONAD_STATE_NAMESPACE_BEGIN
 
-template <class TValueDB>
-struct ValueState
+struct InnerStorage
 {
     using diff_t = diff<bytes32_t>;
     using key_value_map_t = std::unordered_map<bytes32_t, diff_t>;
 
-    struct InnerStorage
+    std::unordered_map<address_t, key_value_map_t> storage_{};
+
+    bool
+    contains_key(address_t const &a, bytes32_t const &key) const noexcept
     {
-        std::unordered_map<address_t, key_value_map_t> storage_{};
+        return storage_.contains(a) && storage_.at(a).contains(key);
+    }
 
-        bool
-        contains_key(address_t const &a, bytes32_t const &key) const noexcept
-        {
-            return storage_.contains(a) && storage_.at(a).contains(key);
-        }
+    void clear() { storage_.clear(); }
+};
 
-        void clear() { storage_.clear(); }
-    };
+
+template <class TValueDB>
+struct ValueState
+{
+    using diff_t = InnerStorage::diff_t;
 
     struct ChangeSet;
 

--- a/src/monad/state/test/value_state.cpp
+++ b/src/monad/state/test/value_state.cpp
@@ -37,6 +37,8 @@ static constexpr auto value3 =
 static constexpr auto null =
     0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
 
+using diff_t = InnerStorage::diff_t;
+
 template <typename TDB>
 struct ValueStateTest : public testing::Test
 {
@@ -88,8 +90,6 @@ TYPED_TEST(ValueStateTest, copy)
 
 TYPED_TEST(ValueStateTest, get_storage)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {b, Account{}}},
@@ -148,8 +148,6 @@ TYPED_TEST(ValueStateTest, set_modify_delete_storage)
 
 TYPED_TEST(ValueStateTest, set_modify_delete_merged)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
@@ -217,8 +215,6 @@ TYPED_TEST(ValueStateTest, multiple_get_and_set_from_storage)
 
 TYPED_TEST(ValueStateTest, multiple_get_and_set_from_merged)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}, {c, Account{}}},
@@ -435,8 +431,6 @@ TYPED_TEST(ValueStateTest, can_merge_delete_merged_modified)
 
 TYPED_TEST(ValueStateTest, cant_merge_colliding_merge)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
@@ -471,8 +465,6 @@ TYPED_TEST(ValueStateTest, cant_merge_deleted_merge)
 
 TYPED_TEST(ValueStateTest, cant_merge_conflicting_adds)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     ValueState s{db};
 
@@ -487,8 +479,6 @@ TYPED_TEST(ValueStateTest, cant_merge_conflicting_adds)
 
 TYPED_TEST(ValueStateTest, cant_merge_conflicting_modifies)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},
@@ -523,8 +513,6 @@ TYPED_TEST(ValueStateTest, cant_merge_conflicting_deleted)
 
 TYPED_TEST(ValueStateTest, cant_merge_delete_conflicts_with_modify)
 {
-    using diff_t = typename ValueState<TypeParam>::diff_t;
-
     auto db = test::make_db<TypeParam>();
     db.commit(StateChanges{
         .account_changes = {{a, Account{}}},


### PR DESCRIPTION
Problem:
- InnerStorage as a subclass unfortunately unnecessarily templated due to being a subclass.

Solution:
- Pull it out.