### PR TITLE
recover senders before execute_block

### DIFF
--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -13,6 +13,7 @@
 #include <monad/execution/execute_block.hpp>
 #include <monad/execution/execute_transaction.hpp>
 #include <monad/execution/validate_block.hpp>
+#include <monad/execution/validate_transaction.hpp>
 #include <monad/fiber/priority_pool.hpp>
 #include <monad/procfs/statm.h>
 #include <monad/state2/block_state.hpp>
@@ -92,6 +93,17 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
 
         BOOST_OUTCOME_TRY(static_validate_block(rev, block));
 
+        auto const recovered_senders =
+            recover_senders(block.transactions, priority_pool);
+        std::vector<Address> senders(block.transactions.size());
+        for (unsigned i = 0; i < recovered_senders.size(); ++i) {
+            if (recovered_senders[i].has_value()) {
+                senders[i] = recovered_senders[i].value();
+            }
+            else {
+                return TransactionError::MissingSender;
+            }
+        }
         // Ethereum: always execute off of the parent proposal round, commit to
         // `round = block_number`, and finalize immediately after that.
         db.set_block_and_round(
@@ -106,18 +118,17 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
                 chain,
                 rev,
                 block,
+                senders,
                 block_state,
                 block_hash_buffer,
                 priority_pool));
 
         std::vector<Receipt> receipts(results.size());
         std::vector<std::vector<CallFrame>> call_frames(results.size());
-        std::vector<Address> senders(results.size());
         for (unsigned i = 0; i < results.size(); ++i) {
             auto &result = results[i];
             receipts[i] = std::move(result.receipt);
             call_frames[i] = (std::move(result.call_frames));
-            senders[i] = result.sender;
         }
 
         block_state.log_debug();

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -16,6 +16,7 @@
 #include <monad/execution/execute_block.hpp>
 #include <monad/execution/execute_transaction.hpp>
 #include <monad/execution/validate_block.hpp>
+#include <monad/execution/validate_transaction.hpp>
 #include <monad/execution/wal_reader.hpp>
 #include <monad/fiber/priority_pool.hpp>
 #include <monad/mpt/db.hpp>
@@ -148,20 +149,35 @@ Result<std::pair<bytes32_t, uint64_t>> propose_block(
         is_first_block ? std::nullopt
                        : std::make_optional(consensus_header.parent_round()));
 
+    auto const recovered_senders =
+        recover_senders(block.transactions, priority_pool);
+    std::vector<Address> senders(block.transactions.size());
+    for (unsigned i = 0; i < recovered_senders.size(); ++i) {
+        if (recovered_senders[i].has_value()) {
+            senders[i] = recovered_senders[i].value();
+        }
+        else {
+            return TransactionError::MissingSender;
+        }
+    }
     BlockState block_state(db);
     BOOST_OUTCOME_TRY(
         auto results,
         execute_block(
-            chain, rev, block, block_state, block_hash_buffer, priority_pool));
+            chain,
+            rev,
+            block,
+            senders,
+            block_state,
+            block_hash_buffer,
+            priority_pool));
 
     std::vector<Receipt> receipts(results.size());
     std::vector<std::vector<CallFrame>> call_frames(results.size());
-    std::vector<Address> senders(results.size());
     for (unsigned i = 0; i < results.size(); ++i) {
         auto &result = results[i];
         receipts[i] = std::move(result.receipt);
         call_frames[i] = (std::move(result.call_frames));
-        senders[i] = result.sender;
     }
 
     block_state.log_debug();

--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -914,8 +914,15 @@ TYPED_TEST(DBTest, call_frames_stress_test)
 
     fiber::PriorityPool pool{1, 1};
 
+    auto const recovered_senders =
+        recover_senders(block.value().transactions, pool);
+    std::vector<Address> senders(block.value().transactions.size());
+    for (unsigned i = 0; i < recovered_senders.size(); ++i) {
+        MONAD_ASSERT(recovered_senders[i].has_value());
+        senders[i] = recovered_senders[i].value();
+    }
     auto const results = execute_block<EVMC_SHANGHAI>(
-        EthereumMainnet{}, block.value(), bs, block_hash_buffer, pool);
+        EthereumMainnet{}, block.value(), senders, bs, block_hash_buffer, pool);
 
     ASSERT_TRUE(!results.has_error());
 
@@ -1011,8 +1018,20 @@ TYPED_TEST(DBTest, call_frames_refund)
 
     fiber::PriorityPool pool{1, 1};
 
+    auto const recovered_senders =
+        recover_senders(block.value().transactions, pool);
+    std::vector<Address> senders(block.value().transactions.size());
+    for (unsigned i = 0; i < recovered_senders.size(); ++i) {
+        MONAD_ASSERT(recovered_senders[i].has_value());
+        senders[i] = recovered_senders[i].value();
+    }
     auto const results = execute_block<EVMC_SHANGHAI>(
-        ShanghaiEthereumMainnet{}, block.value(), bs, block_hash_buffer, pool);
+        ShanghaiEthereumMainnet{},
+        block.value(),
+        senders,
+        bs,
+        block_hash_buffer,
+        pool);
 
     ASSERT_TRUE(!results.has_error());
 

--- a/libs/execution/src/monad/execution/execute_block.hpp
+++ b/libs/execution/src/monad/execution/execute_block.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <monad/config.hpp>
+#include <monad/core/address.hpp>
 #include <monad/core/receipt.hpp>
 #include <monad/core/result.hpp>
 #include <monad/execution/trace/call_tracer.hpp>
@@ -8,6 +9,7 @@
 
 #include <evmc/evmc.h>
 
+#include <optional>
 #include <vector>
 
 MONAD_NAMESPACE_BEGIN
@@ -19,11 +21,14 @@ struct ExecutionResult;
 
 template <evmc_revision rev>
 Result<std::vector<ExecutionResult>> execute_block(
-    Chain const &, Block &, BlockState &, BlockHashBuffer const &,
-    fiber::PriorityPool &);
+    Chain const &, Block &, std::vector<Address> const &senders, BlockState &,
+    BlockHashBuffer const &, fiber::PriorityPool &);
 
 Result<std::vector<ExecutionResult>> execute_block(
-    Chain const &, evmc_revision, Block &, BlockState &,
-    BlockHashBuffer const &, fiber::PriorityPool &);
+    Chain const &, evmc_revision, Block &, std::vector<Address> const &senders,
+    BlockState &, BlockHashBuffer const &, fiber::PriorityPool &);
+
+std::vector<std::optional<Address>>
+recover_senders(std::vector<Transaction> const &, fiber::PriorityPool &);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -29,7 +29,6 @@ struct EvmcHost;
 struct ExecutionResult
 {
     Receipt receipt;
-    Address sender;
     std::vector<CallFrame> call_frames;
 };
 
@@ -44,15 +43,9 @@ evmc::Result execute_impl_no_validation(
     Address const &beneficiary, uint64_t max_code_size);
 
 template <evmc_revision rev>
-Result<ExecutionResult> execute_impl(
-    Chain const &, uint64_t i, Transaction const &, Address const &sender,
+Result<ExecutionResult> execute(
+    Chain const &, uint64_t i, Transaction const &, Address const &,
     BlockHeader const &, BlockHashBuffer const &, BlockState &,
     boost::fibers::promise<void> &prev);
-
-template <evmc_revision rev>
-Result<ExecutionResult> execute(
-    Chain const &, uint64_t i, Transaction const &,
-    std::optional<Address> const &, BlockHeader const &,
-    BlockHashBuffer const &, BlockState &, boost::fibers::promise<void> &prev);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
@@ -63,7 +63,7 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     boost::fibers::promise<void> prev{};
     prev.set_value();
 
-    auto const result = execute_impl<EVMC_SHANGHAI>(
+    auto const result = execute<EVMC_SHANGHAI>(
         EthereumMainnet{}, 0, tx, from, header, block_hash_buffer, bs, prev);
 
     ASSERT_TRUE(!result.has_error());


### PR DESCRIPTION
main
```
2025-06-09 19:33:53.436436884 [119657] main.cpp:410 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 135s, num transactions = 753163, tps = 5578, gps = 190 M
```
this pr
```
2025-06-09 19:30:11.671182588 [118218] main.cpp:410 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 136s, num transactions = 753163, tps = 5537, gps = 189 M
```

and in memory

main
```
2025-06-09 19:35:48.405984712 [119964] main.cpp:410 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 35s, num transactions = 753163, tps = 21518, gps = 735 M
```
this pr
```
2025-06-09 19:37:37.819180752 [121430] main.cpp:410 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 35s, num transactions = 753163, tps = 21518, gps = 735 M
```
