### PR TITLE
:new:Integrate DB to CodeState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,8 @@ add_library(
     ${PROJECT_SOURCE_DIR}/src/monad/db/file_db.cpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/prepare_state.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/trie_db_interface.hpp
+    ${PROJECT_SOURCE_DIR}/include/monad/db/rocks_db_helper.hpp
+    ${PROJECT_SOURCE_DIR}/src/monad/db/rocks_db_helper.cpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/rocks_db.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/rocks_trie_db.hpp
     ${PROJECT_SOURCE_DIR}/include/monad/db/in_memory_db.hpp

--- a/include/monad/db/db_interface.hpp
+++ b/include/monad/db/db_interface.hpp
@@ -3,6 +3,7 @@
 #include <monad/core/account.hpp>
 #include <monad/core/address.hpp>
 #include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/db/concepts.hpp>
 #include <monad/db/config.hpp>
@@ -26,6 +27,7 @@ struct DBInterface
     // Accessors
     ////////////////////////////////////////////////////////////////////
 
+    // Account
     [[nodiscard]] constexpr std::optional<Account> try_find(address_t const &a)
         requires Readable<TPermission>
     {
@@ -48,6 +50,7 @@ struct DBInterface
         return ret.value();
     }
 
+    // Storage
     [[nodiscard]] constexpr bytes32_t
     try_find(address_t const &a, bytes32_t const &k)
         requires Readable<TPermission>
@@ -69,6 +72,29 @@ struct DBInterface
     {
         auto const ret = try_find(a, k);
         MONAD_ASSERT(ret != bytes32_t{});
+        return ret;
+    }
+
+    // Code
+    [[nodiscard]] constexpr byte_string try_find(bytes32_t const &ch)
+        requires Readable<TPermission>
+    {
+        return TExecutor::execute(
+            [=, this]() { return self().try_find_impl(ch); });
+    }
+
+    [[nodiscard]] constexpr bool contains(bytes32_t const &ch)
+        requires Readable<TPermission>
+    {
+        return TExecutor::execute(
+            [=, this]() { return self().contains_impl(ch); });
+    }
+
+    [[nodiscard]] constexpr byte_string at(bytes32_t const &ch)
+        requires Readable<TPermission>
+    {
+        auto const ret = try_find(ch);
+        MONAD_ASSERT(ret != byte_string{});
         return ret;
     }
 

--- a/include/monad/db/rocks_db_helper.hpp
+++ b/include/monad/db/rocks_db_helper.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <monad/core/bytes.hpp>
+
+#include <monad/db/assert.h>
+#include <monad/db/concepts.hpp>
+#include <monad/db/config.hpp>
+#include <monad/db/util.hpp>
+
+#include <monad/state/concepts.hpp>
+#include <monad/state/state_changes.hpp>
+
+#include <rocksdb/db.h>
+
+#include <memory>
+
+MONAD_DB_NAMESPACE_BEGIN
+
+namespace detail
+{
+    void commit_code_to_rocks_db_batch(
+        rocksdb::WriteBatch &batch, state::changeset auto const &obj,
+        rocksdb::ColumnFamilyHandle *cf)
+    {
+        for (auto const &[ch, c] : obj.code_changes) {
+            auto const res = batch.Put(cf, to_slice(ch), to_slice(c));
+            MONAD_ROCKS_ASSERT(res);
+        }
+    }
+
+    [[nodiscard]] bool rocks_db_contains_impl(
+        bytes32_t const &b, std::shared_ptr<rocksdb::DB> db,
+        rocksdb::ColumnFamilyHandle *cf);
+
+    [[nodiscard]] byte_string rocks_db_try_find_impl(
+        bytes32_t const &b, std::shared_ptr<rocksdb::DB> db,
+        rocksdb::ColumnFamilyHandle *cf);
+}
+
+MONAD_DB_NAMESPACE_END

--- a/include/monad/db/trie_db_interface.hpp
+++ b/include/monad/db/trie_db_interface.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <monad/core/address.hpp>
+#include <monad/core/bytes.hpp>
 #include <monad/core/likely.h>
 #include <monad/db/config.hpp>
 #include <monad/db/db_interface.hpp>
@@ -79,6 +81,11 @@ struct TrieDBInterface
         return find(a, k).has_value();
     }
 
+    [[nodiscard]] constexpr bool contains_impl(bytes32_t const &b)
+    {
+        return self().contains_impl(b);
+    }
+
     [[nodiscard]] std::optional<Account> try_find_impl(address_t const &a)
         requires Readable<TPermission>
     {
@@ -139,6 +146,11 @@ struct TrieDBInterface
                 static_cast<uint8_t>(sizeof(bytes32_t) - zeroless.size())));
         MONAD_ASSERT(ret != bytes32_t{});
         return ret;
+    }
+
+    [[nodiscard]] byte_string try_find_impl(bytes32_t const &b)
+    {
+        return self().try_find_impl(b);
     }
 
     ////////////////////////////////////////////////////////////////////

--- a/include/monad/state/concepts.hpp
+++ b/include/monad/state/concepts.hpp
@@ -2,6 +2,9 @@
 
 #include <monad/core/account.hpp>
 #include <monad/core/address.hpp>
+#include <monad/core/byte_string.hpp>
+#include <monad/core/bytes.hpp>
+
 #include <monad/state/config.hpp>
 
 #include <concepts>
@@ -29,7 +32,14 @@ concept storage_changes = requires(T obj) {
 };
 
 template <typename T>
-concept changeset = account_changes<T> && storage_changes<T>;
+concept code_changes = requires(T obj) {
+    { obj.code_changes } -> std::ranges::range;
+    { *obj.code_changes.begin() } -> std::convertible_to<std::pair<bytes32_t, byte_string>>;
+    { obj.code_changes.empty() } -> std::same_as<bool>;
+};
+
+template <typename T>
+concept changeset = account_changes<T> && storage_changes<T> && code_changes<T>;
 
 // clang-format on
 

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -180,8 +180,7 @@ struct State
             return code_.copy_code(get_code_hash(a), offset, buffer, size);
         }
 
-        [[nodiscard]] byte_string_view
-        get_code(bytes32_t const &b) const noexcept
+        [[nodiscard]] byte_string get_code(bytes32_t const &b) const noexcept
         {
             return code_.code_at(b);
         }
@@ -283,13 +282,13 @@ struct State
 
     void commit()
     {
-        code_.commit_all_merged();
         db_.commit(StateChanges{
             .account_changes = accounts_.gather_changes(),
             .storage_changes = storage_.gather_changes(),
-        });
+            .code_changes = code_.gather_changes()});
         accounts_.clear_changes();
         storage_.clear_changes();
+        code_.clear_changes();
         current_txn_ = 0;
         gas_award_ = 0;
     }

--- a/include/monad/state/state_changes.hpp
+++ b/include/monad/state/state_changes.hpp
@@ -2,6 +2,7 @@
 
 #include <monad/core/account.hpp>
 #include <monad/core/address.hpp>
+#include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/state/config.hpp>
 
@@ -16,8 +17,10 @@ struct StateChanges
         std::vector<std::pair<address_t, std::optional<Account>>>;
     using StorageChanges = std::unordered_map<
         address_t, std::vector<std::pair<bytes32_t, bytes32_t>>>;
+    using CodeChanges = std::vector<std::pair<bytes32_t, byte_string>>;
     AccountChanges account_changes;
     StorageChanges storage_changes;
+    CodeChanges code_changes;
 };
 
 MONAD_STATE_NAMESPACE_END

--- a/src/monad/db/rocks_db_helper.cpp
+++ b/src/monad/db/rocks_db_helper.cpp
@@ -1,0 +1,51 @@
+#include <monad/core/byte_string.hpp>
+#include <monad/core/bytes.hpp>
+
+#include <monad/db/assert.h>
+#include <monad/db/config.hpp>
+#include <monad/db/rocks_db_helper.hpp>
+#include <monad/db/util.hpp>
+
+#include <monad/state/state_changes.hpp>
+
+#include <rocksdb/db.h>
+
+#include <memory>
+
+MONAD_DB_NAMESPACE_BEGIN
+
+namespace detail
+{
+    [[nodiscard]] bool rocks_db_contains_impl(
+        bytes32_t const &ch, std::shared_ptr<rocksdb::DB> db,
+        rocksdb::ColumnFamilyHandle *cf)
+    {
+        rocksdb::PinnableSlice value;
+        auto const res =
+            db->Get(rocksdb::ReadOptions{}, cf, to_slice(ch), &value);
+        MONAD_ASSERT(res.ok() || res.IsNotFound());
+        return res.ok();
+    }
+
+    [[nodiscard]] byte_string rocks_db_try_find_impl(
+        bytes32_t const &ch, std::shared_ptr<rocksdb::DB> db,
+        rocksdb::ColumnFamilyHandle *cf)
+    {
+        rocksdb::PinnableSlice value;
+        auto const res =
+            db->Get(rocksdb::ReadOptions{}, cf, to_slice(ch), &value);
+        if (res.IsNotFound()) {
+            return byte_string{};
+        }
+        MONAD_ROCKS_ASSERT(res);
+        byte_string ret{
+            reinterpret_cast<byte_string_view::value_type const *>(
+                value.data()),
+            value.size()};
+
+        return ret;
+    }
+
+}
+
+MONAD_DB_NAMESPACE_END

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -1,7 +1,15 @@
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
 
+#include <monad/db/in_memory_db.hpp>
+#include <monad/db/in_memory_trie_db.hpp>
+#include <monad/db/rocks_db.hpp>
+#include <monad/db/rocks_trie_db.hpp>
+
 #include <monad/state/code_state.hpp>
+#include <monad/state/state_changes.hpp>
+
+#include <monad/test/make_db.hpp>
 
 #include <gtest/gtest.h>
 
@@ -10,240 +18,274 @@
 using namespace monad;
 using namespace monad::state;
 
-static constexpr auto a =
+static constexpr auto a = 0x5353535353535353535353535353535353535353_address;
+static constexpr auto b = 0xbebebebebebebebebebebebebebebebebebebebe_address;
+static constexpr auto code_hash1 =
     0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32;
-static constexpr auto b =
+static constexpr auto code_hash2 =
     0x1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c_bytes32;
-static constexpr auto c =
+static constexpr auto code_hash3 =
     0x5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b_bytes32;
-static constexpr auto c1 =
+static constexpr auto code1 =
     byte_string{0x65, 0x74, 0x68, 0x65, 0x72, 0x6d, 0x69};
-static constexpr auto c2 =
+static constexpr auto code2 =
     byte_string{0x6e, 0x65, 0x20, 0x2d, 0x20, 0x45, 0x55, 0x31, 0x34};
-static constexpr auto c3 =
+static constexpr auto code3 =
     byte_string{0x6e, 0x63, 0x40, 0x2d, 0x20, 0x45, 0x55, 0x31, 0x33};
 
-using db_t = std::unordered_map<bytes32_t, byte_string>;
-
-TEST(CodeState, code_at)
+template <typename TDB>
+struct CodeStateTest : public testing::Test
 {
-    db_t db{};
-    db.insert({a, c1});
+};
+using DBTypes = ::testing::Types<
+    db::InMemoryDB, db::RocksDB, db::InMemoryTrieDB, db::RocksTrieDB>;
+TYPED_TEST_SUITE(CodeStateTest, DBTypes);
+
+TYPED_TEST(CodeStateTest, code_at)
+{
+    auto db = test::make_db<TypeParam>();
+
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
-    auto const code = s.code_at(a);
-    EXPECT_EQ(code, c1);
+    EXPECT_EQ(code1, s.code_at(code_hash1));
 }
 
-TEST(CodeState, changeset)
+TYPED_TEST(CodeStateTest, changeset_code_at)
 {
-    db_t db{};
-    db.insert({a, c1});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
-    auto t = decltype(s)::ChangeSet{s};
-    auto const code_1 = t.code_at(a);
-    EXPECT_EQ(code_1, c1);
+    typename decltype(s)::ChangeSet changeset{s};
+    EXPECT_EQ(code1, changeset.code_at(code_hash1));
 }
 
-TEST(CodeStateChangeSet, set_code)
+TYPED_TEST(CodeStateTest, set_code)
 {
-    db_t db{};
-    db.insert({a, c1});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
-    auto t = decltype(s)::ChangeSet{s};
-    t.set_code(b, c2);
-    t.set_code(c, byte_string{});
+    typename decltype(s)::ChangeSet changeset{s};
+    changeset.set_code(code_hash2, code2);
+    changeset.set_code(code_hash3, byte_string{});
 
-    auto const code_1 = t.code_at(a);
-    auto const code_2 = t.code_at(b);
-    auto const code_3 = t.code_at(c);
-    EXPECT_EQ(code_1, c1);
-    EXPECT_EQ(code_2, c2);
-    EXPECT_EQ(code_3, byte_string{});
+    EXPECT_EQ(changeset.code_at(code_hash1), code1);
+    EXPECT_EQ(changeset.code_at(code_hash2), code2);
+    EXPECT_EQ(changeset.code_at(code_hash3), byte_string{});
 }
 
-TEST(CodeStateChangeSet, get_code_size)
+TYPED_TEST(CodeStateTest, get_code_size)
 {
-    db_t db{};
-    db.insert({a, c1});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
-    auto t = decltype(s)::ChangeSet{s};
-    auto const size = t.get_code_size(a);
+    typename decltype(s)::ChangeSet changeset{s};
 
-    EXPECT_EQ(size, c1.size());
+    EXPECT_EQ(changeset.get_code_size(code_hash1), code1.size());
 }
 
-TEST(CodeStateChangeSet, copy_code)
+TYPED_TEST(CodeStateTest, copy_code)
 {
-    db_t db{};
-    db.insert({a, c1});
-    db.insert({b, c2});
+    auto db = test::make_db<TypeParam>();
+    Account acct_a{.code_hash = code_hash1};
+    Account acct_b{.code_hash = code_hash2};
+
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct_a}, {b, acct_b}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}, {code_hash2, code2}}});
     CodeState s{db};
+
     static constexpr unsigned size{8};
     uint8_t buffer[size];
 
-    auto t = decltype(s)::ChangeSet{s};
+    typename decltype(s)::ChangeSet changeset{s};
 
     { // underflow
-        auto const total = t.copy_code(a, 0u, buffer, size);
-        EXPECT_EQ(total, c1.size());
-        EXPECT_EQ(0, std::memcmp(buffer, c1.c_str(), total));
+        auto const total = changeset.copy_code(code_hash1, 0u, buffer, size);
+        EXPECT_EQ(total, code1.size());
+        EXPECT_EQ(0, std::memcmp(buffer, code1.c_str(), total));
     }
     { // offset
         static constexpr auto offset = 2u;
         static constexpr auto to_copy = 3u;
-        auto const offset_total = t.copy_code(a, offset, buffer, to_copy);
+        auto const offset_total =
+            changeset.copy_code(code_hash1, offset, buffer, to_copy);
         EXPECT_EQ(offset_total, to_copy);
-        EXPECT_EQ(0, std::memcmp(buffer, c1.c_str() + offset, offset_total));
+        EXPECT_EQ(0, std::memcmp(buffer, code1.c_str() + offset, offset_total));
     }
     { // offset overflow
         static constexpr auto offset = 4u;
-        auto const offset_total = t.copy_code(a, offset, buffer, size);
+        auto const offset_total =
+            changeset.copy_code(code_hash1, offset, buffer, size);
         EXPECT_EQ(offset_total, 3u);
-        EXPECT_EQ(0, std::memcmp(buffer, c1.c_str() + offset, offset_total));
+        EXPECT_EQ(0, std::memcmp(buffer, code1.c_str() + offset, offset_total));
     }
     { // regular overflow
-        auto const total = t.copy_code(b, 0u, buffer, size);
+        auto const total = changeset.copy_code(code_hash2, 0u, buffer, size);
         EXPECT_EQ(total, size);
-        EXPECT_EQ(0, std::memcmp(buffer, c2.c_str(), total));
+        EXPECT_EQ(0, std::memcmp(buffer, code2.c_str(), total));
     }
 }
 
-TEST(CodeState, can_merge)
+TYPED_TEST(CodeStateTest, merge_changes)
 {
-    db_t db{};
-    db.insert({a, c1});
-    CodeState s{db};
-
-    auto t = decltype(s)::ChangeSet{s};
-    t.set_code(b, c2);
-    EXPECT_TRUE(s.can_merge(t));
-}
-
-TEST(CodeState, merge_changes)
-{
-    db_t db{};
-    db.insert({a, c1});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(b, c2);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash2, code2);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
     }
-    EXPECT_EQ(s.code_at(b), c2);
-}
-
-TEST(CodeState, revert)
-{
-    db_t db{};
-    db.insert({a, c1});
-    CodeState s{db};
+    EXPECT_EQ(s.code_at(code_hash2), code2);
 
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(b, c2);
-        EXPECT_TRUE(s.can_merge(t));
-        t.revert();
-        s.merge_changes(t);
-    }
-    EXPECT_EQ(0, s.code_at(b).size());
-}
-
-TEST(CodeState, cant_merge_colliding_merge)
-{
-    db_t db{};
-    CodeState s{db};
-
-    {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(a, c1);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
-    }
-    {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(a, c2);
-        EXPECT_FALSE(s.can_merge(t));
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code3);
+        EXPECT_FALSE(s.can_merge(changeset));
     }
 }
 
-TEST(CodeState, cant_merge_colliding_store)
+TYPED_TEST(CodeStateTest, revert)
 {
-    db_t db{};
-    db.insert({a, c1});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
     CodeState s{db};
 
-    auto t = decltype(s)::ChangeSet{s};
-    t.set_code(a, c2);
-    EXPECT_FALSE(s.can_merge(t));
+    {
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash2, code2);
+        EXPECT_TRUE(s.can_merge(changeset));
+        changeset.revert();
+        s.merge_changes(changeset);
+    }
+    EXPECT_EQ(0, s.code_at(code_hash2).size());
 }
 
-TEST(CodeState, merge_multiple_changes)
+TYPED_TEST(CodeStateTest, cant_merge_colliding_merge)
 {
-    db_t db{};
+    auto db = test::make_db<TypeParam>();
     CodeState s{db};
 
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(a, c1);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code1);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
     }
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(b, c2);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code2);
+        EXPECT_FALSE(s.can_merge(changeset));
     }
-    EXPECT_EQ(s.code_at(a), c1);
-    EXPECT_EQ(s.code_at(b), c2);
 }
 
-TEST(CodeState, can_commit)
+TYPED_TEST(CodeStateTest, cant_merge_colliding_store)
 {
-    db_t db{};
-    db.insert({c, c3});
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
+    CodeState s{db};
+
+    typename decltype(s)::ChangeSet changeset{s};
+    changeset.set_code(code_hash1, code2);
+    EXPECT_FALSE(s.can_merge(changeset));
+}
+
+TYPED_TEST(CodeStateTest, merge_multiple_changes)
+{
+    auto db = test::make_db<TypeParam>();
     CodeState s{db};
 
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(a, c1);
-        t.set_code(b, c2);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code1);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
+    }
+    {
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash2, code2);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
+    }
+    EXPECT_EQ(s.code_at(code_hash1), code1);
+    EXPECT_EQ(s.code_at(code_hash2), code2);
+}
+
+TYPED_TEST(CodeStateTest, can_commit)
+{
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash3};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash3, code3}}});
+    CodeState s{db};
+
+    {
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code1);
+        changeset.set_code(code_hash2, code2);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
     }
     EXPECT_TRUE(s.can_commit());
 }
 
-TEST(CodeState, can_commit_multiple)
+TYPED_TEST(CodeStateTest, can_commit_multiple)
 {
-    db_t db{};
+    auto db = test::make_db<TypeParam>();
     CodeState s{db};
 
     {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(a, c1);
-        t.set_code(b, c2);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash1, code1);
+        changeset.set_code(code_hash2, code2);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
     }
-    EXPECT_TRUE(s.can_commit());
-    s.commit_all_merged();
-    {
-        auto t = decltype(s)::ChangeSet{s};
-        t.set_code(c, c3);
-        EXPECT_TRUE(s.can_merge(t));
-        s.merge_changes(t);
-    }
-    EXPECT_TRUE(s.can_commit());
-    s.commit_all_merged();
 
-    EXPECT_EQ(s.code_at(a), c1);
-    EXPECT_EQ(s.code_at(b), c2);
-    EXPECT_EQ(s.code_at(c), c3);
+    EXPECT_TRUE(s.can_commit());
+
+    {
+        typename decltype(s)::ChangeSet changeset{s};
+        changeset.set_code(code_hash3, code3);
+        EXPECT_TRUE(s.can_merge(changeset));
+        s.merge_changes(changeset);
+    }
+    EXPECT_TRUE(s.can_commit());
 }

--- a/src/monad/state/test/value_state.cpp
+++ b/src/monad/state/test/value_state.cpp
@@ -672,8 +672,6 @@ TYPED_TEST(ValueStateTest, commit_all_merged)
         s.merge_touched(u);
         EXPECT_TRUE(s.can_commit());
     }
-
-    auto _ = s.gather_changes();
 }
 
 TYPED_TEST(ValueStateTest, get_after_set)


### PR DESCRIPTION
Problem:
- Currently, our code base uses simple stl unordered_map for storing account's code.
- However, some rpc method will query account's code, so we need a persistant storage.

Solution:
- Adding all 4 DB support for CodeState

By the way, I need to give more thoughts on how we handle empty byte_string. The currently version should work but not very performant / strict. 