### PR TITLE
[Db internal] enforce strict update rules

### DIFF
--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -506,6 +506,13 @@ mpt::Compute &MachineBase::get_compute() const
     }
 }
 
+bool MachineBase::is_variable_length() const
+{
+    return depth > prefix_len() &&
+           (table == TableType::Transaction || table == TableType::Receipt ||
+            table == TableType::Withdrawal || table == TableType::CallFrame);
+}
+
 void MachineBase::down(unsigned char const nibble)
 {
     ++depth;
@@ -554,12 +561,17 @@ void MachineBase::down(unsigned char const nibble)
         else if (nibble == BLOCK_HASH_NIBBLE) {
             table = TableType::BlockHash;
         }
+        else if (nibble == BLOCKHEADER_NIBBLE) {
+            table = TableType::BlockHeader;
+        }
+        else if (nibble == OMMER_NIBBLE) {
+            table = TableType::Ommer;
+        }
+        else if (nibble == CALL_FRAME_NIBBLE) {
+            table = TableType::CallFrame;
+        }
         else {
-            // No subtrie in the rest tables, thus treated the same as
-            // Table::Prefix
-            MONAD_ASSERT(
-                nibble == BLOCKHEADER_NIBBLE || nibble == OMMER_NIBBLE ||
-                nibble == CALL_FRAME_NIBBLE);
+            MONAD_ABORT_PRINTF("Invalid nibble %u", (unsigned)nibble);
         }
     }
 }

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -46,7 +46,10 @@ struct MachineBase : public mpt::StateMachine
         Transaction,
         Withdrawal,
         TxHash,
-        BlockHash
+        BlockHash,
+        BlockHeader,
+        Ommer,
+        CallFrame,
     };
 
     uint8_t depth{0};
@@ -56,6 +59,7 @@ struct MachineBase : public mpt::StateMachine
     virtual mpt::Compute &get_compute() const override;
     virtual void down(unsigned char const nibble) override;
     virtual void up(size_t const n) override;
+    virtual bool is_variable_length() const override;
     constexpr uint8_t prefix_len() const;
 
     constexpr uint8_t max_depth(uint8_t const prefix_length) const

--- a/category/mpt/state_machine.hpp
+++ b/category/mpt/state_machine.hpp
@@ -18,6 +18,7 @@ struct StateMachine
     virtual Compute &get_compute() const = 0;
     virtual bool cache() const = 0;
     virtual bool compact() const = 0;
+    virtual bool is_variable_length() const = 0;
 
     virtual bool auto_expire() const
     {

--- a/category/mpt/test/append_test.cpp
+++ b/category/mpt/test/append_test.cpp
@@ -86,14 +86,15 @@ TYPED_TEST(AppendTest, works)
     while (it != this->state()->keys.end()) {
         std::vector<Update> updates;
         updates.reserve(1000);
+        UpdateList update_ls;
         for (auto i = 0; i < 1000; ++i, ++it) {
-            updates.push_back(make_update(it->first, it->first));
+            update_ls.push_front(
+                updates.emplace_back(make_update(it->first, it->first)));
         }
-        this->state()->root = upsert_vector(
-            this->state()->aux,
-            this->state()->sm,
+        this->state()->root = this->state()->aux.do_update(
             std::move(this->state()->root),
-            std::move(updates),
+            this->state()->sm,
+            std::move(update_ls),
             this->state()->version++);
     }
 

--- a/category/mpt/test/compaction_test.cpp
+++ b/category/mpt/test/compaction_test.cpp
@@ -45,12 +45,11 @@ TEST_F(CompactionTest, first_chunk_is_compacted)
     for (auto &i : updates) {
         update_ls.push_front(i);
     }
-    state()->root = upsert(
-        state()->aux,
-        state()->version++,
-        state()->sm,
+    state()->root = state()->aux.do_update(
         std::move(state()->root),
-        std::move(update_ls));
+        state()->sm,
+        std::move(update_ls),
+        state()->version++);
     std::cout << "\nBefore compaction:";
     state()->print(std::cout);
     // TODO DO COMPACTION

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -30,38 +30,71 @@ TYPED_TEST_SUITE(PlainTrieTest, PlainTrieTypes);
 
 namespace updates
 {
-    std::vector<std::pair<monad::byte_string, monad::byte_string>> const kv{
+    std::vector<std::pair<monad::byte_string, monad::byte_string>> const
+        var_len_kv{
+            {0x01111111_hex, 0xdead_hex}, // 0
+            {0x11111111_hex, 0xbeef_hex}, // 1
+            {0x11111111aaaa_hex, 0xdeafbeef_hex}, // 2
+            {0x11111111aacd_hex, 0xabcd_hex}, // 3
+            {0x111a1111_hex, 0xba_hex}, // 4
+            {0x111b1111_hex, 0xbabe_hex}, // 5
+            {0x111b1111aaaaaaaa_hex, 0xcafe_hex}, // 6
+            {0x111b1111bbbbbbbb_hex, 0xbe_hex}, // 7
+        };
+
+    std::vector<std::pair<monad::byte_string, monad::byte_string>> const top_kv{
         {0x01111111_hex, 0xdead_hex}, // 0
         {0x11111111_hex, 0xbeef_hex}, // 1
-        {0x11111111aaaa_hex, 0xdeafbeef_hex}, // 2
-        {0x11111111aacd_hex, 0xabcd_hex}, // 3
-        {0x111a1111_hex, 0xba_hex}, // 4
-        {0x111b1111_hex, 0xbabe_hex}, // 5
-        {0x111b1111aaaaaaaa_hex, 0xcafe_hex}, // 6
-        {0x111b1111bbbbbbbb_hex, 0xbe_hex}, // 7
+        {0x111a1111_hex, 0xba_hex}, // 2
+        {0x111b1111_hex, 0xbabe_hex}, // 3
     };
+
+    std::vector<std::pair<monad::byte_string, monad::byte_string>> const
+        nested_kv{
+            {0xaaaa_hex, 0xdeafbeef_hex},
+            {0xaacd_hex, 0xabcd_hex},
+            {0xaaaaaaaa_hex, 0xcafe_hex},
+            {0xbbbbbbbb_hex, 0xbe_hex},
+        };
 }
 
 TYPED_TEST(PlainTrieTest, leaf_nodes_persist)
 {
+    UpdateList nested;
+    auto const prefix = 0x00_hex;
+    auto const key1 = 0x11_hex;
+    auto const key2 = 0x22_hex;
+    auto u1 = make_update(key1, monad::byte_string_view{});
+    auto u2 = make_update(key2, monad::byte_string_view{});
+    nested.push_front(u1);
+    nested.push_front(u2);
     this->root = upsert_updates(
         this->aux,
         *this->sm,
         std::move(this->root),
-        make_update(0x11_hex, monad::byte_string_view{}),
-        make_update(0x1111_hex, monad::byte_string_view{}),
-        make_update(0x1122_hex, monad::byte_string_view{}));
+        make_update(prefix, {}, false, std::move(nested)));
     EXPECT_EQ(this->root->mask, 0b110);
 
+    UpdateList nested2;
+    auto e1 = make_erase(key1);
+    nested2.push_front(e1);
+
     this->root = upsert_updates(
-        this->aux, *this->sm, std::move(this->root), make_erase(0x1111_hex));
+        this->aux,
+        *this->sm,
+        std::move(this->root),
+        make_update(prefix, {}, false, std::move(nested2)));
     EXPECT_EQ(this->root->mask, 0b100);
 }
 
-TYPED_TEST(PlainTrieTest, var_length)
+TYPED_TEST(PlainTrieTest, var_length_trie)
 {
+    // Variable-length tables support only a one-time insert; no deletions or
+    // further updates are allowed.
+    this->sm = std::make_unique<StateMachinePlainVarLen>();
+
     constexpr uint64_t version = 0;
-    auto const &kv = updates::kv;
+    auto const &kv = updates::var_len_kv;
     // insert kv 0,1,2,3
     this->root = upsert_updates(
         this->aux,
@@ -70,7 +103,11 @@ TYPED_TEST(PlainTrieTest, var_length)
         make_update(kv[0].first, kv[0].second),
         make_update(kv[1].first, kv[1].second),
         make_update(kv[2].first, kv[2].second),
-        make_update(kv[3].first, kv[3].second));
+        make_update(kv[3].first, kv[3].second),
+        make_update(kv[4].first, kv[4].second),
+        make_update(kv[5].first, kv[5].second),
+        make_update(kv[6].first, kv[6].second),
+        make_update(kv[7].first, kv[7].second));
 
     EXPECT_EQ(
         find_blocking(this->aux, *this->root, kv[0].first, version)
@@ -89,47 +126,6 @@ TYPED_TEST(PlainTrieTest, var_length)
             .first.node->value(),
         kv[3].second);
 
-    EXPECT_EQ(this->root->mask, 0b11);
-    EXPECT_EQ(this->root->value_len, 0);
-    EXPECT_EQ(this->root->bitpacked.data_len, 0);
-    EXPECT_EQ(this->root->path_bytes(), 0);
-    Node *node0 = this->root->next(0);
-    Node *node1 = this->root->next(1);
-    EXPECT_EQ(node0->mask, 0);
-    EXPECT_EQ(
-        node0->path_nibble_view(), (NibblesView{1, 8, kv[0].first.data()}));
-    EXPECT_EQ(node0->value(), kv[0].second);
-    EXPECT_EQ(node1->mask, 1u << 0xa);
-    EXPECT_EQ(
-        node1->path_nibble_view(), (NibblesView{1, 8, kv[1].first.data()}));
-    EXPECT_EQ(node1->value(), kv[1].second);
-    Node *node1aa = node1->next(0);
-    EXPECT_EQ(node1aa->mask, 1u << 0xa | 1u << 0xc);
-    EXPECT_EQ(
-        node1aa->path_nibble_view(), (NibblesView{9, 10, kv[3].first.data()}));
-
-    EXPECT_EQ(node1aa->path_bytes(), 1);
-    EXPECT_EQ(node1aa->value_len, 0);
-    Node *node1aaaa = node1aa->next(0);
-    Node *node1aacd = node1aa->next(1);
-    EXPECT_EQ(node1aaaa->mask, 0);
-    EXPECT_EQ(
-        node1aaaa->path_nibble_view(),
-        (NibblesView{11, 12, kv[2].first.data()}));
-    EXPECT_EQ(node1aaaa->value(), kv[2].second);
-    EXPECT_EQ(node1aacd->mask, 0);
-    EXPECT_EQ(
-        node1aacd->path_nibble_view(),
-        (NibblesView{11, 12, kv[3].first.data()}));
-    EXPECT_EQ(node1aacd->value(), kv[3].second);
-
-    // insert kv 4,5
-    this->root = upsert_updates(
-        this->aux,
-        *this->sm,
-        std::move(this->root),
-        make_update(kv[4].first, kv[4].second),
-        make_update(kv[5].first, kv[5].second));
     EXPECT_EQ(
         find_blocking(this->aux, *this->root, kv[0].first, version)
             .first.node->value(),
@@ -155,29 +151,6 @@ TYPED_TEST(PlainTrieTest, var_length)
             .first.node->value(),
         kv[5].second);
 
-    EXPECT_EQ(this->root->mask, 0b11);
-    node1 = this->root->next(1); // 1111... 111a... 111b...
-    EXPECT_EQ(node1->mask, 1u << 1 | 1u << 0xa | 1u << 0xb);
-    Node *node1111 = node1->next(0);
-    Node *node111a = node1->next(1);
-    Node *node111b = node1->next(2);
-    EXPECT_EQ(node1111->value(), kv[1].second);
-    EXPECT_EQ(
-        node111a->path_nibble_view(), (NibblesView{4, 8, kv[4].first.data()}));
-    EXPECT_EQ(node111a->value(), kv[4].second);
-    EXPECT_EQ(node111b->value(), kv[5].second);
-
-    // insert kv 6,7
-    this->root = upsert_updates(
-        this->aux,
-        *this->sm,
-        std::move(this->root),
-        make_update(kv[6].first, kv[6].second),
-        make_update(kv[7].first, kv[7].second));
-    EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[5].first, version)
-            .first.node->value(),
-        kv[5].second);
     EXPECT_EQ(
         find_blocking(this->aux, *this->root, kv[6].first, version)
             .first.node->value(),
@@ -187,8 +160,33 @@ TYPED_TEST(PlainTrieTest, var_length)
             .first.node->value(),
         kv[7].second);
 
-    node1 = this->root->next(this->root->to_child_index(1));
-    node111b = node1->next(node1->to_child_index(0xb));
+    EXPECT_EQ(this->root->mask, 0b11);
+    EXPECT_FALSE(this->root->has_value());
+    EXPECT_EQ(this->root->bitpacked.data_len, 0);
+    EXPECT_EQ(this->root->path_nibbles_len(), 0);
+    Node *const node0 = this->root->next(0);
+    Node *const node1 = this->root->next(1); // 1111... 111a... 111b...
+    EXPECT_EQ(node0->mask, 0);
+    EXPECT_EQ(node1->mask, 1u << 1 | 1u << 0xa | 1u << 0xb);
+    EXPECT_EQ(
+        node0->path_nibble_view(), (NibblesView{1, 8, kv[0].first.data()}));
+    EXPECT_EQ(node0->value(), kv[0].second);
+    EXPECT_EQ(
+        node1->path_nibble_view(), (NibblesView{1, 3, kv[1].first.data()}));
+
+    Node *const node1111 = node1->next(0);
+    Node *const node111a = node1->next(1);
+    Node *const node111b = node1->next(2);
+    EXPECT_EQ(node1111->value(), kv[1].second);
+    EXPECT_EQ(node1111->mask, 1u << 0xa);
+    Node *const node1111_aa = node1111->next(0);
+    EXPECT_EQ(node1111_aa->mask, 1u << 0xa | 1u << 0xc);
+    EXPECT_EQ(node1111_aa->next(0)->value(), kv[2].second);
+    EXPECT_EQ(node1111_aa->next(1)->value(), kv[3].second);
+    EXPECT_EQ(
+        node111a->path_nibble_view(), (NibblesView{4, 8, kv[4].first.data()}));
+    EXPECT_EQ(node111a->value(), kv[4].second);
+    EXPECT_EQ(node111b->value(), kv[5].second);
     EXPECT_EQ(node111b->mask, 1u << 0xa | 1u << 0xb);
     EXPECT_EQ(
         node111b->next(node111b->to_child_index(0xa))->value(), kv[6].second);
@@ -299,7 +297,20 @@ TYPED_TEST(PlainTrieTest, mismatch)
 
 TYPED_TEST(PlainTrieTest, delete_wo_incarnation)
 {
-    auto const &kv = updates::kv;
+    auto const &kv = updates::top_kv;
+    auto const &nested_kv = updates::nested_kv;
+
+    UpdateList nested1;
+    Update u1 = make_update(nested_kv[0].first, nested_kv[0].second);
+    Update u2 = make_update(nested_kv[1].first, nested_kv[1].second);
+    nested1.push_front(u1);
+    nested1.push_front(u2);
+
+    UpdateList nested2;
+    Update u3 = make_update(nested_kv[2].first, nested_kv[2].second);
+    Update u4 = make_update(nested_kv[3].first, nested_kv[3].second);
+    nested2.push_front(u3);
+    nested2.push_front(u4);
 
     // insert all
     this->root = upsert_updates(
@@ -307,14 +318,10 @@ TYPED_TEST(PlainTrieTest, delete_wo_incarnation)
         *this->sm,
         std::move(this->root),
         make_update(kv[0].first, kv[0].second),
-        make_update(kv[1].first, kv[1].second),
+        make_update(kv[1].first, kv[1].second, false, std::move(nested1)),
         make_update(kv[2].first, kv[2].second),
-        make_update(kv[3].first, kv[3].second),
-        make_update(kv[4].first, kv[4].second),
-        make_update(kv[5].first, kv[5].second),
-        make_update(kv[6].first, kv[6].second),
-        make_update(kv[7].first, kv[7].second));
-    // erase 0
+        make_update(kv[3].first, kv[3].second, false, std::move(nested2)));
+    // erase kv0
     this->root = upsert_updates(
         this->aux, *this->sm, std::move(this->root), make_erase(kv[0].first));
     EXPECT_EQ(this->root->mask, 2 | 1u << 0xa | 1u << 0xb);
@@ -322,57 +329,47 @@ TYPED_TEST(PlainTrieTest, delete_wo_incarnation)
         this->root->path_nibble_view(),
         (NibblesView{0, 3, kv[1].first.data()}));
 
-    // erase 5, a leaf with children (consequently 6 and 7 are erased)
+    // erase kv3, so as its subtrie
     this->root = upsert_updates(
-        this->aux, *this->sm, std::move(this->root), make_erase(kv[5].first));
+        this->aux, *this->sm, std::move(this->root), make_erase(kv[3].first));
     EXPECT_EQ(this->root->mask, 2 | 1u << 0xa);
     EXPECT_EQ(
         this->root->path_nibble_view(),
         (NibblesView{0, 3, kv[1].first.data()}));
 
-    // erase 1, consequently 2,3 are erased
+    // erase kv1, so as its subtrie
     this->root = upsert_updates(
         this->aux, *this->sm, std::move(this->root), make_erase(kv[1].first));
+    // only kv2 left
     EXPECT_EQ(this->root->mask, 0);
-    EXPECT_EQ(this->root->value(), kv[4].second);
+    EXPECT_EQ(this->root->value(), kv[2].second);
     EXPECT_EQ(
         this->root->path_nibble_view(),
-        (NibblesView{0, 8, kv[4].first.data()}));
+        (NibblesView{0, 8, kv[2].first.data()}));
 }
 
 TYPED_TEST(PlainTrieTest, delete_with_incarnation)
 {
     constexpr uint64_t version = 0;
     // upsert a bunch of var lengths kv
-    auto const &kv = updates::kv;
-    // insert
-    this->root = upsert_updates(
-        this->aux,
-        *this->sm,
-        std::move(this->root),
-        make_update(kv[0].first, kv[0].second), // 0x01111111
-        make_update(kv[1].first, kv[1].second), // 0x11111111
-        make_update(kv[2].first, kv[2].second)); // 0x11111111aaaa
-    EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
-            .first.node->value(),
-        kv[0].second);
-    EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
-            .first.node->value(),
-        kv[1].second);
-    EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version)
-            .first.node->value(),
-        kv[2].second);
+    auto const &kv = updates::top_kv;
+    auto const &nested_kv = updates::nested_kv;
 
-    // upsert a bunch of new kvs, with incarnation flag set
-    this->root = upsert_updates(
-        this->aux,
-        *this->sm,
-        std::move(this->root),
-        make_update(kv[1].first, kv[1].second, true), // 0x11111111
-        make_update(kv[3].first, kv[3].second)); // 0x11111111aacd
+    {
+        UpdateList nested;
+        Update u = make_update(nested_kv[0].first, nested_kv[0].second);
+        nested.push_front(u);
+        this->root = upsert_updates(
+            this->aux,
+            *this->sm,
+            std::move(this->root),
+            make_update(kv[0].first, kv[0].second), // 0x01111111
+            make_update( // 0x11111111 -> 0xaaaa
+                kv[1].first,
+                kv[1].second,
+                false,
+                std::move(nested)));
+    }
     EXPECT_EQ(
         find_blocking(this->aux, *this->root, kv[0].first, version)
             .first.node->value(),
@@ -382,11 +379,39 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first, version)
+        find_blocking(
+            this->aux, *this->root, kv[1].first + nested_kv[0].first, version)
             .first.node->value(),
-        kv[3].second);
+        nested_kv[0].second);
+
+    {
+        UpdateList nested;
+        Update u = make_update(nested_kv[1].first, nested_kv[1].second);
+        nested.push_front(u);
+        // upsert kv[1] with incarnation and new nested key
+        this->root = upsert_updates( // 0x11111111 -> 0xaacd
+            this->aux,
+            *this->sm,
+            std::move(this->root),
+            make_update(kv[1].first, kv[1].second, true, std::move(nested)));
+    }
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version).second,
+        find_blocking(this->aux, *this->root, kv[0].first, version)
+            .first.node->value(),
+        kv[0].second);
+    EXPECT_EQ(
+        find_blocking(this->aux, *this->root, kv[1].first, version)
+            .first.node->value(),
+        kv[1].second);
+    EXPECT_EQ(
+        find_blocking(
+            this->aux, *this->root, kv[1].first + nested_kv[1].first, version)
+            .first.node->value(),
+        nested_kv[1].second);
+    EXPECT_EQ(
+        find_blocking(
+            this->aux, *this->root, kv[1].first + nested_kv[0].first, version)
+            .second,
         find_result::key_mismatch_failure);
 }
 
@@ -471,9 +496,15 @@ TYPED_TEST(PlainTrieTest, large_values)
 
 TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
 {
+    constexpr unsigned prefix_len = 6;
+    using TestStateMachine = StateMachineAlways<
+        EmptyCompute,
+        StateMachineConfig{.variable_length_start_depth = prefix_len}>;
+
+    this->sm = std::make_unique<TestStateMachine>();
     constexpr uint64_t version = 0;
     // upsert a bunch of var lengths kv
-    auto const &kv = updates::kv;
+    auto const &kv = updates::var_len_kv;
     // always insert the same updates to the second level trie
     Update u1 = make_update(kv[0].first, kv[0].second); // 0x01111111
     Update u2 = make_update(kv[1].first, kv[1].second); // 0x11111111
@@ -481,6 +512,7 @@ TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
 
     auto upsert_and_find_with_prefix = [&](monad::byte_string const prefix,
                                            monad::byte_string const top_value) {
+        MONAD_ASSERT(NibblesView{prefix}.nibble_size() == prefix_len);
         UpdateList updates;
         updates.push_front(u1);
         updates.push_front(u2);

--- a/category/mpt/test/state_machine_test.cpp
+++ b/category/mpt/test/state_machine_test.cpp
@@ -87,6 +87,11 @@ namespace
         {
             return false;
         }
+
+        virtual bool is_variable_length() const override
+        {
+            return false;
+        }
     };
 }
 
@@ -103,21 +108,15 @@ struct StateMachineTestFixture : public Base
         this->sm = std::make_unique<TestStateMachine>(
             down_calls, up_calls, compute_calls, cache_calls);
 
-        UpdateList updates;
-        UpdateList sub;
-        auto const key1 = 0x11_hex;
-        auto const key2 = 0x22_hex;
-        auto sub1 = make_update(key1, monad::byte_string_view{});
-        auto sub2 = make_update(key2, monad::byte_string_view{});
-        sub.push_front(sub1);
-        sub.push_front(sub2);
-        auto const keytop = 0x11_hex;
-        auto top =
-            make_update(keytop, monad::byte_string{}, false, std::move(sub));
-        updates.push_front(top);
+        auto const key1 = 0x1111_hex;
+        auto const key2 = 0x1122_hex;
 
-        this->root = upsert(
-            this->aux, 0, *this->sm, std::move(this->root), std::move(updates));
+        this->root = upsert_updates(
+            this->aux,
+            *this->sm,
+            std::move(this->root),
+            make_update(key1, monad::byte_string_view{}),
+            make_update(key2, monad::byte_string_view{}));
     }
 
     void validate_down_calls(DownCalls const &expected)


### PR DESCRIPTION
This change sets the stage for storing full (local table) paths in mpt::Node, replacing the current use of relative paths.

Here we define and enforce stricter rules for the format of trie updates:
- Disallow deletions and updates in variable-length tables. Make updates and deletions only possible for fixed-length tables
- Disallow a **flat** `Update` to **nested** trie key-value pairs using a concatenated path of parent and child table prefixes. Instead, we enforce using nested updates for nested (fixed-length) tables.

     For example, to insert or update the second level of a two-level trie, the correct format is `UpdateList` of with entry `key = P`, `value = val_p`, `next` update list for second-level table.
A flat `UpdateList` entry with`key = concat(P, A)` is disallowed.

 ```
 Level 1:     P (has value)

           /  |  \

 Level 2: A   B   C 
```
This eliminates possible ambiguity in trie updates, especially as we move towards storing full table paths.

To enforce these rules, a new `mpt::StateMachine` function, `is_variable_length()`, is introduced to distinguish between variable-length and fixed-length key tables. Appropriate assertions have been added to catch invalid update formats.