### PR TITLE
Use ZSTD to compress call frames before committing to db

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endfunction()
 find_package(Boost REQUIRED COMPONENTS fiber json)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
+pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
 
 # BLAKE3
 add_subdirectory(third_party/BLAKE3/c)

--- a/libs/execution/CMakeLists.txt
+++ b/libs/execution/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(
   PRIVATE Boost::fiber
   PRIVATE Boost::json
   PRIVATE PkgConfig::brotli
+  PRIVATE PkgConfig::zstd
   PUBLIC ethash::keccak
   PUBLIC evmc
   PUBLIC intx::intx

--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -142,7 +142,7 @@ namespace
                 return c.first < NibblesView{c2.first};
             });
 
-        byte_string const call_frames_encoded = std::accumulate(
+        byte_string const call_frames_compressed = std::accumulate(
             std::make_move_iterator(chunks.begin()),
             std::make_move_iterator(chunks.end()),
             byte_string{},
@@ -150,10 +150,14 @@ namespace
                 return std::move(acc) + std::move(chunk.second);
             });
 
-        byte_string_view view{call_frames_encoded};
-        auto const call_frame = rlp::decode_call_frames(view);
+        byte_string_view view{call_frames_compressed};
+        auto const call_frames_encoded = decompress_call_frames(view);
+        MONAD_ASSERT(!call_frames_encoded.has_error());
+
+        byte_string_view view2{call_frames_encoded.value()};
+        auto const call_frame = rlp::decode_call_frames(view2);
         MONAD_ASSERT(!call_frame.has_error());
-        MONAD_ASSERT(view.empty());
+        MONAD_ASSERT(view2.empty());
         return call_frame.value();
     }
 

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -296,8 +296,10 @@ void TrieDb::commit(
 
         // Call frames
         std::span<CallFrame const> frames{call_frames[i]};
+        auto const rlp_call_frames = rlp::encode_call_frames(frames);
+
         byte_string_view frame_view =
-            bytes_alloc_.emplace_back(rlp::encode_call_frames(frames));
+            bytes_alloc_.emplace_back(compress_call_frames(rlp_call_frames));
         uint8_t chunk_index = 0;
         auto const call_frame_prefix =
             serialize_as_big_endian<sizeof(uint32_t)>(i);

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -144,4 +144,8 @@ mpt::Nibbles proposal_prefix(uint64_t);
 
 std::vector<uint64_t> get_proposal_rounds(mpt::Db &, uint64_t block_number);
 
+byte_string compress_call_frames(byte_string_view const);
+
+Result<byte_string> decompress_call_frames(byte_string_view &);
+
 MONAD_NAMESPACE_END


### PR DESCRIPTION
**Run from block 12M - 12M + 1000**

**Current branch (ZSTD)** 
3M: tps=20921  gps=714 M
12M: tps=7284  gps=451 M
15M: tps=5546  gps=468 M
18M: tps=2898  gps=312 M
19M: tps=3615  gps=323 M

1. Call Trace Saving Statistics (level = 1):
       Size before compression: 143.369MB
       Size after comression: 44.552MB
       Space saving ratio: 3.22

2. Block Saving Statistics (level = 3):
Size before compression: 46.204MB
Size after compression: 23.984MB
Space saving ratio: 1.92


**Brotli**
3M: tps=20921 gps=714 M
12M: tps=7239 gps=449 M
15M: tps=5435 gps=459 M
18M: tps=2761 gps=297 M
19M: tps=3566 gps=319 M

1. Call Trace Saving Statistics (level = 1):
Size before compression: 143.369MB
Size after comression: 54.931MB
Space saving ratio: 2.61

2. Block Saving Statistics (level = 11):
Size before compression: 46.204MB
Size after compression: 23.664MB
Space saving ratio: 1.95

**LZ4**
3M: tps=20921  gps=714 M
12M: tps=7253  gps=450 M
15M: tps=5466  gps=463 M
18M: tps=2899  gps=312 M
19M: tps=3612  gps=323 M

1. Call Trace Saving Statistics (level = default):
       Size before compression: 143.369MB
       Size after comression: 48.848MB
       Space saving ratio: 2.94

**Main**
3M: tps=23536 gps=803 M
12M: tps=7559 gps=468 M
15M: tps=5440 gps=459 M
18M: tps=2925 gps=315 M
19M: tps=3793 gps=339 M