### PR TITLE
:recycle: get rid of Nibbles construction from unpacked nibbles array

### DIFF
--- a/include/monad/trie/nibbles.hpp
+++ b/include/monad/trie/nibbles.hpp
@@ -17,8 +17,7 @@ MONAD_TRIE_NAMESPACE_BEGIN
 
 namespace impl
 {
-    template <typename TNibbles>
-    constexpr void copy_from_nibbles(byte_string &dest, TNibbles const &nibbles)
+    constexpr void copy_from_nibbles(byte_string &dest, NibblesView nibbles)
     {
         for (size_t i = 0; i < nibbles.size(); i += 2) {
             assert(nibbles[i] <= 0xF);
@@ -48,11 +47,7 @@ struct Nibbles
     constexpr Nibbles(Nibbles &&) = default;
     constexpr Nibbles &operator=(Nibbles const &) = default;
 
-    struct FromBytes
-    {
-    };
-
-    constexpr explicit Nibbles(FromBytes, byte_string_view bytes)
+    constexpr explicit Nibbles(byte_string_view bytes)
     {
         MONAD_DEBUG_ASSERT(
             (bytes.size() * 2) <=
@@ -61,17 +56,8 @@ struct Nibbles
         rep.append(bytes);
     }
 
-    constexpr explicit Nibbles(byte_string_view nibbles)
-    {
-        assert(nibbles.size() <= MAX_SIZE);
-
-        rep.push_back(static_cast<byte_string::value_type>(nibbles.size()));
-
-        impl::copy_from_nibbles(rep, nibbles);
-    }
-
     constexpr explicit Nibbles(bytes32_t const &b32)
-        : Nibbles{FromBytes{}, byte_string_view{b32.bytes, sizeof(bytes32_t)}}
+        : Nibbles{byte_string_view{b32.bytes, sizeof(bytes32_t)}}
     {
         static_assert(sizeof(bytes32_t) * 2 == MAX_SIZE);
     }

--- a/src/monad/trie/test/compact_encode.cpp
+++ b/src/monad/trie/test/compact_encode.cpp
@@ -1,3 +1,4 @@
+#include <monad/test/make_nibbles.hpp>
 #include <monad/trie/compact_encode.hpp>
 #include <monad/trie/config.hpp>
 #include <monad/trie/nibbles.hpp>
@@ -9,26 +10,26 @@ using namespace monad::trie;
 
 TEST(CompactEncoding, Sanity)
 {
-    auto path = Nibbles(byte_string{0x01, 0x02, 0x03, 0x04, 0x05});
+    auto path = test::make_nibbles({0x12, 0x34, 0x50}, 5);
 
     EXPECT_EQ(compact_encode(path, false), byte_string({0x11, 0x23, 0x45}));
     EXPECT_EQ(compact_encode(path, true), byte_string({0x31, 0x23, 0x45}));
 
-    path = Nibbles(byte_string{0x00, 0x01, 0x02, 0x03, 0x04, 0x05});
+    path = test::make_nibbles({0x01, 0x23, 0x45});
 
     EXPECT_EQ(
         compact_encode(path, false), byte_string({0x00, 0x01, 0x23, 0x45}));
     EXPECT_EQ(
         compact_encode(path, true), byte_string({0x20, 0x01, 0x23, 0x45}));
 
-    path = Nibbles(byte_string{0x00, 0x0f, 0x01, 0x0c, 0x0b, 0x08});
+    path = test::make_nibbles({0x0f, 0x1c, 0xb8});
 
     EXPECT_EQ(
         compact_encode(path, false), byte_string({0x00, 0x0f, 0x1c, 0xb8}));
     EXPECT_EQ(
         compact_encode(path, true), byte_string({0x20, 0x0f, 0x1c, 0xb8}));
 
-    path = Nibbles(byte_string{0x0f, 0x01, 0x0c, 0x0b, 0x08});
+    path = test::make_nibbles({0xf1, 0xcb, 0x80}, 5);
     EXPECT_EQ(compact_encode(path, false), byte_string({0x1f, 0x1c, 0xb8}));
     EXPECT_EQ(compact_encode(path, true), byte_string({0x3f, 0x1c, 0xb8}));
 }

--- a/src/monad/trie/test/single_trie.cpp
+++ b/src/monad/trie/test/single_trie.cpp
@@ -1,3 +1,4 @@
+#include <monad/test/make_nibbles.hpp>
 #include <monad/test/one_hundred_updates.hpp>
 #include <monad/test/trie_fixture.hpp>
 
@@ -16,11 +17,11 @@ using namespace evmc::literals;
 namespace
 {
     template <typename T>
-    T basic_node(std::optional<size_t> key_size, byte_string path_to_node)
+    T basic_node(std::optional<size_t> key_size, Nibbles path_to_node)
     {
         T node;
         node.key_size = key_size;
-        node.path_to_node = Nibbles(path_to_node);
+        node.path_to_node = path_to_node;
         return node;
     }
 
@@ -55,13 +56,13 @@ public:
     {
         process_updates({
             test::make_upsert(
-                Nibbles(byte_string{0x04, 0x02, 0x02, 0x01}), {0xff}),
+                test::make_nibbles(byte_string{0x42, 0x21}), {0xff}),
             test::make_upsert(
-                Nibbles(byte_string{0x04, 0x02, 0x03, 0x02}), {0xff}),
+                test::make_nibbles(byte_string{0x42, 0x32}), {0xff}),
             test::make_upsert(
-                Nibbles(byte_string{0x04, 0x02, 0x03, 0x06}), {0xff}),
+                test::make_nibbles(byte_string{0x42, 0x36}), {0xff}),
             test::make_upsert(
-                Nibbles(byte_string{0x04, 0x05, 0x02, 0x01}), {0xff}),
+                test::make_nibbles(byte_string{0x45, 0x21}), {0xff}),
         });
     }
 };
@@ -264,11 +265,11 @@ TYPED_TEST(GenerateTransformationListTest, OneUpdate)
     // ----------------------------------------------------------------
 
     std::vector updates = {test::make_upsert(
-        Nibbles(byte_string({0x05, 0x05, 0x05, 0x05})), {0xff})};
+        test::make_nibbles(byte_string({0x55, 0x55})), {0xff})};
 
     std::list<Node> expected = {
-        basic_node<Branch>(0, {0x04}),
-        basic_node<Leaf>(std::nullopt, {0x05, 0x05, 0x05, 0x05})};
+        basic_node<Branch>(0, test::make_nibbles({0x40}, 1)),
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x55, 0x55}))};
 
     EXPECT_TRUE(validate_list(
         this->trie_.generate_transformation_list(updates), expected));
@@ -276,11 +277,11 @@ TYPED_TEST(GenerateTransformationListTest, OneUpdate)
     // ----------------------------------------------------------------
 
     updates = {test::make_upsert(
-        Nibbles(byte_string({0x03, 0x03, 0x03, 0x03})), {0xff})};
+        test::make_nibbles(byte_string({0x33, 0x33})), {0xff})};
 
     expected = std::list<Node>({
-        basic_node<Leaf>(std::nullopt, {0x03, 0x03, 0x03, 0x03}),
-        basic_node<Branch>(0, {0x04}),
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x33, 0x33})),
+        basic_node<Branch>(0, test::make_nibbles({0x40}, 1)),
     });
 
     EXPECT_TRUE(validate_list(
@@ -289,11 +290,11 @@ TYPED_TEST(GenerateTransformationListTest, OneUpdate)
     // ----------------------------------------------------------------
 
     updates = {test::make_upsert(
-        Nibbles(byte_string({0x04, 0x06, 0x02, 0x01})), {0xff})};
+        test::make_nibbles(byte_string({0x46, 0x21})), {0xff})};
 
     expected = std::list<Node>(
-        {basic_node<Branch>(0, {0x04}),
-         basic_node<Leaf>(std::nullopt, {0x04, 0x06, 0x02, 0x01})});
+        {basic_node<Branch>(0, test::make_nibbles({0x40}, 1)),
+         basic_node<Leaf>(std::nullopt, test::make_nibbles({0x46, 0x21}))});
 
     EXPECT_TRUE(validate_list(
         this->trie_.generate_transformation_list(updates), expected));
@@ -301,12 +302,12 @@ TYPED_TEST(GenerateTransformationListTest, OneUpdate)
     // ----------------------------------------------------------------
 
     updates = {test::make_upsert(
-        Nibbles(byte_string({0x04, 0x05, 0x02, 0x02})), {0xff})};
+        test::make_nibbles(byte_string({0x45, 0x22})), {0xff})};
 
     expected = std::list<Node>(
-        {basic_node<Branch>(2, {0x04, 0x02}),
-         basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01}),
-         basic_node<Leaf>(std::nullopt, {0x04, 0x05, 0x02, 0x02})});
+        {basic_node<Branch>(2, test::make_nibbles({0x42})),
+         basic_node<Leaf>(2, test::make_nibbles({0x45, 0x21})),
+         basic_node<Leaf>(std::nullopt, test::make_nibbles({0x45, 0x22}))});
 
     EXPECT_TRUE(validate_list(
         this->trie_.generate_transformation_list(updates), expected));
@@ -314,14 +315,14 @@ TYPED_TEST(GenerateTransformationListTest, OneUpdate)
     // ----------------------------------------------------------------
 
     updates = {test::make_upsert(
-        Nibbles(byte_string({0x04, 0x02, 0x03, 0x04})), {0xff})};
+        test::make_nibbles(byte_string({0x42, 0x34})), {0xff})};
 
     expected = std::list<Node>({
-        basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
-        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x02}),
-        basic_node<Leaf>(std::nullopt, {0x04, 0x02, 0x03, 0x04}),
-        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x06}),
-        basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01}),
+        basic_node<Leaf>(3, test::make_nibbles({0x42, 0x21})),
+        basic_node<Leaf>(4, test::make_nibbles({0x42, 0x32})),
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x42, 0x34})),
+        basic_node<Leaf>(4, test::make_nibbles({0x42, 0x36})),
+        basic_node<Leaf>(2, test::make_nibbles({0x45, 0x21})),
     });
 
     EXPECT_TRUE(validate_list(
@@ -334,13 +335,13 @@ TYPED_TEST(GenerateTransformationListTest, MultipleUpdates)
 
     std::vector updates = {
         test::make_upsert(
-            Nibbles(byte_string({0x04, 0x02, 0x02, 0x01})), {0xff}),
-        test::make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x06})))};
+            test::make_nibbles(byte_string({0x42, 0x21})), {0xff}),
+        test::make_del(test::make_nibbles(byte_string({0x42, 0x36})))};
 
     std::vector<Node> expected = {
-        basic_node<Leaf>(std::nullopt, {0x04, 0x02, 0x02, 0x01}),
-        basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x02}),
-        basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01})};
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x42, 0x21})),
+        basic_node<Leaf>(4, test::make_nibbles({0x42, 0x32})),
+        basic_node<Leaf>(2, test::make_nibbles({0x45, 0x21}))};
 
     EXPECT_TRUE(validate_list(
         this->trie_.generate_transformation_list(updates), expected));
@@ -348,16 +349,16 @@ TYPED_TEST(GenerateTransformationListTest, MultipleUpdates)
     // ----------------------------------------------------------------
 
     updates = {
-        test::make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x02}))),
+        test::make_del(test::make_nibbles(byte_string({0x42, 0x32}))),
         test::make_upsert(
-            Nibbles(byte_string({0x04, 0x02, 0x03, 0x03})), {0xff}),
+            test::make_nibbles(byte_string({0x42, 0x33})), {0xff}),
     };
 
     expected = std::vector<Node>(
-        {basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
-         basic_node<Leaf>(std::nullopt, {0x04, 0x02, 0x03, 0x03}),
-         basic_node<Leaf>(4, {0x04, 0x02, 0x03, 0x06}),
-         basic_node<Leaf>(2, {0x04, 0x05, 0x02, 0x01})});
+        {basic_node<Leaf>(3, test::make_nibbles({0x42, 0x21})),
+         basic_node<Leaf>(std::nullopt, test::make_nibbles({0x42, 0x33})),
+         basic_node<Leaf>(4, test::make_nibbles({0x42, 0x36})),
+         basic_node<Leaf>(2, test::make_nibbles({0x45, 0x21}))});
 
     EXPECT_TRUE(validate_list(
         this->trie_.generate_transformation_list(updates), expected));
@@ -365,10 +366,10 @@ TYPED_TEST(GenerateTransformationListTest, MultipleUpdates)
     // ----------------------------------------------------------------
 
     updates = {
-        test::make_del(Nibbles(byte_string({0x04, 0x02, 0x02, 0x01}))),
-        test::make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x02}))),
-        test::make_del(Nibbles(byte_string({0x04, 0x02, 0x03, 0x06}))),
-        test::make_del(Nibbles(byte_string({0x04, 0x05, 0x02, 0x01}))),
+        test::make_del(test::make_nibbles(byte_string({0x42, 0x21}))),
+        test::make_del(test::make_nibbles(byte_string({0x42, 0x32}))),
+        test::make_del(test::make_nibbles(byte_string({0x42, 0x36}))),
+        test::make_del(test::make_nibbles(byte_string({0x45, 0x21}))),
     };
 
     expected.clear();
@@ -380,17 +381,17 @@ TYPED_TEST(GenerateTransformationListTest, MultipleUpdates)
 
     updates = {
         test::make_upsert(
-            Nibbles(byte_string({0x04, 0x02, 0x02, 0x00})), {0xff}),
+            test::make_nibbles(byte_string({0x42, 0x20})), {0xff}),
         test::make_upsert(
-            Nibbles(byte_string({0x04, 0x02, 0x03, 0x07})), {0xff}),
-        test::make_del(Nibbles(byte_string({0x04, 0x05, 0x02, 0x01}))),
+            test::make_nibbles(byte_string({0x42, 0x37})), {0xff}),
+        test::make_del(test::make_nibbles(byte_string({0x45, 0x21}))),
     };
 
     expected = std::vector<Node>({
-        basic_node<Leaf>(std::nullopt, {0x04, 0x02, 0x02, 0x00}),
-        basic_node<Leaf>(3, {0x04, 0x02, 0x02, 0x01}),
-        basic_node<Branch>(3, {0x04, 0x02, 0x03}),
-        basic_node<Leaf>(std::nullopt, {0x04, 0x02, 0x03, 0x07}),
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x42, 0x20})),
+        basic_node<Leaf>(3, test::make_nibbles({0x42, 0x21})),
+        basic_node<Branch>(3, test::make_nibbles({0x42, 0x30}, 3)),
+        basic_node<Leaf>(std::nullopt, test::make_nibbles({0x42, 0x37})),
     });
 
     EXPECT_TRUE(validate_list(

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -2,9 +2,10 @@ add_library(
   monad_unit_test_common STATIC
   ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/config.hpp
   ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/environment.hpp
-  ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/trie_fixture.hpp
+  ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/make_db.hpp
+  ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/make_nibbles.hpp
   ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/one_hundred_updates.hpp
-  ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/make_db.hpp)
+  ${PROJECT_SOURCE_DIR}/test/unit/common/include/monad/test/trie_fixture.hpp)
 
 target_include_directories(
   monad_unit_test_common PUBLIC ${PROJECT_SOURCE_DIR}/test/unit/common/include)

--- a/test/unit/common/include/monad/test/make_nibbles.hpp
+++ b/test/unit/common/include/monad/test/make_nibbles.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <monad/test/config.hpp>
+#include <monad/trie/nibbles.hpp>
+
+#include <string>
+
+MONAD_TEST_NAMESPACE_BEGIN
+
+constexpr trie::Nibbles
+make_nibbles(byte_string const &bytes, size_t size = std::string::npos)
+{
+    if ((bytes.size() * 2) <= size) {
+        return trie::Nibbles{bytes};
+    }
+    else if ((size % 2) == 0) {
+        return trie::Nibbles{bytes.substr(0, size / 2)};
+    }
+    MONAD_ASSERT(size <= std::numeric_limits<uint8_t>::max());
+    return trie::Nibbles{
+        trie::Nibbles{bytes}.prefix(static_cast<uint8_t>(size))};
+}
+
+MONAD_TEST_NAMESPACE_END


### PR DESCRIPTION
Problem:
- That form of construction is only used during testing, so exposing a constructor in the Nibbles class is not needed

Solution:
- introduce monad::test::make_nibbles