### PR TITLE
Add async Sender interface for `Db::get()` and `Db::get_data()`.

### DIFF
--- a/libs/db/src/monad/mpt/cli_tool_impl.cpp
+++ b/libs/db/src/monad/mpt/cli_tool_impl.cpp
@@ -762,10 +762,10 @@ public:
             UINT32_MAX);
         monad::mpt::detail::unsigned_20 slow_list_base_insertion_count(
             UINT32_MAX);
-        uint32_t fast_list_begin_index{UINT32_MAX},
-            fast_list_end_index{UINT32_MAX};
-        uint32_t slow_list_begin_index{UINT32_MAX},
-            slow_list_end_index{UINT32_MAX};
+        uint32_t fast_list_begin_index{UINT32_MAX};
+        uint32_t fast_list_end_index{UINT32_MAX};
+        uint32_t slow_list_begin_index{UINT32_MAX};
+        uint32_t slow_list_end_index{UINT32_MAX};
         for (auto &i : todecompress) {
             if (i.type == monad::async::storage_pool::cnv && i.chunk_id == 0) {
                 auto const *old_metadata =
@@ -1004,9 +1004,9 @@ public:
             aux.db_metadata()->slow_list.begin == slow_list_begin_index);
         MONAD_ASSERT(aux.db_metadata()->slow_list.end == slow_list_end_index);
 
-        for (auto it = chunks.begin(); it != chunks.end(); ++it) {
-            if (*it != UINT32_MAX) {
-                aux.append(monad::mpt::UpdateAuxImpl::chunk_list::free, *it);
+        for (unsigned int &chunk : chunks) {
+            if (chunk != UINT32_MAX) {
+                aux.append(monad::mpt::UpdateAuxImpl::chunk_list::free, chunk);
             }
         }
 

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <monad/async/concepts.hpp>
 #include <monad/async/io.hpp>
 #include <monad/async/storage_pool.hpp>
 #include <monad/core/result.hpp>
 #include <monad/io/buffers.hpp>
 #include <monad/io/ring.hpp>
 #include <monad/mpt/config.hpp>
+#include <monad/mpt/nibbles_view.hpp>
 #include <monad/mpt/node.hpp>
 #include <monad/mpt/trie.hpp>
 #include <monad/mpt/update.hpp>
@@ -17,8 +19,17 @@ struct ReadOnlyOnDiskDbConfig;
 struct StateMachine;
 struct TraverseMachine;
 
+namespace detail
+{
+    template <class T>
+    struct DbGetSender;
+}
+
 class Db
 {
+    template <class T>
+    friend struct detail::DbGetSender;
+
 private:
     struct Impl;
     struct RWOnDisk;
@@ -63,6 +74,93 @@ public:
     // Load the tree of nodes in the current DB root as far as the caching
     // policy allows. RW only.
     size_t prefetch();
+    // Pump any async DB operations. RO only.
+    size_t poll(bool blocking, size_t count = 1);
 };
+
+template <class T>
+struct detail::DbGetSender
+{
+    using result_type = async::result<T>;
+
+public:
+    Db &db;
+
+    enum op_t : uint8_t
+    {
+        op_get1,
+        op_get_data1,
+        op_get2,
+        op_get_data2
+    } op_type;
+
+    NodeCursor cur;
+    Nibbles const nv;
+    uint64_t const block_id{0};
+
+    find_result_type res_;
+
+public:
+    constexpr DbGetSender(
+        Db &db_, op_t const op_type_, NibblesView const n,
+        uint64_t const block_id_ = 0)
+        : db(db_)
+        , op_type(op_type_)
+        , nv(n)
+        , block_id(block_id_)
+    {
+    }
+
+    constexpr DbGetSender(
+        Db &db_, op_t const op_type_, NodeCursor const cur_,
+        NibblesView const n)
+        : db(db_)
+        , op_type(op_type_)
+        , cur(cur_)
+        , nv(n)
+    {
+    }
+
+    DbGetSender(DbGetSender &&o) noexcept
+        : db(o.db)
+        , op_type(o.op_type)
+        , cur(o.cur)
+        , nv(const_cast<Nibbles &&>(std::move(o.nv)))
+        , block_id(o.block_id)
+        , res_(std::move(o.res_))
+    {
+    }
+
+    async::result<void>
+    operator()(async::erased_connected_operation *io_state) noexcept;
+
+    result_type completed(
+        async::erased_connected_operation *, async::result<void> res) noexcept;
+};
+
+inline constexpr detail::DbGetSender<byte_string>
+make_get_sender(Db &db, NibblesView const nv, uint64_t const block_id = 0)
+{
+    return {db, detail::DbGetSender<byte_string>::op_t::op_get1, nv, block_id};
+}
+
+inline constexpr detail::DbGetSender<byte_string>
+make_get_data_sender(Db &db, NibblesView const nv, uint64_t const block_id = 0)
+{
+    return {
+        db, detail::DbGetSender<byte_string>::op_t::op_get_data1, nv, block_id};
+}
+
+inline constexpr detail::DbGetSender<NodeCursor>
+make_get_sender(Db &db, NodeCursor const cur, NibblesView const nv)
+{
+    return {db, detail::DbGetSender<NodeCursor>::op_t::op_get2, cur, nv};
+}
+
+inline constexpr detail::DbGetSender<byte_string>
+make_get_data_sender(Db &db, NodeCursor const cur, NibblesView const nv)
+{
+    return {db, detail::DbGetSender<byte_string>::op_t::op_get_data2, cur, nv};
+}
 
 MONAD_MPT_NAMESPACE_END

--- a/libs/db/src/monad/mpt/nibbles_view.hpp
+++ b/libs/db/src/monad/mpt/nibbles_view.hpp
@@ -32,6 +32,10 @@ public:
 
     constexpr Nibbles() = default;
 
+    Nibbles(Nibbles &&) = default;
+
+    Nibbles &operator=(Nibbles &&) = default;
+
     explicit Nibbles(size_t const end_nibble)
         : data_(std::make_unique<unsigned char[]>((end_nibble + 1) / 2))
         , begin_nibble_(false)


### PR DESCRIPTION
As part of implementing https://github.com/monad-crypto/monad-internal/issues/232