### PR TITLE
Remove extra block_number parameter in eth_call

### DIFF
--- a/libs/rpc/src/monad/rpc/eth_call.hpp
+++ b/libs/rpc/src/monad/rpc/eth_call.hpp
@@ -60,6 +60,5 @@ struct monad_state_override_set
 monad_evmc_result eth_call(
     monad_chain_config, std::vector<uint8_t> const &rlp_txn,
     std::vector<uint8_t> const &rlp_header,
-    std::vector<uint8_t> const &rlp_sender, uint64_t const block_number,
-    std::string const &triedb_path,
+    std::vector<uint8_t> const &rlp_sender, std::string const &triedb_path,
     monad_state_override_set const &state_overrides);

--- a/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
@@ -89,7 +89,6 @@ TEST_F(EthCallFixture, simple_success_call)
         rlp_tx,
         rlp_header,
         rlp_sender,
-        256u,
         dbname,
         state_override);
 
@@ -128,7 +127,6 @@ TEST_F(EthCallFixture, failed_to_read)
         rlp_tx,
         rlp_header,
         rlp_sender,
-        1256u,
         dbname,
         state_override);
     EXPECT_EQ(result.status_code, EVMC_REJECTED);
@@ -164,7 +162,6 @@ TEST_F(EthCallFixture, contract_deployment_success)
         rlp_tx,
         rlp_header,
         rlp_sender,
-        256u,
         dbname,
         state_override);
 
@@ -222,7 +219,6 @@ TEST_F(EthCallFixture, from_contract_account)
         rlp_tx,
         rlp_header,
         rlp_sender,
-        0,
         dbname,
         state_override);
 


### PR DESCRIPTION
Problem: `eth_call` takes in both `block_header.number` and `block_number`, the second one is redundant.
Solution: Remove the `block_number` param. 

PR on the bft side: https://github.com/category-labs/monad-bft/pull/1508