### PR TITLE
[cmake] build libblst.a ourselves

### DIFF
--- a/cmake/blst.cmake
+++ b/cmake/blst.cmake
@@ -1,22 +1,17 @@
-include(ExternalProject)
-
 set(BLST_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/blst")
-set(BLST_CC "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}")
 
-ExternalProject_Add(
-    blst
-    SOURCE_DIR "${BLST_SOURCE_DIR}"
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ./build.sh CC='${BLST_CC}' AR='${CMAKE_AR}'
-    BUILD_IN_SOURCE TRUE
-    BUILD_BYPRODUCTS "<SOURCE_DIR>/${CMAKE_STATIC_LIBRARY_PREFIX}blst${CMAKE_STATIC_LIBRARY_SUFFIX}"
-    LOG_BUILD TRUE
-    LOG_OUTPUT_ON_FAILURE TRUE
-    INSTALL_COMMAND ""
-)
+enable_language(ASM)
 
-add_library(blst::blst STATIC IMPORTED GLOBAL)
-set_target_properties(blst::blst PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES ${BLST_SOURCE_DIR}/bindings
-    IMPORTED_LOCATION ${BLST_SOURCE_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}blst${CMAKE_STATIC_LIBRARY_SUFFIX}
-)
+add_library(blst STATIC
+    "${BLST_SOURCE_DIR}/build/assembly.S"
+    "${BLST_SOURCE_DIR}/src/server.c")
+
+target_include_directories(blst PUBLIC ${BLST_SOURCE_DIR}/bindings)
+
+# The compilation options and defintions match what build.sh would do; if you
+# upgrade libblst, ensure this is still the case
+target_compile_options(blst PRIVATE -Wall -Wextra -Werror)
+target_compile_definitions(blst PRIVATE __ADX__)
+set_target_properties(blst PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+add_library(blst::blst ALIAS blst)


### PR DESCRIPTION
The build system for libblst.a is a custom bash script. Previously we used ExternalProject_Add to build it, then created an imported target (blst::blst) to link the compiled build artifact.

When targets using libblst.a are built via the Rust build system (build.rs calling CMake) this intermittently fails in the CI environment and this failure is not reproducible anywhere else.

Since this is only two files, just build it ourselves for now. The compile options and definitions we use are the same as are echoed to terminal when running `build.sh` manually.
