### PR TITLE
:new: add in capability to specify fork when running ethereum tests

### DIFF
--- a/test/ethereum_test/include/ethereum_test.hpp
+++ b/test/ethereum_test/include/ethereum_test.hpp
@@ -16,34 +16,49 @@
 
 MONAD_TEST_NAMESPACE_BEGIN
 
-class EthereumTests : public testing::Test
-{
-    std::filesystem::path json_test_file_;
-    std::string suite_name_;
-    std::string test_name_;
-    std::string file_name_;
+inline std::unordered_map<std::string, size_t> const fork_index_map = {
+    {"Frontier", 0},
+    {"Homestead", 1},
+    // DAO and Tangerine Whistle not covered by Ethereum Tests
+    {"EIP158", 4},
+    {"Byzantium", 5},
+    {"Constantinople", 6},
+    {"Istanbul", 7},
+    {"Berlin", 8},
+    {"London", 9}};
 
-public:
+struct EthereumTests : public testing::Test
+{
+    std::filesystem::path json_test_file;
+    std::string suite_name;
+    std::string test_name;
+    std::string file_name;
+    std::optional<size_t> fork_index;
+
     EthereumTests(
         std::filesystem::path json_test_file, std::string suite_name,
-        std::string test_name, std::string file_name) noexcept
-        : json_test_file_{json_test_file}
-        , suite_name_{suite_name}
-        , test_name_{test_name}
-        , file_name_{file_name}
+        std::string test_name, std::string file_name,
+        std::optional<size_t> fork_index) noexcept
+        : json_test_file{json_test_file}
+        , suite_name{suite_name}
+        , test_name{test_name}
+        , file_name{file_name}
+        , fork_index{fork_index}
     {
     }
 
     static void register_test(
-        std::string const &suite_name, std::filesystem::path const &file);
+        std::string const &suite_name, std::filesystem::path const &file,
+        std::optional<size_t> fork_index);
 
-    static void register_test_files(std::filesystem::path const &root);
+    static void register_test_files(
+        std::filesystem::path const &root, std::optional<size_t> fork_index);
 
     void TestBody() override;
 
     [[nodiscard]] static StateTransitionTest load_state_test(
         nlohmann::json json, std::string suite_name, std::string test_name,
-        std::string file_name);
+        std::string file_name, std::optional<size_t> fork_index);
 
     static void
     run_state_test(StateTransitionTest const &test, nlohmann::json const &json);

--- a/test/ethereum_test/src/main.cpp
+++ b/test/ethereum_test/src/main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
     monad::log::level_t evmone_baseline_interpreter_log_level =
         quill::LogLevel::None;
     monad::log::level_t state_log_level = quill::LogLevel::None;
+    std::optional<size_t> fork_index = std::nullopt;
 
     // The default test filter. To enable all tests use `--gtest_filter=*`.
     testing::FLAGS_gtest_filter =
@@ -63,8 +64,6 @@ int main(int argc, char *argv[])
     testing::InitGoogleTest(&argc, argv); // Process GoogleTest flags.
 
     CLI::App app{"monad ethereum tests runner"};
-
-    std::vector<std::string> paths;
 
     auto *log_levels = app.add_subcommand("log_levels", "level of logging");
     log_levels
@@ -88,6 +87,10 @@ int main(int argc, char *argv[])
     log_levels->add_option("--state", state_log_level, "Log level for state")
         ->transform(CLI::CheckedTransformer(log_levels_map, CLI::ignore_case));
 
+    app.add_option("--fork", fork_index, "Fork to run unit tests for")
+        ->transform(CLI::CheckedTransformer(
+            monad::test::fork_index_map, CLI::ignore_case));
+
     CLI11_PARSE(app, argc, argv);
 
     monad::log::logger_t::set_log_level(
@@ -103,7 +106,8 @@ int main(int argc, char *argv[])
 
     // only worrying about GeneralStateTests folder for now
     monad::test::EthereumTests::register_test_files(
-        monad::test_resource::ethereum_tests_dir / "GeneralStateTests");
+        monad::test_resource::ethereum_tests_dir / "GeneralStateTests",
+        fork_index);
 
     int return_code = RUN_ALL_TESTS();
 


### PR DESCRIPTION
Problem:
- each ethereum test is ran for multiple forks, and we have no way of specifying which fork we care about

Solution:
- Add in a command line argument 'fork' which allows us to specify fork

This is implemented as a command line options as opposed to registering several tests with GTEST representing different forks to avoid the expensive json parsing at registration time, which gets executed every time the binary is ran .