### PR TITLE
[monad] carve out most of runloop_ethereum

### DIFF
--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -17,6 +17,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/procfs/statm.h>
@@ -42,46 +43,173 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <vector>
 
-MONAD_NAMESPACE_BEGIN
-
-using BOOST_OUTCOME_V2_NAMESPACE::success;
-
-namespace
-{
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-    void log_tps(
-        uint64_t const block_num, uint64_t const nblocks, uint64_t const ntxs,
-        uint64_t const gas, std::chrono::steady_clock::time_point const begin)
-    {
-        auto const now = std::chrono::steady_clock::now();
-        auto const elapsed = std::max(
-            static_cast<uint64_t>(
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    now - begin)
-                    .count()),
-            1UL); // for the unlikely case that elapsed < 1 mic
-        uint64_t const tps = (ntxs) * 1'000'000 / elapsed;
-        uint64_t const gps = gas / elapsed;
+void log_tps(
+    uint64_t const block_num, uint64_t const nblocks, uint64_t const ntxs,
+    uint64_t const gas, std::chrono::steady_clock::time_point const begin)
+{
+    auto const now = std::chrono::steady_clock::now();
+    auto const elapsed = std::max(
+        static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(now - begin)
+                .count()),
+        1UL); // for the unlikely case that elapsed < 1 mic
+    uint64_t const tps = (ntxs) * 1'000'000 / elapsed;
+    uint64_t const gps = gas / elapsed;
 
-        LOG_INFO(
-            "Run {:4d} blocks to {:8d}, number of transactions {:6d}, "
-            "tps = {:5d}, gps = {:4d} M, rss = {:6d} MB",
-            nblocks,
-            block_num,
-            ntxs,
-            tps,
-            gps,
-            monad_procfs_self_resident() / (1L << 20));
-    };
+    LOG_INFO(
+        "Run {:4d} blocks to {:8d}, number of transactions {:6d}, "
+        "tps = {:5d}, gps = {:4d} M, rss = {:6d} MB",
+        nblocks,
+        block_num,
+        ntxs,
+        tps,
+        gps,
+        monad_procfs_self_resident() / (1L << 20));
+};
 
 #pragma GCC diagnostic pop
 
+// Process a single historical Ethereum block
+template <Traits traits>
+Result<void> process_ethereum_block(
+    Chain const &chain, Db &db, vm::VM &vm,
+    BlockHashBufferFinalized &block_hash_buffer,
+    fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
+    bytes32_t const &parent_block_id, bool const enable_tracing)
+{
+    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
+    auto const block_begin = std::chrono::steady_clock::now();
+
+    // Block input validation
+    BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
+
+    // Sender and authority recovery
+    auto const sender_recovery_begin = std::chrono::steady_clock::now();
+    auto const recovered_senders =
+        recover_senders(block.transactions, priority_pool);
+    auto const recovered_authorities =
+        recover_authorities(block.transactions, priority_pool);
+    [[maybe_unused]] auto const sender_recovery_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - sender_recovery_begin);
+    std::vector<Address> senders(block.transactions.size());
+    for (unsigned i = 0; i < recovered_senders.size(); ++i) {
+        if (recovered_senders[i].has_value()) {
+            senders[i] = recovered_senders[i].value();
+        }
+        else {
+            return TransactionError::MissingSender;
+        }
+    }
+
+    // Call tracer initialization
+    std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};
+    std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
+        block.transactions.size()};
+    for (unsigned i = 0; i < block.transactions.size(); ++i) {
+        call_tracers[i] =
+            enable_tracing
+                ? std::unique_ptr<CallTracerBase>{std::make_unique<CallTracer>(
+                      block.transactions[i], call_frames[i])}
+                : std::unique_ptr<CallTracerBase>{
+                      std::make_unique<NoopCallTracer>()};
+    }
+
+    // Core execution: transaction-level EVM execution that tracks state
+    // changes but does not commit them
+    db.set_block_and_prefix(block.header.number - 1, parent_block_id);
+    BlockMetrics block_metrics;
+    BlockState block_state(db, vm);
+    BOOST_OUTCOME_TRY(
+        auto const receipts,
+        execute_block<traits>(
+            chain,
+            block,
+            senders,
+            recovered_authorities,
+            block_state,
+            block_hash_buffer,
+            priority_pool,
+            block_metrics,
+            call_tracers));
+
+    // Database commit of state changes (incl. Merkle root calculations)
+    block_state.log_debug();
+    auto const commit_begin = std::chrono::steady_clock::now();
+    block_state.commit(
+        bytes32_t{block.header.number},
+        block.header,
+        receipts,
+        call_frames,
+        senders,
+        block.transactions,
+        block.ommers,
+        block.withdrawals);
+    [[maybe_unused]] auto const commit_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - commit_begin);
+
+    // Post-commit validation of header, with Merkle root fields filled in
+    auto const output_header = db.read_eth_header();
+    BOOST_OUTCOME_TRY(
+        chain.validate_output_header(block.header, output_header));
+
+    // Commit prologue: database finalization, computation of the Ethereum
+    // block hash to append to the circular hash buffer
+    db.finalize(block.header.number, block_id);
+    db.update_verified_block(block.header.number);
+    auto const eth_block_hash =
+        to_bytes(keccak256(rlp::encode_block_header(output_header)));
+    block_hash_buffer.set(block.header.number, eth_block_hash);
+
+    // Emit the block metrics log line
+    [[maybe_unused]] auto const block_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - block_begin);
+    LOG_INFO(
+        "__exec_block,bl={:8},ts={}"
+        ",tx={:5},rt={:4},rtp={:5.2f}%"
+        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
+        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        block.header.number,
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            block_start.time_since_epoch())
+            .count(),
+        block.transactions.size(),
+        block_metrics.num_retries(),
+        100.0 * (double)block_metrics.num_retries() /
+            std::max(1.0, (double)block.transactions.size()),
+        sender_recovery_time,
+        block_metrics.tx_exec_time(),
+        commit_time,
+        block_time,
+        block.transactions.size() * 1'000'000 /
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+        block.transactions.size() * 1'000'000 /
+            (uint64_t)std::max(1L, block_time.count()),
+        output_header.gas_used,
+        output_header.gas_used /
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+        output_header.gas_used / (uint64_t)std::max(1L, block_time.count()),
+        db.print_stats(),
+        vm.print_and_reset_block_counts(),
+        vm.print_compiler_stats());
+
+    return outcome_e::success();
 }
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
     Chain const &chain, std::filesystem::path const &ledger_dir, Db &db,
@@ -102,159 +230,51 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
     BlockDb block_db(ledger_dir);
     bytes32_t parent_block_id{};
     while (block_num <= end_block_num && stop == 0) {
-        [[maybe_unused]] auto const block_start =
-            std::chrono::system_clock::now();
-        auto const block_begin = std::chrono::steady_clock::now();
         Block block;
         MONAD_ASSERT_PRINTF(
             block_db.get(block_num, block),
             "Could not query %lu from blockdb",
             block_num);
 
-        BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
-
+        bytes32_t const block_id = bytes32_t{block.header.number};
         evmc_revision const rev =
             chain.get_revision(block.header.number, block.header.timestamp);
 
-        auto const body = [&]<Traits traits>() -> Result<void> {
-            BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
-
-            auto const sender_recovery_begin = std::chrono::steady_clock::now();
-            auto const recovered_senders =
-                recover_senders(block.transactions, priority_pool);
-            auto const recovered_authorities =
-                recover_authorities(block.transactions, priority_pool);
-            [[maybe_unused]] auto const sender_recovery_time =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    std::chrono::steady_clock::now() - sender_recovery_begin);
-            std::vector<Address> senders(block.transactions.size());
-            for (unsigned i = 0; i < recovered_senders.size(); ++i) {
-                if (recovered_senders[i].has_value()) {
-                    senders[i] = recovered_senders[i].value();
-                }
-                else {
-                    return TransactionError::MissingSender;
-                }
-            }
-            db.set_block_and_prefix(block.header.number - 1, parent_block_id);
-            BlockState block_state(db, vm);
-            BlockMetrics block_metrics;
-
-            std::vector<std::vector<CallFrame>> call_frames{
-                block.transactions.size()};
-            std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
-                block.transactions.size()};
-            for (unsigned i = 0; i < block.transactions.size(); ++i) {
-                call_tracers[i] =
-                    enable_tracing
-                        ? std::unique_ptr<
-                              CallTracerBase>{std::make_unique<CallTracer>(
-                              block.transactions[i], call_frames[i])}
-                        : std::unique_ptr<CallTracerBase>{
-                              std::make_unique<NoopCallTracer>()};
-            }
-
-            BOOST_OUTCOME_TRY(
-                auto const receipts,
-                execute_block<traits>(
-                    chain,
-                    block,
-                    senders,
-                    recovered_authorities,
-                    block_state,
-                    block_hash_buffer,
-                    priority_pool,
-                    block_metrics,
-                    call_tracers));
-
-            block_state.log_debug();
-            auto const commit_begin = std::chrono::steady_clock::now();
-            block_state.commit(
-                bytes32_t{block.header.number},
-                block.header,
-                receipts,
-                call_frames,
-                senders,
-                block.transactions,
-                block.ommers,
-                block.withdrawals);
-            [[maybe_unused]] auto const commit_time =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    std::chrono::steady_clock::now() - commit_begin);
-            auto const output_header = db.read_eth_header();
-            BOOST_OUTCOME_TRY(
-                chain.validate_output_header(block.header, output_header));
-
-            db.finalize(block.header.number, bytes32_t{block.header.number});
-            db.update_verified_block(block.header.number);
-
-            auto const h =
-                to_bytes(keccak256(rlp::encode_block_header(output_header)));
-            block_hash_buffer.set(block_num, h);
-
-            [[maybe_unused]] auto const block_time =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    std::chrono::steady_clock::now() - block_begin);
-            LOG_INFO(
-                "__exec_block,bl={:8},ts={}"
-                ",tx={:5},rt={:4},rtp={:5.2f}%"
-                ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-                ",gas={:9},gpse={:4},gps={:3}{}{}{}",
-                block.header.number,
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    block_start.time_since_epoch())
-                    .count(),
-                block.transactions.size(),
-                block_metrics.num_retries(),
-                100.0 * (double)block_metrics.num_retries() /
-                    std::max(1.0, (double)block.transactions.size()),
-                sender_recovery_time,
-                block_metrics.tx_exec_time(),
-                commit_time,
-                block_time,
-                block.transactions.size() * 1'000'000 /
-                    (uint64_t)std::max(
-                        1L, block_metrics.tx_exec_time().count()),
-                block.transactions.size() * 1'000'000 /
-                    (uint64_t)std::max(1L, block_time.count()),
-                output_header.gas_used,
-                output_header.gas_used /
-                    (uint64_t)std::max(
-                        1L, block_metrics.tx_exec_time().count()),
-                output_header.gas_used /
-                    (uint64_t)std::max(1L, block_time.count()),
-                db.print_stats(),
-                vm.print_and_reset_block_counts(),
-                vm.print_compiler_stats());
-
-            ntxs += block.transactions.size();
-            batch_num_txs += block.transactions.size();
-            total_gas += block.header.gas_used;
-            batch_gas += block.header.gas_used;
-            ++batch_num_blocks;
-
-            if (block_num % batch_size == 0) {
-                log_tps(
-                    block_num,
-                    batch_num_blocks,
-                    batch_num_txs,
-                    batch_gas,
-                    batch_begin);
-                batch_num_blocks = 0;
-                batch_num_txs = 0;
-                batch_gas = 0;
-                batch_begin = std::chrono::steady_clock::now();
-            }
-            parent_block_id = bytes32_t{block_num};
-            ++block_num;
-
-            return success();
-        };
-
         BOOST_OUTCOME_TRY([&] {
-            SWITCH_EVM_TRAITS(body.template operator());
-            MONAD_ASSERT(false);
+            SWITCH_EVM_TRAITS(
+                process_ethereum_block,
+                chain,
+                db,
+                vm,
+                block_hash_buffer,
+                priority_pool,
+                block,
+                block_id,
+                parent_block_id,
+                enable_tracing);
+            MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
+
+        ntxs += block.transactions.size();
+        batch_num_txs += block.transactions.size();
+        total_gas += block.header.gas_used;
+        batch_gas += block.header.gas_used;
+        ++batch_num_blocks;
+
+        if (block_num % batch_size == 0) {
+            log_tps(
+                block_num,
+                batch_num_blocks,
+                batch_num_txs,
+                batch_gas,
+                batch_begin);
+            batch_num_blocks = 0;
+            batch_num_txs = 0;
+            batch_gas = 0;
+            batch_begin = std::chrono::steady_clock::now();
+        }
+        parent_block_id = block_id;
+        ++block_num;
     }
     if (batch_num_blocks > 0) {
         log_tps(


### PR DESCRIPTION
Previously, `runloop_ethereum` did a lot of work. This splits it into two functions:

  - `process_ethereum_block` does most of the "real work" that the old runloop_ethereum used to do; it is also parameterized by the chain traits

  - `runloop_ethereum` is now an "outer shell": it loads the next block from the BlockDb, calls `process_ethereum_block` to do real work, and updates the log_tps stuff afterwards