### PR TITLE
Remove nblocks == 0 check

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -413,10 +413,6 @@ int main(int const argc, char const *argv[])
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - load_start_time));
 
-    if (nblocks == 0) {
-        return EXIT_SUCCESS;
-    }
-
     uint64_t const start_block_num = init_block_num + 1;
 
     LOG_INFO(


### PR DESCRIPTION
The early exit when `nblocks == 0` prevents using `monad` to do things like dumping a state snapshot from a pre-existing triedb. This is useful for Flexnet tests, where we would like to start a network with some existing state, requiring a snapshot, but this check causes `monad` to exit before the snapshot is dumped. It doesn't look to me like this has any negative impacts - pretty much just that things will get initialized even though `run_monad()` will ultimately have nothing to do and return immediately.