### PR TITLE
Implement statesync traversal abort

### DIFF
--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -238,6 +238,7 @@ int main(int const argc, char const *argv[])
     monad_statesync_server *sync = nullptr;
     if (!statesync.empty()) {
         ctx = std::make_unique<monad_statesync_server_context>(triedb);
+        net.value().aborted = &ctx->aborted;
         sync = monad_statesync_server_create(
             ctx.get(),
             &net.value(),

--- a/libs/statesync/src/monad/statesync/statesync_messages.h
+++ b/libs/statesync/src/monad/statesync/statesync_messages.h
@@ -21,6 +21,7 @@ enum monad_sync_type : uint8_t
     SYNC_TYPE_UPSERT_ACCOUNT_DELETE = 6,
     SYNC_TYPE_UPSERT_STORAGE_DELETE = 7,
     SYNC_TYPE_UPSERT_HEADER = 8,
+    SYNC_TYPE_ABORT = 9,
 };
 
 static_assert(sizeof(enum monad_sync_type) == 1);

--- a/libs/statesync/src/monad/statesync/statesync_server.h
+++ b/libs/statesync/src/monad/statesync/statesync_server.h
@@ -7,16 +7,16 @@ struct monad_statesync_server_context;
 struct monad_statesync_server_network;
 
 struct monad_statesync_server *monad_statesync_server_create(
-    struct monad_statesync_server_context *,
-    struct monad_statesync_server_network *,
-    ssize_t (*statesync_server_recv)(
-        struct monad_statesync_server_network *, unsigned char *, size_t),
+    monad_statesync_server_context *const ctx,
+    monad_statesync_server_network *const net,
+    monad_sync_request (*statesync_server_recv)(
+        monad_statesync_server_network *),
     void (*statesync_server_send_upsert)(
-        struct monad_statesync_server_network *, enum monad_sync_type,
+        monad_statesync_server_network *, monad_sync_type,
         unsigned char const *v1, uint64_t size1, unsigned char const *v2,
         uint64_t size2),
     void (*statesync_server_send_done)(
-        struct monad_statesync_server_network *, struct monad_sync_done));
+        monad_statesync_server_network *, struct monad_sync_done));
 
 void monad_statesync_server_run_once(struct monad_statesync_server *);
 

--- a/libs/statesync/src/monad/statesync/statesync_server_context.hpp
+++ b/libs/statesync/src/monad/statesync/statesync_server_context.hpp
@@ -80,6 +80,7 @@ struct monad_statesync_server_context final : public monad::Db
     monad::mpt::Db *ro;
     std::deque<monad::ProposedDeletions> proposals;
     monad::FinalizedDeletions deletions;
+    std::atomic<bool> aborted{false};
 
     explicit monad_statesync_server_context(monad::TrieDb &rw);
 

--- a/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/fuzz_statesync.cpp
@@ -47,20 +47,12 @@ void statesync_send_request(
     }
 }
 
-ssize_t statesync_server_recv(
-    monad_statesync_server_network *const net, unsigned char *const buf,
-    size_t const len)
+monad_sync_request
+statesync_server_recv(monad_statesync_server_network *const net)
 {
-    if (len == 1) {
-        constexpr auto MSG_TYPE = SYNC_TYPE_REQUEST;
-        std::memcpy(buf, &MSG_TYPE, 1);
-    }
-    else {
-        MONAD_ASSERT(len == sizeof(monad_sync_request));
-        std::memcpy(buf, &net->client->rqs.front(), sizeof(monad_sync_request));
-        net->client->rqs.pop_front();
-    }
-    return static_cast<ssize_t>(len);
+    auto rq = net->client->rqs.front();
+    net->client->rqs.pop_front();
+    return rq;
 }
 
 void statesync_server_send_upsert(

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -76,21 +76,12 @@ namespace
         monad_statesync_client_handle_target(ctx, rlp.data(), rlp.size());
     }
 
-    ssize_t statesync_server_recv(
-        monad_statesync_server_network *const net, unsigned char *const buf,
-        size_t const len)
+    monad_sync_request
+    statesync_server_recv(monad_statesync_server_network *const net)
     {
-        if (len == 1) {
-            constexpr auto MSG_TYPE = SYNC_TYPE_REQUEST;
-            std::memcpy(buf, &MSG_TYPE, 1);
-        }
-        else {
-            EXPECT_EQ(len, sizeof(monad_sync_request));
-            std::memcpy(
-                buf, &net->client->rqs.front(), sizeof(monad_sync_request));
-            net->client->rqs.pop_front();
-        }
-        return static_cast<ssize_t>(len);
+        auto rq = net->client->rqs.front();
+        net->client->rqs.pop_front();
+        return rq;
     }
 
     void statesync_server_send_upsert(


### PR DESCRIPTION
If the statesync client goes away, interrupt traversal. The consensus signals abort by sending a message with single byte SYNC_TYPE_ABORT.

Create a thread for reading messages from socket to check for abort asynchronously with traversal.