### PR TITLE
Add DB APIs to introspect triedb memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option(HUNTER_ENABLED OFF)
 
 option(EVMONE_TRACING
        "Enable instruction-level tracing for the evmone interpreter" OFF)
+option(TRIEDB_INSTRUMENT_MEM_USAGE
+       "Enable memory usage statistics on TrieDb Nodes" OFF)
 option(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(BUILD_SHARED_LIBS OFF)
 
@@ -45,6 +47,10 @@ function(monad_compile_options target)
 
   if(EVMONE_TRACING)
     target_compile_definitions(${target} PUBLIC EVMONE_TRACING=1)
+  endif()
+
+  if(TRIEDB_INSTRUMENT_MEM_USAGE)
+    target_compile_definitions(${target} PUBLIC "TRIEDB_INSTRUMENT_MEM_USAGE=1")
   endif()
 endfunction()
 

--- a/libs/db/src/monad/mpt/db.cpp
+++ b/libs/db/src/monad/mpt/db.cpp
@@ -904,6 +904,15 @@ uint64_t Db::get_history_length() const
     return is_on_disk() ? impl_->aux().version_history_length() : 1;
 }
 
+std::pair<uint64_t, uint64_t> Db::get_trie_memory_usage() const
+{
+#ifdef TRIEDB_INSTRUMENT_MEM_USAGE
+    return Node::trie_memory_usage();
+#else
+    return {};
+#endif
+}
+
 AsyncContext::AsyncContext(Db &db, size_t lru_size)
     : aux(db.impl_->aux())
     , root_cache(lru_size)

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -89,6 +89,9 @@ public:
 
     bool is_on_disk() const;
     bool is_read_only() const;
+
+    // Returns the memory footprint of TrieDb
+    std::pair<uint64_t, uint64_t> get_trie_memory_usage() const;
 };
 
 // The following are not threadsafe. Please use async get from the RODb owning

--- a/libs/db/src/monad/mpt/node.cpp
+++ b/libs/db/src/monad/mpt/node.cpp
@@ -87,6 +87,11 @@ Node::~Node()
         }
         set_next(index, nullptr);
     }
+#ifdef TRIEDB_INSTRUMENT_MEM_USAGE
+    auto const node_size = static_cast<uint64_t>(get_mem_size());
+    Node::num_nodes_in_memory.fetch_sub(1, std::memory_order_acq_rel);
+    Node::node_memory_footprint.fetch_sub(node_size, std::memory_order_acq_rel);
+#endif
 }
 
 unsigned Node::to_child_index(unsigned const branch) const noexcept


### PR DESCRIPTION
  * The feature is gated by `TRIEDB_INSTRUMENT_MEM_USAGE` flag. Adds two atomic acq-rel operations for node allocation and deallocation.
  * When enabled, returns a tuple of `[trie_memory_usage, triedb_num_nodes]`.
  * [Intended for use by RPC](https://github.com/monad-crypto/monad-bft/tree/kkuehler/instrument) to determine if RODb is causing OOM issues.