### PR TITLE
Improve eth_call latency and UX: tiered pools by gas limit, and add queuing controls

### DIFF
--- a/libs/rpc/src/monad/rpc/eth_call.h
+++ b/libs/rpc/src/monad/rpc/eth_call.h
@@ -64,7 +64,8 @@ void monad_eth_call_result_release(monad_eth_call_result *);
 
 struct monad_eth_call_executor *monad_eth_call_executor_create(
     unsigned num_threads, unsigned num_fibers, unsigned node_lru_size,
-    unsigned high_pool_timeout_sec, char const *dbpath);
+    unsigned low_pool_timeout_sec, unsigned high_pool_timeout_sec,
+    char const *dbpath);
 
 void monad_eth_call_executor_destroy(struct monad_eth_call_executor *);
 

--- a/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
+++ b/libs/rpc/src/monad/rpc/test/test_eth_call.cpp
@@ -27,6 +27,7 @@ using namespace monad::test;
 namespace
 {
     constexpr unsigned node_lru_size = 10240;
+    constexpr unsigned max_timeout = std::numeric_limits<unsigned>::max();
 
     std::vector<uint8_t> to_vec(byte_string const &bs)
     {
@@ -129,7 +130,12 @@ namespace
             to_vec(rlp::encode_address(std::make_optional(from)));
 
         auto executor = monad_eth_call_executor_create(
-            1, 1, node_lru_size, 30, dbname.string().c_str());
+            1,
+            1,
+            node_lru_size,
+            max_timeout,
+            max_timeout,
+            dbname.string().c_str());
         auto state_override = monad_state_override_create();
 
         struct callback_context ctx;
@@ -213,7 +219,7 @@ TEST_F(EthCallFixture, simple_success_call)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -271,7 +277,7 @@ TEST_F(EthCallFixture, insufficient_balance)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -330,7 +336,7 @@ TEST_F(EthCallFixture, on_proposed_block)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -388,7 +394,7 @@ TEST_F(EthCallFixture, failed_to_read)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -448,7 +454,7 @@ TEST_F(EthCallFixture, contract_deployment_success)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -529,7 +535,7 @@ TEST_F(EthCallFixture, from_contract_account)
     auto const rlp_sender = to_vec(rlp::encode_address(std::make_optional(ca)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;
@@ -601,7 +607,12 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
     Transaction tx{.gas_limit = 100000u, .to = ca, .data = from_hex(tx_data)};
 
     auto executor = monad_eth_call_executor_create(
-        2, 10, node_lru_size, 30, dbname.string().c_str());
+        2,
+        10,
+        node_lru_size,
+        max_timeout,
+        max_timeout,
+        dbname.string().c_str());
 
     std::deque<std::unique_ptr<callback_context>> ctxs;
     std::deque<boost::fibers::future<void>> futures;
@@ -709,7 +720,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_trace)
         to_vec(rlp::encode_address(std::make_optional(from)));
 
     auto executor = monad_eth_call_executor_create(
-        1, 1, node_lru_size, 30, dbname.string().c_str());
+        1, 1, node_lru_size, max_timeout, max_timeout, dbname.string().c_str());
     auto state_override = monad_state_override_create();
 
     struct callback_context ctx;


### PR DESCRIPTION
**Two-tired priority pools by gas limit:**
Improve io intensive eth call latency and ux: split to low and high gas limit pools but respect the user-specified gas. 
1. gas specified -> submit to appropriate pool based on the specified gas, return result of that execution
2. gas unspecified -> submit to low gas pool first, and if OOG, retry in high gas pool

We cap low pool gas limit to 400'000 in order to cap the execution time of each call. 

**How is 400 Kgas calculated?**

SLOAD is probably the most expensive opcode in terms of time / gas. It is priced as: [sload_gas=100](https://www.evm.codes/)
Say we want to cap low pool execution latency to 100ms, and we assume 25 us / read (average of node cache lookup and disk read). All the reads inside a call are sequential: 
```100ms / (25us / sload) * (100 gas / sload) = 400Kgas. ```

**Queuing controls**
Also add queue limit (fixed cap 20) and user configurable queuing timeout for high gas limit pool.
Note: the timeout is measured from when a call is first submitted to the low gas limit pool until it is assigned a fiber and begins execution.

bft PR https://github.com/category-labs/monad-bft/pull/1736