### PR TITLE
:bug: Create beneficiary account before transferring to in selfdestruct.

### DIFF
--- a/include/monad/state/account_state.hpp
+++ b/include/monad/state/account_state.hpp
@@ -245,6 +245,9 @@ struct AccountState<TAccountDB>::ChangeSet : public AccountState<TAccountDB>
     selfdestruct(address_t const &a, address_t const &beneficiary) noexcept
     {
         if (get_account(a).has_value()) {
+            if (!account_exists(beneficiary)) {
+                create_account(beneficiary);
+            }
             set_balance(
                 beneficiary,
                 intx::be::load<uint256_t>(get_balance(beneficiary)) +

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -562,3 +562,18 @@ TYPED_TEST(StateTest, commit_twice_apply_reward)
     EXPECT_EQ(ds.get_balance(a), bytes32_t{220});
     EXPECT_EQ(ds.get_balance(b), bytes32_t{300});
 }
+
+TYPED_TEST(StateTest, selfdestruct_nonexisting_beneficiary)
+{
+    auto db = test::make_db<TypeParam>();
+    AccountState accounts{db};
+    ValueState values{db};
+    CodeState code{db};
+    State t{accounts, values, code, block_cache, db};
+    auto change_set = t.get_new_changeset(0u);
+    change_set.create_account(a);
+    change_set.set_balance(a, 0x10000000);
+    EXPECT_TRUE(change_set.selfdestruct(a, b));
+    t.merge_changes(change_set);
+    t.commit();
+}


### PR DESCRIPTION
Note:
- This is already fixed in the `state2` implementation.

Problem:
- Currently, when calling selfdestruct with a beneficiary account that doesn't exist, an assertion trips and the program crashes.

Solution:
- Before transferring the destructed account's balance to the beneficiary, we create the beneficiary account.