### PR TITLE
Add BlockHashChain

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -108,7 +108,7 @@ Result<std::pair<uint64_t, uint64_t>> run_monad(
     auto batch_begin = std::chrono::steady_clock::now();
     uint64_t ntxs = 0;
 
-    BlockHashBuffer block_hash_buffer;
+    BlockHashBufferFinalized block_hash_buffer;
     for (uint64_t i = block_num < 256 ? 1 : block_num - 255;
          i < block_num && stop == 0;) {
         auto const block = try_get(i);

--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -721,7 +721,7 @@ TYPED_TEST(DBTest, call_frames_stress_test)
     auto block = rlp::decode_block(block_rlp_view);
     ASSERT_TRUE(!block.has_error());
 
-    BlockHashBuffer block_hash_buffer;
+    BlockHashBufferFinalized block_hash_buffer;
     block_hash_buffer.set(
         block.value().header.number - 1, block.value().header.parent_hash);
 
@@ -814,7 +814,7 @@ TYPED_TEST(DBTest, call_frames_refund)
     auto block = rlp::decode_block(block_rlp_view);
     ASSERT_TRUE(!block.has_error());
 
-    BlockHashBuffer block_hash_buffer;
+    BlockHashBufferFinalized block_hash_buffer;
     block_hash_buffer.set(
         block.value().header.number - 1, block.value().header.parent_hash);
 

--- a/libs/execution/src/monad/execution/block_hash_buffer.cpp
+++ b/libs/execution/src/monad/execution/block_hash_buffer.cpp
@@ -1,16 +1,129 @@
 #include <monad/config.hpp>
+#include <monad/core/assert.h>
 #include <monad/core/bytes.hpp>
 #include <monad/execution/block_hash_buffer.hpp>
 
 MONAD_NAMESPACE_BEGIN
 
-BlockHashBuffer::BlockHashBuffer()
+BlockHashBufferFinalized::BlockHashBufferFinalized()
     : b_{}
     , n_{0}
 {
     for (auto &h : b_) {
         h = NULL_HASH;
     }
+}
+
+uint64_t BlockHashBufferFinalized::n() const
+{
+    return n_;
+};
+
+bytes32_t const &BlockHashBufferFinalized::get(uint64_t const n) const
+{
+    MONAD_ASSERT(n < n_ && n + N >= n_);
+    return b_[n % N];
+}
+
+void BlockHashBufferFinalized::set(uint64_t const n, bytes32_t const &h)
+{
+    MONAD_ASSERT(!n_ || n == n_);
+    b_[n % N] = h;
+    n_ = n + 1;
+}
+
+BlockHashBufferProposal::BlockHashBufferProposal(
+    bytes32_t const &h, BlockHashBufferFinalized const &buf)
+    : n_{buf.n() + 1}
+    , buf_{&buf}
+    , deltas_{h}
+{
+}
+
+BlockHashBufferProposal::BlockHashBufferProposal(
+    bytes32_t const &h, BlockHashBufferProposal const &parent)
+    : n_{parent.n_ + 1}
+    , buf_{parent.buf_}
+{
+    MONAD_ASSERT(n_ > 0 && n_ > buf_->n());
+    deltas_.push_back(h);
+    deltas_.insert(deltas_.end(), parent.deltas_.begin(), parent.deltas_.end());
+    deltas_.resize(n_ - buf_->n());
+}
+
+uint64_t BlockHashBufferProposal::n() const
+{
+    return n_;
+}
+
+bytes32_t const &BlockHashBufferProposal::get(uint64_t const n) const
+{
+    MONAD_ASSERT(n < n_ && n + N >= n_);
+    size_t const idx = n_ - n - 1;
+    if (idx < deltas_.size()) {
+        return deltas_.at(idx);
+    }
+    return buf_->get(n);
+}
+
+BlockHashChain::BlockHashChain(
+    BlockHashBufferFinalized &buf, uint64_t last_finalized_round)
+    : buf_{buf}
+    , last_finalized_round_{last_finalized_round}
+{
+}
+
+void BlockHashChain::propose(
+    bytes32_t const &hash, uint64_t const round, uint64_t const parent_round)
+{
+    for (auto it = proposals_.rbegin(); it != proposals_.rend(); ++it) {
+        if (it->round == parent_round) {
+            proposals_.emplace_back(Proposal{
+                .round = round,
+                .parent_round = parent_round,
+                .buf = BlockHashBufferProposal(hash, it->buf)});
+            return;
+        }
+    }
+    MONAD_ASSERT(parent_round == last_finalized_round_);
+    proposals_.emplace_back(Proposal{
+        .round = round,
+        .parent_round = parent_round,
+        .buf = BlockHashBufferProposal(hash, buf_)});
+}
+
+void BlockHashChain::finalize(uint64_t const round)
+{
+    auto const to_finalize = buf_.n();
+
+    auto winner_it = std::find_if(
+        proposals_.rbegin(), proposals_.rend(), [round](Proposal const &p) {
+            return round == p.round;
+        });
+    MONAD_ASSERT(winner_it != proposals_.rend())
+    MONAD_ASSERT((winner_it->buf.n() - 1) == to_finalize);
+
+    buf_.set(to_finalize, winner_it->buf.get(to_finalize));
+    last_finalized_round_ = round;
+
+    // cleanup chains
+    std::remove_if(
+        proposals_.begin(), proposals_.end(), [round](Proposal const &p) {
+            return round <= p.round;
+        });
+}
+
+BlockHashBuffer const &BlockHashChain::find_chain(uint64_t const round) const
+{
+    auto it = std::find_if(
+        proposals_.rbegin(), proposals_.rend(), [round](Proposal const &p) {
+            return round == p.round;
+        });
+    if (MONAD_UNLIKELY(it == proposals_.rend())) {
+        MONAD_ASSERT(round == last_finalized_round_)
+        return buf_;
+    }
+    return it->buf;
 }
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/block_hash_buffer.hpp
+++ b/libs/execution/src/monad/execution/block_hash_buffer.hpp
@@ -1,35 +1,73 @@
 #pragma once
 
 #include <monad/config.hpp>
-#include <monad/core/assert.h>
 #include <monad/core/bytes.hpp>
 
 #include <cstdint>
+#include <deque>
+#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
 class BlockHashBuffer
 {
+public:
     static constexpr unsigned N = 256;
 
+    virtual uint64_t n() const = 0;
+    virtual bytes32_t const &get(uint64_t) const = 0;
+    virtual ~BlockHashBuffer() = default;
+};
+
+class BlockHashBufferFinalized : public BlockHashBuffer
+{
     bytes32_t b_[N];
     uint64_t n_;
 
 public:
-    BlockHashBuffer();
+    BlockHashBufferFinalized();
 
-    void set(uint64_t const n, bytes32_t const &h)
-    {
-        MONAD_ASSERT(!n_ || n == n_);
-        b_[n % N] = h;
-        n_ = n + 1;
-    }
+    uint64_t n() const override;
+    bytes32_t const &get(uint64_t) const override;
 
-    bytes32_t const &get(uint64_t const n) const
+    void set(uint64_t, bytes32_t const &);
+};
+
+class BlockHashBufferProposal : public BlockHashBuffer
+{
+    uint64_t n_;
+    BlockHashBuffer const *buf_;
+    std::vector<bytes32_t> deltas_;
+
+public:
+    BlockHashBufferProposal(
+        bytes32_t const &, BlockHashBufferFinalized const &);
+    BlockHashBufferProposal(bytes32_t const &, BlockHashBufferProposal const &);
+
+    uint64_t n() const override;
+    bytes32_t const &get(uint64_t) const override;
+};
+
+class BlockHashChain
+{
+    BlockHashBufferFinalized &buf_;
+    uint64_t last_finalized_round_;
+
+    struct Proposal
     {
-        MONAD_ASSERT(n < n_ && n + N >= n_);
-        return b_[n % N];
-    }
+        uint64_t round;
+        uint64_t parent_round;
+        BlockHashBufferProposal buf;
+    };
+
+    std::deque<Proposal> proposals_;
+
+public:
+    BlockHashChain(
+        BlockHashBufferFinalized &, uint64_t last_finalized_round = 0);
+    void propose(bytes32_t const &, uint64_t round, uint64_t parent_round);
+    void finalize(uint64_t const round);
+    BlockHashBuffer const &find_chain(uint64_t) const;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/test/test_block_hash_buffer.cpp
+++ b/libs/execution/src/monad/execution/test/test_block_hash_buffer.cpp
@@ -1,0 +1,176 @@
+#include <monad/execution/block_hash_buffer.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+
+TEST(BlockHashBuffer, simple_chain)
+{
+    BlockHashBufferFinalized buf;
+    buf.set(0, bytes32_t{0}); // genesis
+
+    BlockHashChain chain(buf);
+
+    uint64_t round = 1;
+    uint64_t parent_round = 0;
+    chain.propose(bytes32_t{1}, round, parent_round);
+    chain.finalize(round);
+
+    ++round;
+    ++parent_round;
+    chain.propose(bytes32_t{2}, round, parent_round);
+    chain.finalize(round);
+
+    ++round;
+    ++parent_round;
+    chain.propose(bytes32_t{3}, round, parent_round);
+    chain.finalize(round);
+
+    EXPECT_EQ(buf.n(), 4);
+    EXPECT_EQ(buf.get(0), bytes32_t{0});
+    EXPECT_EQ(buf.get(1), bytes32_t{1});
+    EXPECT_EQ(buf.get(2), bytes32_t{2});
+    EXPECT_EQ(buf.get(3), bytes32_t{3});
+}
+
+TEST(BlockHashBuffer, from_seeded_buf)
+{
+    BlockHashBufferFinalized buf;
+    buf.set(0, bytes32_t{1});
+    buf.set(1, bytes32_t{2});
+
+    BlockHashChain chain(buf, 1 /* last_finalized_round */);
+
+    chain.propose(bytes32_t{3}, 2, 1);
+    chain.finalize(2);
+
+    EXPECT_EQ(buf.get(0), bytes32_t{1});
+    EXPECT_EQ(buf.get(1), bytes32_t{2});
+    EXPECT_EQ(buf.get(2), bytes32_t{3});
+}
+
+TEST(BlockHashBuffer, fork)
+{
+    BlockHashBufferFinalized buf;
+    buf.set(0, bytes32_t{0}); // genesis
+
+    BlockHashChain chain(buf);
+
+    chain.propose(bytes32_t{1}, 1 /* round */, 0 /* parent_round */);
+    chain.finalize(1);
+
+    // fork at block 1
+    chain.propose(bytes32_t{2}, 2 /* round */, 1 /* parent_round */);
+    chain.propose(bytes32_t{3}, 3 /* round */, 1 /* parent_round */);
+
+    // fork continues on block 2
+    chain.propose(bytes32_t{4}, 4 /* round */, 3 /* parent_round */);
+    chain.propose(bytes32_t{5}, 5 /* round */, 2 /* parent_round */);
+
+    // check the forks are distinct
+    auto const &fork1 = chain.find_chain(4);
+    EXPECT_EQ(fork1.n(), 4);
+    EXPECT_EQ(fork1.get(0), bytes32_t{0});
+    EXPECT_EQ(fork1.get(1), bytes32_t{1});
+    EXPECT_EQ(fork1.get(2), bytes32_t{3});
+    EXPECT_EQ(fork1.get(3), bytes32_t{4});
+
+    auto const &fork2 = chain.find_chain(5);
+    EXPECT_EQ(fork2.n(), 4);
+    EXPECT_EQ(fork2.get(0), bytes32_t{0});
+    EXPECT_EQ(fork2.get(1), bytes32_t{1});
+    EXPECT_EQ(fork2.get(2), bytes32_t{2});
+    EXPECT_EQ(fork2.get(3), bytes32_t{5});
+
+    // ... and that the finalized chain is unmodified
+    EXPECT_EQ(buf.n(), 2);
+
+    // finalize chain {0, 1, 2, 5}
+    chain.finalize(2);
+    chain.finalize(5);
+
+    // finalized chain should match fork
+    EXPECT_EQ(buf.n(), 4);
+    EXPECT_EQ(buf.get(0), bytes32_t{0});
+    EXPECT_EQ(buf.get(1), bytes32_t{1});
+    EXPECT_EQ(buf.get(2), bytes32_t{2});
+    EXPECT_EQ(buf.get(3), bytes32_t{5});
+}
+
+TEST(BlockHashBuffer, keep_latest_duplicate)
+{
+    BlockHashBufferFinalized buf;
+    buf.set(0, bytes32_t{0}); // genesis
+
+    BlockHashChain chain(buf);
+
+    chain.propose(bytes32_t{1}, 1 /* round */, 0 /* parent_round */);
+    chain.finalize(1);
+
+    chain.propose(bytes32_t{2}, 2 /* round */, 1 /* parent_round */);
+    chain.propose(bytes32_t{3}, 3 /* round */, 1 /* parent_round */);
+    chain.propose(bytes32_t{4}, 2 /* round */, 1 /* parent_round */);
+    chain.finalize(2);
+
+    EXPECT_EQ(buf.n(), 3);
+    EXPECT_EQ(buf.get(0), bytes32_t{0});
+    EXPECT_EQ(buf.get(1), bytes32_t{1});
+    EXPECT_EQ(buf.get(2), bytes32_t{4});
+}
+
+TEST(BlockHashBuffer, propose_after_crash)
+{
+    BlockHashBufferFinalized buf;
+    for (uint64_t i = 0; i < 100; ++i) {
+        buf.set(i, bytes32_t{i});
+    }
+    ASSERT_EQ(buf.n(), 100);
+
+    BlockHashChain chain(buf, 99 /* last_finalized_round */);
+    auto &buf2 = chain.find_chain(99);
+    EXPECT_EQ(&buf, &buf2);
+
+    chain.propose(bytes32_t{100}, 100 /* round */, 99 /* parent_round */);
+    chain.finalize(100);
+    EXPECT_EQ(buf.n() - 1, 100);
+
+    for (uint64_t i = 0; i < buf.n(); ++i) {
+        EXPECT_EQ(bytes32_t{i}, buf.get(i));
+    }
+}
+
+TEST(BlockHashBufferDeathTest, bogus_round)
+{
+    BlockHashBufferFinalized buf;
+    for (uint64_t i = 0; i < buf.N; ++i) {
+        buf.set(i, bytes32_t{i});
+    }
+
+    BlockHashChain chain(buf, buf.n());
+
+    // actual finalized round that is earlier than latest finalized
+    EXPECT_DEATH(chain.find_chain(20), ".*");
+    EXPECT_DEATH(
+        chain.propose(
+            bytes32_t{1}, buf.n() + 1 /* round */, 20 /* parent_round */),
+        ".*");
+
+    // bogus round
+    EXPECT_DEATH(chain.find_chain(3000), ".*");
+    EXPECT_DEATH(
+        chain.propose(
+            bytes32_t{1}, buf.n() + 1 /* round */, 3000 /* parent_round */),
+        ".*");
+}
+
+TEST(BlockHashBufferDeathTest, double_finalize)
+{
+    BlockHashBufferFinalized buf;
+    buf.set(0, bytes32_t{0}); // genesis
+
+    BlockHashChain chain(buf);
+
+    chain.propose(bytes32_t{1}, 1 /* round */, 0 /* parent_round */);
+    chain.finalize(1);
+    EXPECT_DEATH(chain.finalize(1), ".*");
+}

--- a/libs/execution/src/monad/execution/test/test_call_trace.cpp
+++ b/libs/execution/src/monad/execution/test/test_call_trace.cpp
@@ -128,7 +128,7 @@ TEST(CallTrace, execute_success)
     auto const &beneficiary = ADDR_A;
 
     evmc_tx_context const tx_context{};
-    BlockHashBuffer buffer{};
+    BlockHashBufferFinalized buffer{};
     CallTracer call_tracer{tx};
     EvmcHost<EVMC_SHANGHAI> host(call_tracer, tx_context, buffer, s);
 
@@ -194,7 +194,7 @@ TEST(CallTrace, execute_reverted_insufficient_balance)
     auto const &beneficiary = ADDR_A;
 
     evmc_tx_context const tx_context{};
-    BlockHashBuffer buffer{};
+    BlockHashBufferFinalized buffer{};
     CallTracer call_tracer{tx};
     EvmcHost<EVMC_SHANGHAI> host(call_tracer, tx_context, buffer, s);
 

--- a/libs/execution/src/monad/execution/test/test_evm.cpp
+++ b/libs/execution/src/monad/execution/test/test_evm.cpp
@@ -58,7 +58,7 @@ TEST(Evm, create_with_insufficient)
     uint256_t const v{70'000'000'000'000'000}; // too much
     intx::be::store(m.value.bytes, v);
 
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
     auto const result = create_contract_account<EVMC_SHANGHAI>(&h, s, m);
@@ -102,7 +102,7 @@ TEST(Evm, eip684_existing_code)
     uint256_t const v{70'000'000};
     intx::be::store(m.value.bytes, v);
 
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
     auto const result = create_contract_account<EVMC_SHANGHAI>(&h, s, m);
@@ -278,7 +278,7 @@ TEST(Evm, create_nonce_out_of_range)
     static constexpr auto new_addr{
         0x58f3f9ebd5dbdf751f12d747b02d00324837077d_address};
 
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 
@@ -321,7 +321,7 @@ TEST(Evm, static_precompile_execution)
     static constexpr auto code_address{
         0x0000000000000000000000000000000000000004_address};
 
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 
@@ -370,7 +370,7 @@ TEST(Evm, out_of_gas_static_precompile_execution)
     static constexpr auto code_address{
         0x0000000000000000000000000000000000000001_address};
 
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 

--- a/libs/execution/src/monad/execution/test/test_evmc_host.cpp
+++ b/libs/execution/src/monad/execution/test/test_evmc_host.cpp
@@ -118,7 +118,7 @@ TEST(EvmcHost, emit_log)
     db_t tdb{db};
     BlockState bs{tdb};
     State state{bs, Incarnation{0, 0}};
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evmc_host_t host{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, state};
 
@@ -145,7 +145,7 @@ TEST(EvmcHost, access_precompile)
     db_t tdb{db};
     BlockState bs{tdb};
     State state{bs, Incarnation{0, 0}};
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
     evmc_host_t host{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, state};
 

--- a/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
@@ -59,7 +59,7 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     };
 
     BlockHeader const header{.beneficiary = bene};
-    BlockHashBuffer const block_hash_buffer;
+    BlockHashBufferFinalized const block_hash_buffer;
 
     boost::fibers::promise<void> prev{};
     prev.set_value();

--- a/libs/rpc/src/monad/rpc/eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/eth_call.cpp
@@ -261,7 +261,7 @@ monad_evmc_result eth_call(
     MONAD_ASSERT(!sender_result.has_error());
     auto const sender = sender_result.value();
 
-    BlockHashBuffer buffer{};
+    BlockHashBufferFinalized buffer{};
     for (size_t i = block_number < 256 ? 1 : block_number - 255;
          i <= block_number;
          ++i) {

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -192,7 +192,7 @@ void BlockchainTest::TestBody()
             bs.commit({}, {}, {}, {}, {}, std::nullopt);
         }
 
-        BlockHashBuffer block_hash_buffer;
+        BlockHashBufferFinalized block_hash_buffer;
         for (auto const &j_block : j_contents.at("blocks")) {
 
             auto const block_rlp = j_block.at("rlp").get<byte_string>();


### PR DESCRIPTION
BlockHashChain: Add data structure to support multiple BlockHashBuffer proposal chains
    
The high level design is as follows:
    
The BlockHashBufferProposal is an unfinalized chain. It maintains a
reference to the latest BlockHashBuffer. Any proposed hashes are kept as
a vector of deltas. On finalize, the winning chain is merged into the
parent BlockHashBuffer. In practice, the deltas vector should be
relatively small, with only 1-2 proposals buffered up before consensus
signals finalization.