### PR TITLE
Implement userspace concurrency limiting for the new i/o executor, replacing entirely the one in `AsyncIO` which wasn't especially efficient.

### DIFF
--- a/libs/runloop/Readme.md
+++ b/libs/runloop/Readme.md
@@ -268,8 +268,9 @@ static monad_c_result mytask(monad_async_task task)
 
 - Need to test cancellation works at every possible lifecycle and suspend state
 a task can have.
-- Should be able to clamp max i/o concurrency, and have `AsyncIO` wrapper set that from its config.
-- `AsyncIO` wrapper doesn't currently handle `EAGAIN`.
+- `AsyncIO` wrapper doesn't currently handle `EAGAIN`. _Probably_ doesn't matter as
+99% of that should be handled internally by the new runloop. But not ALL of it is
+handled, some is passed on.
 - Multiple context switcher types at the same time should work, but is completely untested
 and ought to become tested. Including with perf impact (as they usually have to
 thunk when switching between disparate contexts)

--- a/libs/runloop/rust/async.rs
+++ b/libs/runloop/rust/async.rs
@@ -789,12 +789,15 @@ pub struct monad_async_executor_head__bindgen_ty_1 {
 pub struct monad_async_executor_attr {
     pub io_uring_ring: monad_async_executor_attr__bindgen_ty_1,
     pub io_uring_wr_ring: monad_async_executor_attr__bindgen_ty_1,
+    #[doc = " \\brief For file i/o, the maximum concurrent read or write ops is\nconstrained by registered i/o buffers available. However, as i/o\nbuffers remain in use for a while, one may wish to reduce max i/o\nconcurrency still further.\n\nThe kernel considerably gates i/o concurrency on its own, however\nit has been benchmarked that io_uring appears to not scale well\nto outstanding i/o (I think it uses linear lists). So for highly\nbursty concurrent i/o loads, gating i/o concurrency in user space\ncan prove to be an overall win.\n\nYou should benchmark turning this on, as it does add a fair bit of\noverhead so it can be an overall loss as well as a win.\n\nIf enabled, this will ensure that `total_io_submitted - total_io_completed\n<= max_io_concurrency`."]
+    pub max_io_concurrency: ::std::os::raw::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct monad_async_executor_attr__bindgen_ty_1 {
     #[doc = "! \\brief If this is zero, this executor will be incapable of doing\n! i/o! It also no longer initialises io_uring for this executor."]
     pub entries: ::std::os::raw::c_uint,
+    #[doc = "! \\brief The parameters to give to io_uring during ring\n! construction."]
     pub params: io_uring_params,
     pub registered_buffers: monad_async_executor_attr__bindgen_ty_1__bindgen_ty_1,
 }

--- a/libs/runloop/src/monad/async/task_impl.h
+++ b/libs/runloop/src/monad/async/task_impl.h
@@ -17,6 +17,11 @@ struct io_buffer_awaiting_list_item_t
 {
     struct io_buffer_awaiting_list_item_t *prev, *next;
 };
+
+struct max_concurrent_io_list_item_t
+{
+    struct max_concurrent_io_list_item_t *prev, *next;
+};
 struct monad_async_executor_impl;
 
 enum monad_async_task_impl_please_cancel_invoked_status : uint8_t
@@ -45,7 +50,12 @@ struct monad_async_task_impl
         size_t count;
     } io_submitted, io_completed;
 
-    struct io_buffer_awaiting_list_item_t io_buffer_awaiting;
+    union
+    {
+        struct io_buffer_awaiting_list_item_t io_buffer_awaiting;
+        struct max_concurrent_io_list_item_t max_concurrent_io_awaiting;
+    };
+
     monad_async_io_status **completed;
     bool io_buffer_awaiting_was_inserted_at_front;
     bool io_buffer_awaiting_is_for_write;


### PR DESCRIPTION
This has improved both max i/o per second AND reduced both mean and
max latencies in `benchmark_io_test`. Basically it's a win all
round across the board -- perf is up with a few percent improvement.

Note going forth: the new empirically tested ideal max i/o
concurrency is 128, greatly reduced down from 1024 in the current
`AsyncIO`. 128 should become the new default for RODB and RWDB
settings post-merge.