### PR TITLE
Fix UB in silkpre backed precompiles

### DIFF
--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -157,6 +157,14 @@ PrecompileResult ecrecover_execute(byte_string_view const input)
 
 PrecompileResult sha256_execute(byte_string_view const input)
 {
+    if (MONAD_UNLIKELY(input.data() == nullptr)) {
+        // Passing a null pointer to the Silkpre sha256 implementation invokes
+        // undefined behaviour. We sidestep the UB here by passing a pointer to
+        // the empty string instead.
+        byte_string_view const nonnull{
+            reinterpret_cast<unsigned char const *>(""), 0UL};
+        return silkpre_execute<silkpre_sha256_run>(nonnull);
+    }
     return silkpre_execute<silkpre_sha256_run>(input);
 }
 


### PR DESCRIPTION
The silkpre library expects input data pointers to be non-null. However, the input data field is allowed to be null in `evmc_message`.

Passing a nullptr to silkpre causes undefined behaviour in the `memcpy` in [silkpre/lib/sha256.c:100](https://github.com/category-labs/silkpre/blob/4506d3dff25d51c52008cc0b97b537fb99499d3c/lib/silkpre/sha256.c#L110).

This patch fixes the problem by passing a pointer to the empty string instead of a `nullptr`.