### PR TITLE
Align compaction offsets with min referenced offsets; revise chunk release logic to releasing offsets before min referenced offsets 

### DIFF
--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -201,6 +201,12 @@ class UpdateAuxImpl
 
     void update_disk_growth_data();
 
+    // Get minimum virtual offsets that a given trie has reference, note that
+    // a `MIN_COMPACT_VIRTUAL_OFFSET` return means the trie has no underlying
+    // node in that chunk list.
+    std::pair<compact_virtual_chunk_offset_t, compact_virtual_chunk_offset_t>
+    min_referenced_offsets(Node &node) const;
+
     /******** Compaction ********/
     uint32_t chunks_to_remove_before_count_fast_{0};
     uint32_t chunks_to_remove_before_count_slow_{0};


### PR DESCRIPTION
Saw a lot of zero active reference in compaction ("fast to slow 0") on `devnet21` 

example log:
```
2025-05-02 10:33:28.240831860 [9] update_aux.cpp:1607 LOG_INFO  Version 14879846: nodes created or updated for upsert = 2219, nodes updated for expire = 478, nreads for expire = 624
   Fast: total growth ~ 1984 KB, compact range 47680 KB, bytes copied fast to slow 0.00 KB, active data ratio 0.00%
   Slow: no advance of compaction offset
[Nodes Copied]
   Fast: fast to slow 0 (0.00%), fast to fast 0 (0.00%)
[Reads]
   Fast: compact reads within compaction range 0 / total compact reads 0 = 0.00%
   Fast: bytes read within compaction range 0.00 KB / compaction range 47680 KB = 0.00%, bytes read out of compaction range 0.00 KB
```
Investigate on compaction offsets and minimum offsets the root has referenced to, and found a big gap there. 
This PR remove the gap. 
```
(monaddb) version 14946901
Success! Set version to 14946901

2025-05-02 20:21:14.373024961 [32] db.cpp:287 LOG_INFO	compaction offsets fast=80474952,slow=0
2025-05-02 20:21:14.373038122 [32] db.cpp:291 LOG_INFO	min referenced offsets fast=227132088, slow=0
List sections of version 14946901:
    finalized : yes
    proposals : [15664823]

Type "proposal [round]" or "finalized" to set section
Took 1088986ns
```