### PR TITLE
Enable traversal to trim irrelevant subtries

### DIFF
--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -812,11 +812,11 @@ nlohmann::json TrieDb::to_json()
         {
         }
 
-        virtual void down(unsigned char const branch, Node const &node) override
+        virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
                 MONAD_ASSERT(node.path_nibble_view().nibble_size() == 0);
-                return;
+                return true;
             }
             path = concat(NibblesView{path}, branch, node.path_nibble_view());
 
@@ -827,6 +827,7 @@ nlohmann::json TrieDb::to_json()
                 path.nibble_size() == ((KECCAK256_SIZE + KECCAK256_SIZE) * 2)) {
                 handle_storage(node);
             }
+            return true;
         }
 
         virtual void up(unsigned char const branch, Node const &node) override


### PR DESCRIPTION
`TraverseMachine` API changed to:
```
    virtual ~TraverseMachine() = default;
    // Implement the logic to decide when to stop, return true for continue,
    // false for stop
    virtual bool down(unsigned char branch, Node const &) = 0;
    virtual void up(unsigned char branch, Node const &) = 0;
    virtual std::unique_ptr<TraverseMachine> clone() const = 0;
    virtual bool stop(Node const &, unsigned char)
    {
        return false;
    }
```
It allows user to implement the stop logic into either `down()` or `stop()` or both.

Along with some unit test bug fixes.