### PR TITLE
:recycle: Remove incarnation from db interface

### DIFF
--- a/include/monad/db/db.hpp
+++ b/include/monad/db/db.hpp
@@ -17,9 +17,8 @@ struct Db
 {
     virtual std::optional<Account> read_account(address_t const &) const = 0;
 
-    virtual bytes32_t read_storage(
-        address_t const &, uint64_t incarnation,
-        bytes32_t const &key) const = 0;
+    virtual bytes32_t
+    read_storage(address_t const &, bytes32_t const &key) const = 0;
 
     virtual byte_string read_code(bytes32_t const &) const = 0;
 

--- a/include/monad/db/in_memory_trie_db.hpp
+++ b/include/monad/db/in_memory_trie_db.hpp
@@ -70,13 +70,11 @@ struct InMemoryTrieDB : public Db
             accounts_trie.make_trie_cursor());
     }
 
-    [[nodiscard]] bytes32_t read_storage(
-        address_t const &a, uint64_t incarnation,
-        bytes32_t const &key) const override
+    [[nodiscard]] bytes32_t
+    read_storage(address_t const &a, bytes32_t const &key) const override
     {
         return trie_db_read_storage(
             a,
-            incarnation,
             key,
             storage_trie.make_leaf_cursor(),
             storage_trie.make_trie_cursor());

--- a/include/monad/db/rocks_trie_db.hpp
+++ b/include/monad/db/rocks_trie_db.hpp
@@ -211,13 +211,11 @@ struct RocksTrieDB : public Db
             accounts_trie.make_trie_cursor());
     }
 
-    [[nodiscard]] bytes32_t read_storage(
-        address_t const &a, uint64_t incarnation,
-        bytes32_t const &key) const override
+    [[nodiscard]] bytes32_t
+    read_storage(address_t const &a, bytes32_t const &key) const override
     {
         return trie_db_read_storage(
             a,
-            incarnation,
             key,
             storage_trie.make_leaf_cursor(),
             storage_trie.make_trie_cursor());

--- a/include/monad/db/state_db.hpp
+++ b/include/monad/db/state_db.hpp
@@ -44,13 +44,11 @@ public:
     std::optional<Account>
     read_account_history(address_t const &, uint64_t block_number);
 
-    virtual bytes32_t read_storage(
-        address_t const &, uint64_t incarnation,
-        bytes32_t const &location) const override;
+    virtual bytes32_t
+    read_storage(address_t const &, bytes32_t const &location) const override;
 
     bytes32_t read_storage_history(
-        address_t const &, uint64_t incarnation, bytes32_t const &location,
-        uint64_t block_number);
+        address_t const &, bytes32_t const &location, uint64_t block_number);
 
     virtual byte_string read_code(bytes32_t const &) const override;
 

--- a/include/monad/db/trie_db_read_storage.hpp
+++ b/include/monad/db/trie_db_read_storage.hpp
@@ -9,8 +9,8 @@ MONAD_NAMESPACE_BEGIN
 
 template <typename TCursor>
 [[nodiscard]] bytes32_t trie_db_read_storage_with_hashed_key(
-    address_t const &a, uint64_t, trie::Nibbles const &k,
-    TCursor &&leaves_cursor, TCursor &&trie_cursor)
+    address_t const &a, trie::Nibbles const &k, TCursor &&leaves_cursor,
+    TCursor &&trie_cursor)
 {
     leaves_cursor.set_prefix(a);
 
@@ -56,14 +56,13 @@ template <typename TCursor>
 
 template <typename TCursor>
 [[nodiscard]] bytes32_t trie_db_read_storage(
-    address_t const &a, uint64_t incarnation, bytes32_t const &k,
-    TCursor &&leaves_cursor, TCursor &&trie_cursor)
+    address_t const &a, bytes32_t const &k, TCursor &&leaves_cursor,
+    TCursor &&trie_cursor)
 {
     auto const hashed_storage_key = trie::Nibbles{
         std::bit_cast<bytes32_t>(ethash::keccak256(k.bytes, sizeof(k.bytes)))};
     return trie_db_read_storage_with_hashed_key(
         a,
-        incarnation,
         hashed_storage_key,
         std::forward<TCursor>(leaves_cursor),
         std::forward<TCursor>(trie_cursor));

--- a/include/monad/state/value_state.hpp
+++ b/include/monad/state/value_state.hpp
@@ -14,11 +14,6 @@
 
 MONAD_STATE_NAMESPACE_BEGIN
 
-namespace detail
-{
-    constexpr auto incarnation = 0ull;
-}
-
 struct InnerStorage
 {
     using diff_t = diff<bytes32_t>;
@@ -55,7 +50,7 @@ struct ValueState
         if (merged_.contains_key(a, key)) {
             return merged_.storage_.at(a).at(key).updated;
         }
-        return db_.read_storage(a, detail::incarnation, key);
+        return db_.read_storage(a, key);
     }
 
     // Note: just for debug testing
@@ -67,7 +62,7 @@ struct ValueState
                     continue;
                 }
 
-                if (db_.read_storage(a, detail::incarnation, k) != dv.orig) {
+                if (db_.read_storage(a, k) != dv.orig) {
                     return false;
                 }
             }

--- a/src/monad/db/state_db.cpp
+++ b/src/monad/db/state_db.cpp
@@ -129,14 +129,12 @@ std::optional<Account> StateDb::read_account_history(
     return {};
 }
 
-bytes32_t StateDb::read_storage(
-    address_t const &address, uint64_t const incarnation,
-    bytes32_t const &location) const
+bytes32_t
+StateDb::read_storage(address_t const &address, bytes32_t const &location) const
 {
-    byte_string_fixed<60> key;
+    byte_string_fixed<52> key;
     std::memcpy(&key[0], address.bytes, 20);
-    boost::endian::store_big_u64(&key[20], incarnation);
-    std::memcpy(&key[28], location.bytes, 32);
+    std::memcpy(&key[20], location.bytes, 32);
 
     rocksdb::PinnableSlice value;
     auto const status =
@@ -152,14 +150,13 @@ bytes32_t StateDb::read_storage(
 }
 
 bytes32_t StateDb::read_storage_history(
-    address_t const &address, uint64_t const incarnation,
-    bytes32_t const &location, uint64_t const block_number)
+    address_t const &address, bytes32_t const &location,
+    uint64_t const block_number)
 {
-    byte_string_fixed<68> key;
+    byte_string_fixed<60> key;
     std::memcpy(&key[0], address.bytes, 20);
-    boost::endian::store_big_u64(&key[20], incarnation);
-    std::memcpy(&key[28], location.bytes, 32);
-    boost::endian::store_big_u64(&key[60], block_number);
+    std::memcpy(&key[20], location.bytes, 32);
+    boost::endian::store_big_u64(&key[52], block_number);
 
     std::unique_ptr<rocksdb::Iterator> const it{
         db_->NewIterator(rocksdb::ReadOptions{}, cfs_[6])};

--- a/src/monad/db/test/db.cpp
+++ b/src/monad/db/test/db.cpp
@@ -27,7 +27,6 @@ static constexpr auto code_hash1 =
     0x1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c_bytes32;
 static constexpr auto code_hash2 =
     0x1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1bbbbbbbbb_bytes32;
-static constexpr auto incarnation = 0u;
 
 template <typename TDB>
 struct DBTest : public testing::Test
@@ -56,7 +55,7 @@ TYPED_TEST(DBTest, read_storage)
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
         Code{});
 
-    EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
+    EXPECT_EQ(db.read_storage(a, key1), value1);
 
     db.commit(
         StateDeltas{
@@ -66,7 +65,7 @@ TYPED_TEST(DBTest, read_storage)
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
         Code{});
     EXPECT_EQ(db.read_account(b), acct);
-    EXPECT_EQ(db.read_storage(b, incarnation, key1), value1);
+    EXPECT_EQ(db.read_storage(b, key1), value1);
 }
 
 TYPED_TEST(DBTest, read_nonexistent_storage)
@@ -82,11 +81,11 @@ TYPED_TEST(DBTest, read_nonexistent_storage)
         Code{});
 
     // Non-existing key
-    EXPECT_EQ(db.read_storage(a, incarnation, key2), bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key2), bytes32_t{});
 
     // Non-existing account
     EXPECT_FALSE(db.read_account(b).has_value());
-    EXPECT_EQ(db.read_storage(b, incarnation, key1), bytes32_t{});
+    EXPECT_EQ(db.read_storage(b, key1), bytes32_t{});
 }
 
 TYPED_TEST(DBTest, read_code)
@@ -149,8 +148,8 @@ TEST(InMemoryTrieDB, erase)
                      {{key1, {value1, value2}}, {key2, {value2, value1}}}}}},
         Code{});
 
-    EXPECT_EQ(db.read_storage(a, incarnation, key1), bytes32_t{});
-    EXPECT_EQ(db.read_storage(a, incarnation, key2), bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key1), bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key2), bytes32_t{});
     EXPECT_TRUE(db.accounts_trie.leaves_storage.empty());
     EXPECT_TRUE(db.accounts_trie.trie_storage.empty());
     EXPECT_TRUE(db.storage_trie.leaves_storage.empty());
@@ -221,7 +220,7 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
         Code{});
 
     EXPECT_EQ(db.read_account(a), std::nullopt);
-    EXPECT_EQ(db.read_storage(a, 0u, key1), bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key1), bytes32_t{});
     EXPECT_EQ(db.state_root(), NULL_ROOT);
 }
 
@@ -251,8 +250,8 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
         db.create_and_prune_block_history(block_number++);
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -270,8 +269,8 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
         auto db = TypeParam{Writable{}, root, block_number, BLOCK_HISTORY};
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -293,8 +292,8 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
         db.create_and_prune_block_history(block_number++);
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value1);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value1);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -307,8 +306,8 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
     {
         auto db = TypeParam{Writable{}, root, block_number, BLOCK_HISTORY};
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value1);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value1);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -322,8 +321,8 @@ TYPED_TEST(RocksDBTest, block_history_for_constructor_with_start_block_number)
         auto db = TypeParam{Writable{}, root, block_number - 1, BLOCK_HISTORY};
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -366,8 +365,8 @@ TYPED_TEST(
         db.create_and_prune_block_history(block_number++);
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -384,8 +383,8 @@ TYPED_TEST(
         auto db = TypeParam{Writable{}, root, std::nullopt, BLOCK_HISTORY};
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -406,8 +405,8 @@ TYPED_TEST(
         db.create_and_prune_block_history(block_number++);
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value1);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value1);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -422,8 +421,8 @@ TYPED_TEST(
         auto db = TypeParam{Writable{}, root, std::nullopt, BLOCK_HISTORY};
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value1);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value1);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -464,8 +463,8 @@ TYPED_TEST(RocksDBTest, block_history_pruning)
         db.create_and_prune_block_history(block_number++);
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -481,8 +480,8 @@ TYPED_TEST(RocksDBTest, block_history_pruning)
         auto db = TypeParam{Writable{}, root, block_number, BLOCK_HISTORY};
 
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(
@@ -536,8 +535,8 @@ TYPED_TEST(RocksDBTest, read_only)
     {
         auto db = TypeParam{ReadOnly{}, root, 1};
         EXPECT_EQ(db.read_account(a), acct);
-        EXPECT_EQ(db.read_storage(a, incarnation, key1), value1);
-        EXPECT_EQ(db.read_storage(a, incarnation, key2), value2);
+        EXPECT_EQ(db.read_storage(a, key1), value1);
+        EXPECT_EQ(db.read_storage(a, key2), value2);
 
         if constexpr (std::same_as<TypeParam, RocksTrieDB>) {
             EXPECT_EQ(

--- a/src/monad/state/test/state.cpp
+++ b/src/monad/state/test/state.cpp
@@ -34,7 +34,6 @@ static constexpr auto code_hash =
     0x00000000000000000000000000000000000000000000000000000000cccccccc_bytes32;
 static constexpr auto c1 =
     byte_string{0x65, 0x74, 0x68, 0x65, 0x72, 0x6d, 0x69};
-static constexpr auto incarnation = 0ull;
 
 template <typename TDB>
 struct StateTest : public testing::Test
@@ -471,7 +470,7 @@ TYPED_TEST(TrieDBTest, set_and_then_clear_storage_in_same_commit)
     t.merge_changes(changeset);
     t.commit();
 
-    EXPECT_EQ(db.read_storage(a, incarnation, key1), monad::bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key1), monad::bytes32_t{});
 }
 
 TYPED_TEST(StateTest, commit_twice)

--- a/src/monad/state2/block_state_ops.cpp
+++ b/src/monad/state2/block_state_ops.cpp
@@ -51,7 +51,7 @@ std::optional<Account> &read_account(
 
 template <class Mutex>
 delta_t<bytes32_t> &read_storage(
-    address_t const &address, uint64_t const incarnation,
+    address_t const &address, uint64_t const /*incarnation*/,
     bytes32_t const &location, StateDeltas &state,
     BlockState<Mutex> &block_state, Db &db)
 {
@@ -83,7 +83,7 @@ delta_t<bytes32_t> &read_storage(
         }
     }
     // database
-    auto result = db.read_storage(address, incarnation, location);
+    auto result = db.read_storage(address, location);
     {
         std::lock_guard<Mutex> const lock{block_state.mutex};
         auto const it = block_state.state.find(address);
@@ -103,8 +103,7 @@ delta_t<bytes32_t> &read_storage(
 
 template <class Mutex>
 byte_string &read_code(
-    bytes32_t const &hash, Code &code, BlockState<Mutex> &block_state,
-    Db &db)
+    bytes32_t const &hash, Code &code, BlockState<Mutex> &block_state, Db &db)
 {
     // code
     {
@@ -144,7 +143,7 @@ template delta_t<bytes32_t> &read_storage(
     address_t const &, uint64_t, bytes32_t const &, StateDeltas &,
     BlockState<std::shared_mutex> &, Db &);
 
-template byte_string &read_code(
-    bytes32_t const &, Code &, BlockState<std::shared_mutex> &, Db &);
+template byte_string &
+read_code(bytes32_t const &, Code &, BlockState<std::shared_mutex> &, Db &);
 
 MONAD_NAMESPACE_END

--- a/src/monad/state2/test/state.cpp
+++ b/src/monad/state2/test/state.cpp
@@ -942,7 +942,7 @@ TYPED_TEST(TrieDBTest, commit_storage_and_account_together_regression)
 
     EXPECT_TRUE(db.read_account(a).has_value());
     EXPECT_EQ(db.read_account(a).value().balance, 1u);
-    EXPECT_EQ(db.read_storage(a, 0u, key1), value1);
+    EXPECT_EQ(db.read_storage(a, key1), value1);
 }
 
 TYPED_TEST(TrieDBTest, set_and_then_clear_storage_in_same_commit)
@@ -958,7 +958,7 @@ TYPED_TEST(TrieDBTest, set_and_then_clear_storage_in_same_commit)
     merge(bs.state, as.state_);
     db.commit(bs.state, bs.code);
 
-    EXPECT_EQ(db.read_storage(a, 0u, key1), monad::bytes32_t{});
+    EXPECT_EQ(db.read_storage(a, key1), monad::bytes32_t{});
 }
 
 TYPED_TEST(StateTest, commit_twice)
@@ -998,8 +998,8 @@ TYPED_TEST(StateTest, commit_twice)
         merge(bs.state, as.state_);
         db.commit(bs.state, bs.code);
 
-        EXPECT_EQ(db.read_storage(b, 0u, key1), value2);
-        EXPECT_EQ(db.read_storage(b, 0u, key2), value2);
+        EXPECT_EQ(db.read_storage(b, key1), value2);
+        EXPECT_EQ(db.read_storage(b, key2), value2);
     }
     {
         // Block 1, Txn 0
@@ -1015,8 +1015,8 @@ TYPED_TEST(StateTest, commit_twice)
         merge(bs.state, cs.state_);
         db.commit(bs.state, bs.code);
 
-        EXPECT_EQ(db.read_storage(c, 0u, key1), monad::bytes32_t{});
-        EXPECT_EQ(db.read_storage(c, 0u, key2), monad::bytes32_t{});
+        EXPECT_EQ(db.read_storage(c, key1), monad::bytes32_t{});
+        EXPECT_EQ(db.read_storage(c, key2), monad::bytes32_t{});
     }
 }
 

--- a/test/unit/common/include/monad/test/dump_state_from_db.hpp
+++ b/test/unit/common/include/monad/test/dump_state_from_db.hpp
@@ -56,7 +56,6 @@ namespace detail
         bytes32_t const storage_value =
             monad::trie_db_read_storage_with_hashed_key(
                 account_address,
-                0u,
                 keccaked_storage_key_nibbles,
                 leaf_cursor,
                 trie_cursor);


### PR DESCRIPTION
- Incarnation is no longer needed for reading from db (because reading from db guarantees incarnation = 0)