### PR TITLE
eth_call refactor

### DIFF
--- a/cmd/monad.cpp
+++ b/cmd/monad.cpp
@@ -97,43 +97,6 @@ void log_tps(
         monad_procfs_self_resident() / (1L << 20));
 };
 
-void init_block_hash_buffer(
-    mpt::Db &rodb, uint64_t const block_number,
-    BlockHashBufferFinalized &block_hash_buffer)
-{
-    TrieDb tdb{rodb};
-    for (uint64_t b = block_number < 256 ? 0 : block_number - 256;
-         b < block_number;
-         ++b) {
-        tdb.set_block_number(b);
-        auto const header = tdb.read_header();
-        if (!header.has_value()) {
-            LOG_ERROR("Could not query block header {} from TrieDb", b);
-            MONAD_ASSERT(false);
-        }
-        auto const h = std::bit_cast<bytes32_t>(
-            keccak256(rlp::encode_block_header(header.value())));
-        block_hash_buffer.set(b, h);
-    }
-}
-
-void init_block_hash_buffer(
-    BlockDb &block_db, uint64_t const block_number,
-    BlockHashBufferFinalized &block_hash_buffer)
-{
-    for (uint64_t b = block_number < 256 ? 1 : block_number - 255;
-         b <= block_number;
-         ++b) {
-        Block block;
-        auto const ok = block_db.get(b, block);
-        if (!ok) {
-            LOG_ERROR("Could not query block {} from blockdb.", b);
-            MONAD_ASSERT(false);
-        }
-        block_hash_buffer.set(b - 1, block.header.parent_hash);
-    }
-}
-
 Result<bytes32_t> on_proposal_event(
     Block &block, BlockHashBuffer const &block_hash_buffer, Chain const &chain,
     Db &db, fiber::PriorityPool &priority_pool)
@@ -584,12 +547,18 @@ int main(int const argc, char const *argv[])
          chain_config == ChainConfig::EthereumMainnet) ||
         chain->get_revision(init_block_num) <= EVMC_BYZANTIUM) {
         BlockDb block_db{block_db_path};
-        init_block_hash_buffer(block_db, start_block_num, block_hash_buffer);
+        if (MONAD_UNLIKELY(!init_block_hash_buffer(
+                block_db, start_block_num, block_hash_buffer))) {
+            LOG_ERROR("Can't initialize block hash buffer");
+        }
     }
     else {
         mpt::Db rodb{mpt::ReadOnlyOnDiskDbConfig{
             .sq_thread_cpu = ro_sq_thread_cpu, .dbname_paths = dbname_paths}};
-        init_block_hash_buffer(rodb, start_block_num, block_hash_buffer);
+        if (MONAD_UNLIKELY(!init_block_hash_buffer(
+                rodb, start_block_num, block_hash_buffer))) {
+            LOG_ERROR("Can't initialize block hash buffer");
+        }
     }
 
     BlockHashChain block_hash_chain(block_hash_buffer);

--- a/libs/execution/src/monad/execution/block_hash_buffer.cpp
+++ b/libs/execution/src/monad/execution/block_hash_buffer.cpp
@@ -1,7 +1,10 @@
 #include <monad/config.hpp>
 #include <monad/core/assert.h>
 #include <monad/core/bytes.hpp>
+#include <monad/core/rlp/block_rlp.hpp>
 #include <monad/execution/block_hash_buffer.hpp>
+
+#include <quill/Quill.h>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -150,6 +153,47 @@ BlockHashChain::find_chain(uint64_t const parent_round) const
         }
     }
     return buf_;
+}
+
+bool init_block_hash_buffer(
+    mpt::Db &rodb, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer)
+{
+    TrieDb tdb{rodb};
+    for (uint64_t b = block_number < 256 ? 0 : block_number - 256;
+         b < block_number;
+         ++b) {
+        tdb.set_block_number(b);
+        auto const header = tdb.read_header();
+        if (MONAD_UNLIKELY(!header.has_value())) {
+            // changed to warning, bc it's not fatal for eth_call
+            LOG_WARNING("Could not query block header {} from TrieDb", b);
+            return false;
+        }
+        auto const h = std::bit_cast<bytes32_t>(
+            keccak256(rlp::encode_block_header(header.value())));
+        block_hash_buffer.set(b, h);
+    }
+    return true;
+}
+
+bool init_block_hash_buffer(
+    BlockDb &block_db, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer)
+{
+    for (uint64_t b = block_number < 256 ? 1 : block_number - 255;
+         b <= block_number;
+         ++b) {
+        Block block;
+        auto const ok = block_db.get(b, block);
+        if (MONAD_UNLIKELY(!ok)) {
+            // same as above
+            LOG_WARNING("Could not query block {} from blockdb.", b);
+            return false;
+        }
+        block_hash_buffer.set(b - 1, block.header.parent_hash);
+    }
+    return true;
 }
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/block_hash_buffer.hpp
+++ b/libs/execution/src/monad/execution/block_hash_buffer.hpp
@@ -2,6 +2,8 @@
 
 #include <monad/config.hpp>
 #include <monad/core/bytes.hpp>
+#include <monad/db/block_db.hpp>
+#include <monad/db/trie_db.hpp>
 
 #include <cstdint>
 #include <deque>
@@ -76,5 +78,13 @@ public:
     BlockHashBuffer const &finalize(uint64_t const round);
     BlockHashBuffer const &find_chain(uint64_t parent_round) const;
 };
+
+bool init_block_hash_buffer(
+    mpt::Db &rodb, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer);
+
+bool init_block_hash_buffer(
+    BlockDb &block_db, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/validate_transaction.cpp
+++ b/libs/execution/src/monad/execution/validate_transaction.cpp
@@ -187,7 +187,10 @@ quick_status_code_from_enum<monad::TransactionError>::value_mappings()
         {TransactionError::WrongChainId, "wrong chain id", {}},
         {TransactionError::MissingSender, "missing sender", {}},
         {TransactionError::GasLimitOverflow, "gas limit overflow", {}},
-        {TransactionError::InvalidSignature, "invalid signature", {}}};
+        {TransactionError::InvalidSignature, "invalid signature", {}},
+        {TransactionError::BlockHashBufferError,
+         "error in constructing block hash buffer",
+         {}}};
 
     return v;
 }

--- a/libs/execution/src/monad/execution/validate_transaction.hpp
+++ b/libs/execution/src/monad/execution/validate_transaction.hpp
@@ -38,6 +38,8 @@ enum class TransactionError
     MissingSender,
     GasLimitOverflow,
     InvalidSignature,
+    // TODO: properly construct this error
+    BlockHashBufferError,
 };
 
 struct Transaction;

--- a/libs/rpc/src/monad/rpc/eth_call.hpp
+++ b/libs/rpc/src/monad/rpc/eth_call.hpp
@@ -58,5 +58,5 @@ struct monad_state_override_set
 monad_evmc_result eth_call(
     std::vector<uint8_t> const &rlp_txn, std::vector<uint8_t> const &rlp_header,
     std::vector<uint8_t> const &rlp_sender, uint64_t const block_number,
-    std::string const &triedb_path, std::string const &blockdb_path,
+    std::string const &triedb_path,
     monad_state_override_set const &state_overrides);


### PR DESCRIPTION
Summary:
1. Use init_block_hash_buffer to initialize buffer. Remove MONAD_ASSERT and return an boost::outcome::error instead
2. Fix evmc_revision issue

TODO:
1. Support eth_call on non-finalized block