### PR TITLE
scripts: bump test timeout

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)} \
-  ctest --output-on-failure --timeout 300 --test-dir build
+  ctest --output-on-failure --timeout 500 --test-dir build
 
 PYTEST_MATCH_ARGS=""
 if [ "${CC}" != "clang" ] || [ "${CMAKE_BUILD_TYPE}" != "RelWithDebInfo" ]; then


### PR DESCRIPTION
The current 300s timeout seems to be just on the edge of how long the tests are taking to run, and causing intermittent failures in building images. This bumps the test timeout to avoid that