### PR TITLE
trie_db: Write monad consensus headers to database

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -3,6 +3,7 @@
 #include <monad/config.hpp>
 #include <monad/core/address.hpp>
 #include <monad/core/keccak.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/db/trie_db.hpp>
 #include <monad/test/config.hpp>
 
@@ -86,9 +87,33 @@ inline auto const H_CODE_HASH = to_bytes(keccak256(H_CODE));
 inline auto const H_CODE_ANALYSIS =
     std::make_shared<CodeAnalysis>(analyze(H_CODE));
 
+inline void commit_sequential(
+    Db &db, StateDeltas const &deltas, Code const &code,
+    BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
+    std::vector<std::vector<CallFrame>> const &call_frames = {},
+    std::vector<Transaction> const &txns = {},
+    std::vector<BlockHeader> const &ommers = {},
+    std::optional<std::vector<Withdrawal>> const &withdrawals = std::nullopt)
+{
+    auto const consensus_header =
+        MonadConsensusBlockHeader::from_eth_header(eth_header);
+    db.commit(
+        deltas,
+        code,
+        consensus_header,
+        receipts,
+        call_frames,
+        txns,
+        ommers,
+        withdrawals);
+    db.finalize(eth_header.number, consensus_header.round);
+    db.set_block_and_round(eth_header.number);
+}
+
 inline void load_db(TrieDb &db, uint64_t const n)
 {
-    db.commit(
+    commit_sequential(
+        db,
         StateDeltas{
             {ADDR_A,
              StateDelta{

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -6,6 +6,7 @@
 #include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/rlp/block_rlp.hpp>
 #include <monad/db/block_db.hpp>
 #include <monad/db/db.hpp>
@@ -86,13 +87,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
 
         block_state.log_debug();
         block_state.commit(
-            block.header,
+            MonadConsensusBlockHeader::from_eth_header(block.header),
             receipts,
             call_frames,
             block.transactions,
             block.ommers,
-            block.withdrawals,
-            block.header.number);
+            block.withdrawals);
         auto const output_header = db.read_eth_header();
         BOOST_OUTCOME_TRY(
             chain.validate_output_header(block.header, output_header));

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -6,6 +6,7 @@
 #include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/rlp/block_rlp.hpp>
 #include <monad/db/db.hpp>
 #include <monad/execution/block_hash_buffer.hpp>
@@ -129,13 +130,13 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
 
         block_state.log_debug();
         block_state.commit(
-            block.header,
+            MonadConsensusBlockHeader::from_eth_header(
+                block.header), // TODO: remove when we parse consensus blocks
             receipts,
             call_frames,
             block.transactions,
             block.ommers,
-            block.withdrawals,
-            block.header.number);
+            block.withdrawals);
         auto const output_header = db.read_eth_header();
         BOOST_OUTCOME_TRY(
             chain.validate_output_header(block.header, output_header));

--- a/libs/execution/src/monad/core/monad_block.hpp
+++ b/libs/execution/src/monad/core/monad_block.hpp
@@ -74,10 +74,12 @@ struct MonadConsensusBlockHeader
         return qc.vote.round;
     }
 
-    static MonadConsensusBlockHeader
-    from_eth_header(BlockHeader const &eth_header)
+    static MonadConsensusBlockHeader from_eth_header(
+        BlockHeader const &eth_header,
+        std::optional<uint64_t> const round_number = std::nullopt)
     {
-        uint64_t const round = eth_header.number;
+        uint64_t const round =
+            round_number.has_value() ? round_number.value() : eth_header.number;
         uint64_t const parent_round = round - std::min(round, 1ul);
         uint64_t const grandparent_round = round - std::min(round, 2ul);
 

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -6,6 +6,7 @@
 #include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/receipt.hpp>
 #include <monad/core/transaction.hpp>
 #include <monad/core/withdrawal.hpp>
@@ -41,13 +42,12 @@ struct Db
     virtual void update_verified_block(uint64_t block_number) = 0;
 
     virtual void commit(
-        StateDeltas const &, Code const &, BlockHeader const &,
+        StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
         std::vector<Receipt> const & = {},
         std::vector<std::vector<CallFrame>> const & = {},
         std::vector<Transaction> const & = {},
         std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt,
-        std::optional<uint64_t> round_number = std::nullopt) = 0;
+        std::optional<std::vector<Withdrawal>> const & = std::nullopt) = 0;
 
     virtual std::string print_stats()
     {

--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -125,17 +125,17 @@ public:
 
     virtual void commit(
         StateDeltas const &state_deltas, Code const &code,
-        BlockHeader const &header, std::vector<Receipt> const &receipts,
+        MonadConsensusBlockHeader const &consensus_header,
+        std::vector<Receipt> const &receipts,
         std::vector<std::vector<CallFrame>> const &call_frames,
         std::vector<Transaction> const &transactions,
         std::vector<BlockHeader> const &ommers,
-        std::optional<std::vector<Withdrawal>> const &withdrawals,
-        std::optional<uint64_t> const round_number) override
+        std::optional<std::vector<Withdrawal>> const &withdrawals) override
     {
         db_.commit(
             state_deltas,
             code,
-            header,
+            consensus_header,
             receipts,
             call_frames,
             transactions,

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -48,16 +48,13 @@ public:
     virtual void set_block_and_round(
         uint64_t block_number,
         std::optional<uint64_t> round_number = std::nullopt) override;
-    // TODO: remove round_number parameter, retrieve it from header instead once
-    // we add the monad fields in BlockHeader
     virtual void commit(
-        StateDeltas const &, Code const &, BlockHeader const &,
+        StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
         std::vector<Receipt> const & = {},
         std::vector<std::vector<CallFrame>> const & = {},
         std::vector<Transaction> const & = {},
         std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt,
-        std::optional<uint64_t> round_number = std::nullopt) override;
+        std::optional<std::vector<Withdrawal>> const & = std::nullopt) override;
     virtual void
     finalize(uint64_t block_number, uint64_t round_number) override;
     virtual void update_verified_block(uint64_t) override;

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -463,7 +463,8 @@ void MachineBase::down(unsigned char const nibble)
          nibble == RECEIPT_NIBBLE || nibble == CALL_FRAME_NIBBLE ||
          nibble == TRANSACTION_NIBBLE || nibble == BLOCKHEADER_NIBBLE ||
          nibble == WITHDRAWAL_NIBBLE || nibble == OMMER_NIBBLE ||
-         nibble == TX_HASH_NIBBLE || nibble == BLOCK_HASH_NIBBLE) ||
+         nibble == TX_HASH_NIBBLE || nibble == BLOCK_HASH_NIBBLE ||
+         nibble == BFT_BLOCK_NIBBLE) ||
         depth != prefix_length);
     if (MONAD_UNLIKELY(depth == prefix_length)) {
         MONAD_ASSERT(table == TableType::Prefix);
@@ -492,8 +493,8 @@ void MachineBase::down(unsigned char const nibble)
             // No subtrie in the rest tables, thus treated the same as
             // Table::Prefix
             MONAD_ASSERT(
-                nibble == BLOCKHEADER_NIBBLE || nibble == OMMER_NIBBLE ||
-                nibble == CALL_FRAME_NIBBLE);
+                nibble == BLOCKHEADER_NIBBLE || nibble == BFT_BLOCK_NIBBLE ||
+                nibble == OMMER_NIBBLE || nibble == CALL_FRAME_NIBBLE);
         }
     }
 }

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -92,6 +92,7 @@ inline constexpr unsigned char OMMER_NIBBLE = 6;
 inline constexpr unsigned char TX_HASH_NIBBLE = 7;
 inline constexpr unsigned char BLOCK_HASH_NIBBLE = 8;
 inline constexpr unsigned char CALL_FRAME_NIBBLE = 9;
+inline constexpr unsigned char BFT_BLOCK_NIBBLE = 10;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
@@ -104,6 +105,7 @@ inline mpt::Nibbles const ommer_nibbles = mpt::concat(OMMER_NIBBLE);
 inline mpt::Nibbles const withdrawal_nibbles = mpt::concat(WITHDRAWAL_NIBBLE);
 inline mpt::Nibbles const tx_hash_nibbles = mpt::concat(TX_HASH_NIBBLE);
 inline mpt::Nibbles const block_hash_nibbles = mpt::concat(BLOCK_HASH_NIBBLE);
+inline mpt::Nibbles const bft_block_nibbles = mpt::concat(BFT_BLOCK_NIBBLE);
 
 //////////////////////////////////////////////////////////
 // Proposed and finialized subtries. Active on all tables.

--- a/libs/execution/src/monad/execution/test/test_block_hash_buffer.cpp
+++ b/libs/execution/src/monad/execution/test/test_block_hash_buffer.cpp
@@ -2,12 +2,14 @@
 #include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/rlp/block_rlp.hpp>
 #include <monad/db/trie_db.hpp>
 #include <monad/db/util.hpp>
 #include <monad/execution/block_hash_buffer.hpp>
 #include <monad/mpt/db.hpp>
 #include <monad/mpt/ondisk_db_config.hpp>
+#include <test_resource_data.h>
 
 #include <gtest/gtest.h>
 #include <stdlib.h>
@@ -16,6 +18,7 @@
 #include <filesystem>
 
 using namespace monad;
+using namespace monad::test;
 
 TEST(BlockHashBuffer, simple_chain)
 {
@@ -188,8 +191,7 @@ TEST(BlockHashBufferTest, init_from_db)
 
     BlockHashBufferFinalized expected;
     for (uint64_t i = 0; i < 256; ++i) {
-        BlockHeader const hdr{.number = i};
-        tdb.commit({}, {}, hdr, {}, {}, {}, {}, std::nullopt);
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
         expected.set(
             i,
             to_bytes(

--- a/libs/execution/src/monad/execution/test/test_block_reward.cpp
+++ b/libs/execution/src/monad/execution/test/test_block_reward.cpp
@@ -7,6 +7,7 @@
 #include <monad/state2/block_state.hpp>
 #include <monad/state2/state_deltas.hpp>
 #include <monad/state3/state.hpp>
+#include <test_resource_data.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -18,6 +19,7 @@
 #include <optional>
 
 using namespace monad;
+using namespace monad::test;
 
 using db_t = TrieDb;
 
@@ -32,7 +34,8 @@ TEST(BlockReward, apply_block_reward)
         InMemoryMachine machine;
         mpt::Db db{machine};
         db_t tdb{db};
-        tdb.commit(
+        commit_sequential(
+            tdb,
             StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
             Code{},
             BlockHeader{});

--- a/libs/execution/src/monad/execution/test/test_call_trace.cpp
+++ b/libs/execution/src/monad/execution/test/test_call_trace.cpp
@@ -95,7 +95,8 @@ TEST(CallTrace, execute_success)
     mpt::Db db{machine};
     TrieDb tdb{db};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {ADDR_A,
              StateDelta{
@@ -161,7 +162,8 @@ TEST(CallTrace, execute_reverted_insufficient_balance)
     mpt::Db db{machine};
     TrieDb tdb{db};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {ADDR_A,
              StateDelta{

--- a/libs/execution/src/monad/execution/test/test_evm.cpp
+++ b/libs/execution/src/monad/execution/test/test_evm.cpp
@@ -10,6 +10,7 @@
 #include <monad/state2/block_state.hpp>
 #include <monad/state2/state_deltas.hpp>
 #include <monad/state3/state.hpp>
+#include <test_resource_data.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -25,6 +26,7 @@
 #include <utility>
 
 using namespace monad;
+using namespace monad::test;
 
 using db_t = TrieDb;
 
@@ -41,7 +43,8 @@ TEST(Evm, create_with_insufficient)
     static constexpr auto from{
         0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {from,
              StateDelta{
@@ -81,7 +84,8 @@ TEST(Evm, eip684_existing_code)
     static constexpr auto code_hash{
         0x6b8cebdc2590b486457bbb286e96011bdd50ccc1d8580c1ffb3c89e828462283_bytes32};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {from,
              StateDelta{
@@ -121,7 +125,8 @@ TEST(Evm, transfer_call_balances)
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {to, StateDelta{.account = {std::nullopt, Account{}}}},
             {from,
@@ -159,7 +164,8 @@ TEST(Evm, transfer_call_balances_to_self)
     static constexpr auto from{
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
     static constexpr auto to = from;
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {from,
              StateDelta{
@@ -197,7 +203,8 @@ TEST(Evm, dont_transfer_on_delegatecall)
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {to, StateDelta{.account = {std::nullopt, Account{}}}},
             {from,
@@ -237,7 +244,8 @@ TEST(Evm, dont_transfer_on_staticcall)
     static constexpr auto to{
         0xdac17f958d2ee523a2206206994597c13d831ec7_address};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {to, StateDelta{.account = {std::nullopt, Account{}}}},
             {from,
@@ -282,7 +290,8 @@ TEST(Evm, create_nonce_out_of_range)
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {from,
              StateDelta{
@@ -325,7 +334,8 @@ TEST(Evm, static_precompile_execution)
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {code_address,
              StateDelta{.account = {std::nullopt, Account{.nonce = 4}}}},
@@ -374,7 +384,8 @@ TEST(Evm, out_of_gas_static_precompile_execution)
     NoopCallTracer call_tracer;
     evm_host_t h{call_tracer, EMPTY_TX_CONTEXT, block_hash_buffer, s};
 
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{
             {code_address,
              StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}},
@@ -409,7 +420,8 @@ TEST(Evm, deploy_contract_code)
     InMemoryMachine machine;
     mpt::Db db{machine};
     db_t tdb{db};
-    tdb.commit(
+    commit_sequential(
+        tdb,
         StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
         Code{},
         BlockHeader{});

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -192,23 +192,22 @@ void BlockState::merge(State const &state)
 }
 
 void BlockState::commit(
-    BlockHeader const &header, std::vector<Receipt> const &receipts,
+    MonadConsensusBlockHeader const &consensus_header,
+    std::vector<Receipt> const &receipts,
     std::vector<std::vector<CallFrame>> const &call_frames,
     std::vector<Transaction> const &transactions,
     std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals,
-    std::optional<uint64_t> round_number)
+    std::optional<std::vector<Withdrawal>> const &withdrawals)
 {
     db_.commit(
         state_,
         code_,
-        header,
+        consensus_header,
         receipts,
         call_frames,
         transactions,
         ommers,
-        withdrawals,
-        round_number);
+        withdrawals);
 }
 
 void BlockState::log_debug()

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -40,12 +40,11 @@ public:
     // TODO: remove round_number parameter, retrieve it from header instead once
     // we add the monad fields in BlockHeader
     void commit(
-        BlockHeader const &, std::vector<Receipt> const &,
+        MonadConsensusBlockHeader const &, std::vector<Receipt> const &,
         std::vector<std::vector<CallFrame>> const &,
         std::vector<Transaction> const &,
         std::vector<BlockHeader> const &ommers,
-        std::optional<std::vector<Withdrawal>> const &,
-        std::optional<uint64_t> round_number = std::nullopt);
+        std::optional<std::vector<Withdrawal>> const &);
 
     void log_debug();
 };

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -173,25 +173,23 @@ void monad_statesync_server_context::update_verified_block(
 
 void monad_statesync_server_context::commit(
     StateDeltas const &state_deltas, Code const &code,
-    BlockHeader const &header, std::vector<Receipt> const &receipts,
+    MonadConsensusBlockHeader const &consensus_header,
+    std::vector<Receipt> const &receipts,
     std::vector<std::vector<CallFrame>> const &call_frames,
     std::vector<Transaction> const &transactions,
     std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals,
-    std::optional<uint64_t> const round_number)
+    std::optional<std::vector<Withdrawal>> const &withdrawals)
 {
-    on_commit(*this, state_deltas, header.number, round_number.value_or(0));
+    auto &header = consensus_header.execution_inputs;
+
+    on_commit(*this, state_deltas, header.number, consensus_header.round);
     rw.commit(
         state_deltas,
         code,
-        header,
+        consensus_header,
         receipts,
         call_frames,
         transactions,
         ommers,
-        withdrawals,
-        round_number);
-    if (MONAD_UNLIKELY(!round_number.has_value())) {
-        on_finalize(*this, header.number, 0);
-    }
+        withdrawals);
 }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -89,11 +89,11 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual void commit(
         monad::StateDeltas const &state_deltas, monad::Code const &code,
-        monad::BlockHeader const &,
+        monad::MonadConsensusBlockHeader const &,
         std::vector<monad::Receipt> const &receipts = {},
         std::vector<std::vector<monad::CallFrame>> const & = {},
         std::vector<monad::Transaction> const &transactions = {},
         std::vector<monad::BlockHeader> const &ommers = {},
-        std::optional<std::vector<monad::Withdrawal>> const & = std::nullopt,
-        std::optional<uint64_t> round_number = std::nullopt) override;
+        std::optional<std::vector<monad::Withdrawal>> const & =
+            std::nullopt) override;
 };

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -80,12 +80,13 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
 
     block_state.log_debug();
     block_state.commit(
-        block.header,
+        MonadConsensusBlockHeader::from_eth_header(block.header),
         receipts,
         call_frames,
         block.transactions,
         block.ommers,
         block.withdrawals);
+    db.finalize(block.header.number, block.header.number);
 
     auto output_header = db.read_eth_header();
     BOOST_OUTCOME_TRY(
@@ -229,13 +230,13 @@ void BlockchainTest::TestBody()
             load_state_from_json(j_contents.at("pre"), state);
             bs.merge(state);
             bs.commit(
-                header,
+                MonadConsensusBlockHeader::from_eth_header(header),
                 {} /* receipts */,
                 {} /* call frames */,
                 {} /* transactions */,
                 {} /* ommers */,
-                withdrawals,
-                std::nullopt);
+                withdrawals);
+            tdb.finalize(0, 0);
             ASSERT_EQ(
                 to_bytes(
                     keccak256(rlp::encode_block_header(tdb.read_eth_header()))),


### PR DESCRIPTION
TrieDb: Commit to MonadConsensusBlockHeader instead of BlockHeader
    
commit() populates the outputs of the eth header. Take that from `MonadConsensusBlockHeader.execution_inputs`.