### PR TITLE
As a prelude to extending DB version history length, when creating a storage pool now allocate three read-write chunks instead of one

### DIFF
--- a/libs/async/src/monad/async/test/storage_pool.cpp
+++ b/libs/async/src/monad/async/test/storage_pool.cpp
@@ -108,7 +108,7 @@ namespace
         memset(buffer.data(), 0x77, buffer.size());
         std::cout << "\n\nWriting to first sequential chunk ..." << std::endl;
         fd = chunk2->write_fd(buffer.size());
-        EXPECT_EQ(fd.second, chunk1->capacity());
+        EXPECT_EQ(fd.second, chunk1->capacity() * 3);
         MONAD_ASSERT(
             -1 != ::pwrite(
                       fd.first,
@@ -120,7 +120,7 @@ namespace
 
         memset(buffer.data(), 0x55, buffer.size());
         fd = chunk2->write_fd(buffer.size());
-        EXPECT_EQ(fd.second, chunk1->capacity() + buffer.size());
+        EXPECT_EQ(fd.second, chunk1->capacity() * 3 + buffer.size());
         MONAD_ASSERT(
             -1 != ::pwrite(
                       fd.first,
@@ -135,8 +135,9 @@ namespace
         fd = chunk3->write_fd(buffer.size());
         EXPECT_EQ(
             fd.second,
-            chunk1->capacity() * pool.chunks(storage_pool::seq) /
-                pool.devices().size());
+            chunk1->capacity() * 2 + chunk1->capacity() *
+                                         pool.chunks(storage_pool::seq) /
+                                         pool.devices().size());
         MONAD_ASSERT(
             -1 != ::pwrite(
                       fd.first,
@@ -150,7 +151,8 @@ namespace
         fd = chunk3->write_fd(buffer.size());
         EXPECT_EQ(
             fd.second,
-            chunk1->capacity() * pool.chunks(storage_pool::seq) /
+            chunk1->capacity() * 2 +
+                chunk1->capacity() * pool.chunks(storage_pool::seq) /
                     pool.devices().size() +
                 buffer.size());
         MONAD_ASSERT(
@@ -276,9 +278,9 @@ namespace
             };
             static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
             std::filesystem::path devs[] = {
-                create_temp_file(20 * BLKSIZE),
-                create_temp_file(10 * BLKSIZE),
-                create_temp_file(5 * BLKSIZE)};
+                create_temp_file(22 * BLKSIZE),
+                create_temp_file(12 * BLKSIZE),
+                create_temp_file(7 * BLKSIZE)};
             auto undevs = monad::make_scope_exit([&]() noexcept {
                 for (auto &p : devs) {
                     std::filesystem::remove(p);
@@ -329,12 +331,12 @@ namespace
         };
         auto print_stddev = [](size_t devid, std::vector<size_t> const &vals) {
             double mean = 0;
-            for (const auto &i : vals) {
+            for (auto const &i : vals) {
                 mean += static_cast<double>(i);
             }
             mean /= static_cast<double>(vals.size());
             double variance = 0;
-            for (const auto &i : vals) {
+            for (auto const &i : vals) {
                 variance += pow(static_cast<double>(i) - mean, 2);
             }
             variance /= static_cast<double>(vals.size());

--- a/libs/db/src/monad/mpt/detail/db_metadata.hpp
+++ b/libs/db/src/monad/mpt/detail/db_metadata.hpp
@@ -580,6 +580,8 @@ namespace detail
 
     static_assert(std::is_trivially_copyable_v<db_metadata>);
     static_assert(std::is_trivially_copy_assignable_v<db_metadata>);
+    static_assert(sizeof(db_metadata) == 524384);
+    static_assert(alignof(db_metadata) == 8);
 
     inline void atomic_memcpy(
         void *__restrict__ dest_, void const *__restrict__ src_, size_t bytes,

--- a/libs/db/src/monad/mpt/test/cli_tool_test.cpp
+++ b/libs/db/src/monad/mpt/test/cli_tool_test.cpp
@@ -137,7 +137,7 @@ struct cli_tool_fixture
         if (Config.interleave_multiple_sources) {
             if (-1 == truncate(
                           dbpath2a,
-                          (1 + Config.chunks_max / 2) *
+                          (4 + Config.chunks_max / 2) *
                                   MONAD_ASYNC_NAMESPACE::AsyncIO::
                                       MONAD_IO_BUFFERS_WRITE_SIZE +
                               24576)) {
@@ -145,7 +145,7 @@ struct cli_tool_fixture
             }
             if (-1 == truncate(
                           dbpath2b,
-                          (1 + Config.chunks_max / 2) *
+                          (4 + Config.chunks_max / 2) *
                                   MONAD_ASYNC_NAMESPACE::AsyncIO::
                                       MONAD_IO_BUFFERS_WRITE_SIZE +
                               24576)) {
@@ -155,11 +155,12 @@ struct cli_tool_fixture
             dbpath2.push_back(dbpath2b);
         }
         else {
-            if (-1 == truncate(
-                          dbpath2a,
-                          Config.chunks_max * MONAD_ASYNC_NAMESPACE::AsyncIO::
+            if (-1 ==
+                truncate(
+                    dbpath2a,
+                    (3 + Config.chunks_max) * MONAD_ASYNC_NAMESPACE::AsyncIO::
                                                   MONAD_IO_BUFFERS_WRITE_SIZE +
-                              24576)) {
+                        24576)) {
                 abort();
             }
             dbpath2.push_back(dbpath2a);
@@ -232,11 +233,12 @@ struct cli_tool_fixture
             if (-1 == fd) {
                 abort();
             }
-            if (-1 == ftruncate(
-                          fd,
-                          Config.chunks_max * MONAD_ASYNC_NAMESPACE::AsyncIO::
+            if (-1 ==
+                ftruncate(
+                    fd,
+                    (3 + Config.chunks_max) * MONAD_ASYNC_NAMESPACE::AsyncIO::
                                                   MONAD_IO_BUFFERS_WRITE_SIZE +
-                              24576)) {
+                        24576)) {
                 abort();
             }
             ::close(fd);
@@ -332,7 +334,7 @@ TEST_F(cli_tool_archives_restores, archives_restores)
  identically sized DBs, this test ensures that this will remain so.
  */
 struct cli_tool_one_chunk_too_many
-    : public cli_tool_fixture<config{.chunks_to_fill = 4, .chunks_max = 6}>
+    : public cli_tool_fixture<config{.chunks_to_fill = 4, .chunks_max = 5}>
 {
 };
 
@@ -344,7 +346,7 @@ TEST_F(cli_tool_one_chunk_too_many, one_chunk_too_many)
 struct cli_tool_non_one_one_chunk_ids
     : public cli_tool_fixture<config{
           .chunks_to_fill = 4,
-          .chunks_max = 6,
+          .chunks_max = 5,
           .interleave_multiple_sources = true}>
 {
 };

--- a/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
+++ b/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
@@ -453,12 +453,12 @@ namespace monad::test
                 if (-1 == fd) {
                     abort();
                 }
-                if (-1 ==
-                    ftruncate(
-                        fd,
-                        Config.chunks_max * MONAD_ASYNC_NAMESPACE::AsyncIO::
-                                                MONAD_IO_BUFFERS_WRITE_SIZE +
-                            24576)) {
+                if (-1 == ftruncate(
+                              fd,
+                              (3 + Config.chunks_max) *
+                                      MONAD_ASYNC_NAMESPACE::AsyncIO::
+                                          MONAD_IO_BUFFERS_WRITE_SIZE +
+                                  24576)) {
                     abort();
                 }
                 ::close(fd);


### PR DESCRIPTION
 (the second and third cnv chunks will be used to store DB version history in a later PR).