### PR TITLE
[core][cmake] only compile Linux-dependent files on Linux

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -136,23 +136,23 @@ add_library(
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # Append Linux-specific implementation files
   target_sources(
-    monad_core
-    PRIVATE # core
-            "src/monad/core/cgroup.c"
-            "src/monad/core/cgroup.h"
-            "src/monad/core/cpuset.c"
-            "src/monad/core/cpuset.h"
-            # io
-            "src/monad/io/buffers.cpp"
-            "src/monad/io/buffers.hpp"
-            "src/monad/io/ring.hpp"
-            "src/monad/io/ring.cpp"
-            # mem
-            "src/monad/mem/huge_mem.hpp"
-            "src/monad/mem/huge_mem.cpp"
-            # procfs
-            "src/monad/procfs/statm.c"
-            "src/monad/procfs/statm.h")
+    monad_core PRIVATE
+    # core
+    "src/monad/core/cgroup.c"
+    "src/monad/core/cgroup.h"
+    "src/monad/core/cpuset.c"
+    "src/monad/core/cpuset.h"
+    # io
+    "src/monad/io/buffers.cpp"
+    "src/monad/io/buffers.hpp"
+    "src/monad/io/ring.hpp"
+    "src/monad/io/ring.cpp"
+    # mem
+    "src/monad/mem/huge_mem.hpp"
+    "src/monad/mem/huge_mem.cpp"
+    # procfs
+    "src/monad/procfs/statm.c"
+    "src/monad/procfs/statm.h")
 endif()
 
 target_include_directories(monad_core PUBLIC "src")


### PR DESCRIPTION
This is not the ideal way to handle this sort of thing, but in the interest of time, we're taking a short-cut. This (along with other changes) will allow the target `monad_core` to compile, but if any of the functions in these translation units are used, a linker error will occur. This will allow development of targets that link to `monad_core` to proceed on other platforms as long as the final binary does not need any of the Linux functions, e.g., an isolated test suite binary.

The "right way" to do this would involve figuring the "right interface" to support (perhaps it is even the Linux one) and implementing that interface on other platforms. This is possible for features like those in "cpuset.h" or "statm.h". Every operating system has the support for what these are doing, but most have different APIs.

There is other functionality here that not every OS supports, e.g., allowing the user to directly manipulate large page mappings with mmap(2). Some systems (Linux, FreeBSD, Windows) allow this, but others do not.

These issues will be solved on an as-needed basis, as they come up in the development workflow. If they never come up, they will likely never be solved.

Part of the #892 refactor series