### PR TITLE
[event] move some functions to event_ring.h

### DIFF
--- a/libs/core/src/monad/event/event_iterator.h
+++ b/libs/core/src/monad/event/event_iterator.h
@@ -38,30 +38,6 @@ enum monad_event_next_result
 static enum monad_event_next_result monad_event_iterator_try_next(
     struct monad_event_iterator *, struct monad_event_descriptor *);
 
-/// Try to copy the descriptor corresponding to a particular sequence number;
-/// returns true only if the descriptor was available and its contents were
-/// copied into descriptor output buffer
-static bool monad_event_iterator_try_copy(
-    struct monad_event_iterator const *, uint64_t seqno,
-    struct monad_event_descriptor *);
-
-/// Obtain a pointer to the event's payload in shared memory in a zero-copy
-/// fashion; to check for expiration, call monad_event_payload_check
-static void const *monad_event_payload_peek(
-    struct monad_event_iterator const *, struct monad_event_descriptor const *);
-
-/// Return true if the zero-copy buffer returned by monad_event_payload_peek
-/// still contains the event payload for the given descriptor; returns false if
-/// the event payload has been overwritten
-static bool monad_event_payload_check(
-    struct monad_event_iterator const *, struct monad_event_descriptor const *);
-
-/// Copy the event payload from shared memory into the supplied buffer, up to
-/// `n` bytes; returns nullptr if the event payload has been overwritten
-static void *monad_event_payload_memcpy(
-    struct monad_event_iterator const *, struct monad_event_descriptor const *,
-    void *dst, size_t n);
-
 /// Reset the iterator to point to the latest event produced; used for gap
 /// recovery
 static uint64_t monad_event_iterator_reset(struct monad_event_iterator *);
@@ -73,9 +49,7 @@ struct monad_event_iterator
 {
     uint64_t read_last_seqno;
     struct monad_event_descriptor const *descriptors;
-    uint8_t const *payload_buf;
     size_t desc_capacity_mask;
-    size_t payload_buf_mask;
     struct monad_event_ring_control const *control;
 };
 

--- a/libs/core/src/monad/event/event_ring.c
+++ b/libs/core/src/monad/event/event_ring.c
@@ -235,6 +235,10 @@ int monad_event_ring_mmap(
             "event ring file `%s` does not contain current magic number",
             error_name);
     }
+    event_ring->desc_capacity_mask =
+        event_ring->header->size.descriptor_capacity - 1;
+    event_ring->payload_buf_mask =
+        event_ring->header->size.payload_buf_size - 1;
 
     // Map the ring descriptor array from the ring fd
     size_t const descriptor_map_len = header->size.descriptor_capacity *
@@ -371,9 +375,7 @@ int monad_event_ring_init_iterator(
         return FORMAT_ERRC(EACCES, "event_ring memory not mapped for reading");
     }
     iter->descriptors = event_ring->descriptors;
-    iter->payload_buf = event_ring->payload_buf;
     iter->desc_capacity_mask = header->size.descriptor_capacity - 1;
-    iter->payload_buf_mask = header->size.payload_buf_size - 1;
     iter->control = &header->control;
     (void)monad_event_iterator_reset(iter);
     return 0;

--- a/libs/core/src/monad/event/event_ring.h
+++ b/libs/core/src/monad/event/event_ring.h
@@ -7,10 +7,12 @@
  *
  *   1. Definitions of the event ring's shared memory structures
  *   2. Functions which initialize and mmap event rings
+ *   3. Payload buffer access inline functions
  */
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <sys/types.h>
 
@@ -37,6 +39,8 @@ struct monad_event_ring
     struct monad_event_descriptor *descriptors; ///< Event descriptor ring array
     uint8_t *payload_buf;                       ///< Payload buffer base address
     void *context_area;                         ///< Ring-specific storage
+    uint64_t desc_capacity_mask;                ///< Descriptor capacity - 1
+    uint64_t payload_buf_mask;                  ///< Payload buffer size - 1
 };
 
 /// Descriptor for an event; this fixed-size object describes the common
@@ -128,6 +132,30 @@ int monad_event_ring_mmap(
 /// space
 void monad_event_ring_unmap(struct monad_event_ring *);
 
+/// Try to copy the event descriptor corresponding to a particular sequence
+/// number; returns true only if the descriptor was available and its contents
+/// were copied into the descriptor output buffer
+static bool monad_event_ring_try_copy(
+    struct monad_event_ring const *, uint64_t seqno,
+    struct monad_event_descriptor *);
+
+/// Obtain a pointer to the event's payload in shared memory in a zero-copy
+/// fashion; to check for expiration, call monad_event_payload_check
+static void const *monad_event_ring_payload_peek(
+    struct monad_event_ring const *, struct monad_event_descriptor const *);
+
+/// Return true if the zero-copy buffer returned by monad_event_payload_peek
+/// still contains the event payload for the given descriptor; returns false if
+/// the event payload has been overwritten
+static bool monad_event_ring_payload_check(
+    struct monad_event_ring const *, struct monad_event_descriptor const *);
+
+/// Copy the event payload from shared memory into the supplied buffer, up to
+/// `n` bytes; returns nullptr if the event payload has been overwritten
+static void *monad_event_ring_payload_memcpy(
+    struct monad_event_ring const *, struct monad_event_descriptor const *,
+    void *dst, size_t n);
+
 /// Initialize an iterator to point to the most recently produced event in the
 /// event ring
 int monad_event_ring_init_iterator(
@@ -150,7 +178,7 @@ constexpr uint8_t MONAD_EVENT_RING_HEADER_VERSION[] = {
 extern char const *g_monad_event_ring_type_names[MONAD_EVENT_RING_TYPE_COUNT];
 
 /*
- * Event size limits
+ * Event ring size limits
  */
 
 constexpr uint8_t MONAD_EVENT_MIN_DESCRIPTORS_SHIFT = 16;
@@ -158,6 +186,63 @@ constexpr uint8_t MONAD_EVENT_MAX_DESCRIPTORS_SHIFT = 32;
 
 constexpr uint8_t MONAD_EVENT_MIN_PAYLOAD_BUF_SHIFT = 27;
 constexpr uint8_t MONAD_EVENT_MAX_PAYLOAD_BUF_SHIFT = 40;
+
+/*
+ * Event ring inline function definitions
+ */
+
+inline bool monad_event_ring_try_copy(
+    struct monad_event_ring const *event_ring, uint64_t seqno,
+    struct monad_event_descriptor *event)
+{
+    if (__builtin_expect(seqno == 0, 0)) {
+        return false;
+    }
+    struct monad_event_descriptor const *const ring_event =
+        &event_ring->descriptors[(seqno - 1) & event_ring->desc_capacity_mask];
+    *event = *ring_event;
+    uint64_t const ring_seqno =
+        __atomic_load_n(&ring_event->seqno, __ATOMIC_ACQUIRE);
+    if (__builtin_expect(ring_seqno != seqno, 0)) {
+        return false;
+    }
+    return true;
+}
+
+inline void const *monad_event_ring_payload_peek(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event)
+{
+    return event_ring->payload_buf +
+           (event->payload_buf_offset & event_ring->payload_buf_mask);
+}
+
+inline bool monad_event_ring_payload_check(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event)
+{
+    return event->payload_buf_offset >=
+           __atomic_load_n(
+               &event_ring->header->control.buffer_window_start,
+               __ATOMIC_ACQUIRE);
+}
+
+inline void *monad_event_ring_payload_memcpy(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, void *dst, size_t n)
+{
+    if (__builtin_expect(
+            !monad_event_ring_payload_check(event_ring, event), 0)) {
+        return nullptr;
+    }
+    void const *const src = monad_event_ring_payload_peek(event_ring, event);
+    memcpy(dst, src, n);
+    if (__builtin_expect(
+            !monad_event_ring_payload_check(event_ring, event), 0)) {
+        return nullptr; // Payload expired
+    }
+    return dst;
+}
 
 #ifdef __cplusplus
 } // extern "C"

--- a/libs/core/test/event_recorder.cpp
+++ b/libs/core/test/event_recorder.cpp
@@ -127,8 +127,8 @@ static void writer_main(
         ASSERT_EQ(event.payload_size, expected_len);
         auto const test_counter =
             *static_cast<monad_test_event_counter const *>(
-                monad_event_payload_peek(&iter, &event));
-        ASSERT_TRUE(monad_event_payload_check(&iter, &event));
+                monad_event_ring_payload_peek(event_ring, &event));
+        ASSERT_TRUE(monad_event_ring_payload_check(event_ring, &event));
         ASSERT_GT(writer_thread_count, test_counter.writer_id);
         EXPECT_EQ(
             expected_counters[test_counter.writer_id], test_counter.counter);


### PR DESCRIPTION
This moves a few inline functions from event_iterator.h to event_ring.h, e.g., monad_event_ring_payload_peek. This was done primarily to benefit the use of these functions in the Rust. In the Rust event ring module, these static functions are wrapped in linkable symbols, but end up inlined in the end, via LTO. It makes sense in Rust for them to be defined on the event ring and not the iterator, although it makes no difference in C.

Before this change, the payload reading API (and try_copy) was exposed via the iterator API because:

  - It collected everything needed for reading onto a single cache line, including the precomputed masks, in `struct monad_event_iterator`

  - It seemed to "make sense" to keep all the reading-related functions together in a single header file

In Rust, this had the unfortunate side effect of requiring the event descriptor type to carry both the event ring and the iterator's reference lifetimes explicitly. With this change, the iterator's lifetime parameter can be removed. The precomputed masks are now kept in the event ring also.