### PR TITLE
log blockdb fstream errors

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -443,6 +443,14 @@ int main(int const argc, char const *argv[])
                 }
                 MONAD_ASSERT(fs::is_regular_file(path));
                 std::ifstream istream(path);
+                if (!istream) {
+                    LOG_ERROR_LIMIT(
+                        std::chrono::seconds(30),
+                        "Opening {} failed with {}",
+                        path,
+                        strerror(errno));
+                    return std::nullopt;
+                }
                 std::ostringstream buf;
                 buf << istream.rdbuf();
                 auto view = byte_string_view{


### PR DESCRIPTION
Followup to https://github.com/monad-crypto/monad/pull/850

We were able to debug this by sshing into the box and tracing the process. This may not be an option for external validators. Log any `fstream` related errors when the file exists but the stream cannot be opened. Since `TryGet` is called in a hot loop, only log this error once every 30 seconds so as not to spam logs.

When the `fstream` has an error, `buf.view().size()` is `0`, causing a decoding failure an empty block. This should make the error case more explicit.

When fds are exhausted execution now prints

```
2024-08-22 14:56:26.528383167 [287581] monad.cpp:451 LOG_ERROR  Opening /home/devnet_data/ledger/1 failed with Too many open files
```