### PR TITLE
Bump buffer size to 4G to load 18M snapshot

### DIFF
--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -77,6 +77,7 @@ void write_to_file(
 
 void load_from_binary(
     mpt::Db &, std::istream &accounts, std::istream &code,
-    uint64_t init_block_number = 0, size_t buf_size = 1ul << 31);
+    uint64_t init_block_number = 0,
+    size_t buf_size = 1ul << 32); // TODO: dynamic loading
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
Temporary solve the loading binary snapshot issue. 
See #782  for a more systematic and dynamic approach
#816 has an alternative approach