### PR TITLE
construct chain from block number and timestamp

### DIFF
--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -1,6 +1,7 @@
 #include "runloop_ethereum.hpp"
 
 #include <monad/chain/chain.hpp>
+#include <monad/chain/ethereum_mainnet.hpp>
 #include <monad/core/assert.h>
 #include <monad/core/block.hpp>
 #include <monad/core/bytes.hpp>
@@ -63,7 +64,7 @@ namespace
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &chain, std::filesystem::path const &ledger_dir, Db &db,
+    std::filesystem::path const &ledger_dir, Db &db,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop)
@@ -85,11 +86,11 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
             block_db.get(block_num, block),
             "Could not query %lu from blockdb",
             block_num);
-
+        EthereumMainnet const chain{
+            block.header.number, block.header.timestamp};
         BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
 
-        evmc_revision const rev =
-            chain.get_revision(block.header.number, block.header.timestamp);
+        evmc_revision const rev = chain.get_revision();
 
         BOOST_OUTCOME_TRY(static_validate_block(rev, block));
 

--- a/cmd/monad/runloop_ethereum.hpp
+++ b/cmd/monad/runloop_ethereum.hpp
@@ -11,7 +11,6 @@
 
 MONAD_NAMESPACE_BEGIN
 
-struct Chain;
 struct Db;
 class BlockHashBufferFinalized;
 
@@ -21,8 +20,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &, std::filesystem::path const &, Db &,
-    BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
-    sig_atomic_t const volatile &);
+    std::filesystem::path const &, Db &, BlockHashBufferFinalized &,
+    fiber::PriorityPool &, uint64_t &, uint64_t, sig_atomic_t const volatile &);
 
 MONAD_NAMESPACE_END

--- a/cmd/monad/runloop_monad.hpp
+++ b/cmd/monad/runloop_monad.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <monad/chain/chain_config.h>
 #include <monad/config.hpp>
 #include <monad/core/result.hpp>
 
@@ -11,7 +12,6 @@
 
 MONAD_NAMESPACE_BEGIN
 
-struct Chain;
 struct Db;
 class BlockHashBufferFinalized;
 
@@ -26,7 +26,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
-    Chain const &, std::filesystem::path const &, mpt::Db &, Db &,
+    monad_chain_config, std::filesystem::path const &, mpt::Db &, Db &,
     BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
     sig_atomic_t const volatile &);
 

--- a/libs/execution/src/monad/chain/chain.cpp
+++ b/libs/execution/src/monad/chain/chain.cpp
@@ -10,6 +10,12 @@ MONAD_NAMESPACE_BEGIN
 
 using BOOST_OUTCOME_V2_NAMESPACE::success;
 
+Chain::Chain(uint64_t const block_number, uint64_t const timestamp)
+    : block_number_{block_number}
+    , timestamp_{timestamp}
+{
+}
+
 Result<void> Chain::static_validate_header(BlockHeader const &) const
 {
     return success();

--- a/libs/execution/src/monad/chain/chain.hpp
+++ b/libs/execution/src/monad/chain/chain.hpp
@@ -14,14 +14,20 @@ struct BlockHeader;
 struct Receipt;
 struct Transaction;
 
-struct Chain
+class Chain
 {
+protected:
+    uint64_t block_number_{0};
+    uint64_t timestamp_{0};
+
+public:
+    Chain() = default;
+    Chain(uint64_t block_number, uint64_t timestamp);
     virtual ~Chain() = default;
 
     virtual uint256_t get_chain_id() const = 0;
 
-    virtual evmc_revision
-    get_revision(uint64_t block_number, uint64_t timestamp) const = 0;
+    virtual evmc_revision get_revision() const = 0;
 
     virtual Result<void> static_validate_header(BlockHeader const &) const;
 
@@ -29,11 +35,9 @@ struct Chain
         BlockHeader const &input, BlockHeader const &output) const = 0;
 
     virtual uint64_t compute_gas_refund(
-        uint64_t block_number, uint64_t timestamp, Transaction const &,
-        uint64_t gas_remaining, uint64_t refund) const = 0;
+        Transaction const &, uint64_t gas_remaining, uint64_t refund) const = 0;
 
-    virtual size_t
-    get_max_code_size(uint64_t block_number, uint64_t timestamp) const = 0;
+    virtual size_t get_max_code_size() const = 0;
 
     virtual GenesisState get_genesis_state() const = 0;
 };

--- a/libs/execution/src/monad/chain/ethereum_mainnet.cpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.cpp
@@ -27,42 +27,41 @@ uint256_t EthereumMainnet::get_chain_id() const
     return 1;
 };
 
-evmc_revision EthereumMainnet::get_revision(
-    uint64_t const block_number, uint64_t const timestamp) const
+evmc_revision EthereumMainnet::get_revision() const
 {
     // TODO: update to include Prague once we can replay those blocks
 
-    if (MONAD_LIKELY(timestamp >= 1710338135)) {
+    if (MONAD_LIKELY(timestamp_ >= 1710338135)) {
         return EVMC_CANCUN;
     }
-    else if (timestamp >= 1681338455) {
+    else if (timestamp_ >= 1681338455) {
         return EVMC_SHANGHAI;
     }
-    else if (block_number >= 15537394) {
+    else if (block_number_ >= 15537394) {
         return EVMC_PARIS;
     }
-    else if (block_number >= 12965000) {
+    else if (block_number_ >= 12965000) {
         return EVMC_LONDON;
     }
-    else if (block_number >= 12244000) {
+    else if (block_number_ >= 12244000) {
         return EVMC_BERLIN;
     }
-    else if (block_number >= 9069000) {
+    else if (block_number_ >= 9069000) {
         return EVMC_ISTANBUL;
     }
-    else if (block_number >= 7280000) {
+    else if (block_number_ >= 7280000) {
         return EVMC_PETERSBURG;
     }
-    else if (block_number >= 4370000) {
+    else if (block_number_ >= 4370000) {
         return EVMC_BYZANTIUM;
     }
-    else if (block_number >= 2675000) {
+    else if (block_number_ >= 2675000) {
         return EVMC_SPURIOUS_DRAGON;
     }
-    else if (block_number >= 2463000) {
+    else if (block_number_ >= 2463000) {
         return EVMC_TANGERINE_WHISTLE;
     }
-    else if (block_number >= 1150000) {
+    else if (block_number_ >= 1150000) {
         return EVMC_HOMESTEAD;
     }
     return EVMC_FRONTIER;
@@ -128,18 +127,15 @@ Result<void> EthereumMainnet::validate_output_header(
 }
 
 uint64_t EthereumMainnet::compute_gas_refund(
-    uint64_t const block_number, uint64_t const timestamp,
     Transaction const &tx, uint64_t const gas_remaining,
     uint64_t const refund) const
 {
-    auto const rev = get_revision(block_number, timestamp);
-    return g_star(rev, tx, gas_remaining, refund);
+    return g_star(get_revision(), tx, gas_remaining, refund);
 }
 
-size_t EthereumMainnet::get_max_code_size(
-    uint64_t const block_number, uint64_t const timestamp) const
+size_t EthereumMainnet::get_max_code_size() const
 {
-    return get_revision(block_number, timestamp) >= EVMC_SPURIOUS_DRAGON
+    return get_revision() >= EVMC_SPURIOUS_DRAGON
                ? MAX_CODE_SIZE_EIP170
                : std::numeric_limits<size_t>::max();
 }

--- a/libs/execution/src/monad/chain/ethereum_mainnet.hpp
+++ b/libs/execution/src/monad/chain/ethereum_mainnet.hpp
@@ -19,10 +19,11 @@ inline constexpr size_t MAX_CODE_SIZE_EIP170 = 24 * 1024; // 0x6000
 
 struct EthereumMainnet : Chain
 {
+    using Chain::Chain;
+
     virtual uint256_t get_chain_id() const override;
 
-    virtual evmc_revision
-    get_revision(uint64_t block_number, uint64_t timestamp) const override;
+    virtual evmc_revision get_revision() const override;
 
     virtual Result<void>
     static_validate_header(BlockHeader const &) const override;
@@ -31,11 +32,10 @@ struct EthereumMainnet : Chain
         BlockHeader const &input, BlockHeader const &output) const override;
 
     virtual uint64_t compute_gas_refund(
-        uint64_t block_number, uint64_t timestamp, Transaction const &,
-        uint64_t gas_remaining, uint64_t refund) const override;
+        Transaction const &, uint64_t gas_remaining,
+        uint64_t refund) const override;
 
-    virtual size_t
-    get_max_code_size(uint64_t block_number, uint64_t timestamp) const override;
+    virtual size_t get_max_code_size() const override;
 
     virtual GenesisState get_genesis_state() const override;
 };

--- a/libs/execution/src/monad/chain/monad_chain.cpp
+++ b/libs/execution/src/monad/chain/monad_chain.cpp
@@ -11,8 +11,7 @@ MONAD_NAMESPACE_BEGIN
 
 using BOOST_OUTCOME_V2_NAMESPACE::success;
 
-evmc_revision MonadChain::get_revision(
-    uint64_t /* block_number */, uint64_t /* timestamp */) const
+evmc_revision MonadChain::get_revision() const
 {
     return EVMC_CANCUN;
 }
@@ -38,27 +37,24 @@ Result<void> MonadChain::validate_output_header(
 }
 
 uint64_t MonadChain::compute_gas_refund(
-    uint64_t const block_number, uint64_t const timestamp,
     Transaction const &tx, uint64_t const gas_remaining,
     uint64_t const refund) const
 {
-    auto const monad_rev = get_monad_revision(block_number, timestamp);
+    auto const monad_rev = get_monad_revision();
     if (MONAD_LIKELY(monad_rev >= MONAD_ONE)) {
         return 0;
     }
     else if (monad_rev == MONAD_ZERO) {
-        auto const rev = get_revision(block_number, timestamp);
-        return g_star(rev, tx, gas_remaining, refund);
+        return g_star(get_revision(), tx, gas_remaining, refund);
     }
     else {
         MONAD_ABORT("invalid revision");
     }
 }
 
-size_t MonadChain::get_max_code_size(
-    uint64_t const block_number, uint64_t const timestamp) const
+size_t MonadChain::get_max_code_size() const
 {
-    auto const monad_rev = get_monad_revision(block_number, timestamp);
+    auto const monad_rev = get_monad_revision();
     if (MONAD_LIKELY(monad_rev >= MONAD_TWO)) {
         return 128 * 1024;
     }

--- a/libs/execution/src/monad/chain/monad_chain.hpp
+++ b/libs/execution/src/monad/chain/monad_chain.hpp
@@ -14,21 +14,20 @@ struct Transaction;
 
 struct MonadChain : Chain
 {
-    virtual evmc_revision
-    get_revision(uint64_t block_number, uint64_t timestamp) const override;
+    using Chain::Chain;
+
+    virtual evmc_revision get_revision() const override;
 
     virtual Result<void> validate_output_header(
         BlockHeader const &input, BlockHeader const &output) const override;
 
     virtual uint64_t compute_gas_refund(
-        uint64_t block_number, uint64_t timestamp, Transaction const &,
-        uint64_t gas_remaining, uint64_t refund) const override;
+        Transaction const &, uint64_t gas_remaining,
+        uint64_t refund) const override;
 
-    virtual monad_revision
-    get_monad_revision(uint64_t block_number, uint64_t timestamp) const = 0;
+    virtual monad_revision get_monad_revision() const = 0;
 
-    virtual size_t
-    get_max_code_size(uint64_t block_number, uint64_t timestamp) const override;
+    virtual size_t get_max_code_size() const override;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/monad_devnet.cpp
+++ b/libs/execution/src/monad/chain/monad_devnet.cpp
@@ -6,8 +6,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-monad_revision MonadDevnet::get_monad_revision(
-    uint64_t /* block_number */, uint64_t /* timestamp */) const
+monad_revision MonadDevnet::get_monad_revision() const
 {
     return MONAD_TWO;
 }

--- a/libs/execution/src/monad/chain/monad_devnet.hpp
+++ b/libs/execution/src/monad/chain/monad_devnet.hpp
@@ -10,8 +10,9 @@ MONAD_NAMESPACE_BEGIN
 
 struct MonadDevnet : MonadChain
 {
-    virtual monad_revision get_monad_revision(
-        uint64_t block_number, uint64_t timestamp) const override;
+    using MonadChain::MonadChain;
+
+    virtual monad_revision get_monad_revision() const override;
 
     virtual uint256_t get_chain_id() const override;
 

--- a/libs/execution/src/monad/chain/monad_mainnet.cpp
+++ b/libs/execution/src/monad/chain/monad_mainnet.cpp
@@ -10,8 +10,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-monad_revision MonadMainnet::get_monad_revision(
-    uint64_t /* block_number */, uint64_t /* timstamp */) const
+monad_revision MonadMainnet::get_monad_revision() const
 {
     return MONAD_TWO;
 }

--- a/libs/execution/src/monad/chain/monad_mainnet.hpp
+++ b/libs/execution/src/monad/chain/monad_mainnet.hpp
@@ -10,8 +10,9 @@ MONAD_NAMESPACE_BEGIN
 
 struct MonadMainnet : MonadChain
 {
-    virtual monad_revision get_monad_revision(
-        uint64_t block_number, uint64_t timestamp) const override;
+    using MonadChain::MonadChain;
+
+    virtual monad_revision get_monad_revision() const override;
 
     virtual uint256_t get_chain_id() const override;
 

--- a/libs/execution/src/monad/chain/monad_testnet.cpp
+++ b/libs/execution/src/monad/chain/monad_testnet.cpp
@@ -6,13 +6,12 @@
 
 MONAD_NAMESPACE_BEGIN
 
-monad_revision MonadTestnet::get_monad_revision(
-    uint64_t /* block_number */, uint64_t const timestamp) const
+monad_revision MonadTestnet::get_monad_revision() const
 {
-    if (MONAD_LIKELY(timestamp >= 1741978800)) { // 2025-03-14T19:00:00.000Z
+    if (MONAD_LIKELY(timestamp_ >= 1741978800)) { // 2025-03-14T19:00:00.000Z
         return MONAD_TWO;
     }
-    else if (timestamp >= 1739559600) { // 2025-02-14T19:00:00.000Z
+    else if (timestamp_ >= 1739559600) { // 2025-02-14T19:00:00.000Z
         return MONAD_ONE;
     }
     return MONAD_ZERO;

--- a/libs/execution/src/monad/chain/monad_testnet.hpp
+++ b/libs/execution/src/monad/chain/monad_testnet.hpp
@@ -10,8 +10,9 @@ MONAD_NAMESPACE_BEGIN
 
 struct MonadTestnet : MonadChain
 {
-    virtual monad_revision get_monad_revision(
-        uint64_t block_number, uint64_t timestamp) const override;
+    using MonadChain::MonadChain;
+
+    virtual monad_revision get_monad_revision() const override;
 
     virtual uint256_t get_chain_id() const override;
 

--- a/libs/execution/src/monad/chain/monad_testnet2.cpp
+++ b/libs/execution/src/monad/chain/monad_testnet2.cpp
@@ -6,8 +6,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-monad_revision MonadTestnet2::get_monad_revision(
-    uint64_t /* block_number */, uint64_t /* timstamp */) const
+monad_revision MonadTestnet2::get_monad_revision() const
 {
     return MONAD_TWO;
 }

--- a/libs/execution/src/monad/chain/monad_testnet2.hpp
+++ b/libs/execution/src/monad/chain/monad_testnet2.hpp
@@ -10,8 +10,9 @@ MONAD_NAMESPACE_BEGIN
 
 struct MonadTestnet2 : MonadChain
 {
-    virtual monad_revision get_monad_revision(
-        uint64_t block_number, uint64_t timestamp) const override;
+    using MonadChain::MonadChain;
+
+    virtual monad_revision get_monad_revision() const override;
 
     virtual uint256_t get_chain_id() const override;
 

--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -81,9 +81,7 @@ namespace
 
     struct ShanghaiEthereumMainnet : EthereumMainnet
     {
-        virtual evmc_revision get_revision(
-            uint64_t /* block_number */,
-            uint64_t /* timestamp */) const override
+        virtual evmc_revision get_revision() const override
         {
             return EVMC_SHANGHAI;
         }

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -18,7 +18,7 @@ MONAD_NAMESPACE_BEGIN
 class BlockHashBuffer;
 struct BlockHeader;
 class BlockState;
-struct Chain;
+class Chain;
 struct Receipt;
 class State;
 struct Transaction;

--- a/libs/execution/src/monad/execution/test/test_monad_chain.cpp
+++ b/libs/execution/src/monad/execution/test/test_monad_chain.cpp
@@ -19,24 +19,30 @@ using namespace monad;
 
 TEST(MonadChain, compute_gas_refund)
 {
-    MonadTestnet monad_chain;
     Transaction tx{.gas_limit = 21'000};
 
     BlockHeader before_fork{.number = 0, .timestamp = 0};
     BlockHeader after_fork{.number = 1, .timestamp = 1739559600};
 
-    auto const refund_before_fork = monad_chain.compute_gas_refund(
-        before_fork.number, before_fork.timestamp, tx, 20'000, 1000);
-    auto const refund_after_fork = monad_chain.compute_gas_refund(
-        after_fork.number, after_fork.timestamp, tx, 20'000, 1000);
+    MonadTestnet monad_chain{before_fork.number, before_fork.timestamp};
+    auto const refund_before_fork =
+        monad_chain.compute_gas_refund(tx, 20'000, 1000);
+    monad_chain = MonadTestnet{after_fork.number, after_fork.timestamp};
+    auto const refund_after_fork =
+        monad_chain.compute_gas_refund(tx, 20'000, 1000);
     EXPECT_EQ(20'200, refund_before_fork - refund_after_fork);
 }
 
 TEST(MonadChain, get_max_code_size)
 {
-    MonadTestnet const chain;
-    EXPECT_EQ(chain.get_max_code_size(0, 1739559600), MAX_CODE_SIZE_EIP170);
-    EXPECT_EQ(chain.get_max_code_size(0, 1741978800), 128 * 1024);
+    {
+        MonadTestnet const chain{0, 1739559600};
+        EXPECT_EQ(chain.get_max_code_size(), MAX_CODE_SIZE_EIP170);
+    }
+    {
+        MonadTestnet const chain{0, 1741978800};
+        EXPECT_EQ(chain.get_max_code_size(), 128 * 1024);
+    }
 }
 
 TEST(MonadChain, Genesis)

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -67,8 +67,7 @@ struct EthereumMainnetRev : EthereumMainnet
     {
     }
 
-    virtual evmc_revision get_revision(
-        uint64_t /* block_number */, uint64_t /* timestamp */) const override
+    virtual evmc_revision get_revision() const override
     {
         return rev;
     }


### PR DESCRIPTION
- many function rely on block number and timestamp to then get the revision (for either monad or emvc)
- future functions that depend on revision need number and timestamp - if they are part of the signature then calling functions need to pipe those values down as well
- doubly beneficial is construction of MonadChain inside of the monad runloop to be able to call monad functions (get_monad_revision)