### PR TITLE
Event PR4: add libmonad_event.a, for Rust

### DIFF
--- a/category/core/event/event_iterator.h
+++ b/category/core/event/event_iterator.h
@@ -23,7 +23,7 @@ struct monad_event_ring_control;
 
 /// Result of trying to atomically read the next available event and advance
 /// the iterator past it
-enum monad_event_next_result
+enum monad_event_iter_result
 {
     MONAD_EVENT_SUCCESS,         ///< Event read and iterator advanced
     MONAD_EVENT_NOT_READY,       ///< No events are available right now
@@ -35,8 +35,14 @@ enum monad_event_next_result
 /// Copy the next event descriptor and advance the iterator, if the next event
 /// is available; returns MONAD_EVENT_SUCCESS upon success, otherwise returns
 /// a code indicating why the iterator could not be advanced
-static enum monad_event_next_result monad_event_iterator_try_next(
+static enum monad_event_iter_result monad_event_iterator_try_next(
     struct monad_event_iterator *, struct monad_event_descriptor *);
+
+/// Copy the event descriptor at the current iteration point, without advancing
+/// the iterator; returns MONAD_EVENT_SUCCESS upon success, otherwise returns
+/// a code indicating why the descriptor at the iteration point was not ready
+static enum monad_event_iter_result monad_event_iterator_try_copy(
+    struct monad_event_iterator const *, struct monad_event_descriptor *);
 
 /// Reset the iterator to point to the latest event produced; used for gap
 /// recovery

--- a/category/core/test/event_recorder.cpp
+++ b/category/core/test/event_recorder.cpp
@@ -18,13 +18,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <gtest/gtest.h>
-#include <category/core/likely.h>
 #include <category/core/event/event_iterator.h>
 #include <category/core/event/event_recorder.h>
 #include <category/core/event/event_ring.h>
 #include <category/core/event/event_ring_util.h>
 #include <category/core/event/test_event_types.h>
+#include <category/core/likely.h>
+#include <gtest/gtest.h>
 
 static uint8_t PERF_ITER_SHIFT = 20;
 
@@ -113,13 +113,13 @@ static void writer_main(
     uint64_t last_seqno = iter.read_last_seqno = 0;
     while (last_seqno < max_writer_iteration) {
         monad_event_descriptor event;
-        monad_event_next_result const nr =
+        monad_event_iter_result const ir =
             monad_event_iterator_try_next(&iter, &event);
-        if (MONAD_UNLIKELY(nr == MONAD_EVENT_NOT_READY)) {
+        if (MONAD_UNLIKELY(ir == MONAD_EVENT_NOT_READY)) {
             __builtin_ia32_pause();
             continue;
         }
-        ASSERT_EQ(MONAD_EVENT_SUCCESS, nr);
+        ASSERT_EQ(MONAD_EVENT_SUCCESS, ir);
         EXPECT_EQ(last_seqno + 1, event.seqno);
         last_seqno = event.seqno;
 

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -17,9 +17,14 @@ add_library(
   "../core/event/event_ring.c"
   "../core/event/event_ring.h"
   "../core/event/event_ring_util.c"
-  "../core/event/event_ring_util.h")
+  "../core/event/event_ring_util.h"
+  "../execution/ethereum/core/base_ctypes.h"
+  "../execution/ethereum/core/eth_ctypes.h"
+  "../execution/ethereum/event/exec_event_ctypes.h"
+  "../execution/ethereum/event/exec_event_ctypes_metadata.c"
+  "../execution/ethereum/event/exec_iter_help.h")
 
-target_include_directories(monad_event PUBLIC ${CATEGORY_MAIN_DIR})
+target_include_directories(monad_event PUBLIC "../..")
 target_compile_definitions(monad_event PUBLIC _GNU_SOURCE)
 target_compile_features(monad_event PUBLIC c_std_23)
 target_compile_options(monad_event PRIVATE -Wall -Wextra -Wconversion -Werror)

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
   "ethereum/core/fmt/address_fmt.hpp"
   "ethereum/core/fmt/block_fmt.hpp"
   "ethereum/core/fmt/bytes_fmt.hpp"
+  "ethereum/core/fmt/eth_ctypes_fmt.hpp"
   "ethereum/core/fmt/int_fmt.hpp"
   "ethereum/core/fmt/receipt_fmt.hpp"
   "ethereum/core/fmt/signature_fmt.hpp"
@@ -80,6 +81,7 @@ add_library(
   "ethereum/db/util.hpp"
   # ethereum/event
   "ethereum/event/exec_event_ctypes.h"
+  "ethereum/event/exec_event_ctypes_fmt.hpp"
   "ethereum/event/exec_event_ctypes_metadata.c"
   "ethereum/event/exec_event_recorder.cpp"
   "ethereum/event/exec_event_recorder.hpp"

--- a/category/execution/ethereum/core/fmt/eth_ctypes_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/eth_ctypes_fmt.hpp
@@ -1,0 +1,233 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * Defines fmtlib formatters for the C types in `eth_ctypes.h`
+ */
+
+#include <bit>
+#include <cstddef>
+#include <iterator>
+#include <quill/bundled/fmt/format.h>
+#include <span>
+#include <string_view>
+#include <utility>
+
+#include <category/execution/ethereum/core/eth_ctypes.h>
+#include <category/execution/ethereum/core/fmt/address_fmt.hpp>
+#include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/core/fmt/int_fmt.hpp>
+
+template <>
+struct fmt::formatter<monad_c_transaction_type> : fmt::formatter<uint8_t>
+{
+    template <typename FormatContext>
+    auto format(monad_c_transaction_type const &value, FormatContext &ctx) const
+    {
+        return fmt::formatter<uint8_t>::format(std::to_underlying(value), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_access_list_entry>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_c_access_list_entry const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "access_list_entry {{");
+        i = fmt::format_to(i, "address = {}", value.address);
+        i = fmt::format_to(
+            i, ", storage_key_count = {}", value.storage_key_count);
+        *i++ = '}';
+        auto const *p = std::bit_cast<std::byte const *>(&value + 1);
+        i = fmt::format_to(
+            i,
+            ", storage_key list = {}",
+            std::span{
+                std::bit_cast<monad_c_bytes32 const *>(p),
+                static_cast<size_t>(value.storage_key_count)});
+        p += value.storage_key_count * sizeof(monad_c_bytes32);
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_txn_header> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_c_eth_txn_header const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_txn_header {{");
+        i = fmt::format_to(i, "txn_type = {}", value.txn_type);
+        i = fmt::format_to(i, ", chain_id = {}", value.chain_id);
+        i = fmt::format_to(i, ", nonce = {}", value.nonce);
+        i = fmt::format_to(i, ", gas_limit = {}", value.gas_limit);
+        i = fmt::format_to(i, ", max_fee_per_gas = {}", value.max_fee_per_gas);
+        i = fmt::format_to(
+            i,
+            ", max_priority_fee_per_gas = {}",
+            value.max_priority_fee_per_gas);
+        i = fmt::format_to(i, ", value = {}", value.value);
+        i = fmt::format_to(i, ", to = {}", value.to);
+        i = fmt::format_to(
+            i, ", is_contract_creation = {}", value.is_contract_creation);
+        i = fmt::format_to(i, ", r = {}", value.r);
+        i = fmt::format_to(i, ", s = {}", value.s);
+        i = fmt::format_to(i, ", y_parity = {}", value.y_parity);
+        i = fmt::format_to(i, ", data_length = {}", value.data_length);
+        i = fmt::format_to(
+            i, ", access_list_count = {}", value.access_list_count);
+        *i++ = '}';
+        auto const *p = std::bit_cast<std::byte const *>(&value + 1);
+        i = fmt::format_to(
+            i,
+            ", data = {}",
+            std::span{
+                std::bit_cast<uint8_t const *>(p),
+                static_cast<size_t>(value.data_length)});
+        p += value.data_length * sizeof(uint8_t);
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_txn_receipt>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_c_eth_txn_receipt const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_txn_receipt {{");
+        i = fmt::format_to(i, "status = {}", value.status);
+        i = fmt::format_to(i, ", log_count = {}", value.log_count);
+        i = fmt::format_to(i, ", gas_used = {}", value.gas_used);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_txn_log> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_c_eth_txn_log const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_txn_log {{");
+        i = fmt::format_to(i, "index = {}", value.index);
+        i = fmt::format_to(i, ", address = {}", value.address);
+        i = fmt::format_to(i, ", topic_count = {}", value.topic_count);
+        i = fmt::format_to(i, ", data_length = {}", value.data_length);
+        *i++ = '}';
+        auto const *p = std::bit_cast<std::byte const *>(&value + 1);
+        i = fmt::format_to(
+            i,
+            ", topic list = {}",
+            std::span{
+                std::bit_cast<monad_c_bytes32 const *>(p),
+                static_cast<size_t>(value.topic_count)});
+        p += value.topic_count * sizeof(monad_c_bytes32);
+        i = fmt::format_to(
+            i,
+            ", data = {}",
+            std::span{
+                std::bit_cast<uint8_t const *>(p),
+                static_cast<size_t>(value.data_length)});
+        p += value.data_length * sizeof(uint8_t);
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_account_state>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_c_eth_account_state const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_account_state {{");
+        i = fmt::format_to(i, "nonce = {}", value.nonce);
+        i = fmt::format_to(i, ", balance = {}", value.balance);
+        i = fmt::format_to(i, ", code_hash = {}", value.code_hash);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_block_exec_input>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_c_eth_block_exec_input const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_block_exec_input {{");
+        i = fmt::format_to(i, "ommers_hash = {}", value.ommers_hash);
+        i = fmt::format_to(i, ", beneficiary = {}", value.beneficiary);
+        i = fmt::format_to(
+            i, ", transactions_root = {}", value.transactions_root);
+        i = fmt::format_to(i, ", difficulty = {}", value.difficulty);
+        i = fmt::format_to(i, ", number = {}", value.number);
+        i = fmt::format_to(i, ", gas_limit = {}", value.gas_limit);
+        i = fmt::format_to(i, ", timestamp = {}", value.timestamp);
+        i = fmt::format_to(i, ", extra_data = {}", value.extra_data);
+        i = fmt::format_to(
+            i, ", extra_data_length = {}", value.extra_data_length);
+        i = fmt::format_to(i, ", prev_randao = {}", value.prev_randao);
+        i = fmt::format_to(i, ", nonce = {}", value.nonce);
+        i = fmt::format_to(
+            i, ", base_fee_per_gas = {}", value.base_fee_per_gas);
+        i = fmt::format_to(
+            i, ", withdrawals_root = {}", value.withdrawals_root);
+        i = fmt::format_to(i, ", txn_count = {}", value.txn_count);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_c_eth_block_exec_output>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_c_eth_block_exec_output const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "eth_block_exec_output {{");
+        i = fmt::format_to(i, "state_root = {}", value.state_root);
+        i = fmt::format_to(i, ", receipts_root = {}", value.receipts_root);
+        i = fmt::format_to(i, ", logs_bloom = {}", value.logs_bloom);
+        i = fmt::format_to(i, ", gas_used = {}", value.gas_used);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};

--- a/category/execution/ethereum/event/exec_event_ctypes_fmt.hpp
+++ b/category/execution/ethereum/event/exec_event_ctypes_fmt.hpp
@@ -1,0 +1,420 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * Defines fmtlib formatters for the C types in `exec_event_ctypes.h`
+ */
+
+#include <bit>
+#include <cstddef>
+#include <iterator>
+#include <quill/bundled/fmt/format.h>
+#include <span>
+#include <string_view>
+#include <utility>
+
+#include <category/execution/ethereum/core/fmt/eth_ctypes_fmt.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+
+template <>
+struct fmt::formatter<monad_exec_flow_type> : fmt::formatter<uint8_t>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_flow_type const &value, FormatContext &ctx) const
+    {
+        return fmt::formatter<uint8_t>::format(std::to_underlying(value), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_block_tag> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_block_tag const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "block_tag {{");
+        i = fmt::format_to(i, "id = {}", value.id);
+        i = fmt::format_to(i, ", block_number = {}", value.block_number);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_block_start> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_block_start const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "block_start {{");
+        i = fmt::format_to(i, "block_tag = {}", value.block_tag);
+        i = fmt::format_to(i, ", round = {}", value.round);
+        i = fmt::format_to(i, ", epoch = {}", value.epoch);
+        i = fmt::format_to(i, ", parent_eth_hash = {}", value.parent_eth_hash);
+        i = fmt::format_to(i, ", chain_id = {}", value.chain_id);
+        i = fmt::format_to(i, ", exec_input = {}", value.exec_input);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_block_end> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_block_end const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "block_end {{");
+        i = fmt::format_to(i, "eth_block_hash = {}", value.eth_block_hash);
+        i = fmt::format_to(i, ", exec_output = {}", value.exec_output);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_block_qc> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_block_qc const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "block_qc {{");
+        i = fmt::format_to(i, "block_tag = {}", value.block_tag);
+        i = fmt::format_to(i, ", round = {}", value.round);
+        i = fmt::format_to(i, ", epoch = {}", value.epoch);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_block_verified>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_exec_block_verified const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "block_verified {{");
+        i = fmt::format_to(i, "block_number = {}", value.block_number);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_txn_start> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_txn_start const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "txn_start {{");
+        i = fmt::format_to(
+            i, "ingest_epoch_nanos = {}", value.ingest_epoch_nanos);
+        i = fmt::format_to(i, ", txn_hash = {}", value.txn_hash);
+        i = fmt::format_to(i, ", sender = {}", value.sender);
+        i = fmt::format_to(i, ", txn_header = {}", value.txn_header);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_txn_evm_output>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_exec_txn_evm_output const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "txn_evm_output {{");
+        i = fmt::format_to(i, "receipt = {}", value.receipt);
+        i = fmt::format_to(
+            i, ", call_frame_count = {}", value.call_frame_count);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_txn_call_frame>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_exec_txn_call_frame const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "txn_call_frame {{");
+        i = fmt::format_to(i, "index = {}", value.index);
+        i = fmt::format_to(i, ", caller = {}", value.caller);
+        i = fmt::format_to(i, ", call_target = {}", value.call_target);
+        i = fmt::format_to(i, ", opcode = {}", value.opcode);
+        i = fmt::format_to(i, ", value = {}", value.value);
+        i = fmt::format_to(i, ", gas = {}", value.gas);
+        i = fmt::format_to(i, ", gas_used = {}", value.gas_used);
+        i = fmt::format_to(i, ", evmc_status = {}", value.evmc_status);
+        i = fmt::format_to(i, ", depth = {}", value.depth);
+        i = fmt::format_to(i, ", input_length = {}", value.input_length);
+        i = fmt::format_to(i, ", return_length = {}", value.return_length);
+        *i++ = '}';
+        auto const *p = std::bit_cast<std::byte const *>(&value + 1);
+        i = fmt::format_to(
+            i,
+            ", input = {}",
+            std::span{
+                std::bit_cast<uint8_t const *>(p),
+                static_cast<size_t>(value.input_length)});
+        p += value.input_length * sizeof(uint8_t);
+        i = fmt::format_to(
+            i,
+            ", return = {}",
+            std::span{
+                std::bit_cast<uint8_t const *>(p),
+                static_cast<size_t>(value.return_length)});
+        p += value.return_length * sizeof(uint8_t);
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_account_access_context>
+    : fmt::formatter<uint8_t>
+{
+    template <typename FormatContext>
+    auto format(
+        monad_exec_account_access_context const &value,
+        FormatContext &ctx) const
+    {
+        return fmt::formatter<uint8_t>::format(std::to_underlying(value), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_account_access_list_header>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(
+        monad_exec_account_access_list_header const &value,
+        FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "account_access_list_header {{");
+        i = fmt::format_to(i, "entry_count = {}", value.entry_count);
+        i = fmt::format_to(i, ", access_context = {}", value.access_context);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_account_access>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_exec_account_access const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "account_access {{");
+        i = fmt::format_to(i, "index = {}", value.index);
+        i = fmt::format_to(i, ", address = {}", value.address);
+        i = fmt::format_to(i, ", access_context = {}", value.access_context);
+        i = fmt::format_to(
+            i, ", is_balance_modified = {}", value.is_balance_modified);
+        i = fmt::format_to(
+            i, ", is_nonce_modified = {}", value.is_nonce_modified);
+        i = fmt::format_to(i, ", prestate = {}", value.prestate);
+        i = fmt::format_to(
+            i, ", modified_balance = {}", value.modified_balance);
+        i = fmt::format_to(i, ", modified_nonce = {}", value.modified_nonce);
+        i = fmt::format_to(
+            i, ", storage_key_count = {}", value.storage_key_count);
+        i = fmt::format_to(i, ", transient_count = {}", value.transient_count);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_storage_access>
+    : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto
+    format(monad_exec_storage_access const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "storage_access {{");
+        i = fmt::format_to(i, "address = {}", value.address);
+        i = fmt::format_to(i, ", index = {}", value.index);
+        i = fmt::format_to(i, ", access_context = {}", value.access_context);
+        i = fmt::format_to(i, ", modified = {}", value.modified);
+        i = fmt::format_to(i, ", transient = {}", value.transient);
+        i = fmt::format_to(i, ", key = {}", value.key);
+        i = fmt::format_to(i, ", start_value = {}", value.start_value);
+        i = fmt::format_to(i, ", end_value = {}", value.end_value);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<monad_exec_evm_error> : fmt::formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(monad_exec_evm_error const &value, FormatContext &ctx) const
+    {
+        fmt::memory_buffer mb;
+        std::back_insert_iterator i{mb};
+        i = fmt::format_to(i, "evm_error {{");
+        i = fmt::format_to(i, "domain_id = {}", value.domain_id);
+        i = fmt::format_to(i, ", status_code = {}", value.status_code);
+        *i++ = '}';
+
+        std::string_view const view{mb.data(), mb.size()};
+        return fmt::formatter<std::string_view>::format(view, ctx);
+    }
+};
+
+namespace monad
+{
+
+    template <std::output_iterator<char> Out>
+    Out
+    format_as(Out o, void const *payload_buf, monad_exec_event_type event_type)
+    {
+        switch (event_type) {
+        case MONAD_EXEC_BLOCK_START:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_start const *>(payload_buf));
+        case MONAD_EXEC_BLOCK_REJECT:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_reject const *>(payload_buf));
+        case MONAD_EXEC_BLOCK_PERF_EVM_ENTER:
+            return o;
+        case MONAD_EXEC_BLOCK_PERF_EVM_EXIT:
+            return o;
+        case MONAD_EXEC_BLOCK_END:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_end const *>(payload_buf));
+        case MONAD_EXEC_BLOCK_QC:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_qc const *>(payload_buf));
+        case MONAD_EXEC_BLOCK_FINALIZED:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_finalized const *>(payload_buf));
+        case MONAD_EXEC_BLOCK_VERIFIED:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_block_verified const *>(payload_buf));
+        case MONAD_EXEC_TXN_START:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_txn_start const *>(payload_buf));
+        case MONAD_EXEC_TXN_REJECT:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_txn_reject const *>(payload_buf));
+        case MONAD_EXEC_TXN_PERF_EVM_ENTER:
+            return o;
+        case MONAD_EXEC_TXN_PERF_EVM_EXIT:
+            return o;
+        case MONAD_EXEC_TXN_EVM_OUTPUT:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_txn_evm_output const *>(payload_buf));
+        case MONAD_EXEC_TXN_LOG:
+            return fmt::format_to(
+                o, "{}", *static_cast<monad_exec_txn_log const *>(payload_buf));
+        case MONAD_EXEC_TXN_CALL_FRAME:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_txn_call_frame const *>(payload_buf));
+        case MONAD_EXEC_TXN_END:
+            return o;
+        case MONAD_EXEC_ACCOUNT_ACCESS_LIST_HEADER:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_account_access_list_header const *>(
+                    payload_buf));
+        case MONAD_EXEC_ACCOUNT_ACCESS:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_account_access const *>(payload_buf));
+        case MONAD_EXEC_STORAGE_ACCESS:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_storage_access const *>(payload_buf));
+        case MONAD_EXEC_EVM_ERROR:
+            return fmt::format_to(
+                o,
+                "{}",
+                *static_cast<monad_exec_evm_error const *>(payload_buf));
+        default:
+            return fmt::format_to(
+                o, "unknown exec type code {}", std::to_underlying(event_type));
+        }
+        std::unreachable();
+    }
+
+} // namespace monad

--- a/category/execution/ethereum/event/exec_iter_help.h
+++ b/category/execution/ethereum/event/exec_iter_help.h
@@ -1,0 +1,73 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * This file defines iterator helpers for execution event rings. They are used
+ * to efficiently rewind iterators for block-oriented replay, i.e., when the
+ * user wants to replay whole blocks (and block consensus events) for old
+ * events that are still resident in event ring memory.
+ */
+
+#include <category/execution/ethereum/core/base_ctypes.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+enum monad_exec_event_type : uint16_t;
+
+struct monad_event_descriptor;
+struct monad_event_iterator;
+struct monad_event_ring;
+struct monad_exec_block_tag;
+
+/// Extract the block number associated with an execution event; returns false
+/// if the payload has expired or if there is no associated block number
+static bool monad_exec_ring_get_block_number(
+    struct monad_event_ring const *, struct monad_event_descriptor const *,
+    uint64_t *block_number);
+
+/// Return true if the execution event with the given descriptor has an
+/// unexpired payload and is associated with the given block id
+static bool monad_exec_ring_block_id_matches(
+    struct monad_event_ring const *, struct monad_event_descriptor const *,
+    monad_c_bytes32 const *);
+
+/// Rewinds the event ring iterator so that the next event produced by
+/// `monad_event_iterator_try_next` will be the most recent consensus event
+/// of the given type (i.e., `BLOCK_START`, `BLOCK_QC`, `BLOCK_FINALIZED`, or
+/// `BLOCK_VERIFIED` event); also copies out this previous event, i.e., this
+/// behaves like `*--i`; returns false if the iterator cannot be moved back
+static bool monad_exec_iter_consensus_prev(
+    struct monad_event_iterator *, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+/// Rewind to the previous consensus event of the specified type, for the
+/// specified block number, and copy out its event descriptor; the iterator is
+/// set so that the next call to `monad_event_iterator_try_next` will be the
+/// event following the requested consensus event; if false is returned, the
+/// iterator is not moved and the copied out event descriptor is not valid
+static bool monad_exec_iter_block_number_prev(
+    struct monad_event_iterator *, struct monad_event_ring const *,
+    uint64_t block_number, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+/// Given a block tag, seek to the consensus event with that tag and the given
+/// event type; `monad_exec_event_type` can be `BLOCK_START`, `BLOCK_QC`,
+/// or `BLOCK_FINALIZED` to look only for events of this type, or `NONE` to
+/// return events of any type
+static bool monad_exec_iter_block_id_prev(
+    struct monad_event_iterator *, struct monad_event_ring const *,
+    monad_c_bytes32 const *, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#define MONAD_EXEC_ITER_HELP_INTERNAL
+#include "exec_iter_help_inline.h"
+#undef MONAD_EXEC_ITER_HELP_INTERNAL

--- a/category/execution/ethereum/event/exec_iter_help_inline.h
+++ b/category/execution/ethereum/event/exec_iter_help_inline.h
@@ -1,0 +1,262 @@
+#ifndef MONAD_EXEC_ITER_HELP_INTERNAL
+    #error This file should only be included directly by exec_event_iter_help.h
+#endif
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <category/core/event/event_iterator.h>
+#include <category/core/event/event_ring.h>
+#include <category/execution/ethereum/core/base_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+
+// For functions like monad_exec_ring_get_block_number, we expect the user to
+// pass a descriptor containing a consensus event (or BLOCK_START); if this is
+// not the case, we need to seek to the nearest BLOCK_START and copy that
+// event into an API-provided buffer, then reseat the event pointer to refer
+// to that event buffer instead
+static inline bool _monad_exec_ring_ensure_block(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const **event_p,
+    struct monad_event_descriptor *buf)
+{
+    if (__builtin_expect(
+            (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+                (*event_p)->event_type != MONAD_EXEC_BLOCK_START,
+            0)) {
+        if (__builtin_expect(
+                !monad_event_ring_try_copy(
+                    event_ring, (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO], buf),
+                0)) {
+            return false;
+        }
+        *event_p = buf;
+    }
+    return true;
+}
+
+inline bool monad_exec_ring_get_block_number(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, uint64_t *block_number)
+{
+    struct monad_event_descriptor buf;
+    void const *payload;
+
+    if (__builtin_expect(
+            !_monad_exec_ring_ensure_block(event_ring, &event, &buf), 0)) {
+        return false;
+    }
+
+    payload = monad_event_ring_payload_peek(event_ring, event);
+
+    switch (event->event_type) {
+    case MONAD_EXEC_BLOCK_START:
+        *block_number = ((struct monad_exec_block_start const *)payload)
+                            ->block_tag.block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_QC:
+        *block_number = ((struct monad_exec_block_qc const *)payload)
+                            ->block_tag.block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        *block_number =
+            ((struct monad_exec_block_tag const *)payload)->block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_VERIFIED:
+        *block_number =
+            ((struct monad_exec_block_verified *)payload)->block_number;
+        break;
+
+    default:
+        return false;
+    }
+
+    return monad_event_ring_payload_check(event_ring, event);
+}
+
+inline bool monad_exec_ring_block_id_matches(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, monad_c_bytes32 const *block_id)
+{
+    struct monad_event_descriptor buf;
+    void const *payload;
+    bool tag_matches;
+
+    if (__builtin_expect(
+            !_monad_exec_ring_ensure_block(event_ring, &event, &buf), 0)) {
+        return false;
+    }
+
+    payload = monad_event_ring_payload_peek(event_ring, event);
+
+    switch (event->event_type) {
+    case MONAD_EXEC_BLOCK_START:
+        tag_matches = memcmp(
+                          block_id,
+                          ((struct monad_exec_block_start const *)payload)
+                              ->block_tag.id.bytes,
+                          sizeof *block_id) == 0;
+        break;
+
+    case MONAD_EXEC_BLOCK_QC:
+        tag_matches = memcmp(
+                          block_id,
+                          ((struct monad_exec_block_qc const *)payload)
+                              ->block_tag.id.bytes,
+                          sizeof *block_id) == 0;
+        break;
+
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        tag_matches =
+            memcmp(
+                block_id,
+                ((struct monad_exec_block_tag const *)payload)->id.bytes,
+                sizeof &block_id) == 0;
+        break;
+
+    default:
+        return false;
+    }
+
+    return tag_matches && monad_event_ring_payload_check(event_ring, event);
+}
+
+inline bool monad_exec_iter_consensus_prev(
+    struct monad_event_iterator *iter, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *event)
+{
+    struct monad_event_descriptor buf;
+    enum monad_exec_event_type event_type;
+    uint64_t iter_save = iter->read_last_seqno;
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    if (iter->read_last_seqno > 0 &&
+        monad_event_iterator_try_copy(iter, event) == MONAD_EVENT_SUCCESS &&
+        event->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+        event->event_type != MONAD_EXEC_BLOCK_START) {
+        iter->read_last_seqno = event->user[MONAD_FLOW_BLOCK_SEQNO] - 1;
+        // A special case to rewind to the start of a block boundary, if we
+        // didn't start at one
+        if (filter == MONAD_EXEC_NONE || filter == MONAD_EXEC_BLOCK_START) {
+            return monad_event_iterator_try_copy(iter, event) ==
+                   MONAD_EVENT_SUCCESS;
+        }
+    }
+
+    while (__builtin_expect(
+        iter->read_last_seqno > 0 &&
+            monad_event_iterator_try_copy(iter, event) == MONAD_EVENT_SUCCESS,
+        0)) {
+        event_type = (enum monad_exec_event_type)event->event_type;
+        if (event->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+            event->event_type != MONAD_EXEC_BLOCK_START) {
+            iter->read_last_seqno = event->user[MONAD_FLOW_BLOCK_SEQNO] - 1;
+            continue;
+        }
+        --iter->read_last_seqno;
+        if (filter == MONAD_EXEC_NONE || filter == event_type) {
+            return true;
+        }
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}
+
+inline bool monad_exec_iter_block_number_prev(
+    struct monad_event_iterator *iter,
+    struct monad_event_ring const *event_ring, uint64_t block_number,
+    enum monad_exec_event_type filter, struct monad_event_descriptor *event)
+{
+    uint64_t cur_block_number;
+    struct monad_event_descriptor buf;
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    switch (filter) {
+    case MONAD_EXEC_NONE:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_START:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_QC:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_VERIFIED:
+        break;
+    default:
+        return false;
+    }
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    while (__builtin_expect(
+        monad_exec_iter_consensus_prev(iter, filter, event), 1)) {
+        if (!monad_exec_ring_get_block_number(
+                event_ring, event, &cur_block_number)) {
+            break;
+        }
+        if (block_number == cur_block_number) {
+            return true;
+        }
+        if (cur_block_number < block_number &&
+            (filter == MONAD_EXEC_BLOCK_FINALIZED ||
+             filter == MONAD_EXEC_BLOCK_VERIFIED)) {
+            break;
+        }
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}
+
+inline bool monad_exec_iter_block_id_prev(
+    struct monad_event_iterator *iter,
+    struct monad_event_ring const *event_ring, monad_c_bytes32 const *block_id,
+    enum monad_exec_event_type filter, struct monad_event_descriptor *event)
+{
+    struct monad_event_descriptor buf;
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    switch (filter) {
+    case MONAD_EXEC_NONE:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_START:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_QC:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        break;
+    default:
+        return false;
+    }
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    while (__builtin_expect(
+        monad_exec_iter_consensus_prev(iter, filter, event), 1)) {
+        if (event->event_type == MONAD_EXEC_BLOCK_VERIFIED) {
+            continue;
+        }
+        if (monad_exec_ring_block_id_matches(event_ring, event, block_id)) {
+            return true;
+        }
+        assert(
+            (filter == MONAD_EXEC_BLOCK_START ||
+             filter == MONAD_EXEC_BLOCK_QC) &&
+            "block number matched, tag didn't, and not START/QC?");
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}


### PR DESCRIPTION
This also has four other features:

- It finishes the implementation of monad_event_ring_find_writer_pids which is used by the Rust utilities. It changes changes cmd/monad to report who has the exclusive lock if we can't obtain it, using that function

- It adds the fmt::formatter specializations for the execution events, add cmd/eventcap.cpp learns how to format the events

- `monad_event_iterator_try_copy` is added, which copies the event descriptor at the current iteration point without advancing the iterator

- It adds the "execution iterator helpers", which can rewind the iterator to consensus event and block boundaries, for block oriented replay (a simple recovery strategy when all "missing" events are still in memory)
