### PR TITLE
bug fix: trie node alloc_size is 4 bytes more than required

### DIFF
--- a/libs/db/src/monad/mpt/node.cpp
+++ b/libs/db/src/monad/mpt/node.cpp
@@ -607,14 +607,16 @@ deserialize_node_from_buffer(unsigned char const *read_pos, size_t max_bytes)
     // Load the on disk node
     auto const mask = unaligned_load<uint16_t>(read_pos);
     auto const number_of_children = static_cast<unsigned>(std::popcount(mask));
-    auto const alloc_size =
-        static_cast<uint32_t>(disk_size + number_of_children * sizeof(Node *));
+    auto const alloc_size = static_cast<uint32_t>(
+        disk_size + number_of_children * sizeof(Node *) -
+        Node::disk_size_bytes);
     auto node = Node::make(alloc_size);
     std::copy_n(
         read_pos,
         disk_size - Node::disk_size_bytes,
         (unsigned char *)node.get());
     std::memset(node->next_data(), 0, number_of_children * sizeof(Node *));
+    MONAD_ASSERT(alloc_size == node->get_mem_size());
     return node;
 }
 


### PR DESCRIPTION
It was introduced in an earlier change when we split `uint32_t disk_size` out of `Node`.

however this doesn't affect correctness or introduce any memory leak
thanks to @kkuehlz for pointing it out. This was found when looking into oom issue https://github.com/monad-crypto/monad-internal/issues/510

LRU pr actually got it fixed but now that we reverted it, there's still this size mismatch