### PR TITLE
TrieDb: remove duplicate finalization and verification asserts.

### DIFF
--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -466,10 +466,10 @@ void TrieDb::finalize(uint64_t const block_number, uint64_t const round_number)
 {
     // no re-finalization
     if (db_.is_on_disk()) {
-        auto const latest_finalized = db_.get_latest_finalized_block_id();
-        MONAD_ASSERT(
-            latest_finalized == INVALID_BLOCK_ID ||
-            block_number == latest_finalized + 1);
+        // auto const latest_finalized = db_.get_latest_finalized_block_id();
+        // MONAD_ASSERT(
+        //     latest_finalized == INVALID_BLOCK_ID ||
+        //     block_number == latest_finalized + 1);
         auto const src_prefix = proposal_prefix(round_number);
         MONAD_ASSERT(db_.find(src_prefix, block_number).has_value());
         db_.copy_trie(
@@ -482,10 +482,10 @@ void TrieDb::update_verified_block(uint64_t const block_number)
 {
     // no re-verification
     if (db_.is_on_disk()) {
-        auto const latest_verified = db_.get_latest_verified_block_id();
-        MONAD_ASSERT(
-            latest_verified == INVALID_BLOCK_ID ||
-            block_number == latest_verified + 1);
+        // auto const latest_verified = db_.get_latest_verified_block_id();
+        // MONAD_ASSERT(
+        //     latest_verified == INVALID_BLOCK_ID ||
+        //     block_number == latest_verified + 1);
         db_.update_verified_block(block_number);
     }
 }


### PR DESCRIPTION
Currently these assertions are triggered when we stop and resume execution.
We can revert this PR in the future once we have a block emitter that skips re-execution and re-finalization that are already on db.