### PR TITLE
monad_mpt now restores single chunk fast/slow list correctly

### DIFF
--- a/db/include/monad/mpt/trie.hpp
+++ b/db/include/monad/mpt/trie.hpp
@@ -528,6 +528,16 @@ public:
     void append(chunk_list list, uint32_t idx) noexcept;
     void remove(uint32_t idx) noexcept;
 
+    template <typename Func, typename... Args>
+        requires std::invocable<
+            std::function<void(detail::db_metadata *, Args...)>,
+            detail::db_metadata *, Args...>
+    void modify_metadata(Func func, Args &&...args) noexcept
+    {
+        func(db_metadata_[0], std::forward<Args>(args)...);
+        func(db_metadata_[1], std::forward<Args>(args)...);
+    }
+
     // The following two functions should only be invoked after completing a
     // block commit
     void advance_offsets_to(


### PR DESCRIPTION
It becomes a problem because we only archive and restore chunks that are non empty, and then when restore it adds a random chunk to the empty fast/slow list rather than the correct one, which results in metadata mismatch after restore. 