### PR TITLE
Ordered priority for sender recovery

### DIFF
--- a/libs/execution/src/monad/execution/execute_block.cpp
+++ b/libs/execution/src/monad/execution/execute_block.cpp
@@ -117,7 +117,7 @@ Result<std::vector<Receipt>> execute_block(
 
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
         priority_pool.submit(
-            0,
+            i,
             [i = i,
              senders = senders,
              promises = promises,


### PR DESCRIPTION
trace parser #669 won't work with fixed priority for each fiber

**Baseline (lastest main):**
Benchmark:
```
Replay 3000000->3100000 in-memory: tps=25105  gps=857 M
Replay 12000000->12100000 in-memory: tps=15294  gps=948 M
Replay 15000000->15100000 on-disk: tps=6708  gps=567 M
```
Event Trace:
<img width="900" alt="Screenshot 2024-10-18 at 1 40 08 PM" src="https://github.com/user-attachments/assets/71805a81-4d68-4834-8371-ef9c1a7cb29c">


**This branch:**
Benchmark:
```
Replay 3000000->3100000 in-memory: tps=26898  gps=918 M
Replay 12000000->12100000 in-memory: tps=14925  gps=925 M
Replay 15000000->15100000 on-disk: tps=6695  gps=566 M
```
Event Trace:
<img width="848" alt="Screenshot 2024-10-18 at 1 05 58 PM" src="https://github.com/user-attachments/assets/634d7f6a-c243-461e-9e8a-9358489d1157">
