### PR TITLE
[event] adds the "execution iterator helpers"

### DIFF
--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(
   "../execution/ethereum/core/base_ctypes.h"
   "../execution/ethereum/core/eth_ctypes.h"
   "../execution/ethereum/event/exec_event_ctypes.h"
-  "../execution/ethereum/event/exec_event_ctypes_metadata.c")
+  "../execution/ethereum/event/exec_event_ctypes_metadata.c"
+  "../execution/ethereum/event/exec_iter_help.h")
 
 target_include_directories(monad_event PUBLIC "../..")
 target_compile_definitions(monad_event PUBLIC _GNU_SOURCE)

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(
   # ethereum/event
   "ethereum/event/exec_event_ctypes.h"
   "ethereum/event/exec_event_ctypes_metadata.c"
+  "ethereum/event/exec_iter_help.h"
   # ethereum/execution
   "ethereum/block_hash_buffer.cpp"
   "ethereum/block_hash_buffer.hpp"

--- a/category/execution/ethereum/event/exec_iter_help.h
+++ b/category/execution/ethereum/event/exec_iter_help.h
@@ -1,0 +1,82 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * This file defines iterator helpers for execution event rings. They are used
+ * to efficiently rewind iterators for block-oriented replay, i.e., when the
+ * user wants to replay whole blocks (and block consensus events) for old
+ * events that are still resident in event ring memory.
+ *
+ * Note that in the documentation, `BLOCK_START` is considered a "consensus
+ * event" because it represents the first state transition (to "proposed")
+ */
+
+#include <category/execution/ethereum/core/base_ctypes.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+enum monad_exec_event_type : uint16_t;
+
+struct monad_event_descriptor;
+struct monad_event_iterator;
+struct monad_event_ring;
+struct monad_exec_block_tag;
+
+/// Extract the block number associated with an execution event; returns false
+/// if the payload has expired or if there is no associated block number
+static bool monad_exec_ring_get_block_number(
+    struct monad_event_ring const *, struct monad_event_descriptor const *,
+    uint64_t *block_number);
+
+/// Return true if the execution event with the given descriptor relates to the
+/// block with the given id
+static bool monad_exec_ring_block_id_matches(
+    struct monad_event_ring const *, struct monad_event_descriptor const *,
+    monad_c_bytes32 const *);
+
+/// Rewind the event ring iterator so that the next event produced by
+/// `monad_event_iterator_try_next` will be the most recent consensus event
+/// of the filter type, or `NONE` for any type; also copies out this previous
+/// event's descriptor, i.e., behaves like `*--i`; if false is returned, the
+/// iterator is not moved and the copied out event descriptor is not valid
+static bool monad_exec_iter_consensus_prev(
+    struct monad_event_iterator *, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+/// Rewind the event ring iterator, as if by repeatedly calling
+/// `monad_exec_iter_consensus_prev`, stopping only when the block number
+/// associated with the event matches the specified block number
+static bool monad_exec_iter_block_number_prev(
+    struct monad_event_iterator *, struct monad_event_ring const *,
+    uint64_t block_number, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+/// Rewind the event ring iterator, as if by repeatedly calling
+/// `monad_exec_iter_consensus_prev`, stopping only when the block ID
+/// associated with the event matches the specified block ID; BLOCK_VERIFIED
+/// is not an allowed filter type, because block IDs are not recorded for
+/// these events
+static bool monad_exec_iter_block_id_prev(
+    struct monad_event_iterator *, struct monad_event_ring const *,
+    monad_c_bytes32 const *, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *);
+
+/// Rewind the event ring iterator, following the "simple replay strategy",
+/// which is to replay all events that you may not have seen, if the last
+/// finalized block you definitely saw is `block_number`
+static bool monad_exec_iter_rewind_for_simple_replay(
+    struct monad_event_iterator *, struct monad_event_ring const *,
+    uint64_t block_number, struct monad_event_descriptor *);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#define MONAD_EXEC_ITER_HELP_INTERNAL
+#include "exec_iter_help_inline.h"
+#undef MONAD_EXEC_ITER_HELP_INTERNAL

--- a/category/execution/ethereum/event/exec_iter_help_inline.h
+++ b/category/execution/ethereum/event/exec_iter_help_inline.h
@@ -1,0 +1,353 @@
+#ifndef MONAD_EXEC_ITER_HELP_INTERNAL
+    #error This file should only be included directly by exec_iter_help.h
+#endif
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <category/core/event/event_iterator.h>
+#include <category/core/event/event_ring.h>
+#include <category/execution/ethereum/core/base_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+
+// Functions like monad_exec_ring_get_block_number expect the caller to pass a
+// descriptor containing a consensus event; if this is not the case, we need to
+// seek to the nearest BLOCK_START and copy that event into an caller-provided
+// buffer, then reseat the event_p pointer to refer to that event buffer instead
+static inline bool _monad_exec_ring_ensure_block(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const **event_p,
+    struct monad_event_descriptor *buf)
+{
+    if (__builtin_expect(
+            (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+                (*event_p)->event_type != MONAD_EXEC_BLOCK_START,
+            0)) {
+        if (__builtin_expect(
+                !monad_event_ring_try_copy(
+                    event_ring, (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO], buf),
+                0)) {
+            return false;
+        }
+        *event_p = buf;
+    }
+    return true;
+}
+
+// Copy the event descriptor for the consensus event pointed to by `iter`. If
+// `iter` is pointing inside a block, rewind it to BLOCK_START, and copy that
+// out instead (and set `*moved` to true); if false is returned, the event
+// descriptor is not valid
+static inline bool _monad_exec_iter_copy_consensus_event(
+    struct monad_event_iterator *iter, struct monad_event_descriptor *event,
+    bool *moved)
+{
+    *moved = false;
+    if (__builtin_expect(
+            monad_event_iterator_try_copy(iter, event) != MONAD_EVENT_SUCCESS,
+            0)) {
+        return false;
+    }
+    if (event->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+        event->event_type != MONAD_EXEC_BLOCK_START) {
+        uint64_t const iter_save = iter->read_last_seqno;
+        iter->read_last_seqno = event->user[MONAD_FLOW_BLOCK_SEQNO] - 1;
+        if (__builtin_expect(
+                monad_event_iterator_try_copy(iter, event) !=
+                    MONAD_EVENT_SUCCESS,
+                0)) {
+            iter->read_last_seqno = iter_save;
+            return false;
+        }
+        *moved = true;
+    }
+    return true;
+}
+
+static inline bool _monad_exec_ring_is_start_of_block(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, uint64_t block_number)
+{
+    uint64_t b;
+    return event->event_type == MONAD_EXEC_BLOCK_START &&
+           monad_exec_ring_get_block_number(event_ring, event, &b) &&
+           b == block_number;
+}
+
+inline bool monad_exec_ring_get_block_number(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, uint64_t *block_number)
+{
+    struct monad_event_descriptor buf;
+    void const *payload;
+
+    if (__builtin_expect(
+            !_monad_exec_ring_ensure_block(event_ring, &event, &buf), 0)) {
+        return false;
+    }
+
+    payload = monad_event_ring_payload_peek(event_ring, event);
+
+    switch (event->event_type) {
+    case MONAD_EXEC_BLOCK_START:
+        *block_number = ((struct monad_exec_block_start const *)payload)
+                            ->block_tag.block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_QC:
+        *block_number = ((struct monad_exec_block_qc const *)payload)
+                            ->block_tag.block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        *block_number =
+            ((struct monad_exec_block_tag const *)payload)->block_number;
+        break;
+
+    case MONAD_EXEC_BLOCK_VERIFIED:
+        *block_number =
+            ((struct monad_exec_block_verified *)payload)->block_number;
+        break;
+
+    default:
+        return false;
+    }
+
+    return monad_event_ring_payload_check(event_ring, event);
+}
+
+inline bool monad_exec_ring_block_id_matches(
+    struct monad_event_ring const *event_ring,
+    struct monad_event_descriptor const *event, monad_c_bytes32 const *block_id)
+{
+    struct monad_event_descriptor buf;
+    void const *payload;
+    bool tag_matches;
+
+    if (__builtin_expect(
+            !_monad_exec_ring_ensure_block(event_ring, &event, &buf), 0)) {
+        return false;
+    }
+
+    payload = monad_event_ring_payload_peek(event_ring, event);
+
+    switch (event->event_type) {
+    case MONAD_EXEC_BLOCK_START:
+        tag_matches = memcmp(
+                          block_id,
+                          ((struct monad_exec_block_start const *)payload)
+                              ->block_tag.id.bytes,
+                          sizeof *block_id) == 0;
+        break;
+
+    case MONAD_EXEC_BLOCK_QC:
+        tag_matches = memcmp(
+                          block_id,
+                          ((struct monad_exec_block_qc const *)payload)
+                              ->block_tag.id.bytes,
+                          sizeof *block_id) == 0;
+        break;
+
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        tag_matches =
+            memcmp(
+                block_id,
+                ((struct monad_exec_block_tag const *)payload)->id.bytes,
+                sizeof &block_id) == 0;
+        break;
+
+    default:
+        return false;
+    }
+
+    return tag_matches && monad_event_ring_payload_check(event_ring, event);
+}
+
+inline bool monad_exec_iter_consensus_prev(
+    struct monad_event_iterator *iter, enum monad_exec_event_type filter,
+    struct monad_event_descriptor *event)
+{
+    struct monad_event_descriptor buf;
+    bool moved;
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    // Try to copy out the current consensus event
+    if (__builtin_expect(
+            !_monad_exec_iter_copy_consensus_event(iter, event, &moved), 0)) {
+        return false;
+    }
+    if ((filter == MONAD_EXEC_NONE || filter == MONAD_EXEC_BLOCK_START) &&
+        moved) {
+        // The above call rewound the iterator from a block-internal event to
+        // BLOCK_START; if this happens immediately upon entry and we're
+        // interested in stopping at BLOCK_START events, then stop now
+        return true;
+    }
+
+    // After the above check, if the iterator is valid then it is now pointing
+    // at the "current" consensus event. This loop will walk backwards over
+    // these type of events, and will stop in the following cases:
+    //
+    //   - immediately, if filter == MONAD_EXEC_NONE; this means the user
+    //     isn't looking for a particular kind of consensus event, and only
+    //     wants the immediately previous one
+    //
+    //   - as soon as filter == event_type, i.e., we find the immediately
+    //     previous consensus event type with the given block state, e.g.,
+    //     "find the previous BLOCK_FINALIZE"
+    //
+    // If we run out of events before this occurs, the iterator is reset to
+    // its original position, and false is returned
+    while (__builtin_expect(iter->read_last_seqno > 0, 0)) {
+        --iter->read_last_seqno;
+        if (__builtin_expect(
+                !_monad_exec_iter_copy_consensus_event(iter, event, &moved),
+                0)) {
+            break;
+        }
+        if (filter == MONAD_EXEC_NONE ||
+            (uint16_t)filter == event->event_type) {
+            return true;
+        }
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}
+
+inline bool monad_exec_iter_block_number_prev(
+    struct monad_event_iterator *iter,
+    struct monad_event_ring const *event_ring, uint64_t block_number,
+    enum monad_exec_event_type filter, struct monad_event_descriptor *event)
+{
+    uint64_t cur_block_number;
+    struct monad_event_descriptor buf;
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    switch (filter) {
+    case MONAD_EXEC_NONE:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_START:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_QC:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_VERIFIED:
+        break;
+    default:
+        return false; // Not a valid filter value
+    }
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    while (__builtin_expect(
+        monad_exec_iter_consensus_prev(iter, filter, event), 1)) {
+        if (!monad_exec_ring_get_block_number(
+                event_ring, event, &cur_block_number)) {
+            break;
+        }
+        if (block_number == cur_block_number) {
+            return true;
+        }
+        if (cur_block_number < block_number &&
+            (filter == MONAD_EXEC_BLOCK_FINALIZED ||
+             filter == MONAD_EXEC_BLOCK_VERIFIED)) {
+            break;
+        }
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}
+
+inline bool monad_exec_iter_block_id_prev(
+    struct monad_event_iterator *iter,
+    struct monad_event_ring const *event_ring, monad_c_bytes32 const *block_id,
+    enum monad_exec_event_type filter, struct monad_event_descriptor *event)
+{
+    struct monad_event_descriptor buf;
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    switch (filter) {
+    case MONAD_EXEC_NONE:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_START:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_QC:
+        [[fallthrough]];
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        break;
+    default:
+        return false; // Not a valid filter value
+    }
+
+    if (event == nullptr) {
+        event = &buf;
+    }
+
+    while (__builtin_expect(
+        monad_exec_iter_consensus_prev(iter, filter, event), 1)) {
+        if (event->event_type == MONAD_EXEC_BLOCK_VERIFIED) {
+            continue;
+        }
+        if (monad_exec_ring_block_id_matches(event_ring, event, block_id)) {
+            return true;
+        }
+        assert(
+            (filter == MONAD_EXEC_BLOCK_START ||
+             filter == MONAD_EXEC_BLOCK_QC) &&
+            "block number matched, tag didn't, and not START/QC?");
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}
+
+inline bool monad_exec_iter_rewind_for_simple_replay(
+    struct monad_event_iterator *iter,
+    struct monad_event_ring const *event_ring, uint64_t block_number,
+    struct monad_event_descriptor *event)
+{
+    uint64_t const iter_save = iter->read_last_seqno;
+
+    // First, scan backwards to find the BLOCK_FINALIZED for block_number
+    if (!monad_exec_iter_block_number_prev(
+            iter,
+            event_ring,
+            block_number,
+            MONAD_EXEC_BLOCK_FINALIZED,
+            event)) {
+        return false; // No need to restore iter_save, done by callee
+    }
+
+    // There are an unknown number of events (proposed block EVM events,
+    // consensus events) between the original proposal of this finalized block
+    // and its finalization; the one thing we do know is that once we've seen
+    // the BLOCK_START for its original proposal, we want the consensus event
+    // immediately prior to that
+    bool found_finalized_block_start = false;
+    uint64_t prev_read = iter->read_last_seqno;
+
+    while (monad_exec_iter_consensus_prev(iter, MONAD_EXEC_NONE, event) &&
+           !(found_finalized_block_start = _monad_exec_ring_is_start_of_block(
+                 event_ring, event, block_number))) {
+        prev_read = iter->read_last_seqno;
+    }
+
+    if (found_finalized_block_start) {
+        iter->read_last_seqno = prev_read;
+        return monad_event_iterator_try_copy(iter, event) ==
+               MONAD_EVENT_SUCCESS;
+    }
+
+    iter->read_last_seqno = iter_save;
+    return false;
+}


### PR DESCRIPTION
These functions can rewind the iterator to consensus event and block boundaries, for block oriented replay (a simple recovery strategy when all "missing" events are still in memory)