### PR TITLE
Revert ":bug: avoid constructing a byte_string using a nullptr"

### DIFF
--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -181,13 +181,7 @@ namespace fork_traits
                     s.set_code(a, {});
                 }
                 else {
-                    if (result.output_size) {
-                        MONAD_DEBUG_ASSERT(result.output_data);
-                        s.set_code(
-                            a,
-                            byte_string{
-                                result.output_data, result.output_size});
-                    }
+                    s.set_code(a, {result.output_data, result.output_size});
                     result.gas_left -= deploy_cost;
                 }
             }
@@ -260,13 +254,7 @@ namespace fork_traits
                 else {
                     result.create_address = a;
                     result.gas_left -= deploy_cost;
-                    if (result.output_size) {
-                        MONAD_DEBUG_ASSERT(result.output_data);
-                        s.set_code(
-                            a,
-                            byte_string{
-                                result.output_data, result.output_size});
-                    }
+                    s.set_code(a, {result.output_data, result.output_size});
                 }
             }
             return result;

--- a/include/monad/trie/in_memory_writer.hpp
+++ b/include/monad/trie/in_memory_writer.hpp
@@ -27,7 +27,7 @@ struct InMemoryWriter
     {
     }
 
-    void put(KeyBuffer const &key, byte_string const &value)
+    void put(KeyBuffer const &key, byte_string_view value)
     {
         // puts should override any previous actions
         auto const bs = byte_string{key.view()};


### PR DESCRIPTION
This reverts commit 80f0522bd6ae99b13c7ab2e0948864686ba76414.