### PR TITLE
:recycle: remove template on create_and_prune_block_history

### DIFF
--- a/include/monad/db/rocks_db.hpp
+++ b/include/monad/db/rocks_db.hpp
@@ -294,7 +294,7 @@ namespace detail
             requires Writable<TPermission>
         {
             auto const s = ::monad::db::create_and_prune_block_history(
-                *this, block_number);
+                root, db, block_number, block_history_size);
             if (!s.has_value()) {
                 // this is not a critical error in production, we can continue
                 // executing with the current database while someone

--- a/include/monad/db/rocks_trie_db.hpp
+++ b/include/monad/db/rocks_trie_db.hpp
@@ -218,7 +218,7 @@ namespace detail
             requires Writable<TPermission>
         {
             auto const s = ::monad::db::create_and_prune_block_history(
-                *this, block_number);
+                root, db, block_number, block_history_size);
             if (!s.has_value()) {
                 // this is not a critical error in production, we can continue
                 // executing with the current database while someone


### PR DESCRIPTION
Problem:
- create_and_prune_block_history had weird ergonomics since it required a reference of the database. this results in unclear input requirements since TDB was the god object

Solution:
- Remove templating and add in inputs explicitly as part of the function signature