### PR TITLE
:bug: code should be generated from executing init code

### DIFF
--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -170,7 +170,7 @@ namespace fork_traits
         {
             if (result.status_code == EVMC_SUCCESS) {
                 auto const deploy_cost =
-                    static_cast<int64_t>(s.get_code_size(a)) * 200;
+                    static_cast<int64_t>(result.output_size) * 200;
                 result.create_address = a;
 
                 if (result.gas_left < deploy_cost) {
@@ -238,13 +238,16 @@ namespace fork_traits
         {
             if (result.status_code == EVMC_SUCCESS) {
                 auto const deploy_cost =
-                    static_cast<int64_t>(s.get_code_size(a)) * 200;
+                    static_cast<int64_t>(result.output_size) * 200;
 
                 if (result.gas_left < deploy_cost) {
                     // EIP-2: If contract creation does not have enough gas to
                     // pay for the final gas fee for adding the contract code to
                     // the state, the contract creation fails (ie. goes
                     // out-of-gas) rather than leaving an empty contract.
+                    //
+                    // TODO: make sure old initialization code does not get
+                    // committed to the database
                     result.status_code = EVMC_OUT_OF_GAS;
                     result.gas_left = 0;
                 }


### PR DESCRIPTION
Problem:
- currently the code hash associated with an account is that of the
  initialization code
- the YP states that the code stored for an account should be the result
  of executing the init code

From YP: "Additionally, a contract creation transaction (regardless
whether legacy or EIP-2930) contains: init: An unlimited size byte array
specifying the EVM-code for the account initialisation procedure, formally
Ti. init is an EVM-code fragment; it returns the body, a second fragment
of code that executes each time the account receives a message call (either
through a transaction or due to the internal execution of code). init is
executed only once at account creation and gets discarded immediately
thereafter."

Solution:
- Use the body instead of the initialization code for the code hash

On top of #248 