### PR TITLE
Add transaction trie to triedb and compute transactions root

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -152,14 +152,15 @@ Result<std::pair<uint64_t, uint64_t>> run_monad(
         BOOST_OUTCOME_TRY(
             chain.validate_header(receipts, block.value().header));
         block_state.log_debug();
-        block_state.commit(receipts);
+        block_state.commit(receipts, block.value().transactions);
 
         if (!chain.validate_root(
                 rev,
                 block.value().header,
                 db.state_root(),
-                db.receipts_root())) {
-            return BlockError::WrongStateRoot;
+                db.receipts_root(),
+                db.transactions_root())) {
+            return BlockError::WrongMerkleRoot;
         }
 
         ntxs += block.value().transactions.size();

--- a/libs/execution/src/monad/chain/chain.hpp
+++ b/libs/execution/src/monad/chain/chain.hpp
@@ -27,7 +27,8 @@ struct Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root) const = 0;
+        bytes32_t const &receipts_root,
+        bytes32_t const &transactions_root) const = 0;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/ethereum_mainnet.cpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.cpp
@@ -94,7 +94,8 @@ Result<void> EthereumMainnet::validate_header(
 
 bool EthereumMainnet::validate_root(
     evmc_revision const rev, BlockHeader const &hdr,
-    bytes32_t const &state_root, bytes32_t const &receipts_root) const
+    bytes32_t const &state_root, bytes32_t const &receipts_root,
+    bytes32_t const &transactions_root) const
 {
     if (state_root != hdr.state_root) {
         LOG_ERROR(
@@ -114,6 +115,15 @@ bool EthereumMainnet::validate_root(
                 hdr.receipts_root);
             return false;
         }
+    }
+    if (transactions_root != hdr.transactions_root) {
+        LOG_ERROR(
+            "Block: {}, Computed Transactions Root: {}, Expected Transactions "
+            "Root: {}",
+            hdr.number,
+            transactions_root,
+            hdr.transactions_root);
+        return false;
     }
     return true;
 }

--- a/libs/execution/src/monad/chain/ethereum_mainnet.hpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.hpp
@@ -27,7 +27,8 @@ struct EthereumMainnet : Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root) const override;
+        bytes32_t const &receipts_root,
+        bytes32_t const &transactions_root) const override;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/monad_chain.cpp
+++ b/libs/execution/src/monad/chain/monad_chain.cpp
@@ -14,7 +14,7 @@ Result<void> MonadChain::validate_header(
 
 bool MonadChain::validate_root(
     evmc_revision const, BlockHeader const &, bytes32_t const &,
-    bytes32_t const &) const
+    bytes32_t const &, bytes32_t const &) const
 {
     // TODO
     return true;

--- a/libs/execution/src/monad/chain/monad_chain.hpp
+++ b/libs/execution/src/monad/chain/monad_chain.hpp
@@ -17,7 +17,8 @@ struct MonadChain : Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root) const override;
+        bytes32_t const &receipts_root,
+        bytes32_t const &transactions_root) const override;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -26,12 +26,13 @@ struct Db
 
     virtual bytes32_t state_root() = 0;
     virtual bytes32_t receipts_root() = 0;
+    virtual bytes32_t transactions_root() = 0;
 
     virtual void increment_block_number() = 0;
 
     virtual void commit(
-        StateDeltas const &, Code const &,
-        std::vector<Receipt> const & = {}) = 0;
+        StateDeltas const &, Code const &, std::vector<Receipt> const & = {},
+        std::vector<Transaction> const & = {}) = 0;
 
     virtual std::string print_stats()
     {

--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -114,9 +114,10 @@ public:
 
     virtual void commit(
         StateDeltas const &state_deltas, Code const &code,
-        std::vector<Receipt> const &receipts) override
+        std::vector<Receipt> const &receipts,
+        std::vector<Transaction> const &transactions) override
     {
-        db_.commit(state_deltas, code, receipts);
+        db_.commit(state_deltas, code, receipts, transactions);
 
         for (auto it = state_deltas.cbegin(); it != state_deltas.cend(); ++it) {
             auto const &address = it->first;
@@ -156,6 +157,11 @@ public:
     virtual bytes32_t receipts_root() override
     {
         return db_.receipts_root();
+    }
+
+    virtual bytes32_t transactions_root() override
+    {
+        return db_.transactions_root();
     }
 
     virtual std::string print_stats() override

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -4,6 +4,7 @@
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
 #include <monad/core/receipt.hpp>
+#include <monad/core/transaction.hpp>
 #include <monad/db/db.hpp>
 #include <monad/db/util.hpp>
 #include <monad/execution/code_analysis.hpp>
@@ -40,10 +41,11 @@ public:
     virtual std::shared_ptr<CodeAnalysis> read_code(bytes32_t const &) override;
     virtual void increment_block_number() override;
     virtual void commit(
-        StateDeltas const &, Code const &,
-        std::vector<Receipt> const & = {}) override;
+        StateDeltas const &, Code const &, std::vector<Receipt> const & = {},
+        std::vector<Transaction> const & = {}) override;
     virtual bytes32_t state_root() override;
     virtual bytes32_t receipts_root() override;
+    virtual bytes32_t transactions_root() override;
     virtual std::string print_stats() override;
 
     nlohmann::json to_json();

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -26,7 +26,8 @@ struct MachineBase : public mpt::StateMachine
         Prefix,
         State,
         Code,
-        Receipt
+        Receipt,
+        Transaction
     };
 
     uint8_t depth{0};
@@ -57,10 +58,12 @@ struct OnDiskMachine : public MachineBase
 inline constexpr unsigned char STATE_NIBBLE = 0;
 inline constexpr unsigned char CODE_NIBBLE = 1;
 inline constexpr unsigned char RECEIPT_NIBBLE = 2;
+inline constexpr unsigned char TRANSACTION_NIBBLE = 3;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
 inline mpt::Nibbles const receipt_nibbles = mpt::concat(RECEIPT_NIBBLE);
+inline mpt::Nibbles const transaction_nibbles = mpt::concat(TRANSACTION_NIBBLE);
 
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);

--- a/libs/execution/src/monad/execution/validate_block.cpp
+++ b/libs/execution/src/monad/execution/validate_block.cpp
@@ -229,7 +229,7 @@ quick_status_code_from_enum<monad::BlockError>::value_mappings()
         {BlockError::WrongDaoExtraData, "wrong dao extra data", {}},
         {BlockError::WrongLogsBloom, "wrong logs bloom", {}},
         {BlockError::InvalidGasUsed, "invalid gas used", {}},
-        {BlockError::WrongStateRoot, "wrong state root", {}}};
+        {BlockError::WrongMerkleRoot, "wrong merkle root", {}}};
 
     return v;
 }

--- a/libs/execution/src/monad/execution/validate_block.hpp
+++ b/libs/execution/src/monad/execution/validate_block.hpp
@@ -38,7 +38,7 @@ enum class BlockError
     WrongDaoExtraData,
     WrongLogsBloom,
     InvalidGasUsed,
-    WrongStateRoot
+    WrongMerkleRoot
 };
 
 struct Block;

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -190,10 +190,12 @@ void BlockState::merge(State const &state)
     }
 }
 
-void BlockState::commit(std::vector<Receipt> const &receipts)
+void BlockState::commit(
+    std::vector<Receipt> const &receipts,
+    std::vector<Transaction> const &transactions)
 {
     db_.increment_block_number();
-    db_.commit(state_, code_, receipts);
+    db_.commit(state_, code_, receipts, transactions);
 }
 
 void BlockState::log_debug()

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -2,6 +2,7 @@
 
 #include <monad/config.hpp>
 #include <monad/core/receipt.hpp>
+#include <monad/core/transaction.hpp>
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/state_deltas.hpp>
@@ -32,7 +33,7 @@ public:
 
     void merge(State const &);
 
-    void commit(std::vector<Receipt> const &);
+    void commit(std::vector<Receipt> const &, std::vector<Transaction> const &);
 
     void log_debug();
 };

--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -459,7 +459,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({});
+        bs.commit({}, {});
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
     }
@@ -497,7 +497,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({});
+        bs.commit({}, {});
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value2);
         EXPECT_EQ(
@@ -530,7 +530,7 @@ TYPED_TEST(StateTest, selfdestruct_create_destroy_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({});
+        bs.commit({}, {});
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value3);
@@ -1045,7 +1045,7 @@ TYPED_TEST(StateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    bs.commit({});
+    bs.commit({}, {});
 
     EXPECT_TRUE(this->tdb.read_account(a).has_value());
     EXPECT_EQ(this->tdb.read_account(a).value().balance, 1u);
@@ -1062,7 +1062,7 @@ TYPED_TEST(StateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    bs.commit({});
+    bs.commit({}, {});
 
     EXPECT_EQ(
         this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
@@ -1101,7 +1101,7 @@ TYPED_TEST(StateTest, commit_twice)
             as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
-        bs.commit({});
+        bs.commit({}, {});
 
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value2);
@@ -1118,7 +1118,7 @@ TYPED_TEST(StateTest, commit_twice)
         cs.destruct_suicides<EVMC_SHANGHAI>();
         EXPECT_TRUE(bs.can_merge(cs));
         bs.merge(cs);
-        bs.commit({});
+        bs.commit({}, {});
 
         EXPECT_EQ(
             this->tdb.read_storage(c, Incarnation{2, 1}, key1),

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -100,6 +100,11 @@ bytes32_t monad_statesync_server_context::receipts_root()
     return rw.receipts_root();
 }
 
+bytes32_t monad_statesync_server_context::transactions_root()
+{
+    return rw.transactions_root();
+}
+
 void monad_statesync_server_context::increment_block_number()
 {
     rw.increment_block_number();
@@ -107,8 +112,9 @@ void monad_statesync_server_context::increment_block_number()
 
 void monad_statesync_server_context::commit(
     StateDeltas const &state_deltas, Code const &code,
-    std::vector<Receipt> const &receipts)
+    std::vector<Receipt> const &receipts,
+    std::vector<Transaction> const &transactions)
 {
     on_commit(*this, state_deltas);
-    rw.commit(state_deltas, code, receipts);
+    rw.commit(state_deltas, code, receipts, transactions);
 }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -43,9 +43,12 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual monad::bytes32_t receipts_root() override;
 
+    virtual monad::bytes32_t transactions_root() override;
+
     virtual void increment_block_number() override;
 
     virtual void commit(
         monad::StateDeltas const &state_deltas, monad::Code const &code,
-        std::vector<monad::Receipt> const &receipts) override;
+        std::vector<monad::Receipt> const &receipts = {},
+        std::vector<monad::Transaction> const &transactions = {}) override;
 };

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -250,9 +250,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         stdb.increment_block_number();
         sctx.commit(
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
-            Code{},
-            {});
+            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}}, Code{});
     }
     // new storage to existing account
     {
@@ -268,8 +266,7 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {{},
                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-            Code{},
-            {});
+            Code{});
     }
     // add new smart contract
     {
@@ -304,6 +301,7 @@ TEST_F(StateSyncFixture, sync_from_some)
 
             },
             Code{{code_hash, code_analysis}},
+            {},
             {});
     }
     // delete storage
@@ -320,8 +318,7 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
                          {}}}}}}},
-            Code{},
-            {});
+            Code{});
     }
     // account incarnation
     {
@@ -339,8 +336,7 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {{},
                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-            Code{},
-            {});
+            Code{});
     }
     // delete smart contract
     {
@@ -350,9 +346,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         stdb.increment_block_number();
         sctx.commit(
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
-            Code{},
-            {});
+            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}}, Code{});
     }
 
     auto const ctmp = tmp_dbname();
@@ -482,10 +476,9 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                        {bytes32_t{},
                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-        Code{},
-        {});
+        Code{});
     stdb.increment_block_number();
-    sctx.commit({}, {}, {});
+    sctx.commit({}, {}, {}, {});
     stdb.increment_block_number();
     sctx.commit(
         StateDeltas{
@@ -493,8 +486,7 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
              StateDelta{
                  .account = {Account{.balance = 100}, Account{.balance = 200}},
                  .storage = {}}}},
-        {},
-        {});
+        Code{});
     init();
     monad_statesync_client_handle_target(
         cctx, make_target(102, stdb.state_root()));
@@ -514,10 +506,9 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                        {bytes32_t{},
                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-        Code{},
-        {});
+        Code{});
     stdb.increment_block_number();
-    sctx.commit({}, {}, {});
+    sctx.commit({}, {}, {}, {});
     stdb.increment_block_number();
     sctx.commit(
         StateDeltas{
@@ -525,8 +516,7 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
              StateDelta{
                  .account = {Account{.balance = 100}, std::nullopt},
                  .storage = {}}}},
-        {},
-        {});
+        Code{});
     init();
     monad_statesync_client_handle_target(cctx, make_target(102, NULL_ROOT));
 }
@@ -541,8 +531,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 100}},
                  .storage = {}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(1, sctx.state_root()));
     run();
@@ -554,14 +543,13 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
              StateDelta{
                  .account = {Account{.balance = 100}, std::nullopt},
                  .storage = {}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(2, sctx.state_root()));
     client.rqs.clear();
 
     stdb.increment_block_number();
-    sctx.commit({}, {}, {});
+    sctx.commit(StateDeltas{}, Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(3, sctx.state_root()));
     run();
@@ -578,8 +566,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(1, sctx.state_root()));
     run();
@@ -591,8 +578,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
              StateDelta{
                  .account = {a, a},
                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(2, sctx.state_root()));
     client.rqs.pop_front();
@@ -604,8 +590,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(3, sctx.state_root()));
     run();
@@ -627,8 +612,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
                  .storage =
                      {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}},
                       {bytes32_t{1}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(1'000'000, sctx.state_root()));
     run();
@@ -637,8 +621,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
-        {},
-        {});
+        Code{});
 
     stdb.increment_block_number();
     sctx.commit(
@@ -647,8 +630,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
              StateDelta{
                  .account = {std::nullopt, a},
                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        {},
-        {});
+        Code{});
 
     stdb.increment_block_number();
     sctx.commit(
@@ -657,8 +639,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
              StateDelta{
                  .account = {a, a},
                  .storage = {{bytes32_t{}, {bytes32_t{64}, bytes32_t{}}}}}}},
-        {},
-        {});
+        Code{});
     monad_statesync_client_handle_target(
         cctx, make_target(1'000'003, sctx.state_root()));
     run();

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -66,7 +66,7 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
             chain, block, block_state, block_hash_buffer, *pool_));
     BOOST_OUTCOME_TRY(chain.validate_header(receipts, block.header));
     block_state.log_debug();
-    block_state.commit(receipts);
+    block_state.commit(receipts, block.transactions);
     return receipts;
 }
 
@@ -171,7 +171,7 @@ void BlockchainTest::TestBody()
             State state{bs, Incarnation{0, 0}};
             load_state_from_json(j_contents.at("pre"), state);
             bs.merge(state);
-            bs.commit({});
+            bs.commit({}, {});
         }
 
         BlockHashBuffer block_hash_buffer;
@@ -205,6 +205,10 @@ void BlockchainTest::TestBody()
             if (!result.has_error()) {
                 EXPECT_FALSE(j_block.contains("expectException"));
                 EXPECT_EQ(tdb.state_root(), block.value().header.state_root)
+                    << name;
+                EXPECT_EQ(
+                    tdb.transactions_root(),
+                    block.value().header.transactions_root)
                     << name;
                 if (rev >= EVMC_BYZANTIUM) {
                     EXPECT_EQ(


### PR DESCRIPTION
First pr for block data migration: 

- [x] txs
- [ ] block_header
- [ ] ommers
- [ ] withdrawals

benchmark result, 15M is 1-2% slower:  
```
Replay 3000000->3100000 in-memory: tps=26898  gps=918 M
Replay 12000000->12100000 in-memory: tps=14903  gps=924 M
Replay 15000000->15100000 on-disk: tps=7453  gps=630 M
```

Added transactions table to `monad_cli` tool