### PR TITLE
Replace all use of gtest death testing with cmake death testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,17 +153,24 @@ function(monad_add_test_folder target)
   endforeach()
 endfunction()
 
-function(monad_target_gdb_pretty_printer dest target printer)
-  file(REAL_PATH "${printer}" printer)
-  file(RELATIVE_PATH leaf "${CMAKE_SOURCE_DIR}" "${printer}")
-  set(asmfile "${CMAKE_BINARY_DIR}/${leaf}.S")
-  set(GDB_PRETTY_PRINTER_PATH "${printer}")
-  configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/cmake/debug_gdb_scripts.in"
-                 "${asmfile}" @ONLY)
-  add_library(${target} OBJECT "${asmfile}")
-  # The use of TARGET_OBJECTS here turns out to be critical. This was very
-  # non-obvious.
-  target_link_libraries(${dest} PUBLIC "$<TARGET_OBJECTS:${target}>")
+function(monad_add_test_death target)
+  cmake_parse_arguments(ADD_DEATH_TEST "" "FAIL_REGEX"
+    "SOURCES;LINK_LIBRARIES;TEST_PROPERTIES" ${ARGN})
+  if(NOT ADD_DEATH_TEST_FAIL_REGEX)
+    message(FATAL_ERROR "FATAL: FAIL_REGEX is mandatory")
+  endif()
+  add_executable(${target} ${ADD_DEATH_TEST_SOURCES})
+  monad_compile_options(${target})
+  target_link_libraries(${target} PUBLIC GTest::gtest_main
+                        ${ADD_DEATH_TEST_LINK_LIBRARIES})
+  add_test(NAME "${PROJECT_NAME}/${target}"
+           COMMAND ${CMAKE_COMMAND} -E env $<TARGET_FILE:${target}>)
+  set_tests_properties("${PROJECT_NAME}/${target}" PROPERTIES
+           PASS_REGULAR_EXPRESSION "${ADD_DEATH_TEST_FAIL_REGEX}"
+           ${ADD_DEATH_TEST_TEST_PROPERTIES}
+           ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
+           UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
+           TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer)
 endfunction()
 
 # ##############################################################################

--- a/libs/async/src/monad/async/test/CMakeLists.txt
+++ b/libs/async/src/monad/async/test/CMakeLists.txt
@@ -12,7 +12,14 @@ add_async_test(TARGET cpp_coroutine_wrappers_test SOURCES
 
 add_async_test(TARGET io_test SOURCES "io.cpp")
 
-add_async_test(TARGET io_death_test SOURCES "io_death.cpp")
+monad_add_test_death(io_death_write_buffer_exhaustion_causes_death_test
+                     SOURCES "io_death_write_buffer_exhaustion_causes_death.cpp"
+                     LINK_LIBRARIES monad_async
+                     FAIL_REGEX ".*Must fail after this:\nFATAL: no i/o buffers remaining.*")
+monad_add_test_death(io_death_read_buffer_exhaustion_causes_death_test
+                     SOURCES "io_death_read_buffer_exhaustion_causes_death.cpp"
+                     LINK_LIBRARIES monad_async
+                     FAIL_REGEX ".*Must fail after this:\nFATAL: no i/o buffers remaining.*")
 
 add_async_test(TARGET io_worker_pool_test SOURCES "io_worker_pool.cpp")
 target_link_options(io_worker_pool_test PUBLIC "-rdynamic")

--- a/libs/async/src/monad/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
+++ b/libs/async/src/monad/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
@@ -1,0 +1,74 @@
+
+#include <monad/async/concepts.hpp>
+#include <monad/async/config.hpp>
+#include <monad/async/connected_operation.hpp>
+#include <monad/async/detail/scope_polyfill.hpp>
+#include <monad/async/erased_connected_operation.hpp>
+#include <monad/async/io.hpp>
+#include <monad/async/io_senders.hpp>
+#include <monad/async/storage_pool.hpp>
+#include <monad/core/assert.h>
+#include <monad/io/buffers.hpp>
+#include <monad/io/ring.hpp>
+
+#include <gtest/gtest.h>
+
+#include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <csignal>
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    TEST(AsyncIODeathTest, read_buffer_exhaustion_causes_death)
+    {
+        monad::async::storage_pool pool(
+            monad::async::use_anonymous_inode_tag{});
+        monad::io::Ring testring1;
+        monad::io::Ring testring2(1);
+        monad::io::Buffers testrwbuf = make_buffers_for_segregated_read_write(
+            testring1,
+            testring2,
+            1,
+            1,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testrwbuf);
+        std::vector<monad::async::read_single_buffer_sender::buffer_type> bufs;
+        auto empty_testio = monad::make_scope_exit(
+            [&]() noexcept { testio.wait_until_done(); });
+
+        struct empty_receiver
+        {
+            std::vector<monad::async::read_single_buffer_sender::buffer_type>
+                &bufs;
+
+            void set_value(
+                monad::async::erased_connected_operation *,
+                monad::async::read_single_buffer_sender::result_type r)
+            {
+                MONAD_ASSERT(r);
+                // Exactly the same test as the death test, except for this line
+                bufs.emplace_back(std::move(r.assume_value().get()));
+            }
+        };
+
+        auto make = [&] {
+            auto state(testio.make_connected(
+                monad::async::read_single_buffer_sender(
+                    {0, 0}, monad::async::DISK_PAGE_SIZE),
+                empty_receiver{bufs}));
+            state->initiate(); // will reap completions if no buffers free
+            state.release();
+        };
+        for (size_t n = 0; n < 512; n++) {
+            make();
+        }
+        std::cerr << "Must fail after this:" << std::endl;
+        make();
+    }
+}

--- a/libs/async/src/monad/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
+++ b/libs/async/src/monad/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
@@ -13,11 +13,11 @@
 
 #include <gtest/gtest.h>
 
-// DO NOT include gtest_signal_stacktrace_printer.hpp here, it interferes with
-// Google Test's death test handling
+#include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
 
 #include <csignal>
 #include <cstddef>
+#include <iostream>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -26,8 +26,6 @@ namespace
 {
     TEST(AsyncIODeathTest, write_buffer_exhaustion_causes_death)
     {
-        testing::FLAGS_gtest_death_test_style = "threadsafe";
-
         monad::async::storage_pool pool(
             monad::async::use_anonymous_inode_tag{});
         monad::io::Ring testring1;
@@ -67,60 +65,12 @@ namespace
                 states.push_back(std::move(state));
             };
             if (n > 0) {
-                EXPECT_EXIT(make(), ::testing::KilledBySignal(SIGABRT), ".*");
+                std::cerr << "Must fail after this:" << std::endl;
+                make();
             }
             else {
                 make();
             }
         }
-    }
-
-    TEST(AsyncIODeathTest, read_buffer_exhaustion_causes_death)
-    {
-        testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-        monad::async::storage_pool pool(
-            monad::async::use_anonymous_inode_tag{});
-        monad::io::Ring testring1;
-        monad::io::Ring testring2(1);
-        monad::io::Buffers testrwbuf = make_buffers_for_segregated_read_write(
-            testring1,
-            testring2,
-            1,
-            1,
-            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
-            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
-        monad::async::AsyncIO testio(pool, testrwbuf);
-        std::vector<monad::async::read_single_buffer_sender::buffer_type> bufs;
-        auto empty_testio = monad::make_scope_exit(
-            [&]() noexcept { testio.wait_until_done(); });
-
-        struct empty_receiver
-        {
-            std::vector<monad::async::read_single_buffer_sender::buffer_type>
-                &bufs;
-
-            void set_value(
-                monad::async::erased_connected_operation *,
-                monad::async::read_single_buffer_sender::result_type r)
-            {
-                MONAD_ASSERT(r);
-                // Exactly the same test as the death test, except for this line
-                bufs.emplace_back(std::move(r.assume_value().get()));
-            }
-        };
-
-        auto make = [&] {
-            auto state(testio.make_connected(
-                monad::async::read_single_buffer_sender(
-                    {0, 0}, monad::async::DISK_PAGE_SIZE),
-                empty_receiver{bufs}));
-            state->initiate(); // will reap completions if no buffers free
-            state.release();
-        };
-        for (size_t n = 0; n < 512; n++) {
-            make();
-        }
-        EXPECT_EXIT(make(), ::testing::KilledBySignal(SIGABRT), ".*");
     }
 }


### PR DESCRIPTION
GTest death testing is fundamentally broken. Even when it works, it is very slow. This commit replaces GTest death testing with cmake death testing, which is far faster and doesn't have any of the quirks nor bugs. A new `monad_add_test_death` cmake function makes cmake death testing available project wide.

This commit also removes `monad_target_gdb_pretty_printer` which is no longer necessary now we have an IPC bridge to our GDB fork.