### PR TITLE
[cmake] respect the value of BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 endif()
 
+if (BUILD_SHARED_LIBS)
+  # BUILD_SHARED_LIBS=ON does not automatically set -fPIC, leading to
+  # relocations being emitted in object files that can't be patched
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(MONAD_COMPILER_LLVM "Build llvm backend" OFF)
@@ -23,6 +29,14 @@ option(MONAD_COMPILER_COVERAGE "Build with coverage" OFF)
 option(MONAD_COMPILER_TESTING "Build compiler tests" OFF)
 option(MONAD_COMPILER_BENCHMARKS "Build compiler benchmarks" OFF)
 option(MONAD_COMPILER_DUMP_ASM "Dump assembly files into build/asm" OFF)
+
+if (NOT DEFINED BUILD_SHARED_LIBS)
+  # If this isn't defined, evmone has the audacity to define it itself (to ON)
+  # whereas the ordinary default is for static libraries; if it's not specified,
+  # we explicitly set it to OFF, agreeing with the expected default and
+  # preventing evmone from doing something different
+  option(BUILD_SHARED_LIBS "Build monad with shared libraries" OFF)
+endif()
 
 include(cmake/test.cmake)
 

--- a/category/async/CMakeLists.txt
+++ b/category/async/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(Boost 1.83 # 1.83 really is the minimum
 # ##############################################################################
 
 add_library(
-  monad_async STATIC
+  monad_async
   "concepts.hpp"
   "config.hpp"
   "connected_operation.hpp"

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 # ##############################################################################
 
 add_library(
-  monad_core STATIC
+  monad_core
   # config
   "config.hpp"
   # core

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -7,7 +7,7 @@
 project(monad_event)
 
 add_library(
-  monad_event STATIC
+  monad_event
   "../core/format_err.c"
   "../core/format_err.h"
   "../core/srcloc.h"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -13,7 +13,7 @@ project(monad_execution)
 # ##############################################################################
 
 add_library(
-  monad_execution STATIC
+  monad_execution
   # ethereum/chain
   "ethereum/chain/chain_config.h"
   "ethereum/chain/chain.cpp"

--- a/category/execution/ethereum/trace/event_trace.cpp
+++ b/category/execution/ethereum/trace/event_trace.cpp
@@ -12,6 +12,8 @@
 
 MONAD_NAMESPACE_BEGIN
 
+quill::Logger *event_tracer = nullptr;
+
 TraceTimer::TraceTimer(TraceEvent const &event)
     : orig{event}
 {

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -25,7 +25,7 @@ pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
 # ##############################################################################
 
 add_library(
-  monad_trie STATIC
+  monad_trie
   "compute.cpp"
   "compute.hpp"
   "config.hpp"

--- a/category/vm/CMakeLists.txt
+++ b/category/vm/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Main VM library (execution's entry point)
 
-add_library(monad-vm STATIC)
+add_library(monad-vm)
 
 target_sources(monad-vm PRIVATE
     "code.hpp"

--- a/category/vm/compiler/CMakeLists.txt
+++ b/category/vm/compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-compiler STATIC)
+add_library(monad-vm-compiler)
 
 target_sources(monad-vm-compiler PRIVATE
     "transactional_unordered_map.hpp"

--- a/category/vm/core/CMakeLists.txt
+++ b/category/vm/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(C)
 
-add_library(monad-vm-core STATIC)
+add_library(monad-vm-core)
 
 target_sources(monad-vm-core PRIVATE
     "assert.cpp"

--- a/category/vm/evm/CMakeLists.txt
+++ b/category/vm/evm/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-evm STATIC)
+add_library(monad-vm-evm)
 
 set_target_properties(monad-vm-evm PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/category/vm/fuzzing/CMakeLists.txt
+++ b/category/vm/fuzzing/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-fuzzing STATIC)
+add_library(monad-vm-fuzzing)
 
 target_sources(monad-vm-fuzzing PRIVATE
   "generator/choice.hpp"

--- a/category/vm/interpreter/CMakeLists.txt
+++ b/category/vm/interpreter/CMakeLists.txt
@@ -8,7 +8,7 @@ option(MONAD_VM_INTERPRETER_DEBUG "Trace instructions executed by interpreter" O
 # contexts, never in production.
 option(MONAD_VM_INTERPRETER_STATS "Print opcode statistics on program exit" OFF)
 
-add_library(monad-vm-interpreter STATIC)
+add_library(monad-vm-interpreter)
 
 target_sources(monad-vm-interpreter PRIVATE
   "call_runtime.hpp"

--- a/category/vm/llvm/CMakeLists.txt
+++ b/category/vm/llvm/CMakeLists.txt
@@ -8,7 +8,7 @@ option(MONAD_VM_LLVM_DEBUG "Trace instructions executed by llvm backend" OFF)
 # contexts, never in production.
 option(MONAD_VM_LLVM_STATS "Print opcode statistics on program exit" OFF)
 
-add_library(monad-vm-llvm STATIC)
+add_library(monad-vm-llvm)
 
 monad_link_llvm(monad-vm-llvm)
 

--- a/category/vm/runtime/CMakeLists.txt
+++ b/category/vm/runtime/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(ASM)
 
-add_library(monad-vm-runtime STATIC)
+add_library(monad-vm-runtime)
 
 target_sources(monad-vm-runtime PRIVATE
     "allocator.hpp"

--- a/category/vm/utils/CMakeLists.txt
+++ b/category/vm/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(C)
 
-add_library(monad-vm-utils STATIC)
+add_library(monad-vm-utils)
 
 target_sources(monad-vm-utils PRIVATE
     "debug.cpp"

--- a/cmake/evmone.cmake
+++ b/cmake/evmone.cmake
@@ -1,5 +1,4 @@
 # evmone
-set(BUILD_SHARED_LIBS OFF)
 set(HUNTER_ENABLED OFF)
 
 # Both the test suite and the benchmark executables rely on the evmone state

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -55,7 +55,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-quill::Logger *event_tracer = nullptr;
+extern quill::Logger *event_tracer;
 
 MONAD_NAMESPACE_END
 


### PR DESCRIPTION
`BUILD_SHARED_LIBS=ON` is used by the Rust build system when it builds some C++ code to link to. This mechanism broke with some recent evmone build changes that explicitly disabled shared libraries everywhere. This makes it work again.

Before this, most monad libraries explicitly built as static libraries, i.e., `add_library(... STATIC ...)`. A few that are used from Rust are not specified and can build as shared libraries if requested via the CMake `BUILD_SHARED_LIBS` variable. This changes all libraries to work that way.

### Why does Rust set -DBUILD_SHARED_LIBS=ON?

This allows all the C++ parts to be linked into "self-contained" shared libraries, so that Rust executables that use C++ directly (e.g., `monad-rpc`) do not need to explicitly link any dependent C++ libraries.

If we had a static `libmonad_rpc.a`, then `monad-rpc` would need to explicitly link libstdc++, Boost, evmone stuff, any transitive dependencies of either, etc. in the Rust build.rs machinery -- for example with lines such as `println!("cargo:rustc-link-lib=dylib=stdc++");`

CMake knows the full transitive dependencies, but Rust does not, so it's cleaner if CMake produces a shared library with `DT_NEEDED` entries for every third-party library it knows it needs. This way Rust executables can create a single `DT_NEEDED` entry (e.g., for `libmonad_rpc.so`) and the dynamic linker will walk the C++ dependency graph at load time.