### PR TITLE
store tx and recovered sender address together in db

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -91,6 +91,7 @@ inline void commit_sequential(
     Db &db, StateDeltas const &deltas, Code const &code,
     BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
     std::vector<std::vector<CallFrame>> const &call_frames = {},
+    std::vector<Address> const &senders = {},
     std::vector<Transaction> const &txns = {},
     std::vector<BlockHeader> const &ommers = {},
     std::optional<std::vector<Withdrawal>> const &withdrawals = std::nullopt)
@@ -103,6 +104,7 @@ inline void commit_sequential(
         consensus_header,
         receipts,
         call_frames,
+        senders,
         txns,
         ommers,
         withdrawals);

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -79,10 +79,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
 
         std::vector<Receipt> receipts(results.size());
         std::vector<std::vector<CallFrame>> call_frames(results.size());
+        std::vector<Address> senders(results.size());
         for (unsigned i = 0; i < results.size(); ++i) {
             auto &result = results[i];
             receipts[i] = std::move(result.receipt);
             call_frames[i] = (std::move(result.call_frames));
+            senders[i] = result.sender;
         }
 
         block_state.log_debug();
@@ -90,6 +92,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
             MonadConsensusBlockHeader::from_eth_header(block.header),
             receipts,
             call_frames,
+            senders,
             block.transactions,
             block.ommers,
             block.withdrawals);

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -122,10 +122,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
 
         std::vector<Receipt> receipts(results.size());
         std::vector<std::vector<CallFrame>> call_frames(results.size());
+        std::vector<Address> senders(results.size());
         for (unsigned i = 0; i < results.size(); ++i) {
             auto &result = results[i];
             receipts[i] = std::move(result.receipt);
             call_frames[i] = (std::move(result.call_frames));
+            senders[i] = result.sender;
         }
 
         block_state.log_debug();
@@ -134,6 +136,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 block.header), // TODO: remove when we parse consensus blocks
             receipts,
             call_frames,
+            senders,
             block.transactions,
             block.ommers,
             block.withdrawals);

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -45,6 +45,7 @@ struct Db
         StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
         std::vector<Receipt> const & = {},
         std::vector<std::vector<CallFrame>> const & = {},
+        std::vector<Address> const & = {},
         std::vector<Transaction> const & = {},
         std::vector<BlockHeader> const &ommers = {},
         std::optional<std::vector<Withdrawal>> const & = std::nullopt) = 0;

--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -128,6 +128,7 @@ public:
         MonadConsensusBlockHeader const &consensus_header,
         std::vector<Receipt> const &receipts,
         std::vector<std::vector<CallFrame>> const &call_frames,
+        std::vector<Address> const &senders,
         std::vector<Transaction> const &transactions,
         std::vector<BlockHeader> const &ommers,
         std::optional<std::vector<Withdrawal>> const &withdrawals) override
@@ -138,6 +139,7 @@ public:
             consensus_header,
             receipts,
             call_frames,
+            senders,
             transactions,
             ommers,
             withdrawals);

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -52,6 +52,7 @@ public:
         StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
         std::vector<Receipt> const & = {},
         std::vector<std::vector<CallFrame>> const & = {},
+        std::vector<Address> const & = {},
         std::vector<Transaction> const & = {},
         std::vector<BlockHeader> const &ommers = {},
         std::optional<std::vector<Withdrawal>> const & = std::nullopt) override;

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -125,6 +125,8 @@ Result<std::pair<bytes32_t, bytes32_t>> decode_storage_db(byte_string_view &);
 Result<byte_string_view> decode_storage_db_ignore_slot(byte_string_view &);
 
 Result<std::pair<Receipt, size_t>> decode_receipt_db(byte_string_view &);
+Result<std::pair<Transaction, Address>>
+decode_transaction_db(byte_string_view &);
 
 void write_to_file(
     nlohmann::json const &, std::filesystem::path const &,

--- a/libs/execution/src/monad/execution/execute_block.cpp
+++ b/libs/execution/src/monad/execution/execute_block.cpp
@@ -182,7 +182,7 @@ Result<std::vector<ExecutionResult>> execute_block(
 
     // YP eq. 22
     uint64_t cumulative_gas_used = 0;
-    for (auto &[receipt, call_frame] : retvals) {
+    for (auto &[receipt, _, call_frame] : retvals) {
         cumulative_gas_used += receipt.gas_used;
         receipt.gas_used = cumulative_gas_used;
     }

--- a/libs/execution/src/monad/execution/execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/execute_transaction.cpp
@@ -243,6 +243,7 @@ Result<ExecutionResult> execute_impl(
             auto const frames = call_tracer.get_frames();
             return ExecutionResult{
                 .receipt = receipt,
+                .sender = sender,
                 .call_frames = {frames.begin(), frames.end()}};
         }
     }
@@ -276,7 +277,9 @@ Result<ExecutionResult> execute_impl(
 
         auto const frames = call_tracer.get_frames();
         return ExecutionResult{
-            .receipt = receipt, .call_frames = {frames.begin(), frames.end()}};
+            .receipt = receipt,
+            .sender = sender,
+            .call_frames = {frames.begin(), frames.end()}};
     }
 }
 

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -29,6 +29,7 @@ struct EvmcHost;
 struct ExecutionResult
 {
     Receipt receipt;
+    Address sender;
     std::vector<CallFrame> call_frames;
 };
 

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -195,6 +195,7 @@ void BlockState::commit(
     MonadConsensusBlockHeader const &consensus_header,
     std::vector<Receipt> const &receipts,
     std::vector<std::vector<CallFrame>> const &call_frames,
+    std::vector<Address> const &senders,
     std::vector<Transaction> const &transactions,
     std::vector<BlockHeader> const &ommers,
     std::optional<std::vector<Withdrawal>> const &withdrawals)
@@ -205,6 +206,7 @@ void BlockState::commit(
         consensus_header,
         receipts,
         call_frames,
+        senders,
         transactions,
         ommers,
         withdrawals);

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -42,7 +42,7 @@ public:
     void commit(
         MonadConsensusBlockHeader const &, std::vector<Receipt> const &,
         std::vector<std::vector<CallFrame>> const &,
-        std::vector<Transaction> const &,
+        std::vector<Address> const &, std::vector<Transaction> const &,
         std::vector<BlockHeader> const &ommers,
         std::optional<std::vector<Withdrawal>> const &);
 

--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -493,7 +493,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(
@@ -535,7 +535,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
@@ -570,7 +570,7 @@ TYPED_TEST(StateTest, selfdestruct_create_destroy_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(
@@ -1125,7 +1125,7 @@ TYPED_TEST(StateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    bs.commit({}, {}, {}, {}, {}, std::nullopt);
+    bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
     this->tdb.finalize(0, 0);
     this->tdb.set_block_and_round(0);
 
@@ -1144,7 +1144,7 @@ TYPED_TEST(StateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    bs.commit({}, {}, {}, {}, {}, std::nullopt);
+    bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
 
     EXPECT_EQ(
         this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
@@ -1195,6 +1195,7 @@ TYPED_TEST(StateTest, commit_twice)
             {},
             {},
             {},
+            {},
             {});
         this->tdb.finalize(10, 5);
 
@@ -1215,6 +1216,7 @@ TYPED_TEST(StateTest, commit_twice)
         bs.merge(cs);
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 6),
+            {},
             {},
             {},
             {},
@@ -1263,6 +1265,7 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
             BlockHeader{.number = 10}, 5),
         {},
         {},
+        {},
         {});
     {
         // set to block 10 round 5
@@ -1280,6 +1283,7 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
         // Commit block 11 round 8 on top of block 10 round 5
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 8),
+            {},
             {},
             {},
             {},
@@ -1312,6 +1316,7 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
             {},
             {},
             {},
+            {},
             {});
 
         EXPECT_EQ(this->tdb.read_account(b).value().balance, 84'000);
@@ -1339,6 +1344,7 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
         // Commit block 11 round 7 on top of block 10 round 5
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 7),
+            {},
             {},
             {},
             {},

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -176,6 +176,7 @@ void monad_statesync_server_context::commit(
     MonadConsensusBlockHeader const &consensus_header,
     std::vector<Receipt> const &receipts,
     std::vector<std::vector<CallFrame>> const &call_frames,
+    std::vector<Address> const &senders,
     std::vector<Transaction> const &transactions,
     std::vector<BlockHeader> const &ommers,
     std::optional<std::vector<Withdrawal>> const &withdrawals)
@@ -189,6 +190,7 @@ void monad_statesync_server_context::commit(
         consensus_header,
         receipts,
         call_frames,
+        senders,
         transactions,
         ommers,
         withdrawals);

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -92,6 +92,7 @@ struct monad_statesync_server_context final : public monad::Db
         monad::MonadConsensusBlockHeader const &,
         std::vector<monad::Receipt> const &receipts = {},
         std::vector<std::vector<monad::CallFrame>> const & = {},
+        std::vector<monad::Address> const & = {},
         std::vector<monad::Transaction> const &transactions = {},
         std::vector<monad::BlockHeader> const &ommers = {},
         std::optional<std::vector<monad::Withdrawal>> const & =

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -73,9 +73,11 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
             chain, block, block_state, block_hash_buffer, *pool_));
     std::vector<Receipt> receipts(results.size());
     std::vector<std::vector<CallFrame>> call_frames(results.size());
+    std::vector<Address> senders(results.size());
     for (unsigned i = 0; i < results.size(); ++i) {
         receipts[i] = std::move(results[i].receipt);
         call_frames[i] = std::move(results[i].call_frames);
+        senders[i] = results[i].sender;
     }
 
     block_state.log_debug();
@@ -83,6 +85,7 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
         MonadConsensusBlockHeader::from_eth_header(block.header),
         receipts,
         call_frames,
+        senders,
         block.transactions,
         block.ommers,
         block.withdrawals);
@@ -233,6 +236,7 @@ void BlockchainTest::TestBody()
                 MonadConsensusBlockHeader::from_eth_header(header),
                 {} /* receipts */,
                 {} /* call frames */,
+                {} /* senders */,
                 {} /* transactions */,
                 {} /* ommers */,
                 withdrawals);


### PR DESCRIPTION
**Transaction table**
```
key: rlp(txIndex)
value: rlp([rlp_encode_string(encoded_transaction), rlp(sender_addr)])
```

**Tests:**
- existing units passed shows transactions_root calculation remain correct. 
- add unit tests to and verifies read and decode tx from db works correctly
- locally run replay from 12M (after Byzantium fork) with local changes to verify transaction and sender address read from db are correct.