### PR TITLE
Fix poisoning of non-executable stack bit in compiled binaries.

### DIFF
--- a/libs/core/src/monad/core/keccak_impl.S
+++ b/libs/core/src/monad/core/keccak_impl.S
@@ -1,3 +1,7 @@
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
 #if defined(__x86_64__)
     #if defined(__AVX512F__)
         #include <crypto/sha/asm/keccak1600-avx512.S>


### PR DESCRIPTION
Ubuntu 24.04's linker helpfully printed a warning about an issue which had gone unnoticed until now: `keccak_impl.S` was not marked as NX stack compatible, causing all Monad binaries linked to be marked as executable stack. This obviously is a huge security hole.

This commit adds the requisite tag to say the assembler file is NX stack compatible. Before this commit:

```
ned@kate:/mnt/raid0/monad/monad/build$ scanelf -Rqe .
RWX --- ---  ./test/ethereum_test/monad-ethereum-test
!WX --- ---  ./libs/core/CMakeFiles/monad_core.dir/src/monad/core/keccak_impl.S.o
RWX --- ---  ./libs/db/src/monad/mpt/test/append_test
RWX --- ---  ./libs/db/src/monad/mpt/test/compaction_test
RWX --- ---  ./libs/db/src/monad/mpt/test/load_all_test
RWX --- ---  ./libs/db/src/monad/mpt/test/locking_trie_test
RWX --- ---  ./libs/db/src/monad/mpt/test/many_nested_updates
RWX --- ---  ./libs/db/src/monad/mpt/test/min_truncated_offsets_test
RWX --- ---  ./libs/db/src/monad/mpt/test/node_writer_test
RWX --- ---  ./libs/db/src/monad/mpt/test/read_only_db_test
RWX --- ---  ./libs/db/src/monad/mpt/test/fiber_future_wrapped_find_test
RWX --- ---  ./libs/db/src/monad/mpt/test/db_test
RWX --- ---  ./libs/db/src/monad/mpt/test/merkle_trie_test
RWX --- ---  ./libs/db/src/monad/mpt/test/cli_tool_test
RWX --- ---  ./libs/db/src/monad/mpt/test/monad_trie_test
RWX --- ---  ./libs/execution/test_db
RWX --- ---  ./libs/execution/test_block_reward
RWX --- ---  ./libs/execution/test_genesis
RWX --- ---  ./libs/execution/test_state
RWX --- ---  ./libs/execution/test_evm
RWX --- ---  ./libs/execution/test_evmc_host
RWX --- ---  ./libs/execution/test_execute_transaction
RWX --- ---  ./cmd/replay_ethereum
RWX --- ---  ./cmd/monad
```

As you can see, all the binaries including `keccak_impl.S` have been poisoned into running with executable stacks, which is very bad. The tool shows `keccak_impl.S` is the cause.

After this commit:

```
ned@kate:/mnt/raid0/monad/monad/build$ scanelf -Rqe .
```

Now all binaries run with non-executable stacks.