### PR TITLE
[core] if io_uring init fails, show the errno code

### DIFF
--- a/libs/core/src/monad/core/assert.h
+++ b/libs/core/src/monad/core/assert.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <monad/core/likely.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/libs/core/src/monad/io/ring.cpp
+++ b/libs/core/src/monad/io/ring.cpp
@@ -7,6 +7,7 @@
 
 #include <liburing.h>
 #include <liburing/io_uring.h>
+#include <string.h>
 
 MONAD_IO_NAMESPACE_BEGIN
 
@@ -28,7 +29,11 @@ Ring::Ring(RingConfig const &config)
 {
     int const result = io_uring_queue_init_params(
         config.entries, &ring_, const_cast<io_uring_params *>(&params_));
-    MONAD_ASSERT(!result);
+    MONAD_ASSERT_PRINTF(
+        result == 0,
+        "io_uring_queue_init_params failed: %s (%d)",
+        strerror(-result),
+        -result);
 }
 
 Ring::~Ring()


### PR DESCRIPTION
While we're here, fix a missing include of stdio.h in assert.h for snprintf(3)