### PR TITLE
bump OnDiskDbConfig default history_length to 20000

### DIFF
--- a/libs/db/src/monad/mpt/ondisk_db_config.hpp
+++ b/libs/db/src/monad/mpt/ondisk_db_config.hpp
@@ -25,7 +25,7 @@ struct OnDiskDbConfig
     std::vector<std::filesystem::path> dbname_paths{};
     int64_t file_size_db{512}; // truncate files to this size
     unsigned concurrent_read_io_limit{1024};
-    uint64_t history_length{1000};
+    uint64_t history_length{20000};
 };
 
 struct ReadOnlyOnDiskDbConfig


### PR DESCRIPTION
leftover from https://github.com/monad-crypto/monad/pull/942 