### PR TITLE
:bug: Fix get_code_hash for accounts not in ChangeSet

### DIFF
--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -204,7 +204,11 @@ struct AccountState<TAccountDB>::ChangeSet : public AccountState<TAccountDB>
     [[nodiscard]] bytes32_t
     get_code_hash(address_t const &address) const noexcept
     {
-        return changed_.at(address).updated.value_or(Account{}).code_hash;
+        if (changed_.contains(address)) {
+            return changed_.at(address).updated.value_or(Account{}).code_hash;
+        }
+
+        return AccountState::get_code_hash(address);
     }
 
     void set_code_hash(address_t const &address, bytes32_t const &b) noexcept

--- a/src/monad/state/test/account_state.cpp
+++ b/src/monad/state/test/account_state.cpp
@@ -225,6 +225,41 @@ TYPED_TEST(AccountStateTest, get_code_hash_changeset)
     EXPECT_EQ(bs.get_code_hash(b), hash2);
 }
 
+TYPED_TEST(AccountStateTest, get_code_hash_non_existing_account)
+{
+    auto db = test::make_db<TypeParam>();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.code_hash = hash1}}},
+        .storage_changes = {}});
+
+    AccountState s{db};
+
+    auto bs = typename decltype(s)::ChangeSet{s};
+
+    bs.access_account(a);
+
+    EXPECT_EQ(bs.get_code_hash(a), hash1);
+    EXPECT_EQ(bs.get_code_hash(b), NULL_HASH);
+}
+
+TYPED_TEST(AccountStateTest, get_code_hash_account_not_in_changeset)
+{
+    auto db = test::make_db<TypeParam>();
+    db.commit(StateChanges{
+        .account_changes = {{a, Account{.code_hash = hash1}}, {b, Account{.code_hash = hash2}}},
+        .storage_changes = {}});
+
+    AccountState s{db};
+
+    auto bs = typename decltype(s)::ChangeSet{s};
+
+    // this only puts a in changeset, not b
+    bs.access_account(a);
+
+    EXPECT_EQ(bs.get_code_hash(a), hash1);
+    EXPECT_EQ(bs.get_code_hash(b), hash2);
+}
+
 TYPED_TEST(AccountStateTest, create_account_changeset)
 {
     auto db = test::make_db<TypeParam>();


### PR DESCRIPTION
Problem:
- A smart contract could access code hash for any arbitrary account not in `ChangeSet` (it could even not exist!)
- Our code segfaults on this because we require any accessed account to be in `ChangeSet` first

Solution:
- When an account is not in `ChangeSet`, we call `AccountState.get_code_hash()`, which will look at `DB` and return `NULL_HASH` if not exist

Reference Block Number: 68460