### PR TITLE
Increase db history length (which is also compaction length)

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -199,6 +199,7 @@ int main(int const argc, char const *argv[])
     bool no_compaction = false;
     unsigned sq_thread_cpu = static_cast<unsigned>(get_nprocs() - 1);
     unsigned ro_sq_thread_cpu = static_cast<unsigned>(get_nprocs() - 2);
+    uint64_t history_len = 1000;
     std::vector<fs::path> dbname_paths;
     fs::path genesis;
     fs::path snapshot;
@@ -246,6 +247,10 @@ int main(int const argc, char const *argv[])
         "--dump_snapshot",
         dump_snapshot,
         "directory to dump state to at the end of run");
+    cli.add_option(
+        "--history_len",
+        history_len,
+        "history length an empty db is initialized to");
     auto *const group =
         cli.add_option_group("load", "methods to initialize the db");
     group->add_option("--genesis", genesis, "genesis file")
@@ -320,7 +325,8 @@ int main(int const argc, char const *argv[])
                     .wr_buffers = 32,
                     .uring_entries = 128,
                     .sq_thread_cpu = sq_thread_cpu,
-                    .dbname_paths = dbname_paths}};
+                    .dbname_paths = dbname_paths,
+                    .history_length = history_len}};
         }
         machine = std::make_unique<InMemoryMachine>();
         return mpt::Db{*machine};

--- a/libs/db/src/monad/mpt/cli_tool_impl.cpp
+++ b/libs/db/src/monad/mpt/cli_tool_impl.cpp
@@ -825,6 +825,7 @@ public:
                         &old_metadata->root_offsets.arr_,
                         sizeof(metadata->root_offsets.arr_));
                     metadata->slow_fast_ratio = old_metadata->slow_fast_ratio;
+                    metadata->history_length = old_metadata->history_length;
                 });
                 fast_list_base_insertion_count =
                     old_metadata->fast_list_begin()->insertion_count();

--- a/libs/db/src/monad/mpt/db.cpp
+++ b/libs/db/src/monad/mpt/db.cpp
@@ -587,6 +587,10 @@ struct Db::RWOnDisk final : public Db::Impl
                        : Node::UniquePtr{};
         }())
     {
+        if (aux_.db_history_max_version() == INVALID_BLOCK_ID) {
+            // set history length on empty db
+            aux_.update_history_length_metadata(options.history_length);
+        }
     }
 
     ~RWOnDisk()
@@ -894,6 +898,11 @@ bool Db::is_read_only() const
 {
     MONAD_ASSERT(impl_);
     return is_on_disk() && impl_->aux().io->is_read_only();
+}
+
+uint64_t Db::get_history_length() const
+{
+    return is_on_disk() ? impl_->aux().version_history_length() : 1;
 }
 
 AsyncContext::AsyncContext(Db &db, size_t lru_size)

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -76,6 +76,7 @@ public:
     NodeCursor root() const noexcept;
     uint64_t get_latest_block_id() const;
     uint64_t get_earliest_block_id() const;
+    uint64_t get_history_length() const;
     // This function moves trie from source to destination version in db
     // history. Only the RWDb can call this API for state sync purposes.
     void move_trie_version_forward(uint64_t src, uint64_t dest);

--- a/libs/db/src/monad/mpt/ondisk_db_config.hpp
+++ b/libs/db/src/monad/mpt/ondisk_db_config.hpp
@@ -25,6 +25,7 @@ struct OnDiskDbConfig
     std::vector<std::filesystem::path> dbname_paths{};
     int64_t file_size_db{512}; // truncate files to this size
     unsigned concurrent_read_io_limit{1024};
+    uint64_t history_length{20000};
 };
 
 struct ReadOnlyOnDiskDbConfig

--- a/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
@@ -711,7 +711,7 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
         // check db maintain expected historical versions
         if (this->aux.is_on_disk()) {
             if (block_id - start_block_id <
-                UpdateAuxImpl::VERSION_HISTORY_LEN) {
+                this->aux.version_history_length()) {
                 EXPECT_EQ(
                     this->aux.db_history_max_version() -
                         this->aux.db_history_min_valid_version(),
@@ -721,7 +721,7 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
                 EXPECT_EQ(
                     this->aux.db_history_max_version() -
                         this->aux.db_history_min_valid_version(),
-                    UpdateAuxImpl::VERSION_HISTORY_LEN);
+                    this->aux.version_history_length());
             }
         }
     };

--- a/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
+++ b/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
@@ -14,6 +14,8 @@ namespace monad::test
     using namespace monad::mpt;
     using namespace monad::literals;
 
+    constexpr uint64_t MPT_TEST_HISTORY_LENGTH = 1000;
+
     struct DummyComputeLeafData
     {
         // TEMPORARY for POC
@@ -339,7 +341,7 @@ namespace monad::test
                   MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE))
             , io(pool, rwbuf)
             , root()
-            , aux(&io)
+            , aux(&io, MPT_TEST_HISTORY_LENGTH)
         {
         }
 
@@ -467,7 +469,9 @@ namespace monad::test
             MerkleCompute comp;
             Node::UniquePtr root;
             StateMachineAlwaysMerkle sm;
-            UpdateAux<LockType> aux{&io}; // trie section starts from account
+            UpdateAux<LockType> aux{
+                &io,
+                MPT_TEST_HISTORY_LENGTH}; // trie section starts from account
             monad::small_prng rand;
             std::vector<std::pair<monad::byte_string, size_t>> keys;
             uint64_t version{0};

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -435,6 +435,11 @@ uint64_t TrieDb::get_block_number() const
     return block_number_;
 }
 
+uint64_t TrieDb::get_history_length() const
+{
+    return db_.get_history_length();
+}
+
 void TrieDb::set_block_number(uint64_t const n)
 {
     block_number_ = n;

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -49,6 +49,7 @@ public:
     nlohmann::json to_json();
     size_t prefetch_current_root();
     uint64_t get_block_number() const;
+    uint64_t get_history_length() const;
 
     // for testing only
     std::pair<bytes32_t, bytes32_t>

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -22,7 +22,7 @@ MONAD_ANONYMOUS_NAMESPACE_BEGIN
 void on_commit(
     monad_statesync_server_context &ctx, StateDeltas const &state_deltas)
 {
-    MONAD_ASSERT(ctx.deleted.size() <= UpdateAuxImpl::VERSION_HISTORY_LEN);
+    MONAD_ASSERT(ctx.deleted.size() <= ctx.rw.get_history_length());
     auto const n = ctx.rw.get_block_number();
 
     Deleted::accessor it;
@@ -65,8 +65,8 @@ void on_commit(
         }
     }
 
-    if (MONAD_LIKELY(n >= UpdateAuxImpl::VERSION_HISTORY_LEN)) {
-        ctx.deleted.erase(n - UpdateAuxImpl::VERSION_HISTORY_LEN);
+    if (MONAD_LIKELY(n >= ctx.rw.get_history_length())) {
+        ctx.deleted.erase(n - ctx.rw.get_history_length());
     }
 }
 


### PR DESCRIPTION
History length was 1000 blocks which is too small for devnet and state sync. 
This pr increases history length (default to 1000, same as before) and allows user to initialize a db history length that is <= root offsets ring buffer capacity (65536).
It's the first step towards maintaining a dynamic history length that will be helpful for compaction.


Perf result:

> TPS Results:
> Replay 15000000->15100001: 7144
> https://jenkins.devcore4.com/job/replay_ethereum_manual/33/
> TPS Results:
> Replay 15000000->15100001: 6294
> https://jenkins.devcore4.com/job/replay_ethereum_manual/34/

both runs are on pr 806,
run 1 history_len = 1000, same as before, performance also remains the same
run 2 history_len = 20000. slower, could be of compaction variance. [Update: there are other benchmark results showing that more spread out the data and less free disk space impedes the performance.]

Without TRIM on peach9
20000: 8283 tps
1000: 8067 tps
