### PR TITLE
:recycle: Use new DB commit API for unit tests (Below TP)

### DIFF
--- a/src/monad/execution/test/evm.cpp
+++ b/src/monad/execution/test/evm.cpp
@@ -46,11 +46,15 @@ TEST(Evm, make_account_address)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{from, Account{.balance = 10'000'000'000, .nonce = 7}}},
-        .storage_changes = {},
-        .code_changes = {}});
+
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 7}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -81,11 +85,14 @@ TEST(Evm, make_account_address_create2)
         0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32};
     static const uint8_t deadbeef[4]{0xde, 0xad, 0xbe, 0xef};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{from, Account{.balance = 10'000'000'000, .nonce = 5}}},
-        .storage_changes = {},
-        .code_changes = {}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 5}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CREATE2,
@@ -113,10 +120,14 @@ TEST(Evm, create_with_insufficient)
 
     static constexpr auto from{
         0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
-    db.commit(state::StateChanges{
-        .account_changes = {{from, Account{.balance = 10'000'000'000}}},
-        .storage_changes = {},
-        .code_changes = {}});
+
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 10'000'000'000}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -174,10 +185,15 @@ TEST(Evm, transfer_call_balances)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {to, Account{}},
-            {from, Account{.balance = 10'000'000'000, .nonce = 7}}}});
+    db.commit(
+        StateDeltas{
+            {to, StateDelta{.account = {std::nullopt, Account{}}}},
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 7}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -204,9 +220,14 @@ TEST(Evm, transfer_call_balances_to_self)
     static constexpr auto from{
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     static constexpr auto to = from;
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {from, Account{.balance = 10'000'000'000, .nonce = 7}}}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 7}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -234,10 +255,15 @@ TEST(Evm, dont_transfer_on_delegatecall)
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {to, Account{}},
-            {from, Account{.balance = 10'000'000'000, .nonce = 6}}}});
+    db.commit(
+        StateDeltas{
+            {to, StateDelta{.account = {std::nullopt, Account{}}}},
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 6}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_DELEGATECALL,
@@ -266,10 +292,15 @@ TEST(Evm, dont_transfer_on_staticcall)
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {to, Account{}},
-            {from, Account{.balance = 10'000'000'000, .nonce = 6}}}});
+    db.commit(
+        StateDeltas{
+            {to, StateDelta{.account = {std::nullopt, Account{}}}},
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = 6}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -299,8 +330,13 @@ TEST(Evm, create_contract_account)
     static constexpr auto new_addr{
         0x58f3f9ebd5dbdf751f12d747b02d00324837077d_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {{from, Account{.balance = 50'000, .nonce = 1}}}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 50'000, .nonce = 1}}}}},
+        Code{});
 
     evm_host_t h{};
     byte_string code{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
@@ -334,8 +370,13 @@ TEST(Evm, create2_contract_account)
     static constexpr auto new_addr2{
         0xe0e05f8f41129e2087ec0a3759810fdced46edd4_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {{from, Account{.balance = 50'000, .nonce = 1}}}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 50'000, .nonce = 1}}}}},
+        Code{});
 
     evm_host_t h{};
     byte_string code{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
@@ -370,8 +411,13 @@ TEST(Evm, oog_create_account)
     static constexpr auto new_addr{
         0x58f3f9ebd5dbdf751f12d747b02d00324837077d_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {{from, Account{.balance = 50'000, .nonce = 1}}}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 50'000, .nonce = 1}}}}},
+        Code{});
 
     evm_host_t h{};
     fake::Interpreter::_result = evmc::Result{
@@ -401,8 +447,12 @@ TEST(Evm, revert_create_account)
 
     evm_host_t h{};
 
-    db.commit(state::StateChanges{
-        .account_changes = {{from, Account{.balance = 10'000}}}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 10'000}}}}},
+        Code{});
 
     fake::Interpreter::_result = evmc::Result{
         evmc_result{.status_code = EVMC_REVERT, .gas_left = 11'000}};
@@ -430,14 +480,16 @@ TEST(Evm, create_nonce_out_of_range)
 
     evm_host_t h{};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{from,
-              Account{
-                  .balance = 10'000'000'000,
-                  .nonce = std::numeric_limits<uint64_t>::max()}}},
-        .storage_changes = {},
-        .code_changes = {}});
+    db.commit(
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 10'000'000'000,
+                          .nonce = std::numeric_limits<uint64_t>::max()}}}}},
+        Code{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -464,10 +516,15 @@ TEST(Evm, call_evm)
     static constexpr auto to{
         0xf8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8_address};
 
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {to, Account{.balance = 50'000}},
-            {from, Account{.balance = 50'000, .nonce = 1}}}});
+    db.commit(
+        StateDeltas{
+            {to,
+             StateDelta{.account = {std::nullopt, Account{.balance = 50'000}}}},
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 50'000, .nonce = 1}}}}},
+        Code{});
 
     evm_host_t h{};
 
@@ -503,10 +560,14 @@ TEST(Evm, static_precompile_execution)
 
     evm_host_t h{};
 
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {code_address, Account{.nonce = 4}},
-            {from, Account{.balance = 15'000}}}});
+    db.commit(
+        StateDeltas{
+            {code_address,
+             StateDelta{.account = {std::nullopt, Account{.nonce = 4}}}},
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 15'000}}}}},
+        Code{});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);
@@ -543,10 +604,14 @@ TEST(Evm, out_of_gas_static_precompile_execution)
 
     evm_host_t h{};
 
-    db.commit(state::StateChanges{
-        .account_changes = {
-            {code_address, Account{.nonce = 6}},
-            {from, Account{.balance = 15'000}}}});
+    db.commit(
+        StateDeltas{
+            {code_address,
+             StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}},
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 15'000}}}}},
+        Code{});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);

--- a/test/integration/evm_state_host/evm_state_host.cpp
+++ b/test/integration/evm_state_host/evm_state_host.cpp
@@ -70,11 +70,17 @@ TEST(EvmInterpStateHost, return_existing_storage)
         0xf3}; // RETURN
     Account A{.code_hash = code_hash};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{a, A}, {to, Account{}}, {from, Account{.balance = 10'000'000}}},
-        .storage_changes = {{to, {{location, value1}}}},
-        .code_changes = {{code_hash, code}}});
+    db.commit(
+        StateDeltas{
+            {a, StateDelta{.account = {std::nullopt, A}}},
+            {to,
+             StateDelta{
+                 .account = {std::nullopt, Account{}},
+                 .storage = {{location, {bytes32_t{}, value1}}}}},
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 10'000'000}}}}},
+        Code{{code_hash, code}});
 
     BlockHeader const b{}; // Required for the host interface, but not used
     Transaction const t{};
@@ -132,11 +138,14 @@ TEST(EvmInterpStateHost, store_then_return_storage)
         0xf3}; // RETURN
     Account A{.code_hash = code_hash};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{a, A}, {to, Account{}}, {from, Account{.balance = 10'000'000}}},
-        .storage_changes = {},
-        .code_changes = {{code_hash, code}}});
+    db.commit(
+        StateDeltas{
+            {a, StateDelta{.account = {std::nullopt, A}}},
+            {to, StateDelta{.account = {std::nullopt, Account{}}}},
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 10'000'000}}}}},
+        Code{{code_hash, code}});
 
     BlockHeader const b{}; // Required for the host interface, but not used
     Transaction const t{};

--- a/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
+++ b/test/integration/txn_proc_evm_state_host/txn_proc_evm_state_host.cpp
@@ -47,11 +47,13 @@ TEST(TxnProcEvmInterpStateHost, account_transfer_miner_ommer_award)
     BlockState<mutex_t> bs;
     state::State s{bs, db, blocks};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{a, Account{}}, // 'to' doesn't previously exist
-             {from, Account{.balance = 10'000'000}}},
-        .storage_changes = {}});
+    db.commit(
+        StateDeltas{
+            {a, StateDelta{.account = {std::nullopt, Account{}}}},
+            {from,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 10'000'000}}}}},
+        Code{});
 
     BlockHeader const bh{.number = 2, .beneficiary = a};
     BlockHeader const ommer{.number = 1, .beneficiary = o};
@@ -102,12 +104,16 @@ TEST(TxnProcEvmInterpStateHost, out_of_gas_account_creation_failure)
     BlockState<mutex_t> bs;
     state::State s{bs, db, blocks};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{a, Account{}},
-             {creator,
-              Account{.balance = 9'000'000'000'000'000'000, .nonce = 3}}},
-        .storage_changes = {}});
+    db.commit(
+        StateDeltas{
+            {a, StateDelta{.account = {std::nullopt, Account{}}}},
+            {creator,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 9'000'000'000'000'000'000, .nonce = 3}}}}},
+        Code{});
 
     byte_string code = {0x60, 0x60, 0x60, 0x40, 0x52, 0x60, 0x00, 0x80, 0x54,
                         0x60, 0x01, 0x60, 0xa0, 0x60, 0x02, 0x0a, 0x03, 0x19,
@@ -161,12 +167,16 @@ TEST(TxnProcEvmInterpStateHost, out_of_gas_account_creation_failure_with_value)
     BlockState<mutex_t> bs;
     state::State s{bs, db, blocks};
 
-    db.commit(state::StateChanges{
-        .account_changes =
-            {{a, Account{}},
-             {creator,
-              Account{.balance = 4'942'119'596'324'559'240, .nonce = 2}}},
-        .storage_changes = {}});
+    db.commit(
+        StateDeltas{
+            {a, StateDelta{.account = {std::nullopt, Account{}}}},
+            {creator,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 4'942'119'596'324'559'240, .nonce = 2}}}}},
+        Code{});
 
     byte_string code = {0xde, 0xad, 0xbe, 0xef};
     BlockHeader const bh{.number = 48'512, .beneficiary = a};

--- a/test/unit/common/src/test/dump_state_from_db.cpp
+++ b/test/unit/common/src/test/dump_state_from_db.cpp
@@ -14,6 +14,8 @@
 #include <monad/core/transaction.hpp>
 #include <monad/execution/test/fakes.hpp>
 #include <monad/state/code_state.hpp>
+#include <monad/state2/state_deltas.hpp>
+
 using namespace monad;
 
 template <typename>
@@ -131,39 +133,69 @@ TYPED_TEST(StateSerialization, serialize_add)
     auto const h_code_hash = std::bit_cast<bytes32_t>(
         ethash::keccak256(h_code.data(), h_code.size()));
 
-    db.commit(monad::state::StateChanges{
-        .account_changes =
-            {{a,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9ce, .code_hash = a_code_hash}},
-             {b,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9ce, .code_hash = b_code_hash}},
-             {c,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9ce, .code_hash = c_code_hash}},
-             {d,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9ce, .code_hash = d_code_hash}},
-             {e,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9ce, .code_hash = e_code_hash}},
-             {f, monad::Account{.balance = 0x7024c}},
-             {g, monad::Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}},
-             {h,
-              monad::Account{
-                  .balance = 0xba1a9ce0ba1a9cf, .code_hash = h_code_hash}}},
-        .storage_changes =
-            {{a,
-              {{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}},
-        .code_changes = {
+    db.commit(
+        StateDeltas{
+            {a,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9ce,
+                          .code_hash = a_code_hash}},
+                 .storage =
+                     {{bytes32_t{},
+                       {bytes32_t{},
+                        0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}}},
+            {b,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9ce,
+                          .code_hash = b_code_hash}}}},
+            {c,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9ce,
+                          .code_hash = c_code_hash}}}},
+            {d,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9ce,
+                          .code_hash = d_code_hash}}}},
+            {e,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9ce,
+                          .code_hash = e_code_hash}}}},
+            {f,
+             StateDelta{
+                 .account = {std::nullopt, Account{.balance = 0x7024c}}}},
+            {g,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}}}},
+            {h,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0xba1a9ce0ba1a9cf,
+                          .code_hash = h_code_hash}}}}},
+        Code{
             {a_code_hash, a_code},
             {b_code_hash, b_code},
             {c_code_hash, c_code},
             {d_code_hash, d_code},
             {e_code_hash, e_code},
-            {h_code_hash, h_code}}});
+            {h_code_hash, h_code}});
 
     auto const actual_payload = monad::test::dump_state_from_db(db);
     // performs a deep comparison:


### PR DESCRIPTION
- Change all unit tests to use the new `db.commit()` function
- Note that some of them are still using the old (fake) `State` - will change that in the next PR