### PR TITLE
Add block metrics

### DIFF
--- a/libs/execution/src/monad/db/db_cache.hpp
+++ b/libs/execution/src/monad/db/db_cache.hpp
@@ -198,8 +198,8 @@ public:
 
     virtual std::string print_stats() override
     {
-        return db_.print_stats() + " | " + accounts_.print_stats() + " | " +
-               storage_.print_stats();
+        return db_.print_stats() + ",ac=" + accounts_.print_stats() +
+               ",sc=" + storage_.print_stats();
     }
 
 private:

--- a/libs/execution/src/monad/db/test/test_db.cpp
+++ b/libs/execution/src/monad/db/test/test_db.cpp
@@ -17,6 +17,7 @@
 #include <monad/execution/trace/call_tracer.hpp>
 #include <monad/execution/trace/rlp/call_frame_rlp.hpp>
 #include <monad/fiber/priority_pool.hpp>
+#include <monad/metrics/block_metrics.hpp>
 #include <monad/mpt/nibbles_view.hpp>
 #include <monad/mpt/node.hpp>
 #include <monad/mpt/ondisk_db_config.hpp>
@@ -918,6 +919,7 @@ TYPED_TEST(DBTest, call_frames_stress_test)
         block.value().header.number - 1, block.value().header.parent_hash);
 
     BlockState bs(tdb, this->vm);
+    BlockMetrics metrics;
 
     fiber::PriorityPool pool{1, 1};
 
@@ -929,7 +931,13 @@ TYPED_TEST(DBTest, call_frames_stress_test)
         senders[i] = recovered_senders[i].value();
     }
     auto const results = execute_block<EVMC_SHANGHAI>(
-        EthereumMainnet{}, block.value(), senders, bs, block_hash_buffer, pool);
+        EthereumMainnet{},
+        block.value(),
+        senders,
+        bs,
+        block_hash_buffer,
+        pool,
+        metrics);
 
     ASSERT_TRUE(!results.has_error());
 
@@ -1022,6 +1030,7 @@ TYPED_TEST(DBTest, call_frames_refund)
         block.value().header.number - 1, block.value().header.parent_hash);
 
     BlockState bs(tdb, this->vm);
+    BlockMetrics metrics;
 
     fiber::PriorityPool pool{1, 1};
 
@@ -1038,7 +1047,8 @@ TYPED_TEST(DBTest, call_frames_refund)
         senders,
         bs,
         block_hash_buffer,
-        pool);
+        pool,
+        metrics);
 
     ASSERT_TRUE(!results.has_error());
 

--- a/libs/execution/src/monad/db/trie_db.hpp
+++ b/libs/execution/src/monad/db/trie_db.hpp
@@ -76,8 +76,20 @@ public:
 
 private:
     /// STATS
+    std::atomic<uint64_t> n_account_no_value_{0};
+    std::atomic<uint64_t> n_account_value_{0};
     std::atomic<uint64_t> n_storage_no_value_{0};
     std::atomic<uint64_t> n_storage_value_{0};
+
+    void stats_account_no_value()
+    {
+        n_account_no_value_.fetch_add(1, std::memory_order_release);
+    }
+
+    void stats_account_value()
+    {
+        n_account_value_.fetch_add(1, std::memory_order_release);
+    }
 
     void stats_storage_no_value()
     {

--- a/libs/execution/src/monad/execution/execute_block.hpp
+++ b/libs/execution/src/monad/execution/execute_block.hpp
@@ -6,6 +6,7 @@
 #include <monad/core/result.hpp>
 #include <monad/execution/trace/call_tracer.hpp>
 #include <monad/fiber/priority_pool.hpp>
+#include <monad/metrics/block_metrics.hpp>
 
 #include <evmc/evmc.h>
 
@@ -22,11 +23,12 @@ struct ExecutionResult;
 template <evmc_revision rev>
 Result<std::vector<ExecutionResult>> execute_block(
     Chain const &, Block &, std::vector<Address> const &senders, BlockState &,
-    BlockHashBuffer const &, fiber::PriorityPool &);
+    BlockHashBuffer const &, fiber::PriorityPool &, BlockMetrics &);
 
 Result<std::vector<ExecutionResult>> execute_block(
     Chain const &, evmc_revision, Block &, std::vector<Address> const &senders,
-    BlockState &, BlockHashBuffer const &, fiber::PriorityPool &);
+    BlockState &, BlockHashBuffer const &, fiber::PriorityPool &,
+    BlockMetrics &);
 
 std::vector<std::optional<Address>>
 recover_senders(std::vector<Transaction> const &, fiber::PriorityPool &);

--- a/libs/execution/src/monad/execution/execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/execute_transaction.cpp
@@ -18,6 +18,7 @@
 #include <monad/execution/transaction_gas.hpp>
 #include <monad/execution/tx_context.hpp>
 #include <monad/execution/validate_transaction.hpp>
+#include <monad/metrics/block_metrics.hpp>
 #include <monad/state3/state.hpp>
 
 #include <evmc/evmc.h>
@@ -220,7 +221,7 @@ Result<ExecutionResult> execute(
     Chain const &chain, uint64_t const i, Transaction const &tx,
     Address const &sender, BlockHeader const &hdr,
     BlockHashBuffer const &block_hash_buffer, BlockState &block_state,
-    boost::fibers::promise<void> &prev)
+    BlockMetrics &block_metrics, boost::fibers::promise<void> &prev)
 {
     TRACE_TXN_EVENT(StartTxn);
 
@@ -271,6 +272,7 @@ Result<ExecutionResult> execute(
                 .call_frames = std::move(call_tracer).get_frames()};
         }
     }
+    block_metrics.inc_retries();
     {
         TRACE_TXN_EVENT(StartRetry);
 

--- a/libs/execution/src/monad/execution/execute_transaction.hpp
+++ b/libs/execution/src/monad/execution/execute_transaction.hpp
@@ -6,6 +6,7 @@
 #include <monad/core/receipt.hpp>
 #include <monad/core/result.hpp>
 #include <monad/execution/trace/call_frame.hpp>
+#include <monad/metrics/block_metrics.hpp>
 
 #include <evmc/evmc.h>
 
@@ -45,7 +46,7 @@ evmc::Result execute_impl_no_validation(
 template <evmc_revision rev>
 Result<ExecutionResult> execute(
     Chain const &, uint64_t i, Transaction const &, Address const &,
-    BlockHeader const &, BlockHashBuffer const &, BlockState &,
+    BlockHeader const &, BlockHashBuffer const &, BlockState &, BlockMetrics &,
     boost::fibers::promise<void> &prev);
 
 MONAD_NAMESPACE_END

--- a/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
+++ b/libs/execution/src/monad/execution/test/test_execute_transaction.cpp
@@ -39,6 +39,7 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
+    BlockMetrics metrics;
 
     {
         State state{bs, Incarnation{0, 0}};
@@ -65,7 +66,15 @@ TEST(TransactionProcessor, irrevocable_gas_and_refund_new_contract)
     prev.set_value();
 
     auto const result = execute<EVMC_SHANGHAI>(
-        EthereumMainnet{}, 0, tx, from, header, block_hash_buffer, bs, prev);
+        EthereumMainnet{},
+        0,
+        tx,
+        from,
+        header,
+        block_hash_buffer,
+        bs,
+        metrics,
+        prev);
 
     ASSERT_TRUE(!result.has_error());
 

--- a/libs/execution/src/monad/metrics/block_metrics.hpp
+++ b/libs/execution/src/monad/metrics/block_metrics.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <monad/config.hpp>
+
+#include <chrono>
+
+MONAD_NAMESPACE_BEGIN
+
+class BlockMetrics
+{
+    uint32_t n_retries_{0};
+    std::chrono::microseconds tx_exec_time_{1};
+
+public:
+    void inc_retries()
+    {
+        ++n_retries_;
+    }
+
+    uint32_t num_retries() const
+    {
+        return n_retries_;
+    }
+
+    void set_tx_exec_time(std::chrono::microseconds const exec_time)
+    {
+        tx_exec_time_ = exec_time;
+    }
+
+    std::chrono::microseconds tx_exec_time() const
+    {
+        return tx_exec_time_;
+    }
+};
+
+MONAD_NAMESPACE_END


### PR DESCRIPTION
Sample block metrics:
```
// bl   block number
// ro   round number
// ts   block start timestamp
// tx   number of transactions
// rt   number of retries (transactions that failed merge validation)
// rtp  percentage of retries
// sr   sender recovery time (microseconds)
// txe  transaction parallel execution time (includes optimistic execution and re-execution after validation failure)
// cmt  block commit time
// tot  total block execution time
// tpse tps based on transaction execution time only
// tps  tps based on total block time
// gas  gas
// gpse gps based on transaction execution time only
// gps  gps based on total block time
// ae   accounts cache misses where the account was empty
// ane  accounts cache misses where the account was nonempty
// sz   storage cache miss where the value was zero
// snz  storage cache miss where the value was nonzero
// ac   accounts cache size (max 10M)
// sc   storage cache size (max 10M)

2025-07-02 21:26:17.177409348 [255384] runloop_ethereum.cpp:186 LOG_INFO        __exec_block,bl=19000099,ts=1751491577114,tx=  164,rt= 163,rtp=99.39%,sr= 2304µs,txe= 42773µs,cmt= 13254µs,tot= 62880µs,tpse= 3834,tps= 2608,gas= 14182880,gpse= 331,gps=225,ae=  23,ane=  95,sz= 158,snz= 285,ac=   14892,sc=   49640

```
