### PR TITLE
add a state machine function set_compact(). 

### DIFF
--- a/libs/db/src/monad/mpt/state_machine.hpp
+++ b/libs/db/src/monad/mpt/state_machine.hpp
@@ -11,17 +11,31 @@ struct Compute;
 
 struct StateMachine
 {
+private:
+    bool compact_enabled{true};
+
+public:
     virtual ~StateMachine() = default;
     virtual std::unique_ptr<StateMachine> clone() const = 0;
     virtual void down(unsigned char nibble) = 0;
     virtual void up(size_t) = 0;
     virtual Compute &get_compute() const = 0;
     virtual bool cache() const = 0;
-    virtual bool compact() const = 0;
+    virtual bool compactable() const = 0;
 
     virtual bool auto_expire() const
     {
         return false;
+    }
+
+    void set_compact(bool const compact)
+    {
+        compact_enabled = compact;
+    }
+
+    bool compact() const
+    {
+        return compact_enabled && compactable();
     }
 };
 

--- a/libs/db/src/monad/mpt/test/state_machine_test.cpp
+++ b/libs/db/src/monad/mpt/test/state_machine_test.cpp
@@ -83,7 +83,7 @@ namespace
             return path.size() < 2;
         };
 
-        virtual bool compact() const override
+        virtual bool compactable() const override
         {
             return false;
         }

--- a/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
+++ b/libs/db/src/monad/mpt/test/test_fixtures_base.hpp
@@ -101,13 +101,13 @@ namespace monad::test
             return depth < cache_depth;
         }
 
-        virtual constexpr bool compact() const override
+        virtual constexpr bool compactable() const override
         {
             return true;
         }
     };
 
-    static_assert(sizeof(StateMachineMerkleWithPrefix<>) == 16);
+    static_assert(sizeof(StateMachineMerkleWithPrefix<>) == 24);
     static_assert(alignof(StateMachineMerkleWithPrefix<>) == 8);
 
     template <int prefix_len = 2>
@@ -155,13 +155,13 @@ namespace monad::test
             return depth < cache_depth;
         }
 
-        virtual constexpr bool compact() const override
+        virtual constexpr bool compactable() const override
         {
             return true;
         }
     };
 
-    static_assert(sizeof(StateMachineVarLenTrieWithPrefix<>) == 16);
+    static_assert(sizeof(StateMachineVarLenTrieWithPrefix<>) == 24);
     static_assert(alignof(StateMachineVarLenTrieWithPrefix<>) == 8);
 
     struct StateMachineConfig
@@ -206,7 +206,7 @@ namespace monad::test
             return depth < config.cache_depth;
         }
 
-        virtual constexpr bool compact() const override
+        virtual constexpr bool compactable() const override
         {
             return true;
         }

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -1059,6 +1059,7 @@ Node::UniquePtr UpdateAuxImpl::do_update(
     }
     MONAD_ASSERT(is_on_disk());
     set_can_write_to_fast(can_write_to_fast);
+    sm.set_compact(compaction);
 
     if (prev_root) {
         // previous compaction offset

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -569,7 +569,7 @@ bool InMemoryMachine::cache() const
     return true;
 }
 
-bool InMemoryMachine::compact() const
+bool InMemoryMachine::compactable() const
 {
     return false;
 }
@@ -588,7 +588,7 @@ bool OnDiskMachine::cache() const
              table == TableType::TxHash || table == TableType::BlockHash));
 }
 
-bool OnDiskMachine::compact() const
+bool OnDiskMachine::compactable() const
 {
     return depth >= prefix_len();
 }

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -68,14 +68,14 @@ static_assert(alignof(MachineBase) == 8);
 struct InMemoryMachine final : public MachineBase
 {
     virtual bool cache() const override;
-    virtual bool compact() const override;
+    virtual bool compactable() const override;
     virtual std::unique_ptr<StateMachine> clone() const override;
 };
 
 struct OnDiskMachine : public MachineBase
 {
     virtual bool cache() const override;
-    virtual bool compact() const override;
+    virtual bool compactable() const override;
     virtual bool auto_expire() const override;
     virtual std::unique_ptr<StateMachine> clone() const override;
 };


### PR DESCRIPTION
Inline compaction only kick in if `compactable() && compact_enable` is True at current state