### PR TITLE
remove bad assertion when serialized node span across buffer and ends…

### DIFF
--- a/libs/db/src/monad/mpt/test/node_writer_test.cpp
+++ b/libs/db/src/monad/mpt/test/node_writer_test.cpp
@@ -1,6 +1,3 @@
-#include "test_fixtures_base.hpp"
-#include "test_fixtures_gtest.hpp"
-
 #include <monad/core/assert.h>
 
 #include <monad/async/config.hpp>
@@ -14,49 +11,9 @@
 
 using namespace MONAD_MPT_NAMESPACE;
 using namespace MONAD_ASYNC_NAMESPACE;
-using namespace monad::literals;
 
-static constexpr size_t CHUNKS_TO_FILL = 3;
-
-// Note that storage pool is configured with 8MB storage chunks
-struct NodeWriterTest
-    : public monad::test::FillDBWithChunksGTest<
-          monad::test::FillDBWithChunksConfig{.chunks_to_fill = CHUNKS_TO_FILL}>
+namespace
 {
-private:
-    uint32_t rewind_fast_list_(unsigned const remaining_bytes_in_chunk)
-    {
-        auto const fast_chunk_ids = state()->fast_list_ids();
-        EXPECT_TRUE(fast_chunk_ids.size() >= 2);
-
-        // rewind to close to the end of second to last fast chunk in use
-        auto const insertion_index = fast_chunk_ids.size() - 2;
-        auto const rewind_chunk_id = fast_chunk_ids[insertion_index].first;
-        auto chunk = state()->io.storage_pool().chunk(
-            storage_pool::seq, rewind_chunk_id);
-        auto const fast_offset_rewind_to = chunk_offset_t{
-            rewind_chunk_id, chunk->size() - remaining_bytes_in_chunk};
-
-        // reset fast offset to close to the end of last chunk
-        state()->aux.advance_db_offsets_to(
-            fast_offset_rewind_to, state()->aux.get_start_of_wip_slow_offset());
-        state()->aux.append_root_offset(INVALID_OFFSET);
-        state()->aux.rewind_to_match_offsets();
-
-        EXPECT_EQ(
-            state()->aux.node_writer_fast->sender().offset(),
-            fast_offset_rewind_to);
-        uint32_t const curr_node_writer_chunk_id =
-            state()->aux.node_writer_fast->sender().offset().id;
-        EXPECT_EQ(
-            state()
-                ->aux.db_metadata()
-                ->at(curr_node_writer_chunk_id)
-                ->insertion_count(),
-            insertion_index);
-        return curr_node_writer_chunk_id;
-    }
-
     Node::UniquePtr make_node_of_size(unsigned const node_disk_size)
     {
         MONAD_ASSERT(node_disk_size > sizeof(Node) + Node::disk_size_bytes);
@@ -66,78 +23,196 @@ private:
         auto node = make_node(0, {}, {}, value, {}, 0);
         return node;
     }
+}
 
-public:
-    void rewind_then_write_node(
-        unsigned const remaining_bytes_in_chunk, unsigned node_disk_size)
+template <
+    size_t storage_pool_chunk_size = 1 << 28,
+    size_t storage_pool_num_chunks = 64, bool use_anonoymous_inode = true>
+struct NodeWriterTestBase : public ::testing::Test
+{
+    static constexpr size_t chunk_size = storage_pool_chunk_size;
+    static constexpr size_t num_chunks = storage_pool_num_chunks;
+
+    storage_pool pool;
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers rwbuf;
+    AsyncIO io;
+    UpdateAux<> aux;
+
+    NodeWriterTestBase()
+        : pool{[] {
+            storage_pool::creation_flags flags;
+            auto const bitpos = std::countr_zero(storage_pool_chunk_size);
+            flags.chunk_capacity = bitpos;
+            if constexpr (use_anonoymous_inode) {
+                return storage_pool(use_anonymous_inode_tag{}, flags);
+            }
+            char temppath[] = "monad_test_fixture_XXXXXX";
+            int const fd = mkstemp(temppath);
+            if (-1 == fd) {
+                abort();
+            }
+            if (-1 == ftruncate(fd, (3 + num_chunks) * chunk_size + 24576)) {
+                abort();
+            }
+            ::close(fd);
+            std::filesystem::path temppath2(temppath);
+            return MONAD_ASYNC_NAMESPACE::storage_pool(
+                {&temppath2, 1},
+                MONAD_ASYNC_NAMESPACE::storage_pool::mode::create_if_needed,
+                flags);
+        }()}
+        , ring1{2}
+        , ring2{4}
+        , rwbuf{monad::io::make_buffers_for_segregated_read_write(
+              ring1, ring2, 2, 4, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+              AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE)}
+        , io{pool, rwbuf}
+        , aux{&io}
     {
-        auto const curr_node_writer_chunk_id =
-            rewind_fast_list_(remaining_bytes_in_chunk);
-        auto node = make_node_of_size(node_disk_size);
-        EXPECT_EQ(node->get_disk_size(), node_disk_size);
-        auto const chunks_before = state()->fast_list_ids().size();
-        // write node
-        auto const node_offset =
-            async_write_node_set_spare(state()->aux, *node, true);
-        if (node->get_disk_size() > remaining_bytes_in_chunk) {
-            // Node will be written to the start of next chunk
-            auto &new_node_writer = state()->aux.node_writer_fast;
-            uint32_t const new_node_writer_chunk_id =
-                new_node_writer->sender().offset().id;
-            EXPECT_EQ(node_offset.id, new_node_writer_chunk_id);
-            EXPECT_EQ(node_offset.offset, 0);
-            EXPECT_EQ(new_node_writer->sender().offset().offset, 0);
-            // new node writer offset should start at the next chunk
-            EXPECT_NE(new_node_writer_chunk_id, curr_node_writer_chunk_id);
-            EXPECT_EQ(
-                (uint32_t)state()
-                    ->aux.db_metadata()
-                    ->at(new_node_writer_chunk_id)
-                    ->insertion_count(),
-                (uint32_t)state()
-                        ->aux.db_metadata()
-                        ->at(curr_node_writer_chunk_id)
-                        ->insertion_count() +
-                    1);
-            EXPECT_EQ(chunks_before + 1, state()->fast_list_ids().size());
+    }
+
+    ~NodeWriterTestBase()
+    {
+        for (auto &device : pool.devices()) {
+            auto const path = device.current_path();
+            if (std::filesystem::exists(path)) {
+                std::filesystem::remove(path);
+            }
         }
-        else {
-            // Node will be appended to the existing chunk
-            EXPECT_EQ(node_offset.id, curr_node_writer_chunk_id);
-            EXPECT_EQ(chunks_before, state()->fast_list_ids().size());
+    }
+
+    void node_writer_append_dummy_bytes(
+        node_writer_unique_ptr_type &node_writer, size_t bytes)
+    {
+        while (bytes > 0) {
+            auto &sender = node_writer->sender();
+            auto const remaining_bytes = sender.remaining_buffer_bytes();
+            if (bytes <= remaining_bytes) {
+                sender.advance_buffer_append(bytes);
+                return;
+            }
+            if (remaining_bytes > 0) {
+                sender.advance_buffer_append(remaining_bytes);
+                bytes -= remaining_bytes;
+            }
+
+            auto new_node_writer = replace_node_writer(aux, node_writer);
+            MONAD_ASSERT(new_node_writer);
+            node_writer->initiate();
+            // shall be recycled by the i/o receiver
+            node_writer.release();
+            node_writer = std::move(new_node_writer);
         }
+    }
+
+    uint32_t get_writer_chunk_id(node_writer_unique_ptr_type &node_writer)
+    {
+        return node_writer->sender().offset().id;
+    }
+
+    uint32_t get_writer_chunk_count(node_writer_unique_ptr_type &node_writer)
+    {
+        return (uint32_t)aux.db_metadata()
+            ->at(get_writer_chunk_id(node_writer))
+            ->insertion_count();
     }
 };
 
-TEST_F(NodeWriterTest, write_node)
-{
-    // remaining bytes < node size: write node to next chunk
-    rewind_then_write_node(2 * 1024 * 1024, 5 * 1024 * 1024);
+using NodeWriterTest = NodeWriterTestBase<>;
 
-    // reminaing bytes > node size: write node to existing chunk
-    rewind_then_write_node(5 * 1024 * 1024, 2 * 1024 * 1024);
+TEST_F(NodeWriterTest, write_nodes_each_within_buffer)
+{
+    auto const node_writer_chunk_id_before =
+        get_writer_chunk_id(aux.node_writer_fast);
+    auto const node_writer_chunk_count_before =
+        get_writer_chunk_count(aux.node_writer_fast);
+    ASSERT_EQ(node_writer_chunk_count_before, 0);
+
+    unsigned const node_disk_size = 1024;
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+    auto node = make_node_of_size(node_disk_size);
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        auto const node_offset = async_write_node_set_spare(aux, *node, true);
+        EXPECT_EQ(node_offset.offset, node_disk_size * i);
+
+        EXPECT_EQ(node_offset.id, get_writer_chunk_id(aux.node_writer_fast));
+        EXPECT_EQ(
+            get_writer_chunk_id(aux.node_writer_fast),
+            node_writer_chunk_id_before);
+        EXPECT_EQ(
+            aux.node_writer_fast->sender().written_buffer_bytes(),
+            node_offset.offset + node_disk_size);
+    }
+    // first buffer is full
+    EXPECT_EQ(aux.node_writer_fast->sender().remaining_buffer_bytes(), 0);
+    // continue write more node, node writer will switch to next buffer
+    auto const node_offset = async_write_node_set_spare(aux, *node, true);
+    EXPECT_EQ(node_offset.offset, AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    EXPECT_EQ(
+        get_writer_chunk_id(aux.node_writer_fast), node_writer_chunk_id_before);
+    EXPECT_EQ(node_offset.id, node_writer_chunk_id_before);
+    EXPECT_EQ(
+        aux.node_writer_fast->sender().written_buffer_bytes(), node_disk_size);
 }
 
-TEST_F(NodeWriterTest, replace_fast_writer_at_chunk_boundary)
+TEST_F(NodeWriterTest, write_node_across_buffers_ends_at_buffer_boundary)
 {
-    unsigned const node_disk_size = 1024;
-    // After this line, node writer is at the end of a chunk
-    rewind_then_write_node(node_disk_size, node_disk_size);
+    // prepare less than 3 chunks
+    auto const chunk_remaining_bytes =
+        2 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024;
+    MONAD_ASSERT(chunk_remaining_bytes < chunk_size);
+    node_writer_append_dummy_bytes(
+        aux.node_writer_fast, 3 * chunk_size - chunk_remaining_bytes);
 
-    auto const new_writer_offset =
-        state()->aux.node_writer_fast->sender().offset();
+    auto const node_writer_chunk_count_before =
+        get_writer_chunk_count(aux.node_writer_fast);
+    EXPECT_EQ(node_writer_chunk_count_before, 2);
+
+    // node spans buffer 3 buffers
+    auto node = make_node_of_size(chunk_remaining_bytes);
+    auto const node_offset = async_write_node_set_spare(aux, *node, true);
     EXPECT_EQ(
-        new_writer_offset.offset + node_disk_size,
-        state()->aux.io->chunk_capacity(new_writer_offset.id));
+        get_writer_chunk_count(aux.node_writer_fast),
+        node_writer_chunk_count_before);
+    EXPECT_EQ(node_offset.id, get_writer_chunk_id(aux.node_writer_fast));
+    EXPECT_EQ(aux.node_writer_fast->sender().remaining_buffer_bytes(), 0);
 
-    // Replace fast node writer, writer should start at a new chunk that belongs
-    // to fast list
-    auto new_node_writer =
-        replace_node_writer(state()->aux, state()->aux.node_writer_fast);
-    EXPECT_EQ(new_node_writer->sender().offset().offset, 0);
-    EXPECT_NE(new_writer_offset.id, new_node_writer->sender().offset().id);
-    EXPECT_TRUE(state()
-                    ->aux.db_metadata()
-                    ->at(new_node_writer->sender().offset().id)
-                    ->in_fast_list);
+    // write another node, node writer will switch to next buffer at next chunk
+    auto const new_node_offset = async_write_node_set_spare(aux, *node, true);
+    EXPECT_EQ(new_node_offset.offset, 0);
+    auto const node_writer_chunk_count_after =
+        get_writer_chunk_count(aux.node_writer_fast);
+    EXPECT_EQ(
+        aux.db_metadata()->at(new_node_offset.id)->insertion_count(),
+        node_writer_chunk_count_after);
+    EXPECT_EQ(
+        node_writer_chunk_count_before + 1, node_writer_chunk_count_after);
+    EXPECT_EQ(
+        aux.node_writer_fast->sender().written_buffer_bytes(),
+        chunk_remaining_bytes % AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+}
+
+TEST_F(NodeWriterTest, write_node_at_new_chunk)
+{
+    // prepare less than 3 chunks
+    auto const chunk_remaining_bytes = 1024;
+    node_writer_append_dummy_bytes(
+        aux.node_writer_fast, 3 * chunk_size - chunk_remaining_bytes);
+
+    auto const node_writer_chunk_count_before_write_node =
+        get_writer_chunk_count(aux.node_writer_fast);
+    EXPECT_EQ(node_writer_chunk_count_before_write_node, 2);
+
+    // make a node that is too big to fit in current chunk
+    auto node = make_node_of_size(chunk_remaining_bytes + 1024);
+    auto const node_offset = async_write_node_set_spare(aux, *node, true);
+    auto const node_offset_chunk_count =
+        aux.db_metadata()->at(node_offset.id)->insertion_count();
+    EXPECT_EQ(
+        node_offset_chunk_count, node_writer_chunk_count_before_write_node + 1);
+    EXPECT_EQ(
+        node_offset_chunk_count, get_writer_chunk_count(aux.node_writer_fast));
 }

--- a/libs/db/src/monad/mpt/trie.cpp
+++ b/libs/db/src/monad/mpt/trie.cpp
@@ -1839,7 +1839,8 @@ retry:
             MONAD_ASSERT(
                 node_writer->sender().advance_buffer_append(bytes_to_append) !=
                 nullptr);
-            if (node_writer->sender().remaining_buffer_bytes() == 0) {
+            if (offset_in_on_disk_node < size &&
+                node_writer->sender().remaining_buffer_bytes() == 0) {
                 // replace node writer
                 new_node_writer = replace_node_writer(aux, node_writer);
                 if (new_node_writer) {


### PR DESCRIPTION
… at a buffer boundary

first commit is the real bug fix -- removed the bad assertion