### PR TITLE
Use simple copy of into encoded path if possible

### DIFF
--- a/libs/db/src/monad/mpt/nibbles_view.hpp
+++ b/libs/db/src/monad/mpt/nibbles_view.hpp
@@ -119,6 +119,10 @@ class NibblesView
     friend inline std::ostream &
     operator<<(std::ostream &s, NibblesView const &v);
 
+    friend constexpr byte_string_view compact_encode(
+        unsigned char *const res, NibblesView const nibbles,
+        bool const terminating);
+
 private:
     friend class Nibbles;
     friend class Node;


### PR DESCRIPTION
In compact_encode() if both source and destination are aligned, use memory copy instead of shift and or operations.

In the other case only source is not aligned, destination can be assigned full bytes without shifts/ors.