### PR TITLE
♻️ Retrieve the storage delta reference

### DIFF
--- a/include/monad/state2/state_ops.hpp
+++ b/include/monad/state2/state_ops.hpp
@@ -11,11 +11,11 @@
 MONAD_NAMESPACE_BEGIN
 
 template <class Mutex>
-std::optional<Account>&
+std::optional<Account> &
 read_account(address_t const &, State &, BlockState<Mutex> &, Db &);
 
 template <class Mutex>
-bytes32_t read_storage(
+delta_t<bytes32_t> &read_storage(
     address_t const &, uint64_t incarnation, bytes32_t const &location, State &,
     BlockState<Mutex> &, Db &);
 

--- a/src/monad/state2/state_ops.cpp
+++ b/src/monad/state2/state_ops.cpp
@@ -9,7 +9,7 @@
 MONAD_NAMESPACE_BEGIN
 
 template <class Mutex>
-std::optional<Account>& read_account(
+std::optional<Account> &read_account(
     address_t const &address, State &state, BlockState<Mutex> &block_state,
     Db &db)
 {
@@ -49,7 +49,7 @@ std::optional<Account>& read_account(
 }
 
 template <class Mutex>
-bytes32_t read_storage(
+delta_t<bytes32_t> &read_storage(
     address_t const &address, uint64_t const incarnation,
     bytes32_t const &location, State &state, BlockState<Mutex> &block_state,
     Db &db)
@@ -61,7 +61,7 @@ bytes32_t read_storage(
     {
         auto const it = storage.find(location);
         if (MONAD_LIKELY(it != storage.end())) {
-            auto const &result = it->second.second;
+            auto &result = it->second;
             return result;
         }
     }
@@ -75,8 +75,9 @@ bytes32_t read_storage(
             auto const it = block_storage.find(location);
             if (MONAD_LIKELY(it != block_storage.end())) {
                 auto const &result = it->second.second;
-                storage.try_emplace(location, result, result);
-                return result;
+                auto const [it2, _] =
+                    storage.try_emplace(location, result, result);
+                return it2->second;
             }
         }
     }
@@ -95,14 +96,14 @@ bytes32_t read_storage(
             }
         }
     }
-    storage.try_emplace(location, result, result);
-    return result;
+    auto const [it2, _] = storage.try_emplace(location, result, result);
+    return it2->second;
 }
 
-template std::optional<Account>&
+template std::optional<Account> &
 read_account(address_t const &, State &, BlockState<std::shared_mutex> &, Db &);
 
-template bytes32_t read_storage(
+template delta_t<bytes32_t> &read_storage(
     address_t const &, uint64_t, bytes32_t const &, State &,
     BlockState<std::shared_mutex> &, Db &);
 


### PR DESCRIPTION
Problem:
- When setting the storage, the EVMC Host Interface is required to a status so the EVM can accurately assess gas costs per EIP-2200 and EIP-1283.
- To do this, it needs to know what is in committed block history, the current value and the value being set to.

Solution:
- Change read_storage so that just returns the delta_t so set_storage can correctly return this status.
