### PR TITLE
Fiber PR2: add the fiber implementation

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -120,9 +120,6 @@ add_library(
   "src/monad/core/result.hpp"
   "src/monad/core/size_of.hpp"
   "src/monad/core/small_prng.hpp"
-  "src/monad/core/spinlock.h"
-  "src/monad/core/spinloop.h"
-  "src/monad/core/srcloc.h"
   "src/monad/core/srcloc.hpp"
   "src/monad/core/tl_tid.c"
   "src/monad/core/tl_tid.h"
@@ -134,7 +131,10 @@ add_library(
   "src/monad/synchronization/spin_lock.hpp"
   # fiber
   "src/monad/fiber/config.hpp"
+  "src/monad/fiber/fiber.c"
   "src/monad/fiber/fiber.h"
+  "src/monad/fiber/fiber_inline.h"
+  "src/monad/fiber/fiber_thr.c"
   "src/monad/fiber/priority_algorithm.cpp"
   "src/monad/fiber/priority_algorithm.hpp"
   "src/monad/fiber/priority_pool.cpp"
@@ -204,6 +204,8 @@ if(MONAD_CORE_SPINLOCK_TRACK_STATS_ATOMIC)
   target_compile_definitions(monad_core
                              PUBLIC MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
 endif()
+
+target_link_libraries(monad_core PUBLIC monad_boost_context)
 
 target_compile_definitions(monad_core PRIVATE "BOOST_STACKTRACE_LINK=1")
 if(TARGET Boost::stacktrace_backtrace)

--- a/libs/core/src/monad/fiber/fiber-api.md
+++ b/libs/core/src/monad/fiber/fiber-api.md
@@ -107,9 +107,10 @@ int main(int argc, char **argv)
     int rc;
     monad_fiber_t *hello_fiber;
     char const *name;
+    monad_allocator_t *const alloc = nullptr; // Use default allocator
     monad_fiber_attr_t const fiber_attr = {
         .stack_size = 1UL << 17, // 128 KiB stack
-        .alloc = nullptr // Use the default allocator
+        .alloc = alloc
     };
 
     // This application says hello to you using a fiber; it expects your name
@@ -183,6 +184,24 @@ int main(int argc, char **argv)
     return 0;
 }
 ```
+
+## Where is the code?
+
+1. For the fibers themselves:
+   - `fiber.h` - defines the interface for fibers, i.e., the public
+     functions and the central `monad_fiber_t` structure
+   - `fiber_inline.h` - most of the implementation is here, so it can be
+     inlined for performance reasons
+   - `fiber.c` - implementation file for fiber functions whose performance
+     is not critical
+   - `fiber_thr.c` - an implementation file which contains the `thread_local`
+     state for the `monad_thread_executor_t` objects
+
+2. For the synchronization primitives:
+   - To be added in a subsequent commit
+
+3. The scheduler
+   - To be added in a subsequent commit
 
 ## `monad_fiber_t` basic design
 

--- a/libs/core/src/monad/fiber/fiber-impl.md
+++ b/libs/core/src/monad/fiber/fiber-impl.md
@@ -1,0 +1,124 @@
+# `monad_fiber` implementation notes
+
+## Basic design
+
+The fiber implementation has two essential objects:
+
+1. `monad_thread_executor_t` - much the same way as a single CPU core
+   is an execution resource to run threads, a single thread is an
+   execution resource to run fibers. Each thread that wants to call
+   `monad_fiber_run` is explicitly represented by a `monad_thread_executor_t`
+   object; the first time a thread calls `monad_fiber_run`, one of these
+   objects is created to represent it
+
+2. `monad_fiber_t` - this object represents a fiber, which is an execution
+   resource for a user defined function that can be voluntarily suspended
+   and resumed. It owns an execution stack, and some machinery for scheduling
+   and synchronization with other fibers
+
+## Context switching
+
+The context switching logic is deliberately asymmetric: all context switching
+takes place between a user-created fiber and an ordinary thread of execution.
+In other words, fibers cannot be nested: calling `monad_fiber_run` from inside
+a fiber returns `ENOTSUP` ("operation not supported") rather than starting a
+nested execution.
+
+The original implementation was symmetric: it was legal to call
+`monad_fiber_run` when already running a fiber, and this would start a nested
+fiber. This doubled the size of the implementation and the runtime cost of a
+context switch, but was never used. For now, this capability has been removed.
+
+The context switching operation is divided into two layers:
+
+1. **Machine-independent layer** - this is shared by
+   all architectures and addresses how the execution transfers from an
+   ordinary thread context to a fiber conext, and back; this code is mostly
+   in `fiber_inline.h`, and is inherently asymmetric (the switch is always
+   between one fiber context and one ordinary thread context)
+
+2. **Machine-dependent layer** - this consists of only two functions,
+   `monad_make_fcontext` and `monad_jump_fcontext` which were imported
+   from the Boost.Context third-party library. These are the original
+   names of the functions, but with the `monad_` prefix added. They are
+   the low-level context switch functions implemented in assembly
+   language for a particular CPU architecture, calling convention, and ABI.
+
+In the machine-independent layer, the execution context of the thread
+that calls `monad_fiber_run` is modeled by `monad_thread_executor_t` and
+the execution context of a fiber is modeled by `monad_fiber_t`.
+
+The only piece of data needed by the machine-dependent layer is a single
+pointer that represents the value of the stack pointer where execution was
+suspended, upon its last context switch. In both structures, this field is
+called `md_suspended_ctx` (where `md` is "machine-dependent"). The
+machine-dependent context switching *is* inherently symmetric: the code
+from Boost is mostly unchanged, and does not know any details about
+`struct monad_fiber` or `struct monad_thread_executor`.
+
+### Machine-independent switching
+
+#### Context switching into a fiber
+
+The machine-independent part of a context switch into a fiber is
+handled in two phases:
+
+1. The switch starts inside of `monad_fiber_run`
+2. The switch finishes by calling `_monad_finish_switch_to_fiber`
+
+What distinguishes these two phases is which stack we are running on.
+Although both phases take place on the same thread, the `monad_fiber_run`
+function executes on the thread's ordinary execution stack, and the
+`_monad_finish_switch_to_fiber` function is called once control has
+transferred to the fiber, and is running on the fiber's stack.
+
+It is `monad_fiber_run` that calls the machine-dependent context switch
+function, which causes the stack switch to happen at the CPU level.
+Immediately after the CPU-level switch occurs, we are running on the
+stack of the resumed (or newly-started) fiber, and the previously running
+thread context is now suspended; this resumption site must immediately call
+`_monad_finish_switch_to_fiber` to complete the switch. This performs
+critical book-keeping tasks, such as saving the `md_suspended_ctx` of the
+calling thread in its `monad_thread_executor_t` structure.
+
+`_monad_finish_switch_to_fiber` is called in two places: at the start of
+the fiber (see `fiber_entrypoint`), or immediately after a fiber resumes
+after being suspended. It takes a single `struct monad_transfer_t` parameter,
+a small structure that passes information between the "switched from" and
+"switched to" stacks by the machine-dependent layer. It contains the
+`monad_thread_executor_t` of the thread that started the context switch,
+and the `md_suspended_ctx` of the suspension point inside `monad_fiber_run`
+when the switch occurred.
+
+Typically a fiber will *migrate* between threads, as each worker thread
+selects the highest priority fiber that is ready to run; this is why the
+`monad_thread_executor_t` is passed between the low-level jump routines:
+a fiber can be resumed on a different thread than it was originally
+suspended on.
+
+#### Context switching out of a fiber
+
+Fibers run until they voluntarily suspend themselves. This happens via an
+explicit call to `monad_fiber_yield`, going to sleep on a synchronization
+primitive (which calls `_monad_fiber_sleep`), or when the fiber function
+returns (which returns control back to `fiber_entrypoint`). These all call
+the same low-level suspension function, `_monad_suspend_fiber`, which
+performs a context switch back to the thread that originally called
+`monad_fiber_run`.
+
+Because fibers are always suspended inside of `_monad_suspend_fiber`, this
+function is also the point where fibers are resumed.
+
+### Machine-dependent context switching
+
+The tricky part of understanding how this works is becoming familiar with
+the following interesting pattern: when we perform a `monad_jump_fcontext`,
+we are suspended and control is transferred away from us. When control
+transfers back to us, it has the appearance of *returning* from the original
+jump function, which had jumped away. To understand this code at a deep
+level, I suggest working through how the lowest-level machine-dependent
+assembly jump functions work between two execution contexts. It may take
+a few hours to understand all the details and internalize them, but this
+will demystify the essential pattern: when we *return* from a jump, we've
+been resumed and are on the original stack, but are potentially on a
+different host thread than when we were suspended on.

--- a/libs/core/src/monad/fiber/fiber.c
+++ b/libs/core/src/monad/fiber/fiber.c
@@ -1,0 +1,201 @@
+/**
+ * @file
+ *
+ * This file contains the implementation of the performance-insensitive
+ * functions in the fiber library
+ */
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/c_result.h>
+#include <monad/core/likely.h>
+#include <monad/core/spinlock.h>
+#include <monad/fiber/fiber.h>
+
+static monad_fiber_attr_t g_default_fiber_attr = {
+    .stack_size = 1 << 17, // 128 KiB
+    .alloc = nullptr // Default allocator
+};
+
+static atomic_uint g_last_fiber_id = 0;
+
+static int
+alloc_fiber_stack(struct monad_fiber_stack *stack, size_t *stack_size)
+{
+    int const stack_protection = PROT_READ | PROT_WRITE;
+    int const stack_flags = MAP_ANONYMOUS | MAP_PRIVATE
+#if defined(MAP_STACK)
+                            | MAP_STACK
+#endif
+        ;
+
+    size_t const page_size = (size_t)getpagesize();
+    if (stack_size == nullptr || stack == nullptr) {
+        return EFAULT;
+    }
+    if (*stack_size - page_size < page_size) {
+        return EINVAL;
+    }
+    stack->stack_base =
+        mmap(nullptr, *stack_size, stack_protection, stack_flags, -1, 0);
+    if (stack->stack_base == MAP_FAILED) {
+        return errno;
+    }
+    if (mprotect(stack->stack_base, page_size, PROT_NONE) == -1) {
+        return errno;
+    }
+    *stack_size -= page_size;
+    stack->stack_bottom = (uint8_t *)stack->stack_base + page_size;
+    stack->stack_top = (uint8_t *)stack->stack_bottom + *stack_size;
+    return 0;
+}
+
+static void dealloc_fiber_stack(struct monad_fiber_stack stack)
+{
+    size_t const mapped_size = (size_t)((uint8_t const *)stack.stack_top -
+                                        (uint8_t const *)stack.stack_base);
+    munmap(stack.stack_base, mapped_size);
+}
+
+[[noreturn]] static void fiber_entrypoint(struct monad_transfer_t xfer_from)
+{
+    // Entry point of a "user" fiber. When this function is called, we're
+    // running on the fiber's stack for the first time (after the most recent
+    // call to monad_fiber_set_function). We cannot directly return from this
+    // function, but we can transfer control back to the execution context that
+    // jumped here. In our model, that is the context that called the
+    // `monad_fiber_run` function, which is typically a regular thread running
+    // a lightweight scheduler. The info needed to transfer control back to the
+    // suspension point in `monad_fiber_run` is contained within the `xfer_from`
+    // argument
+    monad_c_result mcr;
+    monad_thread_executor_t *thr_exec;
+    monad_fiber_t *self;
+
+    _monad_finish_switch_to_fiber(xfer_from);
+    thr_exec = xfer_from.data;
+    self = thr_exec->cur_fiber;
+
+    // Call the user fiber function
+    mcr = self->ffunc(self->fargs);
+
+    // The fiber function returned, which appears as a kind of suspension to
+    // the caller
+    MONAD_SPINLOCK_LOCK(&self->lock);
+    _monad_suspend_fiber(self, MF_STATE_FINISHED, MF_SUSPEND_RETURN, mcr);
+
+    // This should be unreachable (monad_fiber_run should never resume us after
+    // a "return" suspension)
+    abort();
+}
+
+int monad_fiber_create(monad_fiber_attr_t const *attr, monad_fiber_t **fiber)
+{
+    monad_memblk_t memblk;
+    struct monad_fiber_stack fiber_stack;
+    monad_fiber_t *f;
+    size_t stack_size;
+    int rc;
+
+    if (fiber == nullptr) {
+        return EFAULT;
+    }
+    *fiber = nullptr;
+    if (attr == nullptr) {
+        attr = &g_default_fiber_attr;
+    }
+    stack_size = attr->stack_size;
+    rc = alloc_fiber_stack(&fiber_stack, &stack_size);
+    if (rc != 0) {
+        return rc;
+    }
+    rc = monad_cma_alloc(
+        attr->alloc, sizeof **fiber, alignof(monad_fiber_t), &memblk);
+    if (rc != 0) {
+        dealloc_fiber_stack(fiber_stack);
+        return rc;
+    }
+    *fiber = f = memblk.ptr;
+    memset(f, 0, sizeof *f);
+    monad_spinlock_init(&f->lock);
+    f->fiber_id = ++g_last_fiber_id;
+    f->state = MF_STATE_INIT;
+    f->stack = fiber_stack;
+    f->create_attr = *attr;
+    f->self_memblk = memblk;
+
+    return 0;
+}
+
+void monad_fiber_destroy(monad_fiber_t *fiber)
+{
+    MONAD_ASSERT(fiber != nullptr);
+    dealloc_fiber_stack(fiber->stack);
+    monad_cma_dealloc(fiber->create_attr.alloc, fiber->self_memblk);
+}
+
+int monad_fiber_set_function(
+    monad_fiber_t *fiber, monad_fiber_prio_t priority,
+    monad_fiber_ffunc_t *ffunc, monad_fiber_args_t fargs)
+{
+    size_t stack_size;
+
+    MONAD_SPINLOCK_LOCK(&fiber->lock);
+    switch (fiber->state) {
+    case MF_STATE_INIT:
+        [[fallthrough]];
+    case MF_STATE_FINISHED:
+        // It is legal to modify the fiber in these states
+        break;
+
+    default:
+        // It is not legal to modify the fiber in these states
+        MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+        return EBUSY;
+    }
+    stack_size = (size_t)(fiber->stack.stack_top - fiber->stack.stack_bottom);
+    fiber->state = MF_STATE_CAN_RUN;
+    fiber->md_suspended_ctx = monad_make_fcontext(
+        fiber->stack.stack_top, stack_size, fiber_entrypoint);
+    fiber->priority = priority;
+    fiber->ffunc = ffunc;
+    fiber->fargs = fargs;
+    ++fiber->stats.total_reset;
+    MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+    return 0;
+}
+
+int monad_fiber_get_name(monad_fiber_t *fiber, char *name, size_t size)
+{
+    int rc;
+    if (name == nullptr) {
+        return EFAULT;
+    }
+    MONAD_SPINLOCK_LOCK(&fiber->lock);
+    rc = strlcpy(name, fiber->name, size) >= size ? ERANGE : 0;
+    MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+    return rc;
+}
+
+int monad_fiber_set_name(monad_fiber_t *fiber, char const *name)
+{
+    int rc;
+    if (name == nullptr) {
+        return EFAULT;
+    }
+    MONAD_SPINLOCK_LOCK(&fiber->lock);
+    rc = strlcpy(fiber->name, name, sizeof fiber->name) > MONAD_FIBER_NAME_LEN
+             ? ERANGE
+             : 0;
+    MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+    return rc;
+}

--- a/libs/core/src/monad/fiber/fiber_inline.h
+++ b/libs/core/src/monad/fiber/fiber_inline.h
@@ -1,0 +1,239 @@
+/**
+ * @file
+ *
+ * This file contains the implementation of the performance-sensitive
+ * functions in the fiber library, which are all inlined and included in
+ * fiber.h; see fiber-impl.md for the implementation notes
+ */
+
+#ifndef MONAD_FIBER_INTERNAL
+    #error This is not a public interface, but included into fiber.h for performance reasons; users cannot include it
+#endif
+
+#include <errno.h>
+#include <stdint.h>
+#include <sys/queue.h>
+#include <threads.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/tl_tid.h>
+
+#include <monad-boost/context/fcontext.h>
+
+#if MONAD_HAS_ASAN
+    #include <sanitizer/asan_interface.h>
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// Represents a thread (specifically the information about it needed to
+/// execute a fiber)
+struct monad_thread_executor
+{
+    monad_fcontext_t md_suspended_ctx; ///< Saved thread's ctx when suspended
+    monad_fiber_t *cur_fiber; ///< Fiber this thread is running (or nullptr)
+    thrd_t thread; ///< Opaque system handle for the thread
+    uint64_t thread_id; ///< Public ID for the thread, for debugging
+    struct monad_fiber_stack stack; ///< Descriptor for thread stack
+    monad_fiber_suspend_info_t *suspend_info; ///< To copy out suspension info
+    SLIST_ENTRY(monad_thread_executor) next; ///< Linkage for all thread_locals
+#if MONAD_HAS_ASAN
+    void *fake_stack_save; ///< For ASAN stack support
+#endif
+};
+
+#if MONAD_HAS_ASAN
+    #define MONAD_FIBER_ASAN_START_SWITCH(FAKE_STACK_SAVE, STACK_DESC)         \
+        __sanitizer_start_switch_fiber(                                        \
+            (FAKE_STACK_SAVE),                                                 \
+            (STACK_DESC).stack_bottom,                                         \
+            (size_t)((uint8_t *)((STACK_DESC).stack_top) -                     \
+                     (uint8_t *)((STACK_DESC).stack_bottom)))
+
+    #define MONAD_FIBER_ASAN_FINISH_SWITCH(FAKE_STACK_SAVE)                    \
+        __sanitizer_finish_switch_fiber((FAKE_STACK_SAVE), nullptr, nullptr);
+#else
+    #define MONAD_FIBER_ASAN_START_SWITCH(...)
+    #define MONAD_FIBER_ASAN_FINISH_SWITCH(...)
+#endif
+
+// This constinit is needed on macOS, where the TLS codegen strategy differs
+// between C and C++. The thread executor TLS object lives in `fiber_thr.c`, so
+// it follows the C language rules. These inline functions are usually also
+// included in C++ translation units. Without constinit, this would emit
+// references to an undefined C++ thread_local wrapper function on Darwin. See
+// the comments in clang's `CodeGenModule::EmitGlobalVarDefinition` in
+// CodeGenModule.cpp for more information
+#ifdef __cplusplus
+constinit
+#endif
+    extern thread_local struct monad_thread_executor _monad_tl_thr_exec;
+
+static inline monad_thread_executor_t *_monad_current_thread_executor()
+{
+    extern void _monad_init_thread_executor(monad_thread_executor_t * thr_exec);
+    if (MONAD_UNLIKELY(_monad_tl_thr_exec.thread == 0)) {
+        _monad_init_thread_executor(&_monad_tl_thr_exec);
+    }
+    return &_monad_tl_thr_exec;
+}
+
+// When a fiber stack is first used or is resumed after having been suspended,
+// this function must be called to finish the context switch.
+//
+// There are two places in the code where this can occur:
+//
+//   1. When a fiber initially begins running. This means at the beginning of
+//      the fiber's entrypoint function (the function specified in the
+//      monad_make_fcontext call)
+//
+//   2. Immediately after a call to monad_jump_fcontext returns, in the
+//      `_monad_suspend_fiber` function. Note that a return from
+//      monad_jump_fcontext implies we have been resumed from the suspension
+//      implied by the jump, thus the switch we are finishing is not the same
+//      one that was started by the start switch call
+//
+// We are given a `struct monad_transfer_t`, with two members:
+//
+//   data - the `struct monad_thread_executor_t *` for the thread that
+//          invoked the `monad_fiber_run` call that returned control back to us
+//   fctx - the context pointer (effectively the suspension point) within
+//          the thread where it was suspended upon the switch back to us
+//          (i.e., pointing inside the stack frame of monad_fiber_run)
+static inline void
+_monad_finish_switch_to_fiber(struct monad_transfer_t xfer_from)
+{
+    monad_thread_executor_t *const thr_exec =
+        (monad_thread_executor_t *)xfer_from.data;
+    monad_fiber_t *const fiber = thr_exec->cur_fiber;
+
+    MONAD_FIBER_ASAN_FINISH_SWITCH(fiber->fake_stack_save);
+    MONAD_DEBUG_ASSERT(monad_spinlock_is_self_owned(&fiber->lock));
+
+    // Remember where the thread context suspended
+    thr_exec->md_suspended_ctx = xfer_from.fctx;
+
+    // Finish book-keeping to become the new running fiber
+    fiber->state = MF_STATE_RUNNING;
+    if (MONAD_UNLIKELY(fiber->thr_exec != thr_exec)) {
+        fiber->thr_exec = thr_exec;
+        ++fiber->stats.total_migrate;
+    }
+    ++fiber->stats.total_run;
+
+    MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+}
+
+static inline void _monad_suspend_fiber(
+    monad_fiber_t *self, enum monad_fiber_state suspend_state,
+    enum monad_fiber_suspend_type suspend_type, monad_c_result eval)
+{
+    // Our suspension and scheduling model is that, upon suspension, we jump
+    // back to the context that originally jumped to us. That context is
+    // typically running a lightweight scheduler, which decides which fiber to
+    // run next and calls `monad_fiber_run`. Thus, we are always jumping back
+    // into the body of `monad_fiber_run`, which will return and report our
+    // suspension. `monad_fiber_run` disallows nested fiber execution, so we
+    // know the previously executing context is the current thread's original
+    // execution context
+    monad_thread_executor_t *const thr_exec = self->thr_exec;
+    if (thr_exec->suspend_info) {
+        thr_exec->suspend_info->suspend_type = suspend_type;
+        thr_exec->suspend_info->eval = eval;
+    }
+    self->state = suspend_state;
+    // TODO(ken): we never pass nullptr here to cleanup the fake stack save,
+    //   because the stack can be reused even if the function is done; likely
+    //   we'll never fix this because it will be replaced with Niall's stuff
+    //   anyway.
+    MONAD_FIBER_ASAN_START_SWITCH(&self->fake_stack_save, thr_exec->stack);
+    struct monad_transfer_t const resume_xfer =
+        monad_jump_fcontext(thr_exec->md_suspended_ctx, thr_exec);
+    _monad_finish_switch_to_fiber(resume_xfer);
+}
+
+/*
+ * Implementation of the public API
+ */
+
+inline monad_fiber_t *monad_fiber_self()
+{
+    monad_thread_executor_t *const thr_exec = _monad_current_thread_executor();
+    return thr_exec->cur_fiber;
+}
+
+inline int monad_fiber_run(
+    monad_fiber_t *next_fiber, monad_fiber_suspend_info_t *suspend_info)
+{
+    int err;
+    struct monad_transfer_t resume_xfer;
+    monad_thread_executor_t *thr_exec;
+    // For ASAN:
+    [[maybe_unused]] size_t next_stack_size;
+    [[maybe_unused]] void **fake_stack;
+
+    MONAD_DEBUG_ASSERT(next_fiber != nullptr);
+    thr_exec = _monad_current_thread_executor();
+    if (MONAD_UNLIKELY(thr_exec->cur_fiber != nullptr)) {
+        // The user tried to call monad_fiber_run from an active fiber; the
+        // implementation explicitly disallows nested fibers
+        return ENOTSUP;
+    }
+
+    // The fiber is usually already locked, since fibers remain locked when
+    // returned from the run queue. However, you can also run a fiber directly
+    // e.g., in the test suite. Acquire the lock if we don't have it
+    if (MONAD_UNLIKELY(!monad_spinlock_is_self_owned(&next_fiber->lock))) {
+        MONAD_SPINLOCK_LOCK(&next_fiber->lock);
+    }
+
+    if (next_fiber->state != MF_STATE_CAN_RUN) {
+        // The user tried to resume a fiber that is not in a run state that
+        // can be resumed
+        switch (next_fiber->state) {
+        case MF_STATE_INIT:
+            [[fallthrough]];
+        case MF_STATE_FINISHED:
+            err = ENXIO;
+            break;
+        default:
+            err = EBUSY;
+            break;
+        }
+        MONAD_SPINLOCK_UNLOCK(&next_fiber->lock);
+        return err;
+    }
+
+    thr_exec->suspend_info = suspend_info;
+    thr_exec->cur_fiber = next_fiber;
+
+    MONAD_FIBER_ASAN_START_SWITCH(
+        &thr_exec->fake_stack_save, next_fiber->stack);
+    // Call the machine-dependent context switch function, monad_jump_fcontext.
+    // This atomically suspends the thread's execution context and begins
+    // executing the fiber's context at its last suspension point. When we are
+    // resumed at some later time, it will appear as through we've returned
+    // from this function call to `monad_jump_fcontext`, and we will again be
+    // the currently running context.
+    resume_xfer = monad_jump_fcontext(next_fiber->md_suspended_ctx, thr_exec);
+    MONAD_FIBER_ASAN_FINISH_SWITCH(thr_exec->fake_stack_save);
+    next_fiber->md_suspended_ctx = resume_xfer.fctx;
+    MONAD_SPINLOCK_UNLOCK(&next_fiber->lock);
+    thr_exec->cur_fiber = nullptr;
+    return 0;
+}
+
+inline void monad_fiber_yield(monad_c_result eval)
+{
+    monad_fiber_t *const self = monad_fiber_self();
+    MONAD_DEBUG_ASSERT(self != nullptr);
+    MONAD_SPINLOCK_LOCK(&self->lock);
+    _monad_suspend_fiber(self, MF_STATE_CAN_RUN, MF_SUSPEND_YIELD, eval);
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/libs/core/src/monad/fiber/fiber_thr.c
+++ b/libs/core/src/monad/fiber/fiber_thr.c
@@ -1,0 +1,98 @@
+#include <err.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/queue.h>
+#include <threads.h>
+
+#include <pthread.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/spinlock.h>
+#include <monad/core/tl_tid.h>
+#include <monad/fiber/fiber.h>
+
+// This structure keeps track of a global list of all active
+// monad_thread_executor objects that exist in the process; this is used for
+// debugging
+static struct thr_exec_global_state
+{
+    monad_spinlock_t lock;
+    pthread_key_t key;
+    SLIST_HEAD(, monad_thread_executor) head;
+    size_t count;
+} g_thr_execs;
+
+thread_local struct monad_thread_executor _monad_tl_thr_exec;
+
+static void monad_thread_executor_dtor(void *arg)
+{
+    monad_thread_executor_t *const thr_exec = arg;
+    MONAD_SPINLOCK_LOCK(&g_thr_execs.lock);
+    SLIST_REMOVE(&g_thr_execs.head, thr_exec, monad_thread_executor, next);
+    --g_thr_execs.count;
+    MONAD_SPINLOCK_UNLOCK(&g_thr_execs.lock);
+
+    // XXX: add any final cleanup here
+    (void)thr_exec;
+}
+
+void _monad_init_thread_executor(monad_thread_executor_t *thr_exec)
+{
+    int rc;
+    pthread_attr_t thread_attrs;
+    struct monad_fiber_stack *thread_stack;
+    size_t thread_stack_size;
+
+    memset(thr_exec, 0, sizeof *thr_exec);
+    thr_exec->thread = thrd_current();
+    thr_exec->thread_id = (uint64_t)get_tl_tid();
+
+    // Get the thread's stack area
+    // TODO(ken): is this potentially wrong if mapped with MAP_GROWSDOWN on
+    //  Linux (its size could increase, and we won't know?)
+    thread_stack = &thr_exec->stack;
+    rc = pthread_getattr_np(pthread_self(), &thread_attrs);
+    MONAD_ASSERT_PRINTF(rc == 0, "pthread_getattr_np(3) failed: %d", rc);
+    rc = pthread_attr_getstack(
+        &thread_attrs, &thread_stack->stack_bottom, &thread_stack_size);
+    MONAD_ASSERT_PRINTF(rc == 0, "pthread_attr_getstack(3) failed: %d", rc);
+    (void)pthread_attr_destroy(&thread_attrs);
+
+    thread_stack->stack_base = thread_stack->stack_bottom;
+    thread_stack->stack_top =
+        (uint8_t *)thread_stack->stack_bottom + thread_stack_size;
+
+    MONAD_SPINLOCK_LOCK(&g_thr_execs.lock);
+    SLIST_INSERT_HEAD(&g_thr_execs.head, thr_exec, next);
+    ++g_thr_execs.count;
+    rc = pthread_setspecific(g_thr_execs.key, thr_exec);
+    if (rc != 0) {
+        errno = rc;
+        err(1, "pthread_setspecific(3) failed");
+    }
+    MONAD_SPINLOCK_UNLOCK(&g_thr_execs.lock);
+}
+
+static void __attribute((constructor)) init_thread_executor_list()
+{
+    int rc;
+
+    monad_spinlock_init(&g_thr_execs.lock);
+    rc = pthread_key_create(&g_thr_execs.key, monad_thread_executor_dtor);
+    if (rc != 0) {
+        errno = rc;
+        err(1, "pthread_key_create(3) failed");
+    }
+    SLIST_INIT(&g_thr_execs.head);
+}
+
+static void __attribute__((destructor)) cleanup_thread_executor_list()
+{
+    while (!SLIST_EMPTY(&g_thr_execs.head)) {
+        monad_thread_executor_dtor(SLIST_FIRST(&g_thr_execs.head));
+    }
+    (void)pthread_key_delete(g_thr_execs.key);
+}

--- a/libs/core/test/CMakeLists.txt
+++ b/libs/core/test/CMakeLists.txt
@@ -11,6 +11,7 @@ monad_add_test(backtrace_test "backtrace.cpp")
 monad_add_test(cma_allocators_test "cma_allocators.cpp")
 monad_add_test(cpuset_test "cpuset.cpp")
 monad_add_test(encode_test "encode_test.cpp")
+monad_add_test(fiber_test "fiber.cpp")
 monad_add_test(hugemem_test "huge_mem.cpp")
 target_link_libraries(hugemem_test GTest::gmock)
 monad_add_test(io_buffers_test "io_buffers.cpp")
@@ -25,9 +26,12 @@ target_compile_definitions(
           MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
 monad_add_test(unordered_map_test "unordered_map.cpp")
 
-# Ensure the API demo described in fiber-api.md compiles
-if(0) # Still for exposition only, compiles but does not link
-  add_executable(fiber-hello fiber-hello.c)
-  monad_compile_options(fiber-hello)
-  target_link_libraries(fiber-hello PRIVATE monad_core)
-endif()
+# Ensure the API demo described in fiber-api.md compiles. This was written as
+# a C program but must compile as C++ for now because of a Boost.Outcome issue
+add_executable(fiber-hello fiber-hello.cpp)
+monad_compile_options(fiber-hello)
+target_link_libraries(fiber-hello PRIVATE monad_core)
+
+add_executable(fiber_benchmark fiber_bench.cpp)
+monad_compile_options(fiber_benchmark)
+target_link_libraries(fiber_benchmark PRIVATE monad_core)

--- a/libs/core/test/fiber-hello.cpp
+++ b/libs/core/test/fiber-hello.cpp
@@ -39,10 +39,10 @@ int main(int argc, char **argv)
     int rc;
     monad_fiber_t *hello_fiber;
     char const *name;
+    monad_allocator_t *const alloc = nullptr; // Use default allocator
     monad_fiber_attr_t const fiber_attr = {
         .stack_size = 1UL << 17, // 128 KiB stack
-        .alloc = nullptr // Use the default allocator
-    };
+        .alloc = alloc};
 
     // This application says hello to you using a fiber; it expects your name
     // as the first (and only) positional argument

--- a/libs/core/test/fiber.cpp
+++ b/libs/core/test/fiber.cpp
@@ -1,0 +1,124 @@
+#include <atomic>
+#include <bit>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <monad/core/c_result.h>
+#include <monad/fiber/fiber.h>
+
+static monad_c_result yield_forever(monad_fiber_args_t mfa) noexcept
+{
+    auto *const pdone = std::bit_cast<std::atomic<bool> *>(mfa.arg[0]);
+    std::intptr_t y = 0;
+    while (!pdone->load(std::memory_order::relaxed)) {
+        monad_fiber_yield(monad_c_make_success(y++));
+    }
+    return monad_c_make_success(y);
+}
+
+static monad_c_result no_nesting_func(monad_fiber_args_t /*unused*/) noexcept
+{
+    monad_fiber_t *nested_fiber;
+    std::atomic<bool> done;
+
+    monad_fiber_create(nullptr, &nested_fiber);
+    monad_fiber_set_function(
+        nested_fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        yield_forever,
+        {std::bit_cast<std::uintptr_t>(&done)});
+    // Cannot run a nested fiber
+    int const rc = monad_fiber_run(nested_fiber, nullptr);
+    monad_fiber_destroy(nested_fiber);
+    return rc == 0 ? monad_c_make_success(0) : monad_c_make_failure(rc);
+}
+
+TEST(fiber, basic)
+{
+    monad_fiber_t *fiber;
+    monad_fiber_suspend_info_t suspend_info;
+    std::atomic<bool> done;
+
+    ASSERT_EQ(0, monad_fiber_create(nullptr, &fiber));
+
+    // Nothing to run if we've never set a function
+    ASSERT_EQ(ENXIO, monad_fiber_run(fiber, nullptr));
+
+    ASSERT_EQ(
+        0,
+        monad_fiber_set_function(
+            fiber,
+            MONAD_FIBER_PRIO_HIGHEST,
+            yield_forever,
+            {std::bit_cast<std::uintptr_t>(&done)}));
+
+    done.store(false);
+    for (std::intptr_t expected = 0; expected < 10; ++expected) {
+        ASSERT_EQ(0, monad_fiber_run(fiber, &suspend_info));
+        ASSERT_EQ(MF_SUSPEND_YIELD, suspend_info.suspend_type);
+        ASSERT_TRUE(MONAD_OK(suspend_info.eval));
+        ASSERT_EQ(expected, suspend_info.eval.value);
+    }
+
+    done.store(true);
+    ASSERT_EQ(0, monad_fiber_run(fiber, &suspend_info));
+    ASSERT_EQ(MF_SUSPEND_RETURN, suspend_info.suspend_type);
+    ASSERT_TRUE(MONAD_OK(suspend_info.eval));
+    ASSERT_EQ(10, suspend_info.eval.value);
+    ASSERT_EQ(ENXIO, monad_fiber_run(fiber, &suspend_info));
+
+    // Reset the function; this resets the stack pointer to the beginning,
+    // destroying the stack frame and thus the local state of the function;
+    // the yield sequence will reset at 0.
+    ASSERT_EQ(
+        0,
+        monad_fiber_set_function(
+            fiber,
+            MONAD_FIBER_PRIO_HIGHEST,
+            yield_forever,
+            {std::bit_cast<std::uintptr_t>(&done)}));
+
+    done.store(false);
+    for (std::uintptr_t expected = 0; expected < 10; ++expected) {
+        ASSERT_EQ(0, monad_fiber_run(fiber, &suspend_info));
+        ASSERT_EQ(MF_SUSPEND_YIELD, suspend_info.suspend_type);
+        ASSERT_TRUE(MONAD_OK(suspend_info.eval));
+        ASSERT_EQ(expected, suspend_info.eval.value);
+    }
+
+    // The function cannot be reset at any time, only before it has run or
+    // after it has returned
+    //   TODO(ken): when backporting this, explain why
+    ASSERT_EQ(
+        EBUSY,
+        monad_fiber_set_function(
+            fiber,
+            MONAD_FIBER_PRIO_HIGHEST,
+            yield_forever,
+            {std::bit_cast<std::uintptr_t>(&done)}));
+
+    monad_fiber_destroy(fiber);
+}
+
+TEST(fiber, no_fiber_nesting)
+{
+    monad_fiber_t *fiber;
+    monad_fiber_suspend_info_t suspend_info;
+
+    ASSERT_EQ(0, monad_fiber_create(nullptr, &fiber));
+    ASSERT_EQ(
+        0,
+        monad_fiber_set_function(
+            fiber, MONAD_FIBER_PRIO_HIGHEST, no_nesting_func, {}));
+
+    ASSERT_EQ(0, monad_fiber_run(fiber, &suspend_info));
+    ASSERT_EQ(MF_SUSPEND_RETURN, suspend_info.suspend_type);
+    ASSERT_TRUE(MONAD_FAILED(suspend_info.eval));
+    ASSERT_TRUE(
+        outcome_status_code_equal_generic(&suspend_info.eval.error, ENOTSUP));
+
+    monad_fiber_destroy(fiber);
+}

--- a/libs/core/test/fiber_bench.cpp
+++ b/libs/core/test/fiber_bench.cpp
@@ -1,0 +1,244 @@
+#include <algorithm>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include <err.h>
+#include <getopt.h>
+#include <sysexits.h>
+
+#include <monad/core/c_result.h>
+#include <monad/core/likely.h>
+#include <monad/fiber/fiber.h>
+
+namespace fs = std::filesystem;
+using std::chrono::duration_cast, std::chrono::seconds,
+    std::chrono::nanoseconds;
+
+constexpr intptr_t KIBI_MASK = (1L << 10) - 1;
+
+static size_t g_fiber_stack_size = 1UL << 17; // 128 KiB
+static auto g_benchmark_seconds = seconds{10};
+
+// clang-format off
+static option longopts[] = {
+    {.name = "list", .has_arg = 0, .flag = nullptr, .val = 'L'},
+    {.name = "stack_shift", .has_arg = 1, .flag = nullptr, .val = 's'},
+    {.name = "time", .has_arg = 1, .flag = nullptr, .val = 't'},
+    {.name = "help", .has_arg = 1, .flag = nullptr, .val = 'h'},
+    {}};
+// clang-format on
+
+extern char const *__progname;
+
+static void usage(std::FILE *out)
+{
+    std::fprintf(out, "%s: [-Lh] [-t <sec>] [-s <shift>]\n", __progname);
+}
+
+template <typename... Args>
+[[noreturn]] static void bench_die(
+    std::source_location const &srcloc, std::format_string<Args...> fmt,
+    Args &&...args)
+{
+    // TODO(ken): should use <print> but we don't have it yet
+    std::string s = std::format(
+                        "FATAL at {}@{}:{}:{}: ",
+                        srcloc.function_name(),
+                        fs::path{srcloc.file_name()}.filename().string(),
+                        srcloc.line(),
+                        srcloc.column()) +
+                    std::format(fmt, std::forward<Args>(args)...);
+    if (errno == 0) {
+        std::error_condition const ec{std::errc(errno)};
+        s += std::format(
+            ": {} ({}:{})", ec.message(), ec.category().name(), ec.value());
+    }
+    err(EX_SOFTWARE, "%s", s.c_str());
+}
+
+#define CHECK_Z(X)                                                             \
+    do {                                                                       \
+        if (MONAD_UNLIKELY((X) != 0)) {                                        \
+            errno = (X);                                                       \
+            bench_die(                                                         \
+                std::source_location::current(),                               \
+                "expected a zero return value from {}, got {}",                \
+                #X,                                                            \
+                (X));                                                          \
+        }                                                                      \
+    }                                                                          \
+    while (0)
+
+#define ASSERT_EQ(X, Y)                                                        \
+    do {                                                                       \
+        if (MONAD_UNLIKELY((X) != (Y))) {                                      \
+            errno = 0;                                                         \
+            bench_die(                                                         \
+                std::source_location::current(),                               \
+                "assert failed: {}",                                           \
+                #X " == " #Y);                                                 \
+        }                                                                      \
+    }                                                                          \
+    while (0)
+
+struct benchmark;
+
+static void switch_benchmark(benchmark const &);
+
+static struct benchmark
+{
+    std::string_view name;
+    std::string_view description;
+    void (*func)(benchmark const &);
+} g_bench_table[] = {
+    {.name = "switch",
+     .description = "performance of fiber context switch",
+     .func = switch_benchmark}};
+
+static int parse_options(int argc, char **argv)
+{
+    int ch;
+    std::from_chars_result fcr;
+    unsigned opt_uint;
+
+    while ((ch = getopt_long(argc, argv, "s:t:Lh", longopts, nullptr)) != -1) {
+        char const *const end_optarg =
+            optarg ? optarg + std::strlen(optarg) : nullptr;
+
+        switch (ch) {
+        case 'L':
+            for (benchmark &b : g_bench_table) {
+                std::fprintf(
+                    stdout, "%s:\t%s\n", data(b.name), data(b.description));
+            }
+            std::exit(0);
+
+        case 's':
+            fcr = std::from_chars(optarg, end_optarg, g_fiber_stack_size);
+            if (fcr.ptr != end_optarg || std::to_underlying(fcr.ec) ||
+                g_fiber_stack_size < 10 || g_fiber_stack_size > 30) {
+                errx(EX_CONFIG, "bad -s|--stack-shift value '%s'", optarg);
+            }
+            break;
+
+        case 't':
+            fcr = std::from_chars(optarg, end_optarg, opt_uint);
+            if (fcr.ptr != end_optarg || std::to_underlying(fcr.ec) ||
+                opt_uint == 0 || opt_uint > 3000) {
+                errx(EX_CONFIG, "bad -t|--time value '%s'", optarg);
+            }
+            g_benchmark_seconds = seconds{opt_uint};
+            break;
+
+        case 'h':
+            usage(stdout);
+            exit(0);
+
+        case '?':
+            [[fallthrough]];
+        default:
+            usage(stderr);
+            std::exit(EX_USAGE);
+        }
+    }
+
+    return optind;
+}
+
+static monad_c_result yield_forever(monad_fiber_args_t mfa)
+{
+    auto *const done = (std::atomic<bool> *)mfa.arg[0];
+    intptr_t y = 0;
+    while (!done->load(std::memory_order::relaxed)) {
+        monad_fiber_yield(monad_c_make_success(y++));
+    }
+    return monad_c_make_success(y);
+}
+
+static void switch_benchmark(benchmark const &self)
+{
+    monad_fiber_t *fiber;
+    monad_fiber_suspend_info_t suspend_info;
+    std::atomic<bool> done{false};
+    monad_fiber_attr_t fiber_attr = {
+        .stack_size = g_fiber_stack_size, .alloc = nullptr};
+
+    CHECK_Z(monad_fiber_create(&fiber_attr, &fiber));
+    CHECK_Z(monad_fiber_set_function(
+        fiber,
+        MONAD_FIBER_PRIO_HIGHEST,
+        yield_forever,
+        (monad_fiber_args_t){.arg = {(uintptr_t)&done}}));
+
+    auto const start_time = std::chrono::system_clock::now();
+    do {
+        CHECK_Z(monad_fiber_run(fiber, &suspend_info));
+        ASSERT_EQ(monad_result_has_value(suspend_info.eval), true);
+        if ((suspend_info.eval.value & KIBI_MASK) == 0) {
+            // Every 1024 yields, check if it's time to exit
+            auto const now = std::chrono::system_clock::now();
+            done.store(
+                duration_cast<seconds>(now - start_time) >= g_benchmark_seconds,
+                std::memory_order::release);
+        }
+    }
+    while (!done);
+
+    CHECK_Z(monad_fiber_run(fiber, &suspend_info));
+    ASSERT_EQ(MF_SUSPEND_RETURN, suspend_info.suspend_type);
+    monad_fiber_destroy(fiber);
+
+    intptr_t const context_switch_count = suspend_info.eval.value + 1;
+    double const nanos_per_switch =
+        (double)(duration_cast<nanoseconds>(g_benchmark_seconds).count()) /
+        (double)context_switch_count;
+    std::fprintf(
+        stdout,
+        "%s:\tsingle core context switch rate: %lu sw/s, %.1f ns/sw\n",
+        data(self.name),
+        context_switch_count / g_benchmark_seconds.count(),
+        nanos_per_switch);
+}
+
+int main(int argc, char **argv)
+{
+    char const *pos_arg;
+    int next_pos_arg_idx = parse_options(argc, argv);
+
+    if (next_pos_arg_idx == argc) {
+        // Not specifying any benchmark runs all of them
+        for (benchmark &b : g_bench_table) {
+            b.func(b);
+            std::fflush(stdout);
+        }
+    }
+    while (next_pos_arg_idx != argc) {
+        // If there are position arguments, run the benchmark named by the
+        // argument; run with -L to see a list
+        pos_arg = argv[next_pos_arg_idx++];
+        auto const i_bench =
+            std::ranges::find(g_bench_table, pos_arg, &benchmark::name);
+        if (i_bench != std::end(g_bench_table)) {
+            i_bench->func(*i_bench);
+            std::fflush(stdout);
+        }
+        else {
+            warnx("benchmark %s not found", pos_arg);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR contains enough of the implementation of the fiber interface to make the example program, fiber-hello.c, link and run successfully.


- The overview documentation `fiber-api.md` gains a section describing what each of the files in this directory do; this might be helpful to read first
- A new markdown file, `fiber-impl.md` gives some notes on how the fiber implementation works
- Some of what exists in this PR may be refactored by integration with Niall's context switching machinery in `libs/runloop`