### PR TITLE
Make TrieDb::commit() atomic from reader's perspective

### DIFF
--- a/libs/db/src/monad/mpt/db.cpp
+++ b/libs/db/src/monad/mpt/db.cpp
@@ -28,6 +28,8 @@
 #include <boost/container/deque.hpp>
 #include <boost/fiber/operations.hpp>
 
+#include <quill/Quill.h>
+
 #include <atomic>
 #include <cerrno>
 #include <chrono>
@@ -72,8 +74,8 @@ struct Db::Impl
     virtual Node::UniquePtr &root() = 0;
     virtual UpdateAux<> &aux() = 0;
     virtual void upsert_fiber_blocking(
-        UpdateList &&, uint64_t, bool enable_compaction,
-        bool can_write_to_fast) = 0;
+        UpdateList &&, uint64_t, bool enable_compaction, bool can_write_to_fast,
+        bool write_root) = 0;
     virtual void copy_trie_fiber_blocking(
         uint64_t src_version, NibblesView src, uint64_t dest_version,
         NibblesView dest, bool blocked_by_write = true) = 0;
@@ -153,7 +155,7 @@ struct Db::ROOnDisk final : public Db::Impl
     }
 
     virtual void
-    upsert_fiber_blocking(UpdateList &&, uint64_t, bool, bool) override
+    upsert_fiber_blocking(UpdateList &&, uint64_t, bool, bool, bool) override
     {
         MONAD_ASSERT(false);
     }
@@ -278,7 +280,7 @@ struct Db::InMemory final : public Db::Impl
     }
 
     virtual void upsert_fiber_blocking(
-        UpdateList &&list, uint64_t const version, bool, bool) override
+        UpdateList &&list, uint64_t const version, bool, bool, bool) override
     {
         root_ = aux_.do_update(
             std::move(root_), machine_, std::move(list), version, false);
@@ -352,6 +354,7 @@ struct Db::RWOnDisk final : public Db::Impl
         uint64_t const version;
         bool const enable_compaction;
         bool const can_write_to_fast;
+        bool const write_root;
     };
 
     struct FiberCopyTrieRequest
@@ -518,7 +521,8 @@ struct Db::RWOnDisk final : public Db::Impl
                             std::move(req->updates),
                             req->version,
                             compaction && req->enable_compaction,
-                            req->can_write_to_fast));
+                            req->can_write_to_fast,
+                            req->write_root));
                     }
                     else if (auto *req = std::get_if<3>(&request.front());
                              req != nullptr) {
@@ -650,6 +654,7 @@ struct Db::RWOnDisk final : public Db::Impl
     StateMachine &machine_;
     Node::UniquePtr root_; // owned by worker thread
     uint64_t root_version_{INVALID_BLOCK_ID};
+    uint64_t unflushed_version_{INVALID_BLOCK_ID};
 
     RWOnDisk(OnDiskDbConfig const &options, StateMachine &machine)
         : worker_thread_([&] {
@@ -690,6 +695,7 @@ struct Db::RWOnDisk final : public Db::Impl
                        : Node::UniquePtr{};
         }())
         , root_version_(aux_.db_history_max_version())
+        , unflushed_version_{INVALID_BLOCK_ID}
     {
     }
 
@@ -736,8 +742,23 @@ struct Db::RWOnDisk final : public Db::Impl
     // threadsafe
     virtual void upsert_fiber_blocking(
         UpdateList &&updates, uint64_t const version,
-        bool const enable_compaction, bool const can_write_to_fast) override
+        bool const enable_compaction, bool const can_write_to_fast,
+        bool const write_root) override
     {
+        if (unflushed_version_ != INVALID_BLOCK_ID) {
+            if (unflushed_version_ != version) {
+                LOG_WARNING_CFORMAT(
+                    "Update version %lu while db hasn't flushed the last "
+                    "update on "
+                    "version %lu, the unflushed progress will be lost after "
+                    "this point",
+                    version,
+                    unflushed_version_);
+            }
+            if (write_root) {
+                unflushed_version_ = INVALID_BLOCK_ID;
+            }
+        }
         // reload root to handle out-of-order upserts
         if (version != root_version_ &&
             (version != root_version_ + 1 ||
@@ -753,7 +774,8 @@ struct Db::RWOnDisk final : public Db::Impl
             .updates = std::move(updates),
             .version = version,
             .enable_compaction = enable_compaction,
-            .can_write_to_fast = can_write_to_fast});
+            .can_write_to_fast = can_write_to_fast,
+            .write_root = write_root});
         // promise is racily emptied after this point
         if (worker_->sleeping.load(std::memory_order_acquire)) {
             std::unique_lock const g(lock_);
@@ -761,6 +783,9 @@ struct Db::RWOnDisk final : public Db::Impl
         }
         root_ = fut.get();
         root_version_ = version;
+        if (!write_root) {
+            unflushed_version_ = version;
+        }
     }
 
     virtual void move_trie_version_fiber_blocking(
@@ -988,11 +1013,15 @@ Db::get_data(NibblesView const key, uint64_t const block_id) const
 
 void Db::upsert(
     UpdateList list, uint64_t const block_id, bool const enable_compaction,
-    bool const can_write_to_fast)
+    bool const can_write_to_fast, bool const write_root)
 {
     MONAD_ASSERT(impl_);
     impl_->upsert_fiber_blocking(
-        std::move(list), block_id, enable_compaction, can_write_to_fast);
+        std::move(list),
+        block_id,
+        enable_compaction,
+        can_write_to_fast,
+        write_root);
 }
 
 void Db::copy_trie(

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -65,7 +65,7 @@ public:
 
     void upsert(
         UpdateList, uint64_t block_id, bool enable_compaction = true,
-        bool can_write_to_fast = true);
+        bool can_write_to_fast = true, bool write_root = true);
 
     void update_finalized_block(uint64_t);
     void update_verified_block(uint64_t);

--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -532,7 +532,7 @@ public:
     Node::UniquePtr do_update(
         Node::UniquePtr prev_root, StateMachine &, UpdateList &&,
         uint64_t version, bool compaction = false,
-        bool can_write_to_fast = true);
+        bool can_write_to_fast = true, bool write_root = true);
 
     void adjust_history_length_based_on_disk_usage();
     void move_trie_version_forward(uint64_t src, uint64_t dest);
@@ -998,7 +998,7 @@ void async_read(UpdateAuxImpl &aux, Receiver &&receiver)
 // batch upsert, updates can be nested
 Node::UniquePtr upsert(
     UpdateAuxImpl &, uint64_t, StateMachine &, Node::UniquePtr old,
-    UpdateList &&);
+    UpdateList &&, bool write_root = true);
 
 // Performs a deep copy of a subtrie from `src_root` trie at
 // `src_prefix` to the `dest_root` trie at `dest_prefix`.

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -963,7 +963,8 @@ the middle of a continuous history.
 */
 Node::UniquePtr UpdateAuxImpl::do_update(
     Node::UniquePtr prev_root, StateMachine &sm, UpdateList &&updates,
-    uint64_t const version, bool const compaction, bool const can_write_to_fast)
+    uint64_t const version, bool const compaction, bool const can_write_to_fast,
+    bool const write_root)
 {
     auto g(unique_lock());
     auto g2(set_current_upsert_tid());
@@ -1018,7 +1019,12 @@ Node::UniquePtr UpdateAuxImpl::do_update(
 
     auto upsert_begin = std::chrono::steady_clock::now();
     auto root = upsert(
-        *this, version, sm, std::move(prev_root), std::move(root_updates));
+        *this,
+        version,
+        sm,
+        std::move(prev_root),
+        std::move(root_updates),
+        write_root);
     set_auto_expire_version_metadata(curr_upsert_auto_expire_version);
 
     auto const duration = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -377,7 +377,7 @@ void TrieDb::commit(
         .next = std::move(updates),
         .version = static_cast<int64_t>(block_number_)}));
 
-    db_.upsert(std::move(ls), block_number_);
+    db_.upsert(std::move(ls), block_number_, true, true, false);
 
     BlockHeader complete_header = header;
     if (MONAD_LIKELY(header.receipts_root == NULL_ROOT)) {


### PR DESCRIPTION
guarantees no intermediate state will be read at any time:
- add `bool write_root` option to Db::upsert(),
- change the first upsert in `TrieDb::commit()` to not write root to disk
- unit test to verify no intermediate state can be seen from reader when upsert with `write_root = false` 