### PR TITLE
Terminate statesync traverse if consensus closes connection

### DIFF
--- a/libs/statesync/src/monad/statesync/statesync_server.h
+++ b/libs/statesync/src/monad/statesync/statesync_server.h
@@ -11,7 +11,7 @@ struct monad_statesync_server *monad_statesync_server_create(
     struct monad_statesync_server_network *,
     ssize_t (*statesync_server_recv)(
         struct monad_statesync_server_network *, unsigned char *, size_t),
-    void (*statesync_server_send_upsert)(
+    bool (*statesync_server_send_upsert)(
         struct monad_statesync_server_network *, enum monad_sync_type,
         unsigned char const *v1, uint64_t size1, unsigned char const *v2,
         uint64_t size2),

--- a/libs/statesync/src/monad/statesync/statesync_server_network.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_network.hpp
@@ -16,15 +16,27 @@ struct monad_statesync_server_network
 {
     int fd;
     monad::byte_string obuf;
+    std::string path;
 
     monad_statesync_server_network(char const *const path)
-        : fd{socket(AF_UNIX, SOCK_STREAM, 0)}
+        : fd{-1}
+        , path(path)
     {
+        ensure_connected();
+    }
+
+    void ensure_connected()
+    {
+        if (fd != -1) {
+            return;
+        }
+        fd = socket(AF_UNIX, SOCK_STREAM, 0);
+        MONAD_ASSERT(fd >= 0);
         struct sockaddr_un addr;
         memset(&addr, 0, sizeof(addr));
         addr.sun_family = AF_UNIX;
-        strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
-        while (connect(fd, (sockaddr *)&addr, sizeof(addr)) != 0) {
+        strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+        while (::connect(fd, (sockaddr *)&addr, sizeof(addr)) != 0) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
@@ -36,28 +48,61 @@ namespace
 {
     constexpr size_t SEND_BATCH_SIZE = 64 * 1024;
 
-    void send(int const fd, byte_string_view const buf)
+    /// Returns true if send succeeded, otherwise false.
+    bool send(monad_statesync_server_network *net, byte_string_view const buf)
     {
         size_t nsent = 0;
+        if (net->fd == -1) {
+            return false;
+        }
         while (nsent < buf.size()) {
             ssize_t const res =
-                ::send(fd, buf.data() + nsent, buf.size() - nsent, 0);
+                ::send(net->fd, buf.data() + nsent, buf.size() - nsent, 0);
             if (res == -1) {
-                continue;
+                if (errno == EINTR) {
+                    continue;
+                }
+                else if (errno == EPIPE || errno == ECONNRESET) {
+                    LOG_INFO("statesync connection closed, exiting traverse");
+                    close(net->fd);
+                    net->fd = -1;
+                    return false;
+                }
+                else {
+                    MONAD_ASSERT(false);
+                }
             }
             nsent += static_cast<size_t>(res);
         }
+        return true;
     }
 }
 
 ssize_t statesync_server_recv(
-    monad_statesync_server_network *const net, unsigned char *buf, size_t n)
+    monad_statesync_server_network *net, unsigned char *buf, size_t n)
 {
-    return recv(net->fd, buf, n, MSG_DONTWAIT);
+    while (true) {
+        net->ensure_connected();
+        auto const res = recv(net->fd, buf, n, 0);
+        if (res > 0) {
+            return res;
+        }
+        else if (res == 0) {
+            LOG_INFO("statesync connection closed, reconnecting");
+            close(net->fd);
+            net->fd = -1;
+        }
+        else {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+            MONAD_ASSERT(false);
+        }
+    }
 }
 
-void statesync_server_send_upsert(
-    monad_statesync_server_network *const net, monad_sync_type const type,
+bool statesync_server_send_upsert(
+    monad_statesync_server_network *net, monad_sync_type const type,
     unsigned char const *const v1, uint64_t const size1,
     unsigned char const *const v2, uint64_t const size2)
 {
@@ -83,7 +128,9 @@ void statesync_server_send_upsert(
     }
 
     if (net->obuf.size() >= SEND_BATCH_SIZE) {
-        send(net->fd, net->obuf);
+        if (!send(net, net->obuf)) {
+            return false;
+        }
         net->obuf.clear();
     }
 
@@ -96,16 +143,17 @@ void statesync_server_send_upsert(
             fmt::join(std::as_bytes(std::span(v2, size2)), "")),
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::steady_clock::now() - start));
+    return true;
 }
 
 void statesync_server_send_done(
-    monad_statesync_server_network *const net, monad_sync_done const msg)
+    monad_statesync_server_network *net, monad_sync_done const msg)
 {
     [[maybe_unused]] auto const start = std::chrono::steady_clock::now();
     net->obuf.push_back(SYNC_TYPE_DONE);
     net->obuf.append(
         reinterpret_cast<unsigned char const *>(&msg), sizeof(msg));
-    send(net->fd, net->obuf);
+    (void)send(net, net->obuf);
     net->obuf.clear();
     LOG_DEBUG(
         "sending done success={} prefix={} n={} time={}",

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
@@ -63,7 +63,7 @@ ssize_t statesync_server_recv(
     return static_cast<ssize_t>(len);
 }
 
-void statesync_server_send_upsert(
+bool statesync_server_send_upsert(
     monad_statesync_server_network *const net, monad_sync_type const type,
     unsigned char const *const v1, uint64_t const size1,
     unsigned char const *const v2, uint64_t const size2)
@@ -77,6 +77,7 @@ void statesync_server_send_upsert(
     }
     MONAD_ASSERT(monad_statesync_client_handle_upsert(
         net->cctx, 0, type, net->buf.data(), net->buf.size()));
+    return true;
 }
 
 void statesync_server_send_done(

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -93,8 +93,8 @@ namespace
         return static_cast<ssize_t>(len);
     }
 
-    void statesync_server_send_upsert(
-        monad_statesync_server_network *const net, monad_sync_type const type,
+    bool statesync_server_send_upsert(
+        monad_statesync_server_network *net, monad_sync_type const type,
         unsigned char const *const v1, uint64_t const size1,
         unsigned char const *const v2, uint64_t const size2)
     {
@@ -108,6 +108,7 @@ namespace
         // TODO: prefixes have different protocols
         MONAD_ASSERT(monad_statesync_client_handle_upsert(
             net->cctx, 0, type, net->buf.data(), net->buf.size()));
+        return true;
     }
 
     void statesync_server_send_done(


### PR DESCRIPTION
Add ability to end traverse early if client is not responding.

Check for send error and terminate traverse if consensus process closed connection. This means that the client was inresponsive and traverse should be aborted early.

Handle connection disconnect during receive.