### PR TITLE
:new: add ability to specify txn index in ethereum tests

### DIFF
--- a/test/ethereum_test/include/ethereum_test.hpp
+++ b/test/ethereum_test/include/ethereum_test.hpp
@@ -34,31 +34,36 @@ struct EthereumTests : public testing::Test
     std::string test_name;
     std::string file_name;
     std::optional<size_t> fork_index;
+    std::optional<size_t> txn_index;
 
     EthereumTests(
         std::filesystem::path json_test_file, std::string suite_name,
         std::string test_name, std::string file_name,
-        std::optional<size_t> fork_index) noexcept
+        std::optional<size_t> fork_index,
+        std::optional<size_t> txn_index) noexcept
         : json_test_file{json_test_file}
         , suite_name{suite_name}
         , test_name{test_name}
         , file_name{file_name}
         , fork_index{fork_index}
+        , txn_index(txn_index)
     {
     }
 
     static void register_test(
         std::string const &suite_name, std::filesystem::path const &file,
-        std::optional<size_t> fork_index);
+        std::optional<size_t> fork_index, std::optional<size_t> txn_index);
 
     static void register_test_files(
-        std::filesystem::path const &root, std::optional<size_t> fork_index);
+        std::filesystem::path const &root, std::optional<size_t> fork_index,
+        std::optional<size_t> txn_index);
 
     void TestBody() override;
 
     [[nodiscard]] static StateTransitionTest load_state_test(
         nlohmann::json json, std::string suite_name, std::string test_name,
-        std::string file_name, std::optional<size_t> fork_index);
+        std::string file_name, std::optional<size_t> fork_index,
+        std::optional<size_t> txn_index);
 
     static void run_state_test(
         StateTransitionTest const &test, nlohmann::json const &json,

--- a/test/ethereum_test/src/main.cpp
+++ b/test/ethereum_test/src/main.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
         quill::LogLevel::None;
     monad::log::level_t state_log_level = quill::LogLevel::None;
     std::optional<size_t> fork_index = std::nullopt;
+    std::optional<size_t> txn_index = std::nullopt;
 
     // The default test filter. To enable all tests use `--gtest_filter=*`.
     testing::FLAGS_gtest_filter =
@@ -91,6 +92,8 @@ int main(int argc, char *argv[])
         ->transform(CLI::CheckedTransformer(
             monad::test::fork_index_map, CLI::ignore_case));
 
+    app.add_option("--txn", txn_index, "Index of transaction to run");
+
     CLI11_PARSE(app, argc, argv);
 
     monad::log::logger_t::set_log_level(
@@ -107,7 +110,8 @@ int main(int argc, char *argv[])
     // only worrying about GeneralStateTests folder for now
     monad::test::EthereumTests::register_test_files(
         monad::test_resource::ethereum_tests_dir / "GeneralStateTests",
-        fork_index);
+        fork_index,
+        txn_index);
 
     int return_code = RUN_ALL_TESTS();
 


### PR DESCRIPTION
Problem:
- Currently there is no way to specify the specific transaction to run

Solution:
- Add command line option to specify transaction by index

Also requested by @rgarc for his scripting work.