### PR TITLE
`replay_ethereum` now loads into memory the top five levels of the latest block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(ASAN "Turn on Address Sanitizer")
 option(UBSAN "Turn on Undefined Behavior Sanitizer")
 option(EVMONE_TRACING
        "Enable instruction-level tracing for the evmone interpreter" OFF)
+option(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(cmake/test.cmake)
 

--- a/c++/monad/db/trie_db.cpp
+++ b/c++/monad/db/trie_db.cpp
@@ -4,8 +4,8 @@
 #include <monad/core/assert.h>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
-#include <monad/core/fmt/bytes_fmt.hpp>
-#include <monad/core/fmt/int_fmt.hpp>
+#include <monad/core/fmt/bytes_fmt.hpp> // NOLINT
+#include <monad/core/fmt/int_fmt.hpp> // NOLINT
 #include <monad/core/int.hpp>
 #include <monad/core/keccak.h>
 #include <monad/core/likely.h>
@@ -21,7 +21,7 @@
 #include <monad/mpt/compute.hpp>
 #include <monad/mpt/db.hpp>
 #include <monad/mpt/nibbles_view.hpp>
-#include <monad/mpt/nibbles_view_fmt.hpp>
+#include <monad/mpt/nibbles_view_fmt.hpp> // NOLINT
 #include <monad/mpt/node.hpp>
 #include <monad/mpt/ondisk_db_config.hpp>
 #include <monad/mpt/state_machine.hpp>
@@ -516,7 +516,7 @@ struct TrieDb::OnDiskMachine final : public TrieDb::Machine
 
     virtual bool cache() const override
     {
-        return depth <= cache_depth;
+        return depth <= cache_depth && trie_section != TrieType::Receipt;
     }
 
     virtual bool compact() const override
@@ -860,6 +860,13 @@ nlohmann::json TrieDb::to_json()
     db_.traverse(state_nibbles, traverse, curr_block_id_);
 
     return traverse.json;
+}
+
+size_t TrieDb::prefetch_current_root()
+{
+    size_t const nodes_loaded = db_.prefetch();
+    MONAD_ASSERT(machine_->trie_section == Machine::TrieType::Prefix);
+    return nodes_loaded;
 }
 
 uint64_t TrieDb::current_block_number() const

--- a/c++/monad/db/trie_db.hpp
+++ b/c++/monad/db/trie_db.hpp
@@ -54,6 +54,7 @@ public:
     virtual void create_and_prune_block_history(uint64_t) const override;
 
     nlohmann::json to_json();
+    size_t prefetch_current_root();
     uint64_t current_block_number() const;
 };
 

--- a/c++/monad/db/util.cpp
+++ b/c++/monad/db/util.cpp
@@ -4,7 +4,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <quill/Quill.h>
+#include <quill/Quill.h> // NOLINT
 #include <quill/detail/LogMacros.h>
 
 #include <chrono>

--- a/c++/monad/execution/trace.cpp
+++ b/c++/monad/execution/trace.cpp
@@ -1,9 +1,9 @@
 #include <monad/config.hpp>
 #include <monad/core/assert.h>
-#include <monad/execution/fmt/trace_fmt.hpp>
+#include <monad/execution/fmt/trace_fmt.hpp> // NOLINT
 #include <monad/execution/trace.hpp>
 
-#include <quill/Quill.h>
+#include <quill/Quill.h> // NOLINT
 #include <quill/detail/LogMacros.h>
 
 #include <chrono>

--- a/c++/monad/state2/block_state.cpp
+++ b/c++/monad/state2/block_state.cpp
@@ -8,7 +8,7 @@
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/block_state.hpp>
-#include <monad/state2/fmt/state_deltas_fmt.hpp>
+#include <monad/state2/fmt/state_deltas_fmt.hpp> // NOLINT
 #include <monad/state2/state_deltas.hpp>
 #include <monad/state3/state.hpp>
 

--- a/cmd/replay_ethereum.cpp
+++ b/cmd/replay_ethereum.cpp
@@ -151,6 +151,17 @@ int main(int const argc, char const *argv[])
 
     if (load_snapshot.empty()) {
         init_block_number = db.current_block_number();
+        LOG_INFO("Loading current root into memory");
+        auto const start_time = std::chrono::steady_clock::now();
+        auto const nodes_loaded = db.prefetch_current_root();
+        auto const finish_time = std::chrono::steady_clock::now();
+        auto const elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+            finish_time - start_time);
+        LOG_INFO(
+            "Finish loading current root into memory, time_elapsed = {}, "
+            "nodes_loaded = {}",
+            elapsed,
+            nodes_loaded);
     }
     if (init_block_number == 0) {
         MONAD_ASSERT(*has_genesis_file);

--- a/db/include/monad/mpt/db.hpp
+++ b/db/include/monad/mpt/db.hpp
@@ -54,10 +54,13 @@ public:
     std::optional<uint64_t> get_latest_block_id() const;
     std::optional<uint64_t> get_earliest_block_id() const;
 
-    // Only valid for RO. True if this DB is the latest DB (fast)
+    // Always true if not RO. True if this DB is the latest DB (fast)
     bool is_latest() const;
-    // Only valid for RO. Load the latest DB root
+    // Load the latest DB root
     void load_latest();
+    // Load the tree of nodes in the current DB root as far as the caching
+    // policy allows. RW only.
+    size_t prefetch();
 };
 
 MONAD_MPT_NAMESPACE_END

--- a/db/include/monad/mpt/trie.hpp
+++ b/db/include/monad/mpt/trie.hpp
@@ -749,6 +749,9 @@ public:
 Node::UniquePtr
 upsert(UpdateAuxImpl &, StateMachine &, Node::UniquePtr old, UpdateList &&);
 
+// load all nodes as far as caching policy would allow
+size_t load_all(UpdateAuxImpl &, StateMachine &, NodeCursor);
+
 //////////////////////////////////////////////////////////////////////////////
 
 enum class find_result : uint8_t

--- a/db/src/monad/async/io.cpp
+++ b/db/src/monad/async/io.cpp
@@ -328,7 +328,7 @@ void AsyncIO::submit_request_(
     MONAD_DEBUG_ASSERT(uring_data != nullptr);
     assert((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
 #ifndef NDEBUG
-    for (auto &buffer : buffers) {
+    for (auto const &buffer : buffers) {
         assert(buffer.iov_base != nullptr);
         memset(buffer.iov_base, 0xff, buffer.iov_len);
     }

--- a/db/src/monad/async/test/benchmark_io_test.cpp
+++ b/db/src/monad/async/test/benchmark_io_test.cpp
@@ -138,7 +138,7 @@ struct shared_state_t
                 std::remove_if(
                     ret.begin(),
                     ret.end(),
-                    [](const auto &x) { return x.second == 0; }),
+                    [](auto const &x) { return x.second == 0; }),
                 ret.end());
             return ret;
         }())
@@ -419,8 +419,8 @@ set it to the desired size beforehand).
 
         auto const begin = std::chrono::steady_clock::now();
         auto print_statistics = [&] {
-            const auto now = std::chrono::steady_clock::now();
-            const auto elapsed =
+            auto const now = std::chrono::steady_clock::now();
+            auto const elapsed =
                 double(std::chrono::duration_cast<std::chrono::milliseconds>(
                            now - begin)
                            .count());

--- a/db/src/monad/async/test/cpp_coroutine_wrappers.cpp
+++ b/db/src/monad/async/test/cpp_coroutine_wrappers.cpp
@@ -126,15 +126,15 @@ TEST_F(CppCoroutineWrappers, resume_execution_upon)
         thread_ids;
     std::atomic<bool> done{false};
     auto impl = [&]() -> awaitables::eager<void> {
-        const pid_t original_tid = gettid();
+        pid_t const original_tid = gettid();
         MONAD_ASSERT(thread_ids.push(original_tid));
         (void)co_await co_resume_execution_upon(*other);
-        const pid_t new_tid = gettid();
+        pid_t const new_tid = gettid();
         MONAD_ASSERT(thread_ids.push(new_tid));
         // Can't complete on a thread different to original, it would be a
         // race.
         (void)co_await co_resume_execution_upon(*shared_state_()->testio);
-        const pid_t final_tid = gettid();
+        pid_t const final_tid = gettid();
         MONAD_ASSERT(thread_ids.push(final_tid));
         done = true;
         co_return;

--- a/db/src/monad/mpt/test/CMakeLists.txt
+++ b/db/src/monad/mpt/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_trie_test(TARGET fiber_future_wrapped_find_test SOURCES
 add_trie_test(TARGET fiber_future_wrapped_read_test SOURCES
               "fiber_future_wrapped_read.cpp")
 add_trie_test(TARGET find_min_max_key_test SOURCES "find_min_max_key_test.cpp")
+add_trie_test(TARGET load_all_test SOURCES "load_all_test.cpp")
 add_trie_test(TARGET locking_trie_test SOURCES "locking_trie_test.cpp" LINK_LIBRARIES Boost::thread)
 add_trie_test(TARGET many_nested_updates SOURCES "many_nested_updates.cpp" LINK_LIBRARIES Boost::json)
 add_trie_test(TARGET merkle_trie_test SOURCES "merkle_trie_test.cpp")

--- a/db/src/monad/mpt/test/db_test.cpp
+++ b/db/src/monad/mpt/test/db_test.cpp
@@ -1,5 +1,7 @@
 #include "test_fixtures_base.hpp"
 
+#include <gtest/gtest.h>
+
 #include <monad/async/config.hpp>
 #include <monad/async/util.hpp>
 #include <monad/core/assert.h>
@@ -13,6 +15,7 @@
 #include <monad/mpt/trie.hpp>
 #include <monad/mpt/update.hpp>
 #include <monad/mpt/util.hpp>
+
 #include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
 
 #include <gtest/gtest.h>
@@ -33,6 +36,7 @@
 #include <utility>
 #include <vector>
 
+#include <stdlib.h>
 #include <unistd.h>
 
 using namespace monad::mpt;

--- a/db/src/monad/mpt/test/load_all_test.cpp
+++ b/db/src/monad/mpt/test/load_all_test.cpp
@@ -1,0 +1,29 @@
+#include "test_fixtures_gtest.hpp"
+
+#include <monad/mpt/node.hpp>
+#include <monad/mpt/trie.hpp>
+
+#include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <iostream>
+#include <ostream>
+
+struct LoadAllTest
+    : public monad::test::FillDBWithChunksGTest<
+          monad::test::FillDBWithChunksConfig{.chunks_to_fill = 2}>
+{
+};
+
+TEST_F(LoadAllTest, works)
+{
+    monad::test::UpdateAux<void> aux{&state()->io};
+    monad::test::StateMachineAlwaysMerkle sm;
+    monad::mpt::Node::UniquePtr root{
+        monad::mpt::read_node_blocking(state()->pool, aux.get_root_offset())};
+    auto nodes_loaded = monad::mpt::load_all(aux, sm, *root);
+    EXPECT_GE(nodes_loaded, state()->keys.size());
+    std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;
+    nodes_loaded = monad::mpt::load_all(aux, sm, *root);
+    EXPECT_EQ(nodes_loaded, 0);
+    std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;
+}

--- a/db/src/monad/mpt/test/monad_trie_test.cpp
+++ b/db/src/monad/mpt/test/monad_trie_test.cpp
@@ -57,6 +57,8 @@
 #include <utility>
 #include <vector>
 
+#include <linux/fs.h>
+
 #undef BLOCK_SIZE // without this concurrentqueue.h gets sad
 #include "concurrentqueue.h"
 
@@ -453,7 +455,6 @@ int main(int argc, char *argv[])
                     std::ifstream s(runtime_reconfig.path);
                     std::string key;
                     std::string equals;
-                    std::string value;
                     while (!s.eof()) {
                         s >> key >> equals;
                         if (equals == "=") {

--- a/db/src/monad/mpt/test/node_disk_pages_spare_test.cpp
+++ b/db/src/monad/mpt/test/node_disk_pages_spare_test.cpp
@@ -1,4 +1,5 @@
 #include <monad/mpt/config.hpp>
+
 #include <monad/mpt/node.hpp>
 
 #include <gtest/gtest.h>

--- a/db/src/monad/mpt/test/node_test.cpp
+++ b/db/src/monad/mpt/test/node_test.cpp
@@ -3,6 +3,7 @@
 #include <monad/mpt/compute.hpp>
 #include <monad/mpt/nibbles_view.hpp>
 #include <monad/mpt/node.hpp>
+
 #include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
 
 #include <gtest/gtest.h>

--- a/db/src/monad/mpt/test/read_only_db_test.cpp
+++ b/db/src/monad/mpt/test/read_only_db_test.cpp
@@ -9,6 +9,7 @@
 #include <monad/mpt/config.hpp>
 #include <monad/mpt/node.hpp>
 #include <monad/mpt/trie.hpp>
+
 #include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
 
 #include <atomic>
@@ -93,7 +94,7 @@ TEST_F(ReadOnlyDBTest, read_only_dbs_track_writable_db)
 
         // Now try to keep up ...
         while (done.load(std::memory_order_acquire) > 0) {
-            const auto root_offset = aux.get_root_offset();
+            auto const root_offset = aux.get_root_offset();
             if (root_offset == last_root_offset) {
                 std::this_thread::yield();
                 continue;

--- a/db/src/monad/mpt/update_aux.cpp
+++ b/db/src/monad/mpt/update_aux.cpp
@@ -1,15 +1,14 @@
 #include <monad/async/config.hpp>
+#include <monad/async/detail/start_lifetime_as_polyfill.hpp>
 #include <monad/core/assert.h>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/small_prng.hpp>
 #include <monad/mpt/config.hpp>
+#include <monad/mpt/detail/unsigned_20.hpp>
 #include <monad/mpt/state_machine.hpp>
 #include <monad/mpt/trie.hpp>
 #include <monad/mpt/update.hpp>
 #include <monad/mpt/util.hpp>
-
-#include <monad/async/detail/start_lifetime_as_polyfill.hpp>
-#include <monad/mpt/detail/unsigned_20.hpp>
 
 #include <algorithm>
 #include <atomic>


### PR DESCRIPTION
... so the memory cache is fully "warm" and benchmarks are more representative of real world performance.

Many thanks to Vicky for the assist.