### PR TITLE
:recycle: Move genesis logic from ReplayBlockDb to replay_ethereum

### DIFF
--- a/include/monad/db/state_db.hpp
+++ b/include/monad/db/state_db.hpp
@@ -38,7 +38,8 @@ public:
     StateDb(std::filesystem::path const &);
     ~StateDb();
 
-    virtual std::optional<Account> read_account(address_t const &) const override;
+    virtual std::optional<Account>
+    read_account(address_t const &) const override;
 
     std::optional<Account>
     read_account_history(address_t const &, uint64_t block_number);

--- a/include/monad/execution/replay_block_db.hpp
+++ b/include/monad/execution/replay_block_db.hpp
@@ -122,17 +122,6 @@ public:
                 return Result{Status::DECODE_BLOCK_ERROR, current_block_number};
             case TBlockDb::Status::SUCCESS: {
 
-                // TODO: Do we need to support functionality to specify genesis
-                // file location?
-                if (current_block_number == 0u &&
-                    TTraits::last_block_number == 1'149'999u) { // genesis block
-                    auto const genesis_file_path =
-                        test_resource::ethereum_genesis_dir / "mainnet.json";
-
-                    [[maybe_unused]] auto const block_header =
-                        read_genesis(genesis_file_path, state.accounts_.db_);
-                }
-
                 TTraits::validate_block(block);
 
                 TAllTxnBlockProcessor<TExecution> block_processor{};

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -59,6 +59,7 @@ int main(int argc, char *argv[])
 
     std::filesystem::path block_db_path{};
     std::filesystem::path state_db_path{};
+    std::filesystem::path genesis_file_path{};
     uint64_t block_history_size = 1u;
     std::optional<monad::block_num_t> finish_block_number = std::nullopt;
 
@@ -92,6 +93,8 @@ int main(int argc, char *argv[])
         ->required();
     cli.add_option("--state_db", state_db_path, "state_db directory")
         ->required();
+    auto *has_genesis_file = cli.add_option(
+        "--genesis_file", genesis_file_path, "genesis file directory");
     cli.add_option(
         "--block_history_size",
         block_history_size,
@@ -163,6 +166,12 @@ int main(int argc, char *argv[])
         block_history_size,
         start_block_number,
         finish_block_number);
+
+    if (start_block_number == 0) {
+        MONAD_DEBUG_ASSERT(*has_genesis_file);
+        read_and_verify_genesis(block_db, db, genesis_file_path);
+        start_block_number = 1u;
+    }
 
     receipt_collector_t receipt_collector;
 

--- a/src/monad/execution/ethereum/test/genesis.cpp
+++ b/src/monad/execution/ethereum/test/genesis.cpp
@@ -1,5 +1,6 @@
 #include <monad/core/block.hpp>
 
+#include <monad/db/block_db.hpp>
 #include <monad/db/in_memory_trie_db.hpp>
 #include <monad/db/rocks_trie_db.hpp>
 
@@ -19,13 +20,13 @@ using namespace monad;
 using namespace monad::execution;
 
 template <typename TDB>
-struct GenesisStateRootTest : public testing::Test
+struct GenesisTest : public testing::Test
 {
 };
 
 using TrieDBTypes = ::testing::Types<db::InMemoryTrieDB, db::RocksTrieDB>;
 
-TYPED_TEST_SUITE(GenesisStateRootTest, TrieDBTypes);
+TYPED_TEST_SUITE(GenesisTest, TrieDBTypes);
 
 TEST(Genesis, read_ethereum_mainnet_genesis_header)
 {
@@ -57,7 +58,7 @@ TEST(Genesis, read_ethereum_mainnet_genesis_header)
     EXPECT_EQ(block_header.timestamp, 0);
 }
 
-TYPED_TEST(GenesisStateRootTest, ethereum_mainnet_genesis_state_root)
+TYPED_TEST(GenesisTest, ethereum_mainnet_genesis_state_root)
 {
     auto const genesis_file_path =
         test_resource::ethereum_genesis_dir / "mainnet.json";
@@ -69,4 +70,13 @@ TYPED_TEST(GenesisStateRootTest, ethereum_mainnet_genesis_state_root)
     auto expected_state_root{
         0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544_bytes32};
     EXPECT_EQ(block_header.state_root, expected_state_root);
+}
+
+TYPED_TEST(GenesisTest, read_and_verify_genesis_block)
+{
+    auto const genesis_file_path =
+        test_resource::ethereum_genesis_dir / "mainnet.json";
+    db::BlockDb block_db(test_resource::correct_block_data_dir);
+    auto state_db = test::make_db<TypeParam>();
+    read_and_verify_genesis(block_db, state_db, genesis_file_path);
 }


### PR DESCRIPTION
Problem:
- In BP, we have a conditional checking if block_number = 0, then don't apply block reward

Solution:
- Move genesis logic from ReplayBlockDb to replay_ethereum (which means block number always starts > 0 now)