### PR TITLE
Limit the memory allocated for traverse clones during traverse

### DIFF
--- a/libs/db/src/monad/mpt/db.hpp
+++ b/libs/db/src/monad/mpt/db.hpp
@@ -240,7 +240,8 @@ namespace detail
 inline detail::TraverseSender make_traverse_sender(
     AsyncContext *const context, Node::UniquePtr traverse_root,
     std::unique_ptr<TraverseMachine> machine, uint64_t const block_id,
-    size_t const concurrency_limit = 4096)
+    size_t const concurrency_limit = 4096,
+    size_t const max_instance_per_level = 4096)
 {
     MONAD_ASSERT(context);
     return {
@@ -248,7 +249,8 @@ inline detail::TraverseSender make_traverse_sender(
         std::move(traverse_root),
         std::move(machine),
         block_id,
-        concurrency_limit};
+        concurrency_limit,
+        max_instance_per_level};
 }
 
 inline detail::DbGetSender<byte_string> make_get_sender(


### PR DESCRIPTION
Keep track of number of traverse instances created per tree level. If over the limit, stop processing nodes at previous level and add them to delay queue. Once under the limit again, resume processing of previous level nodes.

Since the number of levels in the tree is finite, this puts a limit on the amount of memory a traverse can consume.