### PR TITLE
[cmake] option for the two C++ libs used from Rust to be shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 endif()
 
-if (BUILD_SHARED_LIBS)
-  # BUILD_SHARED_LIBS=ON does not automatically set -fPIC, leading to
-  # relocations being emitted in object files that can't be patched
+if (BUILD_SHARED_LIBS OR MONAD_RPC_SHARED OR MONAD_STATESYNC_SHARED)
+  # We're going to produce libraries for dynamic linking; ensure that any
+  # static library targets we create (possibly via third-party build systems)
+  # have -fPIC too
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 

--- a/category/rpc/CMakeLists.txt
+++ b/category/rpc/CMakeLists.txt
@@ -4,11 +4,15 @@ cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad_rpc)
 
-add_library(
-  monad_rpc
-  # rpc
-  "eth_call.cpp" "eth_call.h")
+option(MONAD_RPC_SHARED "Build monad_rpc shared, regardless of BUILD_SHARED_LIBS setting" OFF)
 
+if (MONAD_RPC_SHARED)
+  add_library(monad_rpc SHARED)
+else()
+  add_library(monad_rpc)
+endif()
+
+target_sources(monad_rpc PRIVATE "eth_call.cpp" "eth_call.h")
 target_include_directories(monad_rpc PUBLIC ${CATEGORY_MAIN_DIR})
 
 monad_compile_options(monad_rpc)

--- a/category/statesync/CMakeLists.txt
+++ b/category/statesync/CMakeLists.txt
@@ -4,8 +4,17 @@ cmake_policy(SET CMP0144 NEW) # find_package uses upper-case _ROOT variables
 
 project(monad_statesync)
 
-add_library(
+option(MONAD_STATESYNC_SHARED "Build monad_statesync shared, regardless of BUILD_SHARED_LIBS setting" OFF)
+
+if (MONAD_STATESYNC_SHARED)
+  add_library(monad_statesync SHARED)
+else()
+  add_library(monad_statesync)
+endif()
+
+target_sources(
   monad_statesync
+  PRIVATE
   # server
   "statesync_client.cpp"
   "statesync_client.h"


### PR DESCRIPTION
Before last week, all libraries were explicitly built as STATIC, except monad_rpc and monad_statesync. This had a nice property: when BUILD_SHARED_LIBS=ON was set in Rust, the `ldd` dynamic link dependency list for monad-node only had libmonad_rpc.so and libmonad_statesync.so as shared library dependencies.

Once STATIC was removed from most libraries, a with BUILD_SHARED_LIBS=ON, builds _everything_  shared, and monad-node has 10+ different libraries as dependencies (libmonad_core.so, libmonad_async.so, libmonad-vm-*.so, etc.), all of which have to be explicitly copied around when making the docker image.

This change helps restore the old system somewhat: now we can choose all static, all shared, or "always build the C++ libraries used from Rust as shared." If we do the latter and BUILD_SHARED_LIBS=OFF (the default), we'll force -fPIC on and get the old behavior of a small number of top-level dependencies.