### PR TITLE
recover signatures before tx execution

### DIFF
--- a/libs/execution/src/monad/execution/execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/execute_transaction.cpp
@@ -263,12 +263,11 @@ EXPLICIT_EVMC_REVISION(execute_impl);
 template <evmc_revision rev>
 Result<Receipt> execute(
     Chain const &chain, uint64_t const i, Transaction const &tx,
-    BlockHeader const &hdr, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, boost::fibers::promise<void> &prev)
+    std::optional<Address> const &sender, BlockHeader const &hdr,
+    BlockHashBuffer const &block_hash_buffer, BlockState &block_state,
+    boost::fibers::promise<void> &prev)
 {
     TRACE_TXN_EVENT(StartTxn);
-
-    auto const sender = recover_sender(tx);
 
     if (MONAD_UNLIKELY(!sender.has_value())) {
         return TransactionError::MissingSender;

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -38,7 +38,8 @@ Result<Receipt> execute_impl(
 
 template <evmc_revision rev>
 Result<Receipt> execute(
-    Chain const &, uint64_t i, Transaction const &, BlockHeader const &,
+    Chain const &, uint64_t i, Transaction const &,
+    std::optional<Address> const &, BlockHeader const &,
     BlockHashBuffer const &, BlockState &, boost::fibers::promise<void> &prev);
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
allows for further logic changes taking into account known sender and sender nonce as well as other potential optimizations

see same performance on 12M in-memory tps