### PR TITLE
:bug: make ethereum tests open a unique persistent store on every run

### DIFF
--- a/test/ethereum_test/src/ethereum_test.cpp
+++ b/test/ethereum_test/src/ethereum_test.cpp
@@ -260,12 +260,14 @@ void EthereumTests::run_state_test(
             }();
 
             monad::execution::fake::BlockDb fake_block_db;
-            db_t db{
-                db::Writable{},
-                monad::test_resource::build_dir / "rocksdb" / suite_name /
-                    test_name / fork_name,
-                std::nullopt,
-                0};
+
+            static auto const time = fmt::format(
+                "{}", std::chrono::system_clock::now().time_since_epoch());
+            auto const dir = monad::test_resource::build_dir / "rocksdb" /
+                             time / suite_name / test_name / fork_name /
+                             std::to_string(case_index);
+            MONAD_ASSERT(!std::filesystem::exists(dir));
+            db_t db{db::Writable{}, dir, std::nullopt, 0};
 
             monad::state::AccountState accounts{db};
             monad::state::ValueState values{db};


### PR DESCRIPTION
Problem:
- The same persistent store is shared across runs and also between transactions within a single test

Solution:
- Start from clean database state by changing the directory structure to include epoch time and case index

Thanks to @rgarc for noticing.