### PR TITLE
Make lru_time_ data-race-free

### DIFF
--- a/c++/monad/cache/account_storage_cache.hpp
+++ b/c++/monad/cache/account_storage_cache.hpp
@@ -81,7 +81,7 @@ private:
 
         bool check_lru_time() const
         {
-            int64_t lru_time = lru_time_.load(std::memory_order_acquire);
+            int64_t const lru_time = lru_time_.load(std::memory_order_acquire);
             return (cur_time() - lru_time) >= lru_update_period;
         }
 


### PR DESCRIPTION
Fix data-race on `lru_time_` which is read without holding the lock. No effect on performance on TSO. Atomic load acquire and store release instead of regular load and store.