### PR TITLE
consensus block formatting changes for bftv2

### DIFF
--- a/cmd/monad/file_io.cpp
+++ b/cmd/monad/file_io.cpp
@@ -29,8 +29,9 @@ namespace
 
 }
 
-MonadConsensusBlockHeader
-read_header(bytes32_t const &id, std::filesystem::path const &dir)
+MonadConsensusBlockHeader read_header(
+    MonadChain const &chain, bytes32_t const &id,
+    std::filesystem::path const &dir)
 {
     auto const filename = evmc::hex(id);
     auto const path = dir / filename;
@@ -40,7 +41,7 @@ read_header(bytes32_t const &id, std::filesystem::path const &dir)
     MONAD_ASSERT_PRINTF(
         checksum == id, "Checksum failed for bft header: %s", filename.c_str());
     byte_string_view view{data};
-    auto const res = rlp::decode_consensus_block_header(view);
+    auto const res = rlp::decode_consensus_block_header(chain, view);
     MONAD_ASSERT_PRINTF(
         !res.has_error(), "Could not rlp decode file: %s", filename.c_str());
     return res.value();

--- a/cmd/monad/file_io.hpp
+++ b/cmd/monad/file_io.hpp
@@ -8,8 +8,10 @@
 
 MONAD_NAMESPACE_BEGIN
 
-MonadConsensusBlockHeader
-read_header(bytes32_t const &, std::filesystem::path const &);
+struct MonadChain;
+
+MonadConsensusBlockHeader read_header(
+    MonadChain const &, bytes32_t const &, std::filesystem::path const &);
 
 MonadConsensusBlockBody
 read_body(bytes32_t const &, std::filesystem::path const &);

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -374,7 +374,7 @@ int main(int const argc, char const *argv[])
         case CHAIN_CONFIG_MONAD_MAINNET:
         case CHAIN_CONFIG_MONAD_TESTNET2:
             return runloop_monad(
-                *chain,
+                dynamic_cast<MonadChain const &>(*chain),
                 block_db_path,
                 db,
                 db_cache,

--- a/cmd/monad/runloop_monad.hpp
+++ b/cmd/monad/runloop_monad.hpp
@@ -12,7 +12,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-struct Chain;
+struct MonadChain;
 struct Db;
 class BlockHashBufferFinalized;
 
@@ -27,8 +27,8 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
-    Chain const &, std::filesystem::path const &, mpt::Db &, Db &, vm::VM &,
-    BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
-    sig_atomic_t const volatile &);
+    MonadChain const &, std::filesystem::path const &, mpt::Db &, Db &,
+    vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
+    uint64_t, sig_atomic_t const volatile &);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/monad_chain.hpp
+++ b/libs/execution/src/monad/chain/monad_chain.hpp
@@ -10,6 +10,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct BlockHeader;
+struct MonadConsensusBlockHeader;
 struct Transaction;
 
 struct MonadChain : Chain
@@ -29,6 +30,9 @@ struct MonadChain : Chain
 
     virtual size_t
     get_max_code_size(uint64_t block_number, uint64_t timestamp) const override;
+
+    Result<void>
+    static_validate_consensus_header(MonadConsensusBlockHeader const &) const;
 };
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/chain/monad_devnet.cpp
+++ b/libs/execution/src/monad/chain/monad_devnet.cpp
@@ -9,7 +9,7 @@ MONAD_NAMESPACE_BEGIN
 monad_revision MonadDevnet::get_monad_revision(
     uint64_t /* block_number */, uint64_t /* timestamp */) const
 {
-    return MONAD_TWO;
+    return MONAD_THREE;
 }
 
 uint256_t MonadDevnet::get_chain_id() const

--- a/libs/execution/src/monad/chain/monad_revision.h
+++ b/libs/execution/src/monad/chain/monad_revision.h
@@ -10,6 +10,7 @@ enum monad_revision
     MONAD_ZERO = 0,
     MONAD_ONE = 1,
     MONAD_TWO = 2,
+    MONAD_THREE = 3,
 };
 
 #ifdef __cplusplus

--- a/libs/execution/src/monad/core/rlp/monad_block_rlp.hpp
+++ b/libs/execution/src/monad/core/rlp/monad_block_rlp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <monad/chain/monad_chain.hpp>
 #include <monad/core/byte_string.hpp>
 #include <monad/core/monad_block.hpp>
 #include <monad/core/result.hpp>
@@ -13,6 +14,6 @@ encode_consensus_block_header(MonadConsensusBlockHeader const &header);
 
 Result<MonadConsensusBlockBody> decode_consensus_block_body(byte_string_view &);
 Result<MonadConsensusBlockHeader>
-decode_consensus_block_header(byte_string_view &);
+decode_consensus_block_header(MonadChain const &, byte_string_view &);
 
 MONAD_RLP_NAMESPACE_END

--- a/libs/execution/src/monad/db/util.cpp
+++ b/libs/execution/src/monad/db/util.cpp
@@ -1,3 +1,4 @@
+#include <monad/chain/monad_chain.hpp>
 #include <monad/config.hpp>
 #include <monad/core/account.hpp>
 #include <monad/core/assert.h>
@@ -885,12 +886,14 @@ std::optional<byte_string> query_consensus_header(
 }
 
 std::optional<MonadConsensusBlockHeader> read_consensus_header(
-    mpt::Db const &db, uint64_t const block, mpt::NibblesView const prefix)
+    MonadChain const &chain, mpt::Db const &db, uint64_t const block,
+    mpt::NibblesView const prefix)
 {
     return query_consensus_header(db, block, prefix)
-        .transform([](byte_string const &data) {
+        .transform([&chain](byte_string const &data) {
             byte_string_view view{data};
-            auto const decoded = rlp::decode_consensus_block_header(view);
+            auto const decoded =
+                rlp::decode_consensus_block_header(chain, view);
             MONAD_ASSERT(decoded.has_value());
             return decoded.value();
         });

--- a/libs/execution/src/monad/db/util.hpp
+++ b/libs/execution/src/monad/db/util.hpp
@@ -18,6 +18,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct BlockHeader;
+struct MonadChain;
 
 struct MachineBase : public mpt::StateMachine
 {
@@ -157,6 +158,7 @@ std::optional<byte_string> query_consensus_header(
     mpt::Db const &db, uint64_t block, mpt::NibblesView prefix);
 
 std::optional<MonadConsensusBlockHeader> read_consensus_header(
-    mpt::Db const &db, uint64_t block, mpt::NibblesView prefix);
+    MonadChain const &, mpt::Db const &, uint64_t block,
+    mpt::NibblesView prefix);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/validate_block.cpp
+++ b/libs/execution/src/monad/execution/validate_block.cpp
@@ -239,7 +239,9 @@ quick_status_code_from_enum<monad::BlockError>::value_mappings()
         {BlockError::WrongDaoExtraData, "wrong dao extra data", {}},
         {BlockError::WrongLogsBloom, "wrong logs bloom", {}},
         {BlockError::InvalidGasUsed, "invalid gas used", {}},
-        {BlockError::WrongMerkleRoot, "wrong merkle root", {}}};
+        {BlockError::WrongMerkleRoot, "wrong merkle root", {}},
+        {BlockError::TimestampMismatch, "timestamp mismatch", {}},
+    };
 
     return v;
 }

--- a/libs/execution/src/monad/execution/validate_block.hpp
+++ b/libs/execution/src/monad/execution/validate_block.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <monad/chain/monad_revision.h>
 #include <monad/config.hpp>
 #include <monad/core/bytes.hpp>
 #include <monad/core/receipt.hpp>
@@ -39,11 +40,13 @@ enum class BlockError
     WrongDaoExtraData,
     WrongLogsBloom,
     InvalidGasUsed,
-    WrongMerkleRoot
+    WrongMerkleRoot,
+    TimestampMismatch,
 };
 
 struct Block;
 struct BlockHeader;
+struct MonadConsensusBlockHeader;
 
 Receipt::Bloom compute_bloom(std::vector<Receipt> const &);
 
@@ -51,6 +54,9 @@ bytes32_t compute_ommers_hash(std::vector<BlockHeader> const &);
 
 template <evmc_revision rev>
 Result<void> static_validate_header(BlockHeader const &);
+
+Result<void> static_validate_consensus_header(
+    monad_revision, MonadConsensusBlockHeader const &);
 
 template <evmc_revision rev>
 Result<void> static_validate_block(Block const &);

--- a/libs/execution/src/monad/execution/wal_reader.cpp
+++ b/libs/execution/src/monad/execution/wal_reader.cpp
@@ -34,8 +34,10 @@ namespace
     }
 }
 
-WalReader::WalReader(std::filesystem::path const &ledger_dir)
-    : ledger_dir_{ledger_dir}
+WalReader::WalReader(
+    MonadChain const &chain, std::filesystem::path const &ledger_dir)
+    : chain_{chain}
+    , ledger_dir_{ledger_dir}
 {
     cursor_.open(ledger_dir_ / "wal", std::ios::binary);
     MONAD_ASSERT(cursor_);
@@ -57,7 +59,8 @@ std::optional<WalReader::Result> WalReader::next()
             checksum_header == entry.id,
             "Checksum failed for bft header %s",
             header_filename.c_str());
-        auto const header_res = rlp::decode_consensus_block_header(header_view);
+        auto const header_res =
+            rlp::decode_consensus_block_header(chain_, header_view);
         MONAD_ASSERT_PRINTF(
             !header_res.has_error(),
             "Could not rlp decode file %s",

--- a/libs/execution/src/monad/execution/wal_reader.hpp
+++ b/libs/execution/src/monad/execution/wal_reader.hpp
@@ -11,6 +11,8 @@
 
 MONAD_NAMESPACE_BEGIN
 
+struct MonadChain;
+
 enum class WalAction : uint8_t
 {
     PROPOSE = 0,
@@ -31,6 +33,7 @@ static_assert(alignof(WalEntry) == 1);
 
 class WalReader
 {
+    MonadChain const &chain_;
     std::ifstream cursor_;
     std::filesystem::path ledger_dir_;
 
@@ -42,7 +45,7 @@ public:
         MonadConsensusBlockBody body;
     };
 
-    WalReader(std::filesystem::path const &ledger_dir);
+    WalReader(MonadChain const &, std::filesystem::path const &ledger_dir);
 
     std::optional<Result> next();
 

--- a/libs/execution/src/monad/rlp/config.hpp
+++ b/libs/execution/src/monad/rlp/config.hpp
@@ -9,3 +9,12 @@
 #define MONAD_RLP_NAMESPACE_END                                                \
     }                                                                          \
     MONAD_NAMESPACE_END
+
+#define MONAD_RLP_ANONYMOUS_NAMESPACE_BEGIN                                    \
+    MONAD_RLP_NAMESPACE_BEGIN                                                  \
+    namespace                                                                  \
+    {
+
+#define MONAD_RLP_ANONYMOUS_NAMESPACE_END                                      \
+    }                                                                          \
+    MONAD_RLP_NAMESPACE_END


### PR DESCRIPTION
parses out the timestamp_ns in the consensus header, gets the monad revision, and parses the rest of the header based on it