### PR TITLE
fix invalid offsets check in `rewind_to_match_offsets()`

### DIFF
--- a/libs/db/src/monad/mpt/test/rewind_test.cpp
+++ b/libs/db/src/monad/mpt/test/rewind_test.cpp
@@ -57,3 +57,48 @@ TEST_F(RewindTest, works)
     EXPECT_EQ(991, aux.db_history_min_valid_version());
     EXPECT_EQ(991, aux.db_history_max_version());
 }
+
+struct RewindTestFillOne
+    : public monad::test::FillDBWithChunksGTest<
+          monad::test::FillDBWithChunksConfig{
+              .chunks_to_fill = 1,
+              .history_len = 65535,
+              .updates_per_block = 1,
+              .use_anonymous_inode = false}>
+{
+};
+
+TEST_F(
+    RewindTestFillOne,
+    works_when_fast_writer_chunk_is_ahead_of_last_root_offset_chunk)
+{
+    // Test case to cover the case where fast writer is advanced to a newer
+    // chunk than the latest root offset is at
+    auto const path = this->state()->pool.devices()[0].current_path();
+    auto &aux = this->state()->aux;
+    auto &io = this->state()->io;
+    auto const latest_root_offset = aux.get_latest_root_offset();
+    std::cout << "DB is at " << path << ". Last root offset ["
+              << latest_root_offset.id << ", " << latest_root_offset.offset
+              << "]. " << std::endl;
+
+    // advance fast writer head to the next chunk
+    auto const fast_writer_offset = aux.node_writer_fast->sender().offset();
+    auto const *ci = aux.db_metadata()->free_list_end();
+    ASSERT_TRUE(ci != nullptr);
+    auto const idx = ci->index(aux.db_metadata());
+    aux.remove(idx);
+    aux.append(monad::mpt::UpdateAuxImpl::chunk_list::fast, idx);
+    monad::async::chunk_offset_t const new_fast_writer_offset{idx, 0};
+    aux.advance_db_offsets_to(
+        new_fast_writer_offset, aux.node_writer_slow->sender().offset());
+    std::cout << "Advanced start of fast list offset on disk from ["
+              << fast_writer_offset.id << ", " << fast_writer_offset.offset
+              << "] to the beginning of a new chunk, id: " << idx << std::endl;
+
+    std::cout << "Closing and reopening Db ...\n" << std::endl;
+    aux.unset_io();
+
+    // verifies set_io() succeeds
+    aux.set_io(&io);
+}


### PR DESCRIPTION
Add a test that demonstrates the bad assert triggered when fast writer is advanced to a new chunk with smaller id than last root offset.
Fix the bad assert by comparing using virtual offsets, only that would make sense.