### PR TITLE
[compiler] Log asm produced in the emitter tests

### DIFF
--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -602,6 +602,14 @@ namespace monad::vm::compiler::native
         }
     }
 
+    void Emitter::flush_debug_logger()
+    {
+        if (debug_logger_.file()) {
+            int const err = fflush(debug_logger_.file());
+            MONAD_VM_ASSERT(err == 0);
+        }
+    }
+
     entrypoint_t Emitter::finish_contract(asmjit::JitRuntime &rt)
     {
         contract_epilogue();

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -209,6 +209,9 @@ namespace monad::vm::compiler::native
 
         ~Emitter();
 
+        // Flush the debug logger to ensure buffered lines are written.
+        void flush_debug_logger();
+
         entrypoint_t finish_contract(asmjit::JitRuntime &);
 
         ////////// Debug functionality //////////

--- a/test/vm/unit/CMakeLists.txt
+++ b/test/vm/unit/CMakeLists.txt
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 add_executable(vm-unit-tests
-    "${PROJECT_SOURCE_DIR}/test/unit/common/src/test/main.cpp"
     async_compile_tests.cpp
     bin_tests.cpp
     compiler_tests.cpp
@@ -36,6 +35,7 @@ add_executable(vm-unit-tests
     emitter_tests.cpp
     interpreter_tests.cpp
     lru_weight_cache_tests.cpp
+    test_params.cpp
     runtime/fixture.cpp
     runtime/transmute_tests.cpp
     runtime/math_tests.cpp
@@ -46,6 +46,7 @@ add_executable(vm-unit-tests
     runtime/call_tests.cpp
     runtime/data_tests.cpp
     runtime/create_tests.cpp
+    main.cpp
 )
 
 if(MONAD_COMPILER_COVERAGE)
@@ -57,7 +58,9 @@ monad_compile_options(vm-unit-tests)
 target_link_libraries(vm-unit-tests
     PRIVATE evmone
     PRIVATE monad-vm::monad-vm-fuzzing
-    PRIVATE GTest::gtest_main
+    PRIVATE monad-vm::monad-vm-interpreter
+    PRIVATE monad-vm::monad-vm-utils
+    PRIVATE GTest::gtest
     PRIVATE evmc::mocked_host
     PRIVATE monad_execution
     PRIVATE monad_core

--- a/test/vm/unit/emitter_tests.cpp
+++ b/test/vm/unit/emitter_tests.cpp
@@ -25,6 +25,8 @@
 #include <category/vm/runtime/types.hpp>
 #include <category/vm/runtime/uint256.hpp>
 
+#include "test_params.hpp"
+
 #include <asmjit/core/globals.h>
 #include <asmjit/core/jitruntime.h>
 
@@ -51,6 +53,58 @@ using namespace monad::vm::runtime;
 
 namespace
 {
+    static int test_emitter_ix = 0;
+
+    std::string new_emitter_asm_log_path()
+    {
+        test_emitter_ix++;
+        return std::string(std::format(
+            "/tmp/monad_vm_test_logs/emitter_test_{}.s", test_emitter_ix));
+    }
+
+    struct TestEmitter : Emitter
+    {
+
+        std::string log_path_storage_;
+
+        CompilerConfig add_asm_log_path(CompilerConfig c, std::string log_path)
+        {
+            if (!c.asm_log_path &&
+                monad::vm::compiler::test::params.dump_asm_on_failure) {
+                c.asm_log_path = log_path.c_str();
+            }
+            return c;
+        }
+
+        // Default log path, used if c.asm_log_path is not set. The only reason
+        // to have this constructor is so that the lifetime of the
+        // new_emitter_asm_log_path extends to after the Emitter constructor.
+        TestEmitter(
+            asmjit::JitRuntime const &rt, code_size_t bytecode_size,
+            CompilerConfig const &c = {},
+            std::string const &log_path = new_emitter_asm_log_path())
+            : Emitter(rt, bytecode_size, add_asm_log_path(c, log_path))
+            , log_path_storage_(log_path)
+        {
+        }
+
+        // Override finish_contract to flush debug_logger_'s file handle
+        entrypoint_t finish_contract(asmjit::JitRuntime &rt)
+        {
+            auto entrypoint = Emitter::finish_contract(rt);
+
+            // Flush the debug logger in case the code segfaults before the
+            // Emitter destructor is called.
+            flush_debug_logger();
+            if (monad::vm::compiler::test::params.dump_asm_on_failure) {
+                std::cout << "See disassembly at:\n  " << log_path_storage_
+                          << std::endl;
+            }
+
+            return entrypoint;
+        }
+    };
+
     evmc::address max_address()
     {
         evmc::address ret;
@@ -214,7 +268,7 @@ namespace
                     right, Emitter::location_type_to_string(right_loc)) << std::endl;
 #endif
 
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks()[0]);
         emit.push(right);
         if (dup) {
@@ -276,7 +330,7 @@ namespace
             << std::endl;
 #endif
 
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks()[0]);
         emit.push(input);
         if (dup) {
@@ -427,7 +481,7 @@ namespace
                        {PUSH0, PUSH0, PUSH0, JUMP, JUMPDEST, RETURN});
 
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
 
         for (auto const &[k, _] : ir.jump_dests()) {
             emit.add_jump_dest(k);
@@ -537,7 +591,7 @@ namespace
         auto ir =
             get_jumpi_ir(deferred_comparison, swap, dup, jumpdest_fallthrough);
 
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
 
         for (auto const &[k, _] : ir.jump_dests()) {
             emit.add_jump_dest(k);
@@ -654,7 +708,7 @@ namespace
              RETURN});
 
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
 
         (void)emit.begin_new_block(ir.blocks()[0]);
         emit.push(1);
@@ -724,7 +778,7 @@ namespace
 TEST(Emitter, empty)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
 
     entrypoint_t entry = emit.finish_contract(rt);
     auto ctx = test_context();
@@ -740,7 +794,7 @@ TEST(Emitter, empty)
 TEST(Emitter, stop)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, bin<1>};
+    TestEmitter emit{rt, bin<1>};
     emit.stop();
 
     entrypoint_t entry = emit.finish_contract(rt);
@@ -755,7 +809,7 @@ TEST(Emitter, stop)
 TEST(Emitter, fail_with_error)
 {
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, bin<1>};
+    TestEmitter emit{rt, bin<1>};
     // Test that asmjit error handler is in place:
     EXPECT_THROW(emit.fail_with_error(asmjit::kErrorOk), Emitter::Error);
 }
@@ -763,7 +817,7 @@ TEST(Emitter, fail_with_error)
 TEST(Emitter, invalid_instruction)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, bin<1>};
+    TestEmitter emit{rt, bin<1>};
     emit.invalid_instruction();
 
     entrypoint_t entry = emit.finish_contract(rt);
@@ -778,7 +832,7 @@ TEST(Emitter, invalid_instruction)
 TEST(Emitter, gas_decrement_no_check_1)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
     emit.gas_decrement_no_check(2);
 
     entrypoint_t entry = emit.finish_contract(rt);
@@ -792,7 +846,7 @@ TEST(Emitter, gas_decrement_no_check_1)
 TEST(Emitter, gas_decrement_no_check_2)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
     emit.gas_decrement_no_check(7);
 
     entrypoint_t entry = emit.finish_contract(rt);
@@ -806,7 +860,7 @@ TEST(Emitter, gas_decrement_no_check_2)
 TEST(Emitter, gas_decrement_check_non_negative_1)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
     emit.gas_decrement_check_non_negative(6);
     emit.stop();
 
@@ -823,7 +877,7 @@ TEST(Emitter, gas_decrement_check_non_negative_1)
 TEST(Emitter, gas_decrement_check_non_negative_2)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
     emit.gas_decrement_check_non_negative(5);
     emit.stop();
 
@@ -840,7 +894,7 @@ TEST(Emitter, gas_decrement_check_non_negative_2)
 TEST(Emitter, gas_decrement_check_non_negative_3)
 {
     asmjit::JitRuntime rt;
-    Emitter emit{rt, code_size_t{}};
+    TestEmitter emit{rt, code_size_t{}};
     emit.gas_decrement_check_non_negative(4);
     emit.stop();
 
@@ -859,7 +913,7 @@ TEST(Emitter, return_)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH1, 1, PUSH1, 2});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     uint256_t const size_value = uint256_t{1} << 255;
     uint256_t const offset_value =
@@ -884,7 +938,7 @@ TEST(Emitter, revert)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH1, 1, PUSH1, 2});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     uint256_t const size_value = uint256_t{1} << 31;
     uint256_t const offset_value = (uint256_t{1} << 31) - 1;
@@ -908,7 +962,7 @@ TEST(Emitter, mov_stack_index_to_avx_reg)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH1, 1, PUSH1, 2});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     Stack &stack = emit.get_stack();
     emit.push(1);
@@ -981,7 +1035,7 @@ TEST(Emitter, mov_literal_to_ymm)
                 {PUSH0, PUSH0, RETURN});
 
             asmjit::JitRuntime rt;
-            Emitter emit{rt, ir.codesize};
+            TestEmitter emit{rt, ir.codesize};
             (void)emit.begin_new_block(ir.blocks()[0]);
             Stack &stack = emit.get_stack();
             emit.push(lit0);
@@ -1022,7 +1076,7 @@ TEST(Emitter, mov_stack_index_to_general_reg)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH1, 1, PUSH1, 2});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     Stack &stack = emit.get_stack();
     emit.push(1);
@@ -1082,7 +1136,7 @@ TEST(Emitter, mov_stack_index_to_stack_offset)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH1, 1, PUSH1, 2});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     Stack &stack = emit.get_stack();
     emit.push(1);
@@ -1155,7 +1209,7 @@ TEST(Emitter, discharge_deferred_comparison)
         {PUSH0, PUSH0, LT, DUP1, DUP1, PUSH0, SWAP1, POP, LT, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     Stack const &stack = emit.get_stack();
     emit.push(2);
@@ -1222,7 +1276,7 @@ TEST(Emitter, discharge_negated_deferred_comparison)
          RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     Stack const &stack = emit.get_stack();
     emit.push(2);
@@ -1320,7 +1374,7 @@ TEST(Emitter, lt_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, LT});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -1362,7 +1416,7 @@ TEST(Emitter, gt_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, GT});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -1420,7 +1474,7 @@ TEST(Emitter, slt_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, SLT});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -1478,7 +1532,7 @@ TEST(Emitter, sgt_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, SGT});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -1536,7 +1590,7 @@ TEST(Emitter, sub_identity)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SUB});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(10);
@@ -1597,7 +1651,7 @@ TEST(Emitter, add_identity_right)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, ADD});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(10);
@@ -1611,7 +1665,7 @@ TEST(Emitter, add_identity_left)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, ADD});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(10);
     emit.push(0);
@@ -2220,7 +2274,7 @@ TEST(Emitter, and_identity_left)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, AND});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(10);
     emit.push(std::numeric_limits<uint256_t>::max());
@@ -2234,7 +2288,7 @@ TEST(Emitter, and_identity_right)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, AND});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(std::numeric_limits<uint256_t>::max());
     emit.push(10);
@@ -2280,7 +2334,7 @@ TEST(Emitter, or_identity_left)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, OR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(10);
     emit.push(0);
@@ -2294,7 +2348,7 @@ TEST(Emitter, or_identity_right)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, AND});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(10);
@@ -2349,7 +2403,7 @@ TEST(Emitter, xor_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, XOR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -2402,7 +2456,7 @@ TEST(Emitter, eq_same)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, DUP1, EQ});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.dup(1);
@@ -2574,7 +2628,7 @@ TEST(Emitter, shl_identity)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SHL});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(2);
     emit.push(0);
@@ -2588,7 +2642,7 @@ TEST(Emitter, shl_0)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SHL});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(2);
@@ -2643,7 +2697,7 @@ TEST(Emitter, shr_identity)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SHR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(2);
     emit.push(0);
@@ -2657,7 +2711,7 @@ TEST(Emitter, shr_0)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SHR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(2);
@@ -2749,7 +2803,7 @@ TEST(Emitter, sar_identity)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SAR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(2);
     emit.push(0);
@@ -2763,7 +2817,7 @@ TEST(Emitter, sar_0)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SAR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(2);
@@ -2777,7 +2831,7 @@ TEST(Emitter, sar_max)
 {
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, SAR});
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(std::numeric_limits<uint256_t>::max());
     emit.push(2);
@@ -2829,7 +2883,7 @@ TEST(Emitter, call_runtime_12_arg_fun)
          RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     for (int32_t i = 0; i < 10; ++i) {
         emit.push(i);
@@ -2866,7 +2920,7 @@ TEST(Emitter, call_runtime_11_arg_fun)
          RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     for (int32_t i = 0; i < 9; ++i) {
         emit.push(i);
@@ -2892,7 +2946,7 @@ TEST(Emitter, runtime_exit)
         {PUSH0, PUSH0, PUSH0, EXP, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.push(300);
@@ -2915,7 +2969,7 @@ TEST(Emitter, address)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({ADDRESS, ADDRESS});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.address();
     emit.address();
@@ -2945,7 +2999,7 @@ TEST(Emitter, origin)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({ORIGIN, ORIGIN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.origin();
     emit.origin();
@@ -2968,7 +3022,7 @@ TEST(Emitter, gasprice)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({GASPRICE, GASPRICE});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.gasprice();
     emit.gasprice();
@@ -2991,7 +3045,7 @@ TEST(Emitter, gaslimit)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({GASLIMIT, GASLIMIT});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.gaslimit();
     emit.gaslimit();
@@ -3014,7 +3068,7 @@ TEST(Emitter, coinbase)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({COINBASE, COINBASE});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.coinbase();
     emit.coinbase();
@@ -3037,7 +3091,7 @@ TEST(Emitter, timestamp)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({TIMESTAMP, TIMESTAMP});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.timestamp();
     emit.timestamp();
@@ -3060,7 +3114,7 @@ TEST(Emitter, number)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({NUMBER, NUMBER});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.number();
     emit.number();
@@ -3084,7 +3138,7 @@ TEST(Emitter, prevrandao)
         basic_blocks::BasicBlocksIR::unsafe_from({DIFFICULTY, DIFFICULTY});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.prevrandao();
     emit.prevrandao();
@@ -3107,7 +3161,7 @@ TEST(Emitter, chainid)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({CHAINID, CHAINID});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.chainid();
     emit.chainid();
@@ -3130,7 +3184,7 @@ TEST(Emitter, basefee)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({BASEFEE, BASEFEE});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.basefee();
     emit.basefee();
@@ -3154,7 +3208,7 @@ TEST(Emitter, blobbasefee)
         basic_blocks::BasicBlocksIR::unsafe_from({BLOBBASEFEE, BLOBBASEFEE});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.blobbasefee();
     emit.blobbasefee();
@@ -3177,7 +3231,7 @@ TEST(Emitter, caller)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({CALLER, CALLER});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.caller();
     emit.caller();
@@ -3208,7 +3262,7 @@ TEST(Emitter, calldatasize)
         {CALLDATASIZE, CALLDATASIZE, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.calldatasize();
     emit.calldatasize();
@@ -3231,7 +3285,7 @@ TEST(Emitter, returndatasize)
         {RETURNDATASIZE, RETURNDATASIZE, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.returndatasize();
     emit.returndatasize();
@@ -3253,7 +3307,7 @@ TEST(Emitter, msize)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({MSIZE, MSIZE, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.msize();
     emit.msize();
@@ -3280,7 +3334,7 @@ TEST(Emitter, MemoryInstructions)
                                        Emitter::LocationType store_loc2,
                                        Emitter::LocationType load_loc) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks()[0]);
 
         int32_t top_ix = -1;
@@ -3418,7 +3472,7 @@ TEST(Emitter, mstore_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(0);
@@ -3439,7 +3493,7 @@ TEST(Emitter, mstore_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(0);
@@ -3467,7 +3521,7 @@ TEST(Emitter, mload_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push((uint256_t{1} << runtime::Memory::offset_bits) - 1);
@@ -3487,7 +3541,7 @@ TEST(Emitter, mload_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(uint256_t{1} << runtime::Memory::offset_bits);
@@ -3534,7 +3588,7 @@ TEST(Emitter, calldataload)
                     basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
                 asmjit::JitRuntime rt;
-                Emitter emit{rt, ir.codesize, {.asm_log_path = "/tmp/file.s"}};
+                TestEmitter emit{rt, ir.codesize};
                 (void)emit.begin_new_block(ir.blocks()[0]);
 
                 int32_t top_ix = -1;
@@ -3589,7 +3643,7 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(input_data_size - 1);
@@ -3614,7 +3668,7 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(input_data_size);
@@ -3639,7 +3693,7 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
 
     for (auto loc : all_locations) {
         asmjit::JitRuntime rt;
-        Emitter emit{rt, ir.codesize};
+        TestEmitter emit{rt, ir.codesize};
         (void)emit.begin_new_block(ir.blocks().at(0));
 
         emit.push(uint256_t{input_data_size} + 1);
@@ -3668,7 +3722,7 @@ TEST(Emitter, gas)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({GAS, GAS, RETURN});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.gas(2);
     emit.gas(2);
@@ -3689,7 +3743,7 @@ TEST(Emitter, callvalue)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({CALLVALUE, CALLVALUE});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.callvalue();
     emit.callvalue();
@@ -3753,7 +3807,7 @@ TEST(Emitter, jump_bad_jumpdest)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, JUMP});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(0);
     emit.jump();
@@ -3798,7 +3852,7 @@ TEST(Emitter, jumpi_bad_jumpdest)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0, PUSH0, JUMPI});
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
     emit.push(1);
     emit.push(1);
@@ -3843,7 +3897,7 @@ TEST(Emitter, SpillGeneralRegister)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
 
     Stack &stack = emit.get_stack();
@@ -3875,7 +3929,7 @@ TEST(Emitter, SpillAvxRegister)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks()[0]);
 
     Stack &stack = emit.get_stack();
@@ -3918,7 +3972,7 @@ TEST(Emitter, QuadraticCompileTimeRegression)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
     asmjit::JitRuntime const rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks().at(0));
 
     for (int i = 0; i < 1000; ++i) {
@@ -3945,7 +3999,7 @@ TEST(Emitter, SpillInMovGeneralRegToAvxRegRegression)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks().at(0));
 
     Stack &stack = emit.get_stack();
@@ -3982,7 +4036,7 @@ TEST(Emitter, ReleaseSrcAndDestRegression)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from(bytecode);
 
     asmjit::JitRuntime rt;
-    Emitter emit{rt, ir.codesize};
+    TestEmitter emit{rt, ir.codesize};
     (void)emit.begin_new_block(ir.blocks().at(0));
 
     Stack &stack = emit.get_stack();

--- a/test/vm/unit/main.cpp
+++ b/test/vm/unit/main.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "test_params.hpp"
+
+#include <monad/test/environment.hpp>
+
+#include <CLI/CLI.hpp>
+#include <filesystem>
+#include <gtest/gtest.h>
+
+int main(int argc, char *argv[])
+{
+    // Process GoogleTest flags.
+    testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment(new monad::test::Environment);
+
+    // Then our own flags.
+    CLI::App app{"Monad VM unit tests", "vm-unit-tests"};
+    app.add_flag(
+        "--dump-asm",
+        monad::vm::compiler::test::params.dump_asm_on_failure,
+        "Save assembly on failure");
+    CLI11_PARSE(app, argc, argv);
+
+    // Create test log directory
+    std::filesystem::path test_log_dir = "/tmp/monad_vm_test_logs";
+    bool const needs_test_logs =
+        monad::vm::compiler::test::params.dump_asm_on_failure;
+    if (needs_test_logs && !std::filesystem::exists(test_log_dir)) {
+        std::filesystem::create_directory(test_log_dir);
+    }
+
+    return RUN_ALL_TESTS();
+}

--- a/test/vm/unit/test_params.cpp
+++ b/test/vm/unit/test_params.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "test_params.hpp"
+
+namespace monad::vm::compiler::test
+{
+    struct TestParams params = TestParams(false);
+}

--- a/test/vm/unit/test_params.hpp
+++ b/test/vm/unit/test_params.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+namespace monad::vm::compiler::test
+{
+    struct TestParams
+    {
+    public:
+        bool dump_asm_on_failure = false;
+
+        TestParams(bool dump_asm_on_failure = false)
+            : dump_asm_on_failure(dump_asm_on_failure)
+        {
+        }
+    };
+
+    // We could use testing::AddGlobalTestEnvironment(new TestParams(...))
+    // instead of using a global variable like google suggests, but that's
+    // overkill for our usage, where we simply want to pass a flag to the tests.
+    extern struct TestParams params;
+}


### PR DESCRIPTION
## Context

I often want to see the code that caused some emitter test to fail. This requires setting the `asm_log_path` parameter on the `CompilerConfig` which can be annoying, especially when you want to see the code of multiple tests.

This PR sets the `asm_log_path` parameter by default such that every test case get its own log file. On failure, the path of the log file is printed to let the user know about the existence of this debug file like so:

```
/home/lhuberdeau/monad/category/vm/test/unit/emitter_tests.cpp:244: Failure
Expected equality of these values:
  uint256_t::load_le(ret.size)
    Which is: 32-byte object <AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA FF-FF FF-FF FF-FF>
  result
    Which is: 32-byte object <AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA AA-AA FF-FF FF-FF>

See disassembly at:
/tmp/monad_vm_test_logs/emitter_test_0.s
```

A few things I wasn't sure about:
- ~The path can be pretty long, I thought about hashing it to make it shorter but then it would lose any meaning.~
- ~The log files are written to `/tmp/` but maybe writing them to the `build` directory would make finding those files easier.~
- ~On my machine, it makes the execution time jump of `vm-unit-tests` from 9s to 25s. That's probably too long, but maybe it's worth if we find it useful enough. Maybe we want to condition the logging on a flag?~