### PR TITLE
[core] Enhance the spinlock type, used extensively in the fiber implementation

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -7,8 +7,25 @@ project(monad_core LANGUAGES C CXX ASM)
 
 option(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(_monad_spinlock_track_owner_info ON)
+  set(_monad_spinlock_track_stats ON)
+else()
+  set(_monad_spinlock_track_owner_info OFF)
+  set(_monad_spinlock_track_stats OFF)
+endif()
+
 option(MONAD_CORE_FORCE_DEBUG_ASSERT
        "Enable MONAD_DEBUG_ASSERT in any build mode" OFF)
+
+option(MONAD_CORE_SPINLOCK_TRACK_OWNER_INFO
+       "enable source location of owner in spinlocks"
+       ${_monad_spinlock_track_owner_info})
+option(MONAD_CORE_SPINLOCK_TRACK_STATS
+       "enable contention statistics tracking of spinlocks"
+       ${_monad_spinlock_track_stats})
+option(MONAD_CORE_SPINLOCK_TRACK_STATS_ATOMIC
+       "use fetch_add on atomics statistics tracking" OFF)
 
 # ##############################################################################
 # deps
@@ -86,7 +103,6 @@ add_library(
   "src/monad/core/cmemory.hpp"
   "src/monad/core/cleanup.h"
   "src/monad/core/cleanup.c"
-  "src/monad/core/cpu_relax.h"
   "src/monad/core/endian.hpp"
   "src/monad/core/hash.hpp"
   "src/monad/core/hex_literal.hpp"
@@ -101,6 +117,9 @@ add_library(
   "src/monad/core/size_of.hpp"
   "src/monad/core/small_prng.hpp"
   "src/monad/core/spinlock.h"
+  "src/monad/core/spinloop.h"
+  "src/monad/core/srcloc.h"
+  "src/monad/core/srcloc.hpp"
   "src/monad/core/tl_tid.c"
   "src/monad/core/tl_tid.h"
   "src/monad/core/unaligned.hpp"
@@ -158,6 +177,19 @@ target_include_directories(monad_core PUBLIC "src")
 
 if(MONAD_CORE_FORCE_DEBUG_ASSERT)
   target_compile_definitions(monad_core PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT")
+endif()
+
+if(MONAD_CORE_SPINLOCK_TRACK_OWNER_INFO)
+  target_compile_definitions(monad_core PUBLIC MONAD_SPINLOCK_TRACK_OWNER_INFO)
+endif()
+
+if(MONAD_CORE_SPINLOCK_TRACK_STATS)
+  target_compile_definitions(monad_core PUBLIC MONAD_SPINLOCK_TRACK_STATS)
+endif()
+
+if(MONAD_CORE_SPINLOCK_TRACK_STATS_ATOMIC)
+  target_compile_definitions(monad_core
+                             PUBLIC MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
 endif()
 
 target_compile_definitions(monad_core PRIVATE "BOOST_STACKTRACE_LINK=1")

--- a/libs/core/src/monad/core/cpu_relax.h
+++ b/libs/core/src/monad/core/cpu_relax.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#ifdef __x86_64__
-    #define cpu_relax() __builtin_ia32_pause();
-#else
-    #error unsupported arch
-#endif

--- a/libs/core/src/monad/core/spinlock.h
+++ b/libs/core/src/monad/core/spinlock.h
@@ -16,6 +16,10 @@
 #include <stddef.h>
 #include <string.h>
 
+#ifdef __cplusplus
+    #include <new>
+#endif
+
 static_assert(ATOMIC_INT_LOCK_FREE == 2);
 
 typedef struct monad_spinlock monad_spinlock_t;

--- a/libs/core/src/monad/core/spinlock.h
+++ b/libs/core/src/monad/core/spinlock.h
@@ -1,63 +1,185 @@
 #pragma once
 
-#include <monad/core/cpu_relax.h>
+#include <monad/core/assert.h>
 #include <monad/core/likely.h>
+#include <monad/core/spinloop.h>
 #include <monad/core/tl_tid.h>
+
+#if MONAD_SPINLOCK_TRACK_OWNER_INFO
+    #include <monad/core/srcloc.h>
+#endif
 
 #include <assert.h>
 #include <stdatomic.h>
+#include <stdbit.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
 
 static_assert(ATOMIC_INT_LOCK_FREE == 2);
 
-typedef atomic_int spinlock_t;
+typedef struct monad_spinlock monad_spinlock_t;
 
-static inline void spinlock_init(spinlock_t *const lock)
+#if MONAD_SPINLOCK_TRACK_STATS_ATOMIC
+typedef atomic_ulong monad_spinstat_t;
+    #define MONAD_SPINSTAT_INC(X) atomic_fetch_add(&(X), 1)
+#else
+typedef unsigned long monad_spinstat_t;
+    #define MONAD_SPINSTAT_INC(X) ++(X)
+#endif
+
+// TODO(ken): remove this workaround when we have clang-19
+#if defined(__clang__) && __clang_major__ < 19
+    #define MONAD_SPINLOCK_HIST_BUCKETS 15
+#else
+constexpr size_t MONAD_SPINLOCK_HIST_BUCKETS = 15;
+#endif
+
+// clang-format off
+/// Lock statistics; these may not be 100% accurate, since we may not be
+/// atomically incrementing them (some data could be lost)
+struct monad_spinlock_stats
 {
-    atomic_init(lock, 0);
+    monad_spinstat_t total_try_locks;      ///< # times try_lock is called
+    monad_spinstat_t total_try_lock_fail;  ///< # times try_lock failed
+    monad_spinstat_t total_locks;          ///< # times lock is called
+    monad_spinstat_t total_lock_init_fail; ///< # times lock needed > 1 try
+    monad_spinstat_t
+        tries_histogram[MONAD_SPINLOCK_HIST_BUCKETS + 1]; /// lock tries histo
+};
+
+// clang-format on
+
+struct monad_spinlock
+{
+    atomic_int owner_tid; ///< System ID of thread that owns lock
+#if MONAD_SPINLOCK_TRACK_STATS
+    struct monad_spinlock_stats stats; ///< Lock contention stats
+#endif
+#if MONAD_SPINLOCK_TRACK_OWNER_INFO
+    monad_source_location_t srcloc; ///< Location in code where lock taken
+#endif
+};
+
+static inline bool monad_spinlock_is_owned(monad_spinlock_t *const lock)
+{
+    return atomic_load_explicit(&lock->owner_tid, memory_order_acquire) ==
+           get_tl_tid();
 }
 
-static inline bool spinlock_try_lock(spinlock_t *const lock)
+static inline bool monad_spinlock_is_unowned(monad_spinlock_t *const lock)
+{
+    return atomic_load_explicit(&lock->owner_tid, memory_order_acquire) == 0;
+}
+
+static inline void monad_spinlock_init(monad_spinlock_t *const lock)
+{
+    lock->owner_tid = 0;
+#if MONAD_SPINLOCK_TRACK_OWNER_INFO
+    memset(&lock->srcloc, 0, sizeof lock->srcloc);
+#endif
+#if MONAD_SPINLOCK_TRACK_STATS
+    #ifdef __cplusplus
+    new (&lock->stats) monad_spinlock_stats{};
+    #else
+    memset(&lock->stats, 0, sizeof lock->stats);
+    #endif
+#endif
+}
+
+static inline bool monad_spinlock_try_lock(monad_spinlock_t *const lock)
 {
     int expected = 0;
     int const desired = get_tl_tid();
-    return atomic_compare_exchange_weak_explicit(
-        lock, &expected, desired, memory_order_acquire, memory_order_relaxed);
+    bool const is_locked = atomic_compare_exchange_weak_explicit(
+        &lock->owner_tid,
+        &expected,
+        desired,
+        memory_order_acquire,
+        memory_order_relaxed);
+#if MONAD_SPINLOCK_TRACK_STATS
+    MONAD_SPINSTAT_INC(lock->stats.total_try_locks);
+    if (MONAD_UNLIKELY(!is_locked)) {
+        MONAD_SPINSTAT_INC(lock->stats.total_try_lock_fail);
+    }
+#endif
+    return is_locked;
 }
 
-static inline void spinlock_lock(spinlock_t *const lock)
+static inline void monad_spinlock_lock(monad_spinlock_t *const lock)
 {
     int const desired = get_tl_tid();
-    for (;;) {
-        /**
-         * TODO further analysis of retry logic
-         * - if weak cmpxch fails, spin again or cpu relax?
-         * - compare intel vs arm
-         * - benchmark with real use cases
-        */
-        unsigned retries = 0;
-        while (
-            MONAD_UNLIKELY(atomic_load_explicit(lock, memory_order_relaxed))) {
-            if (MONAD_LIKELY(retries < 128)) {
-                ++retries;
-            }
-            else {
-                cpu_relax();
-            }
-        }
-        int expected = 0;
-        if (MONAD_LIKELY(atomic_compare_exchange_weak_explicit(
-                lock,
-                &expected,
-                desired,
-                memory_order_acquire,
-                memory_order_relaxed))) {
-            break;
-        }
+    int expected;
+    bool owned;
+    [[maybe_unused]] unsigned long tries = 0;
+    [[maybe_unused]] unsigned histo_bucket;
+
+    MONAD_DEBUG_ASSERT(!monad_spinlock_is_owned(lock));
+
+TryAgain:
+    expected = 0;
+    owned = atomic_compare_exchange_weak_explicit(
+        &lock->owner_tid,
+        &expected,
+        desired,
+        memory_order_acquire,
+        memory_order_relaxed);
+    if (MONAD_UNLIKELY(!owned)) {
+        monad_spinloop_hint();
+#if MONAD_SPINLOCK_TRACK_STATS
+        ++tries;
+#endif
+        goto TryAgain;
     }
+
+#if MONAD_SPINLOCK_TRACK_STATS
+    MONAD_SPINSTAT_INC(lock->stats.total_locks);
+    if (MONAD_LIKELY(tries > 1)) {
+        MONAD_SPINSTAT_INC(lock->stats.total_lock_init_fail);
+    }
+    histo_bucket = stdc_bit_width(tries - 1);
+    if (MONAD_UNLIKELY(histo_bucket >= MONAD_SPINLOCK_HIST_BUCKETS)) {
+        histo_bucket = MONAD_SPINLOCK_HIST_BUCKETS;
+    }
+    MONAD_SPINSTAT_INC(lock->stats.tries_histogram[histo_bucket]);
+#endif
 }
 
-static inline void spinlock_unlock(spinlock_t *const lock)
+static inline void monad_spinlock_unlock(monad_spinlock_t *const lock)
 {
-    atomic_store_explicit(lock, 0, memory_order_release);
+    MONAD_DEBUG_ASSERT(monad_spinlock_is_owned(lock));
+    atomic_store_explicit(&lock->owner_tid, 0, memory_order_release);
 }
+
+#if MONAD_SPINLOCK_TRACK_OWNER_INFO
+static inline bool monad_spinlock_try_lock_with_srcloc(
+    monad_spinlock_t *const lock, monad_source_location_t srcloc)
+{
+    bool const have_lock = monad_spinlock_try_lock(lock);
+    if (have_lock) {
+        lock->srcloc = srcloc;
+    }
+    return have_lock;
+}
+
+static inline void monad_spinlock_lock_with_srcloc(
+    monad_spinlock_t *const lock, monad_source_location_t srcloc)
+{
+    monad_spinlock_lock(lock);
+    lock->srcloc = srcloc;
+}
+
+    #define MONAD_SPINLOCK_TRY_LOCK(LCK)                                       \
+        monad_spinlock_try_lock_with_srcloc(                                   \
+            (LCK), MONAD_SOURCE_LOCATION_CURRENT())
+
+    #define MONAD_SPINLOCK_LOCK(LCK)                                           \
+        monad_spinlock_lock_with_srcloc((LCK), MONAD_SOURCE_LOCATION_CURRENT())
+#else
+
+    #define MONAD_SPINLOCK_TRY_LOCK(LCK) monad_spinlock_try_lock((LCK))
+    #define MONAD_SPINLOCK_LOCK(LCK) monad_spinlock_lock((LCK))
+
+#endif
+
+#define MONAD_SPINLOCK_UNLOCK(LCK) monad_spinlock_unlock((LCK))

--- a/libs/core/src/monad/core/spinlock.h
+++ b/libs/core/src/monad/core/spinlock.h
@@ -38,12 +38,7 @@ typedef struct monad_spinlock monad_spinlock_t;
     #define MONAD_SPINSTAT_INC(X)
 #endif
 
-// TODO(ken): remove this workaround when we have clang-19
-#if defined(__clang__) && __clang_major__ < 19
-    #define MONAD_SPINLOCK_HIST_BUCKETS 15
-#else
-constexpr size_t MONAD_SPINLOCK_HIST_BUCKETS = 15;
-#endif
+#define MONAD_SPINLOCK_HIST_BUCKETS 15
 
 // clang-format off
 /// Lock statistics; these may not be 100% accurate, since we may not be

--- a/libs/core/src/monad/core/spinlock_disas.c
+++ b/libs/core/src/monad/core/spinlock_disas.c
@@ -1,21 +1,21 @@
 #include <monad/core/spinlock.h>
 
-void spinlock_init_disas(spinlock_t *const lock)
+void spinlock_init_disas(monad_spinlock_t *const lock)
 {
-    spinlock_init(lock);
+    monad_spinlock_init(lock);
 }
 
-bool spinlock_try_lock_disas(spinlock_t *const lock)
+bool spinlock_try_lock_disas(monad_spinlock_t *const lock)
 {
-    return spinlock_try_lock(lock);
+    return monad_spinlock_try_lock(lock);
 }
 
-void spinlock_lock_disas(spinlock_t *const lock)
+void spinlock_lock_disas(monad_spinlock_t *const lock)
 {
-    spinlock_lock(lock);
+    monad_spinlock_lock(lock);
 }
 
-void spinlock_unlock_disas(spinlock_t *const lock)
+void spinlock_unlock_disas(monad_spinlock_t *const lock)
 {
-    spinlock_unlock(lock);
+    monad_spinlock_unlock(lock);
 }

--- a/libs/core/src/monad/core/spinloop.h
+++ b/libs/core/src/monad/core/spinloop.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * This file defines an architecture-dependent macro to accelerate the
+ * performance of code containing spin loops. These are used in the spinlock
+ * implementation, but should appear in any kind of tight atomic
+ * synchronization loop.
+ *
+ * A surface-level explanation of what these intrinsics do can be found in
+ * the description of the PAUSE instruction in the Intel Developers Manual,
+ * Volume 2B. A more detailed explanation of why these are needed can be found
+ * here:
+ *
+ *   https://stackoverflow.com/questions/12894078/what-is-the-purpose-of-the-pause-instruction-in-x86
+ */
+
+#ifdef __x86_64__
+    #define monad_spinloop_hint() __builtin_ia32_pause()
+#elif __aarch64__
+    // Per Linux arch/arm64/include/asm/processor.h
+    #define monad_spinloop_hint() asm volatile("yield" ::: "memory")
+#else
+    #define monad_spinloop_hint()
+    #warning this CPU type should define monad_spinloop_hint()
+#endif

--- a/libs/core/src/monad/core/srcloc.h
+++ b/libs/core/src/monad/core/srcloc.h
@@ -1,0 +1,17 @@
+#pragma once
+
+typedef struct monad_source_location monad_source_location_t;
+
+/// A pure C structure compatible with C++20's std::source_location
+struct monad_source_location
+{
+    char const *function_name;
+    char const *file_name;
+    unsigned line;
+    unsigned column;
+};
+
+/// Creates a compound literal of the current source location for use in a
+/// macro, similar to the C++20 consteval std::source_location::current()
+#define MONAD_SOURCE_LOCATION_CURRENT()                                        \
+    ((monad_source_location_t){__PRETTY_FUNCTION__, __FILE__, __LINE__, 0})

--- a/libs/core/src/monad/core/srcloc.h
+++ b/libs/core/src/monad/core/srcloc.h
@@ -2,7 +2,7 @@
 
 typedef struct monad_source_location monad_source_location_t;
 
-/// A pure C structure compatible with C++20's std::source_location
+/// A pure C structure similar to C++20's std::source_location
 struct monad_source_location
 {
     char const *function_name;

--- a/libs/core/src/monad/core/srcloc.hpp
+++ b/libs/core/src/monad/core/srcloc.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <monad/config.hpp>
+#include <monad/core/srcloc.h>
+#include <source_location>
+
+MONAD_NAMESPACE_BEGIN
+
+constexpr monad_source_location_t make_srcloc(std::source_location const &s)
+{
+    return monad_source_location_t{
+        .function_name = s.function_name(),
+        .file_name = s.file_name(),
+        .line = s.line(),
+        .column = s.column()};
+}
+
+MONAD_NAMESPACE_END

--- a/libs/core/test/CMakeLists.txt
+++ b/libs/core/test/CMakeLists.txt
@@ -22,4 +22,6 @@ target_compile_definitions(
   spinlock_all_options_test
   PRIVATE MONAD_SPINLOCK_TRACK_OWNER_INFO MONAD_SPINLOCK_TRACK_STATS
           MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
+set_tests_properties(spinlock_test spinlock_all_options_test
+                     PROPERTIES RUN_SERIAL TRUE)
 monad_add_test(unordered_map_test "unordered_map.cpp")

--- a/libs/core/test/CMakeLists.txt
+++ b/libs/core/test/CMakeLists.txt
@@ -16,4 +16,10 @@ monad_add_test(io_buffers_test "io_buffers.cpp")
 monad_add_test(literal_test "literal_test.cpp")
 monad_add_test(priority_pool_test "priority_pool_test.cpp")
 set_tests_properties(priority_pool_test PROPERTIES RUN_SERIAL TRUE)
+monad_add_test(spinlock_test "spinlock.cpp")
+monad_add_test(spinlock_all_options_test "spinlock.cpp")
+target_compile_definitions(
+  spinlock_all_options_test
+  PRIVATE MONAD_SPINLOCK_TRACK_OWNER_INFO MONAD_SPINLOCK_TRACK_STATS
+          MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
 monad_add_test(unordered_map_test "unordered_map.cpp")

--- a/libs/core/test/spinlock.cpp
+++ b/libs/core/test/spinlock.cpp
@@ -1,0 +1,82 @@
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <monad/core/spinlock.h>
+
+struct shared_state
+{
+    monad_spinlock_t lock;
+    unsigned counter;
+    unsigned odd_count;
+    unsigned even_count;
+};
+
+#if NDEBUG
+constexpr unsigned ITER_MAX = 1 << 22;
+#else
+constexpr unsigned ITER_MAX = 1 << 20;
+#endif
+
+static void thread_function(shared_state &s)
+{
+    while (true) {
+        MONAD_SPINLOCK_LOCK(&s.lock);
+        ASSERT_TRUE(monad_spinlock_is_owned(&s.lock));
+        if (s.counter == ITER_MAX) [[unlikely]] {
+            MONAD_SPINLOCK_UNLOCK(&s.lock);
+            return;
+        }
+        if (s.counter % 2 == 0) {
+            ++s.counter;
+            ++s.odd_count;
+        }
+        MONAD_SPINLOCK_UNLOCK(&s.lock);
+    }
+}
+
+// A basic test of the spinlock, where two threads fight for the lock. This
+// deliberately does not use std::this_thread::yield(), so that more lock
+// contention is caused. This allows it to double as a performance test, but
+// the statistics are not stable unless ITER_MAX is set to a higher number
+// (normally we don't want to wait that long in the test suite)
+TEST(spinlock, basic)
+{
+    shared_state s{};
+    bool done;
+    monad_spinlock_init(&s.lock);
+    ASSERT_TRUE(monad_spinlock_is_unowned(&s.lock));
+
+    auto const start_time = std::chrono::system_clock::now();
+    std::thread thr{thread_function, std::ref(s)};
+    do {
+        MONAD_SPINLOCK_LOCK(&s.lock);
+        ASSERT_TRUE(monad_spinlock_is_owned(&s.lock));
+        if (s.counter % 2 == 1) {
+            ++s.counter;
+            ++s.even_count;
+        }
+        done = s.counter == ITER_MAX;
+        MONAD_SPINLOCK_UNLOCK(&s.lock);
+    }
+    while (!done);
+    auto const end_time = std::chrono::system_clock::now();
+
+    thr.join();
+    ASSERT_EQ(s.counter / 2, s.odd_count);
+    ASSERT_EQ(s.counter / 2, s.even_count);
+
+    // Average time it takes for the odd or even thread to make its update.
+    // This is essentially a measure of lock contention.
+    auto const avg_cycle_time =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            end_time - start_time)
+            .count() /
+        s.counter;
+    std::fprintf(
+        stdout,
+        "avg. cycle time: %lu\n",
+        static_cast<unsigned long>(avg_cycle_time));
+}

--- a/libs/core/test/spinlock.cpp
+++ b/libs/core/test/spinlock.cpp
@@ -1,79 +1,199 @@
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
+#include <functional>
+#include <latch>
+#include <numeric>
 #include <thread>
+#include <vector>
+
+#include <pthread.h>
+#include <sched.h>
 
 #include <gtest/gtest.h>
 
+#include <monad/core/assert.h>
 #include <monad/core/spinlock.h>
+#include <monad/core/spinloop.h>
+
+constexpr unsigned NUM_THREADS = 4;
 
 struct shared_state
 {
-    monad_spinlock_t lock;
-    unsigned counter;
-    unsigned odd_count;
-    unsigned even_count;
+    alignas(64) monad_spinlock_t lock;
+    uint64_t counter;
+    uint64_t thread_count[NUM_THREADS];
+    alignas(64) std::atomic<unsigned> done;
 };
 
 #if NDEBUG
 constexpr unsigned ITER_MAX = 1 << 22;
 #else
-constexpr unsigned ITER_MAX = 1 << 20;
+constexpr unsigned ITER_MAX = 1 << 18;
 #endif
 
-static void thread_function(shared_state &s)
+static void
+lock_thread_function(shared_state &s, unsigned value, std::latch &latch)
 {
+    latch.arrive_and_wait();
     while (true) {
         MONAD_SPINLOCK_LOCK(&s.lock);
-        ASSERT_TRUE(monad_spinlock_is_owned(&s.lock));
+        ASSERT_TRUE(monad_spinlock_is_self_owned(&s.lock));
         if (s.counter == ITER_MAX) [[unlikely]] {
             MONAD_SPINLOCK_UNLOCK(&s.lock);
+            s.done.fetch_add(1);
             return;
         }
-        if (s.counter % 2 == 0) {
+        if (s.counter % NUM_THREADS == value) {
             ++s.counter;
-            ++s.odd_count;
+            ++s.thread_count[value];
         }
         MONAD_SPINLOCK_UNLOCK(&s.lock);
+    }
+}
+
+static void
+try_lock_thread_function(shared_state &s, unsigned value, std::latch &latch)
+{
+    latch.arrive_and_wait();
+    while (true) {
+        while (!MONAD_SPINLOCK_TRY_LOCK(&s.lock)) {
+            monad_spinloop_hint();
+        }
+        ASSERT_TRUE(monad_spinlock_is_self_owned(&s.lock));
+        if (s.counter == ITER_MAX) [[unlikely]] {
+            MONAD_SPINLOCK_UNLOCK(&s.lock);
+            s.done.fetch_add(1);
+            return;
+        }
+        if (s.counter % NUM_THREADS == value) {
+            ++s.counter;
+            ++s.thread_count[value];
+        }
+        MONAD_SPINLOCK_UNLOCK(&s.lock);
+    }
+}
+
+static int alloc_next_free_cpu(cpu_set_t *cpus, int start)
+{
+    for (int i = start; i < CPU_SETSIZE; ++i) {
+        if (CPU_ISSET(i, cpus)) {
+            CPU_CLR(i, cpus);
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void pin_threads_to_cores(std::vector<std::thread> &threads)
+{
+    cpu_set_t proc_affinity;
+    cpu_set_t free_cpus;
+    ASSERT_EQ(0, sched_getaffinity(0, sizeof proc_affinity, &proc_affinity));
+    ASSERT_LT(NUM_THREADS, CPU_COUNT(&proc_affinity));
+
+    CPU_ZERO(&free_cpus);
+    CPU_OR(&free_cpus, &proc_affinity, &free_cpus);
+
+    int cpu_id = 1;
+    for (std::thread &thr : threads) {
+        cpu_set_t thread_set;
+        CPU_ZERO(&thread_set);
+        cpu_id = alloc_next_free_cpu(&free_cpus, cpu_id);
+        MONAD_ASSERT(cpu_id != -1);
+        CPU_SET(cpu_id++, &thread_set);
+        ASSERT_EQ(
+            0,
+            pthread_setaffinity_np(
+                thr.native_handle(), sizeof thread_set, &thread_set));
     }
 }
 
 // A basic test of the spinlock, where two threads fight for the lock. This
 // deliberately does not use std::this_thread::yield(), so that more lock
 // contention is caused. This allows it to double as a performance test, but
-// the statistics are not stable unless ITER_MAX is set to a higher number
-// (normally we don't want to wait that long in the test suite)
-TEST(spinlock, basic)
+// the statistics are not stable unless ITER_MAX is set to a higher number,
+// like 1 << 29 (normally we can't wait that long in the automated test suite)
+TEST(spinlock, lock_basic)
 {
     shared_state s{};
-    bool done;
+    std::latch latch{NUM_THREADS + 1};
     monad_spinlock_init(&s.lock);
     ASSERT_TRUE(monad_spinlock_is_unowned(&s.lock));
 
-    auto const start_time = std::chrono::system_clock::now();
-    std::thread thr{thread_function, std::ref(s)};
-    do {
-        MONAD_SPINLOCK_LOCK(&s.lock);
-        ASSERT_TRUE(monad_spinlock_is_owned(&s.lock));
-        if (s.counter % 2 == 1) {
-            ++s.counter;
-            ++s.even_count;
-        }
-        done = s.counter == ITER_MAX;
-        MONAD_SPINLOCK_UNLOCK(&s.lock);
+    std::vector<std::thread> threads;
+    for (unsigned i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back(
+            lock_thread_function, std::ref(s), i, std::ref(latch));
     }
-    while (!done);
-    auto const end_time = std::chrono::system_clock::now();
+    pin_threads_to_cores(threads);
 
-    thr.join();
-    ASSERT_EQ(s.counter / 2, s.odd_count);
-    ASSERT_EQ(s.counter / 2, s.even_count);
+    latch.arrive_and_wait();
+    auto const start_time = std::chrono::system_clock::now();
+    while (s.done.load(std::memory_order::acquire) < NUM_THREADS) {
+        monad_spinloop_hint();
+    }
+    auto const end_time = std::chrono::system_clock::now();
+    for (std::thread &t : threads) {
+        t.join();
+    }
+
+    uint64_t const total = std::accumulate(
+        std::begin(s.thread_count), std::end(s.thread_count), 0UL);
+    ASSERT_EQ(ITER_MAX, total);
 
     // Average time it takes for the odd or even thread to make its update.
     // This is essentially a measure of lock contention.
     auto const avg_cycle_time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            end_time - start_time)
-            .count() /
+        static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                end_time - start_time)
+                .count()) /
+        s.counter;
+    std::fprintf(
+        stdout,
+        "avg. cycle time: %lu\n",
+        static_cast<unsigned long>(avg_cycle_time));
+}
+
+TEST(spinlock, try_lock_basic)
+{
+    shared_state s{};
+    std::latch latch{NUM_THREADS + 1};
+    monad_spinlock_init(&s.lock);
+    ASSERT_TRUE(monad_spinlock_is_unowned(&s.lock));
+
+    std::vector<std::thread> threads;
+    for (unsigned i = 0; i < NUM_THREADS; ++i) {
+        threads.emplace_back(
+            try_lock_thread_function, std::ref(s), i, std::ref(latch));
+    }
+    pin_threads_to_cores(threads);
+
+    latch.arrive_and_wait();
+    std::atomic_thread_fence(std::memory_order::seq_cst);
+    auto const start_time = std::chrono::system_clock::now();
+    while (s.done.load(std::memory_order::acquire) < NUM_THREADS) {
+        monad_spinloop_hint();
+    }
+    auto const end_time = std::chrono::system_clock::now();
+    std::atomic_thread_fence(std::memory_order::seq_cst);
+    for (std::thread &t : threads) {
+        t.join();
+    }
+
+    uint64_t const total = std::accumulate(
+        std::begin(s.thread_count), std::end(s.thread_count), 0UL);
+    ASSERT_EQ(ITER_MAX, total);
+
+    // Average time it takes for the odd or even thread to make its update.
+    // This is essentially a measure of lock contention.
+    auto const avg_cycle_time =
+        static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                end_time - start_time)
+                .count()) /
         s.counter;
     std::fprintf(
         stdout,

--- a/libs/core/test/spinlock.cpp
+++ b/libs/core/test/spinlock.cpp
@@ -172,13 +172,11 @@ TEST(spinlock, try_lock_basic)
     pin_threads_to_cores(threads);
 
     latch.arrive_and_wait();
-    std::atomic_thread_fence(std::memory_order::seq_cst);
     auto const start_time = std::chrono::system_clock::now();
     while (s.done.load(std::memory_order::acquire) < NUM_THREADS) {
         monad_spinloop_hint();
     }
     auto const end_time = std::chrono::system_clock::now();
-    std::atomic_thread_fence(std::memory_order::seq_cst);
     for (std::thread &t : threads) {
         t.join();
     }


### PR DESCRIPTION
This PR contains debugging enhancements to the existing `spinlock_t` type, which is renamed to `monad_spinlock_t`. This is an isolated change, because the spinlock was not currently used by any other code. To simplify the fiber implementation, there is no fancy lock-free programming in the subsequent PRs; the all major objects (the fibers, the synchronization primitives, and the scheduler) are simple implementations covered by a single spinlock. The locks are held for very short periods, which can be verified by enabling the locking statistics option. The other feature this adds is source location tracking for the location where the lock was last taken, so it adds a formal source location object for C, similar to `std::source_location`, and a C++ conversion function between the two.