### PR TITLE
release.Dockerfile install git

### DIFF
--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -44,6 +44,7 @@ RUN apt update && apt install -y \
 
 RUN apt update && apt install -y \
   gdb \
+  git \
   valgrind
 
 FROM base as build


### PR DESCRIPTION
```
31.76   ** AsmJit Summary **
31.76      ASMJIT_DIR=/usr/src/monad-bft/monad-cxx/monad-execution/third_party/compiler/third_party/asmjit
31.76      ASMJIT_TEST=FALSE
31.76      ASMJIT_TARGET_TYPE=SHARED
31.76      ASMJIT_DEPS=c
31.76      ASMJIT_LIBS=asmjit;c
31.76      ASMJIT_CFLAGS=
31.76      ASMJIT_PRIVATE_CFLAGS=-Wall;-Wextra;-Wconversion;-fno-math-errno;-fno-threadsafe-statics;-fno-semantic-interposition
31.76      ASMJIT_PRIVATE_CFLAGS_DBG=
31.76      ASMJIT_PRIVATE_CFLAGS_REL=-O2;-fmerge-all-constants;-fno-enforce-eh-specs
31.76   CMake Error at /usr/share/cmake-3.28/Modules/ExternalProject.cmake:2910 (message):
31.76     error: could not find git for clone of rpmalloc-external
31.76   Call Stack (most recent call first):
31.76     /usr/share/cmake-3.28/Modules/ExternalProject.cmake:4418 (_ep_add_download_command)
31.76     /usr/src/monad-bft/monad-cxx/monad-execution/CMakeLists.txt:87 (ExternalProject_Add)
```