### PR TITLE
load snapshot to slow list

### DIFF
--- a/db/include/monad/mpt/db.hpp
+++ b/db/include/monad/mpt/db.hpp
@@ -44,8 +44,9 @@ public:
     Result<NodeCursor> get(NodeCursor, NibblesView) const;
     Result<byte_string_view> get_data(NodeCursor, NibblesView) const;
 
-    void
-    upsert(UpdateList, uint64_t block_id = 0, bool enable_compaction = true);
+    void upsert(
+        UpdateList, uint64_t block_id = 0, bool enable_compaction = true,
+        bool can_write_to_fast = true);
     // It is always called from the main thread and should never wait on a
     // fiber future.
     void traverse(NibblesView prefix, TraverseMachine &, uint64_t block_id = 0);

--- a/db/include/monad/mpt/trie.hpp
+++ b/db/include/monad/mpt/trie.hpp
@@ -332,7 +332,7 @@ public:
     node_writer_unique_ptr_type node_writer_slow{};
 
     // currently maintain a fixed len history
-    static constexpr unsigned version_history_len = 200;
+    static constexpr unsigned version_history_len = 1000;
 
     UpdateAuxImpl(MONAD_ASYNC_NAMESPACE::AsyncIO *io_ = nullptr)
     {
@@ -488,7 +488,8 @@ public:
 
     Node::UniquePtr do_update(
         Node::UniquePtr prev_root, StateMachine &, UpdateList &&,
-        uint64_t version, bool compaction = false);
+        uint64_t version, bool compaction = false,
+        bool can_write_to_fast = true);
 
 #if MONAD_MPT_COLLECT_STATS
     detail::TrieUpdateCollectedStats stats;

--- a/db/src/monad/mpt/trie.cpp
+++ b/db/src/monad/mpt/trie.cpp
@@ -1200,11 +1200,12 @@ async_write_node_result async_write_node(
 chunk_offset_t
 async_write_node_set_spare(UpdateAuxImpl &aux, Node &node, bool write_to_fast)
 {
+    write_to_fast &= aux.can_write_to_fast();
     if (aux.alternate_slow_fast_writer()) {
         // alternate between slow and fast writer
-        write_to_fast &= aux.can_write_to_fast();
         aux.set_can_write_to_fast(!aux.can_write_to_fast());
     }
+
     auto off = async_write_node(
                    aux,
                    write_to_fast ? aux.node_writer_fast : aux.node_writer_slow,

--- a/src/monad/db/trie_db.cpp
+++ b/src/monad/db/trie_db.cpp
@@ -206,7 +206,7 @@ namespace
                         .next = std::move(account_updates)};
                     updates.push_front(state_update);
 
-                    db_.upsert(std::move(updates), block_id_, false);
+                    db_.upsert(std::move(updates), block_id_, false, false);
 
                     update_alloc_.clear();
                     bytes_alloc_.clear();
@@ -225,7 +225,7 @@ namespace
                         .next = std::move(code_updates)};
                     updates.push_front(code_update);
 
-                    db_.upsert(std::move(updates), block_id_, false);
+                    db_.upsert(std::move(updates), block_id_, false, false);
 
                     update_alloc_.clear();
                     bytes_alloc_.clear();


### PR DESCRIPTION
this can speed up initial blocks after load snapshot when compaction is on

with warmed cache, replay from 12m for 2000 blocks is around 4k tps