### PR TITLE
Use temporary files for test

### DIFF
--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -77,14 +77,8 @@ namespace
     struct TwoOnDisk : public ::testing::Test
     {
         OnDiskMachine machine;
-        mpt::Db db1{
-            machine,
-            mpt::OnDiskDbConfig{
-                .dbname_paths = {"/tmp/db1"}, .file_size_db = 8}};
-        mpt::Db db2{
-            machine,
-            mpt::OnDiskDbConfig{
-                .dbname_paths = {"/tmp/db2"}, .file_size_db = 8}};
+        mpt::Db db1{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
+        mpt::Db db2{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
         TrieDb tdb1{db1};
         TrieDb tdb2{db2};
         vm::VM vm;


### PR DESCRIPTION
Use temporary files instead of explicitly named to ensure there is no conflict and files are deleted after test completes.