### PR TITLE
:bug: revert state if unsuccessful code execution in call_evm

### DIFF
--- a/include/monad/execution/evm.hpp
+++ b/include/monad/execution/evm.hpp
@@ -90,7 +90,7 @@ struct Evm
                 })
                 .value();
 
-        if (result.status_code == EVMC_REVERT) {
+        if (result.status_code != EVMC_SUCCESS) {
             state.revert();
         }
 

--- a/src/monad/execution/test/evm.cpp
+++ b/src/monad/execution/test/evm.cpp
@@ -523,3 +523,30 @@ TEST(Evm, revert_call_evm)
     EXPECT_TRUE(s._accounts.empty()); // revert was called on the fake
     EXPECT_EQ(result.gas_left, 6'000);
 }
+
+TEST(Evm, unsuccessful_call_evm)
+{
+    static constexpr auto from{
+        0x5353535353535353535353535353535353535353_address};
+    static constexpr auto code_address{
+        0x0000000000000000000000000000000000000003_address};
+    fake::State::ChangeSet s{};
+    evm_host_t h{};
+    s._accounts.emplace(from, Account{.balance = 15'000});
+    s._accounts.emplace(code_address, Account{.nonce = 10});
+    fake::Interpreter::_result = evmc::Result{evmc_result{
+        .status_code = EVMC_BAD_JUMP_DESTINATION, .gas_left = 6'000}};
+
+    evmc_message m{
+        .kind = EVMC_CALL,
+        .gas = 12'000,
+        .recipient = code_address,
+        .sender = from,
+        .code_address = code_address};
+
+    auto const result = evm_t::call_evm(&h, s, m);
+
+    EXPECT_EQ(result.status_code, EVMC_BAD_JUMP_DESTINATION);
+    EXPECT_TRUE(s._accounts.empty()); // revert was called on the fake
+    EXPECT_EQ(result.gas_left, 6'000);
+}


### PR DESCRIPTION
Problem:
- State reversion should happen as long as the interpreter does not return EVMC_SUCCESS
- Currently stae reversion only occurs when the interpreter returns EVMC_REVERT

Solution:
- Revert state if interpreter returns anything other than EVMC_SUCCESS