### PR TITLE
:bug: ethereum tests should differentiate between zero and no to address

### DIFF
--- a/test/ethereum_test/include/types.hpp
+++ b/test/ethereum_test/include/types.hpp
@@ -14,6 +14,8 @@
 #include <monad/state/value_state.hpp>
 #include <monad/test/config.hpp>
 
+#include <optional>
+
 MONAD_TEST_NAMESPACE_BEGIN
 
 struct SharedTransactionData
@@ -33,7 +35,7 @@ struct SharedTransactionData
     // the following fields are shared among all transactions in a test file
     uint64_t nonce;
     monad::address_t sender;
-    monad::address_t to;
+    std::optional<monad::address_t> to;
     monad::Transaction::Type transaction_type;
     uint64_t gas_price;
     uint64_t priority_fee;


### PR DESCRIPTION
Problem:
- If to does not exist in the json, ethereum tests interprets that as a transaction sending to zero, when it should interpret that as a create.

Solution:
- Change the type of to in SharedTransactionData to be an optional

This passes `./test/ethereum_test/monad-ethereum-test --gtest_filter=stCodeSizeLimit.codesizeValid` on the state2-integration branch. 