### PR TITLE
Remove copy_loggable for NibblesView

### DIFF
--- a/libs/db/src/monad/mpt/nibbles_view_fmt.hpp
+++ b/libs/db/src/monad/mpt/nibbles_view_fmt.hpp
@@ -7,7 +7,7 @@
 #include <quill/bundled/fmt/format.h>
 
 template <>
-struct quill::copy_loggable<monad::mpt::NibblesView> : std::true_type
+struct quill::copy_loggable<monad::mpt::NibblesView> : std::false_type
 {
 };
 


### PR DESCRIPTION
Reason:
copy_loggable will copy the data to quill backend, but since NibbleView is a view, it will do a shallow copy.