### PR TITLE
expand MAGIC string to allow 3 digits versions

### DIFF
--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -395,15 +395,17 @@ void UpdateAuxImpl::set_io(
             }
         }
     }
-
+    constexpr unsigned magic_version_len = 3;
     constexpr unsigned magic_prefix_len =
-        detail::db_metadata::MAGIC_STRING_LEN - 1;
+        detail::db_metadata::MAGIC_STRING_LEN - magic_version_len;
     if (0 == memcmp(
                  db_metadata_[0].main->magic,
                  detail::db_metadata::MAGIC,
                  magic_prefix_len) &&
-        db_metadata_[0].main->magic[magic_prefix_len] !=
-            detail::db_metadata::MAGIC[magic_prefix_len]) {
+        memcmp(
+            db_metadata_[0].main->magic + magic_prefix_len,
+            detail::db_metadata::MAGIC + magic_prefix_len,
+            magic_version_len)) {
         std::stringstream ss;
         ss << "DB was generated with version " << db_metadata_[0].main->magic
            << ". The current code base is on version "


### PR DESCRIPTION
Error we will see if open db generated by old code with this code: 
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Trying to initialise new DB but storage pool contains existing data, stopping now to prevent data loss.
```