### PR TITLE
main runloop log block_num should not exceed end_block_num

### DIFF
--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -127,6 +127,10 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
         }
         ++block_num;
     }
+    if (block_num > end_block_num) {
+        MONAD_ASSERT(block_num == end_block_num + 1);
+        block_num = end_block_num;
+    }
     if (batch_num_blocks > 0) {
         log_tps(
             block_num, batch_num_blocks, batch_num_txs, batch_gas, batch_begin);

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -171,6 +171,10 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
         }
         ++block_num;
     }
+    if (block_num > end_block_num) {
+        MONAD_ASSERT(block_num == end_block_num + 1);
+        block_num = end_block_num;
+    }
     if (batch_num_blocks > 0) {
         log_tps(
             block_num, batch_num_blocks, batch_num_txs, batch_gas, batch_begin);


### PR DESCRIPTION
The current block number in the last log_tps and final log message is off by one, also leading to wrong filename when dump snapshot. This PR fixes it.

Run 1 block from 3M, last log should be 3000001 instead of 3000002
```
$ ./cmd/monad --block_db /home/jhunsaker/block_db --chain ethereum_mainnet --snapshot /home/jhunsaker/checkpoints/3000000 --nblocks 1 --db ../test.db --sq_thread_cpu 15 --dump_snapshot .

2025-02-04 17:04:41.702287847 [1394797] main.cpp:168 LOG_INFO   running with commit 'd5a4d51a6a336b120f063d90349cacb5f75ba6a2'
2025-02-04 17:04:41.727754383 [1394797] main.cpp:212 LOG_INFO   Loading from binary checkpoint in /home/jhunsaker/checkpoints/3000000
2025-02-04 17:04:45.388611707 [1394799] update_aux.cpp:1054 LOG_INFO    Finish upserting version 3000000. Time elapsed: 3019281 us. Disk usage: 0.2727. Chunks: 1 fast, 2 slow, 8 free. Writer offsets: fast={0,0}, slow={1,214459904}.
2025-02-04 17:04:45.388611816 [1394799] update_aux.cpp:1059 LOG_WARNING Upsert version 3000000 takes longer than 0.5 s, time elapsed: 3019281 us.
2025-02-04 17:04:45.635200608 [1394799] update_aux.cpp:1054 LOG_INFO    Finish upserting version 3000000. Time elapsed: 10056 us. Disk usage: 0.2727. Chunks: 1 fast, 2 slow, 8 free. Writer offsets: fast={0,0}, slow={1,239947776}.
2025-02-04 17:04:45.653052177 [1394799] update_aux.cpp:1054 LOG_INFO    Finish upserting version 3000000. Time elapsed: 44 us. Disk usage: 0.2727. Chunks: 1 fast, 2 slow, 8 free. Writer offsets: fast={0,1024}, slow={1,239947776}.
2025-02-04 17:04:45.680509767 [1394797] main.cpp:268 LOG_INFO   Finished initializing db at block = 3000000, last finalized block = 3000000, last verified block = 18446744073709551615, state root = 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, time elapsed = 3978ms
2025-02-04 17:04:45.680509926 [1394797] main.cpp:277 LOG_INFO   Running with block_db = /home/jhunsaker/block_db, start block number = 3000001, number blocks = 1
2025-02-04 17:04:45.681252567 [1394797] block_hash_buffer.cpp:149 LOG_WARNING   Could not query block header 2999745 from TrieDb -- key not found
2025-02-04 17:04:45.740481927 [1394799] update_aux.cpp:1501 LOG_INFO    Version 3000001: nodes created or updated for upsert = 15, nodes updated for expire = 0, nreads for expire = 0

2025-02-04 17:04:45.740481975 [1394799] update_aux.cpp:1054 LOG_INFO    Finish upserting version 3000001. Time elapsed: 142 us. Disk usage: 0.2727. Chunks: 1 fast, 2 slow, 8 free. Writer offsets: fast={0,7680}, slow={1,239947776}.
2025-02-04 17:04:45.740616615 [1394799] update_aux.cpp:1054 LOG_INFO    Finish upserting version 3000001. Time elapsed: 44 us. Disk usage: 0.2727. Chunks: 1 fast, 2 slow, 8 free. Writer offsets: fast={0,8704}, slow={1,239947776}.
2025-02-04 17:04:45.740749915 [1394797] util.cpp:39 LOG_INFO    Run    1 blocks to  3000002, number of transactions      0, tps =     0, gps =    0 M, rss =    571 MB
2025-02-04 17:04:45.740750345 [1394797] main.cpp:366 LOG_INFO   Finish running, finish(stopped) block number = 3000002, number of blocks run = 1, time_elapsed = 0s, num transactions = 0, tps = 0, gps = 0 M
2025-02-04 17:04:45.740750465 [1394797] main.cpp:376 LOG_INFO   Dump db of block: 3000002
```
