### PR TITLE
:bug: do not apply the self destruct refund twice

### DIFF
--- a/include/monad/core/concepts.hpp
+++ b/include/monad/core/concepts.hpp
@@ -31,7 +31,6 @@ namespace concepts
         { T::starting_nonce() } -> std::convertible_to<uint64_t>;
         { T::last_block_number } -> std::convertible_to<uint64_t>;
         { T::n_precompiles } -> std::convertible_to<uint64_t>;
-        { T::get_selfdestruct_refund(s) } -> std::convertible_to<uint64_t>;
         { T::max_refund_quotient() } -> std::convertible_to<int>;
         { T::destruct_touched_dead(s) } -> std::convertible_to<void>;
         { T::deploy_contract_code(s, a, std::move(r)) }

--- a/include/monad/execution/ethereum/fork_traits.hpp
+++ b/include/monad/execution/ethereum/fork_traits.hpp
@@ -91,13 +91,6 @@ namespace fork_traits
             return 0u;
         }
 
-        template <class TState>
-        [[nodiscard]] static constexpr uint64_t
-        get_selfdestruct_refund(TState const &s) noexcept
-        {
-            return s.total_selfdestructs() * 24'000;
-        }
-
         [[nodiscard]] static constexpr uint64_t max_refund_quotient() noexcept
         {
             return 2u;
@@ -466,13 +459,6 @@ namespace fork_traits
         static constexpr auto last_block_number = 15'537'393u;
 
         // https://eips.ethereum.org/EIPS/eip-3529
-        template <class TState>
-        [[nodiscard]] static constexpr uint64_t
-        get_selfdestruct_refund(TState const &) noexcept
-        {
-            return 0u;
-        }
-
         [[nodiscard]] static constexpr uint64_t max_refund_quotient() noexcept
         {
             return 5u;

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -392,7 +392,6 @@ namespace fake
             using next_fork_t = alpha;
 
             static constexpr evmc_revision rev = EVMC_FRONTIER;
-            static inline uint64_t _sd_refund{};
             static inline uint64_t last_block_number{
                 std::numeric_limits<uint64_t>::max()};
             static constexpr uint64_t n_precompiles = 4;
@@ -412,10 +411,6 @@ namespace fake
             }
             static auto starting_nonce() { return 1u; }
             static auto max_refund_quotient() { return _max_refund_quotient; }
-            static auto get_selfdestruct_refund(TState const &)
-            {
-                return _sd_refund;
-            }
             static void destruct_touched_dead(TState &s)
             {
                 s.destruct_touched_dead();

--- a/include/monad/execution/transaction_processor.hpp
+++ b/include/monad/execution/transaction_processor.hpp
@@ -45,12 +45,9 @@ struct TransactionProcessor
     }
 
     // YP Eqn 72
-    [[nodiscard]] uint64_t g_star(
-        TState &s, Transaction const &t, uint64_t gas_remaining,
-        uint64_t refund) const
+    [[nodiscard]] uint64_t
+    g_star(Transaction const &t, uint64_t gas_remaining, uint64_t refund) const
     {
-        refund += TTraits::get_selfdestruct_refund(s);
-
         auto const refund_allowance =
             (t.gas_limit - gas_remaining) / TTraits::max_refund_quotient();
 
@@ -62,7 +59,7 @@ struct TransactionProcessor
         uint64_t const gas_leftover, uint64_t refund) const
     {
         // refund and priority, Eqn. 73-76
-        auto const gas_remaining = g_star(s, t, gas_leftover, refund);
+        auto const gas_remaining = g_star(t, gas_leftover, refund);
         auto const gas_cost = TTraits::gas_price(t, base_fee_per_gas);
 
         auto const sender_balance =

--- a/src/monad/execution/ethereum/test/fork_traits.cpp
+++ b/src/monad/execution/ethereum/test/fork_traits.cpp
@@ -55,7 +55,6 @@ TEST(fork_traits, frontier)
     execution::fake::State::ChangeSet s{};
     s._selfdestructs = 10;
 
-    EXPECT_EQ(f.get_selfdestruct_refund(s), 240'000);
     EXPECT_EQ(f.max_refund_quotient(), 2);
 
     s._touched_dead = 10;
@@ -364,7 +363,6 @@ TEST(fork_traits, london)
     execution::fake::State::ChangeSet s{};
     s._selfdestructs = 10;
 
-    EXPECT_EQ(l.get_selfdestruct_refund(s), 0);
     EXPECT_EQ(l.max_refund_quotient(), 5);
 
     byte_string const illegal_code{0xef, 0x60};

--- a/src/monad/execution/test/transaction_processor.cpp
+++ b/src/monad/execution/test/transaction_processor.cpp
@@ -17,8 +17,6 @@ using evm_host_t = fake::EvmHost<
 
 TEST(TransactionProcessor, g_star)
 {
-    fake::State::ChangeSet s{};
-    traits_t::_sd_refund = 10'000;
     traits_t::_max_refund_quotient = 2;
 
     static Transaction const t{
@@ -27,10 +25,10 @@ TEST(TransactionProcessor, g_star)
 
     processor_t p{};
 
-    EXPECT_EQ(p.g_star(s, t, 1'002, 15'000), 26'001);
-    EXPECT_EQ(p.g_star(s, t, 1'001, 15'000), 26'000);
-    EXPECT_EQ(p.g_star(s, t, 1'000, 15'000), 26'000);
-    EXPECT_EQ(p.g_star(s, t, 999, 15'000), 25'999);
+    EXPECT_EQ(p.g_star(t, 1'002, 15'000), 16'002);
+    EXPECT_EQ(p.g_star(t, 1'001, 15'000), 16'001);
+    EXPECT_EQ(p.g_star(t, 1'000, 15'000), 16'000);
+    EXPECT_EQ(p.g_star(t, 999, 15'000), 15'999);
 }
 
 TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
@@ -45,7 +43,6 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     s._accounts[from] = {.balance = 56'000'000'000'000'000, .nonce = 25};
     h._result = {.status_code = EVMC_SUCCESS, .gas_left = 15'000};
     h._receipt = {.status = 1u};
-    traits_t::_sd_refund = 24'000;
 
     static Transaction const t{
         .nonce = 25,
@@ -60,9 +57,9 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     EXPECT_EQ(status, processor_t::Status::SUCCESS);
     auto result = p.execute(s, h, t, 10u, bene);
     EXPECT_EQ(result.status, 1u);
-    EXPECT_EQ(s._accounts[from].balance, uint256_t{55'999'999'999'800'000});
+    EXPECT_EQ(s._accounts[from].balance, uint256_t{55'999'999'999'600'000});
     EXPECT_EQ(s._accounts[from].nonce, 25); // EVMC will inc for creation
 
     // check if miner gets the right reward
-    EXPECT_EQ(s._reward, uint256_t{200'000});
+    EXPECT_EQ(s._reward, uint256_t{400'000});
 }


### PR DESCRIPTION
Problem:
- self destruct refund is being applied twice - once by us and once by evmone

Solution:
- let evmone apply self destruct refund

This resolves `/test/ethereum_test/monad-ethereum-test --fork istanbul --gtest_filter=VMTests/vmTests.suicide` on Shea's integration branch. Others may have also been resolved, will need to do an audit. Not including it in the filter here because current state does not handle non-existent beneficiaries correctly (see #323 )