### PR TITLE
Fix asan and ubsan build error

### DIFF
--- a/libs/execution/src/monad/state2/test/test_state.cpp
+++ b/libs/execution/src/monad/state2/test/test_state.cpp
@@ -1420,6 +1420,11 @@ TEST_F(OnDiskTrieDbFixture, proposal_basics)
     EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC push_options
+    #pragma GCC optimize("-fno-var-tracking-assignments")
+#endif
+
 TEST_F(OnDiskTrieDbFixture, undecided_proposals)
 {
     load_header(this->db, BlockHeader{.number = 9});
@@ -1624,6 +1629,10 @@ TEST_F(OnDiskTrieDbFixture, undecided_proposals)
     ASSERT_TRUE(data_131.has_value());
     EXPECT_EQ(state_root_round_131, to_bytes(data_131.value()));
 }
+
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC pop_options
+#endif
 
 namespace
 {

--- a/libs/rpc/src/monad/rpc/eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/eth_call.cpp
@@ -518,8 +518,8 @@ struct monad_eth_call_executor
             result->status_code = EVMC_REJECTED;
             constexpr auto len = BLOCKHASH_ERR_MSG.size();
             result->message = new char[len + 1];
-            std::strncpy(result->message, BLOCKHASH_ERR_MSG.data(), len);
-            result->message[len] = 0;
+            std::memcpy(result->message, BLOCKHASH_ERR_MSG.data(), len);
+            result->message[len] = '\0';
             complete(result, user);
             return;
         }


### PR DESCRIPTION
Current asan and ubsan build fails in 2 places
1. in test_state.cpp, it reaches variable size tracking limit
2. in eth_call.cpp, std::strncpy has output truncated before terminating nul copying error