### PR TITLE
Alee/warning

### DIFF
--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -22,7 +22,7 @@
 #include <test_resource_data.h>
 
 #include <bit>
-#include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <optional>
@@ -188,7 +188,10 @@ TYPED_TEST_SUITE(DBTest, DBTypes);
 
 TEST(DBTest, read_only)
 {
-    auto const name = std::tmpnam(nullptr);
+    auto const name =
+        std::filesystem::temp_directory_path() /
+        (::testing::UnitTest::GetInstance()->current_test_info()->name() +
+         std::to_string(rand()));
     {
         TrieDb rw(mpt::OnDiskDbConfig{.dbname_paths = {name}});
 


### PR DESCRIPTION
resolves the below error + warning at build time
```
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x23
CMakeFiles/test_db.dir/src/monad/db/test/test_db.cpp.o: in function `DBTest_read_only_Test::TestBody()':
test_db.cpp:(.text+0x14): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
```