### PR TITLE
Triedb: Improve async read test and add inflight map for roots

### DIFF
--- a/libs/db/src/monad/mpt/ondisk_db_config.hpp
+++ b/libs/db/src/monad/mpt/ondisk_db_config.hpp
@@ -35,8 +35,6 @@ struct ReadOnlyOnDiskDbConfig
     bool eager_completions{false};
     unsigned rd_buffers{8};
     unsigned uring_entries{8};
-    // number of historical tries cached
-    unsigned historical_trie_lru_size{64};
     // default to disable sqpoll kernel thread since now ReadOnlyDb uses
     // blocking read
     std::optional<unsigned> sq_thread_cpu{std::nullopt};


### PR DESCRIPTION
Improve `OnDiskDbWithFileFixture.read_only_db_single_thread_async` to test
async reads. Previously, the test would poll between each read. The new test 
uncovers a bug that has been present on main since async was added. 
`find_get_sender()` was not passed an inflight map, so during async reads, 
the sender will issue duplicate reads and override existing nodes.
    
In 715c99d we added support for async root nodes. Similar to the
find_request_sender, add an inflight map for pending root nodes.
    
Reduce the dependency of async APIs on the DB class. The `AsyncContext`
struct has all the data needed for an async read without cluttering the
Db class with all these implementation details.  For example, we are
able to remove `db.trie_root_cache()` getter from the Db interface.