### PR TITLE
:recycle: add add_to_balance and subtract_from_balance

### DIFF
--- a/include/monad/execution/evm.hpp
+++ b/include/monad/execution/evm.hpp
@@ -126,11 +126,8 @@ struct Evm
         TState &s, evmc_message const &m, address_t const &to) noexcept
     {
         auto const value = intx::be::load<uint256_t>(m.value);
-        auto const from_balance =
-            intx::be::load<uint256_t>(s.get_balance(m.sender));
-        s.set_balance(m.sender, from_balance - value);
-        auto const to_balance = intx::be::load<uint256_t>(s.get_balance(to));
-        s.set_balance(to, to_balance + value);
+        s.subtract_from_balance(m.sender, value);
+        s.add_to_balance(to, value);
     }
 
     [[nodiscard]] static std::optional<evmc_result>
@@ -200,13 +197,6 @@ struct Evm
                 return result.error();
             }
             else if (m.flags != EVMC_STATIC) {
-                if (!s.account_exists(m.sender)) {
-                    s.create_account(m.sender);
-                }
-
-                if (!s.account_exists(m.recipient)) {
-                    s.create_account(m.recipient);
-                }
                 transfer_balances(s, m, m.recipient);
             }
         }

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -147,9 +147,16 @@ namespace fake
                     _accounts.at(address).balance);
             }
 
-            void set_balance(address_t const &address, uint256_t new_balance)
+            void
+            add_to_balance(address_t const &address, uint256_t const &delta)
             {
-                _accounts[address].balance = new_balance;
+                _accounts[address].balance += delta;
+            }
+
+            void subtract_from_balance(
+                address_t const &address, uint256_t const &delta)
+            {
+                _accounts[address].balance -= delta;
             }
 
             [[nodiscard]] auto
@@ -264,13 +271,6 @@ namespace fake
             TRY_LATER,
             COLLISION_DETECTED,
         };
-
-        std::unordered_map<address_t, uint256_t> _block_reward{};
-
-        void apply_reward(address_t const &a, uint256_t const &r)
-        {
-            _block_reward.insert({a, r});
-        }
 
         // Had to name this variable using post_ because we access it directly
         AccountState accounts_{};

--- a/include/monad/execution/transaction_processor.hpp
+++ b/include/monad/execution/transaction_processor.hpp
@@ -40,8 +40,8 @@ struct TransactionProcessor
             auto const nonce = s.get_nonce(*t.from);
             s.set_nonce(*t.from, nonce + 1);
         }
-        auto const balance = intx::be::load<uint256_t>(s.get_balance(*t.from));
-        s.set_balance(*t.from, balance - upfront_cost_);
+        MONAD_DEBUG_ASSERT(t.from.has_value());
+        s.subtract_from_balance(t.from.value(), upfront_cost_);
     }
 
     // YP Eqn 72
@@ -62,10 +62,9 @@ struct TransactionProcessor
         auto const gas_remaining = g_star(t, gas_leftover, refund);
         auto const gas_cost = TTraits::gas_price(t, base_fee_per_gas);
 
-        auto const sender_balance =
-            intx::be::load<uint256_t>(s.get_balance(*t.from));
+        MONAD_DEBUG_ASSERT(t.from.has_value());
+        s.add_to_balance(t.from.value(), gas_cost * gas_remaining);
 
-        s.set_balance(*t.from, sender_balance + (gas_cost * gas_remaining));
         return gas_remaining;
     }
 

--- a/test/ethereum_test/include/ethereum_test.hpp
+++ b/test/ethereum_test/include/ethereum_test.hpp
@@ -93,7 +93,7 @@ void load_state_from_json(nlohmann::json const &j, TState &state)
                 account_address, j_acc.at("code").get<monad::byte_string>());
         }
 
-        state.set_balance(
+        state.add_to_balance(
             account_address, j_acc.at("balance").get<intx::uint256>());
         // we cannot use the nlohmann::json from_json<uint64_t> because
         // it does not use the strtoull implementation, whereas we need


### PR DESCRIPTION
Problem:
- It makes sense to add to a nonexistent account but not to subtract a non-zero amount fromn a non-exitent account
- We had code scattered around to handle cases of non-existent accounts

Solution:
- Add in add_to_balance and subtract_from_balance which captures this logic