### PR TITLE
Db fix off-by-one error in `MIN_HISTORY_LENGTH`, now set to 257.

### DIFF
--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -64,7 +64,6 @@ namespace
             unaligned_load<uint32_t>(bytes.data() + sizeof(uint32_t)));
         return {fast_offset, slow_offset};
     }
-
 }
 
 // Define to avoid randomisation of free list chunks on pool creation
@@ -1171,7 +1170,6 @@ void UpdateAuxImpl::adjust_history_length_based_on_disk_usage()
 {
     constexpr double upper_bound = 0.8;
     constexpr double lower_bound = 0.6;
-    constexpr uint64_t min_history_length = 256;
 
     // Shorten history length when disk usage is high
     auto const max_version = db_history_max_version();
@@ -1182,20 +1180,20 @@ void UpdateAuxImpl::adjust_history_length_based_on_disk_usage()
         max_version - db_history_min_valid_version() + 1;
     auto const current_disk_usage = disk_usage();
     if (current_disk_usage > upper_bound &&
-        history_length_before > min_history_length) {
+        history_length_before > MIN_HISTORY_LENGTH) {
         while (disk_usage() > upper_bound &&
-               version_history_length() > min_history_length) {
+               version_history_length() > MIN_HISTORY_LENGTH) {
             auto const version_to_erase = db_history_min_valid_version();
             MONAD_ASSERT(
                 version_to_erase != INVALID_BLOCK_ID &&
                 version_to_erase < max_version);
             erase_version(version_to_erase);
             update_history_length_metadata(
-                std::max(max_version - version_to_erase, min_history_length));
+                std::max(max_version - version_to_erase, MIN_HISTORY_LENGTH));
         }
         MONAD_ASSERT(
             disk_usage() <= upper_bound ||
-            version_history_length() == min_history_length);
+            version_history_length() == MIN_HISTORY_LENGTH);
         LOG_INFO_CFORMAT(
             "Adjust db history length down from %lu to %lu",
             history_length_before,

--- a/libs/db/src/monad/mpt/util.hpp
+++ b/libs/db/src/monad/mpt/util.hpp
@@ -29,6 +29,7 @@ static constexpr uint8_t INVALID_BRANCH = 255;
 static constexpr uint8_t INVALID_PATH_INDEX = 255;
 static constexpr uint64_t INVALID_BLOCK_ID = uint64_t(-1);
 static constexpr uint64_t INVALID_ROUND_NUM = uint64_t(-1);
+static constexpr uint64_t MIN_HISTORY_LENGTH = 257;
 
 static byte_string const empty_trie_hash = [] {
     using namespace ::monad::literals;


### PR DESCRIPTION
test_statesync: add a new test `sync_one_account_client_has_min_history_length` to reproduce the bug blockvision reported, the test configures client db to use a fixed minimum history length. This test fails before and passes after the fix.

```
test_statesync: /home/vickychen/github/monad2/libs/db/src/monad/mpt/trie.cpp:1940: chunk_offset_t monad::mpt::write_new_root_node(UpdateAuxImpl &, Node &, const uint64_t): 
Assertion 'version >= ((max_version_in_db >= aux.version_history_length()) ? max_version_in_db - aux.version_history_length() + 1 : 0)' failed.
```