### PR TITLE
thread_local boost pool allocators

### DIFF
--- a/libs/db/src/monad/mpt/db.cpp
+++ b/libs/db/src/monad/mpt/db.cpp
@@ -413,6 +413,7 @@ struct Db::RWOnDisk final : public Db::Impl
             }
             worker_->run();
             std::unique_lock const g(lock_);
+            root_.reset();
             worker_.reset();
         })
         , machine_{machine}

--- a/libs/db/src/monad/mpt/node.cpp
+++ b/libs/db/src/monad/mpt/node.cpp
@@ -36,8 +36,8 @@ allocators::detail::type_raw_alloc_pair<
     std::allocator<Node>, Node::BytesAllocator>
 Node::pool()
 {
-    static std::allocator<Node> a;
-    static BytesAllocator b;
+    static thread_local std::allocator<Node> a;
+    static thread_local BytesAllocator b;
     return {a, b};
 }
 

--- a/libs/db/src/monad/mpt/upward_tnode.hpp
+++ b/libs/db/src/monad/mpt/upward_tnode.hpp
@@ -55,7 +55,7 @@ struct UpwardTreeNode
 
     static allocator_type &pool()
     {
-        static allocator_type v;
+        static thread_local allocator_type v;
         return v;
     }
 
@@ -147,7 +147,7 @@ struct CompactTNode
 
     static allocator_type &pool()
     {
-        static allocator_type v;
+        static thread_local allocator_type v;
         return v;
     }
 


### PR DESCRIPTION
related to https://github.com/monad-crypto/monad-internal/issues/80 and https://github.com/monad-crypto/monad-internal/issues/112

It now should allow opening one RW/RO db per thread at a time, for however many threads we need in testing. 