### PR TITLE
New i/o executor bug fixes for cancellation

### DIFF
--- a/libs/runloop/Readme.md
+++ b/libs/runloop/Readme.md
@@ -266,10 +266,10 @@ static monad_c_result mytask(monad_async_task task)
 
 ## Todo
 
-- When a task exits, all i/o still occurring on that task ought to be pumped and dumped out
-(right now it aborts the process instead)
 - Need to test cancellation works at every possible lifecycle and suspend state
 a task can have.
+- Should be able to clamp max i/o concurrency, and have `AsyncIO` wrapper set that from its config.
+- `AsyncIO` wrapper doesn't currently handle `EAGAIN`.
 - Multiple context switcher types at the same time should work, but is completely untested
 and ought to become tested. Including with perf impact (as they usually have to
 thunk when switching between disparate contexts)
@@ -280,3 +280,5 @@ frame is: `struct msvc_frame_prefix { void(*factivate)(void*); uint16_t index, f
 Implementation is a state machine based on switching `index`.
     - GCC/clang coroutine frame: Frame prefix | Promise | Unknown | Local
 variables. Coroutine frame is: `struct clang_frame_prefix { void(*factivate)(void*); void(*fdestroy)(void*);};`.
+- When a task exits, all i/o still occurring on that task ought to be pumped and dumped out
+(right now it aborts the process instead)

--- a/libs/runloop/src/monad/async/socket_io.c
+++ b/libs/runloop/src/monad/async/socket_io.c
@@ -95,7 +95,10 @@ monad_c_result monad_async_task_socket_create_from_existing_fd(
     p->head.executor = &ex->head;
     p->io_uring_file_index = (unsigned)-1;
     struct monad_async_task_impl *task = (struct monad_async_task_impl *)task_;
-    if (task->please_cancel_invoked) {
+    if (task->please_cancel_status != please_cancel_not_invoked) {
+        if (task->please_cancel_status < please_cancel_invoked_seen) {
+            task->please_cancel_status = please_cancel_invoked_seen;
+        }
         (void)monad_async_task_socket_destroy(task_, (monad_async_socket)p);
         return monad_c_make_failure(ECANCELED);
     }
@@ -207,12 +210,9 @@ monad_async_task_socket_listen(monad_async_socket sock_, int backlog)
 static inline monad_c_result monad_async_task_socket_task_op_cancel(
     struct monad_async_executor_impl *ex, struct monad_async_task_impl *task)
 {
-    struct io_uring_sqe *sqe = get_sqe_suspending_if_necessary(
-        ex,
-        (struct monad_async_task_impl *)atomic_load_explicit(
-            &ex->head.current_task, memory_order_acquire),
-        false);
+    struct io_uring_sqe *sqe = get_sqe_for_cancellation(ex);
     io_uring_prep_cancel(sqe, io_uring_mangle_into_data(task), 0);
+    sqe->user_data = (__u64)io_uring_mangle_into_data(task);
     return monad_c_make_failure(EAGAIN); // Canceller needs to wait
 }
 
@@ -223,8 +223,9 @@ static inline monad_c_result monad_async_task_socket_iostatus_op_cancel(
     struct monad_async_executor_impl *ex =
         (struct monad_async_executor_impl *)atomic_load_explicit(
             &task->head.current_executor, memory_order_acquire);
-    struct io_uring_sqe *sqe = get_sqe_suspending_if_necessary(ex, task, false);
+    struct io_uring_sqe *sqe = get_sqe_for_cancellation(ex);
     io_uring_prep_cancel(sqe, io_uring_mangle_into_data(iostatus), 0);
+    sqe->user_data = (__u64)io_uring_mangle_into_data(iostatus);
     return monad_c_make_failure(EAGAIN); // Canceller needs to wait
 }
 
@@ -257,7 +258,7 @@ monad_c_result monad_async_task_socket_transfer_to_uring(
         struct io_uring_sqe *sqe =
             get_sqe_suspending_if_necessary(ex, task, true);
         if (sqe == nullptr) {
-            assert(task->please_cancel_invoked);
+            assert(task->please_cancel_status != please_cancel_not_invoked);
             (void)monad_async_task_socket_destroy(task_, sock_);
             return monad_c_make_failure(ECANCELED);
         }
@@ -336,7 +337,10 @@ monad_c_result monad_async_task_socket_accept(
         return monad_c_make_failure(EINVAL);
     }
     struct monad_async_task_impl *task = (struct monad_async_task_impl *)task_;
-    if (task->please_cancel_invoked) {
+    if (task->please_cancel_status != please_cancel_not_invoked) {
+        if (task->please_cancel_status < please_cancel_invoked_seen) {
+            task->please_cancel_status = please_cancel_invoked_seen;
+        }
         return monad_c_make_failure(ECANCELED);
     }
     struct monad_async_executor_impl *ex =

--- a/libs/runloop/src/monad/async/test/CMakeLists.txt
+++ b/libs/runloop/src/monad/async/test/CMakeLists.txt
@@ -11,11 +11,13 @@ function(monad_test target)
                TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer)
 endfunction()
 
+monad_test(cancellation_test "cancellation.cpp")
+
 monad_test(executor_test "executor.cpp")
 
-monad_test(foreign_executor_test "foreign_executor.cpp")
-
 monad_test(file_io_test "file_io.cpp")
+
+monad_test(foreign_executor_test "foreign_executor.cpp")
 
 monad_test(socket_io_test "socket_io.cpp")
 

--- a/libs/runloop/src/monad/async/test/cancellation.cpp
+++ b/libs/runloop/src/monad/async/test/cancellation.cpp
@@ -1,0 +1,229 @@
+#include <gtest/gtest.h>
+
+#include "../../test_common.hpp"
+
+#include "../executor.h"
+#include "monad/async/cpp_helpers.hpp"
+#include "monad/async/task.h"
+#include "monad/context/boost_result.h"
+#include "monad/context/config.h"
+#include "monad/context/context_switcher.h"
+
+#include <monad/core/small_prng.hpp>
+
+#include <chrono>
+#include <type_traits>
+
+template <class F>
+    requires(std::is_invocable_r_v<monad_c_result, F, monad_async_task>)
+static void test_cancellation(char const *desc, F &&op)
+{
+    {
+        monad_async_executor_attr ex_attr{};
+        ex_attr.io_uring_ring.entries = 64;
+        auto ex = make_executor(ex_attr);
+        auto switcher = make_context_switcher(monad_context_switcher_fcontext);
+
+        struct shared_t
+        {
+            F &op;
+            bool done{false};
+            uint32_t ops{0};
+        } shared{op};
+
+        auto task_impl = +[](monad_context_task task_) -> monad_c_result {
+            auto *task = (monad_async_task)task_;
+            auto *shared = (shared_t *)task->derived.user_ptr;
+            while (!shared->done) {
+                BOOST_OUTCOME_C_RESULT_SYSTEM_TRY(shared->op(task));
+                shared->ops++;
+            }
+            return monad_c_make_success(0);
+        };
+
+        std::vector<task_ptr> tasks;
+        tasks.reserve(ex_attr.io_uring_ring.entries + 8);
+        monad_async_task_attr task_attr{};
+        for (size_t n = 0; n < tasks.capacity(); n++) {
+            tasks.push_back(make_task(switcher.get(), task_attr));
+            tasks.back()->derived.user_code = task_impl;
+            tasks.back()->derived.user_ptr = &shared;
+            to_result(
+                monad_async_task_attach(ex.get(), tasks.back().get(), nullptr))
+                .value();
+        }
+
+        monad::small_prng rand;
+
+        const struct timespec nowait = {};
+
+        std::cout << "Beginning testing " << desc
+                  << " for correctness in cancellation for three seconds ..."
+                  << std::endl;
+        uint32_t implicit_cancels = 0, explicit_cancels = 0;
+        auto const begin = std::chrono::steady_clock::now();
+        do {
+            auto const v = rand();
+            task_ptr &i = tasks[v % tasks.size()];
+            assert(i);
+            if ((v >> 29) == 0) {
+                // Implicit cancellation
+                i.reset();
+                implicit_cancels++;
+            }
+            else {
+                // Explicit cancellation
+                auto r = to_result(monad_async_task_cancel(ex.get(), i.get()));
+                if (!r) {
+                    if (r.assume_error() !=
+                        errc::resource_unavailable_try_again) {
+                        r.value();
+                    }
+                }
+                while (!monad_async_task_has_exited(i.get())) {
+                    auto r = to_result(monad_async_executor_run(
+                        ex.get(), size_t(-1), &nowait));
+                    if (!r && r.assume_error() != errc::stream_timeout) {
+                        r.value();
+                    }
+                }
+                explicit_cancels++;
+            }
+            i = make_task(switcher.get(), task_attr);
+            i->derived.user_code = task_impl;
+            i->derived.user_ptr = &shared;
+            to_result(monad_async_task_attach(ex.get(), i.get(), nullptr))
+                .value();
+            auto r = to_result(
+                monad_async_executor_run(ex.get(), size_t(-1), &nowait));
+            if (!r && r.assume_error() != errc::stream_timeout) {
+                r.value();
+            }
+        }
+        while (std::chrono::steady_clock::now() - begin <
+               std::chrono::seconds(3));
+        shared.done = true;
+        while (monad_async_executor_has_work(ex.get())) {
+            to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
+                .value();
+        }
+        EXPECT_GT(shared.ops, 0);
+        EXPECT_GT(implicit_cancels, 0);
+        EXPECT_GT(explicit_cancels, 0);
+        std::cout << "\nTesting of " << desc
+                  << " for correctness in cancellation complete. Did "
+                  << shared.ops << " successful ops, " << implicit_cancels
+                  << " implicit cancels, " << explicit_cancels
+                  << " explicit cancels, " << ex->total_io_submitted
+                  << " i/o submitted and " << ex->total_io_completed
+                  << " i/o completed." << std::endl;
+        EXPECT_EQ(ex->total_io_submitted, ex->total_io_completed);
+    }
+    std::cout << "Testing of " << desc
+              << " for correctness in cancellation has torn down everything "
+                 "successfully."
+              << std::endl;
+}
+
+TEST(cancellation, yield)
+{
+    test_cancellation("yield", [](monad_async_task task) -> monad_c_result {
+        return monad_async_task_suspend_for_duration(nullptr, task, 0);
+    });
+}
+
+TEST(cancellation, suspend_for_duration)
+{
+    test_cancellation(
+        "suspend for duration", [](monad_async_task task) -> monad_c_result {
+            return monad_async_task_suspend_for_duration(
+                nullptr, task, 1000000ULL); // 1 millisecond
+        });
+}
+
+// This code will be used in further tests yet to be written
+#if 0
+        CHECK_RESULT(monad_async_task_suspend_for_duration(
+            nullptr,
+            ((monad_async_task)task),
+            10000000ULL)); // 10 milliseconds
+        EXPECT_EQ(ex->total_io_submitted, 1);
+        EXPECT_EQ(ex->total_io_completed, 1);
+        for (size_t n = 0; n < 100; n++) {
+            CHECK_RESULT(monad_async_task_suspend_for_duration(
+                nullptr,
+                ((monad_async_task)task),
+                1000000ULL)); // 1 milliseconds
+        }
+        EXPECT_EQ(ex->total_io_submitted, 101);
+        EXPECT_EQ(ex->total_io_completed, 101);
+
+        struct open_how how
+        {
+            .flags = O_RDWR, .mode = 0, .resolve = 0
+        };
+
+        char tempfilepath[256];
+        close(monad_async_make_temporary_file(
+            tempfilepath, sizeof(tempfilepath)));
+        auto fh = make_file(task, nullptr, tempfilepath, how);
+        unlink(tempfilepath);
+        EXPECT_EQ(ex->total_io_submitted, 103);
+        EXPECT_EQ(ex->total_io_completed, 103);
+        CHECK_RESULT(
+            monad_async_task_file_fallocate(task, fh.get(), 0, 0, 1024));
+        EXPECT_EQ(ex->total_io_submitted, 104);
+        EXPECT_EQ(ex->total_io_completed, 104);
+
+        std::array<
+            std::pair<
+                monad_async_io_status,
+                monad_async_task_registered_io_buffer>,
+            1000>
+            iostatuses;
+        auto process_completion = [&](monad_async_io_status *completed) {
+            if (completed == nullptr) {
+                return;
+            }
+            EXPECT_TRUE(to_result(completed->result).has_value());
+            auto *i = (std::pair<
+                       monad_async_io_status,
+                       monad_async_task_registered_io_buffer> *)completed;
+            CHECK_RESULT(monad_async_task_release_registered_io_buffer(
+                task, i->second.index));
+        };
+        for (size_t n = 0; n < iostatuses.size(); n++) {
+            monad_async_task_file_read(
+                &iostatuses[n].first,
+                task,
+                fh.get(),
+                &iostatuses[n].second,
+                1,
+                n,
+                0);
+            process_completion(monad_async_task_completed_io(task));
+        }
+        EXPECT_EQ(ex->total_io_submitted, 1104);
+        EXPECT_LE(ex->total_io_completed, 1104);
+        for (;;) {
+            monad_async_io_status *completed = nullptr;
+            CHECK_RESULT(monad_async_task_suspend_until_completed_io(
+                &completed,
+                task,
+                monad_async_duration_infinite_non_cancelling));
+            if (completed == nullptr) {
+                break;
+            }
+            process_completion(completed);
+        }
+        EXPECT_EQ(ex->total_io_submitted, 1104);
+        EXPECT_EQ(ex->total_io_completed, 1104);
+
+        return monad_c_make_success(0);
+    };
+    CHECK_RESULT(monad_async_task_attach(ex.get(), task.get(), nullptr));
+    while (monad_async_executor_has_work(ex.get())) {
+        to_result(monad_async_executor_run(ex.get(), size_t(-1), nullptr))
+            .value();
+    }
+#endif

--- a/libs/runloop/src/monad/context/context_switcher.h
+++ b/libs/runloop/src/monad/context/context_switcher.h
@@ -30,7 +30,7 @@ typedef struct monad_context_head *monad_context;
 //! monad_context_task_head`
 #define MONAD_CONTEXT_TASK_ALLOCATION_SIZE (296)
 //! \brief How many of those bytes are used by the i/o executor for its state
-#define MONAD_ASYNC_TASK_FOOTPRINT (296)
+#define MONAD_ASYNC_TASK_FOOTPRINT (288)
 
 //! \brief The public attributes of a task
 typedef struct monad_context_task_head


### PR DESCRIPTION
To the new i/o executor add a test that cancellation of a suspend for duration works. This found lots of bugs all of which are now fixed.

More tests shall follow for other operations such as i/o in future
PRs.