### PR TITLE
change throw to using MONAD_ABORT/ASSERT

### DIFF
--- a/category/async/test/storage_pool.cpp
+++ b/category/async/test/storage_pool.cpp
@@ -1,3 +1,4 @@
+#include "gtest/gtest-death-test.h"
 #include "gtest/gtest.h"
 
 #include <category/async/config.hpp>
@@ -243,18 +244,13 @@ namespace
 
     TEST(StoragePool, raw_partitions)
     {
-        std::filesystem::path const devs[] = {
-            "/dev/mapper/raid0-rawblk0", "/dev/mapper/raid0-rawblk1"};
-        try {
-            storage_pool pool(devs, storage_pool::mode::truncate);
-            run_tests(pool);
-        }
-        catch (std::system_error const &e) {
-            if (e.code() != std::errc::no_such_file_or_directory &&
-                e.code() != std::errc::permission_denied) {
-                throw;
-            }
-        }
+        ASSERT_DEATH(
+            ({
+                std::filesystem::path const devs[] = {
+                    "/dev/mapper/raid0-rawblk0", "/dev/mapper/raid0-rawblk1"};
+                storage_pool pool(devs, storage_pool::mode::truncate);
+            }),
+            "open failed");
     }
 
     TEST(StoragePool, device_interleaving)
@@ -403,7 +399,10 @@ namespace
             storage_pool const _{devs};
         }
         std::filesystem::path const devs2[] = {devs[0], devs[1]};
-        EXPECT_THROW(storage_pool{devs2}, std::runtime_error);
+        ASSERT_DEATH(
+            storage_pool{devs2},
+            "was initialised with a configuration different to this storage "
+            "pool");
         storage_pool{devs2, storage_pool::mode::truncate};
     }
 

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -132,14 +132,14 @@ AsyncIOContext::AsyncIOContext(OnDiskDbConfig const &options)
             if (!std::filesystem::exists(dbname_path)) {
                 int const fd = ::open(
                     dbname_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
-                if (-1 == fd) {
-                    throw std::system_error(errno, std::system_category());
-                }
+                MONAD_ASSERT_PRINTF(
+                    fd != -1, "open failed due to %s", strerror(errno));
                 auto unfd =
                     monad::make_scope_exit([fd]() noexcept { ::close(fd); });
-                if (-1 == ::ftruncate(fd, len)) {
-                    throw std::system_error(errno, std::system_category());
-                }
+                MONAD_ASSERT_PRINTF(
+                    ::ftruncate(fd, len) != -1,
+                    "ftruncate failed due to %s",
+                    strerror(errno));
             }
         }
         return async::storage_pool{

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -111,10 +111,12 @@ TEST(update_aux_test, set_io_reader_dirty)
     monad::async::AsyncIO testio(pool_ro, testrobuf);
 
     // This should throw. Dirty bit stays set.
-    monad::mpt::UpdateAux<> aux_reader_throw{};
-    EXPECT_THROW(
-        aux_reader_throw.set_io(&testio, AUX_TEST_HISTORY_LENGTH),
-        std::runtime_error);
+    ASSERT_DEATH(
+        ({
+            monad::mpt::UpdateAux<> aux_reader{};
+            aux_reader.set_io(&testio, AUX_TEST_HISTORY_LENGTH);
+        }),
+        "DB metadata was closed dirty, but not opened for healing");
 
     // TestAux adds instrumentation to turn off the dirty bit. Should not throw.
     TestAux aux_reader(aux_writer);


### PR DESCRIPTION
this is also to address to auditor's comment:

> Throwing C++ exceptions across a Rust->C++ FFI call boundary is undefined behaviour.
