### PR TITLE
:recycle: Rename AccountDeltas to StateDelta

### DIFF
--- a/include/monad/state2/state_deltas.hpp
+++ b/include/monad/state2/state_deltas.hpp
@@ -26,17 +26,17 @@ using StorageDelta = delta_t<bytes32_t>;
 static_assert(sizeof(StorageDelta) == 64);
 static_assert(alignof(StorageDelta) == 1);
 
-struct AccountDeltas
+struct StateDelta
 {
     AccountDelta account;
     ankerl::unordered_dense::segmented_map<bytes32_t, StorageDelta> storage;
 };
 
-static_assert(sizeof(AccountDeltas) == 224);
-static_assert(alignof(AccountDeltas) == 8);
+static_assert(sizeof(StateDelta) == 224);
+static_assert(alignof(StateDelta) == 8);
 
 using StateDeltas =
-    ankerl::unordered_dense::segmented_map<address_t, AccountDeltas>;
+    ankerl::unordered_dense::segmented_map<address_t, StateDelta>;
 
 static_assert(sizeof(StateDeltas) == 64);
 static_assert(alignof(StateDeltas) == 8);

--- a/src/monad/state2/block_state_ops.cpp
+++ b/src/monad/state2/block_state_ops.cpp
@@ -30,7 +30,7 @@ std::optional<Account> &read_account(
             auto const &result = it->second.account.second;
             auto const [it, _] = state.try_emplace(
                 address,
-                AccountDeltas{.account = {result, result}, .storage = {}});
+                StateDelta{.account = {result, result}, .storage = {}});
             return it->second.account.second;
         }
     }
@@ -39,13 +39,13 @@ std::optional<Account> &read_account(
     {
         std::lock_guard<Mutex> const lock{block_state.mutex};
         auto const [it, inserted] = block_state.state.try_emplace(
-            address, AccountDeltas{.account = {result, result}, .storage = {}});
+            address, StateDelta{.account = {result, result}, .storage = {}});
         if (MONAD_UNLIKELY(!inserted)) {
             result = it->second.account.second;
         }
     }
     auto const [it, _] = state.try_emplace(
-        address, AccountDeltas{.account = {result, result}, .storage = {}});
+        address, StateDelta{.account = {result, result}, .storage = {}});
     return it->second.account.second;
 }
 


### PR DESCRIPTION
Problem:
- An account delta is a structure of account changes and storage changes, which is makes AccountDeltas not as clear.

Solution:
- Rename AccountDeltas to StateDelta