### PR TITLE
`mpt::Db` API changes: `traverse()` starts from a `NodeCursor`, rename `get` that returns a cursor to `find` 

### DIFF
--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -50,10 +50,14 @@ public:
     ~Db();
 
     // May wait on a fiber future
-    Result<byte_string_view> get(NibblesView, uint64_t block_id = 0) const;
-    Result<byte_string_view> get_data(NibblesView, uint64_t block_id = 0) const;
     Result<NodeCursor>
-    get(NodeCursor, NibblesView, uint64_t block_id = 0) const;
+    find(NodeCursor, NibblesView, uint64_t block_id = 0) const;
+    // Search path includes block id in the prefix
+    Result<NodeCursor> find(NibblesView prefix, uint64_t block_id = 0) const;
+    // Search path includes block id in the prefix
+    Result<byte_string_view> get(NibblesView, uint64_t block_id = 0) const;
+    // Search path includes block id in the prefix
+    Result<byte_string_view> get_data(NibblesView, uint64_t block_id = 0) const;
     Result<byte_string_view>
     get_data(NodeCursor, NibblesView, uint64_t block_id = 0) const;
 

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -906,26 +906,20 @@ nlohmann::json TrieDb::to_json()
     auto json = nlohmann::json::object();
     Traverse traverse(*this, json);
 
-    auto res = db_.get(
-        db_.root(),
-        concat(
-            NibblesView{
-                serialize_as_big_endian<BLOCK_NUM_BYTES>(block_number_)},
-            state_nibble),
-        block_number_);
-    MONAD_ASSERT(res.has_value());
-    MONAD_ASSERT(res.value().is_valid());
+    auto res_cursor = db_.find(state_nibbles, block_number_);
+    MONAD_ASSERT(res_cursor.has_value());
+    MONAD_ASSERT(res_cursor.value().is_valid());
     // RWOndisk Db prevents any parallel traversal that does blocking i/o
     // from running on the triedb thread, which include to_json. Thus, we can
     // only use blocking traversal for RWOnDisk Db, but can still do parallel
     // traverse in other cases.
     if (mode_ == Mode::OnDisk) {
         MONAD_ASSERT(
-            db_.traverse_blocking(res.value(), traverse, block_number_));
+            db_.traverse_blocking(res_cursor.value(), traverse, block_number_));
     }
     else {
         // WARNING: excessive memory usage in parallel traverse
-        MONAD_ASSERT(db_.traverse(res.value(), traverse, block_number_));
+        MONAD_ASSERT(db_.traverse(res_cursor.value(), traverse, block_number_));
     }
 
     return json;


### PR DESCRIPTION

```
    // May wait on a fiber future
    Result<NodeCursor> find(NodeCursor, NibblesView, uint64_t block_id = 0) const;
    // Search path includes block id in the prefix
    Result<NodeCursor> find(NibblesView prefix, uint64_t block_id = 0) const;
    // Search path includes block id in the prefix
    Result<byte_string_view> get(NibblesView, uint64_t block_id = 0) const;
    // Search path includes block id in the prefix
    Result<byte_string_view> get_data(NibblesView, uint64_t block_id = 0) const;
    Result<byte_string_view> get_data(NodeCursor, NibblesView, uint64_t block_id = 0) const;

    bool traverse(NodeCursor, TraverseMachine &, uint64_t block_id = 0);
    // Blocking traverse never wait on a fiber future.
    bool traverse_blocking(NodeCursor, TraverseMachine &, uint64_t block_id = 0);
```