### PR TITLE
:bug: Fix CodeState can_merge logic

### DIFF
--- a/include/monad/state/code_state.hpp
+++ b/include/monad/state/code_state.hpp
@@ -47,8 +47,9 @@ struct CodeState
 
     [[nodiscard]] bool can_merge(ChangeSet const &w) const
     {
-        return std::ranges::none_of(w.code_, [&](auto const &a) {
-            return merged_.contains(a.first) || db_.contains(a.first);
+        return std::ranges::all_of(w.code_, [&](auto const &a) {
+            auto const &existing_value = code_at(a.first);
+            return existing_value == empty || a.second == existing_value;
         });
     }
 
@@ -56,9 +57,8 @@ struct CodeState
     {
         assert(can_merge(w));
 
-        for (auto &[a, code] : w.code_) {
-            auto const &[_, inserted] = merged_.emplace(a, std::move(code));
-            MONAD_DEBUG_ASSERT(inserted);
+        for (auto &[code_hash, code] : w.code_) {
+            merged_.emplace(code_hash, std::move(code));
         }
     }
 

--- a/src/monad/state/test/code_state.cpp
+++ b/src/monad/state/test/code_state.cpp
@@ -172,6 +172,22 @@ TYPED_TEST(CodeStateTest, merge_changes)
     }
 }
 
+TYPED_TEST(CodeStateTest, can_merge_after_set_same_code)
+{
+    auto db = test::make_db<TypeParam>();
+    Account acct{.code_hash = code_hash1};
+    db.commit(state::StateChanges{
+        .account_changes = {{a, acct}},
+        .storage_changes = {},
+        .code_changes = {{code_hash1, code1}}});
+    CodeState s{db};
+
+    typename decltype(s)::ChangeSet changeset{s};
+    changeset.set_code(code_hash1, code1);
+    EXPECT_TRUE(s.can_merge(changeset));
+    s.merge_changes(changeset);
+}
+
 TYPED_TEST(CodeStateTest, revert)
 {
     auto db = test::make_db<TypeParam>();


### PR DESCRIPTION
Problem:
- Copy the same code to another address is allowed. However, since our code is stored based on hash, when we are replicating code, our current `can_merge` will fail because it assert that the same hash existed

Solution:
- Return false when key is the same but value is not the same instead
- Remove `MONAD_DEBUG_ASSERT()` in `merge_changes`