### PR TITLE
:white_check_mark: Run byzantium and constantinoplefix tests.

### DIFF
--- a/scripts/ethereum-test-filter/filter
+++ b/scripts/ethereum-test-filter/filter
@@ -1,3 +1,5 @@
 frontier -stRefundTest.refundResetFrontier
 homestead -VMTests/vmIOandFlowOperations.jumpToPush
 eip158 -VMTests/vmIOandFlowOperations.jumpToPush
+byzantium -VMTests/vmIOandFlowOperations.jumpToPush
+constantinoplefix -VMTests/vmIOandFlowOperations.jumpToPush

--- a/test/ethereum_test/include/ethereum_test.hpp
+++ b/test/ethereum_test/include/ethereum_test.hpp
@@ -22,7 +22,7 @@ inline std::unordered_map<std::string, size_t> const fork_index_map = {
     // DAO and Tangerine Whistle not covered by Ethereum Tests
     {"EIP158", 4},
     {"Byzantium", 5},
-    {"Constantinople", 6},
+    {"ConstantinopleFix", 6},
     {"Istanbul", 7},
     {"Berlin", 8},
     {"London", 9},


### PR DESCRIPTION
Problem:
- We want to ignore the `Constantinople` tests in lieu of the `ConstantinopleFix` tests.

Solution:
- Fix the name in our fork mapping.
- Add byzantium and constantinoplefix to the CI test filter.