### PR TITLE
:recycle: Use promise/future to merge result into block state

### DIFF
--- a/include/monad/execution/block_processor.hpp
+++ b/include/monad/execution/block_processor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <monad/core/assert.h>
 #include <monad/core/block.hpp>
 #include <monad/core/receipt.hpp>
 #include <monad/core/transaction.hpp>
@@ -10,17 +11,46 @@
 
 #include <monad/logging/monad_log.hpp>
 
+#include <monad/state2/block_state.hpp>
+#include <monad/state2/state.hpp>
+#include <monad/state2/state_deltas.hpp>
+
 #include <chrono>
 #include <vector>
 
+#include <boost/fiber/all.hpp>
+
 MONAD_EXECUTION_NAMESPACE_BEGIN
 
-template <class TExecution>
+template <class TResult, class TFnObject>
+struct PromiseReturningInvocable
+{
+    boost::fibers::promise<TResult> p_;
+    TFnObject obj_;
+
+    PromiseReturningInvocable(
+        boost::fibers::promise<TResult> &&p, TFnObject &&obj)
+        : p_{std::move(p)}
+        , obj_{std::move(obj)}
+    {
+    }
+
+    void operator()()
+    {
+        obj_();
+        p_.set_value(std::move(obj_.get_result()));
+    }
+};
+
 struct AllTxnBlockProcessor
 {
-    template <class TState, class TTraits, class TFiberData>
-    [[nodiscard]] std::vector<Receipt> execute(TState &s, Block &b)
+    template <class TMutex, class TTraits, class TxnProcData, class TBlockCache>
+    [[nodiscard]] std::vector<Receipt>
+    execute(Block &b, Db &db, TBlockCache &block_cache)
     {
+        using result_t = typename TxnProcData::result_t;
+        using obj_task_t = PromiseReturningInvocable<result_t, TxnProcData>;
+
         auto *block_logger = log::logger_t::get_logger("block_logger");
         auto const start_time = std::chrono::steady_clock::now();
         MONAD_LOG_INFO(
@@ -30,36 +60,88 @@ struct AllTxnBlockProcessor
             b.transactions.size());
         MONAD_LOG_DEBUG(block_logger, "BlockHeader Fields: {}", b.header);
 
-        TTraits::transfer_balance_dao(s, b.header.number);
+        BlockState<TMutex> block_state{};
 
-        std::vector<TFiberData> data{};
-        std::vector<typename TExecution::fiber_t> fibers{};
+        // Apply DAO hack reversal
+        TTraits::transfer_balance_dao(block_state, db, block_cache, b.header.number);
 
-        data.reserve(b.transactions.size());
-        fibers.reserve(b.transactions.size());
-
-        unsigned int i = 0;
-        for (auto &txn : b.transactions) {
-            txn.from = recover_sender(txn);
-            data.push_back({s, txn, b.header, i});
-            fibers.emplace_back(data.back());
-            ++i;
-        }
-        TExecution::yield();
-
+        std::vector<boost::fibers::future<result_t>> futures{};
+        std::vector<boost::fibers::fiber> fibers{};
         std::vector<Receipt> r{};
+
+        futures.reserve(b.transactions.size());
+        fibers.reserve(b.transactions.size());
         r.reserve(b.transactions.size());
-        for (auto &fiber : fibers) {
-            fiber.join();
-        }
-        for (auto &d : data) {
-            r.push_back(d.get_receipt());
+
+        // Construct fibers from all transactions
+        for (unsigned index = 0u; auto &txn : b.transactions) {
+            txn.from = recover_sender(txn);
+            boost::fibers::promise<result_t> p{};
+            futures.push_back(p.get_future());
+            TxnProcData data{
+                db, block_state, txn, b.header, block_cache, index};
+            obj_task_t t{std::move(p), std::move(data)};
+            fibers.emplace_back(std::move(t));
+            ++index;
         }
 
-        TTraits::process_withdrawal(s, b.withdrawals);
+        // Merge in order, or re-run if necessary
+        for (unsigned index = 0u; auto &future : futures) {
+            auto txn_result = future.get();
+            auto &result = txn_result.first;
+            auto &state = txn_result.second;
 
-        if (b.header.number != 0u) {
-            TTraits::apply_block_award(s, b);
+            if (std::shared_lock<TMutex> const lock{block_state.mutex};
+                can_merge(block_state.state, state.state_)) {
+                merge(block_state.state, state.state_);
+                merge(block_state.code, state.code_);
+                goto get_receipt;
+            }
+            else {
+                goto rerun;
+            }
+
+        get_receipt:
+            MONAD_LOG_INFO(block_logger, "Merged {}", index);
+            fibers[index].join();
+            r.push_back(result);
+            ++index;
+            continue;
+
+        rerun:
+            MONAD_LOG_INFO(block_logger, "Re-running {}...", index);
+            TxnProcData new_run{
+                db,
+                block_state,
+                b.transactions[index],
+                b.header,
+                block_cache,
+                index};
+            new_run();
+            auto &new_result = new_run.result_;
+            {
+                std::shared_lock<TMutex> const lock{block_state.mutex};
+                MONAD_DEBUG_ASSERT(
+                    can_merge(block_state.state, new_result.second.state_));
+                merge(block_state.state, new_result.second.state_);
+                merge(block_state.code, new_result.second.code_);
+            }
+            r.push_back(new_result.first);
+            fibers[index].join();
+            ++index;
+        }
+
+        // Process withdrawls
+        TTraits::process_withdrawal(block_state, db, block_cache, b.withdrawals);
+
+        { // Apply block reward to beneficiary
+            state::State state{block_state, db, block_cache};
+
+            if (b.header.number != 0u) {
+                TTraits::apply_block_award(state, b);
+            }
+            MONAD_DEBUG_ASSERT(can_merge(block_state.state, state.state_));
+            merge(block_state.state, state.state_);
         }
 
         auto const finished_time = std::chrono::steady_clock::now();
@@ -73,7 +155,26 @@ struct AllTxnBlockProcessor
             elapsed_ms);
         MONAD_LOG_DEBUG(block_logger, "Receipts: {}", r);
 
+        commit(block_state, db);
+
         return r;
+    }
+
+    template <class TMutex>
+    void commit(BlockState<TMutex> &block_state, Db &db)
+    {
+        auto *block_logger = log::logger_t::get_logger("block_logger");
+        auto const start_time = std::chrono::steady_clock::now();
+        MONAD_LOG_INFO(block_logger, {}, "Committing to DB...");
+
+        db.commit(block_state.state, block_state.code);
+
+        auto const finished_time = std::chrono::steady_clock::now();
+        auto const elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                finished_time - start_time);
+        MONAD_LOG_INFO(
+            block_logger, "Finished committing, time elapsed = {}", elapsed_ms);
     }
 };
 

--- a/include/monad/execution/test/fakes.hpp
+++ b/include/monad/execution/test/fakes.hpp
@@ -11,6 +11,8 @@
 #include <monad/core/transaction.hpp>
 #include <monad/core/withdrawal.hpp>
 
+#include <monad/db/db.hpp>
+
 #include <monad/execution/config.hpp>
 
 #include <monad/state/state_changes.hpp>
@@ -437,8 +439,9 @@ namespace fake
                 return c;
             }
 
-            static constexpr void
-            transfer_balance_dao(TState &, block_num_t const)
+            template <class TBlockState, class TBlockCache>
+            static constexpr void transfer_balance_dao(
+                TBlockState &, monad::Db &, TBlockCache const &, block_num_t const)
             {
             }
 
@@ -446,9 +449,10 @@ namespace fake
 
             static constexpr void warm_coinbase(TState &, address_t const &) {}
 
+            template <class TBlockState, class TBlockCache>
             static constexpr void process_withdrawal(
-                TState &,
-                std::optional<std::vector<Withdrawal>> const &) noexcept
+                TBlockState &, monad::Db &, TBlockCache const &,
+                std::optional<std::vector<Withdrawal>> const &)
             {
             }
 

--- a/src/monad/execution/test/CMakeLists.txt
+++ b/src/monad/execution/test/CMakeLists.txt
@@ -2,7 +2,7 @@ add_unit_test(
     TARGET
     monad-executiontests
     SOURCES
-    # block_processor.cpp // TODO: Comment back once BP is refactored
+    block_processor.cpp
     create_contract_address.cpp
     evm.cpp
     evmc_host.cpp


### PR DESCRIPTION
Problem:
- Currently, when joining a fiber, the txn processor data is destroyed
- The new state model pulls results rather than having them pushed into the block state.

Solution:
- Track a set of futures that represents the txn results.
- Merge them in order, and re-run if the result is unmergable.

Note: move semantics, goto, and fibers...Oh my!  The `goto`s might seem pretty ugly at first, but I couldn't think of a different way to minimize the critical section and continue on.  Also, there is a lot of moving because promises are move-only.  Open to feedback.

- [ ] Write test for the re-processing logic