### PR TITLE
Vicky/copy trie

### DIFF
--- a/libs/db/CMakeLists.txt
+++ b/libs/db/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   "src/monad/mpt/compute.cpp"
   "src/monad/mpt/compute.hpp"
   "src/monad/mpt/config.hpp"
+  "src/monad/mpt/copy_trie.cpp"
   "src/monad/mpt/db.cpp"
   "src/monad/mpt/db.hpp"
   "src/monad/mpt/db_error.hpp"

--- a/libs/db/src/monad/mpt/copy_trie.cpp
+++ b/libs/db/src/monad/mpt/copy_trie.cpp
@@ -1,0 +1,295 @@
+#include <monad/core/assert.h>
+#include <monad/core/byte_string.hpp>
+#include <monad/mpt/config.hpp>
+#include <monad/mpt/nibbles_view.hpp>
+#include <monad/mpt/node.hpp>
+#include <monad/mpt/trie.hpp>
+#include <monad/mpt/util.hpp>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <stack>
+#include <utility>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+Node::UniquePtr create_node_add_new_branch(
+    UpdateAuxImpl &aux, Node *const node, unsigned char const new_branch,
+    Node::UniquePtr new_child, uint64_t const new_version,
+    std::optional<byte_string_view> opt_value)
+{
+    uint16_t const mask =
+        static_cast<uint16_t>(node->mask | (1u << new_branch));
+    std::array<ChildData, 16> children;
+    for (unsigned i = 0, old_j = 0, bit = 1; i < 16; ++i, bit <<= 1) {
+        if (i == new_branch) {
+            auto &child = children[i];
+            child.branch = (unsigned char)i;
+            child.ptr = std::move(new_child);
+            child.subtrie_min_version = calc_min_version(*child.ptr);
+            if (aux.is_on_disk()) {
+                child.offset =
+                    async_write_node_set_spare(aux, *child.ptr, true);
+                std::tie(child.min_offset_fast, child.min_offset_slow) =
+                    calc_min_offsets(
+                        *child.ptr, aux.physical_to_virtual(child.offset));
+            }
+        }
+        else if (mask & bit) {
+            auto &child = children[i];
+            child.branch = (unsigned char)i;
+            child.ptr = node->move_next(old_j);
+            child.subtrie_min_version = node->subtrie_min_version(old_j);
+            if (aux.is_on_disk()) {
+                child.min_offset_fast = node->min_offset_fast(old_j);
+                child.min_offset_slow = node->min_offset_slow(old_j);
+                child.offset = node->fnext(old_j);
+                MONAD_ASSERT(child.offset != INVALID_OFFSET);
+            }
+        }
+    }
+    return make_node(
+        mask,
+        children,
+        node->path_nibble_view(),
+        opt_value,
+        0,
+        static_cast<int64_t>(new_version));
+}
+
+Node::UniquePtr create_node_with_two_children(
+    UpdateAuxImpl &aux, NibblesView const path, unsigned char const branch0,
+    Node::UniquePtr child0, unsigned char const branch1, Node::UniquePtr child1,
+    uint64_t const new_version, std::optional<byte_string_view> opt_value)
+{
+    // mismatch: split node's path: turn node to a branch node with two
+    // children
+    uint16_t const mask =
+        static_cast<uint16_t>((1u << branch0) | (1u << branch1));
+    bool const zero_comes_first = branch0 < branch1;
+    ChildData children[2];
+    {
+        auto &child = children[!zero_comes_first];
+        child.ptr = std::move(child0);
+        child.subtrie_min_version = calc_min_version(*child.ptr);
+        child.branch = branch0;
+        if (aux.is_on_disk()) {
+            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            std::tie(child.min_offset_fast, child.min_offset_slow) =
+                calc_min_offsets(*child.ptr);
+        }
+    }
+    {
+        auto &child = children[zero_comes_first];
+        child.ptr = std::move(child1);
+        child.subtrie_min_version = calc_min_version(*child.ptr);
+        child.branch = branch1;
+        if (aux.is_on_disk()) {
+            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            std::tie(child.min_offset_fast, child.min_offset_slow) =
+                calc_min_offsets(*child.ptr);
+        }
+    }
+    return make_node(
+        mask,
+        std::span(children),
+        path,
+        opt_value,
+        0,
+        static_cast<int64_t>(new_version));
+}
+
+Node::UniquePtr copy_trie_impl(
+    UpdateAuxImpl &aux, Node &src_root, NibblesView const src_prefix,
+    Node::UniquePtr root, NibblesView const dest, uint64_t const dest_version)
+{
+    auto [src_cursor, res] = find_blocking(aux, src_root, src_prefix);
+    MONAD_ASSERT(res == find_result::success);
+    Node &src_node = *src_cursor.node;
+    if (!root) {
+        auto new_node = make_node(
+            src_node,
+            dest.substr(1),
+            src_node.opt_value(),
+            static_cast<int64_t>(dest_version));
+        ChildData child{.ptr = std::move(new_node), .branch = dest.get(0)};
+        child.subtrie_min_version = calc_min_version(*child.ptr);
+        if (aux.is_on_disk()) {
+            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            std::tie(child.min_offset_fast, child.min_offset_slow) =
+                calc_min_offsets(
+                    *child.ptr, aux.physical_to_virtual(child.offset));
+        }
+        return make_node(
+            static_cast<uint16_t>(1u << child.branch),
+            {&child, 1},
+            {},
+            src_root.value(),
+            0,
+            static_cast<int64_t>(dest_version));
+    }
+    // serialize to buffer for each new node created
+    Node *parent = nullptr;
+    unsigned char branch = INVALID_BRANCH;
+    Node *node = root.get();
+    Node::UniquePtr new_node{};
+    unsigned prefix_index = 0;
+    unsigned node_prefix_index = 0;
+
+    using ParentIndexPair = std::pair<Node *, unsigned char>;
+    std::vector<ParentIndexPair> vec_pairs;
+    vec_pairs.reserve(16);
+    std::stack<ParentIndexPair, std::vector<ParentIndexPair>>
+        parents_and_indexes{std::move(vec_pairs)};
+
+    // Insert `dest` to trie, create the `dest` node to have the same
+    // children as node at `src`. Disconnect src_node's in memory children to
+    // avoid double references
+    while (prefix_index < dest.nibble_size()) {
+        auto const nibble = dest.get(prefix_index);
+        if (node_prefix_index < node->path_nibbles_len()) {
+            // not yet end of path in node
+            auto const node_nibble =
+                node->path_nibble_view().get(node_prefix_index);
+            if (nibble == node_nibble) {
+                ++prefix_index;
+                ++node_prefix_index;
+                continue;
+            }
+            MONAD_DEBUG_ASSERT(
+                prefix_index < std::numeric_limits<unsigned char>::max());
+            auto const node_path = node->path_nibble_view();
+            // copy children of src_node to under `dest` prefix, move the in
+            // memory children to `dest` node
+            auto dest_latter_half = make_node(
+                src_node,
+                dest.substr(static_cast<unsigned char>(prefix_index) + 1u),
+                src_node.opt_value(),
+                src_node.version);
+            auto node_latter_half = make_node(
+                *node,
+                node_path.substr(
+                    static_cast<unsigned char>(node_prefix_index) + 1),
+                node->opt_value(),
+                node->version);
+            new_node = create_node_with_two_children(
+                aux,
+                node_path.substr(0, node_prefix_index),
+                nibble,
+                std::move(dest_latter_half),
+                node_nibble,
+                std::move(node_latter_half),
+                dest_version,
+                node == root.get() ? std::make_optional(src_root.value())
+                                   : std::nullopt);
+            break;
+        }
+        // end of node path
+        if (node->mask & (1u << nibble)) {
+            auto const index = node->to_child_index(nibble);
+            if (node->next(index) == nullptr) {
+                node->set_next(
+                    index,
+                    read_node_blocking(
+                        aux.io->storage_pool(), node->fnext(index)));
+            }
+            // there is a matched branch, go to next child
+            parent = node;
+            branch = nibble;
+            parents_and_indexes.emplace(std::make_pair(parent, index));
+            node = node->next(index);
+            node_prefix_index = 0;
+            ++prefix_index;
+            continue;
+        }
+        MONAD_DEBUG_ASSERT(
+            prefix_index < std::numeric_limits<unsigned char>::max());
+        auto dest_node = make_node(
+            src_node,
+            dest.substr(static_cast<unsigned char>(prefix_index) + 1u),
+            src_node.opt_value(),
+            src_node.version);
+        new_node = create_node_add_new_branch(
+            aux,
+            node,
+            nibble,
+            std::move(dest_node),
+            dest_version,
+            node == root.get() ? std::make_optional(src_root.value())
+                               : std::nullopt);
+        break;
+    }
+
+    if (prefix_index == dest.nibble_size()) { // replace existing `dest` trie
+        MONAD_ASSERT(node_prefix_index == node->path_nibbles_len());
+        new_node = make_node(
+            src_node,
+            node->path_nibble_view(),
+            src_node.opt_value(),
+            static_cast<int64_t>(dest_version));
+    }
+    if (node == root.get()) {
+        MONAD_ASSERT(parents_and_indexes.empty());
+        root = std::move(new_node);
+    }
+    else {
+        MONAD_ASSERT(parent != nullptr);
+        auto const child_index = parent->to_child_index(branch);
+        // reset child at `branch` to the new_node
+        parent->move_next(child_index).reset();
+        parent->set_next(child_index, std::move(new_node));
+        parents_and_indexes.emplace(std::make_pair(parent, child_index));
+        // serialize nodes of insert path up until root (excludes root)
+        while (!parents_and_indexes.empty()) {
+            auto const &[p, i] = parents_and_indexes.top();
+            auto &node = *p->next(i);
+            p->set_fnext(i, async_write_node_set_spare(aux, node, true));
+            auto const [min_offset_fast, min_offset_slow] =
+                calc_min_offsets(node);
+            p->set_min_offset_fast(i, min_offset_fast);
+            p->set_min_offset_slow(i, min_offset_slow);
+            p->set_subtrie_min_version(i, calc_min_version(node));
+            parents_and_indexes.pop();
+        }
+    }
+
+    return root;
+}
+
+Node::UniquePtr copy_trie_to_dest(
+    UpdateAuxImpl &aux, Node &src_root, NibblesView const src_prefix,
+    Node::UniquePtr root, NibblesView const dest_prefix,
+    uint64_t const dest_version, bool const must_write_to_disk)
+{
+    auto impl = [&]() -> Node::UniquePtr {
+        root = copy_trie_impl(
+            aux,
+            src_root,
+            src_prefix,
+            std::move(root),
+            dest_prefix,
+            dest_version);
+        if (must_write_to_disk && aux.version_is_valid_ondisk(dest_version) &&
+            aux.is_on_disk()) { // DO NOT write new version to disk, only
+                                // upsert() should write new version
+            write_new_root_node(aux, *root, dest_version);
+            MONAD_ASSERT(aux.db_history_max_version() >= dest_version);
+        }
+        if (aux.is_on_disk()) {
+            MONAD_ASSERT(root->value_len == sizeof(uint32_t) * 2);
+        }
+        return std::move(root);
+    };
+    if (aux.is_current_thread_upserting()) {
+        return impl();
+    }
+    else {
+        auto g(aux.unique_lock());
+        auto g2(aux.set_current_upsert_tid());
+        return impl();
+    }
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -58,9 +58,14 @@ public:
 
     NodeCursor load_root_for_version(uint64_t block_id) const;
 
+    void copy_trie(
+        uint64_t src_version, NibblesView src, uint64_t dest_version,
+        NibblesView dest, bool blocked_by_write = true);
+
     void upsert(
         UpdateList, uint64_t block_id, bool enable_compaction = true,
         bool can_write_to_fast = true);
+
     // Traverse APIs: return value indicates if we have finished the full
     // traversal or not.
     // Parallel traversal is a single threaded out of order traverse using async

--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -149,7 +149,10 @@ public:
 };
 
 chunk_offset_t
-async_write_node_set_spare(UpdateAuxImpl &aux, Node &node, bool is_fast);
+async_write_node_set_spare(UpdateAuxImpl &, Node &, bool is_fast);
+
+chunk_offset_t
+write_new_root_node(UpdateAuxImpl &, Node &root, uint64_t version);
 
 node_writer_unique_ptr_type
 replace_node_writer(UpdateAuxImpl &, node_writer_unique_ptr_type const &);
@@ -973,6 +976,16 @@ void async_read(UpdateAuxImpl &aux, Receiver &&receiver)
 Node::UniquePtr upsert(
     UpdateAuxImpl &, uint64_t, StateMachine &, Node::UniquePtr old,
     UpdateList &&);
+
+// Performs a deep copy of a subtrie from `src_root` trie at
+// `src_prefix` to the `dest_root` trie at `dest_prefix`.
+// Note that `src_root` may be of a different version than `dest_root`.
+// Any pre-existing trie at `dest_prefix` will be overwritten.
+// The in-memory effect is similar to a move operation.
+Node::UniquePtr copy_trie_to_dest(
+    UpdateAuxImpl &, Node &src_root, NibblesView src_prefix,
+    Node::UniquePtr dest_root, NibblesView dest_prefx,
+    uint64_t const dest_version, bool must_write_to_disk);
 
 // load all nodes as far as caching policy would allow
 size_t load_all(UpdateAuxImpl &, StateMachine &, NodeCursor);


### PR DESCRIPTION
`copy_trie_to_dest()` does a deep copy of a subtrie from `src_root` 
trie at `src_prefix` to the `dest_root` trie at `dest_prefix`.

Note that `src_root` may be of a different version than `dest_root`.
Any pre-existing trie at `dest_prefix` will be overwritten.

The in-memory effect is similar to a move operation.
```
Node::UniquePtr copy_trie_to_dest(
    UpdateAuxImpl &, Node &src_trie, NibblesView src_prefix,
    Node::UniquePtr dest_root, NibblesView dest_prefx,
    uint64_t const dest_version, bool must_write_to_disk);
```

How we plan to use it?
please refer to branch [vicky/replay_proposal_then_finalize](https://github.com/monad-crypto/monad/tree/vicky/replay_proposal_then_finalize) on how we are going to use `copy_trie` for proposal execution: