### PR TITLE
Add gdb pretty printer for NibblesView

### DIFF
--- a/gdb-scripts/monad_pretty_printer.py
+++ b/gdb-scripts/monad_pretty_printer.py
@@ -1,0 +1,62 @@
+
+import sys
+
+# Add /usr/share/gcc to sys.path if it's not already there
+if '/usr/share/gcc' not in sys.path:
+    sys.path.append('/usr/share/gcc/python')
+
+from libstdcxx.v6.printers import unique_ptr_get
+
+def nibble_begin(val):
+    return val['begin_nibble_'].cast(gdb.lookup_type('int'))
+
+def nibble_size(val):
+    return val['end_nibble_'] - nibble_begin(val)
+
+def get_nibble(val, data, i):
+    n = nibble_begin(val) + i
+    c = data[n / 2]
+    if n % 2 == 0:
+        return c >> 4
+    else:
+        return c & 0xf
+
+def nibble_to_string(val, data):
+    if nibble_size(val) == 0:
+        return '(empty)'
+    s = '0x'
+    for i in range(0, nibble_size(val)):
+        s += '%x' % get_nibble(val, data, i)
+    return s
+
+class NibblesViewPrettyPrinter(gdb.ValuePrinter):
+    "Print nibbles view"
+
+    def __init__(self, val):
+        size = nibble_size(val)
+        if val.type.tag == 'monad::mpt::Nibbles':
+            data = unique_ptr_get(val['data_'])
+        else:
+            data = val['data_']
+        self.__values = [('size', size), ('value', nibble_to_string(val, data))]
+
+    def children(self):
+        return self.__values
+
+    def num_children(self):
+        return len(self.__values)
+
+import gdb.printing
+
+def build_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("monad")
+    pp.add_printer('NibblesView', 'monad::mpt::NibblesView$', NibblesViewPrettyPrinter)
+    pp.add_printer('NibblesView', 'monad::mpt::Nibbles$', NibblesViewPrettyPrinter)
+    return pp
+
+try:
+    gdb.printing.register_pretty_printer(gdb.current_objfile(), build_pretty_printer())
+except:
+    pass
+
+


### PR DESCRIPTION
Displays NibblesView as 

(gdb) p ext
$2 = {size = 63, value = 0x3601462093b5945d1676df093446790fd31b20e7b12a2e8e5e09d068109616b}

instead of default

$1 = {data_ = 0x555555e1e850 "\003`\024b\t;YE\321gm\360\223Dg\220\3751\262\016{\022\242\350\345\340\235\006\201\tak\340\224\251OSt\374\345\355\274\216*\206\227\301S1g~n\277\v\200\001\210\v\241\251\316\v\232\247\201",
  begin_nibble_ = true, end_nibble_ = 64 '@', static npos = 4294967295}
