### PR TITLE
BugFix: pass in a valid node offset to `calc_min_offset()` to maintain correct min offsets information

### DIFF
--- a/libs/db/src/monad/mpt/trie.cpp
+++ b/libs/db/src/monad/mpt/trie.cpp
@@ -1431,7 +1431,10 @@ void fillin_parent_after_expiration(
         auto const new_offset =
             async_write_node_set_spare(aux, *new_node, true);
         auto const &[min_offset_fast, min_offset_slow] =
-            calc_min_offsets(*new_node, INVALID_VIRTUAL_OFFSET);
+            calc_min_offsets(*new_node, aux.physical_to_virtual(new_offset));
+        MONAD_DEBUG_ASSERT(
+            min_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET ||
+            min_offset_slow != INVALID_COMPACT_VIRTUAL_OFFSET);
         auto const min_version = calc_min_version(*new_node);
         MONAD_DEBUG_ASSERT(min_version >= aux.min_version_after_upsert);
         if (parent->type == tnode_type::update) {


### PR DESCRIPTION
Currently, when `calc_min_offset()` from a leaf node without any children, the output would be two invalid (which is defined as `uint32_t::max()`) min offsets, which is very wrong. Instead, at least one of `min_offset_fast, min_offset_slow` pair should be valid, they are stored later to `node->min_offset_fast/slow(i)` respectively, which are the minimum offsets of the subtrie under branch i. Compaction relies on these to know which branch has nodes to be garbage collected, it will skip branches where each of the stored value of that subtrie are greater than `aux.compact_offset_fast/slow`. Current code stores that information as MAX, which means when that branch falls in the range that needs to compacted, nothing would be copied. The offset that fall out of range is still being referenced in the db, but data of that offset is erased (GC to free chunk). That is why we saw reading from a free chunk.