### PR TITLE
:new: add in ability to construct nibbles from byte_string_view

### DIFF
--- a/include/monad/trie/nibbles.hpp
+++ b/include/monad/trie/nibbles.hpp
@@ -48,6 +48,19 @@ struct Nibbles
     constexpr Nibbles(Nibbles &&) = default;
     constexpr Nibbles &operator=(Nibbles const &) = default;
 
+    struct FromBytes
+    {
+    };
+
+    constexpr explicit Nibbles(FromBytes, byte_string_view bytes)
+    {
+        MONAD_DEBUG_ASSERT(
+            (bytes.size() * 2) <=
+            std::numeric_limits<byte_string::value_type>::max());
+        rep.push_back(static_cast<byte_string::value_type>(bytes.size() * 2));
+        rep.append(bytes);
+    }
+
     constexpr explicit Nibbles(byte_string_view nibbles)
     {
         assert(nibbles.size() <= MAX_SIZE);
@@ -58,10 +71,9 @@ struct Nibbles
     }
 
     constexpr explicit Nibbles(bytes32_t const &b32)
+        : Nibbles{FromBytes{}, byte_string_view{b32.bytes, sizeof(bytes32_t)}}
     {
         static_assert(sizeof(bytes32_t) * 2 == MAX_SIZE);
-        rep.push_back(MAX_SIZE);
-        rep.append(b32.bytes, sizeof(bytes32_t));
     }
 
     constexpr explicit Nibbles(NibblesView const &nibbles)

--- a/src/monad/trie/test/nibbles.cpp
+++ b/src/monad/trie/test/nibbles.cpp
@@ -277,3 +277,46 @@ TEST(Nibbles, PushAndPopBack)
     EXPECT_EQ(nibbles, Nibbles());
     EXPECT_TRUE(nibbles.empty());
 }
+
+TEST(Nibbles, BytesEmpty)
+{
+    auto const nibbles = Nibbles{Nibbles::FromBytes{}, byte_string{}};
+    EXPECT_EQ(nibbles, Nibbles{});
+    EXPECT_EQ(nibbles, nibbles.prefix(0));
+    EXPECT_TRUE(nibbles.empty());
+    EXPECT_EQ(nibbles.size(), 0);
+}
+
+TEST(Nibbles, BytesThatLookLikeNibbles)
+{
+    auto const nibbles =
+        Nibbles{Nibbles::FromBytes{}, byte_string{0x01, 0x02, 0x03, 0x04}};
+    EXPECT_FALSE(nibbles.empty());
+    EXPECT_EQ(nibbles.size(), 8);
+    EXPECT_EQ(nibbles, nibbles.prefix(8));
+    EXPECT_EQ(nibbles[0], 0x00);
+    EXPECT_EQ(nibbles[1], 0x01);
+    EXPECT_EQ(nibbles[2], 0x00);
+    EXPECT_EQ(nibbles[3], 0x02);
+    EXPECT_EQ(nibbles[4], 0x00);
+    EXPECT_EQ(nibbles[5], 0x03);
+    EXPECT_EQ(nibbles[6], 0x00);
+    EXPECT_EQ(nibbles[7], 0x04);
+}
+
+TEST(Nibbles, Bytes)
+{
+    auto const nibbles =
+        Nibbles{Nibbles::FromBytes{}, byte_string{0x12, 0x34, 0x56, 0x78}};
+    EXPECT_FALSE(nibbles.empty());
+    EXPECT_EQ(nibbles.size(), 8);
+    EXPECT_EQ(nibbles, nibbles.prefix(8));
+    EXPECT_EQ(nibbles[0], 0x01);
+    EXPECT_EQ(nibbles[1], 0x02);
+    EXPECT_EQ(nibbles[2], 0x03);
+    EXPECT_EQ(nibbles[3], 0x04);
+    EXPECT_EQ(nibbles[4], 0x05);
+    EXPECT_EQ(nibbles[5], 0x06);
+    EXPECT_EQ(nibbles[6], 0x07);
+    EXPECT_EQ(nibbles[7], 0x08);
+}


### PR DESCRIPTION
Problem:
- Keys to the receipt trie are variable sized
- Nibbles currently only supports bytes32_t and a range of nibbles

Solution:
- Offer a constructor which converts directly from an array of bytes to the nibbles representation

Requested by @tongzhi1998. Going to do some cleanup of nibbles and delete the `nibbles` constructor as it's only used during testing. 