### PR TITLE
Bump minimum cmake required to v3.27 as we are using cmake policy CMP0144 which requires cmake v3.27 or later.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.27)
+
+cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad)
 

--- a/libs/db/CMakeLists.txt
+++ b/libs/db/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.27)
 
 cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 

--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.27)
+
+cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad_execution)
 

--- a/libs/rpc/CMakeLists.txt
+++ b/libs/rpc/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.27)
+
+cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad_rpc)
 

--- a/libs/runloop/CMakeLists.txt
+++ b/libs/runloop/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.27)
+
+cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad-runloop LANGUAGES C CXX ASM)
 

--- a/libs/statesync/CMakeLists.txt
+++ b/libs/statesync/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.27)
+
+cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad_statesync)
 


### PR DESCRIPTION
Ubuntu 24.04 LTS's system cmake is v3.28, in case you were about to ask.

This will resolve:

https://github.com/monad-crypto/monad-internal/issues/659