### PR TITLE
Fiber PR3: add the thread-safe priority queue

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -27,6 +27,13 @@ option(MONAD_CORE_SPINLOCK_TRACK_STATS
 option(MONAD_CORE_SPINLOCK_TRACK_STATS_ATOMIC
        "use fetch_add on atomics statistics tracking" OFF)
 
+# This is reasonable behavior to have, that is not strictly needed at the moment
+# for `monad` but could cause surprises later and failures in the test suite.
+# This should be the normal behavior (without a configuration option) if we can
+# figure out how to avoid the slight performance hit
+option(MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO
+       "Allow the run_queue to support equal priority fibers" ON)
+
 # ##############################################################################
 # deps
 # ##############################################################################
@@ -143,6 +150,8 @@ add_library(
   "src/monad/fiber/priority_queue.cpp"
   "src/monad/fiber/priority_queue.hpp"
   "src/monad/fiber/priority_task.hpp"
+  "src/monad/fiber/run_queue.c"
+  "src/monad/fiber/run_queue.h"
   # io
   "src/monad/io/buffer_pool.cpp"
   "src/monad/io/buffer_pool.hpp"
@@ -203,6 +212,11 @@ endif()
 if(MONAD_CORE_SPINLOCK_TRACK_STATS_ATOMIC)
   target_compile_definitions(monad_core
                              PUBLIC MONAD_SPINLOCK_TRACK_STATS_ATOMIC)
+endif()
+
+if(MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO)
+  target_compile_definitions(monad_core
+                             PUBLIC MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO)
 endif()
 
 target_link_libraries(monad_core PUBLIC monad_boost_context)

--- a/libs/core/src/monad/fiber/fiber.h
+++ b/libs/core/src/monad/fiber/fiber.h
@@ -31,6 +31,7 @@ extern "C"
  */
 
 typedef void *monad_fcontext_t;
+typedef struct monad_run_queue monad_run_queue_t;
 typedef struct monad_thread_executor monad_thread_executor_t;
 
 /*
@@ -162,6 +163,10 @@ struct monad_fiber
     enum monad_fiber_state state;        ///< Run state the fiber is in
     unsigned fiber_id;                   ///< Unique ID of fiber
     monad_fiber_prio_t priority;         ///< Scheduling priority
+    #if MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO
+    __int128_t rq_priority;              ///< Adjusted priority, see run_queue.h
+    #endif
+    monad_run_queue_t *run_queue;        ///< Most recent run queue
     monad_fcontext_t md_suspended_ctx;   ///< Suspended context pointer
     monad_thread_executor_t *thr_exec;   ///< Current thread we're running on
     void *user_data;                     ///< Opaque user data
@@ -181,6 +186,7 @@ enum monad_fiber_state : unsigned
 {
     MF_STATE_INIT,      ///< Fiber function not run yet
     MF_STATE_CAN_RUN,   ///< Not running but able to run
+    MF_STATE_RUN_QUEUE, ///< Scheduled on a run queue
     MF_STATE_RUNNING,   ///< Fiber or thread is running
     MF_STATE_FINISHED   ///< Suspended by function return; fiber is finished
 };

--- a/libs/core/src/monad/fiber/run_queue.c
+++ b/libs/core/src/monad/fiber/run_queue.c
@@ -1,0 +1,69 @@
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/spinlock.h>
+#include <monad/fiber/fiber.h>
+#include <monad/fiber/run_queue.h>
+
+int monad_run_queue_create(
+    monad_allocator_t *alloc, size_t capacity, monad_run_queue_t **rq)
+{
+    static_assert(alignof(monad_run_queue_t) >= alignof(monad_run_queue_t *));
+    monad_run_queue_t *run_queue;
+    monad_memblk_t memblk;
+    int rc;
+    size_t const total_size =
+        sizeof *run_queue + capacity * sizeof(monad_fiber_t *);
+    if (rq == nullptr) {
+        return EFAULT;
+    }
+    rc =
+        monad_cma_alloc(alloc, total_size, alignof(monad_run_queue_t), &memblk);
+    if (rc != 0) {
+        return rc;
+    }
+    *rq = run_queue = memblk.ptr;
+    memset(run_queue, 0, sizeof *run_queue);
+    monad_spinlock_init(&run_queue->lock);
+    run_queue->fibers = (monad_fiber_t **)(run_queue + 1);
+    run_queue->capacity = capacity;
+    run_queue->alloc = alloc;
+    run_queue->self_memblk = memblk;
+    run_queue->size = 0;
+    rc = monad_cma_calloc(
+        alloc,
+        stdc_bit_width(capacity),
+        sizeof(size_t),
+        alignof(size_t),
+        &run_queue->stats.histogram_blk);
+    ;
+    if (rc != 0) {
+        monad_run_queue_destroy(run_queue);
+        return rc;
+    }
+    run_queue->stats.heapify_iter_histogram =
+        run_queue->stats.histogram_blk.ptr;
+    memset(
+        run_queue->stats.heapify_iter_histogram,
+        0,
+        sizeof(size_t) * stdc_bit_width(capacity));
+    return 0;
+}
+
+void monad_run_queue_destroy(monad_run_queue_t *rq)
+{
+    MONAD_ASSERT(rq != nullptr);
+    if (rq->stats.histogram_blk.ptr) {
+        monad_cma_dealloc(rq->alloc, rq->stats.histogram_blk);
+    }
+    monad_cma_dealloc(rq->alloc, rq->self_memblk);
+}
+
+int _monad_run_queue_try_push_global(
+    monad_run_queue_t *rq, monad_fiber_t *fiber)
+{
+    return monad_run_queue_try_push(rq, fiber);
+}

--- a/libs/core/src/monad/fiber/run_queue.h
+++ b/libs/core/src/monad/fiber/run_queue.h
@@ -1,0 +1,273 @@
+#pragma once
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdbit.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/likely.h>
+#include <monad/core/spinlock.h>
+#include <monad/fiber/fiber.h>
+#include <monad/mem/cma/cma_alloc.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+struct monad_run_queue_stats;
+typedef struct monad_run_queue monad_run_queue_t;
+
+/// Create a fiber run queue of the specified fixed size; this is a priority
+/// queue of fibers, ordered by the monad_fiber_t scheduling "priority" field
+int monad_run_queue_create(
+    monad_allocator_t *alloc, size_t capacity, monad_run_queue_t **rq);
+
+/// Destroys a fiber run queue; destruction is not thread safe, so all push and
+/// pop operations must be finished
+void monad_run_queue_destroy(monad_run_queue_t *rq);
+
+/// Try to push a fiber onto the priority queue; this is non-blocking and
+/// returns ENOBUFS immediately is there is insufficient space in the queue
+static int
+monad_run_queue_try_push(monad_run_queue_t *rq, monad_fiber_t *fiber);
+
+/// Try to pop the highest priority fiber from the queue; this is non-blocking
+/// and returns nullptr if the queue is empty, otherwise it returns a locked
+/// fiber
+static monad_fiber_t *monad_run_queue_try_pop(monad_run_queue_t *rq);
+
+/// Returns true if the run queue is currently empty; be aware that this has
+/// a TOCTOU race in multithreaded code, e.g., this could change asynchronously
+/// because of another thread
+static bool monad_run_queue_is_empty(monad_run_queue_t const *rq);
+
+// clang-format off
+
+/// Scheduling statistics; some writes to these are unlocked without the use
+/// of fetch_add atomic semantics, so they are only approximate
+struct monad_run_queue_stats
+{
+    size_t total_pop;            ///< # of times caller tried to pop a fiber
+    size_t total_pop_empty;      ///< # of times there was no fiber in queue
+    size_t total_push;           ///< # of times caller tried to push a fiber
+    size_t total_push_full;      ///< # of times fiber queue was full
+    size_t total_push_not_ready; ///< # of times pushed fiber unready
+    size_t *heapify_iter_histogram; ///< Histogram of heapify iterations
+    monad_memblk_t histogram_blk;   ///< Allocator handle for histo memory
+};
+
+// clang-format on
+
+/// A priority queue, implemented using a min-heap; used to pick the highest
+/// priority fiber to schedule next. For reference, see
+/// [CLRS 6.5: Priority Queues]
+struct monad_run_queue
+{
+    alignas(64) monad_spinlock_t lock;
+    monad_fiber_t **fibers;
+    size_t capacity;
+    monad_allocator_t *alloc;
+    monad_memblk_t self_memblk;
+    alignas(64) atomic_size_t size;
+    uint64_t serial_id;
+    alignas(64) struct monad_run_queue_stats stats;
+};
+
+#define PQ_PARENT_IDX(i) ((i - 1) / 2)
+#define PQ_LEFT_CHILD_IDX(i) (2 * i + 1)
+#define PQ_RIGHT_CHILD_IDX(i) (2 * i + 2)
+
+#if MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO
+    #define PQ_IS_HIGHER_PRIO(L, R) ((L)->rq_priority < (R)->rq_priority)
+#else
+    #define PQ_IS_HIGHER_PRIO(L, R) ((L)->priority < (R)->priority)
+#endif
+
+// Same as monad_run_queue_try_push, but as a global (non-inlinable) symbol;
+// this is needed to work around a circular dependency, because the inlinable
+// code in run_queue.h and fiber_impl.h both want to call each other
+extern int
+_monad_run_queue_try_push_global(monad_run_queue_t *rq, monad_fiber_t *fiber);
+
+static inline void
+_monad_fiber_ptr_swap(monad_fiber_t const **p1, monad_fiber_t const **p2)
+{
+    monad_fiber_t const *const t = *p2;
+    *p2 = *p1;
+    *p1 = t;
+}
+
+static inline unsigned prio_queue_min_heapify(
+    monad_fiber_t const **fibers, size_t queue_size, size_t parent_idx)
+{
+    unsigned iters = 1;
+HeapifyNextLevel:
+    size_t highest_prio_idx = parent_idx;
+    size_t left_idx = PQ_LEFT_CHILD_IDX(parent_idx);
+    size_t right_idx = PQ_RIGHT_CHILD_IDX(parent_idx);
+
+    if (left_idx < queue_size &&
+        PQ_IS_HIGHER_PRIO(fibers[left_idx], fibers[highest_prio_idx])) {
+        highest_prio_idx = left_idx;
+    }
+
+    if (right_idx < queue_size &&
+        PQ_IS_HIGHER_PRIO(fibers[right_idx], fibers[highest_prio_idx])) {
+        highest_prio_idx = right_idx;
+    }
+
+    if (highest_prio_idx == parent_idx) {
+        return iters;
+    }
+
+    _monad_fiber_ptr_swap(&fibers[parent_idx], &fibers[highest_prio_idx]);
+    parent_idx = highest_prio_idx;
+    ++iters;
+    goto HeapifyNextLevel;
+}
+
+inline int monad_run_queue_try_push(monad_run_queue_t *rq, monad_fiber_t *fiber)
+{
+    size_t idx;
+    size_t size;
+    int rc = 0;
+    unsigned heapify_iters = 0;
+
+    MONAD_DEBUG_ASSERT(rq != nullptr && fiber != nullptr);
+    MONAD_SPINLOCK_LOCK(&rq->lock);
+    ++rq->stats.total_push;
+    // Relaxed because it isn't ordered before the spinlock acquisition
+    size = atomic_load_explicit(&rq->size, memory_order_relaxed);
+    if (MONAD_UNLIKELY(size == rq->capacity)) {
+        ++rq->stats.total_push_full;
+        rc = ENOBUFS;
+        goto Finish;
+    }
+
+    if (MONAD_UNLIKELY(!monad_spinlock_is_self_owned(&fiber->lock))) {
+        MONAD_SPINLOCK_LOCK(&fiber->lock);
+    }
+    switch (fiber->state) {
+    case MF_STATE_INIT:
+        [[fallthrough]];
+    case MF_STATE_FINISHED:
+        rc = ENXIO;
+        ++rq->stats.total_push_not_ready;
+        goto Finish;
+
+    case MF_STATE_CAN_RUN:
+        rc = 0;
+        break;
+
+    default:
+        rc = EBUSY;
+        ++rq->stats.total_push_not_ready;
+        goto Finish;
+    }
+
+    idx = size++;
+#if MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO
+    // To robustly support fibers with equal priority, we need to adjust the
+    // scheduling priority so that reinsertion effectively lowers the priority,
+    // see the comment in the run_queue.equal_round_robin unit test
+    fiber->rq_priority =
+        ((__int128_t)fiber->priority << 64) | (rq->serial_id++);
+#endif
+    rq->fibers[idx] = fiber;
+    while (idx != 0 &&
+           PQ_IS_HIGHER_PRIO(rq->fibers[idx], rq->fibers[PQ_PARENT_IDX(idx)])) {
+        _monad_fiber_ptr_swap(
+            (monad_fiber_t const **)&rq->fibers[idx],
+            (monad_fiber_t const **)&rq->fibers[PQ_PARENT_IDX(idx)]);
+        idx = PQ_PARENT_IDX(idx);
+        ++heapify_iters;
+    }
+    fiber->run_queue = rq;
+    fiber->state = MF_STATE_RUN_QUEUE;
+    MONAD_SPINLOCK_UNLOCK(&fiber->lock);
+    atomic_store_explicit(&rq->size, size, memory_order_relaxed);
+    ++rq->stats.heapify_iter_histogram[stdc_bit_width(heapify_iters)];
+Finish:
+    MONAD_SPINLOCK_UNLOCK(&rq->lock);
+    return rc;
+}
+
+inline monad_fiber_t *monad_run_queue_try_pop(monad_run_queue_t *rq)
+{
+    monad_fiber_t *min_prio_fiber;
+    size_t size;
+    unsigned heapify_iter;
+
+    MONAD_DEBUG_ASSERT(rq != nullptr);
+    ++rq->stats.total_pop;
+    // Because we're I/O bound, the run_queue is usually empty (we're often
+    // waiting for any fiber to become runnable again). To prevent constant lock
+    // contention, the queue size is atomic and we can poll it
+    size = atomic_load_explicit(&rq->size, memory_order_acquire);
+    if (MONAD_UNLIKELY(size == 0)) {
+        ++rq->stats.total_pop_empty;
+        return nullptr;
+    }
+    if (MONAD_UNLIKELY(!MONAD_SPINLOCK_TRY_LOCK(&rq->lock))) {
+        ++rq->stats.total_pop_empty;
+        // We failed to get the lock; the likeliest sequence of events is that
+        // we had multiple pollers and only one fiber became available. By
+        // failing to get the lock, we likely would fail completely (the size
+        // will probably be zero soon)
+        return nullptr;
+    }
+    // The size may have changed in between our polling of the size and getting
+    // the lock that protects writes to it; the load is relaxed here since we
+    // piggy-back off the memory ordering imposed by the spinlock
+    size = atomic_load_explicit(&rq->size, memory_order_relaxed);
+    if (MONAD_UNLIKELY(size == 0)) {
+        ++rq->stats.total_pop_empty;
+        MONAD_SPINLOCK_UNLOCK(&rq->lock);
+        return nullptr;
+    }
+
+    min_prio_fiber = rq->fibers[0];
+
+#if MONAD_CORE_RUN_QUEUE_NO_MIGRATE
+    if (min_prio_fiber->last_thread != 0 &&
+        min_prio_fiber->last_thread != pthread_self()) {
+        MONAD_SPINLOCK_UNLOCK(&rq->lock);
+        return nullptr;
+    }
+#endif
+
+    --size;
+    atomic_store_explicit(&rq->size, size, memory_order_release);
+    if (MONAD_LIKELY(size > 0)) {
+        _monad_fiber_ptr_swap(
+            (monad_fiber_t const **)&rq->fibers[0],
+            (monad_fiber_t const **)&rq->fibers[size]);
+        heapify_iter =
+            prio_queue_min_heapify((monad_fiber_t const **)rq->fibers, size, 0);
+        ++rq->stats.heapify_iter_histogram[stdc_bit_width(heapify_iter)];
+    }
+    MONAD_SPINLOCK_UNLOCK(&rq->lock);
+
+    // Return the fiber in a locked state; the caller is almost certainly going
+    // to call monad_fiber_run immediately
+    MONAD_SPINLOCK_LOCK(&min_prio_fiber->lock);
+    min_prio_fiber->state = MF_STATE_CAN_RUN;
+    return min_prio_fiber;
+}
+
+inline bool monad_run_queue_is_empty(monad_run_queue_t const *rq)
+{
+    return atomic_load_explicit(&rq->size, memory_order_relaxed) == 0;
+}
+
+#undef PQ_PARENT_IDX
+#undef PQ_LEFT_CHILD_IDX
+#undef PQ_RIGHT_CHILD_IDX
+#undef PQ_IS_HIGHER_PRIO
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/libs/core/test/CMakeLists.txt
+++ b/libs/core/test/CMakeLists.txt
@@ -18,6 +18,7 @@ monad_add_test(io_buffers_test "io_buffers.cpp")
 monad_add_test(literal_test "literal_test.cpp")
 monad_add_test(priority_pool_test "priority_pool_test.cpp")
 set_tests_properties(priority_pool_test PROPERTIES RUN_SERIAL TRUE)
+monad_add_test(run_queue_test "run_queue_test.cpp")
 monad_add_test(spinlock_test "spinlock.cpp")
 monad_add_test(spinlock_all_options_test "spinlock.cpp")
 target_compile_definitions(

--- a/libs/core/test/run_queue_test.cpp
+++ b/libs/core/test/run_queue_test.cpp
@@ -1,0 +1,125 @@
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <errno.h>
+#include <gtest/gtest.h>
+
+#include <monad/fiber/fiber.h>
+#include <monad/fiber/run_queue.h>
+
+static monad_c_result dummy_function(monad_fiber_args_t)
+{
+    return monad_c_make_success(0);
+}
+
+TEST(run_queue, basic_test)
+{
+    constexpr std::size_t NumberOfFibers = 256;
+    constexpr std::size_t NumberOfTrials = 2048;
+    std::vector<monad_fiber_t *> fibers;
+    monad_run_queue_t *rq;
+
+    for (std::size_t i = 0; i < NumberOfFibers; ++i) {
+        auto &fiber = fibers.emplace_back();
+        ASSERT_EQ(0, monad_fiber_create(nullptr, &fiber));
+
+        // Install a dummy function for the fiber; if we don't do this, the
+        // run queue will think it is not in a runnable state, and would return
+        // ENXIO
+        auto const prio = static_cast<monad_fiber_prio_t>(i);
+        ASSERT_EQ(0, monad_fiber_set_function(fiber, prio, dummy_function, {}));
+    }
+    ASSERT_EQ(0, monad_run_queue_create(nullptr, NumberOfFibers, &rq));
+    std::default_random_engine rand_engine{std::random_device{}()};
+    std::uniform_int_distribution prio_dist{
+        MONAD_FIBER_PRIO_HIGHEST, MONAD_FIBER_PRIO_LOWEST};
+
+    for (std::size_t i = 0; i < NumberOfTrials; ++i) {
+        // A trial is an assignment of a random priority to all fibers, followed
+        // by their insertion into the priority queue. Then we check that the
+        // popped sequence is always in priority order.
+        ASSERT_TRUE(monad_run_queue_is_empty(rq));
+
+        for (auto *fiber : fibers) {
+            fiber->priority = prio_dist(rand_engine);
+            ASSERT_EQ(0, monad_run_queue_try_push(rq, fiber));
+        }
+
+        // Verify that we aren't allowed to overflow the queue
+        ASSERT_EQ(ENOBUFS, monad_run_queue_try_push(rq, fibers.front()));
+
+        monad_fiber_prio_t last_prio = MONAD_FIBER_PRIO_HIGHEST;
+        while (!monad_run_queue_is_empty(rq)) {
+            monad_fiber_t *const fiber = monad_run_queue_try_pop(rq);
+            ASSERT_NE(nullptr, fiber);
+            // The last priority always has higher (or equal) priority than
+            // the next one we're going to run. A higher priority is represented
+            // by a smaller number, so >= priority is <= numerically.
+            ASSERT_LE(last_prio, fiber->priority);
+            last_prio = fiber->priority;
+        }
+
+        // When empty, pop nullptr
+        ASSERT_EQ(nullptr, monad_run_queue_try_pop(rq));
+    }
+
+    monad_run_queue_destroy(rq);
+    for (auto *fiber : fibers) {
+        monad_fiber_destroy(fiber);
+    }
+}
+
+#if MONAD_CORE_RUN_QUEUE_SUPPORT_EQUAL_PRIO
+
+TEST(run_queue, equal_round_robin)
+{
+    constexpr std::size_t NumberOfFibers = 128;
+
+    std::vector<monad_fiber_t *> fibers;
+    monad_run_queue_t *rq;
+
+    for (std::size_t i = 0; i < NumberOfFibers; ++i) {
+        auto &fiber = fibers.emplace_back();
+        ASSERT_EQ(0, monad_fiber_create(nullptr, &fiber));
+
+        // Install a dummy function for the fiber; if we don't do this, the
+        // run queue will think it is not in a runnable state, and would return
+        // ENXIO
+        ASSERT_EQ(
+            0,
+            monad_fiber_set_function(
+                fiber, MONAD_FIBER_PRIO_HIGHEST, dummy_function, {}));
+    }
+    ASSERT_EQ(0, monad_run_queue_create(nullptr, NumberOfFibers, &rq));
+
+    // The round-robin test checks that equal priority fibers are considered
+    // to have lower priority upon reinsertion into the priority queue. If this
+    // were not the case, and we had two fibers F1 and F2 with the same
+    // priority P, we might never run F2. Popping F1 and re-enqueuing it could
+    // return F1 every time, and we will never have a chance to run F2.
+    for (std::size_t i = 0; i < NumberOfFibers; ++i) {
+        ASSERT_EQ(0, monad_run_queue_try_push(rq, fibers[i]));
+    }
+
+    std::unordered_set<monad_fiber_t *> seen_fibers;
+    for (std::size_t i = 0; i < NumberOfFibers; ++i) {
+        monad_fiber_t *const fiber = monad_run_queue_try_pop(rq);
+
+        // Check that we haven't seen this fiber before
+        ASSERT_FALSE(seen_fibers.contains(fiber));
+        seen_fibers.insert(fiber);
+
+        // Push it back into the queue; it should go to the end of the line
+        ASSERT_EQ(0, monad_run_queue_try_push(rq, fiber));
+    }
+    // Everything was seen exactly once
+    ASSERT_EQ(NumberOfFibers, seen_fibers.size());
+
+    monad_run_queue_destroy(rq);
+    for (auto *fiber : fibers) {
+        monad_fiber_destroy(fiber);
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds a thread-safe priority queue, which forms the basis for writing scheduling code. Implementation-wise, it is a simple min-heap priority queue, of the type found in a "Data Structures 101" textbook, and is protected by a spinlock for safety.

Fancy algorithms for lock-free priority queues exist. As the scheduling becomes faster/smarter/better we may add them later.

The way it fits into the overall design is described in an update to `fiber-api.md`. The synchronization primitives need some kind of scheduling concept to exist, so that they can actually do something when it is time to wakeup from sleeping (namely, to be rescheduled), thus this PR is a dependency that must come first