### PR TITLE
Node version

### DIFF
--- a/libs/db/src/monad/mpt/copy_node.cpp
+++ b/libs/db/src/monad/mpt/copy_node.cpp
@@ -58,7 +58,7 @@ Node::UniquePtr copy_node(
                             dest.substr(
                                 static_cast<unsigned char>(prefix_index) + 1u),
                             src_leaf->value(),
-                            aux.current_version)
+                            src_leaf->version)
                             .release();
                     // create a node, with no leaf data
                     uint16_t const mask =
@@ -92,7 +92,7 @@ Node::UniquePtr copy_node(
                                node->path_nibble_view(),
                                std::nullopt,
                                0,
-                               aux.current_version)
+                               leaf->version)
                         .release();
                 }();
                 break;
@@ -115,7 +115,7 @@ Node::UniquePtr copy_node(
                         dest.substr(
                             static_cast<unsigned char>(prefix_index) + 1u),
                         src_leaf->value(),
-                        aux.current_version)
+                        src_leaf->version)
                         .release();
                 Node *node_latter_half =
                     make_node(
@@ -127,7 +127,7 @@ Node::UniquePtr copy_node(
                         node->has_value()
                             ? std::optional<byte_string_view>{node->value()}
                             : std::nullopt,
-                        aux.current_version)
+                        node->version)
                         .release();
                 MONAD_DEBUG_ASSERT(node_latter_half);
                 uint16_t const mask =
@@ -159,7 +159,7 @@ Node::UniquePtr copy_node(
                                node->path_data()},
                            std::nullopt,
                            0,
-                           aux.current_version)
+                           dest_leaf->version)
                     .release();
             }();
             break;
@@ -174,7 +174,7 @@ Node::UniquePtr copy_node(
                            *src_leaf,
                            node->path_nibble_view(),
                            src_leaf->value(),
-                           aux.current_version)
+                           src_leaf->version)
                            .release();
             // clear parent's children other than new_node
             if (aux.is_on_disk()) {

--- a/libs/db/src/monad/mpt/node.hpp
+++ b/libs/db/src/monad/mpt/node.hpp
@@ -142,6 +142,12 @@ public:
     uint8_t path_nibble_index_end{0};
     /* size (in byte) of user-passed leaf data */
     uint32_t value_len{0};
+    /* A note on definition of node version:
+    version(leaf node) corresponds to the block number when it was
+    last updated.
+    version(interior node) >= max(version of the leaf nodes under its prefix),
+    it is greater than only when the latest update in the subtrie contains only
+    deletions. */
     int64_t version{0};
 
 #pragma GCC diagnostic push
@@ -311,6 +317,7 @@ constexpr size_t calculate_node_size(
            total_child_data_size + value_size + path_size + data_size;
 }
 
+// create mpt node
 Node::UniquePtr make_node(
     Node &from, NibblesView path, std::optional<byte_string_view> value,
     int64_t version);

--- a/libs/db/src/monad/mpt/test/monad_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/monad_trie_test.cpp
@@ -111,7 +111,11 @@ Node::UniquePtr batch_upsert_commit(
         state_updates.push_front(update_alloc.emplace_back(
             erase ? make_erase(keccak_keys[i + vec_idx])
                   : make_update(
-                        keccak_keys[i + vec_idx], keccak_values[i + vec_idx])));
+                        keccak_keys[i + vec_idx],
+                        keccak_values[i + vec_idx],
+                        false,
+                        UpdateList{},
+                        block_id)));
     }
 
     auto ts_before = std::chrono::steady_clock::now();

--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -321,7 +321,6 @@ protected:
     };
 
 public:
-    int64_t current_version{0};
     compact_virtual_chunk_offset_t compact_offset_fast{
         MIN_COMPACT_VIRTUAL_OFFSET};
     compact_virtual_chunk_offset_t compact_offset_slow{
@@ -624,7 +623,7 @@ public:
 
 static_assert(
     sizeof(UpdateAuxImpl) ==
-    128 + MONAD_MPT_COLLECT_STATS * sizeof(detail::TrieUpdateCollectedStats));
+    120 + MONAD_MPT_COLLECT_STATS * sizeof(detail::TrieUpdateCollectedStats));
 static_assert(alignof(UpdateAuxImpl) == 8);
 
 template <lockable_or_void LockType = void>
@@ -795,6 +794,7 @@ upsert(UpdateAuxImpl &, StateMachine &, Node::UniquePtr old, UpdateList &&);
 size_t load_all(UpdateAuxImpl &, StateMachine &, NodeCursor);
 
 //////////////////////////////////////////////////////////////////////////////
+// find
 
 enum class find_result : uint8_t
 {
@@ -853,7 +853,8 @@ find_blocking(UpdateAuxImpl const &, NodeCursor, NibblesView key);
 Nibbles find_min_key_blocking(UpdateAuxImpl const &, Node &root);
 Nibbles find_max_key_blocking(UpdateAuxImpl const &, Node &root);
 
-// helper
+//////////////////////////////////////////////////////////////////////////////
+// helpers
 inline constexpr unsigned num_pages(file_offset_t const offset, unsigned bytes)
 {
     auto const rd_offset = round_down_align<DISK_PAGE_BITS>(offset);

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -497,9 +497,6 @@ Node::UniquePtr UpdateAuxImpl::do_update(
     auto g(unique_lock());
     auto g2(set_current_upsert_tid());
 
-    MONAD_ASSERT(version <= std::numeric_limits<int64_t>::max());
-    current_version = static_cast<int64_t>(version);
-
     compaction &= is_on_disk(); // compaction only takes effect for on disk trie
     auto const curr_version_key =
         serialize_as_big_endian<BLOCK_NUM_BYTES>(version);
@@ -553,11 +550,16 @@ Node::UniquePtr UpdateAuxImpl::do_update(
             *this, std::move(prev_root), prev_version, curr_version_key);
     }
     Update u = make_update(
-        curr_version_key, byte_string_view{}, false, std::move(updates));
+        curr_version_key,
+        byte_string_view{},
+        false,
+        std::move(updates),
+        version);
     db_updates.push_front(u);
 
     // 4. upsert version updates
     auto root = upsert(*this, sm, std::move(prev_root), std::move(db_updates));
+    MONAD_ASSERT(root->version == static_cast<int64_t>(version));
     // 5. free compacted chunks and update version metadata if on disk
     if (is_on_disk()) {
         free_compacted_chunks();

--- a/libs/db/src/monad/mpt/upward_tnode.hpp
+++ b/libs/db/src/monad/mpt/upward_tnode.hpp
@@ -33,6 +33,7 @@ struct UpwardTreeNode
     allocators::owning_span<ChildData> children{};
     Nibbles path{};
     std::optional<byte_string_view> opt_leaf_data{std::nullopt};
+    int64_t version{0};
 
     [[nodiscard]] unsigned number_of_children() const
     {
@@ -76,6 +77,7 @@ inline tnode_unique_ptr make_tnode(
     uint16_t const orig_mask, unsigned const prefix_index,
     UpwardTreeNode *const parent = nullptr,
     uint8_t const branch = INVALID_BRANCH, NibblesView const path = {},
+    int64_t const version = 0,
     std::optional<byte_string_view> const opt_leaf_data = std::nullopt,
     Node::UniquePtr old = {})
 {
@@ -91,10 +93,11 @@ inline tnode_unique_ptr make_tnode(
         .old = std::move(old),
         .children = allocators::owning_span<ChildData>{n},
         .path = path,
-        .opt_leaf_data = opt_leaf_data});
+        .opt_leaf_data = opt_leaf_data,
+        .version = version});
 }
 
-static_assert(sizeof(UpwardTreeNode) == 80);
+static_assert(sizeof(UpwardTreeNode) == 88);
 static_assert(alignof(UpwardTreeNode) == 8);
 
 struct CompactTNode


### PR DESCRIPTION
This pr eliminated the global `UpdateAux::current_version`, and changed the way we set `Node::version` to (aka definition):
- Version of leaf node = block number it was last updated at.
- Version of interior node >= `max(leaf versions)` under that prefix, it is greater than only when the latest updates in the subtrie contains only deletions. **Example** demonstrate the greater than case:
    - insert `AA`, `AC` at v1, insert `AB` at v2, `version(NodeA) = 2`
    - erase `AB` at v3, theoretically we want `version(NodeA) = max(AA,AC) = 1`, however that requires looking through all children versions when erase happens, which is too expensive. Instead, the current impl has `version(NodeA) = 2`, carried over from what it was at version 2.

Use case:
- state sync can trim subtries that are out of the target version range during traversal


Next pr: store min version of a subtrie to its parent

Optimized it further and see no perf regression:
before: 8152 tps
```
13:56:38.107125316 [364323] replay_ethereum.cpp:222      LOG_INFO      root         Finish running, finish(stopped) block number = 12010000, number of blocks run = 10000, time_elapsed = 241s, num transactions = 1964870, tps = 8152
```
after: 8119 tps
```
17:08:16.683404885 [490333] replay_ethereum.cpp:222      LOG_INFO      root         Finish running, finish(stopped) block number = 12010000, number of blocks run = 10000, time_elapsed = 242s, num transactions = 1964870, tps = 8119
```