### PR TITLE
eth_call: make sure latest state always cached in Db and not being flushed by non-latest calls

### DIFF
--- a/libs/rpc/src/monad/rpc/eth_call.h
+++ b/libs/rpc/src/monad/rpc/eth_call.h
@@ -67,7 +67,6 @@ void monad_eth_call_executor_submit(
     size_t rlp_txn_len, uint8_t const *rlp_header, size_t rlp_header_len,
     uint8_t const *rlp_sender, size_t rlp_sender_len, uint64_t block_number,
     uint64_t block_round, struct monad_state_override const *overrides,
-
     void (*complete)(monad_eth_call_result *, void *user), void *user);
 
 #ifdef __cplusplus

--- a/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
@@ -62,7 +62,8 @@ namespace
         }
     };
 
-    struct callback_context {
+    struct callback_context
+    {
         monad_eth_call_result *result;
         boost::fibers::promise<void> promise;
 
@@ -72,7 +73,7 @@ namespace
         }
     };
 
-    void complete_callback(monad_eth_call_result * result, void * user)
+    void complete_callback(monad_eth_call_result *result, void *user)
     {
         auto c = (callback_context *)user;
 
@@ -121,7 +122,7 @@ TEST_F(EthCallFixture, simple_success_call)
         mpt::INVALID_ROUND_NUM,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
 
     EXPECT_TRUE(ctx.result->status_code == EVMC_SUCCESS);
@@ -172,7 +173,7 @@ TEST_F(EthCallFixture, insufficient_balance)
         mpt::INVALID_ROUND_NUM,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
 
     EXPECT_TRUE(ctx.result->status_code == EVMC_REJECTED);
@@ -225,9 +226,9 @@ TEST_F(EthCallFixture, on_proposed_block)
         consensus_header.round,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
-    
+
     EXPECT_TRUE(ctx.result->status_code == EVMC_SUCCESS);
     monad_state_override_destroy(state_override);
     monad_eth_call_executor_destroy(executor);
@@ -276,7 +277,7 @@ TEST_F(EthCallFixture, failed_to_read)
         mpt::INVALID_ROUND_NUM,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
 
     EXPECT_EQ(ctx.result->status_code, EVMC_REJECTED);
@@ -325,7 +326,7 @@ TEST_F(EthCallFixture, contract_deployment_success)
         mpt::INVALID_ROUND_NUM,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
 
     std::string deployed_code =
@@ -399,7 +400,7 @@ TEST_F(EthCallFixture, from_contract_account)
         mpt::INVALID_ROUND_NUM,
         state_override,
         complete_callback,
-        (void*)&ctx);
+        (void *)&ctx);
     f.get();
 
     EXPECT_TRUE(ctx.result->status_code == EVMC_SUCCESS);


### PR DESCRIPTION
Details:
two thread_local Dbs, one is dedicated to handle latest calls