### PR TITLE
Refactor DBs to be Class

### DIFF
--- a/src/monad/db/test/db.cpp
+++ b/src/monad/db/test/db.cpp
@@ -114,8 +114,8 @@ TEST(InMemoryTrieDB, account_creation)
     db.commit(
         StateDeltas{{a, StateDelta{.account = {std::nullopt, acct}}}}, Code{});
 
-    EXPECT_EQ(db.accounts_trie.leaves_storage.size(), 1);
-    EXPECT_EQ(db.accounts_trie.trie_storage.size(), 1);
+    EXPECT_EQ(db.get_accounts_trie().leaves_storage.size(), 1);
+    EXPECT_EQ(db.get_accounts_trie().trie_storage.size(), 1);
     EXPECT_EQ(db.read_account(a), acct);
 }
 
@@ -151,10 +151,12 @@ TEST(InMemoryTrieDB, erase)
 
     EXPECT_EQ(db.read_storage(a, incarnation, key1), bytes32_t{});
     EXPECT_EQ(db.read_storage(a, incarnation, key2), bytes32_t{});
-    EXPECT_TRUE(db.accounts_trie.leaves_storage.empty());
-    EXPECT_TRUE(db.accounts_trie.trie_storage.empty());
-    EXPECT_TRUE(db.storage_trie.leaves_storage.empty());
-    EXPECT_TRUE(db.storage_trie.trie_storage.empty());
+    auto const &accounts_trie = db.get_accounts_trie();
+    auto const &storage_trie = db.get_storage_trie();
+    EXPECT_TRUE(accounts_trie.leaves_storage.empty());
+    EXPECT_TRUE(accounts_trie.trie_storage.empty());
+    EXPECT_TRUE(storage_trie.leaves_storage.empty());
+    EXPECT_TRUE(storage_trie.trie_storage.empty());
 
     EXPECT_EQ(db.state_root(), NULL_ROOT);
     EXPECT_EQ(db.storage_root(a), NULL_ROOT);
@@ -263,7 +265,7 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
                 0x3f7578fb3acc297f8847c7885717733b268cb52dc6b8e5a68aff31c254b6b5b3_bytes32);
         }
 
-        EXPECT_EQ(db.starting_block_number, block_number - 1u);
+        EXPECT_EQ(db.get_starting_block_number(), block_number - 1u);
     }
 
     {
@@ -301,7 +303,7 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
                 db.state_root(),
                 0x0169f0b22c30d7d6f0bb7ea2a07be178e216b72f372a6a7bafe55602e5650e60_bytes32);
         }
-        EXPECT_EQ(db.starting_block_number, block_number - 1u);
+        EXPECT_EQ(db.get_starting_block_number(), block_number - 1u);
     }
 
     {
@@ -315,7 +317,7 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
                 db.state_root(),
                 0x0169f0b22c30d7d6f0bb7ea2a07be178e216b72f372a6a7bafe55602e5650e60_bytes32);
         }
-        EXPECT_EQ(db.starting_block_number, block_number);
+        EXPECT_EQ(db.get_starting_block_number(), block_number);
     }
 
     {
@@ -334,7 +336,7 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
                 0x3f7578fb3acc297f8847c7885717733b268cb52dc6b8e5a68aff31c254b6b5b3_bytes32);
         }
 
-        EXPECT_EQ(db.starting_block_number, block_number - 1u);
+        EXPECT_EQ(db.get_starting_block_number(), block_number - 1u);
     }
 }
 
@@ -377,7 +379,7 @@ TYPED_TEST(
                 db.state_root(),
                 0x3f7578fb3acc297f8847c7885717733b268cb52dc6b8e5a68aff31c254b6b5b3_bytes32);
         }
-        EXPECT_EQ(db.starting_block_number, block_number - 1u);
+        EXPECT_EQ(db.get_starting_block_number(), block_number - 1u);
     }
 
     {
@@ -415,7 +417,7 @@ TYPED_TEST(
                 0x0169f0b22c30d7d6f0bb7ea2a07be178e216b72f372a6a7bafe55602e5650e60_bytes32);
         }
 
-        EXPECT_EQ(db.starting_block_number, block_number - 1u);
+        EXPECT_EQ(db.get_starting_block_number(), block_number - 1u);
     }
 
     {
@@ -430,7 +432,7 @@ TYPED_TEST(
                 db.state_root(),
                 0x0169f0b22c30d7d6f0bb7ea2a07be178e216b72f372a6a7bafe55602e5650e60_bytes32);
         }
-        EXPECT_EQ(db.starting_block_number, block_number);
+        EXPECT_EQ(db.get_starting_block_number(), block_number);
     }
 }
 

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     monad::state::CodeState code{db};
     state_t state{accounts, values, code, block_db, db};
 
-    monad::block_num_t start_block_number = db.starting_block_number;
+    monad::block_num_t start_block_number = db.get_starting_block_number();
 
     MONAD_LOG_INFO(
         main_logger,

--- a/test/unit/common/include/monad/test/dump_state_from_db.hpp
+++ b/test/unit/common/include/monad/test/dump_state_from_db.hpp
@@ -94,11 +94,11 @@ dump_accounts_from_db(monad::db::RocksTrieDB &db)
 {
     nlohmann::json state = nlohmann::json::object();
 
-    auto leaf_cursor = db.accounts_trie.make_leaf_cursor();
-    auto trie_cursor = db.accounts_trie.make_trie_cursor();
+    auto leaf_cursor = db.get_accounts_trie().make_leaf_cursor();
+    auto trie_cursor = db.get_accounts_trie().make_trie_cursor();
 
     std::unique_ptr<rocksdb::Iterator> it{
-        db.db->NewIterator({}, db.accounts_trie.leaves_cursor.cf_)};
+        db.get_db()->NewIterator({}, db.get_accounts_trie().leaves_cursor.cf_)};
 
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
         auto const hashed_account_address =
@@ -114,11 +114,11 @@ dump_accounts_from_db(monad::db::RocksTrieDB &db)
 dump_storage_from_db(monad::db::RocksTrieDB &db)
 {
     nlohmann::json state = nlohmann::json::object();
-    auto leaf_cursor = db.storage_trie.make_leaf_cursor();
-    auto trie_cursor = db.storage_trie.make_trie_cursor();
+    auto leaf_cursor = db.get_storage_trie().make_leaf_cursor();
+    auto trie_cursor = db.get_storage_trie().make_trie_cursor();
 
     std::unique_ptr<rocksdb::Iterator> it{
-        db.db->NewIterator({}, db.storage_trie.leaves_cursor.cf_)};
+        db.get_db()->NewIterator({}, db.get_storage_trie().leaves_cursor.cf_)};
 
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
         auto key_slice = monad::db::from_slice(it->key());
@@ -133,10 +133,10 @@ dump_accounts_from_db(monad::db::InMemoryTrieDB &db)
 {
     nlohmann::json state = nlohmann::json::object();
 
-    auto leaf_cursor = db.accounts_trie.make_leaf_cursor();
-    auto trie_cursor = db.accounts_trie.make_trie_cursor();
+    auto leaf_cursor = db.get_accounts_trie().make_leaf_cursor();
+    auto trie_cursor = db.get_accounts_trie().make_trie_cursor();
 
-    for (auto const &[address, _] : db.accounts_trie.leaves_storage) {
+    for (auto const &[address, _] : db.get_accounts_trie().leaves_storage) {
         auto const [hashed_account_address, size] =
             monad::trie::deserialize_nibbles(address);
         detail::dump_accounts_from_trie(
@@ -150,10 +150,10 @@ dump_accounts_from_db(monad::db::InMemoryTrieDB &db)
 dump_storage_from_db(monad::db::InMemoryTrieDB &db)
 {
     nlohmann::json state = nlohmann::json::object();
-    auto leaf_cursor = db.storage_trie.make_leaf_cursor();
-    auto trie_cursor = db.storage_trie.make_trie_cursor();
+    auto leaf_cursor = db.get_storage_trie().make_leaf_cursor();
+    auto trie_cursor = db.get_storage_trie().make_trie_cursor();
 
-    for (auto const &[key, value] : db.storage_trie.leaves_storage) {
+    for (auto const &[key, value] : db.get_storage_trie().leaves_storage) {
         monad::byte_string_view key_slice{key};
         detail::dump_storage_from_trie(
             state, key_slice, leaf_cursor, trie_cursor);


### PR DESCRIPTION
Problem:
- All DBs are declared as Struct right now, which exposes their private members

Solution:
- Make DBs to be class; Name class member variables with suffix _