### PR TITLE
perf: Use OpenSSL keccak instead of ethash 

### DIFF
--- a/libs/execution/src/monad/core/receipt.cpp
+++ b/libs/execution/src/monad/core/receipt.cpp
@@ -1,8 +1,9 @@
 #include <monad/config.hpp>
 #include <monad/core/byte_string.hpp>
+#include <monad/core/keccak.h>
 #include <monad/core/receipt.hpp>
 
-#include <ethash/keccak.hpp>
+#include <ethash/hash_types.hpp>
 
 #include <intx/intx.hpp>
 
@@ -13,14 +14,15 @@ MONAD_NAMESPACE_BEGIN
 void set_3_bits(Receipt::Bloom &bloom, byte_string_view const bytes)
 {
     // YP Eqn 29
-    auto const h{ethash::keccak256(bytes.cbegin(), bytes.size())};
-    for (auto i = 0u; i < 3u; ++i) {
+    ethash::hash256 hash;
+    keccak256(bytes.data(), bytes.size(), hash.bytes);
+    for (unsigned i = 0; i < 3; ++i) {
         // Poorly named intx function, this really is taking from our hash,
         // which is returned as big endian, to host order so we can do calcs on
         // `bit`
         uint16_t const bit =
             intx::to_big_endian(
-                reinterpret_cast<uint16_t const *>(h.bytes)[i]) &
+                reinterpret_cast<uint16_t const *>(hash.bytes)[i]) &
             2047u;
         unsigned int const byte = 255u - bit / 8u;
         bloom[byte] |= static_cast<unsigned char>(1u << (bit & 7u));

--- a/libs/execution/src/monad/core/transaction.cpp
+++ b/libs/execution/src/monad/core/transaction.cpp
@@ -1,6 +1,7 @@
 #include <monad/config.hpp>
 #include <monad/core/address.hpp>
 #include <monad/core/byte_string.hpp>
+#include <monad/core/keccak.h>
 #include <monad/core/rlp/transaction_rlp.hpp>
 #include <monad/core/transaction.hpp>
 #include <monad/execution/trace.hpp>
@@ -8,7 +9,6 @@
 #include <silkpre/ecdsa.h>
 
 #include <ethash/hash_types.hpp>
-#include <ethash/keccak.hpp>
 
 #include <intx/intx.hpp>
 
@@ -24,8 +24,8 @@ std::optional<Address> recover_sender(Transaction const &tx)
 {
     TRACE_TXN_EVENT(StartSenderRecovery);
     byte_string const tx_encoding = rlp::encode_transaction_for_signing(tx);
-    ethash::hash256 const tx_encoding_hash{
-        ethash::keccak256(tx_encoding.data(), tx_encoding.size())};
+    ethash::hash256 tx_encoding_hash;
+    keccak256(tx_encoding.data(), tx_encoding.size(), tx_encoding_hash.bytes);
 
     uint8_t signature[sizeof(tx.sc.r) * 2];
     intx::be::unsafe::store(signature, tx.sc.r);

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -35,10 +35,10 @@
 
 #include <boost/outcome/try.hpp>
 
+#include <ethash/hash_types.hpp>
+
 #include <evmc/evmc.hpp>
 #include <evmc/hex.hpp>
-
-#include <ethash/keccak.hpp>
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
@@ -78,11 +78,9 @@ namespace
         requires std::same_as<T, bytes32_t> || std::same_as<T, Address>
     constexpr byte_string to_key(T const &arg)
     {
-        return byte_string{
-            std::bit_cast<bytes32_t>(
-                ethash::keccak256(arg.bytes, sizeof(arg.bytes)))
-                .bytes,
-            sizeof(bytes32_t)};
+        ethash::hash256 h;
+        keccak256(arg.bytes, sizeof(arg.bytes), h.bytes);
+        return byte_string{h.bytes, sizeof(ethash::hash256)};
     }
 
     byte_string encode_account_db(Account const &account)

--- a/libs/execution/src/monad/execution/create_contract_address.cpp
+++ b/libs/execution/src/monad/execution/create_contract_address.cpp
@@ -2,12 +2,12 @@
 #include <monad/core/address.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
+#include <monad/core/keccak.h>
 #include <monad/core/rlp/address_rlp.hpp>
 #include <monad/core/rlp/int_rlp.hpp>
 #include <monad/rlp/encode2.hpp>
 
 #include <ethash/hash_types.hpp>
-#include <ethash/keccak.hpp>
 
 #include <cstdint>
 #include <cstring>
@@ -17,9 +17,10 @@ MONAD_NAMESPACE_BEGIN
 // YP Sec 7: Eq 85 and 86
 Address hash_and_clip(byte_string const &b)
 {
-    auto const h = ethash::keccak256(b.data(), b.size());
+    ethash_hash256 h;
+    keccak256(b.data(), b.size(), h.bytes);
     Address result{};
-    std::memcpy(result.bytes, &(h.bytes[12]), sizeof(Address));
+    std::memcpy(result.bytes, &h.bytes[12], sizeof(Address));
     return result;
 }
 

--- a/libs/execution/src/monad/execution/evm.cpp
+++ b/libs/execution/src/monad/execution/evm.cpp
@@ -4,6 +4,7 @@
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/int.hpp>
+#include <monad/core/keccak.h>
 #include <monad/core/likely.h>
 #include <monad/execution/baseline_execute.hpp>
 #include <monad/execution/create_contract_address.hpp>
@@ -18,7 +19,7 @@
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 
-#include <ethash/keccak.hpp>
+#include <ethash/hash_types.hpp>
 
 #include <intx/intx.hpp>
 
@@ -131,8 +132,8 @@ std::optional<evmc::Result> pre_create_contract_account(
             return create_contract_address(msg.sender, nonce); // YP Eqn. 85
         }
         else if (msg.kind == EVMC_CREATE2) {
-            auto const code_hash =
-                ethash::keccak256(msg.input_data, msg.input_size);
+            ethash_hash256 code_hash;
+            keccak256(msg.input_data, msg.input_size, code_hash.bytes);
             return create2_contract_address(
                 msg.sender, msg.create2_salt, code_hash);
         }

--- a/libs/execution/src/monad/state3/state.hpp
+++ b/libs/execution/src/monad/state3/state.hpp
@@ -9,6 +9,7 @@
 #include <monad/core/fmt/address_fmt.hpp>
 #include <monad/core/fmt/bytes_fmt.hpp>
 #include <monad/core/fmt/int_fmt.hpp>
+#include <monad/core/keccak.h>
 #include <monad/core/receipt.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/block_state.hpp>
@@ -17,8 +18,6 @@
 #include <monad/types/incarnation.hpp>
 
 #include <evmc/evmc.h>
-
-#include <ethash/keccak.hpp>
 
 #include <ankerl/unordered_dense.h>
 
@@ -468,8 +467,8 @@ public:
             return;
         }
 
-        bytes32_t const code_hash = std::bit_cast<bytes32_t>(
-            ethash::keccak256(code.data(), code.size()));
+        bytes32_t code_hash = {};
+        keccak256(code.data(), code.size(), code_hash.bytes);
         code_[code_hash] = std::make_shared<CodeAnalysis>(analyze(code));
         account.value().code_hash = code_hash;
     }


### PR DESCRIPTION
Keccak hash is called in many places in the code. Some places use
ethash, others use monad's OpenSSL wrapper. Looking at the code, the
ethash code is written in C++, but OpenSSL has assembly implementations
both for AVX2 and AVX512.

I saw improvements on the 12000000 checkpoint. Probably because there are lots more transactions to hash.

### Baseline

```
+ taskset -c 1-6 build/cmd/replay_ethereum --genesis_file test/common/genesis/ethereum/mainnet.json --block_db /home/jhunsaker/block_db --load_snapshot /home/jhunsaker/checkpoints/12000000 --db /dev/nvme1n1 --nblocks 10000 --nthreads 4 --nfibers 128
+ tee -a logs/monad.20240522095609.log
09:56:12.023848917 [302552] replay_ethereum.cpp:146      LOG_INFO      root         Loading from binary checkpoint in /home/jhunsaker/checkpoints/12000000
10:03:39.688822066 [302552] replay_ethereum.cpp:178      LOG_INFO      root         Finished initializing db at block = 12000000, time elapsed = 447665ms
10:03:39.688822236 [302552] replay_ethereum.cpp:189      LOG_INFO      root         Running with block_db = /home/jhunsaker/block_db, start block number = 12000001, number blocks = 10000
10:07:43.488264265 [302552] replay_ethereum.cpp:222      LOG_INFO      root         Finish running, finish(stopped) block number = 12010000, number of blocks run = 10000, **time_elapsed = 243s, num transactions = 1964870, tps = 8085**
```

### This branch

```
ome/jhunsaker/checkpoints/12000000 --db /dev/nvme1n1 --nblocks 10000 --nthreads 4 --nfibers 128
+ tee -a logs/monad.20240522101522.log
10:15:25.334619413 [305846] replay_ethereum.cpp:146      LOG_INFO      root         Loading from binary checkpoint in /home/jhunsaker/checkpoints/12000000
10:22:52.102934073 [305846] replay_ethereum.cpp:178      LOG_INFO      root         Finished initializing db at block = 12000000, time elapsed = 446768ms
10:22:52.102934766 [305846] replay_ethereum.cpp:189      LOG_INFO      root         Running with block_db = /home/jhunsaker/block_db, start block number = 12000001, number blocks = 10000
10:26:50.970768077 [305846] replay_ethereum.cpp:222      LOG_INFO      root         Finish running, finish(stopped) block number = 12010000, number of blocks run = 10000, time_elapsed = 238s, num transactions = 1964870, tps = 8255
```