### PR TITLE
🐛 do not gather change if orig == updated

### DIFF
--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -135,7 +135,9 @@ struct AccountState
 
         StateChanges::AccountChanges account_changes;
         for (auto const &[addr, diff] : merged_) {
-            account_changes.emplace_back(addr, diff.updated);
+            if (diff.orig != diff.updated) {
+                account_changes.emplace_back(addr, diff.updated);
+            }
         }
         return account_changes;
     }

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -82,7 +82,9 @@ struct ValueState
 
         for (auto const &[addr, acct_storage] : merged_.storage_) {
             for (auto const &[key, value] : acct_storage) {
-                storage_changes[addr].emplace_back(key, value.updated);
+                if (value.orig != value.updated) {
+                    storage_changes[addr].emplace_back(key, value.updated);
+                }
             }
         }
         return storage_changes;


### PR DESCRIPTION
Problem:
- Noop updates are quite inefficent on the trie side
- {nullopt, nullopt} updates are invalid since they signal that one is
  deleting a node that does not exist

Solution:
- When gathering nodes, ignore the noop updates

Fixes `stPreCompiledContracts2.CallEcrecover_Overflow` on the spurious dragon fork