### PR TITLE
🐛 avoid constructing a byte_string using a nullptr 

### DIFF
--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -181,7 +181,13 @@ namespace fork_traits
                     s.set_code(a, {});
                 }
                 else {
-                    s.set_code(a, {result.output_data, result.output_size});
+                    if (result.output_size) {
+                        MONAD_DEBUG_ASSERT(result.output_data);
+                        s.set_code(
+                            a,
+                            byte_string{
+                                result.output_data, result.output_size});
+                    }
                     result.gas_left -= deploy_cost;
                 }
             }
@@ -254,7 +260,13 @@ namespace fork_traits
                 else {
                     result.create_address = a;
                     result.gas_left -= deploy_cost;
-                    s.set_code(a, {result.output_data, result.output_size});
+                    if (result.output_size) {
+                        MONAD_DEBUG_ASSERT(result.output_data);
+                        s.set_code(
+                            a,
+                            byte_string{
+                                result.output_data, result.output_size});
+                    }
                 }
             }
             return result;

--- a/include/monad/trie/in_memory_writer.hpp
+++ b/include/monad/trie/in_memory_writer.hpp
@@ -27,7 +27,7 @@ struct InMemoryWriter
     {
     }
 
-    void put(KeyBuffer const &key, byte_string_view value)
+    void put(KeyBuffer const &key, byte_string const &value)
     {
         // puts should override any previous actions
         auto const bs = byte_string{key.view()};


### PR DESCRIPTION
Problem:
- Although the standard does not explicitly state that construction of
  a basic_string with a nullptr and 0 size is invalid, some
  implementation on some platforms use memmove, where it is undefined
  behavior to pass in a nullptr. Worth noting that many implementation
  do accept this form of construction.

Solution:
- Avoid this type of construction to be as portable as possible.