### PR TITLE
New i/o executor counter bug fix

### DIFF
--- a/libs/runloop/Readme.md
+++ b/libs/runloop/Readme.md
@@ -263,10 +263,8 @@ static monad_c_result mytask(monad_async_task task)
 
 ## Todo
 
-- Executor `total_io_completed` never seems to match `total_io_submitted`,
-with them sometimes being very very different. I have walked the code many
-times and I don't see the cause :(
-- When a task exits, all i/o still occurring on that task ought to be pumped and dumped out.
+- When a task exits, all i/o still occurring on that task ought to be pumped and dumped out
+(right now it aborts the process instead)
 - Need to test cancellation works at every possible lifecycle and suspend state
 a task can have.
 - `thread_db.so` ought to be extended so GDB shows all contexts as if kernel threads.

--- a/libs/runloop/src/monad/async/executor_impl.h
+++ b/libs/runloop/src/monad/async/executor_impl.h
@@ -401,7 +401,7 @@ monad_async_executor_setup_eventfd_polling(struct monad_async_executor_impl *p)
     if (sqe == nullptr) {
         abort(); // should never occur
     }
-    p->head.total_io_submitted++;
+    // Do NOT increment total_io_submitted here!
     io_uring_prep_poll_multishot(sqe, p->eventfd, POLLIN);
     io_uring_sqe_set_data(
         sqe, EXECUTOR_EVENTFD_READY_IO_URING_DATA_MAGIC, nullptr, nullptr);
@@ -811,6 +811,7 @@ static inline struct io_uring_sqe *get_sqe_suspending_if_necessary_impl(
                 &ex->head.current_task, memory_order_acquire) == nullptr);
         atomic_store_explicit(
             &ex->head.current_task, &task->head, memory_order_release);
+        bool const please_cancel_invoked = task->please_cancel_invoked;
         task->please_cancel_invoked = false;
         task->please_cancel = nullptr;
         task->completed = nullptr;
@@ -827,10 +828,10 @@ static inline struct io_uring_sqe *get_sqe_suspending_if_necessary_impl(
             (void *)task,
             (void *)sqe,
             is_cancellation_point,
-            task->please_cancel_invoked);
+            please_cancel_invoked);
         fflush(stdout);
     #endif
-        if (is_cancellation_point && task->please_cancel_invoked) {
+        if (is_cancellation_point && please_cancel_invoked) {
             // We need to "throw away" this SQE, as the task has been
             // cancelled We do this by setting the SQE to a noop with
             // CANCELLED_OP_IO_URING_DATA_MAGIC

--- a/libs/runloop/src/monad/async/task.h
+++ b/libs/runloop/src/monad/async/task.h
@@ -60,6 +60,19 @@ typedef struct monad_async_io_status
     MONAD_CONTEXT_PUBLIC_CONST monad_context_cpu_ticks_count_t
         ticks_when_reaped;
 
+#ifdef __cplusplus
+    constexpr monad_async_io_status()
+        : prev{}
+        , next{}
+        , cancel_{}
+        , result{}
+        , ticks_when_initiated{}
+        , ticks_when_completed{}
+        , ticks_when_reaped{}
+    {
+    }
+#endif
+
     // You can place any additional data you want after here ...
 } monad_async_io_status;
 

--- a/libs/runloop/src/monad/async/test/executor.cpp
+++ b/libs/runloop/src/monad/async/test/executor.cpp
@@ -257,6 +257,7 @@ TEST(executor, works)
                               << std::endl;
                 }
             }
+            EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
         };
         test(
             make_context_switcher(monad_context_switcher_fcontext).get(),
@@ -318,6 +319,7 @@ TEST(executor, works)
                            .count()) /
                 double(shared.ops))
             << " ns/op." << std::endl;
+        EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
     }
 
     {
@@ -366,6 +368,7 @@ TEST(executor, works)
                     monad_async_executor_run(ex.get(), size_t(-1), nullptr);
                 CHECK_RESULT(r);
             }
+            EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
             std::cout
                 << "   Suspend-resume "
                 << (1000.0 * double(shared.ops) /
@@ -427,6 +430,9 @@ TEST(executor, foreign_thread)
                         }
                         state->ops += uint32_t(r.assume_value());
                     }
+                    assert(
+                        state->executor->total_io_submitted ==
+                        state->executor->total_io_completed);
                     state->executor.reset();
                 },
                 &executor_threads[n]);

--- a/libs/runloop/src/monad/async/test/file_io.cpp
+++ b/libs/runloop/src/monad/async/test/file_io.cpp
@@ -160,6 +160,7 @@ TEST(file_io, unregistered_buffers)
         to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
             .value();
     }
+    EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
 }
 
 TEST(file_io, registered_buffers)
@@ -324,6 +325,7 @@ TEST(file_io, registered_buffers)
         to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
             .value();
     }
+    EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
 }
 
 TEST(file_io, misc_ops)
@@ -476,6 +478,7 @@ TEST(file_io, misc_ops)
         to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
             .value();
     }
+    EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
 }
 
 TEST(file_io, benchmark)
@@ -640,6 +643,7 @@ TEST(file_io, benchmark)
         to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
             .value();
     }
+    EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
 }
 
 TEST(file_io, sqe_exhaustion_does_not_reorder_writes)
@@ -793,6 +797,9 @@ TEST(file_io, sqe_exhaustion_does_not_reorder_writes)
             .value();
     }
     while (monad_async_executor_has_work(shared_state.ex.get()));
+    EXPECT_EQ(
+        shared_state.ex->total_io_submitted,
+        shared_state.ex->total_io_completed);
     std::cout << "   " << shared_state.seq.size() << " offsets written."
               << std::endl;
 

--- a/libs/runloop/src/monad/async/test/socket_io.cpp
+++ b/libs/runloop/src/monad/async/test/socket_io.cpp
@@ -423,4 +423,5 @@ TEST(socket_io, registered_buffers)
         to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
             .value();
     }
+    EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
 }

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -122,7 +122,7 @@ namespace
         monad_statesync_server_context sctx;
         mpt::Db ro;
         monad_statesync_server_network net;
-        monad_statesync_server *server;
+        monad_statesync_server *server{};
 
         StateSyncFixture()
             : cdbname{tmp_dbname()}


### PR DESCRIPTION
Fix a long standing oddity whereby the new i/o executor's
`total_io_submitted` and `total_io_completed` counter did not match
over time. Turns out the cause is that `AsyncIO`'s dispatch task
would reinitiate a cancellable wait repeatedly and entirely
unnecessarily. It no longer does this, so now the counters match
up and added test code and checks have been added.

I also fixed a very minor issue in `StateSync.benchmark` whereby
the `server` memory variable was being left uninitialised. This
doesn't matter to the main branch, but to the
https://github.com/monad-crypto/monad/pull/817 branch it causes
a segfault during testing.