### PR TITLE
Change error message wording on DB warning bump

### DIFF
--- a/libs/db/src/monad/mpt/cli_tool_impl.cpp
+++ b/libs/db/src/monad/mpt/cli_tool_impl.cpp
@@ -776,9 +776,12 @@ public:
                         monad::mpt::detail::db_metadata::MAGIC,
                         monad::mpt::detail::db_metadata::MAGIC_STRING_LEN)) {
                     std::stringstream ss;
-                    ss << "DB archive was generated with a different version "
-                          "than the current code base, please regenerate "
-                          "archive with the new DB version";
+                    ss << "DB archive was generated with version "
+                       << old_metadata->magic
+                       << ". The current code base is on version "
+                       << monad::mpt::detail::db_metadata::MAGIC
+                       << ". Please regenerate archive with the new DB "
+                          "version.";
                     throw std::runtime_error(ss.str());
                 }
                 auto cnv_chunk =

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -305,6 +305,22 @@ void UpdateAuxImpl::set_io(AsyncIO *io_, uint64_t const history_len)
             }
         }
     }
+
+    constexpr unsigned magic_prefix_len =
+        detail::db_metadata::MAGIC_STRING_LEN - 1;
+    if (0 == memcmp(
+                 db_metadata_[0]->magic,
+                 detail::db_metadata::MAGIC,
+                 magic_prefix_len) &&
+        db_metadata_[0]->magic[magic_prefix_len] !=
+            detail::db_metadata::MAGIC[magic_prefix_len]) {
+        std::stringstream ss;
+        ss << "DB was generated with version " << db_metadata_[0]->magic
+           << ". The current code base is on version "
+           << monad::mpt::detail::db_metadata::MAGIC
+           << ". Please regenerate with the new DB version.";
+        throw std::runtime_error(ss.str());
+    }
     // Replace any dirty copy with the non-dirty copy
     if (0 == memcmp(
                  db_metadata_[0]->magic,


### PR DESCRIPTION
  * Opening a RWDb on a previous version errors on version mismatch
  * Opening RODb on older DB version errors on version mismatch
  * Restoring from archive errors on version mismatch