### PR TITLE
Store block header in db

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -151,7 +151,8 @@ inline void load_db(TrieDb &db, uint64_t const n)
             {C_CODE_HASH, C_CODE_ANALYSIS},
             {D_CODE_HASH, D_CODE_ANALYSIS},
             {E_CODE_HASH, E_CODE_ANALYSIS},
-            {H_CODE_HASH, H_CODE_ANALYSIS}});
+            {H_CODE_HASH, H_CODE_ANALYSIS}},
+        BlockHeader{});
 }
 
 MONAD_TEST_NAMESPACE_END

--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -152,7 +152,8 @@ Result<std::pair<uint64_t, uint64_t>> run_monad(
         BOOST_OUTCOME_TRY(
             chain.validate_header(receipts, block.value().header));
         block_state.log_debug();
-        block_state.commit(receipts, block.value().transactions);
+        block_state.commit(
+            block.value().header, receipts, block.value().transactions);
 
         if (!chain.validate_root(
                 rev,

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -3,9 +3,11 @@
 #include <monad/config.hpp>
 #include <monad/core/account.hpp>
 #include <monad/core/address.hpp>
+#include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
+#include <monad/core/transaction.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/state_deltas.hpp>
 
@@ -31,7 +33,8 @@ struct Db
     virtual void increment_block_number() = 0;
 
     virtual void commit(
-        StateDeltas const &, Code const &, std::vector<Receipt> const & = {},
+        StateDeltas const &, Code const &, BlockHeader const &,
+        std::vector<Receipt> const & = {},
         std::vector<Transaction> const & = {}) = 0;
 
     virtual std::string print_stats()

--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -114,10 +114,10 @@ public:
 
     virtual void commit(
         StateDeltas const &state_deltas, Code const &code,
-        std::vector<Receipt> const &receipts,
+        BlockHeader const &header, std::vector<Receipt> const &receipts,
         std::vector<Transaction> const &transactions) override
     {
-        db_.commit(state_deltas, code, receipts, transactions);
+        db_.commit(state_deltas, code, header, receipts, transactions);
 
         for (auto it = state_deltas.cbegin(); it != state_deltas.cend(); ++it) {
             auto const &address = it->first;

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <monad/config.hpp>
+#include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
 #include <monad/core/receipt.hpp>
@@ -41,7 +42,8 @@ public:
     virtual std::shared_ptr<CodeAnalysis> read_code(bytes32_t const &) override;
     virtual void increment_block_number() override;
     virtual void commit(
-        StateDeltas const &, Code const &, std::vector<Receipt> const & = {},
+        StateDeltas const &, Code const &, BlockHeader const &,
+        std::vector<Receipt> const & = {},
         std::vector<Transaction> const & = {}) override;
     virtual bytes32_t state_root() override;
     virtual bytes32_t receipts_root() override;

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -416,7 +416,8 @@ void MachineBase::down(unsigned char const nibble)
     MONAD_ASSERT(depth <= MAX_DEPTH);
     MONAD_ASSERT(
         (nibble == STATE_NIBBLE || nibble == CODE_NIBBLE ||
-         nibble == RECEIPT_NIBBLE || nibble == TRANSACTION_NIBBLE) ||
+         nibble == RECEIPT_NIBBLE || nibble == TRANSACTION_NIBBLE ||
+         nibble == BLOCKHEADER_NIBBLE) ||
         depth != PREFIX_LEN);
     if (MONAD_UNLIKELY(depth == PREFIX_LEN)) {
         MONAD_ASSERT(trie_section == TrieType::Prefix);
@@ -429,8 +430,11 @@ void MachineBase::down(unsigned char const nibble)
         else if (nibble == TRANSACTION_NIBBLE) {
             trie_section = TrieType::Transaction;
         }
-        else {
+        else if (nibble == CODE_NIBBLE) {
             trie_section = TrieType::Code;
+        }
+        else {
+            MONAD_ASSERT(nibble == BLOCKHEADER_NIBBLE);
         }
     }
 }

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -59,11 +59,14 @@ inline constexpr unsigned char STATE_NIBBLE = 0;
 inline constexpr unsigned char CODE_NIBBLE = 1;
 inline constexpr unsigned char RECEIPT_NIBBLE = 2;
 inline constexpr unsigned char TRANSACTION_NIBBLE = 3;
+inline constexpr unsigned char BLOCKHEADER_NIBBLE = 4;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
 inline mpt::Nibbles const receipt_nibbles = mpt::concat(RECEIPT_NIBBLE);
 inline mpt::Nibbles const transaction_nibbles = mpt::concat(TRANSACTION_NIBBLE);
+inline mpt::Nibbles const block_header_nibbles =
+    mpt::concat(BLOCKHEADER_NIBBLE);
 
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);

--- a/libs/execution/src/monad/execution/test/test_block_reward.cpp
+++ b/libs/execution/src/monad/execution/test/test_block_reward.cpp
@@ -34,7 +34,8 @@ TEST(BlockReward, apply_block_reward)
         db_t tdb{db};
         tdb.commit(
             StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
-            Code{});
+            Code{},
+            BlockHeader{});
 
         BlockState bs{tdb};
         State as{bs, Incarnation{1, 1}};

--- a/libs/execution/src/monad/execution/test/test_evm.cpp
+++ b/libs/execution/src/monad/execution/test/test_evm.cpp
@@ -47,7 +47,8 @@ TEST(Evm, create_with_insufficient)
              StateDelta{
                  .account =
                      {std::nullopt, Account{.balance = 10'000'000'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -89,7 +90,8 @@ TEST(Evm, eip684_existing_code)
             {to,
              StateDelta{
                  .account = {std::nullopt, Account{.code_hash = code_hash}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -125,7 +127,8 @@ TEST(Evm, transfer_call_balances)
                  .account =
                      {std::nullopt,
                       Account{.balance = 10'000'000'000, .nonce = 7}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -161,7 +164,8 @@ TEST(Evm, transfer_call_balances_to_self)
                  .account =
                      {std::nullopt,
                       Account{.balance = 10'000'000'000, .nonce = 7}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -199,7 +203,8 @@ TEST(Evm, dont_transfer_on_delegatecall)
                  .account =
                      {std::nullopt,
                       Account{.balance = 10'000'000'000, .nonce = 6}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_DELEGATECALL,
@@ -238,7 +243,8 @@ TEST(Evm, dont_transfer_on_staticcall)
                  .account =
                      {std::nullopt,
                       Account{.balance = 10'000'000'000, .nonce = 6}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CALL,
@@ -282,7 +288,8 @@ TEST(Evm, create_nonce_out_of_range)
                       Account{
                           .balance = 10'000'000'000,
                           .nonce = std::numeric_limits<uint64_t>::max()}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     evmc_message m{
         .kind = EVMC_CREATE,
@@ -321,7 +328,8 @@ TEST(Evm, static_precompile_execution)
             {from,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 15'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);
@@ -368,7 +376,8 @@ TEST(Evm, out_of_gas_static_precompile_execution)
             {from,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 15'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);
@@ -397,7 +406,8 @@ TEST(Evm, deploy_contract_code)
     db_t tdb{db};
     tdb.commit(
         StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     BlockState bs{tdb};
 
     // Frontier

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -5,6 +5,7 @@
 #include <monad/core/bytes.hpp>
 #include <monad/core/likely.h>
 #include <monad/core/receipt.hpp>
+#include <monad/core/rlp/block_rlp.hpp>
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/block_state.hpp>
@@ -191,11 +192,11 @@ void BlockState::merge(State const &state)
 }
 
 void BlockState::commit(
-    std::vector<Receipt> const &receipts,
+    BlockHeader const &header, std::vector<Receipt> const &receipts,
     std::vector<Transaction> const &transactions)
 {
     db_.increment_block_number();
-    db_.commit(state_, code_, receipts, transactions);
+    db_.commit(state_, code_, header, receipts, transactions);
 }
 
 void BlockState::log_debug()

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <monad/config.hpp>
+#include <monad/core/block.hpp>
+#include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
 #include <monad/core/transaction.hpp>
 #include <monad/db/db.hpp>
@@ -33,7 +35,9 @@ public:
 
     void merge(State const &);
 
-    void commit(std::vector<Receipt> const &, std::vector<Transaction> const &);
+    void commit(
+        BlockHeader const &, std::vector<Receipt> const &,
+        std::vector<Transaction> const &);
 
     void log_debug();
 };

--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -84,7 +84,8 @@ TYPED_TEST(StateTest, access_account)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 10'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -102,7 +103,8 @@ TYPED_TEST(StateTest, account_exists)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 10'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -132,7 +134,8 @@ TYPED_TEST(StateTest, get_balance)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 10'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -147,7 +150,8 @@ TYPED_TEST(StateTest, add_to_balance)
     this->tdb.commit(
         StateDeltas{
             {a, StateDelta{.account = {std::nullopt, Account{.balance = 1}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     s.add_to_balance(a, 10'000);
@@ -163,7 +167,8 @@ TYPED_TEST(StateTest, get_nonce)
     this->tdb.commit(
         StateDeltas{
             {a, StateDelta{.account = {std::nullopt, Account{.nonce = 2}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -190,7 +195,8 @@ TYPED_TEST(StateTest, get_code_hash)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.code_hash = hash1}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -220,7 +226,8 @@ TYPED_TEST(StateTest, selfdestruct)
             {c,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 38'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     s.create_contract(b);
@@ -260,7 +267,8 @@ TYPED_TEST(StateTest, selfdestruct_cancun_separate_tx)
                       Account{
                           .balance = 38'000,
                           .incarnation = Incarnation{1, 1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 2}};
 
@@ -292,7 +300,8 @@ TYPED_TEST(StateTest, selfdestruct_cancun_same_tx)
                       Account{
                           .balance = 38'000,
                           .incarnation = Incarnation{1, 1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -313,7 +322,8 @@ TYPED_TEST(StateTest, selfdestruct_self_separate_tx)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 18'000}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     {
         // Pre-cancun behavior
@@ -349,7 +359,8 @@ TYPED_TEST(StateTest, selfdestruct_self_same_tx)
                       Account{
                           .balance = 18'000,
                           .incarnation = Incarnation{1, 1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     auto run = [&]<evmc_revision rev>() {
         State s{bs, Incarnation{1, 1}};
@@ -374,7 +385,8 @@ TYPED_TEST(StateTest, selfdestruct_merge_incarnation)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 18'000}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     {
         State s1{bs, Incarnation{1, 1}};
 
@@ -401,7 +413,8 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_incarnation)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 18'000}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     {
         State s1{bs, Incarnation{1, 1}};
 
@@ -443,7 +456,8 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 18'000}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     {
         State s1{bs, Incarnation{1, 1}};
 
@@ -459,7 +473,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {});
+        bs.commit({}, {}, {});
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
     }
@@ -476,7 +490,8 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
                  .storage =
                      {{key1, {bytes32_t{}, value2}},
                       {key3, {bytes32_t{}, value3}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     {
         State s1{bs, Incarnation{1, 1}};
 
@@ -497,7 +512,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {});
+        bs.commit({}, {}, {});
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value2);
         EXPECT_EQ(
@@ -530,7 +545,7 @@ TYPED_TEST(StateTest, selfdestruct_create_destroy_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {});
+        bs.commit({}, {}, {});
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value3);
@@ -546,7 +561,8 @@ TYPED_TEST(StateTest, create_conflict_address_incarnation)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 18'000}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s1{bs, Incarnation{1, 1}};
 
@@ -565,7 +581,8 @@ TYPED_TEST(StateTest, destruct_touched_dead)
             {a,
              StateDelta{.account = {std::nullopt, Account{.balance = 10'000}}}},
             {b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
@@ -630,7 +647,8 @@ TYPED_TEST(StateTest, get_storage)
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
@@ -653,7 +671,8 @@ TYPED_TEST(StateTest, set_storage_modified)
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
             {b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
@@ -671,7 +690,8 @@ TYPED_TEST(StateTest, set_storage_deleted)
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -688,7 +708,8 @@ TYPED_TEST(StateTest, set_storage_added)
     BlockState bs{this->tdb};
     this->tdb.commit(
         StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -710,7 +731,8 @@ TYPED_TEST(StateTest, set_storage_different_assigned)
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
             {b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
@@ -730,7 +752,8 @@ TYPED_TEST(StateTest, set_storage_unchanged_assigned)
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
             {b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
@@ -743,7 +766,8 @@ TYPED_TEST(StateTest, set_storage_added_deleted)
     BlockState bs{this->tdb};
     this->tdb.commit(
         StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -758,7 +782,8 @@ TYPED_TEST(StateTest, set_storage_added_deleted_null)
     BlockState bs{this->tdb};
     this->tdb.commit(
         StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -777,7 +802,8 @@ TYPED_TEST(StateTest, set_storage_modify_delete)
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -796,7 +822,8 @@ TYPED_TEST(StateTest, set_storage_delete_restored)
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -815,7 +842,8 @@ TYPED_TEST(StateTest, set_storage_modified_restored)
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
@@ -832,7 +860,8 @@ TYPED_TEST(StateTest, get_code_size)
     Account acct{.code_hash = code_hash1};
     this->tdb.commit(
         StateDeltas{{a, StateDelta{.account = {std::nullopt, acct}}}},
-        Code{{code_hash1, code_analysis1}});
+        Code{{code_hash1, code_analysis1}},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_EQ(s.get_code_size(a), code1.size());
@@ -848,7 +877,8 @@ TYPED_TEST(StateTest, copy_code)
         StateDeltas{
             {a, StateDelta{.account = {std::nullopt, acct_a}}},
             {b, StateDelta{.account = {std::nullopt, acct_b}}}},
-        Code{{code_hash1, code_analysis1}, {code_hash2, code_analysis2}});
+        Code{{code_hash1, code_analysis1}, {code_hash2, code_analysis2}},
+        BlockHeader{});
 
     static constexpr unsigned size{8};
     uint8_t buffer[size];
@@ -899,7 +929,8 @@ TYPED_TEST(StateTest, get_code)
             {a,
              StateDelta{
                  .account = {std::nullopt, Account{.code_hash = code_hash1}}}}},
-        Code{{code_hash1, std::make_shared<CodeAnalysis>(analyze(contract))}});
+        Code{{code_hash1, std::make_shared<CodeAnalysis>(analyze(contract))}},
+        BlockHeader{});
 
     State s{bs, Incarnation{1, 1}};
 
@@ -946,7 +977,8 @@ TYPED_TEST(StateTest, can_merge_same_account_different_storage)
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
                       {key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
@@ -971,7 +1003,8 @@ TYPED_TEST(StateTest, cant_merge_colliding_storage)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 40'000}},
                  .storage = {{key1, {bytes32_t{}, value1}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
@@ -1015,7 +1048,8 @@ TYPED_TEST(StateTest, merge_txn0_and_txn1)
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
                       {key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
@@ -1045,7 +1079,7 @@ TYPED_TEST(StateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    bs.commit({}, {});
+    bs.commit({}, {}, {});
 
     EXPECT_TRUE(this->tdb.read_account(a).has_value());
     EXPECT_EQ(this->tdb.read_account(a).value().balance, 1u);
@@ -1062,7 +1096,7 @@ TYPED_TEST(StateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    bs.commit({}, {});
+    bs.commit({}, {}, {});
 
     EXPECT_EQ(
         this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
@@ -1086,7 +1120,8 @@ TYPED_TEST(StateTest, commit_twice)
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
                       {key2, {bytes32_t{}, value2}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     {
         // Block 0, Txn 0
@@ -1101,7 +1136,7 @@ TYPED_TEST(StateTest, commit_twice)
             as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
-        bs.commit({}, {});
+        bs.commit({}, {}, {});
 
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value2);
@@ -1118,7 +1153,7 @@ TYPED_TEST(StateTest, commit_twice)
         cs.destruct_suicides<EVMC_SHANGHAI>();
         EXPECT_TRUE(bs.can_merge(cs));
         bs.merge(cs);
-        bs.commit({}, {});
+        bs.commit({}, {}, {});
 
         EXPECT_EQ(
             this->tdb.read_storage(c, Incarnation{2, 1}, key1),

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -112,9 +112,9 @@ void monad_statesync_server_context::increment_block_number()
 
 void monad_statesync_server_context::commit(
     StateDeltas const &state_deltas, Code const &code,
-    std::vector<Receipt> const &receipts,
+    BlockHeader const &header, std::vector<Receipt> const &receipts,
     std::vector<Transaction> const &transactions)
 {
     on_commit(*this, state_deltas);
-    rw.commit(state_deltas, code, receipts, transactions);
+    rw.commit(state_deltas, code, header, receipts, transactions);
 }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -49,6 +49,7 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual void commit(
         monad::StateDeltas const &state_deltas, monad::Code const &code,
+        monad::BlockHeader const &,
         std::vector<monad::Receipt> const &receipts = {},
         std::vector<monad::Transaction> const &transactions = {}) override;
 };

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -250,7 +250,9 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         stdb.increment_block_number();
         sctx.commit(
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}}, Code{});
+            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
+            Code{},
+            BlockHeader{});
     }
     // new storage to existing account
     {
@@ -266,7 +268,8 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {{},
                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-            Code{});
+            Code{},
+            BlockHeader{});
     }
     // add new smart contract
     {
@@ -318,7 +321,8 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
                          {}}}}}}},
-            Code{});
+            Code{},
+            BlockHeader{});
     }
     // account incarnation
     {
@@ -336,7 +340,8 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                         {{},
                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-            Code{});
+            Code{},
+            BlockHeader{});
     }
     // delete smart contract
     {
@@ -346,7 +351,9 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         stdb.increment_block_number();
         sctx.commit(
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}}, Code{});
+            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
+            Code{},
+            BlockHeader{});
     }
 
     auto const ctmp = tmp_dbname();
@@ -444,7 +451,8 @@ TEST_F(StateSyncFixture, sync_one_account)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 100}},
                  .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     auto const expected_root = stdb.state_root();
     init();
     monad_statesync_client_handle_target(
@@ -456,7 +464,7 @@ TEST_F(StateSyncFixture, sync_one_account)
 TEST_F(StateSyncFixture, sync_empty)
 {
     stdb.set_block_number(1'000'000);
-    stdb.commit(StateDeltas{}, Code{});
+    stdb.commit(StateDeltas{}, Code{}, BlockHeader{});
     init();
     monad_statesync_client_handle_target(
         cctx, make_target(1'000'000, NULL_ROOT));
@@ -476,7 +484,8 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                        {bytes32_t{},
                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     stdb.increment_block_number();
     sctx.commit({}, {}, {}, {});
     stdb.increment_block_number();
@@ -486,7 +495,8 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
              StateDelta{
                  .account = {Account{.balance = 100}, Account{.balance = 200}},
                  .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     init();
     monad_statesync_client_handle_target(
         cctx, make_target(102, stdb.state_root()));
@@ -506,7 +516,8 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
                        {bytes32_t{},
                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     stdb.increment_block_number();
     sctx.commit({}, {}, {}, {});
     stdb.increment_block_number();
@@ -516,7 +527,8 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
              StateDelta{
                  .account = {Account{.balance = 100}, std::nullopt},
                  .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     init();
     monad_statesync_client_handle_target(cctx, make_target(102, NULL_ROOT));
 }
@@ -531,7 +543,8 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 100}},
                  .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(1, sctx.state_root()));
     run();
@@ -543,13 +556,14 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
              StateDelta{
                  .account = {Account{.balance = 100}, std::nullopt},
                  .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(2, sctx.state_root()));
     client.rqs.clear();
 
     stdb.increment_block_number();
-    sctx.commit(StateDeltas{}, Code{});
+    sctx.commit(StateDeltas{}, Code{}, BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(3, sctx.state_root()));
     run();
@@ -566,7 +580,8 @@ TEST_F(StateSyncFixture, delete_updated_account)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(1, sctx.state_root()));
     run();
@@ -578,7 +593,8 @@ TEST_F(StateSyncFixture, delete_updated_account)
              StateDelta{
                  .account = {a, a},
                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(2, sctx.state_root()));
     client.rqs.pop_front();
@@ -590,7 +606,8 @@ TEST_F(StateSyncFixture, delete_updated_account)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(3, sctx.state_root()));
     run();
@@ -612,7 +629,8 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
                  .storage =
                      {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}},
                       {bytes32_t{1}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(1'000'000, sctx.state_root()));
     run();
@@ -621,7 +639,8 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     sctx.commit(
         StateDeltas{
             {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     stdb.increment_block_number();
     sctx.commit(
@@ -630,7 +649,8 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
              StateDelta{
                  .account = {std::nullopt, a},
                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
 
     stdb.increment_block_number();
     sctx.commit(
@@ -639,7 +659,8 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
              StateDelta{
                  .account = {a, a},
                  .storage = {{bytes32_t{}, {bytes32_t{64}, bytes32_t{}}}}}}},
-        Code{});
+        Code{},
+        BlockHeader{});
     monad_statesync_client_handle_target(
         cctx, make_target(1'000'003, sctx.state_root()));
     run();
@@ -660,7 +681,7 @@ TEST_F(StateSyncFixture, benchmark)
     }
     stdb.set_block_number(1'000'000);
     StateDeltas deltas{v.begin(), v.end()};
-    stdb.commit(deltas, Code{});
+    stdb.commit(deltas, Code{}, BlockHeader{});
     auto const expected_root = stdb.state_root();
     init();
     monad_statesync_client_handle_target(


### PR DESCRIPTION
Second PR on block data migration:

- [x] txs
- [x] block_header
- [ ] ommers
- [ ] withdrawals

Future work:  `validate_block()` for transactions_root and parentHash
