### PR TITLE
Add support for Paris fork

### DIFF
--- a/include/monad/execution/replay_block_db.hpp
+++ b/include/monad/execution/replay_block_db.hpp
@@ -134,6 +134,8 @@ public:
                         read_genesis(genesis_file_path, state.accounts_.db_);
                 }
 
+                TTraits::validate_block(block);
+
                 TAllTxnBlockProcessor<TExecution> block_processor{};
                 auto const receipts = block_processor.template execute<
                     TState,

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -455,6 +455,8 @@ namespace fake
             {
             }
 
+            static constexpr void validate_block(Block const &) {}
+
             static constexpr void warm_coinbase(TState &, address_t const &) {}
 
             static constexpr void process_withdrawal(

--- a/test/ethereum_test/src/ethereum_test.cpp
+++ b/test/ethereum_test/src/ethereum_test.cpp
@@ -161,7 +161,7 @@ void EthereumTests::register_test_files(
     // static assert here to remind anyone who adds a fork to update this
     // function
     static_assert(
-        boost::mp11::mp_size<monad::fork_traits::all_forks_t>::value == 11);
+        boost::mp11::mp_size<monad::fork_traits::all_forks_t>::value == 12);
 
     if (fork_index_map.contains(fork_name)) {
         return fork_index_map.at(fork_name);


### PR DESCRIPTION
Add support for the Paris fork (a.k.a the Merge), which includes the following EIPs:
- EIP-3675: Upgrade consensus to Proof-of-Stake
- EIP-4399: Supplant DIFFICULTY opcode with PREVRANDAO
