### PR TITLE
Avoid auto expiration slowness upon large history length adjustment

### DIFF
--- a/libs/db/src/monad/mpt/cli_tool_impl.cpp
+++ b/libs/db/src/monad/mpt/cli_tool_impl.cpp
@@ -835,6 +835,8 @@ public:
                             old_metadata->latest_finalized_version;
                         metadata->latest_verified_version =
                             old_metadata->latest_verified_version;
+                        metadata->auto_expire_version =
+                            old_metadata->auto_expire_version;
                     });
                     fast_list_base_insertion_count =
                         old_metadata->fast_list_begin()->insertion_count();
@@ -1537,8 +1539,10 @@ opened.
                  << ".\n     It has been configured to retain no more than "
                  << aux.version_history_length()
                  << ".\n     Latest finalized is "
-                 << aux.get_latest_finalized_version() << " latest verified is "
-                 << aux.get_latest_verified_version() << "\n";
+                 << aux.get_latest_finalized_version()
+                 << ", latest verified is " << aux.get_latest_verified_version()
+                 << ", auto expire version is "
+                 << aux.get_auto_expire_version_metadata() << "\n";
 
             if (impl.rewind_database_to) {
                 if (*impl.rewind_database_to <

--- a/libs/db/src/monad/mpt/detail/db_metadata.hpp
+++ b/libs/db/src/monad/mpt/detail/db_metadata.hpp
@@ -47,7 +47,7 @@ namespace detail
     // For the memory map of the first conventional chunk
     struct db_metadata
     {
-        static constexpr char const *MAGIC = "MONAD005";
+        static constexpr char const *MAGIC = "MONAD006";
         static constexpr unsigned MAGIC_STRING_LEN = 8;
 
         friend class MONAD_MPT_NAMESPACE::UpdateAuxImpl;
@@ -142,6 +142,7 @@ namespace detail
         uint64_t history_length;
         uint64_t latest_finalized_version;
         uint64_t latest_verified_version;
+        int64_t auto_expire_version;
 
         // used to know if the metadata was being
         // updated when the process suddenly exited
@@ -457,7 +458,7 @@ namespace detail
 
     static_assert(std::is_trivially_copyable_v<db_metadata>);
     static_assert(std::is_trivially_copy_assignable_v<db_metadata>);
-    static_assert(sizeof(db_metadata) == 524392);
+    static_assert(sizeof(db_metadata) == 524400);
     static_assert(alignof(db_metadata) == 8);
 
     inline void atomic_memcpy(


### PR DESCRIPTION
We now auto expire at most 2 blocks each upsert, so as to mitigate drastic increase of auto expiration workload on db upsert that adjusts history length down significantly.
Note that this includes db version upgrade, and all existing db or archives would need to resync/regenerate.