### PR TITLE
[core][mem] add monad_round_size_to_align

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -122,6 +122,8 @@ add_library(
   "src/monad/io/buffer_pool.cpp"
   "src/monad/io/buffer_pool.hpp"
   "src/monad/io/config.hpp"
+  # mem
+  "src/monad/mem/align.h"
   # rlp
   "src/monad/rlp/config.hpp"
   "src/monad/rlp/encode.hpp"

--- a/libs/core/src/monad/mem/align.h
+++ b/libs/core/src/monad/mem/align.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * Utilities for manually aligning sizes and addresses
+ */
+
+// TODO(ken): <stdbit.h> is not in C++ until C++26 (P3370), for now we have
+//  to work around this until we're ready to support -std=c++26 when this
+//  C header is included by C++ translation units
+#ifdef __cplusplus
+    #include <bit>
+#else
+    #include <stdbit.h>
+#endif
+
+#include <stddef.h>
+
+#include <monad/core/assert.h>
+#include <monad/core/bit_util.h>
+#include <monad/core/likely.h>
+
+#ifdef __cplusplus
+[[gnu::always_inline]] static inline size_t
+monad_round_size_to_align(size_t const size, size_t const align)
+{
+    MONAD_DEBUG_ASSERT(std::has_single_bit(align));
+    return bit_round_up(size, static_cast<unsigned>(std::countr_zero(align)));
+}
+#else
+[[gnu::always_inline]] static inline size_t
+monad_round_size_to_align(size_t const size, size_t const align)
+{
+    // Round size up to the nearest multiple of align. bit_round_up does this,
+    // provided that align has the form 2^b and is expressed as `b`. `b` (which
+    // is `log_2 align`) is computed efficiently using stdc_trailing_zeros,
+    // an intrinsic operation on many platforms (e.g., TZCNT).
+    MONAD_DEBUG_ASSERT(stdc_has_single_bit(align));
+    return bit_round_up(size, stdc_trailing_zeros(align));
+}
+#endif


### PR DESCRIPTION
This is a useful utility that I end up redefining in all my branches. I figured I'd make a PR for it, now that it needs special treatment in C23 vs. C++23 mode (since gcc15)