### PR TITLE
Now one can open a RODb on an empty Db, Along with a few follow-up changes of remove block number pr

### DIFF
--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -58,7 +58,7 @@ public:
     Result<byte_string_view>
     get_data(NodeCursor, NibblesView, uint64_t block_id) const;
 
-    Result<NodeCursor> load_root_for_version(uint64_t block_id) const;
+    NodeCursor load_root_for_version(uint64_t block_id) const;
 
     void upsert(
         UpdateList, uint64_t block_id, bool enable_compaction = true,
@@ -76,8 +76,8 @@ public:
     // Blocking traverse never wait on a fiber future.
     bool traverse_blocking(NodeCursor, TraverseMachine &, uint64_t block_id);
     NodeCursor root() const noexcept;
-    std::optional<uint64_t> get_latest_block_id() const;
-    std::optional<uint64_t> get_earliest_block_id() const;
+    uint64_t get_latest_block_id() const;
+    uint64_t get_earliest_block_id() const;
     // This function moves a source trie to under a destination version,
     // assuming the source trie is the only version present.
     // Only the RWDb can call this API for state sync purposes.

--- a/libs/db/src/monad/mpt/test/monad_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/monad_trie_test.cpp
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
     bool compaction = false;
     bool use_iopoll = false;
     int file_size_db = 512; // truncate to 512 gb by default
-    uint64_t block_id = uint64_t(-1);
+    uint64_t block_id = INVALID_BLOCK_ID;
     unsigned random_read_benchmark_threads = 0;
     unsigned concurrent_read_io_limit = 0;
 
@@ -517,7 +517,7 @@ int main(int argc, char *argv[])
                 root.reset(read_node_blocking(
                     io.storage_pool(), aux.get_latest_root_offset()));
             }
-            if (block_id == uint64_t(-1)) {
+            if (block_id == INVALID_BLOCK_ID) {
                 block_id = aux.max_version_in_db_history();
             }
             printf("starting block id %lu\n", block_id);

--- a/libs/db/src/monad/mpt/util.hpp
+++ b/libs/db/src/monad/mpt/util.hpp
@@ -27,6 +27,7 @@ using MONAD_ASYNC_NAMESPACE::round_up_align;
 
 static constexpr uint8_t INVALID_BRANCH = 255;
 static constexpr uint8_t INVALID_PATH_INDEX = 255;
+static constexpr uint64_t INVALID_BLOCK_ID = uint64_t(-1);
 
 static byte_string const empty_trie_hash = [] {
     using namespace ::monad::literals;


### PR DESCRIPTION
Allow opening an empty RODb whenever a RWDb is created even if empty.

Along with a few follow-up changes of remove block number pr:
* `Db::ROOnDisk` load new root as long as the root offset to load changes from
  `last_loaded_root_offset_`, no longer rely on the assumption that a version 
  on disk would never be updated, which sometimes got violated, i.e. in state sync.
* db_metadata min/max version both init to `INVALID_BLOCK_ID`, which
  avoids any possible confusion caused by earlier behavior where max version was
  initialized to a valid number `0`.
* `Db::get_latest/earliest_block_id()` returns `uint64_t` rather than
  optional of it, also changed its implementation to not rely on
`root()` is valid.
* `UpdateAuxImpl::min/max_version_in_db_history()` returns 0 rather than
  assert for in memory db to match earlier behavior
* modify db unit tests accordingly