### PR TITLE
[NFCI] Rename ExecutionResult to TxnExecOutput and pass that around freely

### DIFF
--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -10,8 +10,12 @@
 #include <evmc/evmc.h>
 
 #include <filesystem>
+#include <optional>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
+
+struct TxnExecOutput;
 
 namespace test_resource
 {
@@ -89,12 +93,10 @@ inline auto const H_CODE_ANALYSIS =
 
 inline void commit_sequential(
     Db &db, StateDeltas const &deltas, Code const &code,
-    BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
-    std::vector<std::vector<CallFrame>> const &call_frames = {},
-    std::vector<Address> const &senders = {},
-    std::vector<Transaction> const &txns = {},
-    std::vector<BlockHeader> const &ommers = {},
-    std::optional<std::vector<Withdrawal>> const &withdrawals = std::nullopt)
+    BlockHeader const &eth_header, std::span<Transaction const> txns = {},
+    std::span<TxnExecOutput const> txn_exec_outputs = {},
+    std::span<BlockHeader const> ommers = {},
+    std::optional<std::span<Withdrawal const>> withdrawals = std::nullopt)
 {
     auto const consensus_header =
         MonadConsensusBlockHeader::from_eth_header(eth_header);
@@ -102,10 +104,8 @@ inline void commit_sequential(
         deltas,
         code,
         consensus_header,
-        receipts,
-        call_frames,
-        senders,
         txns,
+        txn_exec_outputs,
         ommers,
         withdrawals);
     db.finalize(eth_header.number, consensus_header.round);

--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(
   "src/monad/execution/transaction_gas.hpp"
   "src/monad/execution/tx_context.cpp"
   "src/monad/execution/tx_context.hpp"
+  "src/monad/execution/txn_exec_output.hpp"
   "src/monad/execution/validate_block.cpp"
   "src/monad/execution/validate_block.hpp"
   "src/monad/execution/validate_transaction.cpp"

--- a/libs/execution/src/monad/core/rlp/block_rlp.cpp
+++ b/libs/execution/src/monad/core/rlp/block_rlp.cpp
@@ -71,7 +71,7 @@ byte_string encode_block_header(BlockHeader const &block_header)
     return encode_list2(encoded_block_header);
 }
 
-byte_string encode_ommers(std::vector<BlockHeader> const &ommers)
+byte_string encode_ommers(std::span<BlockHeader const> ommers)
 {
     byte_string encoded;
     for (auto const &ommer : ommers) {

--- a/libs/execution/src/monad/core/rlp/block_rlp.hpp
+++ b/libs/execution/src/monad/core/rlp/block_rlp.hpp
@@ -1,17 +1,22 @@
 #pragma once
 
-#include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/result.hpp>
 #include <monad/rlp/config.hpp>
 
+#include <span>
 #include <vector>
+
+MONAD_NAMESPACE_BEGIN
+struct BlockHeader;
+struct Block;
+MONAD_NAMESPACE_END
 
 MONAD_RLP_NAMESPACE_BEGIN
 
 byte_string encode_block_header(BlockHeader const &);
 byte_string encode_block(Block const &);
-byte_string encode_ommers(std::vector<BlockHeader> const &);
+byte_string encode_ommers(std::span<BlockHeader const>);
 
 Result<Block> decode_block(byte_string_view &);
 Result<BlockHeader> decode_block_header(byte_string_view &);

--- a/libs/execution/src/monad/db/db.hpp
+++ b/libs/execution/src/monad/db/db.hpp
@@ -3,22 +3,24 @@
 #include <monad/config.hpp>
 #include <monad/core/account.hpp>
 #include <monad/core/address.hpp>
-#include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/bytes.hpp>
-#include <monad/core/monad_block.hpp>
-#include <monad/core/receipt.hpp>
-#include <monad/core/transaction.hpp>
 #include <monad/core/withdrawal.hpp>
 #include <monad/execution/code_analysis.hpp>
-#include <monad/execution/trace/call_frame.hpp>
 #include <monad/state2/state_deltas.hpp>
 
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
+
+struct BlockHeader;
+struct MonadConsensusBlockHeader;
+struct Transaction;
+struct TxnExecOutput;
+struct Withdrawal;
 
 struct Db
 {
@@ -43,12 +45,9 @@ struct Db
 
     virtual void commit(
         StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
-        std::vector<Receipt> const & = {},
-        std::vector<std::vector<CallFrame>> const & = {},
-        std::vector<Address> const & = {},
-        std::vector<Transaction> const & = {},
-        std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt) = 0;
+        std::span<Transaction const> = {}, std::span<TxnExecOutput const> = {},
+        std::span<BlockHeader const> ommers = {},
+        std::optional<std::span<Withdrawal const>> = std::nullopt) = 0;
 
     virtual std::string print_stats()
     {

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -1,30 +1,30 @@
 #pragma once
 
 #include <monad/config.hpp>
-#include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/keccak.hpp>
-#include <monad/core/receipt.hpp>
-#include <monad/core/transaction.hpp>
 #include <monad/db/db.hpp>
 #include <monad/db/util.hpp>
 #include <monad/execution/code_analysis.hpp>
-#include <monad/execution/trace/call_frame.hpp>
 #include <monad/mpt/compute.hpp>
 #include <monad/mpt/db.hpp>
 #include <monad/mpt/ondisk_db_config.hpp>
 #include <monad/mpt/state_machine.hpp>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <deque>
 #include <istream>
 #include <memory>
 #include <optional>
+#include <span>
 #include <utility>
-#include <vector>
 
 MONAD_NAMESPACE_BEGIN
+
+struct BlockHeader;
+struct Transaction;
+struct TxnExecOutput;
 
 class TrieDb final : public ::monad::Db
 {
@@ -50,12 +50,9 @@ public:
         std::optional<uint64_t> round_number = std::nullopt) override;
     virtual void commit(
         StateDeltas const &, Code const &, MonadConsensusBlockHeader const &,
-        std::vector<Receipt> const & = {},
-        std::vector<std::vector<CallFrame>> const & = {},
-        std::vector<Address> const & = {},
-        std::vector<Transaction> const & = {},
-        std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt) override;
+        std::span<Transaction const> = {}, std::span<TxnExecOutput const> = {},
+        std::span<BlockHeader const> ommers = {},
+        std::optional<std::span<Withdrawal const>> = std::nullopt) override;
     virtual void
     finalize(uint64_t block_number, uint64_t round_number) override;
     virtual void update_verified_block(uint64_t) override;

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -16,6 +16,8 @@
 MONAD_NAMESPACE_BEGIN
 
 struct BlockHeader;
+struct Receipt;
+struct Transaction;
 
 struct MachineBase : public mpt::StateMachine
 {

--- a/libs/execution/src/monad/execution/execute_block.hpp
+++ b/libs/execution/src/monad/execution/execute_block.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <monad/config.hpp>
-#include <monad/core/receipt.hpp>
 #include <monad/core/result.hpp>
-#include <monad/execution/trace/call_tracer.hpp>
 #include <monad/fiber/priority_pool.hpp>
 
 #include <evmc/evmc.h>
@@ -15,14 +13,14 @@ MONAD_NAMESPACE_BEGIN
 struct Block;
 class BlockHashBuffer;
 class BlockState;
-struct ExecutionResult;
+struct TxnExecOutput;
 
 template <evmc_revision rev>
-Result<std::vector<ExecutionResult>> execute_block(
+Result<std::vector<TxnExecOutput>> execute_block(
     Chain const &, Block &, BlockState &, BlockHashBuffer const &,
     fiber::PriorityPool &);
 
-Result<std::vector<ExecutionResult>> execute_block(
+Result<std::vector<TxnExecOutput>> execute_block(
     Chain const &, evmc_revision, Block &, BlockState &,
     BlockHashBuffer const &, fiber::PriorityPool &);
 

--- a/libs/execution/src/monad/execution/execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/execute_transaction.cpp
@@ -16,6 +16,7 @@
 #include <monad/execution/trace/event_trace.hpp>
 #include <monad/execution/transaction_gas.hpp>
 #include <monad/execution/tx_context.hpp>
+#include <monad/execution/txn_exec_output.hpp>
 #include <monad/execution/validate_transaction.hpp>
 #include <monad/state3/state.hpp>
 
@@ -197,7 +198,7 @@ Result<evmc::Result> execute_impl2(
 }
 
 template <evmc_revision rev>
-Result<ExecutionResult> execute_impl(
+Result<TxnExecOutput> execute_impl(
     Chain const &chain, uint64_t const i, Transaction const &tx,
     Address const &sender, BlockHeader const &hdr,
     BlockHashBuffer const &block_hash_buffer, BlockState &block_state,
@@ -241,7 +242,7 @@ Result<ExecutionResult> execute_impl(
             block_state.merge(state);
 
             auto const frames = call_tracer.get_frames();
-            return ExecutionResult{
+            return TxnExecOutput{
                 .receipt = receipt,
                 .sender = sender,
                 .call_frames = {frames.begin(), frames.end()}};
@@ -276,7 +277,7 @@ Result<ExecutionResult> execute_impl(
         block_state.merge(state);
 
         auto const frames = call_tracer.get_frames();
-        return ExecutionResult{
+        return TxnExecOutput{
             .receipt = receipt,
             .sender = sender,
             .call_frames = {frames.begin(), frames.end()}};
@@ -286,7 +287,7 @@ Result<ExecutionResult> execute_impl(
 EXPLICIT_EVMC_REVISION(execute_impl);
 
 template <evmc_revision rev>
-Result<ExecutionResult> execute(
+Result<TxnExecOutput> execute(
     Chain const &chain, uint64_t const i, Transaction const &tx,
     std::optional<Address> const &sender, BlockHeader const &hdr,
     BlockHashBuffer const &block_hash_buffer, BlockState &block_state,

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -3,9 +3,7 @@
 #include <monad/config.hpp>
 #include <monad/core/address.hpp>
 #include <monad/core/int.hpp>
-#include <monad/core/receipt.hpp>
 #include <monad/core/result.hpp>
-#include <monad/execution/trace/call_frame.hpp>
 
 #include <evmc/evmc.h>
 
@@ -19,19 +17,12 @@ class BlockHashBuffer;
 struct BlockHeader;
 class BlockState;
 struct Chain;
-struct Receipt;
 class State;
 struct Transaction;
+struct TxnExecOutput;
 
 template <evmc_revision rev>
 struct EvmcHost;
-
-struct ExecutionResult
-{
-    Receipt receipt;
-    Address sender;
-    std::vector<CallFrame> call_frames;
-};
 
 template <evmc_revision rev>
 evmc::Result execute_impl_no_validation(
@@ -40,13 +31,13 @@ evmc::Result execute_impl_no_validation(
     Address const &beneficiary);
 
 template <evmc_revision rev>
-Result<ExecutionResult> execute_impl(
+Result<TxnExecOutput> execute_impl(
     Chain const &, uint64_t i, Transaction const &, Address const &sender,
     BlockHeader const &, BlockHashBuffer const &, BlockState &,
     boost::fibers::promise<void> &prev);
 
 template <evmc_revision rev>
-Result<ExecutionResult> execute(
+Result<TxnExecOutput> execute(
     Chain const &, uint64_t i, Transaction const &,
     std::optional<Address> const &, BlockHeader const &,
     BlockHashBuffer const &, BlockState &, boost::fibers::promise<void> &prev);

--- a/libs/execution/src/monad/execution/test/test_call_trace.cpp
+++ b/libs/execution/src/monad/execution/test/test_call_trace.cpp
@@ -5,6 +5,7 @@
 #include <monad/execution/block_hash_buffer.hpp>
 #include <monad/execution/evmc_host.hpp>
 #include <monad/execution/execute_transaction.hpp>
+#include <monad/execution/trace/call_frame.hpp>
 #include <monad/execution/trace/call_tracer.hpp>
 #include <monad/state2/block_state.hpp>
 #include <monad/state3/state.hpp>

--- a/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
@@ -7,6 +7,7 @@
 #include <monad/execution/evmc_host.hpp>
 #include <monad/execution/execute_transaction.hpp>
 #include <monad/execution/tx_context.hpp>
+#include <monad/execution/txn_exec_output.hpp>
 #include <monad/execution/validate_transaction.hpp>
 #include <monad/state2/block_state.hpp>
 #include <monad/state3/state.hpp>

--- a/libs/execution/src/monad/execution/trace/call_frame.hpp
+++ b/libs/execution/src/monad/execution/trace/call_frame.hpp
@@ -6,7 +6,7 @@
 #include <monad/core/int.hpp>
 
 #include <evmc/evmc.hpp>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <optional>
 

--- a/libs/execution/src/monad/execution/txn_exec_output.hpp
+++ b/libs/execution/src/monad/execution/txn_exec_output.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <monad/core/address.hpp>
+#include <monad/core/receipt.hpp>
+#include <monad/execution/trace/call_frame.hpp>
+#include <vector>
+
+#include <monad/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+/// Type which holds all the results calculated during transaction execution.
+///
+/// These are only produced for valid transactions that execute "without error".
+/// "Without error" does not mean "success": it means the transaction produced
+/// a receipt and can be included in a block. This includes "failed"
+/// transactions, which are valid transactions that reach an exceptional
+/// halting state in the EVM (e.g., out of gas) and report the EIP-658 status
+/// "failed" status code.
+///
+/// "With error" means something went wrong elsewhere: an invalid transaction
+/// or an internal system error. In this case, an instance of this type should
+/// not be constructed.
+struct TxnExecOutput
+{
+    Receipt receipt;
+    Address sender;
+    std::vector<CallFrame> call_frames;
+};
+
+MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/validate_block.cpp
+++ b/libs/execution/src/monad/execution/validate_block.cpp
@@ -34,18 +34,15 @@ MONAD_NAMESPACE_BEGIN
 
 using BOOST_OUTCOME_V2_NAMESPACE::success;
 
-Receipt::Bloom compute_bloom(std::vector<Receipt> const &receipts)
+Receipt::Bloom &bloom_combine(Receipt::Bloom &lhs, Receipt::Bloom const &rhs)
 {
-    Receipt::Bloom bloom{};
-    for (auto const &receipt : receipts) {
-        for (unsigned i = 0; i < bloom.size(); ++i) {
-            bloom[i] |= receipt.bloom[i];
-        }
+    for (unsigned i = 0; i < lhs.size(); ++i) {
+        lhs[i] |= rhs[i];
     }
-    return bloom;
+    return lhs;
 }
 
-bytes32_t compute_ommers_hash(std::vector<BlockHeader> const &ommers)
+bytes32_t compute_ommers_hash(std::span<BlockHeader const> ommers)
 {
     if (ommers.empty()) {
         return NULL_LIST_HASH;

--- a/libs/execution/src/monad/execution/validate_block.hpp
+++ b/libs/execution/src/monad/execution/validate_block.hpp
@@ -17,7 +17,7 @@
 #endif
 
 #include <initializer_list>
-#include <vector>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -45,9 +45,9 @@ enum class BlockError
 struct Block;
 struct BlockHeader;
 
-Receipt::Bloom compute_bloom(std::vector<Receipt> const &);
+Receipt::Bloom &bloom_combine(Receipt::Bloom &, Receipt::Bloom const &);
 
-bytes32_t compute_ommers_hash(std::vector<BlockHeader> const &);
+bytes32_t compute_ommers_hash(std::span<BlockHeader const>);
 
 template <evmc_revision rev>
 Result<void> static_validate_header(BlockHeader const &);

--- a/libs/execution/src/monad/state2/block_state.cpp
+++ b/libs/execution/src/monad/state2/block_state.cpp
@@ -193,21 +193,17 @@ void BlockState::merge(State const &state)
 
 void BlockState::commit(
     MonadConsensusBlockHeader const &consensus_header,
-    std::vector<Receipt> const &receipts,
-    std::vector<std::vector<CallFrame>> const &call_frames,
-    std::vector<Address> const &senders,
-    std::vector<Transaction> const &transactions,
-    std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals)
+    std::span<Transaction const> transactions,
+    std::span<TxnExecOutput const> txn_exec_outputs,
+    std::span<BlockHeader const> ommers,
+    std::optional<std::span<Withdrawal const>> withdrawals)
 {
     db_.commit(
         state_,
         code_,
         consensus_header,
-        receipts,
-        call_frames,
-        senders,
         transactions,
+        txn_exec_outputs,
         ommers,
         withdrawals);
 }

--- a/libs/execution/src/monad/state2/block_state.hpp
+++ b/libs/execution/src/monad/state2/block_state.hpp
@@ -1,22 +1,23 @@
 #pragma once
 
 #include <monad/config.hpp>
-#include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
-#include <monad/core/receipt.hpp>
-#include <monad/core/transaction.hpp>
 #include <monad/db/db.hpp>
 #include <monad/execution/code_analysis.hpp>
-#include <monad/execution/trace/call_tracer.hpp>
 #include <monad/state2/state_deltas.hpp>
 #include <monad/types/incarnation.hpp>
 
 #include <memory>
-#include <vector>
+#include <optional>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
 
+struct BlockHeader;
 class State;
+struct Transaction;
+struct TxnExecOutput;
+struct Withdrawal;
 
 class BlockState final
 {
@@ -40,11 +41,9 @@ public:
     // TODO: remove round_number parameter, retrieve it from header instead once
     // we add the monad fields in BlockHeader
     void commit(
-        MonadConsensusBlockHeader const &, std::vector<Receipt> const &,
-        std::vector<std::vector<CallFrame>> const &,
-        std::vector<Address> const &, std::vector<Transaction> const &,
-        std::vector<BlockHeader> const &ommers,
-        std::optional<std::vector<Withdrawal>> const &);
+        MonadConsensusBlockHeader const &, std::span<Transaction const>,
+        std::span<TxnExecOutput const>, std::span<BlockHeader const> ommers,
+        std::optional<std::span<Withdrawal const>>);
 
     void log_debug();
 };

--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -493,7 +493,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {});
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(
@@ -535,7 +535,7 @@ TYPED_TEST(StateTest, selfdestruct_merge_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {});
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
@@ -570,7 +570,7 @@ TYPED_TEST(StateTest, selfdestruct_create_destroy_create_commit_incarnation)
         bs.merge(s2);
     }
     {
-        bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
+        bs.commit({}, {}, {}, {}, {});
         this->tdb.finalize(0, 0);
         this->tdb.set_block_and_round(0);
         EXPECT_EQ(
@@ -1125,7 +1125,7 @@ TYPED_TEST(StateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
+    bs.commit({}, {}, {}, {}, {});
     this->tdb.finalize(0, 0);
     this->tdb.set_block_and_round(0);
 
@@ -1144,7 +1144,7 @@ TYPED_TEST(StateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    bs.commit({}, {}, {}, {}, {}, {}, std::nullopt);
+    bs.commit({}, {}, {}, {}, {});
 
     EXPECT_EQ(
         this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
@@ -1194,8 +1194,6 @@ TYPED_TEST(StateTest, commit_twice)
             {},
             {},
             {},
-            {},
-            {},
             {});
         this->tdb.finalize(10, 5);
 
@@ -1216,8 +1214,6 @@ TYPED_TEST(StateTest, commit_twice)
         bs.merge(cs);
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 6),
-            {},
-            {},
             {},
             {},
             {},
@@ -1286,8 +1282,6 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
             {},
             {},
             {},
-            {},
-            {},
             {});
 
         EXPECT_EQ(this->tdb.read_account(b).value().balance, 82'000);
@@ -1312,8 +1306,6 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
         // Commit block 11 round 6 on top of block 10 round 5
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 6),
-            {},
-            {},
             {},
             {},
             {},
@@ -1344,8 +1336,6 @@ TEST_F(OnDiskTrieDbFixture, commit_multiple_proposals)
         // Commit block 11 round 7 on top of block 10 round 5
         bs.commit(
             MonadConsensusBlockHeader::from_eth_header({.number = 11}, 7),
-            {},
-            {},
             {},
             {},
             {},

--- a/libs/statesync/src/monad/statesync/statesync_server_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.cpp
@@ -1,9 +1,11 @@
 #include <monad/config.hpp>
 #include <monad/core/assert.h>
 #include <monad/core/basic_formatter.hpp>
+#include <monad/core/block.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/fmt/address_fmt.hpp>
 #include <monad/core/fmt/bytes_fmt.hpp>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/rlp/bytes_rlp.hpp>
 #include <monad/db/trie_db.hpp>
 #include <monad/mpt/db.hpp>
@@ -174,12 +176,10 @@ void monad_statesync_server_context::update_verified_block(
 void monad_statesync_server_context::commit(
     StateDeltas const &state_deltas, Code const &code,
     MonadConsensusBlockHeader const &consensus_header,
-    std::vector<Receipt> const &receipts,
-    std::vector<std::vector<CallFrame>> const &call_frames,
-    std::vector<Address> const &senders,
-    std::vector<Transaction> const &transactions,
-    std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals)
+    std::span<Transaction const> transactions,
+    std::span<TxnExecOutput const> txn_exec_outputs,
+    std::span<BlockHeader const> ommers,
+    std::optional<std::span<Withdrawal const>> withdrawals)
 {
     auto &header = consensus_header.execution_inputs;
 
@@ -188,10 +188,8 @@ void monad_statesync_server_context::commit(
         state_deltas,
         code,
         consensus_header,
-        receipts,
-        call_frames,
-        senders,
         transactions,
+        txn_exec_outputs,
         ommers,
         withdrawals);
 }

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -8,6 +8,8 @@
 #include <array>
 #include <deque>
 #include <mutex>
+#include <optional>
+#include <span>
 #include <vector>
 
 MONAD_NAMESPACE_BEGIN
@@ -90,11 +92,9 @@ struct monad_statesync_server_context final : public monad::Db
     virtual void commit(
         monad::StateDeltas const &state_deltas, monad::Code const &code,
         monad::MonadConsensusBlockHeader const &,
-        std::vector<monad::Receipt> const &receipts = {},
-        std::vector<std::vector<monad::CallFrame>> const & = {},
-        std::vector<monad::Address> const & = {},
-        std::vector<monad::Transaction> const &transactions = {},
-        std::vector<monad::BlockHeader> const &ommers = {},
-        std::optional<std::vector<monad::Withdrawal>> const & =
+        std::span<monad::Transaction const> = {},
+        std::span<monad::TxnExecOutput const> = {},
+        std::span<monad::BlockHeader const> ommers = {},
+        std::optional<std::span<monad::Withdrawal const>> =
             std::nullopt) override;
 };

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
@@ -1,6 +1,7 @@
 #include <monad/config.hpp>
 #include <monad/core/address.hpp>
 #include <monad/core/assert.h>
+#include <monad/core/monad_block.hpp>
 #include <monad/core/rlp/block_rlp.hpp>
 #include <monad/core/unaligned.hpp>
 #include <monad/db/trie_db.hpp>

--- a/test/ethereum_test/include/blockchain_test.hpp
+++ b/test/ethereum_test/include/blockchain_test.hpp
@@ -21,7 +21,7 @@ MONAD_NAMESPACE_BEGIN
 
 struct Block;
 class BlockHashBuffer;
-struct Receipt;
+struct TxnExecOutput;
 
 MONAD_NAMESPACE_END
 
@@ -35,10 +35,10 @@ class BlockchainTest : public testing::Test
     std::optional<evmc_revision> const revision_;
 
     template <evmc_revision rev>
-    static Result<std::vector<Receipt>>
+    static Result<std::vector<TxnExecOutput>>
     execute(Block &, test::db_t &, BlockHashBuffer const &);
 
-    static Result<std::vector<Receipt>> execute_dispatch(
+    static Result<std::vector<TxnExecOutput>> execute_dispatch(
         evmc_revision, Block &, test::db_t &, BlockHashBuffer const &);
 
     static void

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -21,6 +21,7 @@
 #include <monad/execution/execute_transaction.hpp>
 #include <monad/execution/genesis.hpp>
 #include <monad/execution/switch_evmc_revision.hpp>
+#include <monad/execution/txn_exec_output.hpp>
 #include <monad/execution/validate_block.hpp>
 #include <monad/fiber/priority_pool.hpp>
 #include <monad/mpt/nibbles_view.hpp>
@@ -58,7 +59,7 @@
 MONAD_TEST_NAMESPACE_BEGIN
 
 template <evmc_revision rev>
-Result<std::vector<Receipt>> BlockchainTest::execute(
+Result<std::vector<TxnExecOutput>> BlockchainTest::execute(
     Block &block, test::db_t &db, BlockHashBuffer const &block_hash_buffer)
 {
     using namespace monad::test;
@@ -68,25 +69,15 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
     BlockState block_state(db);
     EthereumMainnet const chain;
     BOOST_OUTCOME_TRY(
-        auto const results,
+        auto txn_exec_outputs,
         execute_block<rev>(
             chain, block, block_state, block_hash_buffer, *pool_));
-    std::vector<Receipt> receipts(results.size());
-    std::vector<std::vector<CallFrame>> call_frames(results.size());
-    std::vector<Address> senders(results.size());
-    for (unsigned i = 0; i < results.size(); ++i) {
-        receipts[i] = std::move(results[i].receipt);
-        call_frames[i] = std::move(results[i].call_frames);
-        senders[i] = results[i].sender;
-    }
 
     block_state.log_debug();
     block_state.commit(
         MonadConsensusBlockHeader::from_eth_header(block.header),
-        receipts,
-        call_frames,
-        senders,
         block.transactions,
+        txn_exec_outputs,
         block.ommers,
         block.withdrawals);
     db.finalize(block.header.number, block.header.number);
@@ -95,10 +86,10 @@ Result<std::vector<Receipt>> BlockchainTest::execute(
     BOOST_OUTCOME_TRY(
         chain.validate_output_header(block.header, output_header));
 
-    return receipts;
+    return txn_exec_outputs;
 }
 
-Result<std::vector<Receipt>> BlockchainTest::execute_dispatch(
+Result<std::vector<TxnExecOutput>> BlockchainTest::execute_dispatch(
     evmc_revision const rev, Block &block, test::db_t &db,
     BlockHashBuffer const &block_hash_buffer)
 {
@@ -234,10 +225,8 @@ void BlockchainTest::TestBody()
             bs.merge(state);
             bs.commit(
                 MonadConsensusBlockHeader::from_eth_header(header),
-                {} /* receipts */,
-                {} /* call frames */,
-                {} /* senders */,
                 {} /* transactions */,
+                {} /* txn_exec_outputs */,
                 {} /* ommers */,
                 withdrawals);
             tdb.finalize(0, 0);


### PR DESCRIPTION
Per the NFCI label, no functionality change is intended. This is a pure refactoring that makes one of my later event PRs eaiser to work with, and I think this cleanup is a nice one.

The commit does four "cleanup" things:

1. The db commit function (and functions in its orbit) used to take (in addition to many other parameters) three parameters, of types `std::vector<Receipt>`, `std::vector<std::vector<CallFrame>>`, and `std::vector<Sender>`. Once upon a time, they took only the receipts, but as the need to pass around more transaction outputs to other parts of the system grew, a lot of functions gained more parameters. This refactors those functions to only pass around the output structure (which already existed) instead of the disaggregated pieces of it.

2. Changes `std::vector<T> const &` parameters to `std::span<T const>`

3. Renames `ExecutionResult` to `TxnExecOutput` (see the comment below for why), and moves it into a different file

4. Forward-declares a lot of stuff rather than including the definition of every structure, everywhere