### PR TITLE
Use nullptr for GetSize unique ptr template arg

### DIFF
--- a/category/core/test/allocators.cpp
+++ b/category/core/test/allocators.cpp
@@ -127,10 +127,7 @@ namespace
     {
         using namespace MONAD_NAMESPACE::allocators;
         reset();
-        allocate_aliasing_unique<
-            custom_allocator,
-            raw_allocator,
-            &get_type_raw_alloc_pair>(16);
+        allocate_aliasing_unique<&get_type_raw_alloc_pair>(16);
         EXPECT_EQ(allocated, 1);
         EXPECT_EQ(constructed, 1);
         EXPECT_EQ(destructed, 1);

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -20,8 +20,8 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/keccak.h>
-#include <category/core/unaligned.hpp>
 #include <category/core/mem/allocators.hpp>
+#include <category/core/unaligned.hpp>
 #include <category/mpt/compute.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/nibbles_view.hpp>
@@ -46,20 +46,6 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-allocators::detail::type_raw_alloc_pair<
-    std::allocator<Node>, Node::BytesAllocator>
-Node::pool()
-{
-    static std::allocator<Node> a;
-    static BytesAllocator b;
-    return {a, b};
-}
-
-size_t Node::get_deallocate_count(Node *node)
-{
-    return node->get_mem_size();
-}
-
 Node::Node(prevent_public_construction_tag) {}
 
 Node::Node(
@@ -68,8 +54,9 @@ Node::Node(
     NibblesView const path, int64_t const version)
     : mask(mask)
     , path_nibble_index_end(path.end_nibble_)
-    , value_len(static_cast<decltype(value_len)>(
-          value.transform(&byte_string_view::size).value_or(0)))
+    , value_len(
+          static_cast<decltype(value_len)>(
+              value.transform(&byte_string_view::size).value_or(0)))
     , version(version)
 {
     MONAD_DEBUG_ASSERT(

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -135,16 +135,9 @@ public:
     static constexpr unsigned disk_size_bytes = sizeof(uint32_t);
     static constexpr size_t max_size =
         max_disk_size + max_number_of_children * KECCAK256_SIZE;
-    using BytesAllocator = allocators::malloc_free_allocator<std::byte>;
-
-    static allocators::detail::type_raw_alloc_pair<
-        std::allocator<Node>, BytesAllocator>
-    pool();
-    static size_t get_deallocate_count(Node *);
 
     using Deleter = allocators::unique_ptr_aliasing_allocator_deleter<
-        std::allocator<Node>, BytesAllocator, &Node::pool,
-        &Node::get_deallocate_count>;
+        &allocators::aliasing_allocator_pair<Node>>;
     using UniquePtr = std::unique_ptr<Node, Deleter>;
 
     /* 16-bit mask for children */
@@ -208,10 +201,7 @@ public:
     {
         MONAD_DEBUG_ASSERT(bytes <= Node::max_size);
         return allocators::allocate_aliasing_unique<
-            std::allocator<Node>,
-            BytesAllocator,
-            &pool,
-            &get_deallocate_count>(
+            &allocators::aliasing_allocator_pair<Node>>(
             bytes,
             prevent_public_construction_tag{},
             std::forward<Args>(args)...);

--- a/category/mpt/test/fuzz/test_fixtures_fuzz.hpp
+++ b/category/mpt/test/fuzz/test_fixtures_fuzz.hpp
@@ -30,7 +30,8 @@ namespace monad::test
 {
     // Used to force Node's pool to be instanced now, not after the test fixture
     // exits
-    static auto force_node_pool_instance_now = Node::pool();
+    static auto force_node_pool_instance_now =
+        allocators::aliasing_allocator_pair<Node>();
 
     namespace detail
     {


### PR DESCRIPTION
Since allocator does not use size parameter for deallocate, pass nullptr instead of get_deallocate_size(). This avoids extra function call per deallocation.

Cleanup template arguments. Deduce allocator types from GetAllocator return type instead of passing them explicitly, reducing amount of boilerplate code.

Add allocator library function for returning allocator pair and use it instead of Node specific implementation.