### PR TITLE
Add ability to roll DB back to a specific history version, with options for discarding trimmed data either immediately or deferred.

### DIFF
--- a/libs/async/src/monad/async/storage_pool.cpp
+++ b/libs/async/src/monad/async/storage_pool.cpp
@@ -255,7 +255,7 @@ bool storage_pool::chunk::try_trim_contents(uint32_t bytes)
         auto const bytesread = (remainder == 0)
                                    ? 0
                                    : ::pread(
-                                         write_fd_,
+                                         read_fd_,
                                          buffer,
                                          DISK_PAGE_SIZE,
                                          static_cast<off_t>(range[0]));

--- a/libs/core/src/monad/io/buffers.cpp
+++ b/libs/core/src/monad/io/buffers.cpp
@@ -12,7 +12,10 @@
 
 #include <bit>
 #include <cstddef>
+#include <cstring>
+#include <iostream>
 #include <optional>
+#include <source_location>
 
 MONAD_IO_NAMESPACE_BEGIN
 
@@ -42,30 +45,43 @@ Buffers::Buffers(
               ? 0
               : (write_buf_->get_size() / write_size)}
 {
+    auto do_register_buffers = [](io_uring *const ring,
+                                  const struct iovec *const iovecs,
+                                  unsigned const nr_iovecs,
+                                  std::source_location loc =
+                                      std::source_location::current()) {
+        if (int const errcode =
+                io_uring_register_buffers(ring, iovecs, nr_iovecs);
+            errcode < 0) {
+            std::cerr
+                << "FATAL: io_uring_register_buffers in buffer.cpp at line "
+                << loc.line() << " failed with '" << strerror(-errcode)
+                << "'. iovecs[0] = { " << iovecs[0].iov_base << ", "
+                << iovecs[0].iov_len << " }" << std::endl;
+            std::terminate();
+        }
+    };
     if (wr_ring_ != nullptr) {
         iovec const iov[2]{
             {.iov_base = read_buf_.get_data(), .iov_len = read_buf_.get_size()},
             {.iov_base = write_buf_.value().get_data(),
              .iov_len = write_buf_.value().get_size()}};
-        MONAD_ASSERT(!io_uring_register_buffers(
-            const_cast<io_uring *>(&ring_.get_ring()), iov, 1));
-        MONAD_ASSERT(!io_uring_register_buffers(
-            const_cast<io_uring *>(&wr_ring_->get_ring()), iov + 1, 1));
+        do_register_buffers(const_cast<io_uring *>(&ring_.get_ring()), iov, 1);
+        do_register_buffers(
+            const_cast<io_uring *>(&wr_ring_->get_ring()), iov + 1, 1);
     }
     else if (!write_buf_.has_value()) {
         iovec const iov[2]{
             {.iov_base = read_buf_.get_data(),
              .iov_len = read_buf_.get_size()}};
-        MONAD_ASSERT(!io_uring_register_buffers(
-            const_cast<io_uring *>(&ring_.get_ring()), iov, 1));
+        do_register_buffers(const_cast<io_uring *>(&ring_.get_ring()), iov, 1);
     }
     else {
         iovec const iov[2]{
             {.iov_base = read_buf_.get_data(), .iov_len = read_buf_.get_size()},
             {.iov_base = write_buf_.value().get_data(),
              .iov_len = write_buf_.value().get_size()}};
-        MONAD_ASSERT(!io_uring_register_buffers(
-            const_cast<io_uring *>(&ring_.get_ring()), iov, 2));
+        do_register_buffers(const_cast<io_uring *>(&ring_.get_ring()), iov, 2);
     }
 }
 

--- a/libs/db/src/monad/mpt/detail/db_metadata.hpp
+++ b/libs/db/src/monad/mpt/detail/db_metadata.hpp
@@ -5,6 +5,7 @@
 #include <monad/core/assert.h>
 #include <monad/mpt/util.hpp>
 
+#include <monad/async/config.hpp>
 #include <monad/async/detail/start_lifetime_as_polyfill.hpp>
 
 #include "unsigned_20.hpp"
@@ -135,6 +136,19 @@ namespace detail
                     push(INVALID_OFFSET);
                 }
                 self()->next_version.store(version, std::memory_order_release);
+            }
+
+            void rewind_to_version(uint64_t const version)
+            {
+                if (max_version() - version > capacity()) {
+                    reset_all(version);
+                    return;
+                }
+                for (uint64_t i = version + 1; i <= max_version(); i++) {
+                    assign(i, async::INVALID_OFFSET);
+                }
+                self()->next_version.store(
+                    version + 1, std::memory_order_release);
             }
 
         } root_offsets;

--- a/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
+++ b/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
@@ -533,6 +533,15 @@ namespace monad::test
                 std::cout << "\n\n   Free list: "
                           << aux.db_metadata()->capacity_in_free_list
                           << " bytes.";
+                auto const most_recent_offset =
+                    aux.db_metadata()
+                        ->root_offsets[aux.db_history_max_version()];
+                std::cout << "\n\n   DB version history is "
+                          << aux.db_history_min_valid_version() << " - "
+                          << aux.db_history_max_version()
+                          << ". Most recent DB history is id "
+                          << most_recent_offset.id << " offset "
+                          << most_recent_offset.offset;
                 std::cout << std::endl;
                 return s;
             }

--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -556,8 +556,10 @@ public:
     void update_slow_fast_ratio_metadata() noexcept;
     void update_history_length_metadata(uint64_t history_len) noexcept;
 
-    // WARNING: This is destructive
+    // WARNING: These are destructive, they discard immediately any extraneous
+    // data.
     void rewind_to_match_offsets();
+    void rewind_to_version(uint64_t version);
 
     void set_initial_insertion_count_unit_testing_only(uint32_t count)
     {


### PR DESCRIPTION
Remove the hand written roll back code in test code now we have
a common routine.

If io_uring buffers fail to register, now print cause. The lack
of this has become quite annoying over time.

Resolves https://github.com/monad-crypto/monad-internal/issues/682