### PR TITLE
Add support for unfinalized blocks to eth-call

### DIFF
--- a/libs/rpc/src/monad/rpc/eth_call.hpp
+++ b/libs/rpc/src/monad/rpc/eth_call.hpp
@@ -61,5 +61,5 @@ monad_evmc_result eth_call(
     monad_chain_config, std::vector<uint8_t> const &rlp_txn,
     std::vector<uint8_t> const &rlp_header,
     std::vector<uint8_t> const &rlp_sender, uint64_t const block_number,
-    std::string const &triedb_path,
+    uint64_t const block_round, std::string const &triedb_path,
     monad_state_override_set const &state_overrides);


### PR DESCRIPTION
Using INVALID_ROUND_NUM instead of std::optional for rust ffi compatibility.

The max block_number that rpc passes will be last_finalized_block_number + 1. This is a short-term hack that allows us to skip initializing the BlockHash buffer from unfinalized proposals.