### PR TITLE
[thirdparty][openssl] change imported keccak1600.c to use stdint.h

### DIFF
--- a/libs/core/third_party/openssl/crypto/sha/keccak1600.c
+++ b/libs/core/third_party/openssl/crypto/sha/keccak1600.c
@@ -5,6 +5,10 @@
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
+ *
+ * Modified 2024 Kenneth Camann:
+ * - Removed #include of OS-dependent header <openssl/e_os2.h> and added
+ *   <stdint.h> for the uintXX_t typdefs; this makes the file freestanding
  */
 
 #include <stdint.h>


### PR DESCRIPTION
The architecture-independent `keccak1600.c` imported from OpenSSL in a previous commit tries to include the header file `<openssl/e_os2.h>`, which is the OpenSSL OS-dependent header. The only thing keccak1600.c needs from here are the uintXX_t typedefs, which we can take from stdint.h instead. If we do that, then we won't need to find the system OpenSSL headers at all.