### PR TITLE
Implement in order traversals

### DIFF
--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -193,8 +193,9 @@ struct DbStateMachine
 
         fmt::println("Success! Set version to {}\n", curr_version);
         if (list_finalized_and_proposals(version)) {
-            fmt::println("Type \"proposal [round]\" or "
-                         "\"finalized\" to set section");
+            fmt::println(
+                "Type \"proposal [round]\" or "
+                "\"finalized\" to set section");
         }
         else {
             fmt::println(
@@ -208,8 +209,9 @@ struct DbStateMachine
     bool list_finalized_and_proposals(uint64_t const version)
     {
         if (version == INVALID_BLOCK_ID) {
-            fmt::println("Error: invalid version to list sections, set to a "
-                         "valid version and try again");
+            fmt::println(
+                "Error: invalid version to list sections, set to a "
+                "valid version and try again");
             return false;
         }
         auto const finalized_res = db.find(finalized_nibbles, version);
@@ -232,8 +234,9 @@ struct DbStateMachine
     void set_proposal_or_finalized(std::optional<uint64_t> const round)
     {
         if (state != DbState::version_number) {
-            fmt::println("Error: at wrong part of trie, only allow set section "
-                         "when cursor is set to a version.");
+            fmt::println(
+                "Error: at wrong part of trie, only allow set section "
+                "when cursor is set to a version.");
             return;
         }
         MONAD_ASSERT(curr_section_prefix.nibble_size() == 0);
@@ -270,8 +273,9 @@ struct DbStateMachine
     void set_table(unsigned char table_id)
     {
         if (state != DbState::proposal_or_finalize) {
-            fmt::println("Error: at wrong part of trie, only allow set table "
-                         "when cursor is set to a specific version number.");
+            fmt::println(
+                "Error: at wrong part of trie, only allow set table "
+                "when cursor is set to a specific version number.");
             return;
         }
         MONAD_ASSERT(curr_section_prefix.nibble_size() > 0);
@@ -294,10 +298,12 @@ struct DbStateMachine
                                                 : to_bytes(cursor.node->data());
                     fmt::println(" * Merkle root is {}", merkle_root);
                 }
-                fmt::println(" * \"node_stats\" will display a summary of node "
-                             "metadata");
-                fmt::println(" * Next, try look up a key in this table using "
-                             "\"get [key]\"");
+                fmt::println(
+                    " * \"node_stats\" will display a summary of node "
+                    "metadata");
+                fmt::println(
+                    " * Next, try look up a key in this table using "
+                    "\"get [key]\"");
             }
             else {
                 fmt::println(
@@ -307,16 +313,18 @@ struct DbStateMachine
             }
         }
         else {
-            fmt::println("Invalid table id: choose table id from 0: state, "
-                         "1: code, 2: receipt.");
+            fmt::println(
+                "Invalid table id: choose table id from 0: state, "
+                "1: code, 2: receipt.");
         }
     }
 
     Result<NodeCursor> lookup(NibblesView const key) const
     {
         if (state != DbState::table) {
-            fmt::println("Error: at wrong part of trie, please navigate cursor "
-                         "to a table before lookup.");
+            fmt::println(
+                "Error: at wrong part of trie, please navigate cursor "
+                "to a table before lookup.");
         }
         MONAD_ASSERT(!curr_section_prefix.empty());
         MONAD_ASSERT(curr_table_id != INVALID_NIBBLE);
@@ -536,8 +544,9 @@ void do_get_receipt(DbStateMachine &sm, std::string_view const receipt)
     size_t receipt_id{};
 
     if (receipt.starts_with("0x")) {
-        fmt::println("Receipts should be entered in base 10 and will be "
-                     "encoded for you.");
+        fmt::println(
+            "Receipts should be entered in base 10 and will be "
+            "encoded for you.");
         return;
     }
     auto [_, ec] = std::from_chars(
@@ -582,23 +591,23 @@ void do_node_stats(DbStateMachine &sm)
         {
         }
 
-        Traverse(Traverse const &other) = default;
+        Traverse(Traverse const &other, unsigned char branch)
+            : TraverseMachine(other, branch)
+            , metadata_{other.metadata_}
+        {
+            had_values_ = other.had_values_;
+        }
 
-        virtual bool down(unsigned char const, Node const &node) override
+        virtual void visit(unsigned char const, Node const &node) override
         {
             had_values_.push_back(node.has_value());
             ++metadata_[had_values_];
-            return true;
         }
 
-        virtual void up(unsigned char const, Node const &) override
+        virtual std::unique_ptr<TraverseMachine>
+        clone(unsigned char branch) const override
         {
-            had_values_.pop_back();
-        }
-
-        virtual std::unique_ptr<TraverseMachine> clone() const override
-        {
-            return std::make_unique<Traverse>(*this);
+            return std::make_unique<Traverse>(*this, branch);
         }
     } traverse(metadata);
 
@@ -665,8 +674,9 @@ void do_node_stats(DbStateMachine &sm)
 int interactive_impl(Db &db)
 {
     if (!isatty(STDIN_FILENO)) {
-        fmt::println("Not running interactively! Pass -it to run inside a "
-                     "docker container.");
+        fmt::println(
+            "Not running interactively! Pass -it to run inside a "
+            "docker container.");
         return 1;
     }
 
@@ -709,8 +719,9 @@ int interactive_impl(Db &db)
                 do_proposal(state_machine, tokens[1]);
             }
             else {
-                fmt::println("Wrong format to set proposal, type 'proposal "
-                             "[round number]'");
+                fmt::println(
+                    "Wrong format to set proposal, type 'proposal "
+                    "[round number]'");
             }
         }
         else if (tokens[0] == "finalized") {
@@ -721,8 +732,9 @@ int interactive_impl(Db &db)
                 do_table(state_machine, tokens[1]);
             }
             else {
-                fmt::println("Wrong format to set table, type 'table "
-                             "[state/code/receipt]'");
+                fmt::println(
+                    "Wrong format to set table, type 'table "
+                    "[state/code/receipt]'");
             }
         }
         else if (tokens[0] == "get") {

--- a/libs/core/src/monad/mem/allocators.hpp
+++ b/libs/core/src/monad/mem/allocators.hpp
@@ -190,7 +190,7 @@ namespace allocators
     template <
         allocator TypeAlloc, allocator RawAlloc,
         detail::type_raw_alloc_pair<TypeAlloc, RawAlloc> (*GetAllocator)(),
-        size_t (*GetSize)(typename TypeAlloc::value_type *)>
+        size_t (*GetSize)(typename TypeAlloc::value_type *) = nullptr>
     struct unique_ptr_aliasing_allocator_deleter
     {
         using allocator_type = TypeAlloc;

--- a/libs/db/src/monad/mpt/nibbles_view.hpp
+++ b/libs/db/src/monad/mpt/nibbles_view.hpp
@@ -238,9 +238,41 @@ public:
     constexpr auto operator<=>(NibblesView const &other) const
     {
         unsigned const min_size = std::min(nibble_size(), other.nibble_size());
-        for (unsigned i = 0; i < min_size; ++i) {
-            if (get(i) != other.get(i)) {
-                return get(i) <=> other.get(i);
+        if (begin_nibble_ == other.begin_nibble_) {
+            if (begin_nibble_) {
+                unsigned char const this_first_nibble =
+                    get_nibble(data_, begin_nibble_);
+                unsigned char const other_first_nibble =
+                    get_nibble(other.data_, other.begin_nibble_);
+                auto ret = this_first_nibble <=> other_first_nibble;
+                if (ret != 0) {
+                    return ret;
+                }
+            }
+
+            auto ret = memcmp(
+                data_ + begin_nibble_,
+                other.data_ + begin_nibble_,
+                static_cast<size_type>(min_size - begin_nibble_) / 2);
+            if (ret != 0) {
+                return ret <=> 0;
+            }
+
+            if ((min_size - begin_nibble_) % 2) {
+                // compare last nibble
+                unsigned char const this_last_nibble = get(min_size - 1);
+                unsigned char const other_last_nibble = other.get(min_size - 1);
+                auto ret = this_last_nibble <=> other_last_nibble;
+                if (ret != 0) {
+                    return ret;
+                }
+            }
+        }
+        else {
+            for (unsigned i = 0; i < min_size; ++i) {
+                if (get(i) != other.get(i)) {
+                    return get(i) <=> other.get(i);
+                }
             }
         }
         return nibble_size() <=> other.nibble_size();

--- a/libs/db/src/monad/mpt/test/min_truncated_offsets_test.cpp
+++ b/libs/db/src/monad/mpt/test/min_truncated_offsets_test.cpp
@@ -89,39 +89,91 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
     EXPECT_EQ(trie_min_offset_fast, 0);
     EXPECT_EQ(trie_min_offset_slow, 0);
 
+    struct traverse_record_t
+    {
+        Node const *node{nullptr};
+        // record the calculated min truncated inorder offsets of trie
+        // rooted at node in traversal
+        compact_virtual_chunk_offset_t test_min_offset_fast{
+            INVALID_COMPACT_VIRTUAL_OFFSET};
+        compact_virtual_chunk_offset_t test_min_offset_slow{
+            INVALID_COMPACT_VIRTUAL_OFFSET};
+    };
+
+    std::stack<traverse_record_t> root_to_node_records;
+
     struct TraverseCalculateAndVerifyMinTruncatedOffsets
         : public TraverseMachine
     {
         UpdateAuxImpl &aux; // for chunk count lookup
-        size_t level{0};
+        Node const *node = nullptr;
 
-        struct traverse_record_t
-        {
-            Node const *node{nullptr};
-            // record the calculated min truncated inorder offsets of trie
-            // rooted at node in traversal
-            compact_virtual_chunk_offset_t test_min_offset_fast{
-                INVALID_COMPACT_VIRTUAL_OFFSET};
-            compact_virtual_chunk_offset_t test_min_offset_slow{
-                INVALID_COMPACT_VIRTUAL_OFFSET};
-        };
+        std::stack<traverse_record_t> &root_to_node_records;
 
-        std::stack<traverse_record_t> root_to_node_records;
-
-        explicit TraverseCalculateAndVerifyMinTruncatedOffsets(
-            UpdateAuxImpl &aux)
+        TraverseCalculateAndVerifyMinTruncatedOffsets(
+            UpdateAuxImpl &aux,
+            std::stack<traverse_record_t> &root_to_node_records)
             : aux(aux)
+            , root_to_node_records(root_to_node_records)
         {
         }
 
-        virtual bool
-        down(unsigned char const branch_in_parent, Node const &node) override
+        TraverseCalculateAndVerifyMinTruncatedOffsets(
+            TraverseCalculateAndVerifyMinTruncatedOffsets const &other,
+            unsigned char branch)
+            : TraverseMachine(other, branch)
+            , aux(other.aux)
+            , root_to_node_records(other.root_to_node_records)
         {
-            ++level; // increment level counter
+        }
+
+        ~TraverseCalculateAndVerifyMinTruncatedOffsets() override
+        {
+            auto const node_record = root_to_node_records.top();
+            root_to_node_records.pop();
+            if (root_to_node_records.empty()) { // node is root
+                // verify that offset equals calculated one in traversal
+                auto [node_branch_min_fast_off, node_branch_min_slow_off] =
+                    calc_min_offsets(
+                        *const_cast<Node *>(node),
+                        aux.physical_to_virtual(aux.get_latest_root_offset()));
+                EXPECT_EQ(
+                    node_record.test_min_offset_fast, node_branch_min_fast_off);
+                EXPECT_EQ(
+                    node_record.test_min_offset_slow, node_branch_min_slow_off);
+            }
+            else {
+                auto &parent_record = root_to_node_records.top();
+                Node *const parent = const_cast<Node *>(parent_record.node);
+                auto const node_branch_min_fast_off =
+                    parent->min_offset_fast(parent->to_child_index(branch));
+                auto const node_branch_min_slow_off =
+                    parent->min_offset_slow(parent->to_child_index(branch));
+                // verify that min offset stored in parent equals the calculated
+                // one during traversal
+                EXPECT_EQ(
+                    node_branch_min_fast_off, node_record.test_min_offset_fast);
+                EXPECT_EQ(
+                    node_branch_min_slow_off, node_record.test_min_offset_slow);
+
+                // update parent record.
+                parent_record.test_min_offset_fast = std::min(
+                    parent_record.test_min_offset_fast,
+                    node_record.test_min_offset_fast);
+                parent_record.test_min_offset_slow = std::min(
+                    parent_record.test_min_offset_slow,
+                    node_record.test_min_offset_slow);
+            }
+        }
+
+        virtual void
+        visit(unsigned char const branch_in_parent, Node const &node) override
+        {
+            this->node = &node;
 
             if (root_to_node_records.empty()) { // indicates node is root
                 root_to_node_records.push(traverse_record_t{.node = &node});
-                return true;
+                return;
             }
             Node *const parent =
                 const_cast<Node *>(root_to_node_records.top().node);
@@ -142,62 +194,24 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                      INVALID_COMPACT_VIRTUAL_OFFSET,
                      compact_virtual_chunk_offset_t{virtual_node_offset}});
             }
-            return true;
         }
 
-        virtual void
-        up(unsigned char const branch_in_parent, Node const &node) override
-        {
-            --level;
-
-            auto const node_record = root_to_node_records.top();
-            root_to_node_records.pop();
-            if (root_to_node_records.empty()) { // node is root
-                // verify that offset equals calculated one in traversal
-                auto [node_branch_min_fast_off, node_branch_min_slow_off] =
-                    calc_min_offsets(
-                        *const_cast<Node *>(&node),
-                        aux.physical_to_virtual(aux.get_latest_root_offset()));
-                EXPECT_EQ(
-                    node_record.test_min_offset_fast, node_branch_min_fast_off);
-                EXPECT_EQ(
-                    node_record.test_min_offset_slow, node_branch_min_slow_off);
-            }
-            else {
-                auto &parent_record = root_to_node_records.top();
-                Node *const parent = const_cast<Node *>(parent_record.node);
-                auto const node_branch_min_fast_off = parent->min_offset_fast(
-                    parent->to_child_index(branch_in_parent));
-                auto const node_branch_min_slow_off = parent->min_offset_slow(
-                    parent->to_child_index(branch_in_parent));
-                // verify that min offset stored in parent equals the calculated
-                // one during traversal
-                EXPECT_EQ(
-                    node_branch_min_fast_off, node_record.test_min_offset_fast);
-                EXPECT_EQ(
-                    node_branch_min_slow_off, node_record.test_min_offset_slow);
-
-                // update parent record.
-                parent_record.test_min_offset_fast = std::min(
-                    parent_record.test_min_offset_fast,
-                    node_record.test_min_offset_fast);
-                parent_record.test_min_offset_slow = std::min(
-                    parent_record.test_min_offset_slow,
-                    node_record.test_min_offset_slow);
-            }
-        }
-
-        virtual std::unique_ptr<TraverseMachine> clone() const override
+        virtual std::unique_ptr<TraverseMachine>
+        clone(unsigned char branch) const override
         {
             return std::make_unique<
-                TraverseCalculateAndVerifyMinTruncatedOffsets>(*this);
+                TraverseCalculateAndVerifyMinTruncatedOffsets>(*this, branch);
         }
+    };
 
-    } traverse{this->aux};
+    auto traverse =
+        std::make_unique<TraverseCalculateAndVerifyMinTruncatedOffsets>(
+            this->aux, root_to_node_records);
 
     // WARNING: test will fail and there are memory leak using parallel traverse
-    ASSERT_TRUE(
-        preorder_traverse_blocking(this->aux, *this->root, traverse, block_id));
-    EXPECT_EQ(traverse.level, 0);
-    EXPECT_EQ(traverse.root_to_node_records.empty(), true);
+    ASSERT_TRUE(preorder_traverse_blocking(
+        this->aux, *this->root, *traverse, block_id));
+
+    traverse.reset();
+    ASSERT_TRUE(root_to_node_records.empty());
 }

--- a/libs/db/src/monad/mpt/traverse.hpp
+++ b/libs/db/src/monad/mpt/traverse.hpp
@@ -13,26 +13,214 @@
 #include <functional>
 
 #include <boost/container/deque.hpp>
+#include <boost/container/small_vector.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/set.hpp>
 
 #include "deserialize_node_from_receiver_result.hpp"
 
 MONAD_MPT_NAMESPACE_BEGIN
 
+struct TraverseMachine;
+
+namespace detail
+{
+    struct TraversePath
+    {
+        TraversePath()
+            : size(0)
+            , capacity(33)
+            , data(static_cast<unsigned char *>(operator new(capacity)))
+        {
+            data[0] = 0;
+        }
+
+        TraversePath(TraversePath const &other, unsigned char branch)
+            : size(other.size)
+        {
+            if (branch != INVALID_BRANCH) {
+                capacity = (size + 1 + 1) / 2 + 32;
+                data = static_cast<unsigned char *>(operator new(capacity));
+                std::memcpy(data, other.data, (other.size + 1 + 1) / 2);
+                if ((size + 1) % 2 == 0) {
+                    data[(size + 1) / 2] = (branch << 4);
+                }
+                else {
+                    data[(size + 1) / 2] |= branch;
+                }
+                ++size;
+            }
+            else {
+                size = other.size;
+                capacity = other.capacity;
+                data = static_cast<unsigned char *>(operator new(capacity));
+                std::memcpy(data, other.data, (other.size + 1 + 1) / 2);
+            }
+        }
+
+        TraversePath(TraversePath &&other) = delete;
+
+        TraversePath &operator=(TraversePath &&other) = delete;
+
+        TraversePath &operator=(TraversePath const &other)
+        {
+            if (this != &other) {
+                operator delete(data);
+                size = other.size;
+                capacity = other.capacity;
+                data = static_cast<unsigned char *>(operator new(capacity));
+                std::memcpy(data, other.data, (other.size + 1 + 1) / 2);
+            }
+            return *this;
+        }
+
+        bool operator<(TraversePath const &other) const
+        {
+            auto min_size = std::min(size, other.size);
+            auto ret = std::memcmp(data, other.data, (min_size + 1 + 1) / 2);
+            if (ret != 0) {
+                return ret < 0;
+            }
+            return size < other.size;
+        }
+
+        void append(unsigned start, unsigned end, unsigned char const *data)
+        {
+            if (start >= end) {
+                return;
+            }
+
+            auto size = this->size;
+            auto add_size = end - start;
+            auto required_capacity = (size + add_size + 1 + 1) / 2;
+            if (required_capacity > capacity) {
+                capacity = required_capacity;
+                auto data =
+                    static_cast<unsigned char *>(operator new(capacity));
+                std::memcpy(data, this->data, (size + 1 + 1) / 2);
+                this->data = data;
+            }
+            if ((size + 1) % 2 != 0) {
+                this->data[(size + 1) / 2] |= get_nibble(data, start);
+                ++start;
+                ++size;
+            }
+            if (start % 2 == 0) {
+                auto bytes = (end - start) / 2;
+                memcpy(this->data + (size + 1) / 2, data + start / 2, bytes);
+                size += bytes * 2;
+                start += bytes * 2;
+            }
+            else {
+                for (; start + 1 < end; start += 2, size += 2) {
+                    this->data[(size + 1) / 2] =
+                        ((data[start / 2] & 0xF) << 4) |
+                        ((data[start / 2 + 1] & 0xF0) >> 4);
+                }
+            }
+            if (start < end) {
+                if ((size + 1) % 2 == 0) {
+                    this->data[(size + 1) / 2] = (get_nibble(data, start) << 4);
+                }
+                else {
+                    this->data[(size + 1) / 2] |= get_nibble(data, start);
+                }
+                ++size;
+            }
+            this->size = size;
+        }
+
+        ~TraversePath()
+        {
+            operator delete(data);
+        }
+
+        uint32_t size;
+        uint32_t capacity;
+        unsigned char *data;
+    };
+
+    struct TraverseSender;
+
+    void async_parallel_preorder_traverse_init(
+        TraverseSender &, async::erased_connected_operation *traverse_state,
+        Node const &);
+
+    void async_parallel_preorder_traverse_impl(
+        TraverseSender &sender,
+        async::erased_connected_operation *traverse_state, Node::UniquePtr node,
+        TraverseMachine &machine);
+
+    bool preorder_traverse_blocking_impl(
+        UpdateAuxImpl &aux, Node const &node, TraverseMachine &traverse,
+        uint64_t const version);
+}
+
 struct TraverseMachine
 {
-    size_t level{0};
+    unsigned char branch{INVALID_BRANCH};
+    boost::intrusive::list_member_hook<> hook;
 
     virtual ~TraverseMachine() = default;
-    // Implement the logic to decide when to stop, return true for continue,
-    // false for stop
-    virtual bool down(unsigned char branch, Node const &) = 0;
-    virtual void up(unsigned char branch, Node const &) = 0;
-    virtual std::unique_ptr<TraverseMachine> clone() const = 0;
+    TraverseMachine() = default;
 
-    virtual bool should_visit(Node const &, unsigned char)
+    TraverseMachine(TraverseMachine const &other, unsigned char branch)
+        : branch(branch)
+        , path_(other.path_, branch)
+    {
+    }
+
+    TraverseMachine(TraverseMachine const &other) = delete;
+    TraverseMachine(TraverseMachine &&other) = delete;
+
+    virtual void visit(unsigned char parent_branch, Node const &node) = 0;
+
+    virtual std::unique_ptr<TraverseMachine>
+    clone(unsigned char branch) const = 0;
+
+    virtual bool should_visit_node(
+        Node const & /* node */, unsigned char /* parent branch */)
     {
         return true;
     }
+
+    virtual bool should_visit_child(
+        Node const & /* parent node */, unsigned char /* child branch */)
+    {
+        return true;
+    }
+
+    NibblesView path() const
+    {
+        return NibblesView{1, path_.size + 1, path_.data};
+    }
+
+    detail::TraversePath const &path_ref() const
+    {
+        return path_;
+    }
+
+private:
+    void update_path(Node const &node)
+    {
+        if (node.path_nibbles_len() != 0) {
+            path_.append(
+                node.bitpacked.path_nibble_index_start,
+                node.path_nibble_index_end,
+                node.path_data());
+        }
+    }
+
+    friend void detail::async_parallel_preorder_traverse_impl(
+        detail::TraverseSender &sender,
+        async::erased_connected_operation *traverse_state, Node::UniquePtr node,
+        TraverseMachine &machine);
+    friend bool detail::preorder_traverse_blocking_impl(
+        UpdateAuxImpl &aux, Node const &node, TraverseMachine &traverse,
+        uint64_t const version);
+
+    detail::TraversePath path_{};
+    Node::UniquePtr node;
 };
 
 // TODO: move definitions out of header file
@@ -44,43 +232,50 @@ namespace detail
         TraverseSender &, async::erased_connected_operation *traverse_state,
         Node const &);
 
-    void async_parallel_preorder_traverse_impl(
-        TraverseSender &sender,
-        async::erased_connected_operation *traverse_state, Node const &node,
-        TraverseMachine &machine, unsigned char const branch);
-
     // current implementation does not contaminate triedb node caching
     inline bool preorder_traverse_blocking_impl(
-        UpdateAuxImpl &aux, unsigned char const branch, Node const &node,
-        TraverseMachine &traverse, uint64_t const version)
+        UpdateAuxImpl &aux, Node const &node, TraverseMachine &traverse,
+        uint64_t const version)
     {
-        ++traverse.level;
-        if (!traverse.down(branch, node)) {
-            --traverse.level;
+        if (traverse.branch != INVALID_BRANCH) {
+            traverse.update_path(node);
+        }
+
+        if (!traverse.should_visit_node(node, traverse.branch)) {
             return true;
         }
-        for (auto const [idx, branch] : NodeChildrenRange(node.mask)) {
-            if (traverse.should_visit(node, branch)) {
+        traverse.visit(traverse.branch, node);
+
+        for (auto const &[idx, branch] : NodeChildrenRange(node.mask)) {
+            if (traverse.should_visit_child(node, branch)) {
                 auto const *const next = node.next(idx);
                 if (next) {
-                    preorder_traverse_blocking_impl(
-                        aux, branch, *next, traverse, version);
+                    auto child_traverse = traverse.clone(branch);
+                    if (!preorder_traverse_blocking_impl(
+                            aux, *next, *child_traverse, version)) {
+                        return false;
+                    }
                     continue;
                 }
                 MONAD_ASSERT(aux.is_on_disk());
                 Node::UniquePtr next_node_ondisk =
                     read_node_blocking(aux, node.fnext(idx), version);
+                auto child_traverse = traverse.clone(branch);
                 if (!next_node_ondisk ||
                     !preorder_traverse_blocking_impl(
-                        aux, branch, *next_node_ondisk, traverse, version)) {
+                        aux, *next_node_ondisk, *child_traverse, version)) {
                     return false;
                 }
             }
         }
-        --traverse.level;
-        traverse.up(branch, node);
         return true;
     }
+
+    using TraverseList = boost::intrusive::list<
+        TraverseMachine,
+        boost::intrusive::member_hook<
+            TraverseMachine, boost::intrusive::list_member_hook<>,
+            &TraverseMachine::hook>>;
 
     /* We need to be able to stop the parallel traversal in the middle of the
     run, perhaps because of version got invalidated. To handle that particular
@@ -98,39 +293,122 @@ namespace detail
 
     struct TraverseSender
     {
-        struct receiver_t
+        struct MachineOffset
         {
-            static constexpr bool lifetime_managed_internally = true;
+            /// Offset in the read buffer where the node data starts
+            uint32_t buffer_off;
 
-            TraverseSender *sender;
-            async::erased_connected_operation *const traverse_state;
-            std::unique_ptr<TraverseMachine> machine;
-            chunk_offset_t rd_offset{0, 0};
-            unsigned bytes_to_read;
-            uint16_t buffer_off;
-            unsigned char const branch;
+            /// Associated traverse machine owned by the sender list
+            TraverseMachine *machine;
+        };
 
-            receiver_t(
-                TraverseSender *sender,
-                async::erased_connected_operation *const traverse_state,
-                unsigned char const branch, chunk_offset_t const offset,
-                std::unique_ptr<TraverseMachine> machine)
-                : sender(sender)
-                , traverse_state(traverse_state)
-                , machine(std::move(machine))
-                , branch(branch)
+        struct NodeRead
+        {
+            NodeRead(chunk_offset_t const offset, TraverseMachine &machine)
+                : rd_offset(offset)
+                , path(&machine.path_ref())
             {
                 auto const num_pages_to_load_node =
                     node_disk_pages_spare_15{offset}.to_pages();
                 bytes_to_read = static_cast<unsigned>(
                     num_pages_to_load_node << DISK_PAGE_BITS);
-                rd_offset = offset;
                 auto const new_offset =
                     round_down_align<DISK_PAGE_BITS>(offset.offset);
                 MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
-                rd_offset.offset = new_offset & chunk_offset_t::max_offset;
-                buffer_off = uint16_t(offset.offset - rd_offset.offset);
+                this->rd_offset.offset =
+                    new_offset & chunk_offset_t::max_offset;
+                auto buffer_off =
+                    uint32_t(offset.offset - this->rd_offset.offset);
+                machine_offsets.emplace_back(
+                    MachineOffset{buffer_off, &machine});
             }
+
+            NodeRead(NodeRead &&other) = default;
+            NodeRead(NodeRead const &other) = delete;
+            NodeRead &operator=(NodeRead &&other) = default;
+            NodeRead &operator=(NodeRead const &other) = delete;
+
+            chunk_offset_t rd_offset;
+            unsigned bytes_to_read;
+            TraversePath const *path;
+            boost::container::small_vector<MachineOffset, 4> machine_offsets;
+
+            struct compare
+            {
+                bool operator()(NodeRead const &a, NodeRead const &b) const
+                {
+                    return *a.path < *b.path;
+                }
+            };
+
+            struct compare_offset
+            {
+                bool operator()(NodeRead const &a, NodeRead const &b) const
+                {
+                    return a.rd_offset < b.rd_offset;
+                }
+            };
+
+            struct compare_offset_key
+            {
+                bool operator()(file_offset_t const &a, NodeRead const &b) const
+                {
+                    return a < b.rd_offset.raw() + b.bytes_to_read;
+                }
+
+                bool operator()(NodeRead const &a, file_offset_t const &b) const
+                {
+                    return a.rd_offset.raw() + a.bytes_to_read < b;
+                }
+            };
+        };
+
+        struct NodeReadInSet : public NodeRead
+        {
+            NodeReadInSet(NodeRead &&read)
+                : NodeRead(std::move(read))
+            {
+            }
+
+            boost::intrusive::set_member_hook<> path_hook;
+            boost::intrusive::set_member_hook<> offset_hook;
+        };
+
+        using PendingReads = boost::intrusive::set<
+            NodeReadInSet,
+            boost::intrusive::member_hook<
+                NodeReadInSet, boost::intrusive::set_member_hook<>,
+                &NodeReadInSet::path_hook>,
+            boost::intrusive::compare<NodeReadInSet::compare>>;
+
+        using OffsetReads = boost::intrusive::set<
+            NodeReadInSet,
+            boost::intrusive::member_hook<
+                NodeReadInSet, boost::intrusive::set_member_hook<>,
+                &NodeReadInSet::offset_hook>,
+            boost::intrusive::compare<NodeReadInSet::compare>>;
+
+        struct receiver_t : public NodeRead
+        {
+            static constexpr bool lifetime_managed_internally = true;
+
+            TraverseSender *sender;
+            async::erased_connected_operation *traverse_state;
+
+            receiver_t(
+                TraverseSender *sender,
+                async::erased_connected_operation *const traverse_state,
+                NodeRead &&read)
+                : NodeRead(std::move(read))
+                , sender(sender)
+                , traverse_state(traverse_state)
+            {
+            }
+
+            receiver_t(receiver_t const &) = delete;
+            receiver_t(receiver_t &&) = default;
+            receiver_t &operator=(receiver_t const &) = delete;
+            receiver_t &operator=(receiver_t &&other) = default;
 
             template <class ResultType>
             void set_value(
@@ -143,37 +421,75 @@ namespace detail
                     !sender->aux.version_is_valid_ondisk(sender->version)) {
                     // async read failure or stopping initiated
                     sender->version_expired_before_complete = true;
-                    sender->reads_to_initiate.clear();
-                    sender->reads_to_initiate_sidx = 0;
-                    sender->reads_to_initiate_eidx = 0;
-                    sender->reads_to_initiate_count = 0;
+                    sender->pending_reads.clear_and_dispose(
+                        [](auto *r) { delete r; });
                 }
                 else { // version is valid after reading the buffer
-                    auto next_node_on_disk =
-                        deserialize_node_from_receiver_result(
-                            std::move(buffer_), buffer_off, io_state);
-                    sender->within_recursion_count++;
-                    async_parallel_preorder_traverse_impl(
-                        *sender,
-                        traverse_state,
-                        *next_node_on_disk,
-                        *machine,
-                        branch);
-                    sender->within_recursion_count--;
+                    if constexpr (std::is_same_v<
+                                      std::decay_t<ResultType>,
+                                      typename monad::async::
+                                          read_single_buffer_sender::
+                                              result_type>) {
+                        auto &buffer = std::move(buffer_).assume_value().get();
+                        for (auto &mo : machine_offsets) {
+                            MONAD_ASSERT(mo.buffer_off < buffer.size());
+                            MONAD_ASSERT(buffer.size() > 0);
+                            auto node = deserialize_node_from_buffer(
+                                (unsigned char *)buffer.data() + mo.buffer_off,
+                                buffer.size() - mo.buffer_off);
+                            async_parallel_preorder_traverse_impl(
+                                *sender,
+                                traverse_state,
+                                std::move(node),
+                                *mo.machine);
+                        }
+
+                        buffer.reset();
+                    }
+                    else if constexpr (std::is_same_v<
+                                           std::decay_t<ResultType>,
+                                           typename monad::async::
+                                               read_multiple_buffer_sender::
+                                                   result_type>) {
+                        auto &buffer = buffer_.assume_value().front();
+                        MONAD_ASSERT(buffer.size() > 0);
+                        // Did the Receiver forget to set
+                        // lifetime_managed_internally?
+                        MONAD_DEBUG_ASSERT(
+                            io_state->lifetime_is_managed_internally());
+                        for (auto &mo : machine_offsets) {
+                            MONAD_ASSERT(mo.buffer_off < buffer.size());
+                            MONAD_ASSERT(buffer.size() > 0);
+                            auto node = deserialize_node_from_buffer(
+                                (unsigned char *)buffer.data() + mo.buffer_off,
+                                buffer.size() - mo.buffer_off);
+                            async_parallel_preorder_traverse_impl(
+                                *sender,
+                                traverse_state,
+                                std::move(node),
+                                *mo.machine);
+                        }
+                    }
+                    else {
+                        static_assert(false);
+                    }
                 }
                 // complete async traverse if no outstanding io AND there is no
                 // recursive traverse call
                 // `async_parallel_preorder_traverse_impl()` in current stack,
                 // which means traverse is still in progress
                 if (sender->within_recursion_count == 0 &&
-                    sender->reads_to_initiate_count == 0 &&
+                    sender->pending_reads.empty() &&
                     sender->outstanding_reads == 0) {
+                    MONAD_ASSERT(
+                        sender->version_expired_before_complete ||
+                        sender->list.empty());
                     traverse_state->completed(async::success());
                 }
             }
         };
 
-        static_assert(sizeof(receiver_t) == 40);
+        static_assert(sizeof(receiver_t) == 128);
         static_assert(alignof(receiver_t) == 8);
 
         using result_type = async::result<bool>;
@@ -185,11 +501,15 @@ namespace detail
         size_t const max_outstanding_reads;
         size_t outstanding_reads{0};
         size_t within_recursion_count{0};
-        std::vector<boost::container::deque<receiver_t>> reads_to_initiate{20};
-        size_t reads_to_initiate_sidx{0}; // exclusive
-        size_t reads_to_initiate_eidx{0}; // inclusive
-        size_t reads_to_initiate_count{0};
         bool version_expired_before_complete{false};
+        TraverseList list;
+
+        // List of pending reads sorted by path.
+        PendingReads pending_reads;
+
+        // List of pending reads sorted by read offset to allow merging
+        // adjacent or overlapping reads.
+        OffsetReads offset_reads;
 
         TraverseSender(
             UpdateAuxImpl &aux, Node::UniquePtr traverse_root,
@@ -201,6 +521,17 @@ namespace detail
             , version(version)
             , max_outstanding_reads(concurrency_limit)
         {
+        }
+
+        TraverseSender(TraverseSender const &) = delete;
+        TraverseSender(TraverseSender &&) = default;
+        TraverseSender &operator=(TraverseSender const &) = delete;
+        TraverseSender &operator=(TraverseSender &&) = default;
+
+        ~TraverseSender()
+        {
+            // Delete incomplete traverse machines in case of early termination
+            list.clear_and_dispose([](auto *n) { delete n; });
         }
 
         async::result<void>
@@ -222,28 +553,134 @@ namespace detail
             return async::success(!version_expired_before_complete);
         }
 
-        void initiate_pending_reads()
+        void initiate_pending_reads(
+            async::erased_connected_operation *traverse_state)
         {
-            auto idx = reads_to_initiate_eidx;
             while (outstanding_reads < max_outstanding_reads &&
-                   idx > reads_to_initiate_sidx) {
-                while (outstanding_reads < max_outstanding_reads &&
-                       !reads_to_initiate[idx].empty()) {
-                    async_read(aux, std::move(reads_to_initiate[idx].front()));
-                    ++outstanding_reads;
-                    reads_to_initiate[idx].pop_front();
-                    --reads_to_initiate_count;
-                }
-                if (reads_to_initiate[idx].empty() &&
-                    idx == reads_to_initiate_eidx) {
-                    --reads_to_initiate_eidx;
-                }
-                --idx;
+                   !pending_reads.empty()) {
+                auto it = pending_reads.begin();
+                auto &read = *it;
+                async_read(
+                    aux, receiver_t(this, traverse_state, std::move(read)));
+                offset_reads.erase(offset_reads.iterator_to(read));
+                pending_reads.erase(it);
+                delete &read;
+                ++outstanding_reads;
             }
-            if (reads_to_initiate_count == 0) {
-                reads_to_initiate_sidx = 0;
-                reads_to_initiate_eidx = 0;
+        }
+
+        static bool can_merge(
+            TraverseSender::NodeRead const &lhs,
+            TraverseSender::NodeRead const &rhs)
+        {
+            auto lhs_offset = lhs.rd_offset.raw();
+            auto rhs_offset = rhs.rd_offset.raw();
+            // check if ranges lhs_offset..lhs_offset+lhs.bytes_to_read and
+            // rhs_offset..rhs_offset+rhs.bytes_to_read are adjacent or
+            // intersecting
+            return (
+                lhs_offset + lhs.bytes_to_read >= rhs_offset &&
+                rhs_offset + rhs.bytes_to_read >= lhs_offset);
+        }
+
+        static bool
+        try_merge(TraverseSender::NodeRead &lhs, TraverseSender::NodeRead &rhs)
+        {
+            auto lhs_offset = lhs.rd_offset.raw();
+            auto rhs_offset = rhs.rd_offset.raw();
+            // check if ranges lhs_offset..lhs_offset+lhs.bytes_to_read and
+            // rhs_offset..rhs_offset+rhs.bytes_to_read are adjacent or
+            // intersecting
+            if (lhs_offset + lhs.bytes_to_read >= rhs_offset &&
+                rhs_offset + rhs.bytes_to_read >= lhs_offset) {
+
+                // std::cout << "Merging reads: " << std::hex
+                //           << "lhs_offset: " << (lhs_offset >> DISK_PAGE_BITS)
+                //           << ", lhs.bytes_to_read: "
+                //           << (lhs.bytes_to_read >> DISK_PAGE_BITS)
+                //           << ", rhs_offset: " << (rhs_offset >>
+                //           DISK_PAGE_BITS)
+                //           << ", rhs.bytes_to_read: "
+                //           << (rhs.bytes_to_read >> DISK_PAGE_BITS) <<
+                //           std::dec
+                //           << std::endl;
+
+                // merge two reads
+                auto start = std::min(lhs_offset, rhs_offset);
+                auto end = std::max(
+                    lhs_offset + lhs.bytes_to_read,
+                    rhs_offset + rhs.bytes_to_read);
+
+                lhs.bytes_to_read = unsigned(end - start);
+                lhs.rd_offset.offset = start & chunk_offset_t::max_offset;
+                lhs.rd_offset.id = (start >> 28) & chunk_offset_t::max_id;
+                lhs.rd_offset.spare = 0; // spare is not used in this context
+
+                // adjust lhs machine offsets
+                if (lhs_offset != start) {
+                    for (auto &mo : lhs.machine_offsets) {
+                        mo.buffer_off += uint32_t(lhs_offset - start);
+                    }
+                }
+                // move machines to lhs adjusting offset
+                for (auto &mo : rhs.machine_offsets) {
+                    mo.buffer_off += uint32_t(rhs_offset - start);
+                    lhs.machine_offsets.emplace_back(std::move(mo));
+                }
+                rhs.machine_offsets.clear();
+                if (*rhs.path < *lhs.path) {
+                    // move rhs path to lhs path
+                    lhs.path = rhs.path;
+                }
+
+                return true;
             }
+            return false;
+        }
+
+        void add_pending_read(NodeRead &&read)
+        {
+            auto new_read = new TraverseSender::NodeReadInSet(std::move(read));
+            // Check if we can merge with existing read.
+            // Find element that ends at or after new element start.
+            // This is leftmost mergeable element. Moreover, if this element
+            // can't be merged, no other element can be merged either (this
+            // element starts after new element ends and previous element
+            // ends before new element starts).
+            auto it = offset_reads.lower_bound(
+                new_read->rd_offset.raw(), NodeRead::compare_offset_key{});
+            while (it != offset_reads.end() && can_merge(*it, *new_read)) {
+                auto &existing_read = *it;
+                // remove existing read from offset_reads and
+                // pending_reads
+                it = offset_reads.erase(it);
+                pending_reads.erase(pending_reads.iterator_to(existing_read));
+
+                // std::cout << "Merging reads: " << std::hex << "lhs_offset: "
+                //           << (existing_read.rd_offset.raw() >>
+                //           DISK_PAGE_BITS)
+                //           << std::dec << ", lhs.bytes_to_read: "
+                //           << (existing_read.bytes_to_read >> DISK_PAGE_BITS)
+                //           << ", lhs num mos: "
+                //           << existing_read.machine_offsets.size() << std::hex
+                //           << ", rhs_offset: "
+                //           << (new_read->rd_offset.raw() >>
+                //           DISK_PAGE_BITS)
+                //           << std::dec << ", rhs.bytes_to_read: "
+                //           << (new_read->bytes_to_read >> DISK_PAGE_BITS)
+                //           << ", rhs num mos: "
+                //           << new_read->machine_offsets.size() << std::dec
+                //           << std::endl;
+
+                (void)try_merge(existing_read, *new_read);
+                delete new_read;
+                new_read = &existing_read;
+            }
+
+            auto pret = pending_reads.insert(*new_read);
+            MONAD_ASSERT(pret.second);
+            auto oret = offset_reads.insert(*new_read);
+            MONAD_ASSERT(oret.second);
         }
     };
 
@@ -251,97 +688,112 @@ namespace detail
         TraverseSender &sender,
         async::erased_connected_operation *traverse_state, Node const &node)
     {
+        if (!sender.aux.version_is_valid_ondisk(sender.version)) {
+            sender.version_expired_before_complete = true;
+            return;
+        }
+        sender.list.push_back(*sender.machine);
         sender.within_recursion_count++;
+        sender.machine->branch = INVALID_BRANCH;
         async_parallel_preorder_traverse_impl(
-            sender, traverse_state, node, *sender.machine, INVALID_BRANCH);
+            sender,
+            traverse_state,
+            copy_node(&node),
+            *sender.machine.release());
         sender.within_recursion_count--;
         MONAD_ASSERT(sender.within_recursion_count == 0);
 
         // complete async traverse if no outstanding ios
-        if (sender.reads_to_initiate_count == 0 &&
-            sender.outstanding_reads == 0) {
+        if (sender.pending_reads.empty() && sender.outstanding_reads == 0) {
             traverse_state->completed(async::success());
         }
     }
 
     inline void async_parallel_preorder_traverse_impl(
         TraverseSender &sender,
-        async::erased_connected_operation *traverse_state, Node const &node,
-        TraverseMachine &machine, unsigned char const branch)
+        async::erased_connected_operation *traverse_state,
+        Node::UniquePtr _node, TraverseMachine &machine)
     {
-        // How many children are considered left side for depth first preference
-        // Two and four was benchmarked as slightly worse than three, so three
-        // appears to be the optimum.
-        static constexpr unsigned LEFT_SIDE = 3;
-        sender.initiate_pending_reads();
-        // Detect if level (which is unsigned) has gone below zero. It never
-        // should if this code is correct. The choice of 256 is completely
-        // arbitrary and means nothing.
-        MONAD_ASSERT(machine.level < 256);
-        ++machine.level;
-        if (!machine.down(branch, node)) {
-            --machine.level;
-            return;
+        machine.node = std::move(_node);
+        sender.initiate_pending_reads(traverse_state);
+        if (machine.branch != INVALID_BRANCH) {
+            machine.update_path(*machine.node);
         }
-        unsigned children_read = 0;
-        for (auto const [idx, branch] : NodeChildrenRange(node.mask)) {
-            if (machine.should_visit(node, branch)) {
-                auto const *const next = node.next(idx);
-                if (next == nullptr) {
-                    MONAD_ASSERT(sender.aux.is_on_disk());
-                    // verify version before read
-                    if (!sender.aux.version_is_valid_ondisk(sender.version)) {
-                        sender.version_expired_before_complete = true;
-                        sender.reads_to_initiate.clear();
-                        sender.reads_to_initiate_sidx = 0;
-                        sender.reads_to_initiate_eidx = 0;
-                        sender.reads_to_initiate_count = 0;
-                        return;
+        auto should_visit_node =
+            machine.should_visit_node(*machine.node, machine.branch);
+        auto it = sender.list.iterator_to(machine);
+        if (should_visit_node) {
+            boost::container::small_vector<TraverseSender::NodeRead, 16> reads;
+            for (auto const [idx, branch] :
+                 NodeChildrenRange(machine.node->mask)) {
+                if (machine.should_visit_child(*machine.node, branch)) {
+                    auto const *const next = machine.node->next(idx);
+                    auto child_machine = machine.clone(branch);
+                    // Insert the child machine into the list after the current
+                    // position of the iterator. All children are sorted after
+                    // the parent since child key is parent key + branch.
+                    //
+                    // The list assumes ownership of the child machine so it is
+                    // released below.
+                    it = sender.list.insert(std::next(it), *child_machine);
+                    if (next == nullptr) {
+                        MONAD_ASSERT(sender.aux.is_on_disk());
+                        reads.emplace_back(
+                            machine.node->fnext(idx), *child_machine.release());
                     }
-                    TraverseSender::receiver_t receiver(
-                        &sender,
-                        traverse_state,
-                        branch,
-                        node.fnext(idx),
-                        machine.clone());
-                    unsigned const this_child_read = children_read++;
-                    if (sender.outstanding_reads >=
-                        sender.max_outstanding_reads) {
-                        // The deepest reads get highest priority
-                        size_t priority = machine.level;
-                        // Left side reads get a bit more priority
-                        if (this_child_read < LEFT_SIDE) {
-                            priority += LEFT_SIDE - this_child_read;
-                        }
-                        MONAD_DEBUG_ASSERT(priority > 0);
-                        if (priority >= sender.reads_to_initiate.size()) {
-                            sender.reads_to_initiate.resize(priority + 1);
-                        }
-                        if (priority > sender.reads_to_initiate_eidx) {
-                            if (sender.reads_to_initiate_eidx == 0) {
-                                sender.reads_to_initiate_sidx = priority - 1;
-                            }
-                            sender.reads_to_initiate_eidx = priority;
-                        }
-                        if (priority <= sender.reads_to_initiate_sidx) {
-                            sender.reads_to_initiate_sidx = priority - 1;
-                        }
-                        sender.reads_to_initiate[priority].emplace_back(
-                            std::move(receiver));
-                        ++sender.reads_to_initiate_count;
-                        continue;
-                    }
-                    async_read(sender.aux, std::move(receiver));
-                    ++sender.outstanding_reads;
-                }
-                else {
-                    async_parallel_preorder_traverse_impl(
-                        sender, traverse_state, *next, machine, branch);
-                    if (sender.version_expired_before_complete) {
-                        return;
+                    else {
+                        async_parallel_preorder_traverse_impl(
+                            sender,
+                            traverse_state,
+                            copy_node(next),
+                            *child_machine.release());
                     }
                 }
             }
+            // for each receiver in receivers, check if we can merge
+            std::sort(
+                reads.begin(),
+                reads.end(),
+                [](auto const &lhs, auto const &rhs) {
+                    return lhs.rd_offset < rhs.rd_offset;
+                });
+            for (auto i = 0u, j = 1u; j < reads.size(); ++j) {
+                if (!TraverseSender::try_merge(reads[i], reads[j])) {
+                    i = j;
+                }
+            }
+
+            for (auto &read : reads) {
+                if (read.machine_offsets.empty()) {
+                    // This read was merged
+                    continue;
+                }
+                if (sender.outstanding_reads >= sender.max_outstanding_reads) {
+                    sender.add_pending_read(std::move(read));
+                }
+                else {
+                    async_read(
+                        sender.aux,
+                        TraverseSender::receiver_t(
+                            &sender, traverse_state, std::move(read)));
+                    ++sender.outstanding_reads;
+                }
+            }
+        }
+        else {
+            sender.list.erase_and_dispose(it, [](auto *n) { delete n; });
+        }
+
+        while (!sender.list.empty()) {
+            auto &traverse = sender.list.front();
+            if (traverse.node == nullptr) {
+                // Next in order node is not ready yet
+                break;
+            }
+
+            traverse.visit(traverse.branch, *traverse.node);
+
+            sender.list.pop_front_and_dispose([](auto *n) { delete n; });
         }
     }
 }
@@ -350,9 +802,11 @@ namespace detail
 inline bool preorder_traverse_blocking(
     UpdateAuxImpl &aux, Node const &node, TraverseMachine &traverse,
     uint64_t const version)
+
 {
+    traverse.branch = INVALID_BRANCH;
     return detail::preorder_traverse_blocking_impl(
-        aux, INVALID_BRANCH, node, traverse, version);
+        aux, node, traverse, version);
 }
 
 inline bool preorder_traverse_ondisk(
@@ -384,10 +838,15 @@ inline bool preorder_traverse_ondisk(
     };
 
     bool version_expired_before_traverse_complete;
+    auto machine_clone = machine.clone(INVALID_BRANCH);
 
     auto *const state = new auto(async::connect(
         detail::TraverseSender(
-            aux, copy_node(&node), machine.clone(), version, concurrency_limit),
+            aux,
+            copy_node(&node),
+            std::move(machine_clone),
+            version,
+            concurrency_limit),
         TraverseReceiver{version_expired_before_traverse_complete}));
     state->initiate();
 

--- a/libs/execution/src/monad/db/db_snapshot_filesystem.cpp
+++ b/libs/execution/src/monad/db/db_snapshot_filesystem.cpp
@@ -98,13 +98,12 @@ uint64_t monad_db_snapshot_write_filesystem(
     }
 
     auto &stream = context->shard.at(shard).at(type);
-    auto const before = stream.foutput.tellp();
     stream.foutput.write(
         reinterpret_cast<char const *>(bytes),
         static_cast<std::streamsize>(len));
     MONAD_ASSERT(stream.foutput.good());
     blake3_hasher_update(&stream.hasher, bytes, len);
-    return static_cast<uint64_t>(stream.foutput.tellp() - before);
+    return len;
 }
 
 void monad_db_snapshot_load_filesystem(

--- a/libs/execution/src/monad/db/trie_db.cpp
+++ b/libs/execution/src/monad/db/trie_db.cpp
@@ -203,8 +203,8 @@ void TrieDb::commit(
         if (account.has_value()) {
             for (auto const &[key, delta] : delta.storage) {
                 if (delta.first != delta.second) {
-                    storage_updates.push_front(
-                        update_alloc_.emplace_back(Update{
+                    storage_updates.push_front(update_alloc_.emplace_back(
+                        Update{
                             .key = hash_alloc_.emplace_back(
                                 keccak256({key.bytes, sizeof(key.bytes)})),
                             .value = delta.second == bytes32_t{}
@@ -226,13 +226,14 @@ void TrieDb::commit(
             bool const incarnation =
                 account.has_value() && delta.account.first.has_value() &&
                 delta.account.first->incarnation != account->incarnation;
-            account_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = hash_alloc_.emplace_back(
-                    keccak256({addr.bytes, sizeof(addr.bytes)})),
-                .value = value,
-                .incarnation = incarnation,
-                .next = std::move(storage_updates),
-                .version = static_cast<int64_t>(block_number_)}));
+            account_updates.push_front(update_alloc_.emplace_back(
+                Update{
+                    .key = hash_alloc_.emplace_back(
+                        keccak256({addr.bytes, sizeof(addr.bytes)})),
+                    .value = value,
+                    .incarnation = incarnation,
+                    .next = std::move(storage_updates),
+                    .version = static_cast<int64_t>(block_number_)}));
         }
     }
 
@@ -240,12 +241,13 @@ void TrieDb::commit(
     for (auto const &[hash, icode] : code) {
         // TODO write intercode object
         MONAD_ASSERT(icode);
-        code_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{to_byte_string_view(hash.bytes)},
-            .value = {{icode->code(), icode->code_size()}},
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
+        code_updates.push_front(update_alloc_.emplace_back(
+            Update{
+                .key = NibblesView{to_byte_string_view(hash.bytes)},
+                .value = {{icode->code(), icode->code_size()}},
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(block_number_)}));
     }
 
     UpdateList receipt_updates;
@@ -259,9 +261,10 @@ void TrieDb::commit(
     auto const &encoded_block_number =
         bytes_alloc_.emplace_back(rlp::encode_unsigned(header.number));
     std::vector<byte_string> index_alloc;
-    index_alloc.reserve(std::max(
-        receipts.size(),
-        withdrawals.transform(&std::vector<Withdrawal>::size).value_or(0)));
+    index_alloc.reserve(
+        std::max(
+            receipts.size(),
+            withdrawals.transform(&std::vector<Withdrawal>::size).value_or(0)));
     size_t log_index_begin = 0;
     for (uint32_t i = 0; i < static_cast<uint32_t>(receipts.size()); ++i) {
         auto const &rlp_index =
@@ -270,28 +273,32 @@ void TrieDb::commit(
         auto const &encoded_receipt = bytes_alloc_.emplace_back(
             encode_receipt_db(receipt, log_index_begin));
         log_index_begin += receipt.logs.size();
-        receipt_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{rlp_index},
-            .value = encoded_receipt,
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
+        receipt_updates.push_front(update_alloc_.emplace_back(
+            Update{
+                .key = NibblesView{rlp_index},
+                .value = encoded_receipt,
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(block_number_)}));
 
         auto const encoded_tx = rlp::encode_transaction(transactions[i]);
-        transaction_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{rlp_index},
-            .value = bytes_alloc_.emplace_back(
-                encode_transaction_db(encoded_tx, senders[i])),
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
-        tx_hash_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{hash_alloc_.emplace_back(keccak256(encoded_tx))},
-            .value = bytes_alloc_.emplace_back(
-                rlp::encode_list2(encoded_block_number, rlp_index)),
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
+        transaction_updates.push_front(update_alloc_.emplace_back(
+            Update{
+                .key = NibblesView{rlp_index},
+                .value = bytes_alloc_.emplace_back(
+                    encode_transaction_db(encoded_tx, senders[i])),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(block_number_)}));
+        tx_hash_updates.push_front(update_alloc_.emplace_back(
+            Update{
+                .key = NibblesView{hash_alloc_.emplace_back(
+                    keccak256(encoded_tx))},
+                .value = bytes_alloc_.emplace_back(
+                    rlp::encode_list2(encoded_block_number, rlp_index)),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(block_number_)}));
 
         // Call frames
         std::span<CallFrame const> frames{call_frames[i]};
@@ -306,12 +313,14 @@ void TrieDb::commit(
             frame_view.remove_prefix(chunk.size());
             byte_string const chunk_key =
                 byte_string{&chunk_index, sizeof(uint8_t)};
-            call_frame_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = bytes_alloc_.emplace_back(call_frame_prefix + chunk_key),
-                .value = chunk,
-                .incarnation = false,
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(block_number_)}));
+            call_frame_updates.push_front(update_alloc_.emplace_back(
+                Update{
+                    .key = bytes_alloc_.emplace_back(
+                        call_frame_prefix + chunk_key),
+                    .value = chunk,
+                    .incarnation = false,
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(block_number_)}));
             ++chunk_index;
         }
     }
@@ -382,29 +391,32 @@ void TrieDb::commit(
             if (i >= index_alloc.size()) {
                 index_alloc.emplace_back(rlp::encode_unsigned(i));
             }
-            withdrawal_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = NibblesView{index_alloc[i]},
-                .value = bytes_alloc_.emplace_back(
-                    rlp::encode_withdrawal(withdrawals.value()[i])),
-                .incarnation = false,
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(block_number_)}));
+            withdrawal_updates.push_front(update_alloc_.emplace_back(
+                Update{
+                    .key = NibblesView{index_alloc[i]},
+                    .value = bytes_alloc_.emplace_back(
+                        rlp::encode_withdrawal(withdrawals.value()[i])),
+                    .incarnation = false,
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(block_number_)}));
         }
-        updates.push_front(update_alloc_.emplace_back(Update{
-            .key = withdrawal_nibbles,
-            .value = byte_string_view{},
-            .incarnation = true,
-            .next = std::move(withdrawal_updates),
-            .version = static_cast<int64_t>(block_number_)}));
+        updates.push_front(update_alloc_.emplace_back(
+            Update{
+                .key = withdrawal_nibbles,
+                .value = byte_string_view{},
+                .incarnation = true,
+                .next = std::move(withdrawal_updates),
+                .version = static_cast<int64_t>(block_number_)}));
     }
 
     UpdateList ls;
-    ls.push_front(update_alloc_.emplace_back(Update{
-        .key = prefix_,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates),
-        .version = static_cast<int64_t>(block_number_)}));
+    ls.push_front(update_alloc_.emplace_back(
+        Update{
+            .key = prefix_,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(updates),
+            .version = static_cast<int64_t>(block_number_)}));
 
     db_.upsert(std::move(ls), block_number_, true, true, false);
 
@@ -430,12 +442,13 @@ void TrieDb::commit(
     auto const eth_header_rlp = rlp::encode_block_header(complete_header);
 
     UpdateList block_hash_nested_updates;
-    block_hash_nested_updates.push_front(update_alloc_.emplace_back(Update{
-        .key = hash_alloc_.emplace_back(keccak256(eth_header_rlp)),
-        .value = encoded_block_number,
-        .incarnation = false,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(block_number_)}));
+    block_hash_nested_updates.push_front(update_alloc_.emplace_back(
+        Update{
+            .key = hash_alloc_.emplace_back(keccak256(eth_header_rlp)),
+            .value = encoded_block_number,
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
 
     UpdateList updates2;
 
@@ -456,12 +469,13 @@ void TrieDb::commit(
     updates2.push_front(block_hash_update);
 
     UpdateList ls2;
-    ls2.push_front(update_alloc_.emplace_back(Update{
-        .key = prefix_,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates2),
-        .version = static_cast<int64_t>(block_number_)}));
+    ls2.push_front(update_alloc_.emplace_back(
+        Update{
+            .key = prefix_,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(updates2),
+            .version = static_cast<int64_t>(block_number_)}));
 
     bool const enable_compaction = false;
     db_.upsert(std::move(ls2), block_number_, enable_compaction);
@@ -606,7 +620,6 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
     {
         TrieDb &db;
         nlohmann::json &json;
-        Nibbles path{};
 
         explicit Traverse(TrieDb &db, nlohmann::json &json)
             : db(db)
@@ -614,41 +627,23 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
         {
         }
 
-        virtual bool down(unsigned char const branch, Node const &node) override
+        Traverse(Traverse const &other, unsigned char branch)
+            : TraverseMachine(other, branch)
+            , db(other.db)
+            , json(other.json)
         {
-            if (branch == INVALID_BRANCH) {
-                MONAD_ASSERT(node.path_nibble_view().nibble_size() == 0);
-                return true;
-            }
-            path = concat(NibblesView{path}, branch, node.path_nibble_view());
+        }
 
-            if (path.nibble_size() == (KECCAK256_SIZE * 2)) {
+        virtual void visit(unsigned char const, Node const &node) override
+        {
+            if (path().nibble_size() == (KECCAK256_SIZE * 2)) {
                 handle_account(node);
             }
             else if (
-                path.nibble_size() == ((KECCAK256_SIZE + KECCAK256_SIZE) * 2)) {
+                path().nibble_size() ==
+                ((KECCAK256_SIZE + KECCAK256_SIZE) * 2)) {
                 handle_storage(node);
             }
-            return true;
-        }
-
-        virtual void up(unsigned char const branch, Node const &node) override
-        {
-            auto const path_view = NibblesView{path};
-            auto const rem_size = [&] {
-                if (branch == INVALID_BRANCH) {
-                    MONAD_ASSERT(path_view.nibble_size() == 0);
-                    return 0;
-                }
-                int const rem_size = path_view.nibble_size() - 1 -
-                                     node.path_nibble_view().nibble_size();
-                MONAD_ASSERT(rem_size >= 0);
-                MONAD_ASSERT(
-                    path_view.substr(static_cast<unsigned>(rem_size)) ==
-                    concat(branch, node.path_nibble_view()));
-                return rem_size;
-            }();
-            path = path_view.substr(0, static_cast<unsigned>(rem_size));
         }
 
         void handle_account(Node const &node)
@@ -660,7 +655,7 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             auto acct = decode_account_db(encoded_account);
             MONAD_DEBUG_ASSERT(!acct.has_error());
 
-            auto const key = fmt::format("{}", NibblesView{path});
+            auto const key = fmt::format("{}", path());
 
             json[key]["address"] = fmt::format("{}", acct.value().first);
             json[key]["balance"] =
@@ -687,13 +682,11 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             auto const storage = decode_storage_db(encoded_storage);
             MONAD_DEBUG_ASSERT(!storage.has_error());
 
-            auto const acct_key = fmt::format(
-                "{}", NibblesView{path}.substr(0, KECCAK256_SIZE * 2));
+            auto const acct_key =
+                fmt::format("{}", path().substr(0, KECCAK256_SIZE * 2));
 
             auto const key = fmt::format(
-                "{}",
-                NibblesView{path}.substr(
-                    KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
+                "{}", path().substr(KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
 
             auto storage_data_json = nlohmann::json::object();
             storage_data_json["slot"] = fmt::format(
@@ -708,9 +701,10 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             json[acct_key]["storage"][key] = storage_data_json;
         }
 
-        virtual std::unique_ptr<TraverseMachine> clone() const override
+        virtual std::unique_ptr<TraverseMachine>
+        clone(unsigned char branch) const override
         {
-            return std::make_unique<Traverse>(*this);
+            return std::make_unique<Traverse>(*this, branch);
         }
     };
 

--- a/libs/statesync/src/monad/statesync/test/test_statesync.cpp
+++ b/libs/statesync/src/monad/statesync/test/test_statesync.cpp
@@ -592,9 +592,10 @@ TEST_F(StateSyncFixture, ignore_unused_code)
     }
 
     auto const code =
-        evmc::from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                       "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
-                       "ffffffffffffffffffffffff")
+        evmc::from_hex(
+            "7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
+            "ffffffffffffffffffffffff")
             .value();
     auto const code_hash = to_bytes(keccak256(code));
     handle_target(
@@ -1005,9 +1006,10 @@ TEST_F(StateSyncFixture, update_contract_twice)
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     auto const code =
-        evmc::from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                       "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
-                       "ffffffffffffffffffffff0160005500")
+        evmc::from_hex(
+            "7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
+            "ffffffffffffffffffffff0160005500")
             .value();
     auto const code_hash = to_bytes(keccak256(code));
     auto const icode = vm::make_shared_intercode(code);


### PR DESCRIPTION
Keep a sorted by key list of TraverseMachine instances that have incomplete ios. Call visit function in the list order. If an io completes and traverse is not in the front of the list, delay calling visit function.

Keep the list of pending ios sorted by key.

Implement merging of overlapping ios on the pending list to improve traverse performance by reducing number of ios necessary.

Miscellaneous performance improvements.