### PR TITLE
`TrieDb::read_*()` using `NodeCursor`, store necessary subtrie iterators in class to reduce redundant navigation from trie root

### DIFF
--- a/c++/monad/db/trie_db.hpp
+++ b/c++/monad/db/trie_db.hpp
@@ -11,6 +11,7 @@
 #include <monad/mpt/state_machine.hpp>
 
 #include <nlohmann/json.hpp>
+#include <tbb/concurrent_hash_map.h>
 
 #include <istream>
 #include <list>
@@ -33,6 +34,14 @@ class TrieDb final : public ::monad::DbRW
     bool is_on_disk_;
 
     mpt::NodeCursor curr_trie_cursor_{}, state_cursor_{}, code_cursor_{};
+
+    using AccountCursorMap = tbb::concurrent_hash_map<Address, mpt::NodeCursor>;
+    using AccountCursorConstAccessor =
+        AccountCursorMap::const_accessor; // for find
+    using AccountCursorAccessor = AccountCursorMap::accessor; // for insert
+    using AccountCursorMapKeyValue = std::pair<Address, mpt::NodeCursor>;
+
+    AccountCursorMap account_cursor_table_{};
 
     bytes32_t read_storage(mpt::NodeCursor account_it, bytes32_t const &key);
     Result<mpt::NodeCursor> access_account(Address const &);


### PR DESCRIPTION
3m -> 3.1m
before 9533 tps, after 9655 tps 

12m for 5000 blocks
before, 4463 tps, result varies 
```
11:14:22.462949364 [455556] replay_ethereum.cpp:217      LOG_INFO      root         Finish running, finish(stopped) block number = 12005000, number of blocks run = 5000, time_elapsed = 224s, num transactions = 999776, tps = 4463

         Event       n 0%(us)  1%(us)  25%(us)  50%(us)  75%(us)   99%(us)  100%(us)
         Block    5000  78.03 1571.62 32992.52 39678.67 49940.32 130823.09 265591.15
        Commit    5000  44.01 1438.03  7409.26  7992.09  8442.96   9992.96  45024.99
     Execution  999776   4.46 3240.19 12597.77 18515.36 26415.12  84081.45 261297.76
   ReadAccount 2085113   0.05    0.15     0.45     0.61     1.07   2133.07   9998.04
      ReadCode  705450   0.06     0.1     0.24     0.43     0.56     10.37   5113.12
   ReadStorage 5240175   1.79    2.88   177.33   308.78   523.38   2296.65  41285.53
         Retry  440277   0.67     0.9     6.96    57.85   163.98   3548.63 109214.29
SenderRecovery  999776  33.41   34.85     36.1    36.76    37.53     41.18   5133.07
         Stall  999776   0.04    0.09   9740.7 16021.09 24344.54  81860.72 261234.36
           Txn  999776  40.95 3404.25 12711.32 18636.84 26553.24  84415.56 261340.42
```
use cursor, 4876 tps, result varies too
```
11:34:45.649046358 [461771] replay_ethereum.cpp:217      LOG_INFO      root         Finish running, finish(stopped) block number = 12005000, number of blocks run = 5000, time_elapsed = 205s, num transactions = 999776, tps = 4876

         Event       n 0%(us)  1%(us)  25%(us)  50%(us)  75%(us)  99%(us)  100%(us)
         Block    5000  86.69  180.64  30142.8  36409.2 45750.48 121446.0 280872.92
        Commit    5000  41.15   174.0  7152.28  7634.64  8029.71  9293.35  53484.55
     Execution  999776   5.25 3080.86 11281.43  16710.6 23944.58 77450.64 276702.49
   ReadAccount 2083728   0.05    0.14     0.45     0.61     1.09  1941.62   9651.86
      ReadCode  703752   0.06     0.1     0.21     0.43     0.56    10.68    5113.0
   ReadStorage 5225724   1.72    2.84   161.71   276.52   474.01  1890.09  72582.53
         Retry  440303   0.67    0.94     7.17    60.03   164.63  3122.63  82234.95
SenderRecovery  999776  33.76   35.21    36.43    37.06    37.81    41.88   5113.51
         Stall  999776   0.04    0.09  8741.48  14482.7 22068.27 74730.18 276664.16
           Txn  999776  41.98 3242.42 11391.56 16831.09 24084.48 78010.99 276764.58
```