### PR TITLE
Missing ethereum execution tests

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -194,9 +194,5 @@ target_link_options(monad_execution PRIVATE LINKER:-z,defs)
 # unit tests
 # ##############################################################################
 
-monad_add_test_folder("ethereum/core")
-monad_add_test_folder("ethereum/db")
-monad_add_test_folder("ethereum/execution")
-monad_add_test_folder("ethereum/rlp")
-monad_add_test_folder("ethereum/state2")
-monad_add_test_folder("monad/core")
+monad_add_test_folder("ethereum")
+monad_add_test_folder("monad")


### PR DESCRIPTION
category/execution/ethereum/test folder is not being compiled or run by cmake. Need to change test directories to full paths, other recursive glob on ethereum/test will add duplicate targets and error out.