### PR TITLE
:recycle: Move the function declarations to the matching impl file

### DIFF
--- a/include/monad/state2/block_state.hpp
+++ b/include/monad/state2/block_state.hpp
@@ -14,4 +14,9 @@ struct BlockState
     Code code;
 };
 
+bool can_merge(StateDeltas const &to, StateDeltas const &from);
+void merge(StateDeltas &to, StateDeltas const &from);
+
+void merge(Code &to, Code &from);
+
 MONAD_NAMESPACE_END

--- a/include/monad/state2/state_deltas.hpp
+++ b/include/monad/state2/state_deltas.hpp
@@ -46,9 +46,4 @@ using Code = ankerl::unordered_dense::segmented_map<bytes32_t, byte_string>;
 static_assert(sizeof(Code) == 64);
 static_assert(alignof(Code) == 8);
 
-bool can_merge(StateDeltas &to, StateDeltas const &from);
-void merge(StateDeltas &to, StateDeltas const &from);
-
-void merge(Code &to, Code &from);
-
 MONAD_NAMESPACE_END


### PR DESCRIPTION
Problem:
- The *merge functions are defined in block_state.cpp, but defined in state_deltas.hpp

Solution:
- Move the defintions to the matching impl file.