### PR TITLE
:bug: Remove old code state assertion.

### DIFF
--- a/include/monad/state/code_state.hpp
+++ b/include/monad/state/code_state.hpp
@@ -100,13 +100,15 @@ struct CodeState<TCodeDB>::ChangeSet : public CodeState<TCodeDB>
         return CodeState::code_at(b);
     }
 
-    void set_code(bytes32_t const &b, byte_string const &code)
+    void set_code(bytes32_t const &code_hash, byte_string const &code)
     {
         if (code.empty()) {
             return;
         }
-        auto const &[_, inserted] = code_.emplace(b, code);
-        MONAD_DEBUG_ASSERT(inserted);
+        auto const &[_, inserted] = code_.emplace(code_hash, code);
+        if (!inserted) {
+            MONAD_DEBUG_ASSERT(code_.at(code_hash) == code);
+        }
     }
 
     [[nodiscard]] size_t get_code_size(bytes32_t const &b) const noexcept

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -289,3 +289,15 @@ TYPED_TEST(CodeStateTest, can_commit_multiple)
     }
     EXPECT_TRUE(s.can_commit());
 }
+
+TYPED_TEST(CodeStateTest, distinct_account_identical_code)
+{
+    auto db = test::make_db<TypeParam>();
+    CodeState s{db};
+
+    typename decltype(s)::ChangeSet changeset{s};
+    changeset.set_code(code_hash1, code1);
+    changeset.set_code(code_hash1, code1);
+    EXPECT_TRUE(s.can_merge(changeset));
+    s.merge_changes(changeset);
+}


### PR DESCRIPTION
Problem:
- In 6b79444, we changed code state to use the hash of the code as the key into the code storage map, but kept the older assertion that was meant to prevent duplicate code insertion. However, now duplicate code insertion is possible if two smart contracts have the same code.

Solution:
- Remove the old assertion, and add a test.