### PR TITLE
[clang-format] change AlignTrailingComments style to Leave

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,8 @@ AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: None
-AlignTrailingComments: false
+AlignTrailingComments:
+  Kind: Leave
 AllowShortFunctionsOnASingleLine: Empty
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false


### PR DESCRIPTION
TLDR: I think my current style "looks nice" and `clang-format` messes it up. This changes `.clang-format` to leave this style alone, while not affecting the current code at all.

## Example of the structure trailing comment style

My structures are generally written in a trailing-documentation-comment style, which is a short English description of what each member of an object is supposed to do, or a little piece of contextual information about it (e.g., "for debug only"). This style originates in the historical UNIX kernel. It looks like this:

```.h
struct monad_fiber {
    alignas(64) monad_spinlock_t lock;     ///< Protects most fiber fields
    enum monad_fiber_state state;          ///< Run state fiber is in
    monad_fiber_prio_t priority;           ///< Scheduling priority
    struct thread_fiber_state *thread_fs;  ///< Book-keeping for thread fiber
    monad_fcontext_t suspended_ctx;        ///< Stack pointer at susp. point
    monad_fiber_t *prev_fiber;             ///< Fiber that transferred control to us
    pthread_t last_thread;                 ///< For debug: last thread we ran on
    int last_thread_id;                    ///< For debug: system ID of last thr
    struct monad_fiber_stats stats;        ///< Statistics about this fiber
    monad_fiber_ffunc_t *ffunc;            ///< Fiber function to run
    uintptr_t fdata;                       ///< Opaque user data passed to ffunc
    monad_fiber_stack_t stack;             ///< Descriptor for fiber's stack
    char name[MONAD_FIBER_NAME_LEN + 1];   ///< Fiber name, for debugging
#if MONAD_HAVE_ASAN
    void *fake_stack_save;                 ///< For ASAN fiber stack support
#endif
};
```

In this style, some comments don't add very much, e.g., this one is kind of redundant


```.h
    enum monad_fiber_state state;          ///< Run state fiber is in
```

whereas others clarify some of the less obvious things you wouldn't know without reading the code in detail, e.g., what `fdata` is in this example:


```.h
    monad_fiber_ffunc_t *ffunc;            ///< Fiber function to run
    uintptr_t fdata;                       ///< Opaque user data passed to ffunc
```

This style first appeared in Research V6 UNIX (circa 1975). Here is an example (in the disk block buffer management system):

https://github.com/dspinellis/unix-history-repo/blob/Research-V6-Snapshot-Development/usr/sys/buf.h

It remains in the BSD derivatives to this day, where I picked it up from. I think it adds maybe 5-10% more "comprehension power" as you get a tiny bit of documentation as you are reading through, but it is not distracting.

## About this clang-format change

The current trailing comment alignment style is `false`, which will do this to my beautiful structure (and turn it into a bizarre visual distraction):

```.h
struct monad_fiber
{
    alignas(64) monad_spinlock_t lock; ///< Protects most fiber fields
    enum monad_fiber_state state; ///< Run state fiber is in
    monad_fiber_prio_t priority; ///< Scheduling priority
    struct thread_fiber_state *thread_fs; ///< Book-keeping for thread fiber
    monad_fcontext_t suspended_ctx; ///< Stack pointer at susp. point
    monad_fiber_t *prev_fiber; ///< Previously running fiber
    pthread_t last_thread; ///< For debug: last thread we ran on
    int last_thread_id; ///< For debug: system ID of last thr
    struct monad_fiber_stats stats; ///< Statistics about this fiber
    monad_fiber_ffunc_t *ffunc; ///< Fiber function to run
    uintptr_t fdata; ///< Opaque user data passed to ffunc
    monad_fiber_stack_t stack; ///< Descriptor for fiber's stack
    char name[MONAD_FIBER_NAME_LEN + 1]; ///< Fiber name, for debugging
#if MONAD_HAVE_ASAN
    void *fake_stack_save; ///< For ASAN fiber stack support
#endif
};
```

This changes it to `Leave`, which will leave this style alone. This means it won't change any existing code, but anyone that uses the style will need to align for themselves (I am fine with aligning it myself, as it's somewhat of an art form).