### PR TITLE
Store withdrawals to db optionally

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -153,14 +153,18 @@ Result<std::pair<uint64_t, uint64_t>> run_monad(
             chain.validate_header(receipts, block.value().header));
         block_state.log_debug();
         block_state.commit(
-            block.value().header, receipts, block.value().transactions);
+            block.value().header,
+            receipts,
+            block.value().transactions,
+            block.value().withdrawals);
 
         if (!chain.validate_root(
                 rev,
                 block.value().header,
                 db.state_root(),
                 db.receipts_root(),
-                db.transactions_root())) {
+                db.transactions_root(),
+                db.withdrawals_root())) {
             return BlockError::WrongMerkleRoot;
         }
 

--- a/libs/execution/src/monad/chain/chain.hpp
+++ b/libs/execution/src/monad/chain/chain.hpp
@@ -27,8 +27,8 @@ struct Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root,
-        bytes32_t const &transactions_root) const = 0;
+        bytes32_t const &receipts_root, bytes32_t const &transactions_root,
+        std::optional<bytes32_t> const &withdrawals_root) const = 0;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/ethereum_mainnet.cpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.cpp
@@ -95,7 +95,8 @@ Result<void> EthereumMainnet::validate_header(
 bool EthereumMainnet::validate_root(
     evmc_revision const rev, BlockHeader const &hdr,
     bytes32_t const &state_root, bytes32_t const &receipts_root,
-    bytes32_t const &transactions_root) const
+    bytes32_t const &transactions_root,
+    std::optional<bytes32_t> const &withdrawals_root) const
 {
     if (state_root != hdr.state_root) {
         LOG_ERROR(
@@ -123,6 +124,15 @@ bool EthereumMainnet::validate_root(
             hdr.number,
             transactions_root,
             hdr.transactions_root);
+        return false;
+    }
+    if (withdrawals_root != hdr.withdrawals_root) {
+        LOG_ERROR(
+            "Block: {}, Computed Withdrawals Root: {}, Expected Withdrawals "
+            "Root: {}",
+            hdr.number,
+            withdrawals_root,
+            hdr.withdrawals_root);
         return false;
     }
     return true;

--- a/libs/execution/src/monad/chain/ethereum_mainnet.hpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.hpp
@@ -27,8 +27,8 @@ struct EthereumMainnet : Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root,
-        bytes32_t const &transactions_root) const override;
+        bytes32_t const &receipts_root, bytes32_t const &transactions_root,
+        std::optional<bytes32_t> const &withdrawals_root) const override;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/monad_chain.cpp
+++ b/libs/execution/src/monad/chain/monad_chain.cpp
@@ -14,7 +14,8 @@ Result<void> MonadChain::validate_header(
 
 bool MonadChain::validate_root(
     evmc_revision const, BlockHeader const &, bytes32_t const &,
-    bytes32_t const &, bytes32_t const &) const
+    bytes32_t const &, bytes32_t const &,
+    std::optional<bytes32_t> const &) const
 {
     // TODO
     return true;

--- a/libs/execution/src/monad/chain/monad_chain.hpp
+++ b/libs/execution/src/monad/chain/monad_chain.hpp
@@ -17,8 +17,8 @@ struct MonadChain : Chain
 
     virtual bool validate_root(
         evmc_revision, BlockHeader const &, bytes32_t const &state_root,
-        bytes32_t const &receipts_root,
-        bytes32_t const &transactions_root) const override;
+        bytes32_t const &receipts_root, bytes32_t const &transactions_root,
+        std::optional<bytes32_t> const &withdrawals_root) const override;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -8,6 +8,7 @@
 #include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
 #include <monad/core/transaction.hpp>
+#include <monad/core/withdrawal.hpp>
 #include <monad/execution/code_analysis.hpp>
 #include <monad/state2/state_deltas.hpp>
 
@@ -29,13 +30,15 @@ struct Db
     virtual bytes32_t state_root() = 0;
     virtual bytes32_t receipts_root() = 0;
     virtual bytes32_t transactions_root() = 0;
+    virtual std::optional<bytes32_t> withdrawals_root() = 0;
 
     virtual void increment_block_number() = 0;
 
     virtual void commit(
         StateDeltas const &, Code const &, BlockHeader const &,
         std::vector<Receipt> const & = {},
-        std::vector<Transaction> const & = {}) = 0;
+        std::vector<Transaction> const & = {},
+        std::optional<std::vector<Withdrawal>> const & = {std::nullopt}) = 0;
 
     virtual std::string print_stats()
     {

--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -115,9 +115,11 @@ public:
     virtual void commit(
         StateDeltas const &state_deltas, Code const &code,
         BlockHeader const &header, std::vector<Receipt> const &receipts,
-        std::vector<Transaction> const &transactions) override
+        std::vector<Transaction> const &transactions,
+        std::optional<std::vector<Withdrawal>> const &withdrawals) override
     {
-        db_.commit(state_deltas, code, header, receipts, transactions);
+        db_.commit(
+            state_deltas, code, header, receipts, transactions, withdrawals);
 
         for (auto it = state_deltas.cbegin(); it != state_deltas.cend(); ++it) {
             auto const &address = it->first;
@@ -162,6 +164,11 @@ public:
     virtual bytes32_t transactions_root() override
     {
         return db_.transactions_root();
+    }
+
+    virtual std::optional<bytes32_t> withdrawals_root() override
+    {
+        return db_.withdrawals_root();
     }
 
     virtual std::string print_stats() override

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -44,10 +44,13 @@ public:
     virtual void commit(
         StateDeltas const &, Code const &, BlockHeader const &,
         std::vector<Receipt> const & = {},
-        std::vector<Transaction> const & = {}) override;
+        std::vector<Transaction> const & = {},
+        std::optional<std::vector<Withdrawal>> const & = {
+            std::nullopt}) override;
     virtual bytes32_t state_root() override;
     virtual bytes32_t receipts_root() override;
     virtual bytes32_t transactions_root() override;
+    virtual std::optional<bytes32_t> withdrawals_root() override;
     virtual std::string print_stats() override;
 
     nlohmann::json to_json();

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -401,7 +401,8 @@ mpt::Compute &MachineBase::get_compute() const
     }
     else if (
         trie_section == TrieType::Receipt ||
-        trie_section == TrieType::Transaction) {
+        trie_section == TrieType::Transaction ||
+        trie_section == TrieType::Withdrawal) {
         return depth == PREFIX_LEN ? generic_root_merkle_compute
                                    : generic_merkle_compute;
     }
@@ -417,7 +418,7 @@ void MachineBase::down(unsigned char const nibble)
     MONAD_ASSERT(
         (nibble == STATE_NIBBLE || nibble == CODE_NIBBLE ||
          nibble == RECEIPT_NIBBLE || nibble == TRANSACTION_NIBBLE ||
-         nibble == BLOCKHEADER_NIBBLE) ||
+         nibble == BLOCKHEADER_NIBBLE || nibble == WITHDRAWAL_NIBBLE) ||
         depth != PREFIX_LEN);
     if (MONAD_UNLIKELY(depth == PREFIX_LEN)) {
         MONAD_ASSERT(trie_section == TrieType::Prefix);
@@ -432,6 +433,9 @@ void MachineBase::down(unsigned char const nibble)
         }
         else if (nibble == CODE_NIBBLE) {
             trie_section = TrieType::Code;
+        }
+        else if (nibble == WITHDRAWAL_NIBBLE) {
+            trie_section = TrieType::Withdrawal;
         }
         else {
             MONAD_ASSERT(nibble == BLOCKHEADER_NIBBLE);

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -27,7 +27,8 @@ struct MachineBase : public mpt::StateMachine
         State,
         Code,
         Receipt,
-        Transaction
+        Transaction,
+        Withdrawal
     };
 
     uint8_t depth{0};
@@ -60,6 +61,7 @@ inline constexpr unsigned char CODE_NIBBLE = 1;
 inline constexpr unsigned char RECEIPT_NIBBLE = 2;
 inline constexpr unsigned char TRANSACTION_NIBBLE = 3;
 inline constexpr unsigned char BLOCKHEADER_NIBBLE = 4;
+inline constexpr unsigned char WITHDRAWAL_NIBBLE = 5;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
@@ -67,6 +69,7 @@ inline mpt::Nibbles const receipt_nibbles = mpt::concat(RECEIPT_NIBBLE);
 inline mpt::Nibbles const transaction_nibbles = mpt::concat(TRANSACTION_NIBBLE);
 inline mpt::Nibbles const block_header_nibbles =
     mpt::concat(BLOCKHEADER_NIBBLE);
+inline mpt::Nibbles const withdrawal_nibbles = mpt::concat(WITHDRAWAL_NIBBLE);
 
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -193,10 +193,11 @@ void BlockState::merge(State const &state)
 
 void BlockState::commit(
     BlockHeader const &header, std::vector<Receipt> const &receipts,
-    std::vector<Transaction> const &transactions)
+    std::vector<Transaction> const &transactions,
+    std::optional<std::vector<Withdrawal>> const &withdrawals)
 {
     db_.increment_block_number();
-    db_.commit(state_, code_, header, receipts, transactions);
+    db_.commit(state_, code_, header, receipts, transactions, withdrawals);
 }
 
 void BlockState::log_debug()

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -37,7 +37,8 @@ public:
 
     void commit(
         BlockHeader const &, std::vector<Receipt> const &,
-        std::vector<Transaction> const &);
+        std::vector<Transaction> const &,
+        std::optional<std::vector<Withdrawal>> const &);
 
     void log_debug();
 };

--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -473,7 +473,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {});
+        bs.commit({}, {}, {}, std::nullopt);
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
     }
@@ -512,7 +512,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {});
+        bs.commit({}, {}, {}, std::nullopt);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value2);
         EXPECT_EQ(
@@ -545,7 +545,7 @@ TYPED_TEST(StateTest, selfdestruct_create_destroy_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {});
+        bs.commit({}, {}, {}, std::nullopt);
         EXPECT_EQ(
             this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value3);
@@ -1079,7 +1079,7 @@ TYPED_TEST(StateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    bs.commit({}, {}, {});
+    bs.commit({}, {}, {}, std::nullopt);
 
     EXPECT_TRUE(this->tdb.read_account(a).has_value());
     EXPECT_EQ(this->tdb.read_account(a).value().balance, 1u);
@@ -1096,7 +1096,7 @@ TYPED_TEST(StateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    bs.commit({}, {}, {});
+    bs.commit({}, {}, {}, std::nullopt);
 
     EXPECT_EQ(
         this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
@@ -1136,7 +1136,7 @@ TYPED_TEST(StateTest, commit_twice)
             as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
-        bs.commit({}, {}, {});
+        bs.commit({}, {}, {}, std::nullopt);
 
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value2);
@@ -1153,7 +1153,7 @@ TYPED_TEST(StateTest, commit_twice)
         cs.destruct_suicides<EVMC_SHANGHAI>();
         EXPECT_TRUE(bs.can_merge(cs));
         bs.merge(cs);
-        bs.commit({}, {}, {});
+        bs.commit({}, {}, {}, std::nullopt);
 
         EXPECT_EQ(
             this->tdb.read_storage(c, Incarnation{2, 1}, key1),

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -105,6 +105,11 @@ bytes32_t monad_statesync_server_context::transactions_root()
     return rw.transactions_root();
 }
 
+std::optional<bytes32_t> monad_statesync_server_context::withdrawals_root()
+{
+    return rw.withdrawals_root();
+}
+
 void monad_statesync_server_context::increment_block_number()
 {
     rw.increment_block_number();
@@ -113,8 +118,9 @@ void monad_statesync_server_context::increment_block_number()
 void monad_statesync_server_context::commit(
     StateDeltas const &state_deltas, Code const &code,
     BlockHeader const &header, std::vector<Receipt> const &receipts,
-    std::vector<Transaction> const &transactions)
+    std::vector<Transaction> const &transactions,
+    std::optional<std::vector<Withdrawal>> const &withdrawals)
 {
     on_commit(*this, state_deltas);
-    rw.commit(state_deltas, code, header, receipts, transactions);
+    rw.commit(state_deltas, code, header, receipts, transactions, withdrawals);
 }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -45,11 +45,14 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual monad::bytes32_t transactions_root() override;
 
+    virtual std::optional<monad::bytes32_t> withdrawals_root() override;
+
     virtual void increment_block_number() override;
 
     virtual void commit(
         monad::StateDeltas const &state_deltas, monad::Code const &code,
         monad::BlockHeader const &,
         std::vector<monad::Receipt> const &receipts = {},
-        std::vector<monad::Transaction> const &transactions = {}) override;
+        std::vector<monad::Transaction> const &transactions = {},
+        std::optional<std::vector<monad::Withdrawal>> const & = {}) override;
 };

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -66,7 +66,8 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
             chain, block, block_state, block_hash_buffer, *pool_));
     BOOST_OUTCOME_TRY(chain.validate_header(receipts, block.header));
     block_state.log_debug();
-    block_state.commit(block.header, receipts, block.transactions);
+    block_state.commit(
+        block.header, receipts, block.transactions, block.withdrawals);
     return receipts;
 }
 
@@ -171,7 +172,7 @@ void BlockchainTest::TestBody()
             State state{bs, Incarnation{0, 0}};
             load_state_from_json(j_contents.at("pre"), state);
             bs.merge(state);
-            bs.commit({}, {}, {});
+            bs.commit({}, {}, {}, std::nullopt);
         }
 
         BlockHashBuffer block_hash_buffer;
@@ -209,6 +210,10 @@ void BlockchainTest::TestBody()
                 EXPECT_EQ(
                     tdb.transactions_root(),
                     block.value().header.transactions_root)
+                    << name;
+                EXPECT_EQ(
+                    tdb.withdrawals_root(),
+                    block.value().header.withdrawals_root)
                     << name;
                 if (rev >= EVMC_BYZANTIUM) {
                     EXPECT_EQ(


### PR DESCRIPTION
Third pr for block data migration: 

- [x] txs
- [x] block_header
- [ ] ommers
- [x] withdrawals
