### PR TITLE
Fiber PR1: add the initial fiber interface

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(
   "src/monad/synchronization/spin_lock.hpp"
   # fiber
   "src/monad/fiber/config.hpp"
+  "src/monad/fiber/fiber.h"
   "src/monad/fiber/priority_algorithm.cpp"
   "src/monad/fiber/priority_algorithm.hpp"
   "src/monad/fiber/priority_pool.cpp"

--- a/libs/core/src/monad/fiber/fiber-api.md
+++ b/libs/core/src/monad/fiber/fiber-api.md
@@ -1,0 +1,258 @@
+# `monad_fiber` design notes
+
+## Goals and overview
+
+### An analogy to threads
+
+The design goal of the `monad_fiber` library can be explained via an
+analogy to the UNIX threading model. UNIX threads involve the following:
+
+- **Thread objects** - the POSIX `pthread` library allows an application
+  to explicitly create, start, and stop threads
+- **Synchronization objects (explicit coordination)** - `pthread` offers
+  synchronization primitives, such as `pthread_mutex_t`, that allow threads
+  to *explicitly* coordinate with each other
+- **I/O operations (implicit coordination)** - the kernel offers blocking
+  I/O routines such as `read(2)` and `write(2)`. These routines may start
+  long-running operations which cause a thread to yield the CPU and go to
+  sleep, allowing other threads to run. This allows threads to *implicitly*
+  coordinate
+- **Scheduling** - the kernel offers a thread scheduler, which is
+  responsible for deciding which threads will run on which CPUs; it also
+  communicates with the coordination mechanisms (the synchronization
+  primitives and the I/O subsystem) to know when it is time to "wake up"
+  a sleeping thread
+
+Needless to say, such a system is complex.
+
+### Simplicity: the goal of `monad_fiber`
+
+Fiber libraries are often full-fledged "frameworks", because they try to
+capture all the sophistication and features that an OS-level threading
+system has. The `monad_fiber` code makes an effort to be much simpler, and
+decidedly does not have many features. It is designed to do only what the
+downstream code needs at the current moment. It sacrifices being generic
+and extensible in favor of being simple, and thus (hopefully) easy to
+change as our internal needs change.
+
+`monad_fiber` offers three things:
+
+1. A fiber object, `monad_fiber_t`, that allows the creation and running
+   of fibers
+2. A small number of synchronization primitives; these are added (and
+   removed) as needed
+3. A trivial scheduling model, based on a thread-safe priority queue
+
+The coupling between the three parts is minimal, and occurs in only a few
+lines of code.
+
+There is no support for I/O operations. I/O-based voluntary context
+switching does exist within the monad codebase, but its scheduling needs
+and cooperation mechanism are completely different, so it is handled in a
+different part of the system.
+
+The implementation is meant to be clear; ideally a programmer can
+understand it fully without much trouble. Take this with a grain of salt
+though: context-switching code can be tricky, so understanding all the
+implementation details will require some time investment!
+
+### "Hello, world!" using fibers
+
+The following listing shows a "Hello, World!" example written in C that
+only uses a fiber object. This example contains no synchronization
+primitives and thus does not need any scheduling code (the fiber is
+run "manually"). The fiber prints a "Hello, World!" style message three
+times, suspending itself after each message is printed. After the last
+message, the fiber finishes.
+
+```.c
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sysexits.h>
+
+#include <monad/core/c_result.h>
+#include <monad/fiber/fiber.h>
+
+// This is the function that will run on the fiber
+monad_c_result say_hello_fiber_function(monad_fiber_args_t mfa)
+{
+    // The fiber greets you by your name, which is passed in as the fiber's
+    // first function argument
+    char const *const name = (char const *)mfa.arg[0];
+
+    // Say hello, then suspend the fiber
+    printf("Hello, %s!\n", name);
+    monad_fiber_yield(monad_c_make_success(0));
+
+    // When we reach here, we've been run again; we resume from the
+    // suspension point of the yield immediately above. We'll say hello
+    // again, then suspend again
+    printf("Welcome back, %s!\n", name);
+    monad_fiber_yield(monad_c_make_success(0));
+
+    // Resumed for the final time; say goodbye, then return. Returning from
+    // the fiber function suspends the fiber until it is given a new function
+    // to run
+    printf("Farewell, %s!\n", name);
+    return monad_c_make_success(0);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    monad_fiber_t *hello_fiber;
+    char const *name;
+    monad_fiber_attr_t const fiber_attr = {
+        .stack_size = 1UL << 17, // 128 KiB stack
+        .alloc = nullptr // Use the default allocator
+    };
+
+    // This application says hello to you using a fiber; it expects your name
+    // as the first (and only) positional argument
+    if (argc != 2) {
+        errx(EX_USAGE, "usage: %s <your-name>", argv[0]);
+    }
+    name = argv[1];
+
+    // Create the fiber, passing in our creation attributes
+    rc = monad_fiber_create(&fiber_attr, &hello_fiber);
+    if (rc != 0) {
+        errno = rc;
+        err(1, "monad_fiber_create failed");
+    }
+
+    // Tell the fiber what function to run; the second argument is
+    // the scheduling priority, which doesn't matter in this example;
+    // the last parameter is passed into the fiber function, as the
+    // argument. We pass a pointer to our name
+    rc = monad_fiber_set_function(
+        hello_fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        say_hello_fiber_function,
+        (monad_fiber_args_t){.arg = {(uintptr_t)name}});
+    assert(rc == 0);
+
+    // Run the fiber until the first suspension point; this will print
+    // "Hello, <name>!", suspend the fiber function, and then our call to
+    // monad_fiber_run will return. If nothing goes wrong, the return code
+    // will be 0. The second parameter (which is nullptr here) allows us to
+    // obtain information about why the fiber suspended; in this example we
+    // don't care, so we pass nullptr
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Run the fiber again, until it yields again; this will print
+    // "Welcome back, <name>!" and then yield back to us once more
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Run the fiber a final time. This will print "Farewell, <name>!" and then
+    // the fiber function will return. The return won't look much different to
+    // us than the yields above: the fiber will suspend and monad_fiber_run will
+    // return 0 to us, as before. The difference is, we can't run the fiber
+    // again. If, instead of passing nullptr as the second argument, we instead
+    // passed a pointer to a `monad_fiber_suspend_info_t`, we could get more
+    // information about the suspension. Namely, that it was a return and not a
+    // yield, and we could also read the `monad_c_result` return code. However,
+    // we don't care in this example.
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Try to run the fiber one more time; we can't do it since the fiber
+    // function returned, so this will fail and return the errno-domain error
+    // code ENXIO
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == ENXIO);
+
+    // At this point, we could reuse the fiber's resources to run the function
+    // a second time. To prepare for a second run, we would reset the function:
+    rc = monad_fiber_set_function(
+        hello_fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        say_hello_fiber_function,
+        (monad_fiber_args_t){.arg = {(uintptr_t)name}});
+    assert(rc == 0);
+
+    // However, that's enough for today; destroy the fiber and exit.
+    monad_fiber_destroy(hello_fiber);
+    return 0;
+}
+```
+
+## `monad_fiber_t` basic design
+
+### How to use `monad_fiber_t`
+
+A fiber is an execution resource for an ordinary function having this
+signature type:
+
+```.h
+typedef monad_c_result (monad_fiber_ffunc_t)(monad_fiber_args_t);
+```
+
+The fiber runs this function until the function decides to suspend itself,
+either by yielding, returning, or going to sleep on some synchronization
+condition that is not met yet (e.g., waiting for a semaphore to signal).
+When the fiber suspends, the current thread will begin executing the code
+for a different fiber. The suspended fiber may later be resumed, at which
+point execution continues at the point where it left off.
+
+#### Why `monad_fiber_args_t`?
+
+In conventional C programming, a user-provided function takes a single
+opaque argument for the user's private data. This usually has type
+`void *`, e.g., as in `pthread_create(3)`. Instead of doing this, fibers
+take an instance of this structure:
+
+```.h
+struct monad_fiber_args
+{
+    uintptr_t arg[MONAD_FIBER_MAX_ARGS];
+};
+```
+
+This design is meant to be friendlier to C++ clients of the C library.
+C++ has stronger idiomatic use of value types than C does, e.g., types
+like `std::string_view` or `std::span<double>`. Because C programs use
+value semantics more sparsely, the natural number of function parameters
+is usually just one: you either have a fundamental type, or you pass a
+pointer to a more complex type.
+
+For C++, there are many useful, value-like types that are the size of two
+or three pointers. Forcing these to be located at a stable memory address
+just so a memory reference to them can be passed around can be burdensome.
+For example, even though a `std::string_view` points to stable,
+externally-managed memory, the `std::string_view` object itself is usually
+a stack-allocated value type. It is an ephemeral object without a stable
+address.
+
+The solution chosen here is to wrap a small set of opaque arguments into
+a C value type, which is nonetheless small enough to be passed in registers
+after it is disaggregated into scalars during optimization.
+
+#### Running and suspending fibers
+
+Most of the implementation can be understood by thinking about exactly
+how and when a fiber performs a context switch. The model we follow is:
+
+- A fiber is started or resumed by calling the `monad_fiber_run`
+  function, passing in the `monad_fiber_t*` describing the fiber that the
+  user wants to run; that is, the context that _calls_ `monad_fiber_run`
+  will switch into the given fiber and begin (or resume) running its
+  associated function
+
+- When a fiber suspends or returns, it jumps back to the context that
+  was executing previously. This is the context that was running the code
+  for `monad_fiber_run` in the first place, so the suspension of a fiber
+  appears to the caller of `monad_fiber_run` as the `monad_fiber_run`
+  function call returning back to them
+
+- Consequently, the function that calls `monad_fiber_run` is always
+  a lightweight scheduler: it decides to run fibers somehow, and typically
+  calls `monad_fiber_run` in a loop, with the sequence of fibers it
+  wishes to run

--- a/libs/core/src/monad/fiber/fiber.h
+++ b/libs/core/src/monad/fiber/fiber.h
@@ -1,0 +1,105 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * This file defines the interface for our lightweight fiber library
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <monad/core/c_result.h>
+#include <monad/mem/cma/cma_alloc.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct monad_fiber monad_fiber_t;
+typedef struct monad_fiber_args monad_fiber_args_t;
+typedef struct monad_fiber_attr monad_fiber_attr_t;
+typedef struct monad_fiber_suspend_info monad_fiber_suspend_info_t;
+
+typedef monad_c_result(monad_fiber_ffunc_t)(monad_fiber_args_t);
+typedef int64_t monad_fiber_prio_t;
+
+// TODO(ken): https://github.com/monad-crypto/monad-internal/issues/498
+static monad_fiber_prio_t const MONAD_FIBER_PRIO_HIGHEST = INT64_MIN;
+static monad_fiber_prio_t const MONAD_FIBER_PRIO_LOWEST = INT64_MAX - 1;
+static monad_fiber_prio_t const MONAD_FIBER_PRIO_NO_CHANGE = INT64_MAX;
+
+#define MONAD_FIBER_MAX_ARGS (4)
+
+enum monad_fiber_suspend_type : unsigned
+{
+    MF_SUSPEND_NONE,
+    MF_SUSPEND_YIELD,
+    MF_SUSPEND_SLEEP,
+    MF_SUSPEND_RETURN
+};
+
+/// When a fiber is suspended, monad_fiber_run will fill out one of these
+/// structures to describe the reason for the suspension
+struct monad_fiber_suspend_info
+{
+    enum monad_fiber_suspend_type suspend_type; ///< Reason for last suspension
+    monad_c_result eval; ///< Value (for YIELD / RETURN)
+};
+
+/// Opaque arguments are passed into fiber functions using this structure
+struct monad_fiber_args
+{
+    uintptr_t arg[MONAD_FIBER_MAX_ARGS];
+};
+
+/// Creation attributes for monad_fiber_create
+struct monad_fiber_attr
+{
+    size_t stack_size; ///< Size of fiber stack
+    monad_allocator_t *alloc; ///< Allocator used for the monad_fiber_t object
+};
+
+/*
+ * Public interface: functions that are called by users of the library
+ */
+
+/// Create a fiber, given a description of its attributes (if nullptr is passed,
+/// the default attributes will be used)
+int monad_fiber_create(
+    monad_fiber_attr_t const *create_attr, monad_fiber_t **fiber);
+
+/// Destroy a fiber previously created with monad_fiber_create
+void monad_fiber_destroy(monad_fiber_t *fiber);
+
+/// Set the function that the fiber will run; this may be called multiple times,
+/// to reuse the fiber's resources (e.g., its stack) to run new functions
+int monad_fiber_set_function(
+    monad_fiber_t *fiber, monad_fiber_prio_t priority,
+    monad_fiber_ffunc_t *ffunc, monad_fiber_args_t fargs);
+
+/// Returns the structure representing the currently executing fiber; returns
+/// nullptr if the current execution context is not a fiber, i.e., if it is an
+/// ordinary thread
+static monad_fiber_t *monad_fiber_self();
+
+/// Begin running a fiber's function on the calling thread, or resume that
+/// function at the suspension point, if it was suspended; this call returns the
+/// next time the function suspends, and populates @ref suspend_info with info
+/// about that suspension
+static int monad_fiber_run(
+    monad_fiber_t *next_fiber, monad_fiber_suspend_info_t *suspend_info);
+
+/// Similar to sched_yield(2) or pthread_yield_np(3), but for fibers: yields
+/// from the currently-running fiber back to the previously-running fiber
+static void monad_fiber_yield(monad_c_result eval);
+
+struct monad_fiber
+{
+    monad_fiber_prio_t priority; ///< Scheduling priority
+};
+
+#if __cplusplus
+} // extern "C"
+#endif

--- a/libs/core/test/CMakeLists.txt
+++ b/libs/core/test/CMakeLists.txt
@@ -24,3 +24,10 @@ target_compile_definitions(
   PRIVATE MONAD_SPINLOCK_TRACK_OWNER_INFO MONAD_SPINLOCK_TRACK_STATS
           MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
 monad_add_test(unordered_map_test "unordered_map.cpp")
+
+# Ensure the API demo described in fiber-api.md compiles
+if(0) # Still for exposition only, compiles but does not link
+  add_executable(fiber-hello fiber-hello.c)
+  monad_compile_options(fiber-hello)
+  target_link_libraries(fiber-hello PRIVATE monad_core)
+endif()

--- a/libs/core/test/fiber-hello.c
+++ b/libs/core/test/fiber-hello.c
@@ -1,0 +1,116 @@
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sysexits.h>
+
+#include <monad/core/c_result.h>
+#include <monad/fiber/fiber.h>
+
+// This is the function that will run on the fiber
+monad_c_result say_hello_fiber_function(monad_fiber_args_t mfa)
+{
+    // The fiber greets you by your name, which is passed in as the fiber's
+    // first function argument
+    char const *const name = (char const *)mfa.arg[0];
+
+    // Say hello, then suspend the fiber
+    printf("Hello, %s!\n", name);
+    monad_fiber_yield(monad_c_make_success(0));
+
+    // When we reach here, we've been run again; we resume from the
+    // suspension point of the yield immediately above. We'll say hello
+    // again, then suspend again
+    printf("Welcome back, %s!\n", name);
+    monad_fiber_yield(monad_c_make_success(0));
+
+    // Resumed for the final time; say goodbye, then return. Returning from
+    // the fiber function suspends the fiber until it is given a new function
+    // to run
+    printf("Farewell, %s!\n", name);
+    return monad_c_make_success(0);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    monad_fiber_t *hello_fiber;
+    char const *name;
+    monad_fiber_attr_t const fiber_attr = {
+        .stack_size = 1UL << 17, // 128 KiB stack
+        .alloc = nullptr // Use the default allocator
+    };
+
+    // This application says hello to you using a fiber; it expects your name
+    // as the first (and only) positional argument
+    if (argc != 2) {
+        errx(EX_USAGE, "usage: %s <your-name>", argv[0]);
+    }
+    name = argv[1];
+
+    // Create the fiber, passing in our creation attributes
+    rc = monad_fiber_create(&fiber_attr, &hello_fiber);
+    if (rc != 0) {
+        errno = rc;
+        err(1, "monad_fiber_create failed");
+    }
+
+    // Tell the fiber what function to run; the second argument is
+    // the scheduling priority, which doesn't matter in this example;
+    // the last parameter is passed into the fiber function, as the
+    // argument. We pass a pointer to our name
+    rc = monad_fiber_set_function(
+        hello_fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        say_hello_fiber_function,
+        (monad_fiber_args_t){.arg = {(uintptr_t)name}});
+    assert(rc == 0);
+
+    // Run the fiber until the first suspension point; this will print
+    // "Hello, <name>!", suspend the fiber function, and then our call to
+    // monad_fiber_run will return. If nothing goes wrong, the return code
+    // will be 0. The second parameter (which is nullptr here) allows us to
+    // obtain information about why the fiber suspended; in this example we
+    // don't care, so we pass nullptr
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Run the fiber again, until it yields again; this will print
+    // "Welcome back, <name>!" and then yield back to us once more
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Run the fiber a final time. This will print "Farewell, <name>!" and then
+    // the fiber function will return. The return won't look much different to
+    // us than the yields above: the fiber will suspend and monad_fiber_run will
+    // return 0 to us, as before. The difference is, we can't run the fiber
+    // again. If, instead of passing nullptr as the second argument, we instead
+    // passed a pointer to a `monad_fiber_suspend_info_t`, we could get more
+    // information about the suspension. Namely, that it was a return and not a
+    // yield, and we could also read the `monad_c_result` return code. However,
+    // we don't care in this example.
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == 0);
+
+    // Try to run the fiber one more time; we can't do it since the fiber
+    // function returned, so this will fail and return the errno-domain error
+    // code ENXIO
+    rc = monad_fiber_run(hello_fiber, nullptr);
+    assert(rc == ENXIO);
+
+    // At this point, we could reuse the fiber's resources to run the function
+    // a second time. To prepare for a second run, we would reset the function:
+    rc = monad_fiber_set_function(
+        hello_fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        say_hello_fiber_function,
+        (monad_fiber_args_t){.arg = {(uintptr_t)name}});
+    assert(rc == 0);
+
+    // However, that's enough for today; destroy the fiber and exit.
+    monad_fiber_destroy(hello_fiber);
+    return 0;
+}


### PR DESCRIPTION
To focus reviewers on the interface alone (and to simplify the review process) this PR only contains the user-facing interface for creating and running and fibers. This is enough to write a tiny example that shows the "create and run" part of the fiber API, which compiles without error (all operations are defined) but does not link (none are implemented)

The PR contains:

- A markdown file containing some high-level documentation, and an explanation of the "simpler is better" design philosophy followed by the changeset. This is in `fiber-api.md`
- A minimal "Hello, World!" style application using fibers, in `fiber-hello.c`. A code listing of this example also appears in `fiber-api.md`. It compiles, but does not link or run, because the fiber implementation is not included in this PR
- The full public interface for a fiber, in the `fiber.h` file. This is similar to header in it's final form, but removes everything not needed for `fiber-hello.c` to compile

## Potential points of reviewer interest

### Keeping of `monad_fiber_suspend_info_t`

In this API, fibers can finish the function they are running, and return. The ultimate downstream user of this code, `priority_pool.{hpp,cpp}`, does not need this: it runs a work-stealing function in an infinite loop. @jhunsaker originally thought the ability to return was overly general, but I thought it was a reasonable thing to have that would introduce some loose coupling without adding much complexity. At the time, I had some intuition that this was true but no experience. Having done the full implementation, I am more confident that this is useful, since it proved to be the natural way of porting all the existing unit tests, and in adding new ones.