### PR TITLE
Build monad support as a single library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,7 @@ function(monad_add_test2 target)
     ${target}
     PRIVATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test/unit/common/include")
   target_include_directories(${target} PRIVATE "${TOP_CURRENT_BINARY_DIR}/test")
-  target_link_libraries(${target} monad_execution monad_statesync monad_rpc
-                        GTest::GTest GTest::Main)
+  target_link_libraries(${target} monad_execution GTest::GTest GTest::Main)
   if("${target}" MATCHES "test_statesync")
     gtest_discover_tests(
       ${target} DISCOVERY_MODE PRE_TEST
@@ -232,6 +231,14 @@ add_subdirectory("category/execution")
 add_subdirectory("category/rpc")
 add_subdirectory("category/statesync")
 add_subdirectory("category/vm")
+
+# Assemble all the object libraries into complete monad runtime library,
+# monad_execution
+add_library(monad_execution)
+target_link_libraries(monad_execution PUBLIC
+    monad_core monad_async monad_trie monad_execution_ethereum
+    monad_execution_native monad_rpc monad_statesync monad-vm monad-vm-core
+    monad-vm-compiler monad-vm-interpreter monad-vm-runtime monad-vm-utils)
 
 # ##############################################################################
 # cmds

--- a/category/async/CMakeLists.txt
+++ b/category/async/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Boost 1.83 # 1.83 really is the minimum
 
 add_library(
   monad_async
+  OBJECT
   "concepts.hpp"
   "config.hpp"
   "connected_operation.hpp"
@@ -50,7 +51,7 @@ function(add_async_test)
   add_executable(${ADD_TRIE_TEST_TARGET} ${ADD_TRIE_TEST_SOURCES})
   monad_compile_options(${ADD_TRIE_TEST_TARGET})
   target_link_libraries(
-    ${ADD_TRIE_TEST_TARGET} PUBLIC monad_async GTest::gtest_main
+    ${ADD_TRIE_TEST_TARGET} PUBLIC monad_execution GTest::gtest_main
                                    ${ADD_TRIE_TEST_LINK_LIBRARIES})
   gtest_discover_tests(
     ${ADD_TRIE_TEST_TARGET}

--- a/category/async/test/CMakeLists.txt
+++ b/category/async/test/CMakeLists.txt
@@ -10,6 +10,7 @@ monad_add_test_death(
   "io_death_write_buffer_exhaustion_causes_death.cpp"
   LINK_LIBRARIES
   monad_async
+  monad_core
   FAIL_REGEX
   ".*Must fail after this:\nFATAL: no i/o buffers remaining.*")
 monad_add_test_death(
@@ -18,6 +19,7 @@ monad_add_test_death(
   "io_death_read_buffer_exhaustion_causes_death.cpp"
   LINK_LIBRARIES
   monad_async
+  monad_core
   FAIL_REGEX
   ".*Must fail after this:\nFATAL: no i/o buffers remaining.*")
 

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -54,21 +54,13 @@ add_subdirectory("third_party/nlohmann_json" SYSTEM)
 
 add_subdirectory("third_party/unordered_dense")
 
-add_library(openssl_sha3 OBJECT)
-target_include_directories(openssl_sha3 PRIVATE "third_party/openssl")
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-  target_sources(openssl_sha3 PRIVATE "keccak_impl.S")
-else()
-  target_sources(openssl_sha3
-                 PRIVATE "third_party/openssl/crypto/sha/keccak1600.c")
-endif()
-
 # ##############################################################################
 # libs
 # ##############################################################################
 
 add_library(
   monad_core
+  OBJECT
   # config
   "config.hpp"
   # core
@@ -171,6 +163,14 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
             "procfs/statm.h")
 endif()
 
+target_include_directories(monad_core PRIVATE "third_party/openssl")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+  target_sources(monad_core PRIVATE "keccak_impl.S")
+else()
+  target_sources(monad_core
+                 PRIVATE "third_party/openssl/crypto/sha/keccak1600.c")
+endif()
+
 monad_compile_options(monad_core)
 target_include_directories(monad_core PUBLIC ${CATEGORY_MAIN_DIR})
 
@@ -188,7 +188,7 @@ else()
   target_link_libraries(monad_core PRIVATE Boost::stacktrace_basic)
 endif()
 
-target_link_libraries(monad_core PUBLIC openssl_sha3 Boost::fiber TBB::tbb)
+target_link_libraries(monad_core PUBLIC Boost::fiber TBB::tbb)
 target_link_libraries(monad_core PUBLIC komihash)
 target_link_libraries(monad_core PUBLIC blake3)
 target_link_libraries(monad_core PUBLIC ethash::keccak)

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -13,7 +13,8 @@ project(monad_execution)
 # ##############################################################################
 
 add_library(
-  monad_execution
+  monad_execution_ethereum
+  OBJECT
   # ethereum/chain
   "ethereum/chain/chain_config.h"
   "ethereum/chain/chain.cpp"
@@ -144,7 +145,11 @@ add_library(
   "ethereum/state3/version_stack.hpp"
   # ethereum/types
   "ethereum/types/incarnation.hpp"
-  "ethereum/types/fmt/incarnation_fmt.hpp"
+  "ethereum/types/fmt/incarnation_fmt.hpp")
+
+add_library(
+  monad_execution_native
+  OBJECT
   # monad/chain
   "monad/chain/monad_chain.cpp"
   "monad/chain/monad_chain.hpp"
@@ -172,14 +177,20 @@ add_library(
   "monad/state2/proposal_state.hpp")
 
 target_include_directories(
-  monad_execution
+  monad_execution_ethereum
   PUBLIC ${CATEGORY_MAIN_DIR}
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
   PRIVATE ${Boost_INCLUDE_DIRS}
   PUBLIC ${silkpre_SOURCE_DIR}/lib)
 
+target_include_directories(
+  monad_execution_native
+  PUBLIC ${CATEGORY_MAIN_DIR}
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
+  PRIVATE ${Boost_INCLUDE_DIRS})
+
 target_link_libraries(
-  monad_execution
+  monad_execution_ethereum
   PUBLIC monad-vm
   PUBLIC monad_core
   PUBLIC monad_trie
@@ -195,9 +206,19 @@ target_link_libraries(
   PUBLIC silkpre
   PUBLIC unordered_dense
   PUBLIC TBB::tbb)
-monad_compile_options(monad_execution)
+monad_compile_options(monad_execution_ethereum)
 
-target_link_options(monad_execution PRIVATE LINKER:-z,defs)
+target_link_options(monad_execution_ethereum PRIVATE LINKER:-z,defs)
+
+target_link_libraries(
+  monad_execution_native
+  PUBLIC monad_execution_ethereum
+  PUBLIC monad_core
+  PUBLIC monad_trie
+  PUBLIC evmc
+  PUBLIC intx::intx
+  PUBLIC quill::quill)
+monad_compile_options(monad_execution_native)
 
 # ##############################################################################
 # unit tests

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -26,6 +26,7 @@ pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
 
 add_library(
   monad_trie
+  OBJECT
   "compute.cpp"
   "compute.hpp"
   "config.hpp"
@@ -61,7 +62,7 @@ target_link_libraries(monad_trie PUBLIC monad_async)
 target_link_libraries(monad_trie PUBLIC quill::quill) # TODO: remove
 add_executable(monad_mpt "cli_tool_main.cpp" "cli_tool_impl.cpp")
 monad_compile_options(monad_mpt)
-target_link_libraries(monad_mpt PUBLIC monad_trie PkgConfig::zstd
+target_link_libraries(monad_mpt PUBLIC monad_execution PkgConfig::zstd
                                        PkgConfig::archive CLI11::CLI11)
 
 function(add_trie_test)
@@ -77,7 +78,7 @@ function(add_trie_test)
   monad_compile_options(${ADD_TRIE_TEST_TARGET})
   target_link_libraries(
     ${ADD_TRIE_TEST_TARGET}
-    PUBLIC monad_trie GTest::GTest monad_unit_test_common
+    PUBLIC monad_execution GTest::GTest monad_unit_test_common
            ${ADD_TRIE_TEST_LINK_LIBRARIES})
   gtest_discover_tests(
     ${ADD_TRIE_TEST_TARGET}

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -46,8 +46,8 @@ add_executable(monad_trie_test "monad_trie_test.cpp")
 monad_compile_options(monad_trie_test)
 target_include_directories(monad_trie_test
                            PRIVATE "${PROJECT_SOURCE_DIR}/third_party")
-target_link_libraries(monad_trie_test PUBLIC monad_core CLI11::CLI11 monad_trie
-                                             quill::quill)
+target_link_libraries(monad_trie_test PUBLIC monad_execution CLI11::CLI11
+                      quill::quill)
 
 add_executable(monad_trie_test_statistical_generation_test
                "monad_trie_test_statistical_generation_test.cpp")
@@ -59,7 +59,6 @@ target_link_libraries(monad_trie_test_statistical_generation_test
 add_executable(read_only_db_stress_test "read_only_db_stress_test.cpp")
 monad_compile_options(read_only_db_stress_test)
 target_link_libraries(
-  read_only_db_stress_test PUBLIC monad_trie monad_async monad_core
-                                  CLI11::CLI11 quill::quill)
+  read_only_db_stress_test PUBLIC monad_execution CLI11::CLI11 quill::quill)
 
 add_subdirectory("geth_freezer_db_analyzer")

--- a/category/mpt/test/fuzz/CMakeLists.txt
+++ b/category/mpt/test/fuzz/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_trie_fuzztest name)
       PRIVATE "MONAD_TRIE_FUZZTEST_FIXTURE=monad::test::${fixture_type}")
     target_link_options(${target} PRIVATE "-fsanitize=fuzzer")
     monad_compile_options(${target})
-    target_link_libraries(${target} PUBLIC monad_trie)
+    target_link_libraries(${target} PUBLIC monad_execution)
     # Set by the clang-fuzz.cmake toolchain file
     if(CMAKE_CXX_FLAGS MATCHES "-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION")
       # Run sixteen parallel cooperating fuzzers for ten seconds

--- a/category/rpc/CMakeLists.txt
+++ b/category/rpc/CMakeLists.txt
@@ -6,12 +6,13 @@ project(monad_rpc)
 
 add_library(
   monad_rpc
+  OBJECT
   # rpc
   "eth_call.cpp" "eth_call.h")
 
 target_include_directories(monad_rpc PUBLIC ${CATEGORY_MAIN_DIR})
 
 monad_compile_options(monad_rpc)
-target_link_libraries(monad_rpc PRIVATE monad_execution)
+target_link_libraries(monad_rpc PRIVATE monad_execution_native)
 
 monad_add_test_folder(".")

--- a/category/statesync/CMakeLists.txt
+++ b/category/statesync/CMakeLists.txt
@@ -6,6 +6,7 @@ project(monad_statesync)
 
 add_library(
   monad_statesync
+  OBJECT
   # server
   "statesync_client.cpp"
   "statesync_client.h"
@@ -25,7 +26,7 @@ add_library(
 target_include_directories(monad_statesync PUBLIC ${CATEGORY_MAIN_DIR})
 
 monad_compile_options(monad_statesync)
-target_link_libraries(monad_statesync PUBLIC monad_execution)
+target_link_libraries(monad_statesync PUBLIC monad_execution_ethereum)
 
 monad_add_test_folder(".")
 
@@ -34,5 +35,5 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(fuzz_statesync PRIVATE "-fsanitize=fuzzer")
   target_link_options(fuzz_statesync PRIVATE "-fsanitize=fuzzer")
   monad_compile_options(fuzz_statesync)
-  target_link_libraries(fuzz_statesync PUBLIC monad_statesync)
+  target_link_libraries(fuzz_statesync PUBLIC monad_execution)
 endif()

--- a/category/vm/CMakeLists.txt
+++ b/category/vm/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Main VM library (execution's entry point)
 
-add_library(monad-vm)
+add_library(monad-vm OBJECT)
 
 target_sources(monad-vm PRIVATE
     "code.hpp"

--- a/category/vm/compiler/CMakeLists.txt
+++ b/category/vm/compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-compiler)
+add_library(monad-vm-compiler OBJECT)
 
 target_sources(monad-vm-compiler PRIVATE
     "transactional_unordered_map.hpp"

--- a/category/vm/core/CMakeLists.txt
+++ b/category/vm/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(C)
 
-add_library(monad-vm-core)
+add_library(monad-vm-core OBJECT)
 
 target_sources(monad-vm-core PRIVATE
     "assert.cpp"

--- a/category/vm/evm/CMakeLists.txt
+++ b/category/vm/evm/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-evm)
+add_library(monad-vm-evm OBJECT)
 
 set_target_properties(monad-vm-evm PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/category/vm/fuzzing/CMakeLists.txt
+++ b/category/vm/fuzzing/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(monad-vm-fuzzing)
+add_library(monad-vm-fuzzing OBJECT)
 
 target_sources(monad-vm-fuzzing PRIVATE
   "generator/choice.hpp"

--- a/category/vm/interpreter/CMakeLists.txt
+++ b/category/vm/interpreter/CMakeLists.txt
@@ -8,7 +8,7 @@ option(MONAD_VM_INTERPRETER_DEBUG "Trace instructions executed by interpreter" O
 # contexts, never in production.
 option(MONAD_VM_INTERPRETER_STATS "Print opcode statistics on program exit" OFF)
 
-add_library(monad-vm-interpreter)
+add_library(monad-vm-interpreter OBJECT)
 
 target_sources(monad-vm-interpreter PRIVATE
   "call_runtime.hpp"

--- a/category/vm/llvm/CMakeLists.txt
+++ b/category/vm/llvm/CMakeLists.txt
@@ -8,7 +8,7 @@ option(MONAD_VM_LLVM_DEBUG "Trace instructions executed by llvm backend" OFF)
 # contexts, never in production.
 option(MONAD_VM_LLVM_STATS "Print opcode statistics on program exit" OFF)
 
-add_library(monad-vm-llvm)
+add_library(monad-vm-llvm OBJECT)
 
 monad_link_llvm(monad-vm-llvm)
 

--- a/category/vm/runtime/CMakeLists.txt
+++ b/category/vm/runtime/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(ASM)
 
-add_library(monad-vm-runtime)
+add_library(monad-vm-runtime OBJECT)
 
 target_sources(monad-vm-runtime PRIVATE
     "allocator.hpp"

--- a/category/vm/utils/CMakeLists.txt
+++ b/category/vm/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_language(C)
 
-add_library(monad-vm-utils)
+add_library(monad-vm-utils OBJECT)
 
 target_sources(monad-vm-utils PRIVATE
     "debug.cpp"

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -14,8 +14,7 @@ add_executable(
 
 monad_compile_options(monad)
 
-target_link_libraries(monad PRIVATE monad_execution monad_statesync
-                                    CLI11::CLI11)
+target_link_libraries(monad PRIVATE monad_execution CLI11::CLI11)
 
 add_executable(monad_cli monad_cli.cpp)
 monad_compile_options(monad_cli)

--- a/cmd/vm/kernel-generator/CMakeLists.txt
+++ b/cmd/vm/kernel-generator/CMakeLists.txt
@@ -9,11 +9,8 @@ target_include_directories(kernel-generator
 )
 
 target_link_libraries(kernel-generator
-  PRIVATE monad-vm::monad-vm-utils
-  PRIVATE monad-vm::monad-vm-compiler
-  PRIVATE CLI11::CLI11
   PRIVATE monad_execution
-  PRIVATE monad_core
+  PRIVATE CLI11::CLI11
 )
 
 monad_compile_options(kernel-generator)

--- a/cmd/vm/mce/CMakeLists.txt
+++ b/cmd/vm/mce/CMakeLists.txt
@@ -17,11 +17,9 @@ target_include_directories(mce
 )
 
 target_link_libraries(mce
+  PRIVATE monad_execution
   PRIVATE evmone
   PRIVATE evmone::state
-  PRIVATE monad-vm::monad-vm-utils
-  PRIVATE monad-vm::monad-vm-compiler
-  PRIVATE monad-vm::monad-vm
   PRIVATE CLI11::CLI11
   PRIVATE nlohmann_json::nlohmann_json
 )

--- a/cmd/vm/parser/CMakeLists.txt
+++ b/cmd/vm/parser/CMakeLists.txt
@@ -8,10 +8,9 @@ target_include_directories(parser-tool
 )
 
 target_link_libraries(parser-tool
+  PRIVATE monad_execution
   PRIVATE evmc::evmc
   PRIVATE evmone
-  PRIVATE monad-vm::monad-vm-utils
-  PRIVATE monad-vm::monad-vm-compiler
   PRIVATE CLI11::CLI11
 )
 

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(
 target_include_directories(
   monad_unit_test_common PUBLIC ${PROJECT_SOURCE_DIR}/test/unit/common/include)
 set_target_properties(monad_unit_test_common PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(monad_unit_test_common PUBLIC monad_execution)
+target_link_libraries(monad_unit_test_common PUBLIC monad_execution_native)
 monad_compile_options(monad_unit_test_common)

--- a/test/vm/blockchain/CMakeLists.txt
+++ b/test/vm/blockchain/CMakeLists.txt
@@ -13,12 +13,8 @@ monad_compile_options(compiler-blockchain-tests)
 
 target_link_libraries(compiler-blockchain-tests
     PRIVATE blockchain-test-vm
-    PRIVATE monad-vm::monad-vm
-    PRIVATE monad-vm::monad-vm-compiler
-    PRIVATE monad-vm::monad-vm-utils
     PRIVATE evmone-blockchaintest-lib
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 # Interpreter Blockchain Tests
@@ -36,11 +32,8 @@ monad_compile_options(interpreter-blockchain-tests)
 
 target_link_libraries(interpreter-blockchain-tests
     PRIVATE blockchain-test-vm
-    PRIVATE monad-vm::monad-vm-utils
-    PRIVATE monad-vm::monad-vm-interpreter
     PRIVATE evmone-blockchaintest-lib
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 # LLVM Blockchain Tests
@@ -65,7 +58,6 @@ if(MONAD_COMPILER_LLVM)
         PRIVATE monad-vm::monad-vm-llvm
         PRIVATE evmone-blockchaintest-lib
         PRIVATE monad_execution
-        PRIVATE monad_core
     )
 endif()
 

--- a/test/vm/compile_benchmarks/CMakeLists.txt
+++ b/test/vm/compile_benchmarks/CMakeLists.txt
@@ -7,9 +7,7 @@ monad_compile_options(compile-benchmarks)
 
 target_link_libraries(compile-benchmarks
     PRIVATE benchmark::benchmark
-    PRIVATE monad-vm::monad-vm-compiler
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 target_include_directories(compile-benchmarks

--- a/test/vm/execution_benchmarks/CMakeLists.txt
+++ b/test/vm/execution_benchmarks/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(execution-benchmarks
     PRIVATE evmone-blockchaintest-lib
     PRIVATE nlohmann_json::nlohmann_json
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 # TODO(BSC): fix this via evmone

--- a/test/vm/fuzzer/CMakeLists.txt
+++ b/test/vm/fuzzer/CMakeLists.txt
@@ -9,10 +9,9 @@ target_sources(monad-compiler-fuzzer PRIVATE
 target_link_libraries(monad-compiler-fuzzer
   PRIVATE evmone::state
   PRIVATE evmone
-  PRIVATE monad-vm::monad-vm-utils
-  PRIVATE monad-vm::monad-vm-compiler
-  PRIVATE monad-vm::monad-vm-fuzzing
   PRIVATE blockchain-test-vm
+  PRIVATE monad-vm::monad-vm-fuzzing
+  PRIVATE monad_execution
   PRIVATE CLI11::CLI11
 )
 monad_compile_options(monad-compiler-fuzzer)

--- a/test/vm/long_benchmarks/CMakeLists.txt
+++ b/test/vm/long_benchmarks/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(long-benchmarks
     PRIVATE evmone-blockchaintest-lib
     PRIVATE nlohmann_json::nlohmann_json
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 # TODO(BSC): fix this via evmone

--- a/test/vm/unit/CMakeLists.txt
+++ b/test/vm/unit/CMakeLists.txt
@@ -40,15 +40,10 @@ endif()
 monad_compile_options(vm-unit-tests)
 target_link_libraries(vm-unit-tests
     PRIVATE evmone
-    PRIVATE monad-vm::monad-vm
-    PRIVATE monad-vm::monad-vm-compiler
     PRIVATE monad-vm::monad-vm-fuzzing
-    PRIVATE monad-vm::monad-vm-interpreter
-    PRIVATE monad-vm::monad-vm-utils
     PRIVATE GTest::gtest_main
     PRIVATE evmc::mocked_host
     PRIVATE monad_execution
-    PRIVATE monad_core
 )
 
 target_include_directories(vm-unit-tests

--- a/test/vm/utils/CMakeLists.txt
+++ b/test/vm/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(directory-type-check directory_type_check.cpp)
 monad_compile_options(directory-type-check)
-target_link_libraries(directory-type-check PRIVATE monad-vm::monad-vm-compiler)
+target_link_libraries(directory-type-check PRIVATE monad_execution)


### PR DESCRIPTION
There are four changes:

- Every "topic area" library is built as an OBJECT library

- The code in category/execution is split into two OBJECT libraries: `monad_execution_ethereum` (core Ethereum execution support, ethereum subdirectory) and `monad_execution_native` (monad subdirectory, stuff native to our own blockchain, to avoid it being called the ugly name `monad_execution_monad`)

- The full suite of library functionality is built as a single library target called "monad_execution"; this name was picked because we refer to the whole suite of functionality (and the repo itself) as "execution" all the time

- Object libraries don't link transitively-dependent object libraries, so any executables have to specify the full dependency set or link monad_execution; the approach followed here is that executables (including all tests) link monad_execution