### PR TITLE
Set expected nonce in original account state

### DIFF
--- a/libs/execution/src/monad/execution/execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/execute_transaction.cpp
@@ -208,6 +208,7 @@ Result<Receipt> execute_impl(
         TRACE_TXN_EVENT(StartExecution);
 
         State state{block_state, Incarnation{hdr.number, i + 1}};
+        state.set_original_nonce(sender, tx.nonce);
 
         auto result = execute_impl2<rev>(
             chain, tx, sender, hdr, block_hash_buffer, state);

--- a/libs/execution/src/monad/state3/state.hpp
+++ b/libs/execution/src/monad/state3/state.hpp
@@ -152,6 +152,16 @@ public:
         return recent_account_state(address).account_;
     }
 
+    void set_original_nonce(Address const &address, uint64_t const nonce)
+    {
+        auto &account_state = original_account_state(address);
+        auto &account = account_state.account_;
+        if (!account.has_value()) {
+            account = Account{};
+        }
+        account->nonce = nonce;
+    }
+
     ////////////////////////////////////////
 
     bool account_exists(Address const &address)


### PR DESCRIPTION
Set expected nonce in original account state
    
Prevents retries when only the only state diff would be nonce increment.
The transaction has the expected nonce. Set that in the sender account
before running the transaction.
    
This PR is a refactor of the research and work done by in
https://github.com/monad-crypto/monad/pull/732 by Maged.
    
Increases TPS by ~1300 on 12M for 25k blocks.

Co-authored-by: Maged Michael <maged.michael@gmail.com>