### PR TITLE
♻️ use root quill logger instead of our own 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ function(monad_compile_options target)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD 23)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
   target_compile_options(${target} PRIVATE -Wall -Wextra -Werror -Wconversion
-                                           -Wpedantic)
+                                           -Wpedantic -DQUILL_ROOT_LOGGER_ONLY)
   target_compile_options(
     ${target}
     PUBLIC $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>)

--- a/include/monad/db/rocks_trie_db.hpp
+++ b/include/monad/db/rocks_trie_db.hpp
@@ -142,8 +142,6 @@ struct RocksTrieDB : public Db
     uint64_t const block_history_size;
     rocksdb::WriteBatch batch;
 
-    quill::Logger *logger;
-
     ////////////////////////////////////////////////////////////////////
     // Constructor & Destructor
     ////////////////////////////////////////////////////////////////////
@@ -168,7 +166,6 @@ struct RocksTrieDB : public Db
         , accounts_trie(db, batch, cfs[1], cfs[2])
         , storage_trie(db, batch, cfs[3], cfs[4])
         , block_history_size(block_history_size)
-        , logger(quill::get_logger("trie_db_logger"))
     {
         MONAD_DEBUG_ASSERT(
             std::holds_alternative<Writable>(permission) ||
@@ -270,8 +267,7 @@ struct RocksTrieDB : public Db
             // this is not a critical error in production, we can continue
             // executing with the current database while someone
             // investigates
-            QUILL_LOG_ERROR(
-                logger,
+            LOG_ERROR(
                 "Unable to save block_number {} for {} error={}",
                 block_number,
                 db_type(),

--- a/include/monad/db/trie_db_process_changes.hpp
+++ b/include/monad/db/trie_db_process_changes.hpp
@@ -43,8 +43,7 @@ void trie_db_process_changes(
         std::ranges::sort(
             storage_trie_updates, std::less<>{}, trie::get_update_key);
 
-        QUILL_LOG_INFO(
-            quill::get_logger("trie_db_logger"),
+        LOG_INFO(
             "STORAGE_UPDATES({}) account={} {}",
             storage_trie_updates.size(),
             u.first,
@@ -96,8 +95,7 @@ void trie_db_process_changes(
     if (!account_trie_updates.empty()) {
         std::ranges::sort(
             account_trie_updates, std::less<>{}, trie::get_update_key);
-        QUILL_LOG_INFO(
-            quill::get_logger("trie_db_logger"),
+        LOG_INFO(
             "ACCOUNT_UPDATES({}) {}",
             account_trie_updates.size(),
             account_trie_updates);
@@ -152,8 +150,7 @@ void trie_db_process_changes(
                 std::ranges::sort(
                     storage_trie_updates, std::less<>{}, trie::get_update_key);
 
-                QUILL_LOG_INFO(
-                    quill::get_logger("trie_db_logger"),
+                LOG_INFO(
                     "STORAGE_UPDATES({}) account={} {}",
                     storage_trie_updates.size(),
                     addr,
@@ -210,8 +207,7 @@ void trie_db_process_changes(
     if (!account_trie_updates.empty()) {
         std::ranges::sort(
             account_trie_updates, std::less<>{}, trie::get_update_key);
-        QUILL_LOG_INFO(
-            quill::get_logger("trie_db_logger"),
+        LOG_INFO(
             "ACCOUNT_UPDATES({}) {}",
             account_trie_updates.size(),
             account_trie_updates);

--- a/include/monad/execution/block_processor.hpp
+++ b/include/monad/execution/block_processor.hpp
@@ -23,14 +23,12 @@ struct AllTxnBlockProcessor
     template <class TState, class TTraits, class TFiberData>
     [[nodiscard]] std::vector<Receipt> execute(TState &s, Block &b)
     {
-        auto *block_logger = log::logger_t::get_logger("block_logger");
         auto const start_time = std::chrono::steady_clock::now();
-        QUILL_LOG_INFO(
-            block_logger,
+        LOG_INFO(
             "Start executing Block {}, with {} transactions",
             b.header.number,
             b.transactions.size());
-        QUILL_LOG_DEBUG(block_logger, "BlockHeader Fields: {}", b.header);
+        LOG_DEBUG("BlockHeader Fields: {}", b.header);
 
         TTraits::transfer_balance_dao(s, b.header.number);
 
@@ -68,12 +66,11 @@ struct AllTxnBlockProcessor
         auto const elapsed_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 finished_time - start_time);
-        QUILL_LOG_INFO(
-            block_logger,
+        LOG_INFO(
             "Finish executing Block {}, time elapsed = {}",
             b.header.number,
             elapsed_ms);
-        QUILL_LOG_DEBUG(block_logger, "Receipts: {}", r);
+        LOG_DEBUG("Receipts: {}", r);
 
         return r;
     }

--- a/include/monad/execution/evmone_baseline_interpreter.hpp
+++ b/include/monad/execution/evmone_baseline_interpreter.hpp
@@ -60,10 +60,7 @@ struct EVMOneBaselineInterpreter
         result = evmc::Result{evmone::baseline::execute(v, m.gas, *es, ca)};
 
 #ifdef EVMONE_TRACING
-        QUILL_LOG_DEBUG(
-            quill::get_logger("evmone_baseline_interpreter_logger"),
-            "{}",
-            instruction_trace_string_stream.str());
+        LOG_DEBUG("{}", instruction_trace_string_stream.str());
 #endif
         return result;
     }

--- a/include/monad/execution/replay_block_db.hpp
+++ b/include/monad/execution/replay_block_db.hpp
@@ -69,8 +69,7 @@ public:
     {
         // TODO: only check for state root hash for now (we don't have receipt
         // and transaction trie building algo yet)
-        QUILL_LOG_INFO(
-            quill ::get_logger("block_logger"),
+        LOG_INFO(
             "Computed State Root: {}, Expected State Root: {}",
             state_root,
             block_header.state_root);

--- a/include/monad/execution/transaction_processor_data.hpp
+++ b/include/monad/execution/transaction_processor_data.hpp
@@ -60,8 +60,7 @@ struct alignas(64) TransactionProcessorFiberData
 
         [[maybe_unused]] auto const start_time =
             std::chrono::steady_clock::now();
-        QUILL_LOG_INFO(
-            quill::get_logger("txn_logger"),
+        LOG_INFO(
             "Start executing Transaction {}, from = {}, to = {}",
             id_,
             txn_.from,
@@ -70,8 +69,7 @@ struct alignas(64) TransactionProcessorFiberData
         auto const validity =
             p.validate(state_, txn_, bh_.base_fee_per_gas.value_or(0));
         if (!is_valid(validity)) {
-            QUILL_LOG_INFO(
-                quill::get_logger("txn_logger"),
+            LOG_INFO(
                 "Transaction {} invalid: {}",
                 id_,
                 std::to_underlying(validity));
@@ -87,8 +85,7 @@ struct alignas(64) TransactionProcessorFiberData
             bh_.base_fee_per_gas.value_or(0),
             bh_.beneficiary);
 
-        QUILL_LOG_INFO(
-            quill::get_logger("txn_logger"),
+        LOG_INFO(
             "Finish executing Transaction {}, time elapsed = {}",
             id_,
             std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/include/monad/state/state.hpp
+++ b/include/monad/state/state.hpp
@@ -34,8 +34,6 @@ struct State
         TBlockCache &block_cache_{};
         unsigned int txn_id_{};
 
-        quill::Logger *logger_;
-
         ChangeSet(
             unsigned int i, typename TAccountState::ChangeSet &&a,
             typename TValueState::ChangeSet &&s,
@@ -45,34 +43,33 @@ struct State
             , code_{std::move(c)}
             , block_cache_{b}
             , txn_id_{i}
-            , logger_{quill::get_logger("change_set_logger")}
         {
         }
 
         void add_txn_award(uint256_t const &a)
         {
-            QUILL_LOG_DEBUG(logger_, "add_txn_award: {}", a);
+            LOG_DEBUG("add_txn_award: {}", a);
             gas_award_ += a;
         }
 
         unsigned int txn_id() const noexcept { return txn_id_; }
         void create_account(address_t const &a) noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "create_account: {}", a);
+            LOG_DEBUG("create_account: {}", a);
             accounts_.create_account(a);
         }
 
         // EVMC Host Interface
         [[nodiscard]] bool account_exists(address_t const &a) const
         {
-            QUILL_LOG_DEBUG(logger_, "account_exists: {}", a);
+            LOG_DEBUG("account_exists: {}", a);
             return accounts_.account_exists(a);
         }
 
         // EVMC Host Interface
         evmc_access_status access_account(address_t const &a) noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "access_account: {}", a);
+            LOG_DEBUG("access_account: {}", a);
             return accounts_.access_account(a);
         }
 
@@ -87,8 +84,7 @@ struct State
             [[maybe_unused]] auto const previous_balance =
                 intx::be::load<monad::uint256_t>(get_balance(a));
 
-            QUILL_LOG_DEBUG(
-                logger_,
+            LOG_DEBUG(
                 "set_balance: {} = {}, ({}{})",
                 a,
                 intx::to_string(new_balance, 16),
@@ -101,38 +97,38 @@ struct State
 
         [[nodiscard]] auto get_nonce(address_t const &a) const noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "get_nonce: {}", a);
+            LOG_DEBUG("get_nonce: {}", a);
             return accounts_.get_nonce(a);
         }
 
         void set_nonce(address_t const &a, uint64_t nonce) noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "set_nonce: {} = {}", a, nonce);
+            LOG_DEBUG("set_nonce: {} = {}", a, nonce);
             accounts_.set_nonce(a, nonce);
         }
 
         // EVMC Host Interface
         [[nodiscard]] bytes32_t get_code_hash(address_t const &a) const noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "get_code_hash: {}", a);
+            LOG_DEBUG("get_code_hash: {}", a);
             return accounts_.get_code_hash(a);
         }
 
         [[nodiscard]] bool selfdestruct(address_t const &a, address_t const &b)
         {
-            QUILL_LOG_DEBUG(logger_, "selfdestruct: {}, {}", a, b);
+            LOG_DEBUG("selfdestruct: {}, {}", a, b);
             return accounts_.selfdestruct(a, b);
         }
 
         void destruct_suicides()
         {
-            QUILL_LOG_DEBUG(logger_, "{}", "destruct_suicides");
+            LOG_DEBUG("{}", "destruct_suicides");
             accounts_.destruct_suicides();
         }
 
         void destruct_touched_dead()
         {
-            QUILL_LOG_DEBUG(logger_, "{}", "destruct_touched_dead");
+            LOG_DEBUG("{}", "destruct_touched_dead");
             accounts_.destruct_touched_dead();
         }
 
@@ -145,7 +141,7 @@ struct State
         evmc_access_status
         access_storage(address_t const &a, bytes32_t const &key)
         {
-            QUILL_LOG_DEBUG(logger_, "access_storage: {}, {}", a, key);
+            LOG_DEBUG("access_storage: {}, {}", a, key);
             return storage_.access_storage(a, key);
         }
 
@@ -153,7 +149,7 @@ struct State
         [[nodiscard]] bytes32_t
         get_storage(address_t const &a, bytes32_t const &key) const noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "get_storage: {}, {}", a, key);
+            LOG_DEBUG("get_storage: {}, {}", a, key);
             return storage_.get_storage(a, key);
         }
 
@@ -161,14 +157,14 @@ struct State
         [[nodiscard]] evmc_storage_status set_storage(
             address_t const &a, bytes32_t const &key, bytes32_t const &value)
         {
-            QUILL_LOG_DEBUG(logger_, "set_storage: {}, {} = {}", a, key, value);
+            LOG_DEBUG("set_storage: {}, {} = {}", a, key, value);
             return storage_.set_storage(a, key, value);
         }
 
         // Account contract accesses
         void set_code(address_t const &a, byte_string const &c)
         {
-            QUILL_LOG_DEBUG(logger_, "set_code: {} = {}", a, evmc::hex(c));
+            LOG_DEBUG("set_code: {} = {}", a, evmc::hex(c));
             auto const code_hash = std::bit_cast<monad::bytes32_t const>(
                 ethash::keccak256(c.data(), c.size()));
 
@@ -197,7 +193,7 @@ struct State
 
         void revert() noexcept
         {
-            QUILL_LOG_DEBUG(logger_, "{}", "revert");
+            LOG_DEBUG("{}", "revert");
             accounts_.revert();
             storage_.revert();
             code_.revert();
@@ -235,8 +231,6 @@ struct State
     TDatabase &db_{};
     unsigned int current_txn_{};
 
-    quill::Logger *logger_;
-
     State(
         TAccountState &a, TValueState &s, TCodeState &c, TBlockCache &bc,
         TDatabase &db)
@@ -245,13 +239,12 @@ struct State
         , code_{c}
         , block_cache_{bc}
         , db_{db}
-        , logger_{quill::get_logger("state_logger")}
     {
     }
 
     void apply_reward(address_t const &a, uint256_t const &reward)
     {
-        QUILL_LOG_DEBUG(logger_, "apply_reward {} {}", a, reward);
+        LOG_DEBUG("apply_reward {} {}", a, reward);
         accounts_.apply_reward(a, reward);
     }
 
@@ -287,12 +280,11 @@ struct State
 
     void merge_changes(ChangeSet &c)
     {
-        QUILL_LOG_DEBUG(logger_, "Account Changeset: {}", c.accounts_.changed_);
+        LOG_DEBUG("Account Changeset: {}", c.accounts_.changed_);
 
-        QUILL_LOG_DEBUG(
-            logger_, "Storage Changeset: {}", c.storage_.touched_.storage_);
+        LOG_DEBUG("Storage Changeset: {}", c.storage_.touched_.storage_);
 
-        QUILL_LOG_DEBUG(logger_, "Code Changeset: {}", c.code_.code_);
+        LOG_DEBUG("Code Changeset: {}", c.code_.code_);
 
         accounts_.merge_changes(c.accounts_);
         storage_.merge_touched(c.storage_);

--- a/src/monad/execution/ethereum/replay_ethereum.cpp
+++ b/src/monad/execution/ethereum/replay_ethereum.cpp
@@ -64,31 +64,9 @@ int main(int argc, char *argv[])
     uint64_t block_history_size = 1u;
     std::optional<monad::block_num_t> finish_block_number = std::nullopt;
 
-    monad::log::logger_t::start();
+    quill::start(true);
 
-    // create all the loggers needed for the program
-    auto *main_logger = monad::log::logger_t::create_logger("main_logger");
-    [[maybe_unused]] auto *block_logger =
-        monad::log::logger_t::create_logger("block_logger");
-    [[maybe_unused]] auto *txn_logger =
-        monad::log::logger_t::create_logger("txn_logger");
-    [[maybe_unused]] auto *state_logger =
-        monad::log::logger_t::create_logger("state_logger");
-    [[maybe_unused]] auto *change_set_logger =
-        monad::log::logger_t::create_logger("change_set_logger");
-    [[maybe_unused]] auto *evmone_baseline_interperter_logger =
-        monad::log::logger_t::create_logger(
-            "evmone_baseline_interpreter_logger");
-    [[maybe_unused]] auto *trie_db_logger =
-        monad::log::logger_t::create_logger("trie_db_logger");
-
-    auto main_log_level = monad::log::level_t::Info;
-    auto block_log_level = monad::log::level_t::Info;
-    auto txn_log_level = monad::log::level_t::Info;
-    auto state_log_level = monad::log::level_t::Info;
-    auto change_set_log_level = monad::log::level_t::Info;
-    auto evmone_baseline_interpreter_log_level = monad::log::level_t::Info;
-    auto trie_db_log_level = monad::log::level_t::Info;
+    auto log_level = quill::LogLevel::Info;
 
     cli.add_option("-b, --block_db", block_db_path, "block_db directory")
         ->required();
@@ -102,20 +80,7 @@ int main(int argc, char *argv[])
         "size of state_db block history");
     cli.add_option(
         "-f, --finish", finish_block_number, "1 pass the last executed block");
-
-    auto *log_levels = cli.add_subcommand("log_levels", "level of logging");
-    log_levels->add_option("--main", main_log_level, "Log level for main");
-    log_levels->add_option("--block", block_log_level, "Log level for block");
-    log_levels->add_option("--txn", txn_log_level, "Log level for transaction");
-    log_levels->add_option("--state", state_log_level, "Log level for state");
-    log_levels->add_option(
-        "--change_set", change_set_log_level, "Log level for change_set");
-    log_levels->add_option(
-        "--evmone",
-        evmone_baseline_interpreter_log_level,
-        "Log level for evmone interpreter");
-    log_levels->add_option(
-        "--trie_db", trie_db_log_level, "Log level for trie_db");
+    cli.add_option("--log_level", log_level, "level of logging");
 
     cli.parse(argc, argv);
 
@@ -137,16 +102,7 @@ int main(int argc, char *argv[])
     using transaction_trie_t = monad::fakeEmptyTransactionTrie;
     using receipt_trie_t = monad::fakeEmptyReceiptTrie;
 
-    monad::log::logger_t::set_log_level("main_logger", main_log_level);
-    monad::log::logger_t::set_log_level("block_logger", block_log_level);
-    monad::log::logger_t::set_log_level("txn_logger", txn_log_level);
-    monad::log::logger_t::set_log_level("state_logger", state_log_level);
-    monad::log::logger_t::set_log_level(
-        "change_set_logger", change_set_log_level);
-    monad::log::logger_t::set_log_level(
-        "evmone_baseline_interpreter_logger",
-        evmone_baseline_interpreter_log_level);
-    monad::log::logger_t::set_log_level("trie_db_logger", trie_db_log_level);
+    quill::get_root_logger()->set_log_level(log_level);
 
     block_db_t block_db(block_db_path);
     db_t db{
@@ -158,8 +114,7 @@ int main(int argc, char *argv[])
 
     monad::block_num_t start_block_number = db.starting_block_number;
 
-    QUILL_LOG_INFO(
-        main_logger,
+    LOG_INFO(
         "Running with block_db = {}, state_db = {}, block_history_size = {}, "
         "(inferred) start_block_number = {}, finish block number = {}",
         block_db_path,
@@ -206,8 +161,7 @@ int main(int argc, char *argv[])
         std::chrono::duration_cast<std::chrono::milliseconds>(
             finished_time - start_time);
 
-    QUILL_LOG_INFO(
-        main_logger,
+    LOG_INFO(
         "Finish running, status = {}, finish(stopped) block number = {}, "
         "number of blocks run = {}, time_elapsed = {}",
         static_cast<int>(result.status),

--- a/test/ethereum_test/src/ethereum_test.cpp
+++ b/test/ethereum_test/src/ethereum_test.cpp
@@ -226,8 +226,7 @@ StateTransitionTest EthereumTests::load_state_test(
          json_test.at("post").items()) {
         auto maybe_fork_index = to_fork_index(revision_name);
         if (!maybe_fork_index.has_value()) {
-            QUILL_LOG_ERROR(
-                quill::get_logger("ethereum_test_logger"),
+            LOG_ERROR(
                 "skipping post state in {}:{}:{} due to invalid "
                 "fork index {}",
                 suite_name,
@@ -309,9 +308,7 @@ void EthereumTests::run_state_test(
             {
                 monad::state::State state{bs, db, fake_block_db};
 
-                QUILL_LOG_INFO(
-                    quill::get_logger("ethereum_test_logger"),
-                    "Starting to load state from json");
+                LOG_INFO("Starting to load state from json");
 
                 load_state_from_json(j_t.at("pre"), state);
                 merge(bs.state, state.state_);
@@ -320,10 +317,7 @@ void EthereumTests::run_state_test(
 
             auto block_header = j_t.at("env").get<monad::BlockHeader>();
 
-            QUILL_LOG_INFO(
-                quill::get_logger("ethereum_test_logger"),
-                "Starting to execute transaction {}",
-                case_index);
+            LOG_INFO("Starting to execute transaction {}", case_index);
 
             monad::state::State state{bs, db, fake_block_db};
             auto maybe_receipt =
@@ -333,12 +327,9 @@ void EthereumTests::run_state_test(
             merge(bs.code, state.code_);
             db.commit(bs.state, bs.code);
 
-            QUILL_LOG_INFO(
-                quill::get_logger("ethereum_test_logger"),
-                "post_state: {}",
-                monad::test::dump_state_from_db(db).dump());
-            QUILL_LOG_INFO(
-                quill::get_logger("ethereum_test_logger"),
+            LOG_INFO(
+                "post_state: {}", monad::test::dump_state_from_db(db).dump());
+            LOG_INFO(
                 "finished transaction index: {} revision: {}, state_root: {}",
                 case_index,
                 fork_name,

--- a/test/unit/common/include/monad/test/environment.hpp
+++ b/test/unit/common/include/monad/test/environment.hpp
@@ -12,27 +12,7 @@ MONAD_TEST_NAMESPACE_BEGIN
 class Environment : public ::testing::Environment
 {
 public:
-    void SetUp() override
-    {
-        quill::start();
-
-        auto *trie_db_logger = quill::create_logger("trie_db_logger");
-        auto *rocks_db_logger = quill::create_logger("rocks_db_logger");
-        auto *block_logger = quill::create_logger("block_logger");
-        auto *evmone_baseline_interpreter_logger =
-            quill::create_logger("evmone_baseline_interpreter_logger");
-        auto *state_logger = quill::create_logger("state_logger");
-        auto *change_set_logger = quill::create_logger("change_set_logger");
-        auto *txn_logger = quill::create_logger("txn_logger");
-
-        MONAD_DEBUG_ASSERT(trie_db_logger);
-        MONAD_DEBUG_ASSERT(rocks_db_logger);
-        MONAD_DEBUG_ASSERT(block_logger);
-        MONAD_DEBUG_ASSERT(evmone_baseline_interpreter_logger);
-        MONAD_DEBUG_ASSERT(state_logger);
-        MONAD_DEBUG_ASSERT(change_set_logger);
-        MONAD_DEBUG_ASSERT(txn_logger);
-    }
+    void SetUp() override { quill::start(); }
 };
 
 MONAD_TEST_NAMESPACE_END


### PR DESCRIPTION
Problem:
- Previously we were creating our own loggers for the purposes of
  filtering

Solution:
- Quill has inhouse solution from filtering, which we should try to use
  instead