### PR TITLE
Fix bug when db version exceeds root offsets capacity with test.

### DIFF
--- a/libs/db/src/monad/mpt/trie.hpp
+++ b/libs/db/src/monad/mpt/trie.hpp
@@ -660,9 +660,10 @@ public:
             {
                 version_lower_bound_.store(0, std::memory_order_release);
                 next_version_.store(0, std::memory_order_release);
-                for (size_t i = 0; i < capacity(); ++i) {
-                    push(INVALID_OFFSET);
-                }
+                memset(
+                    (void *)root_offsets_chunks_.data(),
+                    0xff,
+                    root_offsets_chunks_.size() * sizeof(chunk_offset_t));
                 version_lower_bound_.store(version, std::memory_order_release);
                 next_version_.store(version, std::memory_order_release);
             }

--- a/libs/db/src/monad/mpt/update_aux.cpp
+++ b/libs/db/src/monad/mpt/update_aux.cpp
@@ -200,8 +200,10 @@ void UpdateAuxImpl::fast_forward_next_version(
         auto g = m->hold_dirty();
         auto ro = root_offsets(m == db_metadata_[1].main);
         uint64_t curr_version = ro.max_version();
+        MONAD_ASSERT(
+            curr_version == INVALID_BLOCK_ID || new_version > curr_version);
 
-        if (new_version >= curr_version &&
+        if (curr_version == INVALID_BLOCK_ID ||
             new_version - curr_version >= ro.capacity()) {
             ro.reset_all(new_version);
         }


### PR DESCRIPTION
Closes https://github.com/category-labs/category-internal/issues/1451

before fix, hit assertion when running the new test. The test passed after the fix for both 2^25 and 65536 sized ring buffer.
```
[----------] 1 test from OnDiskDbWithFileFixture
[ RUN      ] OnDiskDbWithFileFixture.history_ring_buffer_wrap_around
15:05:07.814367787 [738134] update_aux.cpp:846           LOG_INFO      root         Initialize db pool with 28 chunks in reverse order.

      0x5852d047010e
      0x5852d046fdc7
      0x5852d046ff38
      0x5852d046fb9a
      0x5852d036ae63
      0x5852d032ed10
      0x5852d03218c4
      0x5852d0321a4f
      0x5852d03614d5
      0x5852d029013f
      0x5852d0292b4b
      0x5852d030629a
      0x5852d0305761
      0x5852d03040f0
      0x5852d03004dc
      0x5852d02fdb0e
      0x78d53eaecdb4
      0x78d53e69caa4
      0x78d53e729c3c

   Attempting async signal unsafe human readable stacktrace (this may hang):
      0x5852d047010e: monad::stack_backtrace_impl::stack_backtrace_impl(std::span<std::byte, 18446744073709551615ul>)
                      [/home/vickychen/github/monad/libs/core/src/monad/core/backtrace.cpp:84]
      0x5852d046fdc7: monad::stack_backtrace::capture(std::span<std::byte, 18446744073709551615ul>)
                      [/home/vickychen/github/monad/libs/core/src/monad/core/backtrace.cpp:167]
      0x5852d046ff38: monad_stack_backtrace_capture_and_print
                      [/home/vickychen/github/monad/libs/core/src/monad/core/backtrace.cpp:186]
      0x5852d046fb9a: monad_assertion_failed
                      [/home/vickychen/github/monad/libs/core/src/monad/core/assert.c:24]
      0x5852d036ae63: monad::mpt::UpdateAuxImpl::db_history_range_lower_bound() const
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/update_aux.cpp:1386]
      0x5852d032ed10: monad::mpt::write_new_root_node(monad::mpt::UpdateAuxImpl&, monad::mpt::Node&, unsigned long)
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/trie.cpp:1934]
      0x5852d03218c4: monad::mpt::upsert(monad::mpt::UpdateAuxImpl&, unsigned long, monad::mpt::StateMachine&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, boost::intrusive::slist<monad::mpt::Update>&&, bool)::{lambda()#1}::operator()() const
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/trie.cpp:138]
      0x5852d0321a4f: monad::mpt::upsert(monad::mpt::UpdateAuxImpl&, unsigned long, monad::mpt::StateMachine&, std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, boost::intrusive::slist<monad::mpt::Update>&&, bool)
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/trie.cpp:141]
      0x5852d03614d5: monad::mpt::UpdateAuxImpl::do_update(std::unique_ptr<monad::mpt::Node, monad::allocators::unique_ptr_aliasing_allocator_deleter<std::allocator<monad::mpt::Node>, monad::allocators::malloc_free_allocator<std::byte>, &monad::mpt::Node::pool, &monad::mpt::Node::get_deallocate_count> >, monad::mpt::StateMachine&, boost::intrusive::slist<monad::mpt::Update>&&, unsigned long, bool, bool, bool)
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/update_aux.cpp:1110]
      0x5852d029013f: monad::mpt::OnDiskWithWorkerThreadImpl::DbAsyncWorker::rwdb_run()
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/db.cpp:625]
      0x5852d0292b4b: monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}::operator()() const
                      [/home/vickychen/github/monad/libs/db/src/monad/mpt/db.cpp:771]
      0x5852d030629a: void std::__invoke_impl<void, monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}>(std::__invoke_other, monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}&&)
      0x5852d0305761: std::__invoke_result<monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}>::type std::__invoke<monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}>(monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}&&)
                      [/usr/include/c++/13/bits/invoke.h:97]
      0x5852d03040f0: void std::thread::_Invoker<std::tuple<monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>)
                      [/usr/include/c++/13/bits/std_thread.h:292]
      0x5852d03004dc: std::thread::_Invoker<std::tuple<monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}> >::operator()()
                      [/usr/include/c++/13/bits/std_thread.h:299]
      0x5852d02fdb0e: std::thread::_State_impl<std::thread::_Invoker<std::tuple<monad::mpt::OnDiskWithWorkerThreadImpl::OnDiskWithWorkerThreadImpl(monad::mpt::OnDiskDbConfig const&)::{lambda()#1}> > >::_M_run()
                      [/usr/include/c++/13/bits/std_thread.h:244]
      0x78d53eaecdb4: 
      0x78d53e69caa4: start_thread
                      [./nptl/pthread_create.c:447]
      0x78d53e729c3c: clone3
                      [../sysdeps/unix/sysv/linux/x86_64/clone3.S:80]
db_test: /home/vickychen/github/monad/libs/db/src/monad/mpt/update_aux.cpp:1385: uint64_t monad::mpt::UpdateAuxImpl::db_history_range_lower_bound() const: Assertion 'ro_version_lower_bound >= history_range_min' failed.
```