### PR TITLE
RangedGetMachine: bugfix

### DIFF
--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -819,7 +819,7 @@ TYPED_TEST(DBTest, commit_call_frames)
         .depth = 1,
     };
 
-    constexpr uint64_t NUM_TXNS = 10;
+    constexpr uint64_t NUM_TXNS = 1000;
 
     static byte_string const encoded_txn = byte_string{0x1a, 0x1b, 0x1c};
     std::vector<CallFrame> const call_frame{call_frame1, call_frame2};


### PR DESCRIPTION
  * in should_visit(), only concatenate branch, not the node. source of the bug
  * down(): check if in range and tell the traversal to stop if not
  * Make min_and max_ Nibbles instead of NibblesView to simplify lifetimes on the consensus side.
  * only manifests when `NUM_TXNS` is greater than 16. Updated the unit test to 1000 txns.