### PR TITLE
:bug: Fix incorrect txn gas reward for miner

### DIFF
--- a/include/monad/execution/transaction_processor.hpp
+++ b/include/monad/execution/transaction_processor.hpp
@@ -111,7 +111,7 @@ struct TransactionProcessor
             s,
             t,
             base_fee_per_gas,
-            t.gas_limit - static_cast<uint64_t>(result.gas_left));
+            t.gas_limit - gas_remaining);
 
         auto receipt =
             h.make_receipt_from_result(result.status_code, t, gas_remaining);

--- a/src/monad/execution/test/transaction_processor.cpp
+++ b/src/monad/execution/test/transaction_processor.cpp
@@ -61,4 +61,7 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     EXPECT_EQ(result.status, 1u);
     EXPECT_EQ(s._accounts[from].balance, uint256_t{55'999'999'999'800'000});
     EXPECT_EQ(s._accounts[from].nonce, 25); // EVMC will inc for creation
+
+    // check if miner gets the right reward
+    EXPECT_EQ(s._reward, uint256_t{200'000});
 }


### PR DESCRIPTION
Problem:
- Our current code award the right gas to sender when there is gas refund, but doesn't deduct the same amount from the txn award
- This causes the miner's eventual award to be wrong

Solution:
- Award the miner the same amount as charged to sender

Reference Block Number: 50111