### PR TITLE
fix keccak.c runtime error from ASAN: memcpy from nullptr

### DIFF
--- a/libs/core/src/monad/core/keccak.c
+++ b/libs/core/src/monad/core/keccak.c
@@ -6,13 +6,13 @@
 #define BLOCK_SIZE ((1600 - 2 * 256) / 8)
 
 extern size_t
-SHA3_absorb(uint64_t A[5][5], const unsigned char *inp, size_t len, size_t r);
+SHA3_absorb(uint64_t A[5][5], unsigned char const *inp, size_t len, size_t r);
 
 extern void
 SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
 
 void keccak256(
-    const unsigned char *const in, unsigned long const len,
+    unsigned char const *const in, unsigned long const len,
     unsigned char out[KECCAK256_SIZE])
 {
     uint64_t A[5][5];
@@ -20,8 +20,10 @@ void keccak256(
 
     __builtin_memset(A, 0, sizeof(A));
 
-    const size_t rem = SHA3_absorb(A, in, len, BLOCK_SIZE);
-    __builtin_memcpy(blk, &in[len - rem], rem);
+    size_t const rem = SHA3_absorb(A, in, len, BLOCK_SIZE);
+    if (in) {
+        __builtin_memcpy(blk, &in[len - rem], rem);
+    }
     __builtin_memset(&blk[rem], 0, BLOCK_SIZE - rem);
     blk[rem] = 0x01;
     blk[BLOCK_SIZE - 1] |= 0x80;


### PR DESCRIPTION
`./test/ethereum_test/monad-ethereum-test --fork cancun --gtest_filter=*BlockchainTests.GeneralStateTests/Pyspecs/byzantium/eip198_modexp_precompile/modexp.json`

ASAN report this:
```
[ RUN      ] BlockchainTests.GeneralStateTests/Pyspecs/byzantium/eip198_modexp_precompile/modexp.json
/home/vickychen/github/monad/libs/core/src/monad/core/keccak.c:24:5: runtime error: null pointer passed as argument 2, which is declared to never be null
```