### PR TITLE
:bug: Make declaration match definition

### DIFF
--- a/include/monad/state2/state_ops.hpp
+++ b/include/monad/state2/state_ops.hpp
@@ -11,7 +11,7 @@
 MONAD_NAMESPACE_BEGIN
 
 template <class Mutex>
-std::optional<Account>
+std::optional<Account>&
 read_account(address_t const &, State &, BlockState<Mutex> &, Db &);
 
 template <class Mutex>


### PR DESCRIPTION
Problem:
- Separation of declaration and definition means the both have to match

Solution:
- Make the declaration of get_account match its definition.

Note: Duh.