### PR TITLE
Fix ubsan error in string copy in eth_call

### DIFF
--- a/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
@@ -281,6 +281,10 @@ TEST_F(EthCallFixture, failed_to_read)
     f.get();
 
     EXPECT_EQ(ctx.result->status_code, EVMC_REJECTED);
+    EXPECT_TRUE(
+        std::strcmp(
+            ctx.result->message, "failure to initialize block hash buffer") ==
+        0);
     monad_state_override_destroy(state_override);
     monad_eth_call_executor_destroy(executor);
 }


### PR DESCRIPTION
std::strncpy triggers `stringop-truncation` compiler warnings because it's not null terminated (even if we manually forced it to be null ternimated later)

**Solution:**
1. Use memcpy, which avoids the ubsan c string null terminator check
2. Use const char* for the variable. 