### PR TITLE
Use steady clock for elapsed time since last LRU update

### DIFF
--- a/category/core/lru/lru_cache.hpp
+++ b/category/core/lru/lru_cache.hpp
@@ -208,7 +208,7 @@ private:
         {
             return (int64_t)
                 std::chrono::duration_cast<std::chrono::nanoseconds>(
-                       std::chrono::system_clock::now().time_since_epoch())
+                       std::chrono::steady_clock::now().time_since_epoch())
                     .count();
         }
     }; /// ListNode


### PR DESCRIPTION
Steady clock is more suitable for measuring elapsed time than system clock.
Thanks @andreaslyn for pointing out.