### PR TITLE
parallel traverse fix excessive mem usage, have limited outstanding I/O

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -523,8 +523,6 @@ int main(int const argc, char const *argv[])
             .dbname_paths = dbname_paths,
             .concurrent_read_io_limit = 128}};
         TrieDb ro_db{db};
-        // WARNING: to_json() does parallel traverse which consumes excessive
-        // memory
         write_to_file(ro_db.to_json(), dump_snapshot, block_num);
     }
     return result.has_error() ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -70,7 +70,9 @@ public:
     // traversal on RWDb, use the `traverse_blocking` api below.
     // TODO: fix the excessive memory issue by pausing traverse when there are N
     // outstanding requests
-    bool traverse(NodeCursor, TraverseMachine &, uint64_t block_id);
+    bool traverse(
+        NodeCursor, TraverseMachine &, uint64_t block_id,
+        size_t concurrency_limit = 4096);
     // Blocking traverse never wait on a fiber future.
     bool traverse_blocking(NodeCursor, TraverseMachine &, uint64_t block_id);
     NodeCursor root() const noexcept;

--- a/libs/db/src/monad/mpt/ondisk_db_config.hpp
+++ b/libs/db/src/monad/mpt/ondisk_db_config.hpp
@@ -36,13 +36,13 @@ struct ReadOnlyOnDiskDbConfig
         false}; // risk of severe data loss
     bool capture_io_latencies{false};
     bool eager_completions{false};
-    unsigned rd_buffers{128};
+    unsigned rd_buffers{1024};
     unsigned uring_entries{128};
     // default to disable sqpoll kernel thread since now ReadOnlyDb uses
     // blocking read
     std::optional<unsigned> sq_thread_cpu{std::nullopt};
     std::vector<std::filesystem::path> dbname_paths;
-    unsigned concurrent_read_io_limit{1024};
+    unsigned concurrent_read_io_limit{600};
 };
 
 MONAD_MPT_NAMESPACE_END

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -428,7 +428,7 @@ std::string TrieDb::print_stats()
     return ret;
 }
 
-nlohmann::json TrieDb::to_json()
+nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
 {
     struct Traverse : public TraverseMachine
     {
@@ -559,8 +559,8 @@ nlohmann::json TrieDb::to_json()
             db_.traverse_blocking(res_cursor.value(), traverse, block_number_));
     }
     else {
-        // WARNING: excessive memory usage in parallel traverse
-        MONAD_ASSERT(db_.traverse(res_cursor.value(), traverse, block_number_));
+        MONAD_ASSERT(db_.traverse(
+            res_cursor.value(), traverse, block_number_, concurrency_limit));
     }
 
     return json;

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -57,7 +57,7 @@ public:
     virtual std::optional<bytes32_t> withdrawals_root() override;
     virtual std::string print_stats() override;
 
-    nlohmann::json to_json();
+    nlohmann::json to_json(size_t concurrency_limit = 4096);
     size_t prefetch_current_root();
     uint64_t get_block_number() const;
     uint64_t get_history_length() const;


### PR DESCRIPTION
With limited outstanding reads, 12M state trie traversal (empty traverse machine) RSS <11GB
finished an empty traverse in 38min

Added back `to_json()` for in memory triedb


we see much slower io perf when the traversal `concurrent_reads_limit = 1024` vs 4096