### PR TITLE
Make the templated struct `StateMachineAlways::compact()` always true, which turns compaction on for `read_only_db_stress_test`

### DIFF
--- a/libs/db/src/monad/mpt/test/db_test.cpp
+++ b/libs/db/src/monad/mpt/test/db_test.cpp
@@ -101,15 +101,13 @@ namespace
     struct OnDiskDbWithFileFixture : public ::testing::Test
     {
         std::filesystem::path const dbname;
-        using StateMachineMerkleWithCompact = StateMachineAlways<
-            MerkleCompute, StateMachineConfig{.compaction = true}>;
-        StateMachineMerkleWithCompact machine;
+        StateMachineAlwaysMerkle machine;
         OnDiskDbConfig config;
         Db db;
 
         OnDiskDbWithFileFixture()
             : dbname{create_temp_file(8)}
-            , machine{StateMachineMerkleWithCompact{}}
+            , machine{StateMachineAlwaysMerkle{}}
             , config{OnDiskDbConfig{
                   .compaction = true,
                   .sq_thread_cpu = std::nullopt,
@@ -787,8 +785,7 @@ TEST(DbTest, out_of_order_upserts_to_nonexist_earlier_version)
     auto const dbname = create_temp_file(2); // 2Gb db
     auto undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlways<EmptyCompute, StateMachineConfig{.compaction = true}>
-        machine{};
+    StateMachineAlwaysEmpty machine{};
     OnDiskDbConfig config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
@@ -849,8 +846,7 @@ TEST(DbTest, out_of_order_upserts_with_compaction)
     auto const dbname = create_temp_file(3); // 3Gb db
     auto undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlways<MerkleCompute, StateMachineConfig{.compaction = true}>
-        machine{};
+    StateMachineAlwaysMerkle machine{};
     OnDiskDbConfig config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
@@ -1324,8 +1320,7 @@ TEST(DbTest, auto_expire_large_set)
         [&]() noexcept { std::filesystem::remove(dbname); });
     StateMachineAlways<
         EmptyCompute,
-        StateMachineConfig{
-            .compaction = true, .expire = true, .cache_depth = 3}>
+        StateMachineConfig{.expire = true, .cache_depth = 3}>
         machine{};
     constexpr auto history_len = 20;
     OnDiskDbConfig config{
@@ -1389,8 +1384,7 @@ TEST(DbTest, auto_expire)
         [&]() noexcept { std::filesystem::remove(dbname); });
     StateMachineAlways<
         EmptyCompute,
-        StateMachineConfig{
-            .compaction = true, .expire = true, .cache_depth = 3}>
+        StateMachineConfig{.expire = true, .cache_depth = 3}>
         machine{};
     OnDiskDbConfig config{
         .compaction = true,

--- a/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
+++ b/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
@@ -166,7 +166,6 @@ namespace monad::test
 
     struct StateMachineConfig
     {
-        bool compaction{false};
         bool expire{false};
         size_t cache_depth{6};
     };
@@ -209,7 +208,7 @@ namespace monad::test
 
         virtual constexpr bool compact() const override
         {
-            return config.compaction;
+            return true;
         }
 
         virtual constexpr bool auto_expire() const override


### PR DESCRIPTION
```cpp
alee@peach16:~/repos/monad-tertiary/build$ ./libs/db/src/monad/mpt/test/read_only_db_stress_test --num-nodes-per-version 10000 --timeout 86400 --db test.db
Running read only DB stress test...
Adjust db history length down from 33554432 to 949
      0x61b3cd6302df
      0x61b3cd63011c
      0x61b3cd5fcc2e
      0x61b3cd60ef7e
      0x61b3cd60ee27
      0x61b3cd60e366
      0x61b3cd620c69
      0x61b3cd61f69c
      0x61b3cd621163
      0x61b3cd5d64cd
      0x61b3cd60de8f
      0x61b3cd60dfcf
      0x61b3cd60421f
      0x61b3cd600a9b
      0x61b3cd5ff476
      0x61b3cd600d2b
      0x61b3cd6008d3
      0x61b3cd5ff476
      0x61b3cd600d2b
      0x61b3cd6008d3
      0x61b3cd5ff476
      0x61b3cd600d2b
      0x61b3cd6008d3
      0x61b3cd5ff476
      0x61b3cd5fec10
      0x61b3cd600998
      0x61b3cd5ff476
      0x61b3cd5fec10
      0x61b3cd600998
      0x61b3cd5fd36e
      0x61b3cd5fd137
      0x61b3cd61906d
      0x61b3cd5dc7d4
      0x61b3cd5db83b
      0x7e6ec2eecdb4
      0x7e6ec2a9ca94
      0x7e6ec2b29c3c
   Attempting async signal unsafe human readable stacktrace (this may hang):
      0x61b3cd6302df: monad_stack_backtrace_capture_and_print
                      [/home/alee/repos/monad-tertiary/libs/core/src/monad/core/backtrace.cpp:186]
      0x61b3cd63011c: monad_assertion_failed
                      [/home/alee/repos/monad-tertiary/libs/core/src/monad/core/assert.c:25]
      0x61b3cd5fcc2e: monad::mpt::deserialize_node_from_buffer(unsigned char const*, unsigned long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/node.cpp:612]
      0x61b3cd60ef7e: void monad::mpt::update_receiver::set_value<boost::outcome_v2::basic_result<std::reference_wrapper<monad::async::filled_read_buffer>, system_error2::errored_status_code<system_error2::detail::erased<long> >, boost::outcome_v2::experimental::policy::status_code_throw<std::reference_wrapper<monad::async::filled_read_buffer>, system_error2::errored_status_code<system_error2::detail::erased<long> >, void> > >(monad::async::erased_connected_operation*, boost::outcome_v2::basic_result<std::reference_wrapper<monad::async::filled_read_buffer>, system_error2::errored_status_code<system_error2::detail::erased<long> >, boost::outcome_v2::experimental::policy::status_code_throw<std::reference_wrapper<monad::async::filled_read_buffer>, system_error2::errored_status_code<system_error2::detail::erased<long> >, void> >)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:318]
      0x61b3cd60ee27: void monad::async::detail::connected_operation_storage<monad::async::erased_connected_operation, monad::mpt::read_short_update_sender, monad::mpt::update_receiver>::completed_impl_<boost::outcome_v2::basic_result<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, boost::outcome_v2::experimental::policy::status_code_throw<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, void> > >(boost::outcome_v2::basic_result<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, boost::outcome_v2::experimental::policy::status_code_throw<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, void> >)
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/detail/connected_operation_storage.hpp:229]
      0x61b3cd60e366: monad::async::detail::connected_operation_completed_implementation<monad::async::detail::connected_operation_storage<monad::async::erased_connected_operation, monad::mpt::read_short_update_sender, monad::mpt::update_receiver>, monad::mpt::read_short_update_sender, monad::mpt::update_receiver, false, true, false, false>::completed(boost::outcome_v2::basic_result<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, boost::outcome_v2::experimental::policy::status_code_throw<unsigned long, system_error2::errored_status_code<system_error2::detail::erased<long> >, void> >)
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/connected_operation.hpp:266]
      0x61b3cd620c69: monad::async::AsyncIO::poll_uring_(bool, unsigned int)::$_2::operator()() const
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/io.cpp:717]
      0x61b3cd61f69c: monad::async::AsyncIO::poll_uring_(bool, unsigned int)
      0x61b3cd621163: monad::async::AsyncIO::poll_uring_while_no_io_buffers_(bool)
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/io.cpp:847]
      0x61b3cd5d64cd: monad::async::read_single_buffer_sender::operator()(monad::async::erased_connected_operation*)
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/io_senders.hpp:76]
      0x61b3cd60de8f: monad::async::detail::connected_operation_storage<monad::async::erased_connected_operation, monad::mpt::read_short_update_sender, monad::mpt::update_receiver>::do_possibly_deferred_initiate_(bool, bool)
      0x61b3cd60dfcf: monad::async::detail::connected_operation_storage<monad::async::erased_connected_operation, monad::mpt::read_short_update_sender, monad::mpt::update_receiver>::do_possibly_deferred_initiate_(bool, bool)
                      [/home/alee/repos/monad-tertiary/libs/async/src/monad/async/detail/connected_operation_storage.hpp:155]
      0x61b3cd60421f: _ZN5monad3mpt10async_readITkNS_5async8receiverENS0_15update_receiverEQaaaagssr5monad5asyncE26compatible_sender_receiverINS0_24read_short_update_senderET_Egssr5monad5asyncE26compatible_sender_receiverINS0_23read_long_update_senderES5_EsrS5_27lifetime_managed_internallyEEvRNS0_13UpdateAuxImplEOS5_
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.hpp:963]
      0x61b3cd600a9b: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1013]
      0x61b3cd5ff476: monad::mpt::dispatch_updates_impl_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, unsigned int, monad::mpt::NibblesView, std::optional<std::basic_string_view<unsigned char, evmc::byte_traits<unsigned char> > >, long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1134]
      0x61b3cd600d2b: monad::mpt::dispatch_updates_flat_list_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, monad::mpt::NibblesView, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1237]
      0x61b3cd6008d3: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1051]
      0x61b3cd5ff476: monad::mpt::dispatch_updates_impl_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, unsigned int, monad::mpt::NibblesView, std::optional<std::basic_string_view<unsigned char, evmc::byte_traits<unsigned char> > >, long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1134]
      0x61b3cd600d2b: monad::mpt::dispatch_updates_flat_list_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, monad::mpt::NibblesView, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1237]
      0x61b3cd6008d3: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1051]
      0x61b3cd5ff476: monad::mpt::dispatch_updates_impl_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, unsigned int, monad::mpt::NibblesView, std::optional<std::basic_string_view<unsigned char, evmc::byte_traits<unsigned char> > >, long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1134]
      0x61b3cd600d2b: monad::mpt::dispatch_updates_flat_list_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, monad::mpt::NibblesView, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1237]
      0x61b3cd6008d3: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1051]
      0x61b3cd5ff476: monad::mpt::dispatch_updates_impl_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, unsigned int, monad::mpt::NibblesView, std::optional<std::basic_string_view<unsigned char, evmc::byte_traits<unsigned char> > >, long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1134]
      0x61b3cd5fec10: monad::mpt::update_value_and_subtrie_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::NibblesView, monad::mpt::Update&)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:861]
      0x61b3cd600998: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1030]
      0x61b3cd5ff476: monad::mpt::dispatch_updates_impl_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::Requests&, unsigned int, monad::mpt::NibblesView, std::optional<std::basic_string_view<unsigned char, evmc::byte_traits<unsigned char> > >, long)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1134]
      0x61b3cd5fec10: monad::mpt::update_value_and_subtrie_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::NibblesView, monad::mpt::Update&)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:861]
      0x61b3cd600998: monad::mpt::upsert_(monad::mpt::UpdateAuxImpl&, monad::mpt::StateMachine&, monad::mpt::UpdateTNode&, monad::mpt::ChildData&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::async::chunk_offset_t, boost::intrusive::slist<monad::mpt::Update>&&, unsigned int, unsigned int)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:1030]
      0x61b3cd5fd36e: monad::mpt::upsert(monad::mpt::UpdateAuxImpl&, unsigned long, monad::mpt::StateMachine&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, boost::intrusive::slist<monad::mpt::Update>&&)::$_0::operator()() const
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/trie.cpp:114]
      0x61b3cd5fd137: monad::mpt::upsert(monad::mpt::UpdateAuxImpl&, unsigned long, monad::mpt::StateMachine&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, boost::intrusive::slist<monad::mpt::Update>&&)
      0x61b3cd61906d: monad::mpt::UpdateAuxImpl::do_update(std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::StateMachine&, boost::intrusive::slist<monad::mpt::Update>&&, unsigned long, bool, bool)
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/update_aux.cpp:866]
      0x61b3cd5dc7d4: monad::mpt::Db::RWOnDisk::TrieDbWorker::run()
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/db.cpp:479]
      0x61b3cd5db83b: monad::mpt::Db::RWOnDisk::RWOnDisk(monad::mpt::OnDiskDbConfig const&, monad::mpt::StateMachine&)::{lambda()#1}::operator()() const
                      [/home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/db.cpp:630]
      0x7e6ec2eecdb4:
      0x7e6ec2a9ca94: start_thread
                      [./nptl/pthread_create.c:447]
      0x7e6ec2b29c3c: clone3
                      [../sysdeps/unix/sysv/linux/x86_64/clone3.S:80]
read_only_db_stress_test: /home/alee/repos/monad-tertiary/libs/db/src/monad/mpt/node.cpp:604: Node::UniquePtr monad::mpt::deserialize_node_from_buffer(const unsigned char *, size_t): Assertion 'disk_size > 0 && disk_size <= Node::max_disk_size' failed.
Aborted (core dumped)
```

StateMachine didn't turn compaction on in the state machine level before the change, but the global level compaction is on for `UpdateAuxImpl::do_update()` , thus it keeps advancing compaction offset, and when we shrink history length, therefore `UpdateAuxImpl` thinks it can safely release those chunks but latest still has reference to objs in the compacted range. Now it's fixed because those are actually compacted away, and no reference anymore.

In short, user of `StateMachine` has to make sure those sections with `compact() = false` has no reference to older version objects. Here it clearly has to be true, cuz each version is based off of the previous versions.