### PR TITLE
Honor size option when using temporary file

### DIFF
--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -156,6 +156,10 @@ struct use_anonymous_inode_tag
 {
 };
 
+struct use_anonymous_sized_inode_tag
+{
+};
+
 //! The invalid file offset
 static constexpr chunk_offset_t INVALID_OFFSET =
     chunk_offset_t::invalid_value();

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -410,6 +410,12 @@ public:
     //! \brief Constructs a storage pool from a temporary anonymous inode.
     //! Useful for test code.
     explicit storage_pool(use_anonymous_inode_tag, creation_flags flags = {});
+
+    //! \brief Constructs a storage pool from a temporary anonymous inode with a
+    //! specific size. Useful for test code.
+    explicit storage_pool(
+        use_anonymous_sized_inode_tag, off_t len, creation_flags flags = {});
+
     ~storage_pool();
 
     //! \brief True if the storage pool was opened read only


### PR DESCRIPTION
Use size option when creating temporary file for db.

Add constructor variant to allocate temporary storage pool with specified size.