### PR TITLE
replace `find_result` with `DbError`, propagate find error to `mpt::Db` level

### DIFF
--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -135,7 +135,7 @@ namespace detail
         uint64_t const block_id;
         uint8_t const cached_levels;
 
-        using find_bytes_result_type = std::pair<byte_string, find_result>;
+        using find_bytes_result_type = std::pair<byte_string, DbError>;
 
         find_result_type res_root;
         find_bytes_result_type res_bytes;

--- a/libs/db/src/monad/mpt/db_error.hpp
+++ b/libs/db/src/monad/mpt/db_error.hpp
@@ -15,7 +15,14 @@ MONAD_MPT_NAMESPACE_BEGIN
 enum class DbError : uint8_t
 {
     unknown,
-    key_not_found
+    success,
+    root_node_is_null_failure,
+    key_mismatch_failure,
+    branch_not_exist_failure,
+    key_ends_earlier_than_node_failure,
+    version_no_longer_exist,
+    node_is_not_leaf_failure,
+    need_to_continue_in_io_thread
 };
 
 MONAD_MPT_NAMESPACE_END
@@ -34,7 +41,28 @@ struct quick_status_code_from_enum<MONAD_MPT_NAMESPACE::DbError>
     static std::initializer_list<mapping> const &value_mappings()
     {
         static std::initializer_list<mapping> const v = {
-            {MONAD_MPT_NAMESPACE::DbError::key_not_found, "key not found", {}},
+            {MONAD_MPT_NAMESPACE::DbError::success, "success", {}},
+            {MONAD_MPT_NAMESPACE::DbError::root_node_is_null_failure,
+             "root node is null",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::key_mismatch_failure,
+             "key mismatch",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::branch_not_exist_failure,
+             "branch node does not exist",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::key_ends_earlier_than_node_failure,
+             "key ends in the middle of a node path",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::version_no_longer_exist,
+             "version no longer exist in db",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::node_is_not_leaf_failure,
+             "non-leaf node",
+             {}},
+            {MONAD_MPT_NAMESPACE::DbError::need_to_continue_in_io_thread,
+             "need to continue in io thread",
+             {}},
             {MONAD_MPT_NAMESPACE::DbError::unknown, "unknown", {}},
         };
         return v;

--- a/libs/db/src/monad/mpt/find.cpp
+++ b/libs/db/src/monad/mpt/find.cpp
@@ -15,7 +15,7 @@ find_blocking(UpdateAuxImpl const &aux, NodeCursor root, NibblesView const key)
 {
     auto g(aux.shared_lock());
     if (!root.is_valid()) {
-        return {NodeCursor{}, find_result::root_node_is_null_failure};
+        return {NodeCursor{}, DbError::root_node_is_null_failure};
     }
     Node *node = root.node;
     unsigned node_prefix_index = root.prefix_index;
@@ -26,7 +26,7 @@ find_blocking(UpdateAuxImpl const &aux, NodeCursor root, NibblesView const key)
             if (!(node->mask & (1u << nibble))) {
                 return {
                     NodeCursor{*node, node_prefix_index},
-                    find_result::branch_not_exist_failure};
+                    DbError::branch_not_exist_failure};
             }
             // go to node's matched child
             if (!node->next(node->to_child_index(nibble))) {
@@ -52,7 +52,7 @@ find_blocking(UpdateAuxImpl const &aux, NodeCursor root, NibblesView const key)
             // return the last matched node and first mismatch prefix index
             return {
                 NodeCursor{*node, node_prefix_index},
-                find_result::key_mismatch_failure};
+                DbError::key_mismatch_failure};
         }
         // nibble is matched
         ++prefix_index;
@@ -62,9 +62,9 @@ find_blocking(UpdateAuxImpl const &aux, NodeCursor root, NibblesView const key)
         // prefix key exists but no leaf ends at `key`
         return {
             NodeCursor{*node, node_prefix_index},
-            find_result::key_ends_earlier_than_node_failure};
+            DbError::key_ends_earlier_than_node_failure};
     }
-    return {NodeCursor{*node, node_prefix_index}, find_result::success};
+    return {NodeCursor{*node, node_prefix_index}, DbError::success};
 }
 
 MONAD_MPT_NAMESPACE_END

--- a/libs/db/src/monad/mpt/find_notify_fiber.cpp
+++ b/libs/db/src/monad/mpt/find_notify_fiber.cpp
@@ -105,8 +105,7 @@ void find_recursive(
 
 {
     if (!root.is_valid()) {
-        promise.set_value(
-            {NodeCursor{}, find_result::root_node_is_null_failure});
+        promise.set_value({NodeCursor{}, DbError::root_node_is_null_failure});
         return;
     }
     unsigned prefix_index = 0;
@@ -117,20 +116,20 @@ void find_recursive(
         if (prefix_index >= key.nibble_size()) {
             promise.set_value(
                 {NodeCursor{*node, node_prefix_index},
-                 find_result::key_ends_earlier_than_node_failure});
+                 DbError::key_ends_earlier_than_node_failure});
             return;
         }
         if (key.get(prefix_index) !=
             get_nibble(node->path_data(), node_prefix_index)) {
             promise.set_value(
                 {NodeCursor{*node, node_prefix_index},
-                 find_result::key_mismatch_failure});
+                 DbError::key_mismatch_failure});
             return;
         }
     }
     if (prefix_index == key.nibble_size()) {
         promise.set_value(
-            {NodeCursor{*node, node_prefix_index}, find_result::success});
+            {NodeCursor{*node, node_prefix_index}, DbError::success});
         return;
     }
     MONAD_ASSERT(prefix_index < key.nibble_size());
@@ -149,7 +148,7 @@ void find_recursive(
         if (aux.io->owning_thread_id() != gettid()) {
             promise.set_value(
                 {NodeCursor{*node, node_prefix_index},
-                 find_result::need_to_continue_in_io_thread});
+                 DbError::need_to_continue_in_io_thread});
             return;
         }
         chunk_offset_t const offset = node->fnext(child_index);
@@ -170,7 +169,7 @@ void find_recursive(
     else {
         promise.set_value(
             {NodeCursor{*node, node_prefix_index},
-             find_result::branch_not_exist_failure});
+             DbError::branch_not_exist_failure});
     }
 }
 

--- a/libs/db/src/monad/mpt/find_request_sender.cpp
+++ b/libs/db/src/monad/mpt/find_request_sender.cpp
@@ -110,14 +110,13 @@ find_request_sender::operator()(erased_connected_operation *io_state) noexcept
              ++node_prefix_index, ++prefix_index) {
             if (prefix_index >= key_.nibble_size()) {
                 res_ = {
-                    byte_string{},
-                    find_result::key_ends_earlier_than_node_failure};
+                    byte_string{}, DbError::key_ends_earlier_than_node_failure};
                 io_state->completed(success());
                 return success();
             }
             if (key_.get(prefix_index) !=
                 get_nibble(node->path_data(), node_prefix_index)) {
-                res_ = {byte_string{}, find_result::key_mismatch_failure};
+                res_ = {byte_string{}, DbError::key_mismatch_failure};
                 io_state->completed(success());
                 return success();
             }
@@ -125,7 +124,7 @@ find_request_sender::operator()(erased_connected_operation *io_state) noexcept
         if (prefix_index == key_.nibble_size()) {
             res_ = {
                 byte_string{return_value_ ? node->value() : node->data()},
-                find_result::success};
+                DbError::success};
             io_state->completed(success());
             return success();
         }
@@ -145,8 +144,7 @@ find_request_sender::operator()(erased_connected_operation *io_state) noexcept
                 MONAD_ASSERT(aux_.io != nullptr);
                 if (aux_.io->owning_thread_id() != gettid()) {
                     res_ = {
-                        byte_string{},
-                        find_result::need_to_continue_in_io_thread};
+                        byte_string{}, DbError::need_to_continue_in_io_thread};
                     return success();
                 }
                 tid_checked_ = true;
@@ -175,7 +173,7 @@ find_request_sender::operator()(erased_connected_operation *io_state) noexcept
             return success();
         }
         else {
-            res_ = {byte_string{}, find_result::branch_not_exist_failure};
+            res_ = {byte_string{}, DbError::branch_not_exist_failure};
             io_state->completed(success());
             return success();
         }

--- a/libs/db/src/monad/mpt/find_request_sender.hpp
+++ b/libs/db/src/monad/mpt/find_request_sender.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <monad/mpt/db_error.hpp>
 #include <monad/mpt/trie.hpp>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-using find_bytes_result_type = std::pair<byte_string, find_result>;
+using find_bytes_result_type = std::pair<byte_string, DbError>;
 
 using inflight_node_t = unordered_dense_map<
     chunk_offset_t,

--- a/libs/db/src/monad/mpt/test/cli_tool_test.cpp
+++ b/libs/db/src/monad/mpt/test/cli_tool_test.cpp
@@ -213,7 +213,7 @@ struct cli_tool_fixture
 
                 for (auto &key : this->state()->keys) {
                     auto ret = monad::mpt::find_blocking(aux, root, key.first);
-                    EXPECT_EQ(ret.second, monad::mpt::find_result::success);
+                    EXPECT_EQ(ret.second, monad::mpt::DbError::success);
                 }
             }).get();
         }
@@ -307,7 +307,7 @@ struct cli_tool_fixture
                     for (auto &key : this->state()->keys) {
                         auto ret =
                             monad::mpt::find_blocking(aux, root, key.first);
-                        EXPECT_EQ(ret.second, monad::mpt::find_result::success);
+                        EXPECT_EQ(ret.second, monad::mpt::DbError::success);
                     }
                 }).get();
             }

--- a/libs/db/src/monad/mpt/test/db_test.cpp
+++ b/libs/db/src/monad/mpt/test/db_test.cpp
@@ -464,7 +464,7 @@ TEST_F(OnDiskDbWithFileAsyncFixture, read_only_db_single_thread_async)
             test_cached_level),
         [&](result_t res) {
             EXPECT_TRUE(res.has_error());
-            EXPECT_EQ(res.error(), DbError::key_not_found);
+            EXPECT_EQ(res.error(), DbError::version_no_longer_exist);
         });
 
     poll_until(1);
@@ -561,7 +561,8 @@ TEST(ReadOnlyDbTest, open_empty_rodb)
     EXPECT_EQ(ro_db.get_latest_block_id(), INVALID_BLOCK_ID);
     EXPECT_EQ(ro_db.get_earliest_block_id(), INVALID_BLOCK_ID);
     // RODb get() from any block will fail
-    EXPECT_EQ(ro_db.get({}, 0).assume_error(), DbError::key_not_found);
+    EXPECT_EQ(
+        ro_db.get({}, 0).assume_error(), DbError::root_node_is_null_failure);
 }
 
 TEST(ReadOnlyDbTest, read_only_db_concurrent)
@@ -1189,7 +1190,7 @@ TEST_F(OnDiskDbFixture, rw_query_old_version)
     write(kv[1].first, kv[1].second, block_id + i);
     auto bad_read = this->db.get(prefix + kv[0].first, block_id);
     EXPECT_TRUE(bad_read.has_error());
-    EXPECT_EQ(bad_read.error(), DbError::key_not_found);
+    EXPECT_EQ(bad_read.error(), DbError::root_node_is_null_failure);
 }
 
 TEST(DbTest, move_trie_causes_discontinuous_history)

--- a/libs/db/src/monad/mpt/test/fiber_future_wrapped_find.cpp
+++ b/libs/db/src/monad/mpt/test/fiber_future_wrapped_find.cpp
@@ -36,7 +36,7 @@ namespace
         find_notify_fiber_future(*aux, *inflights, request);
         auto const [it, errc] = request.promise->get_future().get();
         ASSERT_TRUE(it.is_valid());
-        EXPECT_EQ(errc, monad::mpt::find_result::success);
+        EXPECT_EQ(errc, monad::mpt::DbError::success);
         EXPECT_EQ(it.node->value(), value);
     };
 

--- a/libs/db/src/monad/mpt/test/locking_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/locking_trie_test.cpp
@@ -197,7 +197,7 @@ TEST_F(LockingTrieTest, works)
     {
         aux.lock().clear();
         auto [leaf_it, res] = find_blocking(aux, *root, keys.back().first);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
 
@@ -214,7 +214,7 @@ TEST_F(LockingTrieTest, works)
     {
         aux.lock().clear();
         auto [leaf_it, res] = find_blocking(aux, *root, keys.back().first);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
 
@@ -246,7 +246,7 @@ TEST_F(LockingTrieTest, works)
             aux.io->wait_until_done();
         }
         auto [leaf_it, res] = fut.get();
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
 
@@ -274,7 +274,7 @@ TEST_F(LockingTrieTest, works)
             aux.io->wait_until_done();
         }
         auto [leaf_it, res] = fut.get();
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
 

--- a/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
@@ -228,25 +228,25 @@ TYPED_TEST(TrieTest, insert_unrelated_leaves_then_read)
         0xd339cf4033aca65996859d35da4612b642664cc40734dbdd40738aa47f1e3e44_hex);
 
     auto [leaf_it, res] = find_blocking(this->aux, *this->root, kv[0].first);
-    EXPECT_EQ(res, monad::mpt::find_result::success);
+    EXPECT_EQ(res, monad::mpt::DbError::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[0].second);
     std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[1].first);
-    EXPECT_EQ(res, monad::mpt::find_result::success);
+    EXPECT_EQ(res, monad::mpt::DbError::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[1].second);
     std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[2].first);
-    EXPECT_EQ(res, monad::mpt::find_result::success);
+    EXPECT_EQ(res, monad::mpt::DbError::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[2].second);
     std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[3].first);
-    EXPECT_EQ(res, monad::mpt::find_result::success);
+    EXPECT_EQ(res, monad::mpt::DbError::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
@@ -704,7 +704,7 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
             block_id,
             true /*compaction*/);
         auto [state_it, res] = find_blocking(this->aux, *this->root, prefix);
-        EXPECT_EQ(res, find_result::success);
+        EXPECT_EQ(res, DbError::success);
         EXPECT_EQ(
             state_it.node->data(),
             0x05a697d6698c55ee3e4d472c4907bca2184648bcfdd0e023e7ff7089dc984e7e_hex);
@@ -786,13 +786,13 @@ TYPED_TEST(TrieTest, variable_length_trie)
     // find
     {
         auto [node0, res] = find_blocking(this->aux, *this->root, key0);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_EQ(node0.node->value(), long_value);
     }
 
     {
         auto [node_long, res] = find_blocking(this->aux, *this->root, keylong);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_EQ(node_long.node->value(), long_value);
     }
 }
@@ -836,14 +836,14 @@ TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
     {
         auto [node0, res] =
             find_blocking(this->aux, *this->root, prefix + key0);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_EQ(node0.node->value(), value);
     }
 
     {
         auto [node_long, res] =
             find_blocking(this->aux, *this->root, prefix + keylong);
-        EXPECT_EQ(res, monad::mpt::find_result::success);
+        EXPECT_EQ(res, monad::mpt::DbError::success);
         EXPECT_EQ(node_long.node->value(), value);
     }
 }

--- a/libs/db/src/monad/mpt/test/monad_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/monad_trie_test.cpp
@@ -661,7 +661,7 @@ int main(int argc, char *argv[])
                 root.reset(read_node_blocking(
                     io.storage_pool(), aux.get_latest_root_offset()));
                 auto [res, errc] = find_blocking(aux, *root, state_nibbles);
-                MONAD_ASSERT(errc == find_result::success);
+                MONAD_ASSERT(errc == DbError::success);
                 state_start = res;
                 return ret;
             };
@@ -708,7 +708,7 @@ int main(int argc, char *argv[])
                         auto const [data, errc] = res.assume_value();
                         MONAD_ASSERT(
                             data.size() == KECCAK256_SIZE || data.size() == 0);
-                        MONAD_ASSERT(errc == monad::mpt::find_result::success);
+                        MONAD_ASSERT(errc == monad::mpt::DbError::success);
                         ops++;
 
                         if (!done) {
@@ -749,7 +749,7 @@ int main(int argc, char *argv[])
                     state->receiver().set_value(
                         state.get(),
                         monad::mpt::find_bytes_result_type(
-                            {}, monad::mpt::find_result::success));
+                            {}, monad::mpt::DbError::success));
                 }
 
                 auto begin = std::chrono::steady_clock::now();
@@ -805,7 +805,7 @@ int main(int argc, char *argv[])
                         auto const [node_cursor, errc] =
                             request.promise->get_future().get();
                         MONAD_ASSERT(node_cursor.is_valid());
-                        MONAD_ASSERT(errc == monad::mpt::find_result::success);
+                        MONAD_ASSERT(errc == monad::mpt::DbError::success);
                         MONAD_ASSERT(node_cursor.node->has_value());
                         ops++;
                         boost::this_fiber::yield();
@@ -893,7 +893,7 @@ int main(int argc, char *argv[])
                         auto const [node_cursor, errc] =
                             request.promise->get_future().get();
                         MONAD_ASSERT(node_cursor.is_valid());
-                        MONAD_ASSERT(errc == monad::mpt::find_result::success);
+                        MONAD_ASSERT(errc == monad::mpt::DbError::success);
                         MONAD_ASSERT(node_cursor.node->has_value());
                         ops.fetch_add(1, std::memory_order_relaxed);
                     }
@@ -1041,7 +1041,7 @@ int main(int argc, char *argv[])
                         auto const [node_cursor, errc] =
                             state.receiver().p.get_future().get();
                         MONAD_ASSERT(node_cursor.is_valid());
-                        MONAD_ASSERT(errc == monad::mpt::find_result::success);
+                        MONAD_ASSERT(errc == monad::mpt::DbError::success);
                         MONAD_ASSERT(node_cursor.node->has_value());
                         ops.fetch_add(1, std::memory_order_relaxed);
                     }

--- a/libs/db/src/monad/mpt/test/plain_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/plain_trie_test.cpp
@@ -358,7 +358,7 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
         kv[3].second);
     EXPECT_EQ(
         find_blocking(this->aux, *this->root, kv[2].first).second,
-        find_result::key_mismatch_failure);
+        DbError::key_mismatch_failure);
 }
 
 TYPED_TEST(PlainTrieTest, large_values)
@@ -382,7 +382,7 @@ TYPED_TEST(PlainTrieTest, large_values)
     {
         auto [leaf_it, res] = find_blocking(this->aux, *this->root, key1);
         auto *leaf = leaf_it.node;
-        EXPECT_EQ(res, find_result::success);
+        EXPECT_EQ(res, DbError::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
         EXPECT_EQ(leaf->value(), value1);
@@ -392,7 +392,7 @@ TYPED_TEST(PlainTrieTest, large_values)
     {
         auto [leaf_it, res] = find_blocking(this->aux, *this->root, key2);
         auto *leaf = leaf_it.node;
-        EXPECT_EQ(res, find_result::success);
+        EXPECT_EQ(res, DbError::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
         EXPECT_EQ(leaf->value(), value2);
@@ -411,7 +411,7 @@ TYPED_TEST(PlainTrieTest, large_values)
         }
         auto [leaf_it, res] = fut.get();
         auto *leaf = leaf_it.node;
-        EXPECT_EQ(res, find_result::success);
+        EXPECT_EQ(res, DbError::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
         EXPECT_EQ(leaf->value(), value1);
@@ -430,7 +430,7 @@ TYPED_TEST(PlainTrieTest, large_values)
         }
         auto [leaf_it, res] = fut.get();
         auto *leaf = leaf_it.node;
-        EXPECT_EQ(res, find_result::success);
+        EXPECT_EQ(res, DbError::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
         EXPECT_EQ(leaf->value(), value2);
@@ -462,7 +462,7 @@ TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
             make_update(prefix, top_value, false, std::move(updates)));
         // find blocking on multi-level trie
         auto [begin, errc] = find_blocking(this->aux, *this->root, prefix);
-        EXPECT_EQ(errc, find_result::success);
+        EXPECT_EQ(errc, DbError::success);
         EXPECT_EQ(begin.node->number_of_children(), 2);
         EXPECT_EQ(begin.node->value(), top_value);
 

--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -2,6 +2,7 @@
 
 #include <monad/mpt/compute.hpp>
 #include <monad/mpt/config.hpp>
+#include <monad/mpt/db_error.hpp>
 #include <monad/mpt/detail/collected_stats.hpp>
 #include <monad/mpt/detail/db_metadata.hpp>
 #include <monad/mpt/node.hpp>
@@ -834,19 +835,7 @@ size_t load_all(UpdateAuxImpl &, StateMachine &, NodeCursor);
 
 //////////////////////////////////////////////////////////////////////////////
 // find
-
-enum class find_result : uint8_t
-{
-    unknown,
-    success,
-    version_no_longer_exist,
-    root_node_is_null_failure,
-    key_mismatch_failure,
-    branch_not_exist_failure,
-    key_ends_earlier_than_node_failure,
-    need_to_continue_in_io_thread
-};
-using find_result_type = std::pair<NodeCursor, find_result>;
+using find_result_type = std::pair<NodeCursor, DbError>;
 
 using inflight_map_t = unordered_dense_map<
     chunk_offset_t,


### PR DESCRIPTION
In replace of earlier PR https://github.com/monad-crypto/monad/pull/721. 

The goal is to propagate more detailed error message from `find*()` functions up to the `mpt::Db` level.

The difference between 721 and this one is find won't return error if node doesn't have value, it remains as a db level check before return.