### PR TITLE
Relaxed merge of account nonce and balance

### DIFF
--- a/libs/execution/src/monad/execution/validate_transaction.cpp
+++ b/libs/execution/src/monad/execution/validate_transaction.cpp
@@ -116,7 +116,8 @@ Result<void> static_validate_transaction(
 EXPLICIT_EVMC_REVISION(static_validate_transaction);
 
 Result<void> validate_transaction(
-    Transaction const &tx, std::optional<Account> const &sender_account)
+    Transaction const &tx, std::optional<Account> const &sender_account,
+    bool const relaxed)
 {
     // YP (70)
     uint512_t const v0 =
@@ -141,7 +142,9 @@ Result<void> validate_transaction(
 
     // YP (71)
     if (MONAD_UNLIKELY(sender_account->nonce != tx.nonce)) {
-        return TransactionError::BadNonce;
+        if (!relaxed) {
+            return TransactionError::BadNonce;
+        }
     }
 
     // YP (71)

--- a/libs/execution/src/monad/execution/validate_transaction.hpp
+++ b/libs/execution/src/monad/execution/validate_transaction.hpp
@@ -47,7 +47,8 @@ Result<void> static_validate_transaction(
     Transaction const &, std::optional<uint256_t> const &base_fee_per_gas);
 
 Result<void> validate_transaction(
-    Transaction const &, std::optional<Account> const &sender_account);
+    Transaction const &, std::optional<Account> const &sender_account,
+    bool const relaxed = false);
 
 MONAD_NAMESPACE_END
 

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -121,9 +121,13 @@ bool BlockState::can_merge(State const &state)
         auto const &account = account_state.account_;
         auto const &storage = account_state.storage_;
         StateDeltas::const_accessor it{};
-        MONAD_ASSERT(state_.find(it, address));
-        if (account != it->second.account.second) {
-            return false;
+        [[maybe_unused]] bool const found = state_.find(it, address);
+        MONAD_ASSERT(found);
+        auto const &actual = it->second.account.second;
+        if (account != actual) {
+            if (!fix_account_mismatch(state, address, account_state, actual)) {
+                return false;
+            }
         }
         // TODO account.has_value()???
         for (auto const &[key, value] : storage) {
@@ -200,6 +204,93 @@ void BlockState::log_debug()
 {
     LOG_DEBUG("State Deltas: {}", state_);
     LOG_DEBUG("Code Deltas: {}", code_);
+}
+
+bool BlockState::fix_account_mismatch(
+    State const &state, Address const &address, AccountState const &base_state,
+    std::optional<Account> const &actual)
+{
+    auto const &base = base_state.account_;
+    if (is_dead(base)) {
+        return false;
+    }
+    if (is_dead(actual)) {
+        return false;
+    }
+    if (base->code_hash != actual->code_hash) {
+        return false;
+    }
+    if (base->incarnation != actual->incarnation) {
+        return false;
+    }
+    if (base->nonce != actual->nonce) {
+        if (!state.is_relaxed()) {
+            return false;
+        }
+        if (base_state.match_nonce()) {
+            return false;
+        }
+        if (base_state.match_tx_nonce() &&
+            (base_state.match_tx_nonce() != actual->nonce)) {
+            return false;
+        }
+    }
+    if (base->balance != actual->balance) {
+        if (!state.is_relaxed()) {
+            return false;
+        }
+        if (base_state.match_balance()) {
+            return false;
+        }
+        if (actual->balance < base_state.min_balance()) {
+            return false;
+        }
+    }
+    auto const it = state.state_.find(address);
+    if (it != state.state_.end()) {
+        MONAD_ASSERT(it->second.size() == 1);
+        auto const &local_state = it->second.recent();
+        auto &local =
+            const_cast<std::optional<Account> &>(local_state.account_);
+        if (base->nonce != actual->nonce) {
+            if (is_dead(local)) {
+                return false;
+            }
+            if (local_state.match_nonce()) {
+                return false;
+            }
+            if (local_state.match_tx_nonce() &&
+                (local_state.match_tx_nonce() != actual->nonce)) {
+                return false;
+            }
+            // Fix nonce
+            MONAD_ASSERT(base->nonce < actual->nonce);
+            MONAD_ASSERT(base->nonce <= local->nonce);
+            local->nonce += (actual->nonce - base->nonce);
+            const_cast<std::optional<Account> &>(base)->nonce = actual->nonce;
+        }
+        if (base->balance != actual->balance) {
+            if (local_state.match_balance()) {
+                return false;
+            }
+            if (actual->balance < local_state.min_balance()) {
+                return false;
+            }
+            // Fix balance
+            if (base->balance > actual->balance) {
+                auto const diff = base->balance - actual->balance;
+                MONAD_ASSERT(local->balance >= diff);
+                local->balance -= diff;
+            }
+            else {
+                auto const diff = actual->balance - base->balance;
+                local->balance += diff;
+            }
+            const_cast<std::optional<Account> &>(base)->balance =
+                actual->balance;
+        }
+    }
+    return true;
 }
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -5,6 +5,7 @@
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/state_deltas.hpp>
+#include <monad/state3/account_state.hpp>
 #include <monad/types/incarnation.hpp>
 
 #include <memory>
@@ -35,6 +36,11 @@ public:
     void commit(std::vector<Receipt> const &);
 
     void log_debug();
+
+private:
+    bool fix_account_mismatch(
+        State const &state, Address const &address,
+        AccountState const &base_state, std::optional<Account> const &actual);
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/state3/account_state.hpp
+++ b/libs/execution/src/monad/state3/account_state.hpp
@@ -29,6 +29,11 @@ public: // TODO
     std::optional<Account> account_{};
     Map<bytes32_t, bytes32_t> storage_{};
 
+    bool match_nonce_{false};
+    bool match_balance_{false};
+    uint64_t match_tx_nonce_{0};
+    uint256_t min_balance_{0};
+
     evmc_storage_status zero_out_key(
         bytes32_t const &key, bytes32_t const &original_value,
         bytes32_t const &current_value);
@@ -68,6 +73,46 @@ public:
             return zero_out_key(key, original_value, current_value);
         }
         return set_current_value(key, value, original_value, current_value);
+    }
+
+    bool match_nonce() const
+    {
+        return match_nonce_;
+    }
+
+    bool match_balance() const
+    {
+        return match_balance_;
+    }
+
+    uint64_t match_tx_nonce() const
+    {
+        return match_tx_nonce_;
+    }
+
+    uint256_t const &min_balance() const
+    {
+        return min_balance_;
+    }
+
+    void set_match_nonce()
+    {
+        match_nonce_ = true;
+    }
+
+    void set_match_balance()
+    {
+        match_balance_ = true;
+    }
+
+    void set_match_tx_nonce(uint64_t tx_nonce)
+    {
+        match_tx_nonce_ = tx_nonce;
+    }
+
+    void add_to_min_balance(uint256_t const &delta)
+    {
+        min_balance_ += delta;
     }
 };
 

--- a/libs/execution/src/monad/state3/state.hpp
+++ b/libs/execution/src/monad/state3/state.hpp
@@ -52,6 +52,8 @@ class State
 
     unsigned version_{0};
 
+    bool relaxed_{false};
+
     AccountState &original_account_state(Address const &address)
     {
         auto it = original_.find(address);
@@ -61,17 +63,6 @@ class State
             it = original_.try_emplace(address, account).first;
         }
         return it->second;
-    }
-
-    AccountState const &recent_account_state(Address const &address)
-    {
-        // state
-        auto const it = state_.find(address);
-        if (it != state_.end()) {
-            return it->second.recent();
-        }
-        // original
-        return original_account_state(address);
     }
 
     AccountState &current_account_state(Address const &address)
@@ -126,6 +117,7 @@ public:
     void pop_reject()
     {
         MONAD_ASSERT(version_);
+        set_relaxed(false);
 
         std::vector<Address> removals;
 
@@ -143,6 +135,27 @@ public:
         }
 
         --version_;
+    }
+
+    bool is_relaxed() const
+    {
+        return relaxed_;
+    }
+
+    void set_relaxed(bool value)
+    {
+        relaxed_ = value;
+    }
+
+    AccountState const &recent_account_state(Address const &address)
+    {
+        // state
+        auto const it = state_.find(address);
+        if (it != state_.end()) {
+            return it->second.recent();
+        }
+        // original
+        return original_account_state(address);
     }
 
     ////////////////////////////////////////
@@ -166,6 +179,7 @@ public:
 
     uint64_t get_nonce(Address const &address)
     {
+        MONAD_ASSERT(!is_relaxed());
         auto const &account = recent_account(address);
         if (MONAD_LIKELY(account.has_value())) {
             return account.value().nonce;
@@ -173,9 +187,34 @@ public:
         return 0;
     }
 
+    void sender_changes(
+        Address const &sender, bool const increment, uint256_t const &delta,
+        uint64_t const tx_nonce)
+    {
+        AccountState &account_state = current_account_state(sender);
+        auto &account = account_state.account_;
+        if (!account) {
+            account = Account{.incarnation = incarnation_};
+        }
+        else {
+            account_state.set_match_tx_nonce(tx_nonce);
+        }
+        if (increment) {
+            ++account->nonce;
+        }
+        account_state.touch();
+        if (delta) {
+            MONAD_ASSERT(delta <= account->balance);
+            account->balance -= delta;
+            account_state.add_to_min_balance(delta);
+        }
+    }
+
     bytes32_t get_balance(Address const &address)
     {
-        auto const &account = recent_account(address);
+        auto &account_state = recent_account_state(address);
+        const_cast<AccountState &>(account_state).set_match_balance();
+        auto const &account = account_state.account_;
         if (MONAD_LIKELY(account.has_value())) {
             return intx::be::store<bytes32_t>(account.value().balance);
         }
@@ -261,13 +300,14 @@ public:
         if (MONAD_UNLIKELY(!account.has_value())) {
             account = Account{.incarnation = incarnation_};
         }
-
-        MONAD_ASSERT(
-            std::numeric_limits<uint256_t>::max() - delta >=
-            account.value().balance);
-
-        account.value().balance += delta;
         account_state.touch();
+
+        if (delta) {
+            MONAD_ASSERT(
+                std::numeric_limits<uint256_t>::max() - delta >=
+                account.value().balance);
+            account.value().balance += delta;
+        }
     }
 
     void subtract_from_balance(Address const &address, uint256_t const &delta)
@@ -277,11 +317,12 @@ public:
         if (MONAD_UNLIKELY(!account.has_value())) {
             account = Account{.incarnation = incarnation_};
         }
-
-        MONAD_ASSERT(delta <= account.value().balance);
-
-        account.value().balance -= delta;
         account_state.touch();
+        if (delta) {
+            MONAD_ASSERT(delta <= account.value().balance);
+            account.value().balance -= delta;
+            account_state.add_to_min_balance(delta);
+        }
     }
 
     void set_code_hash(Address const &address, bytes32_t const &hash)
@@ -348,6 +389,7 @@ public:
 
         add_to_balance(beneficiary, account.value().balance);
         account.value().balance = 0;
+        account_state.set_match_balance();
 
         return account_state.destruct();
     }


### PR DESCRIPTION
The relaxed merge applies relative (instead of absolute) checks on the nonce and balance of accounts accessed by transactions.

This PR reduces the number of retries on 12M 10K blocks, 4 threads, 128 fibers:
```
Before: 868765
After:  307027
```