### PR TITLE
[core/contract]: Add BigEndian type

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   "ethereum/core/base_ctypes.h"
   "ethereum/core/block.hpp"
   "ethereum/core/eth_ctypes.h"
+  "ethereum/core/contract/big_endian.hpp"
   "ethereum/core/fmt/account_fmt.hpp"
   "ethereum/core/fmt/address_fmt.hpp"
   "ethereum/core/fmt/block_fmt.hpp"

--- a/category/execution/ethereum/core/contract/big_endian.hpp
+++ b/category/execution/ethereum/core/contract/big_endian.hpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+
+#include <type_traits>
+
+MONAD_NAMESPACE_BEGIN
+
+// BigEndian is a strongly typed big endian wrapper. This is used primarily for
+// writing to state, to allow for simple conversion to and from big endian.
+template <typename T>
+    requires(std::is_integral_v<T> || std::is_same_v<T, uint256_t>)
+struct BigEndian
+{
+    unsigned char bytes[sizeof(T)];
+
+    BigEndian() = default;
+
+    BigEndian(T const &x) noexcept
+    {
+        intx::be::store(bytes, x);
+    }
+
+    bool operator==(BigEndian<T> const &other) const noexcept
+    {
+        return 0 == std::memcmp(this, &other, sizeof(BigEndian<T>));
+    }
+
+    T native() const noexcept
+    {
+        return intx::be::load<T>(bytes);
+    }
+
+    BigEndian<T> &operator=(T const &x) noexcept
+    {
+        intx::be::store(bytes, x);
+        return *this;
+    }
+};
+
+using u16_be = BigEndian<uint16_t>;
+using u32_be = BigEndian<uint32_t>;
+using u64_be = BigEndian<uint64_t>;
+using u256_be = BigEndian<uint256_t>;
+static_assert(sizeof(u16_be) == sizeof(uint16_t));
+static_assert(sizeof(u32_be) == sizeof(uint32_t));
+static_assert(sizeof(u64_be) == sizeof(uint64_t));
+static_assert(sizeof(u256_be) == sizeof(uint256_t));
+
+template <typename T>
+struct is_big_endian_wrapper : std::false_type
+{
+};
+
+template <>
+struct is_big_endian_wrapper<uint8_t> : std::true_type
+{
+};
+
+template <typename U>
+struct is_big_endian_wrapper<BigEndian<U>> : std::true_type
+{
+};
+
+template <typename T>
+concept BigEndianType = is_big_endian_wrapper<T>::value;
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/core/contract/test_big_endian.cpp
+++ b/category/execution/ethereum/core/contract/test_big_endian.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace monad;
+
+TEST(BigEndian, u16)
+{
+    uint16_t const native_u16 = std::numeric_limits<uint16_t>::max();
+    uint16_t const be_u16 = __builtin_bswap16(native_u16);
+    u16_be const be_u16_type = native_u16;
+    EXPECT_EQ(0, std::memcmp(&be_u16, &be_u16_type, sizeof(uint16_t)));
+    EXPECT_EQ(native_u16, be_u16_type.native());
+}
+
+TEST(BigEndian, u32)
+{
+    uint32_t const native_u32 = std::numeric_limits<uint32_t>::max();
+    uint32_t const be_u32 = __builtin_bswap32(native_u32);
+    u32_be const be_u32_type = native_u32;
+    EXPECT_EQ(0, std::memcmp(&be_u32, &be_u32_type, sizeof(uint32_t)));
+    EXPECT_EQ(native_u32, be_u32_type.native());
+}
+
+TEST(BigEndian, u64)
+{
+    uint64_t const native_u64 = std::numeric_limits<uint64_t>::max();
+    uint64_t const be_u64 = __builtin_bswap64(native_u64);
+    u64_be const be_u64_type = native_u64;
+    EXPECT_EQ(0, std::memcmp(&be_u64, &be_u64_type, sizeof(uint64_t)));
+    EXPECT_EQ(native_u64, be_u64_type.native());
+}
+
+TEST(BigEndian, uint256)
+{
+    uint256_t const native_u256 = std::numeric_limits<uint256_t>::max();
+    bytes32_t const be_u256 = intx::be::store<bytes32_t>(native_u256);
+    u256_be const be_u256_type = native_u256;
+    EXPECT_EQ(0, std::memcmp(&be_u256, &be_u256_type, sizeof(uint256_t)));
+    EXPECT_EQ(native_u256, be_u256_type.native());
+}


### PR DESCRIPTION
This adds a BigEndian type that can be easily converted to and from. In the staking contract, all int types are stored in big endian. Of course, our machines are little endian, so we need to convert back and forth when doing computations or when doing lookups. This type aids with that, preventing the contract being polluted with calls to int::be::load and so forth.