### PR TITLE
Refactor CodeState to take code_hash as key

### DIFF
--- a/include/monad/execution/evmone_baseline_interpreter.hpp
+++ b/include/monad/execution/evmone_baseline_interpreter.hpp
@@ -38,7 +38,7 @@ struct EVMOneBaselineInterpreter
                 "evmone_baseline_interpreter_logger");
         evmc::Result result{
             evmc_result{.status_code = EVMC_SUCCESS, .gas_left = m.gas}};
-        auto const code = s.get_code(m.code_address);
+        auto const code = s.get_code(s.get_code_hash(m.code_address));
         if (code.empty()) {
             return result;
         }

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -20,6 +20,9 @@
 
 #include <tl/expected.hpp>
 
+#include <ethash/keccak.hpp>
+
+#include <bit>
 #include <unordered_map>
 
 MONAD_EXECUTION_NAMESPACE_BEGIN
@@ -46,7 +49,7 @@ namespace fake
         struct ChangeSet
         {
             std::unordered_map<address_t, Account> _accounts{};
-            std::unordered_map<address_t, byte_string> _code{};
+            std::unordered_map<bytes32_t, byte_string> _code{};
 
             std::vector<Receipt::Log> _logs{};
             unsigned int _txn_id{};
@@ -151,14 +154,23 @@ namespace fake
 
             void set_code(address_t const &a, byte_string const &c)
             {
-                _code.insert({a, c});
+                auto const code_hash = std::bit_cast<const monad::bytes32_t>(
+                    ethash::keccak256(c.data(), c.size()));
+
+                _code.insert({code_hash, c});
+                if (!account_exists(a)) {
+                    _accounts.emplace(a, Account{.code_hash = code_hash});
+                }
+                else {
+                    _accounts.at(a).code_hash = code_hash;
+                }
             }
 
             // EVMC Host Interface
             [[nodiscard]] size_t
             get_code_size(address_t const &a) const noexcept
             {
-                return _code.at(a).size();
+                return _code.at(get_code_hash(a)).size();
             }
 
             // EVMC Host Interface
@@ -169,9 +181,9 @@ namespace fake
             }
 
             [[nodiscard]] byte_string_view
-            get_code(address_t const &a) const noexcept
+            get_code(bytes32_t const &b) const noexcept
             {
-                return {_code.at(a)};
+                return {_code.at(b)};
             }
 
             void revert() noexcept { _accounts.clear(); }
@@ -216,10 +228,7 @@ namespace fake
 
         unsigned int current_txn() { return _current_txn; }
 
-        ChangeSet get_new_changeset(unsigned int id)
-        {
-            return ChangeSet(id);
-        }
+        ChangeSet get_new_changeset(unsigned int id) { return ChangeSet(id); }
 
         MergeStatus can_merge_changes(ChangeSet const &)
         {

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -162,14 +162,14 @@ struct State
             auto const code_hash = std::bit_cast<const monad::bytes32_t>(
                 ethash::keccak256(c.data(), c.size()));
 
-            code_.set_code(a, c);
+            code_.set_code(code_hash, c);
             accounts_.set_code_hash(a, code_hash);
         }
 
         // EVMC Host Interface
         [[nodiscard]] size_t get_code_size(address_t const &a) const noexcept
         {
-            return code_.get_code_size(a);
+            return code_.get_code_size(get_code_hash(a));
         }
 
         // EVMC Host Interface
@@ -177,13 +177,13 @@ struct State
             address_t const &a, size_t offset, uint8_t *buffer,
             size_t size) const noexcept
         {
-            return code_.copy_code(a, offset, buffer, size);
+            return code_.copy_code(get_code_hash(a), offset, buffer, size);
         }
 
         [[nodiscard]] byte_string_view
-        get_code(address_t const &a) const noexcept
+        get_code(bytes32_t const &b) const noexcept
         {
-            return code_.code_at(a);
+            return code_.code_at(b);
         }
 
         void revert() noexcept

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     auto const start_time = std::chrono::steady_clock::now();
 
     // Real Objects
-    using code_db_t = std::unordered_map<monad::address_t, monad::byte_string>;
+    using code_db_t = std::unordered_map<monad::bytes32_t, monad::byte_string>;
     using db_t = monad::db::RocksTrieDB;
     using block_db_t = monad::db::BlockDb;
     using receipt_collector_t = monad::receiptCollector;

--- a/src/monad/execution/test/evmone_baseline_interpreter.cpp
+++ b/src/monad/execution/test/evmone_baseline_interpreter.cpp
@@ -27,7 +27,7 @@ TEST(Evm1BaselineInterpreter, execute_empty)
     fake::State::ChangeSet s{};
 
     evm_host_t h{};
-    s._code.emplace(a, byte_string{});
+    s.set_code(a, byte_string{});
 
     evmc_message m{.kind = EVMC_CALL, .gas = 10'000, .code_address = a};
 
@@ -50,7 +50,7 @@ TEST(Evm1BaselineInterpreter, execute_simple)
         0x60, // PUSH1, 3 gas
         0x0b, // length
         0x00}; // STOP
-    s._code.emplace(a, code);
+    s.set_code(a, code);
 
     evmc_message m{.kind = EVMC_CALL, .gas = 10'000, .code_address = a};
 
@@ -69,7 +69,7 @@ TEST(Evm1BaselineInterpreter, execute_invalid)
         0x60, // PUSH1, 3 gas
         0x68, // 'h'
         0xfe}; // INVALID
-    s._code.emplace(a, code);
+    s.set_code(a, code);
 
     evmc_message m{.kind = EVMC_CALL, .gas = 10'000, .code_address = a};
 

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -1,5 +1,5 @@
-#include <monad/core/address.hpp>
 #include <monad/core/byte_string.hpp>
+#include <monad/core/bytes.hpp>
 
 #include <monad/state/code_state.hpp>
 
@@ -10,9 +10,12 @@
 using namespace monad;
 using namespace monad::state;
 
-static constexpr auto a = 0x5353535353535353535353535353535353535353_address;
-static constexpr auto b = 0xbebebebebebebebebebebebebebebebebebebebe_address;
-static constexpr auto c = 0xa5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5_address;
+static constexpr auto a =
+    0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32;
+static constexpr auto b =
+    0x1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c_bytes32;
+static constexpr auto c =
+    0x5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b_bytes32;
 static constexpr auto c1 =
     byte_string{0x65, 0x74, 0x68, 0x65, 0x72, 0x6d, 0x69};
 static constexpr auto c2 =
@@ -20,7 +23,7 @@ static constexpr auto c2 =
 static constexpr auto c3 =
     byte_string{0x6e, 0x63, 0x40, 0x2d, 0x20, 0x45, 0x55, 0x31, 0x33};
 
-using db_t = std::unordered_map<address_t, byte_string>;
+using db_t = std::unordered_map<bytes32_t, byte_string>;
 
 TEST(CodeState, code_at)
 {

--- a/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
+++ b/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
@@ -32,7 +32,7 @@ static constexpr auto to = 0xbebebebebebebebebebebebebebebebebebebebe_address;
 static constexpr auto a = 0xa5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5_address;
 static constexpr auto o = 0xb5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5_address;
 
-using code_db_t = std::unordered_map<address_t, byte_string>;
+using code_db_t = std::unordered_map<bytes32_t, byte_string>;
 using account_store_db_t = db::InMemoryDB;
 
 template <class TState, concepts::fork_traits<TState> TTraits>
@@ -94,8 +94,7 @@ TEST(TxnProcEvmInterpStateHost, account_transfer_miner_ommer_award)
     EXPECT_EQ(changeset.get_balance(to), bytes32_t{1'000'000});
 
     EXPECT_EQ(
-        s.can_merge_changes(changeset),
-        decltype(s)::MergeStatus::WILL_SUCCEED);
+        s.can_merge_changes(changeset), decltype(s)::MergeStatus::WILL_SUCCEED);
     s.merge_changes(changeset);
 
     fork_t::apply_block_award(s, b);
@@ -110,8 +109,10 @@ TEST(TxnProcEvmInterpStateHost, account_transfer_miner_ommer_award)
 TEST(TxnProcEvmInterpStateHost, out_of_gas_account_creation_failure)
 {
     // Block 46'402, txn 0
-    static constexpr auto creator = 0xA1E4380A3B1f749673E270229993eE55F35663b4_address;
-    static constexpr auto created = 0x9a049f5d18c239efaa258af9f3e7002949a977a0_address;
+    static constexpr auto creator =
+        0xA1E4380A3B1f749673E270229993eE55F35663b4_address;
+    static constexpr auto created =
+        0x9a049f5d18c239efaa258af9f3e7002949a977a0_address;
     db::BlockDb blocks{test_resource::correct_block_data_dir};
     account_store_db_t db{};
     state::AccountState accounts{db};
@@ -123,7 +124,8 @@ TEST(TxnProcEvmInterpStateHost, out_of_gas_account_creation_failure)
     db.commit(state::StateChanges{
         .account_changes =
             {{a, Account{}},
-             {creator, Account{.balance = 9'000'000'000'000'000'000, .nonce = 3}}},
+             {creator,
+              Account{.balance = 9'000'000'000'000'000'000, .nonce = 3}}},
         .storage_changes = {}});
 
     byte_string code = {0x60, 0x60, 0x60, 0x40, 0x52, 0x60, 0x00, 0x80, 0x54,
@@ -157,12 +159,12 @@ TEST(TxnProcEvmInterpStateHost, out_of_gas_account_creation_failure)
     EXPECT_EQ(r.status, Receipt::Status::FAILED);
     EXPECT_EQ(r.gas_used, 24'000);
     EXPECT_EQ(t.type, Transaction::Type::eip155);
-    EXPECT_EQ(changeset.get_balance(creator), bytes32_t{8'760'000'000'000'000'000});
+    EXPECT_EQ(
+        changeset.get_balance(creator), bytes32_t{8'760'000'000'000'000'000});
     EXPECT_EQ(changeset.get_balance(created), bytes32_t{0});
 
     EXPECT_EQ(
-        s.can_merge_changes(changeset),
-        decltype(s)::MergeStatus::WILL_SUCCEED);
+        s.can_merge_changes(changeset), decltype(s)::MergeStatus::WILL_SUCCEED);
     s.merge_changes(changeset);
 
     fork_t::apply_block_award(s, b);


### PR DESCRIPTION
Problem:
- Taking address as key will create a lot of duplication in our DB (different account having the same code)

Solution:
- Use code_hash instead for the key for CodeState storage

Prev:
#219 