### PR TITLE
Teach statesync deletions about proposal chains

### DIFF
--- a/libs/statesync/src/monad/statesync/statesync_server.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server.cpp
@@ -66,7 +66,7 @@ bool send_deletion(
     auto const prefix = from_prefix(rq.prefix, rq.prefix_bytes);
 
     for (uint64_t i = rq.old_target + 1; i <= rq.target; ++i) {
-        Deleted::const_accessor it;
+        FinalizedDeletions::const_accessor it;
         if (!deleted.find(it, i)) {
             return false;
         }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -21,12 +21,22 @@ MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
 void on_commit(
     monad_statesync_server_context &ctx, StateDeltas const &state_deltas,
-    uint64_t const n)
+    uint64_t const n, uint64_t const round)
 {
-    constexpr auto HISTORY_LENGTH = 1200; // 20 minutes with 1s block times
+    auto &proposals = ctx.proposals;
+    auto it = std::find_if(
+        proposals.begin(), proposals.end(), [round](auto const &p) {
+            return p.round == round;
+        });
 
-    Deleted::accessor it;
-    MONAD_ASSERT(ctx.deleted.emplace(it, n, Deleted::mapped_type{}));
+    if (MONAD_UNLIKELY(it != proposals.end())) {
+        proposals.erase(it);
+    }
+    auto &deletion = proposals
+                         .emplace_back(ProposedDeletions{
+                             .block_number = n, .round = round, .deletion = {}})
+                         .deletion;
+
     for (auto const &[addr, delta] : state_deltas) {
         auto const &account = delta.account.second;
         std::vector<bytes32_t> storage;
@@ -49,17 +59,47 @@ void on_commit(
                 account.has_value() && delta.account.first.has_value() &&
                 delta.account.first->incarnation != account->incarnation;
             if (incarnation || !account.has_value()) {
-                it->second.emplace_back(addr, std::vector<bytes32_t>{});
+                deletion.emplace_back(addr, std::vector<bytes32_t>{});
             }
             if (!storage.empty()) {
-                it->second.emplace_back(addr, std::move(storage));
+                deletion.emplace_back(addr, std::move(storage));
             }
         }
     }
+}
 
-    if (ctx.deleted.size() > HISTORY_LENGTH) {
-        MONAD_ASSERT(ctx.deleted.erase(n - HISTORY_LENGTH));
+void on_finalize(
+    monad_statesync_server_context &ctx, uint64_t const block_number,
+    uint64_t const round_number)
+{
+    auto &proposals = ctx.proposals;
+
+    auto winner_it = std::find_if(
+        proposals.begin(), proposals.end(), [round_number](auto const &p) {
+            return p.round == round_number;
+        });
+
+    if (MONAD_LIKELY(winner_it != proposals.end())) {
+        MONAD_ASSERT(winner_it->block_number == block_number);
+        FinalizedDeletions::accessor finalized_it;
+        MONAD_ASSERT(ctx.deleted.emplace(
+            finalized_it, block_number, std::move(winner_it->deletion)));
     }
+
+    constexpr auto HISTORY_LENGTH = 1200; // 20 minutes with 1s block times
+    if (ctx.deleted.size() > HISTORY_LENGTH) {
+        MONAD_ASSERT(ctx.deleted.erase(block_number - HISTORY_LENGTH));
+    }
+
+    // gc old rounds
+    proposals.erase(
+        std::remove_if(
+            proposals.begin(),
+            proposals.end(),
+            [round_number](ProposedDeletions const &p) {
+                return p.round <= round_number;
+            }),
+        proposals.end());
 }
 
 MONAD_ANONYMOUS_NAMESPACE_END
@@ -122,6 +162,7 @@ void monad_statesync_server_context::set_block_and_round(
 void monad_statesync_server_context::finalize(
     uint64_t const block_number, uint64_t const round_number)
 {
+    on_finalize(*this, block_number, round_number);
     rw.finalize(block_number, round_number);
 }
 
@@ -140,7 +181,7 @@ void monad_statesync_server_context::commit(
     std::optional<std::vector<Withdrawal>> const &withdrawals,
     std::optional<uint64_t> const round_number)
 {
-    on_commit(*this, state_deltas, header.number);
+    on_commit(*this, state_deltas, header.number, round_number.value_or(0));
     rw.commit(
         state_deltas,
         code,
@@ -151,4 +192,7 @@ void monad_statesync_server_context::commit(
         ommers,
         withdrawals,
         round_number);
+    if (MONAD_UNLIKELY(!round_number.has_value())) {
+        on_finalize(*this, header.number, 0);
+    }
 }


### PR DESCRIPTION
Buffer up pending statesync deletions in a deque, identifable by [round, block_number]. On finalize, commit deletions from the winning proposal to the main deletions struct. Note that we only statesync finalized blocks.