### PR TITLE
fix blocking read UB with test: verify version remains valid in blocking read

### DIFF
--- a/libs/db/CMakeLists.txt
+++ b/libs/db/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   "src/monad/mpt/node_cursor.hpp"
   "src/monad/mpt/ondisk_db_config.hpp"
   "src/monad/mpt/request.hpp"
+  "src/monad/mpt/read_node_blocking.cpp"
   "src/monad/mpt/state_machine.hpp"
   "src/monad/mpt/traverse.hpp"
   "src/monad/mpt/trie.cpp"

--- a/libs/db/src/monad/mpt/node.hpp
+++ b/libs/db/src/monad/mpt/node.hpp
@@ -353,11 +353,6 @@ void serialize_node_to_buffer(
 Node::UniquePtr
 deserialize_node_from_buffer(unsigned char const *read_pos, size_t max_bytes);
 
-//! input argument is node's physical offset
-//! chunk_offset_t spare bits store the num page to read
-Node::UniquePtr read_node_blocking(
-    MONAD_ASYNC_NAMESPACE::storage_pool &, chunk_offset_t node_offset);
-
 Node::UniquePtr copy_node(Node const *);
 
 int64_t calc_min_version(Node const &);

--- a/libs/db/src/monad/mpt/read_node_blocking.cpp
+++ b/libs/db/src/monad/mpt/read_node_blocking.cpp
@@ -1,0 +1,60 @@
+#include <monad/async/detail/scope_polyfill.hpp>
+#include <monad/core/assert.h>
+#include <monad/mpt/config.hpp>
+#include <monad/mpt/node.hpp>
+#include <monad/mpt/trie.hpp>
+#include <monad/mpt/util.hpp>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <cstdint>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+Node::UniquePtr read_node_blocking(
+    UpdateAuxImpl const &aux, chunk_offset_t const node_offset,
+    uint64_t const version)
+{
+    MONAD_ASSERT(aux.is_on_disk());
+    if (!aux.version_is_valid_ondisk(version)) {
+        return {};
+    }
+    auto &pool = aux.io->storage_pool();
+    MONAD_DEBUG_ASSERT(
+        node_offset.spare <=
+        round_up_align<DISK_PAGE_BITS>(Node::max_disk_size));
+    // spare bits are number of pages needed to load node
+    unsigned const num_pages_to_load_node =
+        node_disk_pages_spare_15{node_offset}.to_pages();
+    unsigned const bytes_to_read = num_pages_to_load_node << DISK_PAGE_BITS;
+    file_offset_t const rd_offset =
+        round_down_align<DISK_PAGE_BITS>(node_offset.offset);
+    uint16_t const buffer_off = uint16_t(node_offset.offset - rd_offset);
+    auto *buffer =
+        (unsigned char *)aligned_alloc(DISK_PAGE_SIZE, bytes_to_read);
+    auto unbuffer = make_scope_exit([buffer]() noexcept { ::free(buffer); });
+
+    auto chunk = pool.activate_chunk(pool.seq, node_offset.id);
+    auto fd = chunk->read_fd();
+    ssize_t const bytes_read = pread(
+        fd.first,
+        buffer,
+        bytes_to_read,
+        static_cast<off_t>(fd.second + rd_offset));
+    if (bytes_read < 0) {
+        MONAD_ABORT_PRINTF(
+            "FATAL: pread(%u, %llu) failed with '%s'\n",
+            bytes_to_read,
+            rd_offset,
+            strerror(errno));
+    }
+    return aux.version_is_valid_ondisk(version)
+               ? deserialize_node_from_buffer(
+                     buffer + buffer_off, size_t(bytes_read) - buffer_off)
+               : Node::UniquePtr{};
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/libs/db/src/monad/mpt/test/CMakeLists.txt
+++ b/libs/db/src/monad/mpt/test/CMakeLists.txt
@@ -28,6 +28,8 @@ add_trie_test(TARGET min_truncated_offsets_test SOURCES
               "min_truncated_offsets_test.cpp")
 add_trie_test(TARGET mixed_async_sync_loads_test SOURCES
               "mixed_async_sync_loads_test.cpp")
+add_trie_test(TARGET blocking_read_concurrency_test SOURCES
+              "blocking_read_concurrency_test.cpp")
 add_trie_test(TARGET nibbles_view_test SOURCES "nibbles_view_test.cpp")
 add_trie_test(TARGET node_disk_pages_spare_test SOURCES
               "node_disk_pages_spare_test.cpp")

--- a/libs/db/src/monad/mpt/test/append_test.cpp
+++ b/libs/db/src/monad/mpt/test/append_test.cpp
@@ -53,8 +53,8 @@ TYPED_TEST(AppendTest, works)
     EXPECT_EQ(last_fast_off, this->state()->aux.get_start_of_wip_fast_offset());
 
     // Get new current root
-    this->state()->root =
-        read_node_blocking(this->state()->io.storage_pool(), last_root_off);
+    this->state()->root = read_node_blocking(
+        this->state()->aux, last_root_off, last_root_version);
 
     std::cout << "\nAfter rewind:";
     this->state()->print(std::cout);

--- a/libs/db/src/monad/mpt/test/blocking_read_concurrency_test.cpp
+++ b/libs/db/src/monad/mpt/test/blocking_read_concurrency_test.cpp
@@ -1,0 +1,217 @@
+#include "test_fixtures_gtest.hpp"
+
+#include <monad/async/io.hpp>
+#include <monad/io/buffers.hpp>
+#include <monad/io/ring.hpp>
+#include <monad/mpt/node.hpp>
+#include <monad/mpt/traverse.hpp>
+#include <monad/mpt/trie.hpp>
+
+#include <monad/test/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <ostream>
+#include <thread>
+
+using namespace MONAD_ASYNC_NAMESPACE;
+using namespace MONAD_MPT_NAMESPACE;
+
+namespace
+{
+    struct DummyTraverseMachine : public TraverseMachine
+    {
+        Nibbles path{};
+
+        virtual bool down(unsigned char branch, Node const &node) override
+        {
+            if (branch == INVALID_BRANCH) {
+                return true;
+            }
+            path = concat(NibblesView{path}, branch, node.path_nibble_view());
+
+            if (node.has_value()) {
+                MONAD_ASSERT(path.nibble_size() == KECCAK256_SIZE * 2);
+            }
+            return true;
+        }
+
+        virtual void up(unsigned char branch, Node const &node) override
+        {
+            auto const path_view = NibblesView{path};
+            auto const rem_size = [&] {
+                if (branch == INVALID_BRANCH) {
+                    MONAD_ASSERT(path_view.nibble_size() == 0);
+                    return 0;
+                }
+                int const rem_size = path_view.nibble_size() - 1 -
+                                     node.path_nibble_view().nibble_size();
+                MONAD_ASSERT(rem_size >= 0);
+                MONAD_ASSERT(
+                    path_view.substr(static_cast<unsigned>(rem_size)) ==
+                    concat(branch, node.path_nibble_view()));
+                return rem_size;
+            }();
+            path = path_view.substr(0, static_cast<unsigned>(rem_size));
+        }
+
+        virtual std::unique_ptr<TraverseMachine> clone() const override
+        {
+            return std::make_unique<DummyTraverseMachine>(*this);
+        }
+    };
+}
+
+struct DbConcurrencyTest1
+    : public monad::test::FillDBWithChunksGTest<
+          monad::test::FillDBWithChunksConfig{.chunks_to_fill = 1}>
+{
+};
+
+TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
+{
+    // Load root of most recent version
+    auto const latest_version = state()->aux.db_history_max_version();
+    Node::UniquePtr root = read_node_blocking(
+        state()->aux,
+        state()->aux.get_root_offset_at_version(latest_version),
+        latest_version);
+    ASSERT_TRUE(root);
+    auto const &key = state()->keys.front().first;
+    auto const &value = state()->keys.front().first;
+
+    // Create a promise/future pair to track completion
+    std::promise<int> completion_promise;
+    std::future<int> completion_future = completion_promise.get_future();
+    std::mutex lock;
+    std::condition_variable cond;
+
+    auto find_loop = [&](std::stop_token const stop_token) {
+        // Read only aux
+        auto pool = state()->pool.clone_as_read_only();
+        monad::io::Ring ring{2};
+        monad::io::Buffers rwbuf{monad::io::make_buffers_for_read_only(
+            ring, 2, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE)};
+        AsyncIO io{pool, rwbuf};
+        monad::test::UpdateAux<void> ro_aux{&io};
+
+        int count = 0;
+        while (!stop_token.stop_requested()) {
+            // clear all in memory nodes under root
+            for (unsigned idx = 0; idx < root->number_of_children(); ++idx) {
+                root->move_next(idx).reset();
+            }
+            auto [node_cursor, res] =
+                find_blocking(ro_aux, *root, key, latest_version);
+            if (res != find_result::success) {
+                ASSERT_EQ(res, find_result::version_no_longer_exist);
+                completion_promise.set_value(count);
+                return;
+            }
+
+            EXPECT_EQ(node_cursor.node->value(), value);
+            ++count;
+            if (count == 1) {
+                std::unique_lock g(lock);
+                cond.notify_one();
+            }
+        }
+    };
+
+    std::jthread reader{find_loop};
+
+    // Erase the version when the first read finishes
+    {
+        std::unique_lock g(lock);
+        cond.wait(g);
+    }
+    // Erase the version being read should trigger a find failure and ends the
+    // reader thread
+    state()->aux.update_root_offset(latest_version, INVALID_OFFSET);
+    EXPECT_FALSE(state()->aux.version_is_valid_ondisk(latest_version));
+
+    // Wait for completion with timeout
+    auto const status = completion_future.wait_for(std::chrono::seconds(5));
+    ASSERT_NE(status, std::future_status::timeout)
+        << "Test Failure: find loop timeout. Find loop is expected to "
+        << "end with an unsuccessful find immediately after latest "
+        << "version is erased by main thread.";
+    int const nfinished_finds = completion_future.get();
+    EXPECT_GT(nfinished_finds, 0);
+    std::cout << "Did " << nfinished_finds << " successful finds at version "
+              << latest_version << " before it gets erased." << std::endl;
+}
+
+struct DbConcurrencyTest2
+    : public monad::test::FillDBWithChunksGTest<
+          monad::test::FillDBWithChunksConfig{.chunks_to_fill = 1}>
+{
+};
+
+TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
+{
+    // Load root of most recent version
+    auto const latest_version = state()->aux.db_history_max_version();
+    Node::UniquePtr root = read_node_blocking(
+        state()->aux,
+        state()->aux.get_root_offset_at_version(latest_version),
+        latest_version);
+    ASSERT_TRUE(root);
+
+    // Create a promise/future pair to track completion
+    std::promise<int> completion_promise;
+    std::future<int> completion_future = completion_promise.get_future();
+    std::mutex lock;
+    std::condition_variable cond;
+
+    auto traverse_loop = [&](std::stop_token const stop_token) {
+        // Read only aux
+        auto pool = state()->pool.clone_as_read_only();
+        monad::io::Ring ring{2};
+        monad::io::Buffers rwbuf{monad::io::make_buffers_for_read_only(
+            ring, 2, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE)};
+        AsyncIO io{pool, rwbuf};
+        monad::test::UpdateAux<void> ro_aux{&io};
+
+        DummyTraverseMachine traverse{};
+        int count = 0;
+        while (!stop_token.stop_requested()) {
+            if (!preorder_traverse_blocking(
+                    ro_aux, *root, traverse, latest_version)) {
+                std::cout << "Traverse loop ends due to version being erased "
+                             "from history on disk."
+                          << std::endl;
+                completion_promise.set_value(count);
+                return;
+            }
+            ++count;
+            if (count == 1) {
+                std::unique_lock g(lock);
+                cond.notify_one();
+            }
+        }
+    };
+
+    std::jthread reader{traverse_loop};
+    // Erase the version when the first traverse finishes
+    {
+        std::unique_lock g(lock);
+        cond.wait(g);
+    }
+    // Erase the version being read should stop traverse in the reader thread
+    state()->aux.update_root_offset(latest_version, INVALID_OFFSET);
+    EXPECT_FALSE(state()->aux.version_is_valid_ondisk(latest_version));
+
+    // Wait for completion with timeout
+    auto const status = completion_future.wait_for(std::chrono::seconds(5));
+    ASSERT_NE(status, std::future_status::timeout)
+        << "Test Failure: traverse loop timeout. Traverse loop is expected to "
+        << "end with an unsuccessful find immediately after latest "
+        << "version is erased by main thread.";
+    int const nfinished_traversals = completion_future.get();
+    EXPECT_GT(nfinished_traversals, 0);
+    std::cout << "Did " << nfinished_traversals
+              << " successful traversals at version " << latest_version
+              << " before it gets erased." << std::endl;
+}

--- a/libs/db/src/monad/mpt/test/cli_tool_test.cpp
+++ b/libs/db/src/monad/mpt/test/cli_tool_test.cpp
@@ -208,12 +208,15 @@ struct cli_tool_fixture
                         monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                 monad::async::AsyncIO testio(pool, testrwbuf);
                 monad::mpt::UpdateAux<> const aux{&testio};
-                monad::mpt::Node::UniquePtr root_ptr{
-                    read_node_blocking(pool, aux.get_latest_root_offset())};
+                monad::mpt::Node::UniquePtr root_ptr{read_node_blocking(
+                    aux,
+                    aux.get_latest_root_offset(),
+                    aux.db_history_max_version())};
                 monad::mpt::NodeCursor const root(*root_ptr);
 
                 for (auto &key : this->state()->keys) {
-                    auto ret = monad::mpt::find_blocking(aux, root, key.first);
+                    auto ret = monad::mpt::find_blocking(
+                        aux, root, key.first, aux.db_history_max_version());
                     EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                 }
                 EXPECT_EQ(
@@ -308,13 +311,15 @@ struct cli_tool_fixture
                             monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                     monad::async::AsyncIO testio(pool, testrwbuf);
                     monad::mpt::UpdateAux<> const aux{&testio};
-                    monad::mpt::Node::UniquePtr root_ptr{
-                        read_node_blocking(pool, aux.get_latest_root_offset())};
+                    monad::mpt::Node::UniquePtr root_ptr{read_node_blocking(
+                        aux,
+                        aux.get_latest_root_offset(),
+                        aux.db_history_max_version())};
                     monad::mpt::NodeCursor const root(*root_ptr);
 
                     for (auto &key : this->state()->keys) {
-                        auto ret =
-                            monad::mpt::find_blocking(aux, root, key.first);
+                        auto ret = monad::mpt::find_blocking(
+                            aux, root, key.first, aux.db_history_max_version());
                         EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                     }
                     EXPECT_EQ(

--- a/libs/db/src/monad/mpt/test/load_all_test.cpp
+++ b/libs/db/src/monad/mpt/test/load_all_test.cpp
@@ -19,7 +19,9 @@ TEST_F(LoadAllTest, works)
     monad::test::UpdateAux<void> aux{&state()->io};
     monad::test::StateMachineAlwaysMerkle sm;
     monad::mpt::Node::UniquePtr root{monad::mpt::read_node_blocking(
-        state()->pool, aux.get_latest_root_offset())};
+        state()->aux,
+        aux.get_latest_root_offset(),
+        aux.db_history_max_version())};
     auto nodes_loaded = monad::mpt::load_all(aux, sm, *root);
     EXPECT_GE(nodes_loaded, state()->keys.size());
     std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;

--- a/libs/db/src/monad/mpt/test/locking_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/locking_trie_test.cpp
@@ -148,6 +148,7 @@ TEST_F(LockingTrieTest, works)
 {
     auto &aux = this->state()->aux;
     auto *root = this->state()->root.get();
+    auto const version = aux.db_history_max_version();
     auto &keys = this->state()->keys;
     // Appending blocks only does exclusive lock and unlock and nothing else
     {
@@ -196,7 +197,8 @@ TEST_F(LockingTrieTest, works)
     // downgrade back to shared, release
     {
         aux.lock().clear();
-        auto [leaf_it, res] = find_blocking(aux, *root, keys.back().first);
+        auto [leaf_it, res] =
+            find_blocking(aux, *root, keys.back().first, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
@@ -213,7 +215,8 @@ TEST_F(LockingTrieTest, works)
     // Now the node is in cache, no exclusive lock should get taken
     {
         aux.lock().clear();
-        auto [leaf_it, res] = find_blocking(aux, *root, keys.back().first);
+        auto [leaf_it, res] =
+            find_blocking(aux, *root, keys.back().first, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());

--- a/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/merkle_trie_test.cpp
@@ -204,6 +204,7 @@ TYPED_TEST(TrieTest, upsert_fixed_key_length)
 
 TYPED_TEST(TrieTest, insert_unrelated_leaves_then_read)
 {
+    constexpr uint64_t version = 0;
     auto const &kv = unrelated_leaves::kv;
 
     this->root = upsert_updates(
@@ -227,25 +228,29 @@ TYPED_TEST(TrieTest, insert_unrelated_leaves_then_read)
         this->root_hash(),
         0xd339cf4033aca65996859d35da4612b642664cc40734dbdd40738aa47f1e3e44_hex);
 
-    auto [leaf_it, res] = find_blocking(this->aux, *this->root, kv[0].first);
+    auto [leaf_it, res] =
+        find_blocking(this->aux, *this->root, kv[0].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[0].second);
-    std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[1].first);
+    std::tie(leaf_it, res) =
+        find_blocking(this->aux, *this->root, kv[1].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[1].second);
-    std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[2].first);
+    std::tie(leaf_it, res) =
+        find_blocking(this->aux, *this->root, kv[2].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[2].second);
-    std::tie(leaf_it, res) = find_blocking(this->aux, *this->root, kv[3].first);
+    std::tie(leaf_it, res) =
+        find_blocking(this->aux, *this->root, kv[3].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
@@ -703,7 +708,8 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
             std::move(ul_prefix),
             block_id,
             true /*compaction*/);
-        auto [state_it, res] = find_blocking(this->aux, *this->root, prefix);
+        auto [state_it, res] =
+            find_blocking(this->aux, *this->root, prefix, block_id);
         EXPECT_EQ(res, find_result::success);
         EXPECT_EQ(
             state_it.node->data(),
@@ -732,6 +738,7 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
 
 TYPED_TEST(TrieTest, variable_length_trie)
 {
+    constexpr uint64_t version = 0;
     this->sm = std::make_unique<StateMachineAlwaysVarLen>();
 
     auto const key0 = 0x80_hex;
@@ -785,13 +792,15 @@ TYPED_TEST(TrieTest, variable_length_trie)
 
     // find
     {
-        auto [node0, res] = find_blocking(this->aux, *this->root, key0);
+        auto [node0, res] =
+            find_blocking(this->aux, *this->root, key0, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), long_value);
     }
 
     {
-        auto [node_long, res] = find_blocking(this->aux, *this->root, keylong);
+        auto [node_long, res] =
+            find_blocking(this->aux, *this->root, keylong, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), long_value);
     }
@@ -799,6 +808,7 @@ TYPED_TEST(TrieTest, variable_length_trie)
 
 TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
 {
+    constexpr uint64_t version = 0;
     auto const prefix = 0x00_hex;
 
     this->sm = std::make_unique<StateMachineVarLenTrieWithPrefix<2>>();
@@ -835,14 +845,14 @@ TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
     // find
     {
         auto [node0, res] =
-            find_blocking(this->aux, *this->root, prefix + key0);
+            find_blocking(this->aux, *this->root, prefix + key0, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), value);
     }
 
     {
         auto [node_long, res] =
-            find_blocking(this->aux, *this->root, prefix + keylong);
+            find_blocking(this->aux, *this->root, prefix + keylong, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), value);
     }

--- a/libs/db/src/monad/mpt/test/monad_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/monad_trie_test.cpp
@@ -524,7 +524,9 @@ int main(int argc, char *argv[])
             Node::UniquePtr root{};
             if (append) {
                 root = read_node_blocking(
-                    io.storage_pool(), aux.get_latest_root_offset());
+                    aux,
+                    aux.get_latest_root_offset(),
+                    aux.db_history_max_version());
             }
             auto block_id = in_memory ? 0 : (aux.db_history_max_version() + 1);
             printf("starting block id %lu\n", block_id);
@@ -667,8 +669,11 @@ int main(int argc, char *argv[])
                     aux.set_io(&io, history_len);
                 }
                 root = read_node_blocking(
-                    io.storage_pool(), aux.get_latest_root_offset());
-                auto [res, errc] = find_blocking(aux, *root, state_nibbles);
+                    aux,
+                    aux.get_latest_root_offset(),
+                    aux.db_history_max_version());
+                auto [res, errc] = find_blocking(
+                    aux, *root, state_nibbles, aux.db_history_max_version());
                 MONAD_ASSERT(errc == find_result::success);
                 state_start = res;
                 return ret;

--- a/libs/db/src/monad/mpt/test/plain_trie_test.cpp
+++ b/libs/db/src/monad/mpt/test/plain_trie_test.cpp
@@ -60,6 +60,7 @@ TYPED_TEST(PlainTrieTest, leaf_nodes_persist)
 
 TYPED_TEST(PlainTrieTest, var_length)
 {
+    constexpr uint64_t version = 0;
     auto const &kv = updates::kv;
     // insert kv 0,1,2,3
     this->root = upsert_updates(
@@ -72,16 +73,20 @@ TYPED_TEST(PlainTrieTest, var_length)
         make_update(kv[3].first, kv[3].second));
 
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[2].first, version)
+            .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[3].first, version)
+            .first.node->value(),
         kv[3].second);
 
     EXPECT_EQ(this->root->mask, 0b11);
@@ -126,22 +131,28 @@ TYPED_TEST(PlainTrieTest, var_length)
         make_update(kv[4].first, kv[4].second),
         make_update(kv[5].first, kv[5].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[2].first, version)
+            .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[3].first, version)
+            .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[4].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[4].first, version)
+            .first.node->value(),
         kv[4].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[5].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[5].first, version)
+            .first.node->value(),
         kv[5].second);
 
     EXPECT_EQ(this->root->mask, 0b11);
@@ -164,13 +175,16 @@ TYPED_TEST(PlainTrieTest, var_length)
         make_update(kv[6].first, kv[6].second),
         make_update(kv[7].first, kv[7].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[5].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[5].first, version)
+            .first.node->value(),
         kv[5].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[6].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[6].first, version)
+            .first.node->value(),
         kv[6].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[7].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[7].first, version)
+            .first.node->value(),
         kv[7].second);
 
     node1 = this->root->next(this->root->to_child_index(1));
@@ -190,6 +204,7 @@ TYPED_TEST(PlainTrieTest, var_length)
 
 TYPED_TEST(PlainTrieTest, mismatch)
 {
+    constexpr uint64_t version = 0;
     std::vector<std::pair<monad::byte_string, monad::byte_string>> const kv{
         {0x12345678_hex, 0xdead_hex}, // 0
         {0x12346678_hex, 0xbeef_hex}, // 1
@@ -213,13 +228,16 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[1].first, kv[1].second),
         make_update(kv[2].first, kv[2].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[2].first, version)
+            .first.node->value(),
         kv[2].second);
 
     EXPECT_EQ(this->root->mask, 0b11000);
@@ -245,16 +263,20 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[3].first, kv[3].second),
         make_update(kv[4].first, kv[4].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[2].first, version)
+            .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[3].first, version)
+            .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[4].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[4].first, version)
+            .first.node->value(),
         kv[4].second);
 
     EXPECT_EQ(this->root->mask, 0b11000);
@@ -320,6 +342,7 @@ TYPED_TEST(PlainTrieTest, delete_wo_incarnation)
 
 TYPED_TEST(PlainTrieTest, delete_with_incarnation)
 {
+    constexpr uint64_t version = 0;
     // upsert a bunch of var lengths kv
     auto const &kv = updates::kv;
     // insert
@@ -331,13 +354,16 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
         make_update(kv[1].first, kv[1].second), // 0x11111111
         make_update(kv[2].first, kv[2].second)); // 0x11111111aaaa
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[2].first, version)
+            .first.node->value(),
         kv[2].second);
 
     // upsert a bunch of new kvs, with incarnation flag set
@@ -348,21 +374,25 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
         make_update(kv[1].first, kv[1].second, true), // 0x11111111
         make_update(kv[3].first, kv[3].second)); // 0x11111111aacd
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first).first.node->value(),
+        find_blocking(this->aux, *this->root, kv[3].first, version)
+            .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first).second,
+        find_blocking(this->aux, *this->root, kv[2].first, version).second,
         find_result::key_mismatch_failure);
 }
 
 TYPED_TEST(PlainTrieTest, large_values)
 {
+    constexpr uint64_t version = 0;
     // make sure leaves are not cached
     auto const key1 = 0x0000112_hex;
     auto const key2 = 0x0000123_hex;
@@ -380,7 +410,8 @@ TYPED_TEST(PlainTrieTest, large_values)
 
     same_upsert_to_clear_nodes_outside_cache_level();
     {
-        auto [leaf_it, res] = find_blocking(this->aux, *this->root, key1);
+        auto [leaf_it, res] =
+            find_blocking(this->aux, *this->root, key1, version);
         auto *leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
@@ -390,7 +421,8 @@ TYPED_TEST(PlainTrieTest, large_values)
 
     same_upsert_to_clear_nodes_outside_cache_level();
     {
-        auto [leaf_it, res] = find_blocking(this->aux, *this->root, key2);
+        auto [leaf_it, res] =
+            find_blocking(this->aux, *this->root, key2, version);
         auto *leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
@@ -441,6 +473,7 @@ TYPED_TEST(PlainTrieTest, large_values)
 
 TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
 {
+    constexpr uint64_t version = 0;
     // upsert a bunch of var lengths kv
     auto const &kv = updates::kv;
     // always insert the same updates to the second level trie
@@ -461,19 +494,23 @@ TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
             std::move(this->root),
             make_update(prefix, top_value, false, std::move(updates)));
         // find blocking on multi-level trie
-        auto [begin, errc] = find_blocking(this->aux, *this->root, prefix);
+        auto [begin, errc] =
+            find_blocking(this->aux, *this->root, prefix, version);
         EXPECT_EQ(errc, find_result::success);
         EXPECT_EQ(begin.node->number_of_children(), 2);
         EXPECT_EQ(begin.node->value(), top_value);
 
         EXPECT_EQ(
-            find_blocking(this->aux, begin, kv[0].first).first.node->value(),
+            find_blocking(this->aux, begin, kv[0].first, version)
+                .first.node->value(),
             kv[0].second);
         EXPECT_EQ(
-            find_blocking(this->aux, begin, kv[1].first).first.node->value(),
+            find_blocking(this->aux, begin, kv[1].first, version)
+                .first.node->value(),
             kv[1].second);
         EXPECT_EQ(
-            find_blocking(this->aux, begin, kv[2].first).first.node->value(),
+            find_blocking(this->aux, begin, kv[2].first, version)
+                .first.node->value(),
             kv[2].second);
     };
 
@@ -510,8 +547,7 @@ TYPED_TEST(PlainTrieTest, node_version)
 
     auto read_child = [&](Node &parent,
                           unsigned const index) -> Node::UniquePtr {
-        return read_node_blocking(
-            this->aux.io->storage_pool(), parent.fnext(index));
+        return read_node_blocking(this->aux, parent.fnext(index), 0);
     };
     if (this->root->next(0)) {
         EXPECT_EQ(this->root->next(0)->version, 0);

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -1151,8 +1151,8 @@ Node::UniquePtr UpdateAuxImpl::do_update(
 
 void UpdateAuxImpl::erase_version(uint64_t const version)
 {
-    auto root_to_erase = read_node_blocking(
-        io->storage_pool(), get_root_offset_at_version(version));
+    Node::UniquePtr root_to_erase =
+        read_node_blocking(*this, get_root_offset_at_version(version), version);
     auto const [min_offset_fast, min_offset_slow] =
         deserialize_compaction_offsets(root_to_erase->value());
     MONAD_ASSERT(


### PR DESCRIPTION
fix a potential race condition where blocking read occurs concurrently with that read version being erased. It is done by checking read version is valid before read and also before deserializing node from the read buffer. This fix is critical for those that still rely on blocking reads (e.g., blocking find in eth_call).

It also remove unused try catch blocks, which wasn't really doing anything.

Test:
unit test `DbConcurrencyTest.version_outdated_during_blocking_find` failed before this change and passes after these changes.