### PR TITLE
:sparkles: add in support for the petersburg fork

### DIFF
--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -36,7 +36,7 @@ namespace fork_traits
     struct tangerine_whistle;
     struct spurious_dragon;
     struct byzantium;
-    struct constantinople;
+    struct constantinople_and_petersburg;
     struct istanbul;
     struct berlin;
     struct london;
@@ -343,7 +343,7 @@ namespace fork_traits
 
     struct byzantium : public spurious_dragon
     {
-        using next_fork_t = constantinople;
+        using next_fork_t = constantinople_and_petersburg;
 
         static constexpr evmc_revision rev = EVMC_BYZANTIUM;
         static constexpr auto last_block_number = 7'279'999u;
@@ -380,11 +380,13 @@ namespace fork_traits
         }
     };
 
-    struct constantinople : public byzantium
+    // EIP-1716 petersburg and constantinople forks are activated at the same
+    // block on mainnet
+    struct constantinople_and_petersburg : public byzantium
     {
         using next_fork_t = istanbul;
 
-        static constexpr evmc_revision rev = EVMC_CONSTANTINOPLE;
+        static constexpr evmc_revision rev = EVMC_PETERSBURG;
         static constexpr auto last_block_number = 9'068'999;
         static constexpr uint256_t block_reward =
             2'000'000'000'000'000'000; // YP Eqn. 176, EIP-1234
@@ -397,9 +399,8 @@ namespace fork_traits
             apply_mining_award(s, b, block_reward, additional_ommer_reward);
         }
     };
-    // petersburg - 7'280'000
 
-    struct istanbul : public constantinople
+    struct istanbul : public constantinople_and_petersburg
     {
         using next_fork_t = berlin;
 
@@ -420,7 +421,8 @@ namespace fork_traits
 
         using static_precompiles_t = boost::mp11::mp_append<
             boost::mp11::mp_transform<
-                switch_fork_t, constantinople::static_precompiles_t>,
+                switch_fork_t,
+                constantinople_and_petersburg::static_precompiles_t>,
             type_list_t<istanbul, contracts::Blake2F>>;
         static_assert(boost::mp11::mp_size<static_precompiles_t>() == 9);
 

--- a/src/monad/execution/ethereum/test/fork_traits.cpp
+++ b/src/monad/execution/ethereum/test/fork_traits.cpp
@@ -291,8 +291,15 @@ TEST(fork_traits, byzantium)
     EXPECT_EQ(state._block_reward[c], 2'250'000'000'000'000'000);
 }
 
-static_assert(concepts::fork_traits<fork_traits::constantinople, state_t>);
-TEST(fork_traits, constantinople)
+static_assert(
+    concepts::fork_traits<fork_traits::constantinople_and_petersburg, state_t>);
+static_assert(
+    std::derived_from<
+        fork_traits::constantinople_and_petersburg, fork_traits::byzantium>);
+static_assert(std::same_as<
+              fork_traits::constantinople_and_petersburg::next_fork_t,
+              fork_traits::istanbul>);
+TEST(fork_traits, constantinople_and_petersburg)
 {
     // block award
     execution::fake::State state{};
@@ -302,13 +309,18 @@ TEST(fork_traits, constantinople)
         .ommers = {
             BlockHeader{.number = 9, .beneficiary = b},
             BlockHeader{.number = 8, .beneficiary = c}}};
-    fork_traits::constantinople::apply_block_award(state, block);
+    fork_traits::constantinople_and_petersburg::apply_block_award(state, block);
     EXPECT_EQ(state._block_reward[a], 2'125'000'000'000'000'000);
     EXPECT_EQ(state._block_reward[b], 1'750'000'000'000'000'000);
     EXPECT_EQ(state._block_reward[c], 1'500'000'000'000'000'000);
 }
 
 static_assert(concepts::fork_traits<fork_traits::istanbul, state_t>);
+static_assert(
+    std::derived_from<
+        fork_traits::istanbul, fork_traits::constantinople_and_petersburg>);
+static_assert(
+    std::same_as<fork_traits::istanbul::next_fork_t, fork_traits::berlin>);
 TEST(fork_traits, istanbul)
 {
     fork_traits::istanbul i{};

--- a/src/monad/execution/ethereum/test/replay_eth_block_db.cpp
+++ b/src/monad/execution/ethereum/test/replay_eth_block_db.cpp
@@ -485,7 +485,7 @@ TEST(ReplayFromBlockDb_Eth, frontier_to_spurious_dragon)
     }
 }
 
-TEST(ReplayFromBlockDb_Eth, byzantium_to_constantinople)
+TEST(ReplayFromBlockDb_Eth, byzantium_to_constantinople_and_petersburg)
 {
     state_t state;
     fakeBlockDb block_db;
@@ -515,5 +515,5 @@ TEST(ReplayFromBlockDb_Eth, byzantium_to_constantinople)
     EXPECT_EQ(result.block_number, finish_block_number - 1);
     EXPECT_EQ(receipt_collector.size(), 2);
     EXPECT_EQ(receipt_collector[0][0].status, EVMC_BYZANTIUM);
-    EXPECT_EQ(receipt_collector[1][0].status, EVMC_CONSTANTINOPLE);
+    EXPECT_EQ(receipt_collector[1][0].status, EVMC_PETERSBURG);
 }


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-1716

The Constantinople network upgrade was delayed on main-net, so Petersburg was activated at the same block as Constantinople.