### PR TITLE
Ensure usage of `asmjit` dual mapping

### DIFF
--- a/category/vm/libs/runtime/src/monad/vm/runtime/storage.cpp
+++ b/category/vm/libs/runtime/src/monad/vm/runtime/storage.cpp
@@ -1,9 +1,14 @@
 #include <monad/vm/runtime/storage.hpp>
-#include <monad/vm/runtime/transmute.hpp>
 #include <monad/vm/runtime/types.hpp>
 #include <monad/vm/runtime/uint256.hpp>
 
 #include <cstdint>
+
+#ifdef MONAD_COMPILER_TESTING
+    #include <monad/vm/runtime/transmute.hpp>
+#else
+    #include <exception>
+#endif
 
 namespace monad::vm::runtime
 {

--- a/category/vm/libs/vm/src/monad/vm/compiler.cpp
+++ b/category/vm/libs/vm/src/monad/vm/compiler.cpp
@@ -14,7 +14,8 @@
 namespace monad::vm
 {
     Compiler::Compiler(bool enable_async, size_t compile_job_soft_limit)
-        : compile_job_lock_{compile_job_mutex_}
+        : asmjit_rt_{&asmjit_create_params_}
+        , compile_job_lock_{compile_job_mutex_}
         , compile_job_soft_limit_{compile_job_soft_limit}
         , enable_async_compilation_{enable_async}
     {

--- a/category/vm/libs/vm/src/monad/vm/compiler.hpp
+++ b/category/vm/libs/vm/src/monad/vm/compiler.hpp
@@ -85,6 +85,11 @@ namespace monad::vm
         void compile_loop();
         void dispense_compile_jobs();
 
+        static constexpr asmjit::JitAllocator::CreateParams
+            asmjit_create_params_{
+                .options = asmjit::JitAllocatorOptions::kUseDualMapping,
+            };
+
         asmjit::JitRuntime asmjit_rt_;
         VarcodeCache varcode_cache_;
         CompileJobMap compile_job_map_;


### PR DESCRIPTION
Raised by @0xSqualo initially; this PR sets a flag to ensure that we always force asmjit to use dual-mapped JIT pages (their documentation and implementation details are out of sync on whether this is the case by default, so we set the flag ourselves).