### PR TITLE
make nonce uin256_t

### DIFF
--- a/libs/execution/src/monad/core/account.hpp
+++ b/libs/execution/src/monad/core/account.hpp
@@ -14,16 +14,16 @@ struct Account
 {
     uint256_t balance{0}; // sigma[a]_b
     bytes32_t code_hash{NULL_HASH}; // sigma[a]_c
-    uint64_t nonce{0}; // sigma[a]_n
+    uint256_t nonce{0}; // sigma[a]_n
     Incarnation incarnation{0, 0};
 
     friend bool operator==(Account const &, Account const &) = default;
 };
 
-static_assert(sizeof(Account) == 80);
+static_assert(sizeof(Account) == 104);
 static_assert(alignof(Account) == 8);
 
-static_assert(sizeof(std::optional<Account>) == 88);
+static_assert(sizeof(std::optional<Account>) == 112);
 static_assert(alignof(std::optional<Account>) == 8);
 
 // YP (14)

--- a/libs/execution/src/monad/core/transaction.hpp
+++ b/libs/execution/src/monad/core/transaction.hpp
@@ -42,7 +42,7 @@ static_assert(alignof(AccessList) == 8);
 struct Transaction
 {
     SignatureAndChain sc{};
-    uint64_t nonce{};
+    uint256_t nonce{};
     uint256_t max_fee_per_gas{}; // gas_price
     uint64_t gas_limit{};
     uint256_t value{};
@@ -55,7 +55,7 @@ struct Transaction
     friend bool operator==(Transaction const &, Transaction const &) = default;
 };
 
-static_assert(sizeof(Transaction) == 304);
+static_assert(sizeof(Transaction) == 328);
 static_assert(alignof(Transaction) == 8);
 
 std::optional<Address> recover_sender(Transaction const &);

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -666,8 +666,7 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             json[key]["address"] = fmt::format("{}", acct.value().first);
             json[key]["balance"] =
                 fmt::format("{}", acct.value().second.balance);
-            json[key]["nonce"] =
-                fmt::format("0x{:x}", acct.value().second.nonce);
+            json[key]["nonce"] = fmt::format("{}", acct.value().second.nonce);
 
             auto const code_analysis =
                 db.read_code(acct.value().second.code_hash);

--- a/libs/execution/src/monad/execution/create_contract_address.cpp
+++ b/libs/execution/src/monad/execution/create_contract_address.cpp
@@ -24,7 +24,7 @@ Address hash_and_clip(byte_string const &b)
 }
 
 // YP Sec 7: Eq 87, top
-Address create_contract_address(Address const &from, uint64_t const nonce)
+Address create_contract_address(Address const &from, uint256_t const nonce)
 {
     byte_string const b = rlp::encode_list2(
         rlp::encode_address(from) + rlp::encode_unsigned(nonce));

--- a/libs/execution/src/monad/execution/create_contract_address.hpp
+++ b/libs/execution/src/monad/execution/create_contract_address.hpp
@@ -9,7 +9,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-Address create_contract_address(Address const &from, uint64_t const nonce);
+Address create_contract_address(Address const &from, uint256_t nonce);
 Address create2_contract_address(
     Address const &from, bytes32_t const &zeta,
     ethash::hash256 const &code_hash);

--- a/libs/execution/src/monad/state2/state_deltas.hpp
+++ b/libs/execution/src/monad/state2/state_deltas.hpp
@@ -24,7 +24,7 @@ using Delta = std::pair<T const, T>;
 
 using AccountDelta = Delta<std::optional<Account>>;
 
-static_assert(sizeof(AccountDelta) == 176);
+static_assert(sizeof(AccountDelta) == 224);
 static_assert(alignof(AccountDelta) == 8);
 
 using StorageDelta = Delta<bytes32_t>;
@@ -43,7 +43,7 @@ struct StateDelta
     StorageDeltas storage{};
 };
 
-static_assert(sizeof(StateDelta) == 752);
+static_assert(sizeof(StateDelta) == 800);
 static_assert(alignof(StateDelta) == 8);
 
 using StateDeltas = oneapi::tbb::concurrent_hash_map<Address, StateDelta>;

--- a/libs/execution/src/monad/state3/state.hpp
+++ b/libs/execution/src/monad/state3/state.hpp
@@ -152,7 +152,7 @@ public:
         return recent_account_state(address).account_;
     }
 
-    void set_original_nonce(Address const &address, uint64_t const nonce)
+    void set_original_nonce(Address const &address, uint256_t const nonce)
     {
         auto &account_state = original_account_state(address);
         auto &account = account_state.account_;
@@ -174,7 +174,7 @@ public:
         return is_dead(recent_account(address));
     }
 
-    uint64_t get_nonce(Address const &address)
+    uint256_t get_nonce(Address const &address)
     {
         auto const &account = recent_account(address);
         if (MONAD_LIKELY(account.has_value())) {
@@ -261,7 +261,7 @@ public:
 
     ////////////////////////////////////////
 
-    void set_nonce(Address const &address, uint64_t const nonce)
+    void set_nonce(Address const &address, uint256_t const nonce)
     {
         auto &account = current_account(address);
         if (MONAD_UNLIKELY(!account.has_value())) {

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -271,8 +271,8 @@ void BlockchainTest::validate_post_state(
 
         auto const expected_balance =
             fmt::format("{}", j_account.at("balance").get<uint256_t>());
-        auto const expected_nonce = fmt::format(
-            "0x{:x}", integer_from_json<uint64_t>(j_account.at("nonce")));
+        auto const expected_nonce =
+            std::to_string(integer_from_json<uint64_t>(j_account.at("nonce")));
         auto const code = j_account.contains("code")
                               ? j_account.at("code").get<monad::byte_string>()
                               : monad::byte_string{};


### PR DESCRIPTION
peach16, difference in first run is probably due to warming (see subsequent runs)
```
// in memory, this branch
2025-06-17 15:32:12.128965390 [81080] main.cpp:397 LOG_INFO     Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 46s, num transactions = 753163, tps = 16373, gps = 559 M

2025-06-17 17:06:06.169808781 [95834] main.cpp:397 LOG_INFO     Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

2025-06-17 17:07:16.683324962 [95927] main.cpp:397 LOG_INFO     Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

2025-06-17 17:08:16.820930227 [96353] main.cpp:397 LOG_INFO     Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

```

// in memory, main
```
2025-06-17 15:36:07.010196881 [86411] main.cpp:397 LOG_INFO     Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 41s, num transactions = 753163, tps = 18369, gps = 627 M

2025-06-17 17:12:13.197993040 [103152] main.cpp:397 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

2025-06-17 17:13:14.100867692 [103408] main.cpp:397 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

2025-06-17 17:14:17.594988668 [103517] main.cpp:397 LOG_INFO    Finish running, finish(stopped) block number = 3100001, number of blocks run = 100000, time_elapsed = 38s, num transactions = 753163, tps = 19820, gps = 677 M

```