### PR TITLE
Log error message use c_str()

### DIFF
--- a/libs/execution/src/monad/execution/block_hash_buffer.cpp
+++ b/libs/execution/src/monad/execution/block_hash_buffer.cpp
@@ -146,7 +146,7 @@ bool init_block_hash_buffer_from_triedb(
             LOG_WARNING(
                 "Could not query block header {} from TrieDb -- {}",
                 b,
-                header.error().message());
+                header.error().message().c_str());
             return false;
         }
         auto const h = to_bytes(keccak256(header.value()));


### PR DESCRIPTION
It currently logs like this, PR fixed it to print a c string.

```
block_hash_buffer.cpp:149 LOG_WARNING     Could not query block header 2999745 from TrieDb -- ['k', 'e', 'y', ' ', 'n', 'o', 't', ' ', 'f', 'o', 'u', 'n', 'd']
```