### PR TITLE
Block hash table

### DIFF
--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -419,7 +419,8 @@ void MachineBase::down(unsigned char const nibble)
         (nibble == STATE_NIBBLE || nibble == CODE_NIBBLE ||
          nibble == RECEIPT_NIBBLE || nibble == TRANSACTION_NIBBLE ||
          nibble == BLOCKHEADER_NIBBLE || nibble == WITHDRAWAL_NIBBLE ||
-         nibble == OMMER_NIBBLE || nibble == TX_HASH_NIBBLE) ||
+         nibble == OMMER_NIBBLE || nibble == TX_HASH_NIBBLE ||
+         nibble == BLOCK_HASH_NIBBLE) ||
         depth != PREFIX_LEN);
     if (MONAD_UNLIKELY(depth == PREFIX_LEN)) {
         MONAD_ASSERT(trie_section == TrieType::Prefix);
@@ -440,6 +441,9 @@ void MachineBase::down(unsigned char const nibble)
         }
         else if (nibble == TX_HASH_NIBBLE) {
             trie_section = TrieType::TxHash;
+        }
+        else if (nibble == BLOCK_HASH_NIBBLE) {
+            trie_section = TrieType::BlockHash;
         }
         else {
             // No subtrie in the rest tables, thus treated the same as
@@ -479,7 +483,8 @@ bool OnDiskMachine::cache() const
     constexpr uint64_t CACHE_DEPTH = PREFIX_LEN + 5;
     return depth <= CACHE_DEPTH &&
            (trie_section == TrieType::State || trie_section == TrieType::Code ||
-            trie_section == TrieType::TxHash);
+            trie_section == TrieType::TxHash ||
+            trie_section == TrieType::BlockHash);
 }
 
 bool OnDiskMachine::compact() const
@@ -489,7 +494,8 @@ bool OnDiskMachine::compact() const
 
 bool OnDiskMachine::auto_expire() const
 {
-    return trie_section == TrieType::TxHash;
+    return trie_section == TrieType::TxHash ||
+           trie_section == TrieType::BlockHash;
 }
 
 std::unique_ptr<StateMachine> OnDiskMachine::clone() const

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -29,7 +29,8 @@ struct MachineBase : public mpt::StateMachine
         Receipt,
         Transaction,
         Withdrawal,
-        TxHash
+        TxHash,
+        BlockHash
     };
 
     uint8_t depth{0};
@@ -66,6 +67,7 @@ inline constexpr unsigned char BLOCKHEADER_NIBBLE = 4;
 inline constexpr unsigned char WITHDRAWAL_NIBBLE = 5;
 inline constexpr unsigned char OMMER_NIBBLE = 6;
 inline constexpr unsigned char TX_HASH_NIBBLE = 7;
+inline constexpr unsigned char BLOCK_HASH_NIBBLE = 8;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
@@ -76,6 +78,7 @@ inline mpt::Nibbles const block_header_nibbles =
 inline mpt::Nibbles const ommer_nibbles = mpt::concat(OMMER_NIBBLE);
 inline mpt::Nibbles const withdrawal_nibbles = mpt::concat(WITHDRAWAL_NIBBLE);
 inline mpt::Nibbles const tx_hash_nibbles = mpt::concat(TX_HASH_NIBBLE);
+inline mpt::Nibbles const block_hash_nibbles = mpt::concat(BLOCK_HASH_NIBBLE);
 
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -248,6 +248,19 @@ void BlockchainTest::TestBody()
                     auto const decoded_block_header = decode_res.value();
                     EXPECT_EQ(decode_res.value(), block.value().header);
                 }
+                { // look up block hash
+                    auto const block_hash = keccak256(
+                        rlp::encode_block_header(block.value().header));
+                    auto res = db.get(
+                        mpt::concat(
+                            block_hash_nibbles, mpt::NibblesView{block_hash}),
+                        curr_block_number);
+                    EXPECT_TRUE(res.has_value());
+                    auto const decoded_number =
+                        rlp::decode_unsigned<uint64_t>(res.value());
+                    EXPECT_TRUE(decoded_number.has_value());
+                    EXPECT_EQ(decoded_number.value(), curr_block_number);
+                }
                 // verify tx hash
                 for (unsigned i = 0; i < block.value().transactions.size();
                      ++i) {


### PR DESCRIPTION
{BlockHash -> rlp(block_number)}

Not much perf change from this PR:

Before
> Results for branch: vicky/tx-hash-expire
> Replay 3000000->3100000 in-memory: tps=26898 gps=918 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/manual/48/
> 
> Results for branch: vicky/tx-hash-expire
> Replay 12000000->12100000 in-memory: tps=14157 gps=878 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/manual/48/
> 
> Results for branch: vicky/tx-hash-expire
> Replay 15000000->15100000 on-disk: tps=5837 gps=493 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/manual/49/

After
> Results for branch: main
> Replay 3000000->3100000 in-memory: tps=27894  gps=952 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/main/job/main/66/
> Results for branch: main
> Replay 12000000->12100000 in-memory: tps=14269  gps=885 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/main/job/main/66/
> Results for branch: main
> Replay 15000000->15100000 on-disk: tps=5637  gps=476 M
> https://jenkins.devcore4.com/job/execution_replay_ethereum/job/main/job/main/66/