### PR TITLE
[core][cmake] only compile Linux-dependent files on Linux (bug fix)

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -120,11 +120,7 @@ add_library(
   # io
   "src/monad/io/buffer_pool.cpp"
   "src/monad/io/buffer_pool.hpp"
-  "src/monad/io/buffers.cpp"
-  "src/monad/io/buffers.hpp"
   "src/monad/io/config.hpp"
-  "src/monad/io/ring.cpp"
-  "src/monad/io/ring.hpp"
   # rlp
   "src/monad/rlp/config.hpp"
   "src/monad/rlp/encode.hpp"


### PR DESCRIPTION
The original commit moved some Linux-specific source files inside an `if(<linux>)` guard, but didn't remove them from the platform-independent part of the library