### PR TITLE
Add CONFIG to find_package to avoid warning with new cmake

### DIFF
--- a/libs/async/CMakeLists.txt
+++ b/libs/async/CMakeLists.txt
@@ -10,8 +10,7 @@ project(monad_async)
 
 find_package(
   Boost 1.83 # 1.83 really is the minimum
-  COMPONENTS fiber
-  REQUIRED)
+  CONFIG REQUIRED COMPONENTS fiber)
 
 # ##############################################################################
 # libs

--- a/libs/async/src/monad/async/test/CMakeLists.txt
+++ b/libs/async/src/monad/async/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 find_package(
   Boost
-  COMPONENTS fiber
-  REQUIRED)
+  CONFIG REQUIRED COMPONENTS fiber)
 
 add_async_test(TARGET io_test SOURCES "io.cpp")
 

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -17,8 +17,7 @@ option(MONAD_CORE_FORCE_DEBUG_ASSERT
 include("cmake/find_our_dependency.cmake")
 
 find_package(
-  Boost REQUIRED
-  COMPONENTS context fiber stacktrace_basic
+  Boost CONFIG REQUIRED COMPONENTS context fiber stacktrace_basic
   OPTIONAL_COMPONENTS stacktrace_backtrace)
 
 function(check_if_boost_fiber_needs_ucontext_macro)

--- a/libs/db/CMakeLists.txt
+++ b/libs/db/CMakeLists.txt
@@ -14,8 +14,7 @@ option(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(
   Boost 1.83 # 1.83 really is the minimum
-  COMPONENTS context fiber json thread
-  REQUIRED)
+  CONFIG REQUIRED COMPONENTS context fiber json thread)
 find_package(GTest)
 find_package(PkgConfig REQUIRED)
 


### PR DESCRIPTION
Cmake version shipped with ubuntu 25 prints a warning in find_package statement because of changed method for searching for boost package. Add CONFIG to find_package statement to silence the warning. This works with Ubuntu 24 and 25 cmakes.