### PR TITLE
[core] add a MONAD_ABORT macro, allow MONAD_ASSERT to accept a printf-style message

### DIFF
--- a/libs/core/src/monad/core/assert.c
+++ b/libs/core/src/monad/core/assert.c
@@ -43,12 +43,12 @@ void monad_assertion_failed(
             line,
             function);
     }
-    if ((size_t)written >= sizeof(buffer)) {
-        written = (int)(sizeof(buffer) - 1);
+    if (written < 0 || (size_t)written >= sizeof(buffer)) {
+        written = (ssize_t)sizeof(buffer) - 1;
     }
-    if (msg != nullptr && written < (int)(sizeof buffer - 1)) {
+    if (msg != nullptr) {
         written += (ssize_t)strlcpy(
-            buffer + written, msg, sizeof buffer - (size_t)written);
+            buffer + written, msg, sizeof(buffer) - (size_t)written);
         if ((size_t)written >= sizeof(buffer)) {
             written = (int)(sizeof(buffer) - 1);
         }
@@ -57,10 +57,8 @@ void monad_assertion_failed(
         }
     }
     // abort() is async signal safe in glibc
-    written = write(2 /*stderr*/, buffer, (size_t)written);
-    if (written == -1) {
-        // This is to shut up the warning
-        abort();
+    if (write(STDERR_FILENO, buffer, (size_t)written) == -1) {
+        abort(); // Needed because of -Werror=unused-result
     }
     abort();
 }

--- a/libs/core/src/monad/core/assert.h
+++ b/libs/core/src/monad/core/assert.h
@@ -13,10 +13,9 @@ extern "C"
 
 #define MONAD_ASSERTION_FAILED_WITH_MSG(expr, msg)                             \
     /* Ensure msg is a static string at a fixed address; we do this because */ \
-    /* MONAD_ASSERT can be used within a signal handler, and we don't want */  \
-    /* a "double fault" occurring if dereferencing an unknown pointer could */ \
-    /* cause a nested error, e.g., a SIGSEGV raised by reading *msg while */   \
-    /* we're handling another signal */                                        \
+    /* we don't want a fault occurring if dereferencing an unknown pointer */  \
+    /* could cause a nested error, e.g., SIGSEGV raised by reading *msg */     \
+    /* while we're reporting assertion failure */                              \
     static_assert(__builtin_constant_p(msg));                                  \
     monad_assertion_failed(                                                    \
         #expr, __extension__ __PRETTY_FUNCTION__, __FILE__, __LINE__, msg);
@@ -44,16 +43,19 @@ extern "C"
     }                                                                          \
     else {                                                                     \
         char buf[1 << 14]; /* 16 KiB */                                        \
-        char *const buf_end = buf + sizeof buf;                                \
+        int written;                                                           \
+        char *const buf_end = buf + sizeof(buf);                               \
         char *p = stpcpy(buf, "assertion failure message: ");                  \
-        p += snprintf(                                                         \
+        written = snprintf(                                                    \
             p, (size_t)(buf_end - p), (format)__VA_OPT__(, ) __VA_ARGS__);     \
+        /* If snprintf fails (written < 0) we're not sure what state buf */    \
+        /* is in; write as much as possible so we don't lose info, but */      \
+        /* leave room for "\n\0" */                                            \
+        p = written < 0 ? buf_end - 2 : p + written;                           \
         if (p < buf_end) {                                                     \
-            stpncpy(p, "\n", (size_t)(buf_end - p));                           \
+            strncpy(p, "\n", (size_t)(buf_end - p));                           \
         }                                                                      \
-        else {                                                                 \
-            buf_end[-1] = '\0';                                                \
-        }                                                                      \
+        buf_end[-1] = '\0';                                                    \
         monad_assertion_failed(                                                \
             #expr,                                                             \
             __extension__ __PRETTY_FUNCTION__,                                 \
@@ -78,15 +80,17 @@ extern "C"
 #define MONAD_ABORT_PRINTF(format, ...)                                        \
     {                                                                          \
         char buf[1 << 14]; /* 16 KiB */                                        \
-        char *const buf_end = buf + sizeof buf;                                \
+        int written;                                                           \
+        char *const buf_end = buf + sizeof(buf);                               \
         char *p = stpcpy(buf, "abort message: ");                              \
-        p += snprintf(p, buf_end - p, (format)__VA_OPT__(, ) __VA_ARGS__);     \
+        written =                                                              \
+            snprintf(p, buf_end - p, (format)__VA_OPT__(, ) __VA_ARGS__);      \
+        /* See comment in MONAD_ASSERT_PRINTF */                               \
+        p = written < 0 ? buf_end - 2 : p + written;                           \
         if (p < buf_end) {                                                     \
-            stpncpy(p, "\n", buf_end - p);                                     \
+            strncpy(p, "\n", buf_end - p);                                     \
         }                                                                      \
-        else {                                                                 \
-            buf_end[-1] = '\0';                                                \
-        }                                                                      \
+        buf_end[-1] = '\0';                                                    \
         monad_assertion_failed(                                                \
             nullptr,                                                           \
             __extension__ __PRETTY_FUNCTION__,                                 \

--- a/libs/core/test/backtrace.cpp
+++ b/libs/core/test/backtrace.cpp
@@ -41,10 +41,10 @@ namespace
          * because `i_am_null` is not a compile-time constant. The intention is
          * to make it fail unless a fixed-address string is provided. Note that
          * if we wrote `char const *const i_am_null = nullptr` instead, it would
-         * succeed since __builtin_constant_p(i_am_null) is true in that case.
-         * That is OK (nullptr is explicitly checked for); all we're trying to
-         * prevent here is dereferencing runtime-dynamic invalid pointers in a
-         * signal handler. A known compile-time constant `char const *` value
+         * succeed since __builtin_constant_p(i_am_null) is true. That is OK
+         * (nullptr is explicitly checked for); all we're trying to prevent here
+         * here is dereferencing runtime-dynamic invalid pointers during assert
+         * failure handling. A known compile-time constant `char const *` value
          * should either be nullptr or is almost certainly safe to dereference.
          */
         // MONAD_ASSERT(true, i_am_null);


### PR DESCRIPTION
Occasionally we flow to a place in the code where we must die, where there is no obvious choice for the exact expression to assert is false. There are currently about 20 calls to `MONAD_ASSERT(false)` when this happens, which is not very informative.

This adds a `MONAD_ABORT` macro. The advantage over the `abort()` function in <stdlib.h> is that it may include a printf-style message that explains why we cannot continue. It includes the same source location and stack backtrace machinery as the assertion failure function.

The also changes `MONAD_ASSERT` to accept an optional, printf-style message.

Part of the #892 refactor series