### PR TITLE
Use monad-core LRU cache

### DIFF
--- a/include/monad/db/db_cache.hpp
+++ b/include/monad/db/db_cache.hpp
@@ -6,11 +6,10 @@
 #include <monad/core/bytes.hpp>
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
+#include <monad/lru/lru_cache.hpp>
 #include <monad/state2/state_deltas.hpp>
 
 #include <evmc/evmc.hpp>
-
-#include <thread-safe-lru/lru-cache.h>
 
 #include <memory>
 #include <optional>
@@ -21,13 +20,11 @@ class DbCache final : public Db
 {
     Db &db_;
 
-    using AccountCache =
-        tstarling::ThreadSafeLRUCache<Address, std::optional<Account>>;
+    using AccountCache =LruCache<Address, std::optional<Account>>;
 
     AccountCache accounts_{10000000};
 
-    using CodeCache =
-        tstarling::ThreadSafeLRUCache<bytes32_t, std::shared_ptr<CodeAnalysis>>;
+    using CodeCache =LruCache<bytes32_t, std::shared_ptr<CodeAnalysis>>;
 
     CodeCache code_{40000};
 


### PR DESCRIPTION
Uses monad-core LRU cache (https://github.com/monad-crypto/monad-core/pull/163) for accounts and code caches in DbCache.