### PR TITLE
Add sq_thread_cpu arg to monad_statesync_client_context

### DIFF
--- a/libs/statesync/src/monad/statesync/statesync_client.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_client.cpp
@@ -15,13 +15,17 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <optional>
 
 using namespace monad;
 using namespace monad::mpt;
 
+unsigned const MONAD_SQPOLL_DISABLED = unsigned(-1);
+
 monad_statesync_client_context *monad_statesync_client_context_create(
     char const *const *const dbname_paths, size_t const len,
-    char const *const genesis_file, monad_statesync_client *sync,
+    char const *const genesis_file, unsigned const sq_thread_cpu,
+    monad_statesync_client *sync,
     void (*statesync_send_request)(
         monad_statesync_client *, monad_sync_request))
 {
@@ -29,7 +33,13 @@ monad_statesync_client_context *monad_statesync_client_context_create(
         dbname_paths, dbname_paths + len};
     MONAD_ASSERT(!paths.empty());
     return new monad_statesync_client_context{
-        paths, genesis_file, sync, statesync_send_request};
+        paths,
+        genesis_file,
+        sq_thread_cpu == MONAD_SQPOLL_DISABLED
+            ? std::nullopt
+            : std::make_optional(sq_thread_cpu),
+        sync,
+        statesync_send_request};
 }
 
 uint8_t monad_statesync_client_prefix_bytes()

--- a/libs/statesync/src/monad/statesync/statesync_client.h
+++ b/libs/statesync/src/monad/statesync/statesync_client.h
@@ -7,12 +7,14 @@ extern "C"
 {
 #endif
 
+extern const unsigned MONAD_SQPOLL_DISABLED;
+
 struct monad_statesync_client;
 struct monad_statesync_client_context;
 
 struct monad_statesync_client_context *monad_statesync_client_context_create(
     char const *const *dbname_paths, size_t len, char const *genesis_file,
-    struct monad_statesync_client *,
+    unsigned sq_thread_cpu, struct monad_statesync_client *,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request));
 

--- a/libs/statesync/src/monad/statesync/statesync_client_context.cpp
+++ b/libs/statesync/src/monad/statesync/statesync_client_context.cpp
@@ -15,7 +15,9 @@ using namespace monad::mpt;
 
 monad_statesync_client_context::monad_statesync_client_context(
     std::vector<std::filesystem::path> const dbname_paths,
-    std::filesystem::path const genesis, monad_statesync_client *const sync,
+    std::filesystem::path const genesis,
+    std::optional<unsigned> const sq_thread_cpu,
+    monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
     : db{machine,
@@ -26,7 +28,7 @@ monad_statesync_client_context::monad_statesync_client_context(
              .rd_buffers = 8192,
              .wr_buffers = 32,
              .uring_entries = 128,
-             .sq_thread_cpu = get_nprocs() - 1,
+             .sq_thread_cpu = sq_thread_cpu,
              .dbname_paths = dbname_paths}}
     , tdb{db} // open with latest finalized if valid, otherwise init as block 0
     , progress(

--- a/libs/statesync/src/monad/statesync/statesync_client_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_client_context.hpp
@@ -51,7 +51,8 @@ struct monad_statesync_client_context
 
     monad_statesync_client_context(
         std::vector<std::filesystem::path> dbname_paths,
-        std::filesystem::path genesis, monad_statesync_client *,
+        std::filesystem::path genesis, std::optional<unsigned> sq_thread_cpu,
+        monad_statesync_client *,
         void (*statesync_send_request)(
             struct monad_statesync_client *, struct monad_sync_request));
 

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
@@ -21,6 +21,7 @@
 #include <optional>
 #include <span>
 #include <stdio.h>
+#include <sys/sysinfo.h>
 
 using namespace monad;
 using namespace monad::mpt;
@@ -256,7 +257,12 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     monad_statesync_client client;
     monad_statesync_client_context *const cctx =
         monad_statesync_client_context_create(
-            &cdbname_str, 1, "", &client, &statesync_send_request);
+            &cdbname_str,
+            1,
+            "",
+            static_cast<unsigned>(get_nprocs() - 1),
+            &client,
+            &statesync_send_request);
     std::filesystem::path sdbname{tmp_dbname()};
     OnDiskMachine machine;
     mpt::Db sdb{

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -21,6 +21,7 @@
 #include <deque>
 #include <filesystem>
 #include <fstream>
+#include <sys/sysinfo.h>
 
 using namespace monad;
 using namespace monad::mpt;
@@ -149,7 +150,12 @@ namespace
         {
             char const *const str = cdbname.c_str();
             cctx = monad_statesync_client_context_create(
-                &str, 1, genesis.c_str(), &client, &statesync_send_request);
+                &str,
+                1,
+                genesis.c_str(),
+                static_cast<unsigned>(get_nprocs() - 1),
+                &client,
+                &statesync_send_request);
             net = {.client = &client, .cctx = cctx};
             for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
                 monad_statesync_client_handle_new_peer(


### PR DESCRIPTION
Statesync client panics if bft cpuset range doesn't include the last cpu. This PR makes it configurable so bft can set sq_thread_cpu in the range