### PR TITLE
Fix small issues with new i/o executor preventing migration of fibers to Ken's executor

### DIFF
--- a/libs/runloop/src/monad/async/executor_impl.h
+++ b/libs/runloop/src/monad/async/executor_impl.h
@@ -789,10 +789,11 @@ static inline struct io_uring_sqe *get_sqe_suspending_if_necessary_impl(
             (void *)task);
         fflush(stdout);
     #endif
-        atomic_load_explicit(&task->context->switcher, memory_order_acquire)
+        atomic_load_explicit(
+            &task->head.derived.context->switcher, memory_order_acquire)
             ->suspend_and_call_resume(
-                task->context,
-                (newtask != nullptr) ? newtask->context : nullptr);
+                task->head.derived.context,
+                (newtask != nullptr) ? newtask->head.derived.context : nullptr);
         task->head.ticks_when_resumed = get_ticks_count(memory_order_relaxed);
         assert(atomic_load_explicit(wait_list_task_flag, memory_order_acquire));
         atomic_store_explicit(wait_list_task_flag, false, memory_order_release);

--- a/libs/runloop/src/monad/async/task.c
+++ b/libs/runloop/src/monad/async/task.c
@@ -29,16 +29,79 @@ monad_c_result monad_async_task_create(
     p->head.priority.cpu = monad_async_priority_normal;
     p->head.priority.io = monad_async_priority_normal;
     monad_c_result r = switcher->create(
-        &p->context, switcher, &p->head.derived, &attr->derived);
+        &p->head.derived.context, switcher, &p->head.derived, &attr->derived);
     if (BOOST_OUTCOME_C_RESULT_HAS_ERROR(r)) {
         (void)monad_async_task_destroy((monad_async_task)p);
         return r;
     }
     atomic_store_explicit(
-        &p->context->switcher, switcher, memory_order_release);
+        &p->head.derived.context->switcher, switcher, memory_order_release);
     memcpy(p->magic, "MNASTASK", 8);
     *task = (monad_async_task)p;
     return monad_c_make_success(0);
+}
+
+monad_c_result monad_async_task_suspend_save_detach_and_invoke(
+    monad_async_task task_, monad_async_task opt_save,
+    monad_c_result (*to_invoke)(monad_context_task detached_task))
+{
+    struct monad_async_task_impl *task = (struct monad_async_task_impl *)task_;
+    if (opt_save != nullptr) {
+        memcpy(
+            ((char *)opt_save) + sizeof(struct monad_context_task_head),
+            ((char *)task_) + sizeof(struct monad_context_task_head),
+            sizeof(struct monad_async_task_head) -
+                sizeof(struct monad_context_task_head));
+    }
+    monad_context_task context_task = &task_->derived;
+    task->call_after_suspend_to_executor_data = nullptr;
+    task->call_after_suspend_to_executor = to_invoke;
+    monad_async_executor_task_detach(context_task);
+    if (opt_save != nullptr) {
+        opt_save->ticks_when_detached = task->head.ticks_when_detached;
+        opt_save->total_ticks_executed = task->head.total_ticks_executed;
+        atomic_store_explicit(
+            &opt_save->is_running, false, memory_order_release);
+        atomic_store_explicit(
+            &opt_save->current_executor, nullptr, memory_order_release);
+    }
+    // Return to executor
+    task->head.derived.result = monad_c_make_success(0);
+    atomic_load_explicit(&context_task->context->switcher, memory_order_acquire)
+        ->suspend_and_call_resume(context_task->context, nullptr);
+    return task->head.derived.result;
+}
+
+monad_async_task monad_async_task_from_foreign_context(
+    monad_context_task context_task, monad_async_task opt_save)
+{
+    struct monad_async_task_impl *task =
+        (struct monad_async_task_impl *)context_task;
+    if (opt_save != nullptr) {
+        memcpy(
+            ((char *)task) + sizeof(struct monad_context_task_head),
+            ((char *)opt_save) + sizeof(struct monad_context_task_head),
+            sizeof(struct monad_async_task_head) -
+                sizeof(struct monad_context_task_head));
+    }
+    else {
+        memset(
+            ((char *)task) + sizeof(struct monad_context_task_head),
+            0,
+            sizeof(struct monad_async_task_head) -
+                sizeof(struct monad_context_task_head));
+        task->head.io_recipient_task = (monad_async_task)context_task;
+        task->head.priority.cpu = monad_async_priority_normal;
+        task->head.priority.io = monad_async_priority_normal;
+    }
+    task->head.derived.detach = monad_async_executor_task_detach;
+    memset(
+        ((char *)task) + sizeof(struct monad_async_task_head),
+        0,
+        sizeof(struct monad_async_task_impl) -
+            sizeof(struct monad_async_task_head));
+    memcpy(task->magic, "MNASTASK", 8);
+    return &task->head;
 }
 
 monad_c_result monad_async_task_destroy(monad_async_task task)
@@ -63,8 +126,9 @@ monad_c_result monad_async_task_destroy(monad_async_task task)
     }
     memset(p->magic, 0, 8);
     BOOST_OUTCOME_C_RESULT_SYSTEM_TRY(
-        atomic_load_explicit(&p->context->switcher, memory_order_acquire)
-            ->destroy(p->context));
+        atomic_load_explicit(
+            &p->head.derived.context->switcher, memory_order_acquire)
+            ->destroy(p->head.derived.context));
     free(task);
     return monad_c_make_success(0);
 }

--- a/libs/runloop/src/monad/async/task_impl.h
+++ b/libs/runloop/src/monad/async/task_impl.h
@@ -24,7 +24,6 @@ struct monad_async_task_impl
     struct monad_async_task_head head;
     char magic[8];
     struct monad_async_task_impl *prev, *next;
-    monad_context context;
     bool please_cancel_invoked;
     monad_c_result (*please_cancel)(
         struct monad_async_executor_impl *ex,
@@ -47,12 +46,12 @@ struct monad_async_task_impl
 
     - After task has exited and been fully detached from its executor.
     */
-    monad_c_result (*call_after_suspend_to_executor)(
-        struct monad_async_task_impl *task);
+    monad_c_result (*call_after_suspend_to_executor)(monad_context_task task);
     void *call_after_suspend_to_executor_data;
 };
 #if __STDC_VERSION__ >= 202300L || defined(__cplusplus)
-static_assert(sizeof(struct monad_async_task_impl) == 304);
+static_assert(
+    sizeof(struct monad_async_task_impl) == MONAD_ASYNC_TASK_FOOTPRINT);
 static_assert(
     sizeof(struct monad_async_task_impl) <= MONAD_CONTEXT_TASK_ALLOCATION_SIZE);
     #ifdef __cplusplus

--- a/libs/runloop/src/monad/async/test/CMakeLists.txt
+++ b/libs/runloop/src/monad/async/test/CMakeLists.txt
@@ -13,6 +13,8 @@ endfunction()
 
 monad_test(executor_test "executor.cpp")
 
+monad_test(foreign_executor_test "foreign_executor.cpp")
+
 monad_test(file_io_test "file_io.cpp")
 
 monad_test(socket_io_test "socket_io.cpp")

--- a/libs/runloop/src/monad/async/test/foreign_executor.cpp
+++ b/libs/runloop/src/monad/async/test/foreign_executor.cpp
@@ -1,0 +1,177 @@
+#include <atomic>
+#include <gtest/gtest.h>
+
+#include "../../test_common.hpp"
+
+#include <monad/context/config.h>
+
+#include "../executor.h"
+#include "../task.h"
+
+TEST(foreign_executor, works)
+{
+    monad_async_executor_attr ex_attr{};
+    ex_attr.io_uring_ring.entries = 4;
+    auto ex = make_executor(ex_attr);
+    auto switcher = make_context_switcher(monad_context_switcher_sjlj);
+    static auto print_stats = [](monad_async_task task, char const *desc) {
+        std::cout << desc << ":\n   ticks_when_submitted = "
+                  << task->ticks_when_submitted
+                  << "\n   ticks_when_attached = " << task->ticks_when_attached
+                  << "\n   ticks_when_detached = " << task->ticks_when_detached
+                  << "\n   ticks_when_suspended_awaiting = "
+                  << task->ticks_when_suspended_awaiting
+                  << "\n   ticks_when_suspended_completed = "
+                  << task->ticks_when_suspended_completed
+                  << "\n   ticks_when_resumed = " << task->ticks_when_resumed
+                  << "\n   total_ticks_executed = "
+                  << task->total_ticks_executed << std::endl;
+    };
+    monad_async_task_attr t_attr{};
+    auto task = make_task(switcher.get(), t_attr);
+
+    struct shared_t
+    {
+        monad_context context;
+        struct monad_async_task_head saved_async_task;
+        int invokable_called{0}, resumed{0};
+    } shared;
+
+    shared.context = task->derived.context;
+    task->derived.user_ptr = (void *)&shared;
+    task->derived.user_code =
+        +[](monad_context_task context_task) -> monad_c_result {
+        monad_async_task task = (monad_async_task)context_task;
+        auto *shared = (shared_t *)context_task->user_ptr;
+        print_stats(task, "Just after first attach before 10 ms suspend");
+        CHECK_RESULT(monad_async_task_suspend_for_duration(
+            nullptr,
+            ((monad_async_task)task),
+            10000000ULL)); // 10 milliseconds
+        print_stats(
+            task, "After 10 ms suspend before suspend_save_detach_and_invoke");
+
+        auto r = monad_async_task_suspend_save_detach_and_invoke(
+            task,
+            &shared->saved_async_task,
+            +[](monad_context_task context_task) -> monad_c_result {
+                auto *shared = (shared_t *)context_task->user_ptr;
+                shared->invokable_called++;
+                return monad_c_make_success(0);
+            });
+        CHECK_RESULT(r);
+        if (r.value != 5) {
+            abort();
+        }
+        print_stats(
+            &shared->saved_async_task,
+            "After suspend_save_detach_and_invoke in 'naked' context before "
+            "raw suspend 1");
+        context_task->context->switcher.load(std::memory_order_acquire)
+            ->suspend_and_call_resume(context_task->context, nullptr);
+        print_stats(task, "After raw suspend now back within the executor 1");
+
+        r = monad_async_task_suspend_save_detach_and_invoke(
+            task,
+            nullptr,
+            +[](monad_context_task context_task) -> monad_c_result {
+                auto *shared = (shared_t *)context_task->user_ptr;
+                shared->invokable_called++;
+                return monad_c_make_success(0);
+            });
+        CHECK_RESULT(r);
+        if (r.value != 6) {
+            abort();
+        }
+        print_stats(
+            task,
+            "After suspend_save_detach_and_invoke in 'naked' context before "
+            "raw suspend 2");
+        context_task->context->switcher.load(std::memory_order_acquire)
+            ->suspend_and_call_resume(context_task->context, nullptr);
+        print_stats(task, "After raw suspend now back within the executor 2");
+        return monad_c_make_success(0);
+    };
+    CHECK_RESULT(monad_async_task_attach(ex.get(), task.get(), nullptr));
+    // This will exit when the task detaches itself
+    while (monad_async_executor_has_work(ex.get())) {
+        to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
+            .value();
+    }
+    std::cout
+        << "\nBack in main after executor has said there is no more work 1."
+        << std::endl;
+    // Manually resume the context to pretend we are a foreign executor
+    memset(
+        ((char *)task.get()) + sizeof(struct monad_context_task_head),
+        0xff,
+        sizeof(struct monad_async_task_head) -
+            sizeof(struct monad_context_task_head));
+    auto res = monad_c_make_success(5);
+    memcpy((void *)&task->derived.result, &res, sizeof(monad_c_result));
+    switcher->resume_many(
+        switcher.get(),
+        +[](void *user_ptr, monad_context fake_context) -> monad_c_result {
+            auto *shared = (shared_t *)user_ptr;
+            if (!shared->resumed) {
+                shared->resumed = true;
+                fake_context->switcher.load(std::memory_order_acquire)
+                    ->resume(fake_context, shared->context);
+            }
+            return monad_c_make_success(0);
+        },
+        (void *)&shared);
+    std::cout << "\nBack in main after raw context suspended itself as if in a "
+                 "foreign executor 1"
+              << std::endl;
+    CHECK_RESULT(monad_async_task_attach(
+        ex.get(),
+        monad_async_task_from_foreign_context(
+            &task->derived, &shared.saved_async_task),
+        nullptr));
+    while (monad_async_executor_has_work(ex.get())) {
+        to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
+            .value();
+    }
+    print_stats(task.get(), "\bBack in main 1");
+    EXPECT_GT(
+        task->total_ticks_executed,
+        shared.saved_async_task.total_ticks_executed);
+
+    shared.resumed = false;
+    std::cout
+        << "\nBack in main after executor has said there is no more work 2."
+        << std::endl;
+    // Manually resume the context to pretend we are a foreign executor
+    memset(
+        ((char *)task.get()) + sizeof(struct monad_context_task_head),
+        0xff,
+        sizeof(struct monad_async_task_head) -
+            sizeof(struct monad_context_task_head));
+    res = monad_c_make_success(6);
+    memcpy((void *)&task->derived.result, &res, sizeof(monad_c_result));
+    switcher->resume_many(
+        switcher.get(),
+        +[](void *user_ptr, monad_context fake_context) -> monad_c_result {
+            auto *shared = (shared_t *)user_ptr;
+            if (!shared->resumed) {
+                shared->resumed = true;
+                fake_context->switcher.load(std::memory_order_acquire)
+                    ->resume(fake_context, shared->context);
+            }
+            return monad_c_make_success(0);
+        },
+        (void *)&shared);
+    std::cout << "\nBack in main after raw context suspended itself as if in a "
+                 "foreign executor 2"
+              << std::endl;
+    CHECK_RESULT(monad_async_task_attach(
+        ex.get(),
+        monad_async_task_from_foreign_context(&task->derived, nullptr),
+        nullptr));
+    while (monad_async_executor_has_work(ex.get())) {
+        to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
+            .value();
+    }
+    print_stats(task.get(), "\bBack in main wrapping up 2");
+}

--- a/libs/runloop/src/monad/context/context_switcher.h
+++ b/libs/runloop/src/monad/context/context_switcher.h
@@ -24,9 +24,13 @@ extern "C"
 {
 #endif
 
+typedef struct monad_context_head *monad_context;
+
 //! \brief How much memory to allocate to fit all implementations of `struct
 //! monad_context_task_head`
-#define MONAD_CONTEXT_TASK_ALLOCATION_SIZE (304)
+#define MONAD_CONTEXT_TASK_ALLOCATION_SIZE (296)
+//! \brief How many of those bytes are used by the i/o executor for its state
+#define MONAD_ASYNC_TASK_FOOTPRINT (296)
 
 //! \brief The public attributes of a task
 typedef struct monad_context_task_head
@@ -37,6 +41,9 @@ typedef struct monad_context_task_head
         MONAD_CONTEXT_CPP_DEFAULT_INITIALISE;
     //! \brief Any user defined value
     void *user_ptr MONAD_CONTEXT_CPP_DEFAULT_INITIALISE;
+
+    //! \brief The context for the running task
+    monad_context context MONAD_CONTEXT_CPP_DEFAULT_INITIALISE;
 
     // The following are **NOT** user modifiable
     //! \brief Set to the result of the task on exit; also used as scratch
@@ -57,7 +64,7 @@ typedef struct monad_context_task_head
 #endif
 } *monad_context_task;
 #if __STDC_VERSION__ >= 202300L || defined(__cplusplus)
-static_assert(sizeof(struct monad_context_task_head) == 56);
+static_assert(sizeof(struct monad_context_task_head) == 64);
     #ifdef __cplusplus
 static_assert(alignof(struct monad_context_task_head) == 8);
     #endif
@@ -72,8 +79,6 @@ struct monad_context_task_attr
     //! \brief 0 chooses platform default stack size
     size_t stack_size;
 };
-
-typedef struct monad_context_head *monad_context;
 
 typedef struct monad_context_switcher_head
 {


### PR DESCRIPTION
When creating a running fiber bridge between executors with Ken's
executor at https://github.com/monad-crypto/monad/pull/928, it
was realised that there were a few small issues with the current
new i/o executor which prevented the migration of running fibers
out of the i/o executor. This PR fixes those small issues, and
comes with a new test which ensures there won't be regression
again here in the future.