### PR TITLE
Add a few things to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build
 perf.data*
 scratch
 
-### github default cmake ignore
+### CMake ignore
 
 CMakeLists.txt.user
 CMakeCache.txt
@@ -17,6 +17,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+CMakeUserPresets.json
 
 ### github default python ignore
 
@@ -152,3 +153,6 @@ dmypy.json
 
 # vcpkg
 vcpkg_installed/
+
+# Jetbrains IDEs (i.e. CLion)
+/.idea


### PR DESCRIPTION
This adds some stuff to ignore:

1. `.idea` directory, which is created by the CLion C++ IDE. I think I'm the only one here who uses this, but it's pretty nice.
2. `CMakeUserPresets.json` - This is explained below

Presets are described [here](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html). The relevant part is

> One problem that CMake users often face is sharing settings with other people for common ways to configure a project. This may be done to support CI builds, or for users who frequently use the same build. CMake supports two main files, CMakePresets.json and CMakeUserPresets.json, that allow users to specify common configure options and share them with others.

The difference is:

1. `CMakePresets.json` - this one is meant to be checked into git, because it's meant to be used by everyone. This could be used to create "reasonable default" configurations, e.g., for the CI, or for users

2. `CMakeUserPresets.json` - this one is meant to be used by people who want to run CMake in their own weird way, with special settings that are not checked in by definition. Thus why it is ignored.

For the curious, I typically use these files to specify an out-of-tree build directory for each compiler, and I have different toolchain files for different compilers also. Here is an example:

```
{
  "version": 8,
  "cmakeMinimumRequired": {
    "major": 3,
    "minor": 23,
    "patch": 0
  },
  "configurePresets": [
    {
      "name": "debug-default",
      "description": "Default debug",
      "generator": "Ninja",
      "cacheVariables": {
        "CMAKE_BUILD_TYPE": {
          "type": "STRING",
          "value": "Debug"
        }
      }
    },
    {
      "name": "homeopt-debug-gcc13-x64v4",
      "inherits": "debug-default",
      "toolchainFile": "$env{HOME}/share/cmake-toolchains/gcc13-x64v4.cmake",
      "binaryDir": "$env{HOME}/build/monad-debug-gcc13-x64v4"
    },
    {
      "name": "homeopt-debug-clang18-x64v4-libstdcxx",
      "inherits": "debug-default",
      "toolchainFile": "$env{HOME}/share/cmake-toolchains/clang18-x64v4-libstdcxx.cmake",
      "binaryDir": "$env{HOME}/build/monad-debug-clang18-x64v4-libstdcxx"
    }
  ]
}
```