### PR TITLE
add restore prefix implementation

### DIFF
--- a/libs/db/src/monad/mpt/db.cpp
+++ b/libs/db/src/monad/mpt/db.cpp
@@ -960,6 +960,13 @@ Db::find(NodeCursor root, NibblesView const key, uint64_t const block_id) const
     return it;
 }
 
+find_cursor_result_type Db::find_prefix(
+    NodeCursor root, NibblesView const key, uint64_t const block_id) const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->find_fiber_blocking(root, key, block_id);
+}
+
 NodeCursor Db::load_root_for_version(uint64_t const block_id) const
 {
     MONAD_ASSERT(impl_);

--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -71,6 +71,9 @@ public:
     // future.
     Result<NodeCursor> find(NodeCursor, NibblesView, uint64_t block_id) const;
     Result<NodeCursor> find(NibblesView prefix, uint64_t block_id) const;
+    find_cursor_result_type
+    find_prefix(NodeCursor root, NibblesView key, uint64_t block_id) const;
+
     Result<byte_string_view> get(NibblesView, uint64_t block_id) const;
     Result<byte_string_view> get_data(NibblesView, uint64_t block_id) const;
     Result<byte_string_view>

--- a/libs/db/src/monad/mpt/request.hpp
+++ b/libs/db/src/monad/mpt/request.hpp
@@ -91,7 +91,7 @@ struct Requests
     }
 };
 
-static_assert(sizeof(Requests) == 352);
+static_assert(sizeof(Requests) == 360);
 static_assert(alignof(Requests) == 8);
 
 MONAD_MPT_NAMESPACE_END

--- a/libs/db/src/monad/mpt/trie.cpp
+++ b/libs/db/src/monad/mpt/trie.cpp
@@ -74,6 +74,10 @@ void create_node_compute_data_possibly_async(
     UpdateAuxImpl &, StateMachine &, UpdateTNode &parent, ChildData &,
     tnode_unique_ptr, bool might_on_disk = true);
 
+void create_new_trie_from_node_(
+    UpdateAuxImpl &aux, StateMachine &sm, int64_t &parent_version,
+    ChildData &entry, Node *copy_node, NibblesView const path, int64_t version);
+
 void compact_(
     UpdateAuxImpl &, StateMachine &, CompactTNode::unique_ptr_type,
     chunk_offset_t node_offset, bool copy_node_for_fast_or_slow);
@@ -882,7 +886,8 @@ void create_new_trie_(
     }
     if (updates.size() == 1) {
         Update &update = updates.front();
-        MONAD_DEBUG_ASSERT(update.value.has_value());
+        MONAD_ASSERT(
+            update.value.has_value() || (update.prefix_update && update.node));
         auto const path = update.key.substr(prefix_index);
         for (auto i = 0u; i < path.nibble_size(); ++i) {
             sm.down(path.get(i));
@@ -902,6 +907,10 @@ void create_new_trie_(
                 0,
                 update.value,
                 update.version);
+        }
+        else if (update.prefix_update && update.node != nullptr) {
+            create_new_trie_from_node_(
+                aux, sm, parent_version, entry, update.node.get(), path, 0);
         }
         else {
             aux.collect_number_nodes_created_stats();
@@ -946,6 +955,33 @@ void create_new_trie_(
         requests.opt_leaf.has_value() ? requests.opt_leaf.value().version : 0);
     if (prefix_index_start != prefix_index) {
         sm.up(prefix_index - prefix_index_start);
+    }
+}
+
+void create_new_trie_from_node_(
+    UpdateAuxImpl &aux, StateMachine &sm, int64_t &parent_version,
+    ChildData &entry, Node *copy_node, NibblesView const path, int64_t version)
+{
+    // version will be updated bottom up
+    auto const number_of_children = copy_node->number_of_children();
+    uint16_t const mask = copy_node->mask;
+    allocators::owning_span<ChildData> const children(number_of_children);
+    for (unsigned i = 0, j = 0, bit = 1; j < number_of_children;
+         ++i, bit <<= 1) {
+        if (bit & copy_node->mask) {
+            children[j].copy_old_child(copy_node, i);
+            ++j;
+        }
+    }
+    // can have empty children
+    auto node = create_node_from_children_if_any(
+        aux, sm, mask, mask, children, path, copy_node->opt_value(), version);
+    MONAD_ASSERT(node);
+    parent_version = std::max(parent_version, node->version);
+    entry.finalize(std::move(node), sm.get_compute(), sm.cache());
+    if (sm.auto_expire()) {
+        MONAD_ASSERT(
+            entry.subtrie_min_version >= aux.curr_upsert_auto_expire_version);
     }
 }
 
@@ -1024,7 +1060,7 @@ void upsert_(
             prefix_index == updates.front().key.nibble_size()) {
             auto &update = updates.front();
             MONAD_ASSERT(old->path_nibble_index_end == old_prefix_index);
-            MONAD_ASSERT(old->has_value());
+            MONAD_ASSERT(old->has_value() || update.prefix_update);
             update_value_and_subtrie_(
                 aux, sm, parent, entry, std::move(old), path, update);
             break;

--- a/libs/db/src/monad/mpt/update.hpp
+++ b/libs/db/src/monad/mpt/update.hpp
@@ -21,16 +21,18 @@ struct Update
     NibblesView key{};
     std::optional<byte_string_view> value{std::nullopt};
     bool incarnation{false};
+    bool prefix_update{false};
+    Node::UniquePtr node{};
     UpdateList next;
     int64_t version{0};
 
     constexpr bool is_deletion() const noexcept
     {
-        return !value.has_value() && next.empty();
+        return !(value.has_value() || !next.empty() || node != nullptr);
     }
 };
 
-static_assert(sizeof(Update) == 80);
+static_assert(sizeof(Update) == 88);
 static_assert(alignof(Update) == 8);
 
 // An update can mean

--- a/libs/statesync/CMakeLists.txt
+++ b/libs/statesync/CMakeLists.txt
@@ -37,4 +37,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_link_options(fuzz_statesync PRIVATE "-fsanitize=fuzzer")
   monad_compile_options(fuzz_statesync)
   target_link_libraries(fuzz_statesync PUBLIC monad_statesync)
-endif()
+
+  add_executable(
+    fuzz_restore_prefix
+    "${PROJECT_SOURCE_DIR}/src/monad/statesync/test/fuzz_restore_prefix.cpp")
+  target_compile_options(fuzz_restore_prefix PRIVATE "-fsanitize=fuzzer")
+  target_link_options(fuzz_restore_prefix PRIVATE "-fsanitize=fuzzer")
+  monad_compile_options(fuzz_restore_prefix)
+  target_link_libraries(fuzz_restore_prefix PUBLIC monad_statesync)
+  endif()

--- a/libs/statesync/src/monad/statesync/statesync_client.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_client.cpp
@@ -146,6 +146,15 @@ void monad_statesync_client_handle_done(
     }
 }
 
+void monad_statesync_client_restore_prefix(
+    monad_statesync_client_context *const ctx, uint64_t const prefix)
+{
+    auto bytes = from_prefix(prefix, monad_statesync_client_prefix_bytes());
+    ctx->restore_prefix(bytes);
+    ctx->progress[prefix] = {ctx->current - 1, ctx->current - 1};
+    ctx->protocol.at(prefix)->send_request(ctx, prefix);
+}
+
 bool monad_statesync_client_finalize(monad_statesync_client_context *const ctx)
 {
     auto const &tgrt = ctx->tgrt;

--- a/libs/statesync/src/monad/statesync/statesync_client.h
+++ b/libs/statesync/src/monad/statesync/statesync_client.h
@@ -43,6 +43,9 @@ bool monad_statesync_client_finalize(struct monad_statesync_client_context *);
 void monad_statesync_client_context_destroy(
     struct monad_statesync_client_context *);
 
+void monad_statesync_client_restore_prefix(
+    monad_statesync_client_context *ctx, uint64_t const prefix);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/statesync/src/monad/statesync/statesync_client_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_client_context.hpp
@@ -7,6 +7,7 @@
 #include <monad/db/trie_db.hpp>
 #include <monad/db/util.hpp>
 #include <monad/mpt/db.hpp>
+#include <monad/mpt/nibbles_view.hpp>
 #include <monad/statesync/statesync_protocol.hpp>
 
 #include <ankerl/unordered_dense.h>
@@ -57,4 +58,6 @@ struct monad_statesync_client_context
             struct monad_statesync_client *, struct monad_sync_request));
 
     void commit();
+
+    void restore_prefix(monad::mpt::NibblesView prefix);
 };

--- a/libs/statesync/src/monad/statesync/statesync_protocol.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_protocol.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <monad/config.hpp>
+#include <monad/core/byte_string.hpp>
 #include <monad/statesync/statesync_messages.h>
 
 struct monad_statesync_client_context;
@@ -28,5 +29,14 @@ struct StatesyncProtocolV1 : StatesyncProtocol
         monad_statesync_client_context *, monad_sync_type,
         unsigned char const *, uint64_t) const override;
 };
+
+inline byte_string from_prefix(uint64_t const prefix, size_t const n_bytes)
+{
+    byte_string bytes;
+    for (size_t i = 0; i < n_bytes; ++i) {
+        bytes.push_back((prefix >> ((n_bytes - i - 1) * 8)) & 0xff);
+    }
+    return bytes;
+}
 
 MONAD_NAMESPACE_END

--- a/libs/statesync/src/monad/statesync/statesync_server.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_server.cpp
@@ -8,6 +8,7 @@
 #include <monad/core/unaligned.hpp>
 #include <monad/db/util.hpp>
 #include <monad/mpt/traverse.hpp>
+#include <monad/statesync/statesync_protocol.hpp>
 #include <monad/statesync/statesync_server.h>
 #include <monad/statesync/statesync_server_context.hpp>
 
@@ -42,15 +43,6 @@ using namespace monad;
 using namespace monad::mpt;
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
-
-byte_string from_prefix(uint64_t const prefix, size_t const n_bytes)
-{
-    byte_string bytes;
-    for (size_t i = 0; i < n_bytes; ++i) {
-        bytes.push_back((prefix >> ((n_bytes - i - 1) * 8)) & 0xff);
-    }
-    return bytes;
-}
 
 bool send_deletion(
     monad_statesync_server *const sync, monad_sync_request const &rq,

--- a/libs/statesync/src/monad/statesync/test/fuzz_restore_prefix.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_restore_prefix.cpp
@@ -1,0 +1,294 @@
+#include <monad/config.hpp>
+#include <monad/core/address.hpp>
+#include <monad/core/assert.h>
+#include <monad/core/rlp/block_rlp.hpp>
+#include <monad/core/unaligned.hpp>
+#include <monad/db/trie_db.hpp>
+#include <monad/state2/state_deltas.hpp>
+#include <monad/statesync/statesync_client.h>
+#include <monad/statesync/statesync_client_context.hpp>
+#include <monad/statesync/statesync_messages.h>
+#include <monad/statesync/statesync_server.h>
+#include <monad/statesync/statesync_server_context.hpp>
+#include <monad/statesync/statesync_version.h>
+#include <monad/statesync/test/fuzz_statesync.hpp>
+
+#include <ankerl/unordered_dense.h>
+#include <quill/Quill.h>
+
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <optional>
+#include <random>
+#include <span>
+#include <stdio.h>
+#include <sys/sysinfo.h>
+
+using namespace monad;
+using namespace monad::mpt;
+using namespace monad::test_statesync;
+
+struct config
+{
+    uint16_t num_inserts[2];
+    uint16_t num_updates;
+    uint16_t num_deletes;
+    uint16_t num_storage_inserts[2];
+    uint16_t num_storage_updates;
+    uint16_t num_storage_deletes;
+    uint8_t restore_prefix_mask[2];
+    uint64_t seed;
+};
+
+// Generate some data, run statesync to an empty database.
+// After transfer complete, restore random prefixes and rerun requests.
+// Generate some more data including updates and deletes, rerun statesync
+// with prefix restore.
+
+extern "C" int
+LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
+{
+    if (size != sizeof(config)) {
+        return -1;
+    }
+
+    config const *const cfg = reinterpret_cast<config const *>(data);
+
+    if (cfg->num_inserts[0] == 0) {
+        return -1;
+    }
+
+    fprintf(
+        stderr,
+        "inserts =%u/%u updates=%u deletes=%u storage_inserts=%u/%u "
+        "storage_updates=%u storage_deletes=%u\n",
+        cfg->num_inserts[0],
+        cfg->num_inserts[1],
+        cfg->num_updates,
+        cfg->num_deletes,
+        cfg->num_storage_inserts[0],
+        cfg->num_storage_inserts[1],
+        cfg->num_storage_updates,
+        cfg->num_storage_deletes);
+
+    quill::start(false);
+    quill::get_root_logger()->set_log_level(quill::LogLevel::Error);
+    std::filesystem::path const cdbname{tmp_dbname()};
+    char const *const cdbname_str = cdbname.c_str();
+    std::filesystem::path sdbname{tmp_dbname()};
+    OnDiskMachine machine;
+    mpt::Db sdb{
+        machine, OnDiskDbConfig{.append = true, .dbname_paths = {sdbname}}};
+    TrieDb stdb{sdb};
+    std::unique_ptr<monad_statesync_server_context> sctx =
+        std::make_unique<monad_statesync_server_context>(stdb);
+    mpt::AsyncIOContext io_ctx{ReadOnlyOnDiskDbConfig{.dbname_paths{sdbname}}};
+    mpt::Db ro{io_ctx};
+    sctx->ro = &ro;
+    monad_statesync_server_network net{};
+    monad_statesync_server *const server = monad_statesync_server_create(
+        sctx.get(),
+        &net,
+        &statesync_server_recv,
+        &statesync_server_send_upsert,
+        &statesync_server_send_done);
+
+    std::span<uint8_t const> raw{data, size};
+    State state{};
+
+    BlockHeader hdr{.number = 0};
+    sctx->commit(
+        StateDeltas{}, Code{}, MonadConsensusBlockHeader::from_eth_header(hdr));
+    sctx->finalize(0, 0);
+
+    std::mt19937_64 gen(cfg->seed);
+    std::uniform_int_distribution<uint64_t> dist(
+        0, std::numeric_limits<uint64_t>::max());
+
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_inserts[0]; ++i) {
+            new_account(
+                deltas,
+                state,
+                Incarnation{stdb.get_block_number(), 0},
+                dist(gen));
+        }
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_storage_inserts[0]; ++i) {
+            new_storage(deltas, state, stdb, dist(gen));
+        }
+
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+
+    {
+        monad_statesync_client client;
+        monad_statesync_client_context *cctx =
+            monad_statesync_client_context_create(
+                &cdbname_str,
+                1,
+                "",
+                static_cast<unsigned>(get_nprocs() - 1),
+                &client,
+                &statesync_send_request);
+
+        net.cctx = cctx;
+        net.client = &client;
+
+        auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
+        for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
+            monad_statesync_client_handle_new_peer(
+                cctx, i, monad_statesync_version());
+        }
+        monad_statesync_client_handle_target(cctx, rlp.data(), rlp.size());
+        while (!client.rqs.empty()) {
+            monad_statesync_server_run_once(server);
+        }
+        quill::flush();
+        MONAD_ASSERT(monad_statesync_client_has_reached_target(cctx));
+        for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
+            if (cfg->restore_prefix_mask[0] & (1 << i)) {
+                monad_statesync_client_restore_prefix(cctx, i);
+            }
+        }
+        while (!client.rqs.empty()) {
+            monad_statesync_server_run_once(server);
+        }
+        MONAD_ASSERT(monad_statesync_client_has_reached_target(cctx));
+        MONAD_ASSERT(monad_statesync_client_finalize(cctx));
+
+        monad_statesync_client_context_destroy(cctx);
+    }
+
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_inserts[1]; ++i) {
+            new_account(
+                deltas,
+                state,
+                Incarnation{stdb.get_block_number(), 0},
+                dist(gen));
+        }
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_storage_inserts[1]; ++i) {
+            new_storage(deltas, state, stdb, dist(gen));
+        }
+
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_storage_updates; ++i) {
+            update_storage(deltas, state, stdb, dist(gen));
+        }
+
+        for (uint16_t i = 0; i < cfg->num_updates; ++i) {
+            update_account(
+                deltas,
+                state,
+                stdb,
+                dist(gen),
+                Incarnation{stdb.get_block_number(), 0});
+        }
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+
+    {
+        StateDeltas deltas;
+        for (uint16_t i = 0; i < cfg->num_deletes; ++i) {
+            remove_account(deltas, state, stdb);
+        }
+
+        for (uint16_t i = 0; i < cfg->num_storage_deletes; ++i) {
+            remove_storage(deltas, state, stdb, dist(gen));
+        }
+
+        hdr.number = stdb.get_block_number() + 1;
+        MONAD_ASSERT(hdr.number > 0);
+        sctx->set_block_and_round(hdr.number - 1);
+        sctx->commit(
+            deltas, {}, MonadConsensusBlockHeader::from_eth_header(hdr));
+        sctx->finalize(hdr.number, hdr.number);
+    }
+
+    {
+        monad_statesync_client client;
+        monad_statesync_client_context *cctx =
+            monad_statesync_client_context_create(
+                &cdbname_str,
+                1,
+                "",
+                static_cast<unsigned>(get_nprocs() - 1),
+                &client,
+                &statesync_send_request);
+
+        net.cctx = cctx;
+        net.client = &client;
+
+        auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
+        for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
+            monad_statesync_client_handle_new_peer(
+                cctx, i, monad_statesync_version());
+        }
+        monad_statesync_client_handle_target(cctx, rlp.data(), rlp.size());
+
+        while (!client.rqs.empty()) {
+            monad_statesync_server_run_once(server);
+        }
+        quill::flush();
+        MONAD_ASSERT(monad_statesync_client_has_reached_target(cctx));
+
+        for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
+            if (cfg->restore_prefix_mask[1] & (1 << i)) {
+                monad_statesync_client_restore_prefix(cctx, i);
+            }
+        }
+        while (!client.rqs.empty()) {
+            monad_statesync_server_run_once(server);
+        }
+        MONAD_ASSERT(monad_statesync_client_has_reached_target(cctx));
+        MONAD_ASSERT(monad_statesync_client_finalize(cctx));
+
+        monad_statesync_client_context_destroy(cctx);
+    }
+    monad_statesync_server_destroy(server);
+    std::filesystem::remove(cdbname);
+    std::filesystem::remove(sdbname);
+
+    return 0;
+}

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
@@ -11,6 +11,7 @@
 #include <monad/statesync/statesync_server.h>
 #include <monad/statesync/statesync_server_context.hpp>
 #include <monad/statesync/statesync_version.h>
+#include <monad/statesync/test/fuzz_statesync.hpp>
 
 #include <ankerl/unordered_dense.h>
 #include <quill/Quill.h>
@@ -25,223 +26,15 @@
 
 using namespace monad;
 using namespace monad::mpt;
-
-struct monad_statesync_client
-{
-    std::deque<monad_sync_request> rqs;
-    uint64_t mask;
-};
-
-struct monad_statesync_server_network
-{
-    monad_statesync_client *client;
-    monad_statesync_client_context *cctx;
-    byte_string buf;
-};
+using namespace monad::test_statesync;
 
 void statesync_send_request(
     monad_statesync_client *const client, monad_sync_request const rq)
 {
     if (client->mask & (1ull << (rq.prefix % 64))) {
-        client->rqs.push_back(rq);
+        monad::test_statesync::statesync_send_request(client, rq);
     }
 }
-
-ssize_t statesync_server_recv(
-    monad_statesync_server_network *const net, unsigned char *const buf,
-    size_t const len)
-{
-    if (len == 1) {
-        constexpr auto MSG_TYPE = SYNC_TYPE_REQUEST;
-        std::memcpy(buf, &MSG_TYPE, 1);
-    }
-    else {
-        MONAD_ASSERT(len == sizeof(monad_sync_request));
-        std::memcpy(buf, &net->client->rqs.front(), sizeof(monad_sync_request));
-        net->client->rqs.pop_front();
-    }
-    return static_cast<ssize_t>(len);
-}
-
-void statesync_server_send_upsert(
-    monad_statesync_server_network *const net, monad_sync_type const type,
-    unsigned char const *const v1, uint64_t const size1,
-    unsigned char const *const v2, uint64_t const size2)
-{
-    net->buf.clear();
-    if (v1 != nullptr) {
-        net->buf.append(v1, size1);
-    }
-    if (v2 != nullptr) {
-        net->buf.append(v2, size2);
-    }
-    MONAD_ASSERT(monad_statesync_client_handle_upsert(
-        net->cctx, 0, type, net->buf.data(), net->buf.size()));
-}
-
-void statesync_server_send_done(
-    monad_statesync_server_network *const net, monad_sync_done const done)
-{
-    monad_statesync_client_handle_done(net->cctx, done);
-}
-
-MONAD_NAMESPACE_BEGIN
-
-namespace
-{
-    struct Range
-    {
-        uint64_t begin{0};
-        uint64_t end{0};
-    };
-
-    struct State : Range
-    {
-        ankerl::unordered_dense::segmented_map<uint64_t, Range> storage;
-    };
-
-    void new_account(
-        StateDeltas &deltas, State &state, Incarnation const incarnation,
-        uint64_t const n)
-    {
-        bool const success = deltas.emplace(
-            Address{state.end},
-            StateDelta{
-                .account = AccountDelta{
-                    std::nullopt,
-                    Account{.balance = n, .incarnation = incarnation}}});
-        MONAD_ASSERT(success);
-        ++state.end;
-    }
-
-    void update_account(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
-        Incarnation const incarnation)
-    {
-        if (state.begin == state.end) {
-            return;
-        }
-        uint64_t const addr = (n % (state.end - state.begin)) + state.begin;
-        auto const orig = db.read_account(Address{addr});
-        MONAD_ASSERT(orig.has_value());
-        bool const reincarnate = (n % 10) == 1;
-        bool const success = deltas.emplace(
-            Address{addr},
-            StateDelta{
-                .account = AccountDelta{
-                    orig,
-                    Account{
-                        .balance = n,
-                        .incarnation = reincarnate
-                                           ? incarnation
-                                           : orig.value().incarnation}}});
-        MONAD_ASSERT(success);
-        if (reincarnate) {
-            state.storage.erase(addr);
-        }
-    }
-
-    void remove_account(StateDeltas &deltas, State &state, TrieDb &db)
-    {
-        if (state.begin == state.end) {
-            return;
-        }
-        Address const addr{state.begin};
-        bool const success = deltas.emplace(
-            addr,
-            StateDelta{
-                .account = AccountDelta{
-                    db.read_account(Address{state.begin}), std::nullopt}});
-        MONAD_ASSERT(success);
-        state.storage.erase(state.begin);
-        ++state.begin;
-    }
-
-    void
-    new_storage(StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
-    {
-        if (state.begin == state.end) {
-            return;
-        }
-        uint64_t const addr = n % (state.end - state.begin) + state.begin;
-        auto const orig = db.read_account(Address{addr});
-        MONAD_ASSERT(orig.has_value());
-        StateDeltas::accessor it;
-        bytes32_t const end{state.storage[addr].end++};
-        bool success = deltas.emplace(
-            it,
-            Address{addr},
-            StateDelta{
-                .account = {orig, orig},
-                .storage = StorageDeltas{{end, {bytes32_t{}, bytes32_t{n}}}}});
-        MONAD_ASSERT(success);
-    }
-
-    void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
-        bool const erase)
-    {
-        if (state.storage.empty()) {
-            return;
-        }
-        auto const sit = state.storage.begin() +
-                         static_cast<unsigned>(n % state.storage.size());
-        Address const addr{sit->first};
-        auto const orig = db.read_account(addr);
-        MONAD_ASSERT(orig.has_value());
-        auto &[begin, end] = sit->second;
-        MONAD_ASSERT(begin != end);
-        bytes32_t const key{erase ? begin : n % (end - begin) + begin};
-        bytes32_t const value{erase ? 0 : n};
-        auto const sorig = db.read_storage(addr, orig->incarnation, key);
-        bool const success = deltas.emplace(
-            addr,
-            StateDelta{
-                .account = {orig, orig},
-                .storage = StorageDeltas{{key, {sorig, value}}}});
-        MONAD_ASSERT(success && sorig != bytes32_t{});
-        if (erase) {
-            ++begin;
-            if (begin == end) {
-                state.storage.erase(sit);
-            }
-        }
-    }
-
-    void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
-    {
-        update_storage(deltas, state, db, n, false);
-    }
-
-    void remove_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
-    {
-        update_storage(deltas, state, db, n, true);
-    }
-
-    std::filesystem::path tmp_dbname()
-    {
-        std::filesystem::path dbname(
-            MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
-            "monad_fuzz_statesync_XXXXXX");
-        int const fd = ::mkstemp((char *)dbname.native().data());
-        MONAD_ASSERT(fd != -1);
-        MONAD_ASSERT(
-            -1 !=
-            ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
-        ::close(fd);
-        char const *const path = dbname.c_str();
-        OnDiskMachine machine;
-        mpt::Db const db{
-            machine,
-            mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
-        return dbname;
-    }
-
-}
-
-MONAD_NAMESPACE_END
 
 extern "C" int
 LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
@@ -249,6 +42,8 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     if (size < sizeof(uint64_t)) {
         return -1;
     }
+
+    fprintf(stderr, "size=%zu\n", size);
 
     quill::start(false);
     quill::get_root_logger()->set_log_level(quill::LogLevel::Error);
@@ -262,7 +57,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
             "",
             static_cast<unsigned>(get_nprocs() - 1),
             &client,
-            &statesync_send_request);
+            &::statesync_send_request);
     std::filesystem::path sdbname{tmp_dbname()};
     OnDiskMachine machine;
     mpt::Db sdb{

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.hpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.hpp
@@ -1,0 +1,233 @@
+#include <ankerl/unordered_dense.h>
+#include <cstdint>
+#include <monad/core/address.hpp>
+#include <monad/core/assert.h>
+#include <monad/state2/state_deltas.hpp>
+#include <monad/types/incarnation.hpp>
+
+struct monad_statesync_client
+{
+    std::deque<monad_sync_request> rqs;
+    uint64_t mask;
+};
+
+struct monad_statesync_server_network
+{
+    monad_statesync_client *client;
+    monad_statesync_client_context *cctx;
+    monad::byte_string buf;
+};
+
+MONAD_NAMESPACE_BEGIN
+
+namespace test_statesync
+{
+    void statesync_send_request(
+        monad_statesync_client *const client, monad_sync_request const rq)
+    {
+        client->rqs.push_back(rq);
+    }
+
+    ssize_t statesync_server_recv(
+        monad_statesync_server_network *const net, unsigned char *const buf,
+        size_t const len)
+    {
+        if (len == 1) {
+            constexpr auto MSG_TYPE = SYNC_TYPE_REQUEST;
+            std::memcpy(buf, &MSG_TYPE, 1);
+        }
+        else {
+            MONAD_ASSERT(len == sizeof(monad_sync_request));
+            std::memcpy(
+                buf, &net->client->rqs.front(), sizeof(monad_sync_request));
+            net->client->rqs.pop_front();
+        }
+        return static_cast<ssize_t>(len);
+    }
+
+    void statesync_server_send_upsert(
+        monad_statesync_server_network *const net, monad_sync_type const type,
+        unsigned char const *const v1, uint64_t const size1,
+        unsigned char const *const v2, uint64_t const size2)
+    {
+        net->buf.clear();
+        if (v1 != nullptr) {
+            net->buf.append(v1, size1);
+        }
+        if (v2 != nullptr) {
+            net->buf.append(v2, size2);
+        }
+        MONAD_ASSERT(monad_statesync_client_handle_upsert(
+            net->cctx, 0, type, net->buf.data(), net->buf.size()));
+    }
+
+    void statesync_server_send_done(
+        monad_statesync_server_network *const net, monad_sync_done const done)
+    {
+        monad_statesync_client_handle_done(net->cctx, done);
+    }
+
+    struct Range
+    {
+        uint64_t begin{0};
+        uint64_t end{0};
+    };
+
+    struct State : Range
+    {
+        ankerl::unordered_dense::segmented_map<uint64_t, Range> storage;
+    };
+
+    void new_account(
+        StateDeltas &deltas, State &state, Incarnation const incarnation,
+        uint64_t const n)
+    {
+        bool const success = deltas.emplace(
+            Address{state.end},
+            StateDelta{
+                .account = AccountDelta{
+                    std::nullopt,
+                    Account{.balance = n, .incarnation = incarnation}}});
+        MONAD_ASSERT(success);
+        ++state.end;
+    }
+
+    void update_account(
+        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        Incarnation const incarnation)
+    {
+        if (state.begin == state.end) {
+            return;
+        }
+        uint64_t const addr = (n % (state.end - state.begin)) + state.begin;
+        auto const orig = db.read_account(Address{addr});
+        MONAD_ASSERT(orig.has_value());
+        bool const reincarnate = (n % 10) == 1;
+        // possible to generate duplicate key updates
+        if (deltas.emplace(
+                Address{addr},
+                StateDelta{
+                    .account = AccountDelta{
+                        orig,
+                        Account{
+                            .balance = n,
+                            .incarnation = reincarnate
+                                               ? incarnation
+                                               : orig.value().incarnation}}})) {
+            if (reincarnate) {
+                state.storage.erase(addr);
+            }
+        }
+    }
+
+    void remove_account(StateDeltas &deltas, State &state, TrieDb &db)
+    {
+        if (state.begin == state.end) {
+            return;
+        }
+        Address const addr{state.begin};
+        bool const success = deltas.emplace(
+            addr,
+            StateDelta{
+                .account = AccountDelta{
+                    db.read_account(Address{state.begin}), std::nullopt}});
+        MONAD_ASSERT(success);
+        state.storage.erase(state.begin);
+        ++state.begin;
+    }
+
+    void
+    new_storage(StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+    {
+        if (state.begin == state.end) {
+            return;
+        }
+        uint64_t const addr = n % (state.end - state.begin) + state.begin;
+        auto const orig = db.read_account(Address{addr});
+        MONAD_ASSERT(orig.has_value());
+        StateDeltas::accessor it;
+        bytes32_t const end{state.storage[addr].end++};
+        if (!deltas.emplace(
+                it,
+                Address{addr},
+                StateDelta{
+                    .account = {orig, orig},
+                    .storage =
+                        StorageDeltas{{end, {bytes32_t{}, bytes32_t{n}}}}})) {
+            bool success = it->second.storage.emplace(
+                end, StorageDelta{bytes32_t{}, bytes32_t{n}});
+            MONAD_ASSERT(success);
+        }
+    }
+
+    void update_storage(
+        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        bool const erase)
+    {
+        if (state.storage.empty()) {
+            return;
+        }
+        auto const sit = state.storage.begin() +
+                         static_cast<unsigned>(n % state.storage.size());
+        Address const addr{sit->first};
+        auto const orig = db.read_account(addr);
+        MONAD_ASSERT(orig.has_value());
+        auto &[begin, end] = sit->second;
+        MONAD_ASSERT(begin != end);
+        bytes32_t const key{erase ? begin : n % (end - begin) + begin};
+        bytes32_t const value{erase ? 0 : n};
+        auto const sorig = db.read_storage(addr, orig->incarnation, key);
+        MONAD_ASSERT(sorig != bytes32_t{});
+        StateDeltas::accessor it;
+
+        if (!deltas.emplace(
+                it,
+                addr,
+                StateDelta{
+                    .account = {orig, orig},
+                    .storage = StorageDeltas{{key, {sorig, value}}}})) {
+            // possible to generate duplicate key updates
+            (void)it->second.storage.emplace(key, StorageDelta{sorig, value});
+        }
+        if (erase) {
+            ++begin;
+            if (begin == end) {
+                state.storage.erase(sit);
+            }
+        }
+    }
+
+    void update_storage(
+        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+    {
+        update_storage(deltas, state, db, n, false);
+    }
+
+    void remove_storage(
+        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+    {
+        update_storage(deltas, state, db, n, true);
+    }
+
+    std::filesystem::path tmp_dbname()
+    {
+        std::filesystem::path dbname(
+            MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+            "monad_fuzz_statesync_XXXXXX");
+        int const fd = ::mkstemp((char *)dbname.native().data());
+        MONAD_ASSERT(fd != -1);
+        MONAD_ASSERT(
+            -1 !=
+            ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
+        ::close(fd);
+        char const *const path = dbname.c_str();
+        OnDiskMachine machine;
+        mpt::Db const db{
+            machine,
+            mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
+        return dbname;
+    }
+
+}
+
+MONAD_NAMESPACE_END


### PR DESCRIPTION
Modify upsert api to allow subtree deletion and subtree insertion. This option is enabled by setting prefix_update to true.

Restore prefix is to be used by statesync when inconsistency in subtree data is detected to revert to previous state and restart transfer.