### PR TITLE
don't flush write on first upsert in commit

### DIFF
--- a/libs/db/src/monad/mpt/trie.cpp
+++ b/libs/db/src/monad/mpt/trie.cpp
@@ -95,10 +95,6 @@ struct async_write_node_result
     erased_connected_operation *io_state;
 };
 
-// invoke at the end of each block upsert
-void flush_buffered_writes(UpdateAuxImpl &);
-chunk_offset_t write_new_root_node(UpdateAuxImpl &, Node &, uint64_t);
-
 Node::UniquePtr upsert(
     UpdateAuxImpl &aux, uint64_t const version, StateMachine &sm,
     Node::UniquePtr old, UpdateList &&updates, bool const write_root)
@@ -130,9 +126,6 @@ Node::UniquePtr upsert(
         if (aux.is_on_disk() && root) {
             if (write_root) {
                 write_new_root_node(aux, *root, version);
-            }
-            else {
-                flush_buffered_writes(aux);
             }
         }
         return root;

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -580,9 +580,17 @@ std::unique_ptr<StateMachine> InMemoryMachine::clone() const
 bool OnDiskMachine::cache() const
 {
     constexpr uint64_t CACHE_DEPTH_IN_TABLE = 5;
-    return (depth <= prefix_len() + CACHE_DEPTH_IN_TABLE) &&
-           (table == TableType::State || table == TableType::Code ||
-            table == TableType::TxHash || table == TableType::BlockHash);
+    if (table == TableType::Prefix) {
+        return true;
+    }
+    if (table == TableType::Withdrawal || table == TableType::Transaction ||
+        table == TableType::Receipt) {
+        // cache root node
+        return depth <= prefix_len() + 1;
+    }
+    else {
+        return depth <= prefix_len() + CACHE_DEPTH_IN_TABLE;
+    }
 }
 
 bool OnDiskMachine::compact() const


### PR DESCRIPTION
3M benchmark on my machine, ~9% speedup
```
before:5266, 5303, 5266
after: 5749, 5793, 5793
```