### PR TITLE
:bug: Fix access accounts for internal txns

### DIFF
--- a/include/monad/execution/evmc_host.hpp
+++ b/include/monad/execution/evmc_host.hpp
@@ -122,6 +122,8 @@ struct EvmcHost : public evmc::Host
             return TEvm::create_contract_account(this, state_, m);
         }
 
+        access_account(m.code_address);
+        access_account(m.recipient);
         return TEvm::call_evm(this, state_, m);
     }
 

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -104,8 +104,11 @@ namespace fake
             }
 
             // EVMC Host Interface
-            evmc_access_status access_account(address_t const &) noexcept
+            evmc_access_status access_account(address_t const &a) noexcept
             {
+                if (!_accounts.contains(a)) {
+                    _accounts.emplace(a, Account{});
+                }
                 return {};
             }
 

--- a/src/monad/execution/test/evmc_host.cpp
+++ b/src/monad/execution/test/evmc_host.cpp
@@ -128,3 +128,33 @@ TEST(EvmcHost, emit_log)
     EXPECT_EQ(logs[0].topics[0], topic0);
     EXPECT_EQ(logs[0].topics[1], topic1);
 }
+
+TEST(EvmcHost, internal_txn)
+{
+    static constexpr auto from{
+        0x5353535353535353535353535353535353535353_address};
+    static constexpr auto to{
+        0xdac17f958d2ee523a2206206994597c13d831ec7_address};
+    static constexpr auto code_address{
+        0x0000000000000000000000000000000000000003_address};
+    evmc_message m{
+        .kind = EVMC_CALL,
+        .gas = int64_t{10'000},
+        .recipient = to,
+        .sender = from,
+        .input_data = {},
+        .input_size = 0,
+        .code_address = code_address};
+
+    BlockHeader const b{};
+    Transaction const t{};
+    fake::State::ChangeSet s{};
+    s.access_account(from);
+
+    evmc_host_t host{b, t, s};
+    [[maybe_unused]] auto const result = host.call(m);
+
+    EXPECT_TRUE(s.account_exists(from));
+    EXPECT_TRUE(s.account_exists(to));
+    EXPECT_TRUE(s.account_exists(code_address));
+}


### PR DESCRIPTION
Problem:
- We don't access 'recipient' and 'code_address' before calling evm
- That is fine for non-delegated call, but for calls with internal txns, it may cause accessing accounts not in ChangeSet

Solution:
- Access both 'recipient' and 'code_address' before calling EVM in EvmcHost

Reference Block Number: 50111