### PR TITLE
[core/contract]: Add StorageVariable and StorageArray types

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -46,6 +46,8 @@ add_library(
   "ethereum/core/block.hpp"
   "ethereum/core/eth_ctypes.h"
   "ethereum/core/contract/big_endian.hpp"
+  "ethereum/core/contract/storage_array.hpp"
+  "ethereum/core/contract/storage_variable.hpp"
   "ethereum/core/fmt/account_fmt.hpp"
   "ethereum/core/fmt/address_fmt.hpp"
   "ethereum/core/fmt/block_fmt.hpp"

--- a/category/execution/ethereum/core/contract/storage_array.hpp
+++ b/category/execution/ethereum/core/contract/storage_array.hpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/execution/ethereum/core/contract/storage_variable.hpp>
+
+#include <intx/intx.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// An array in the State trie. First index is the size.
+template <typename T>
+    requires std::has_unique_object_representations_v<T>
+class StorageArray
+{
+    // TODO: Move state and address to method calls
+    State &state_;
+    Address const &address_;
+    StorageVariable<u64_be> length_;
+    uint256_t const start_index_;
+
+    static constexpr size_t SLOT_PER_ELEM = StorageVariable<T>::N;
+
+public:
+    StorageArray(State &state, Address const &address, bytes32_t const &slot)
+        : state_{state}
+        , address_{address}
+        , length_{StorageVariable<u64_be>(state, address, slot)}
+        , start_index_{intx::be::load<uint256_t>(slot) + 1}
+    {
+    }
+
+    uint64_t length() const noexcept
+    {
+        return length_.load().native();
+    }
+
+    bool empty() const noexcept
+    {
+        return length() == 0;
+    }
+
+    StorageVariable<T> get(uint64_t const index) const noexcept
+    {
+        uint256_t const offset = start_index_ + index * SLOT_PER_ELEM;
+        return StorageVariable<T>{
+            state_, address_, intx::be::store<bytes32_t>(offset)};
+    }
+
+    void push(T const &value) noexcept
+    {
+        auto const len = length();
+        uint256_t const offset = start_index_ + len * SLOT_PER_ELEM;
+        StorageVariable<T> var{
+            state_, address_, intx::be::store<bytes32_t>(offset)};
+        var.store(value);
+        length_.store(len + 1);
+    }
+
+    T pop() noexcept
+    {
+        uint64_t len = length();
+        MONAD_ASSERT(len > 0);
+        len = len - 1;
+        auto var = get(len);
+        T const value = var.load();
+        var.clear();
+        length_.store(len);
+        return value;
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/core/contract/storage_variable.hpp
+++ b/category/execution/ethereum/core/contract/storage_variable.hpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/unaligned.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+
+#include <intx/intx.hpp>
+
+#include <array>
+#include <cstring>
+#include <optional>
+#include <type_traits>
+
+MONAD_NAMESPACE_BEGIN
+
+template <typename T>
+    requires std::has_unique_object_representations_v<T>
+class StorageVariable
+{
+public:
+    static constexpr size_t N =
+        (sizeof(T) + sizeof(bytes32_t) - 1) / sizeof(bytes32_t);
+    using Slots = std::array<bytes32_t, N>;
+
+    static Slots to_slots(T const &t)
+    {
+        Slots slots{}; // zero-pad the tail
+        std::memcpy(&slots[0].bytes, &t, sizeof(T));
+        return slots;
+    }
+
+    static T from_slots(Slots const &slots)
+    {
+        auto *const base = &slots[0].bytes[0];
+        return unaligned_load<T>(base);
+    }
+
+private:
+    void store_(Slots const &slots)
+    {
+        for (size_t i = 0; i < N; ++i) {
+            state_.set_storage(
+                address_, intx::be::store<bytes32_t>(offset_ + i), slots[i]);
+        }
+    }
+
+    // TODO: Move state and address to method calls
+    State &state_;
+    Address const &address_;
+    uint256_t const offset_;
+
+public:
+    StorageVariable(State &state, Address const &address, bytes32_t const &key)
+        : state_{state}
+        , address_{address}
+        , offset_{intx::be::load<uint256_t>(key)}
+    {
+    }
+
+    StorageVariable(State &state, Address const &address, uint256_t const &key)
+        : state_{state}
+        , address_{address}
+        , offset_{key}
+    {
+    }
+
+    T load() const noexcept
+    {
+        Slots slots;
+        for (size_t i = 0; i < N; ++i) {
+            slots[i] = state_.get_storage(
+                address_, intx::be::store<bytes32_t>(offset_ + i));
+        }
+        return from_slots(slots);
+    }
+
+    std::optional<T> load_checked() const noexcept
+    {
+        Slots slots;
+        bool has_data = false;
+        for (size_t i = 0; i < N; ++i) {
+            slots[i] = state_.get_storage(
+                address_, intx::be::store<bytes32_t>(offset_ + i));
+            has_data |= (slots[i] != bytes32_t{});
+        }
+        return has_data ? from_slots(slots) : std::optional<T>{};
+    }
+
+    void store(T const &value)
+    {
+        store_(to_slots(value));
+    }
+
+    void clear()
+    {
+        store_(Slots{}); // zero all blocks
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/core/contract/test_storage.cpp
+++ b/category/execution/ethereum/core/contract/test_storage.cpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
+#include <category/execution/ethereum/core/contract/storage_array.hpp>
+#include <category/execution/ethereum/core/contract/storage_variable.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/state2/block_state.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/vm/vm.hpp>
+
+#include <test_resource_data.h>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+using namespace monad::test;
+using namespace intx::literals;
+
+struct Storage : public ::testing::Test
+{
+    static constexpr auto ADDRESS{
+        0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
+    OnDiskMachine machine;
+    vm::VM vm;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+
+    void SetUp() override
+    {
+        commit_sequential(
+            tdb,
+            StateDeltas{
+                {ADDRESS,
+                 StateDelta{
+                     .account =
+                         {std::nullopt, Account{.balance = 1, .nonce = 1}}}}},
+            Code{},
+            BlockHeader{});
+        state.touch(ADDRESS);
+    }
+};
+
+TEST_F(Storage, variable)
+{
+    StorageVariable<u256_be> var(state, ADDRESS, bytes32_t{6000});
+    ASSERT_FALSE(var.load_checked().has_value());
+    var.store(5_u256);
+    ASSERT_TRUE(var.load_checked().has_value());
+    EXPECT_EQ(var.load().native(), 5_u256);
+    var.store(2000_u256);
+    EXPECT_EQ(var.load().native(), 2000_u256);
+    var.clear();
+    EXPECT_FALSE(var.load_checked().has_value());
+}
+
+TEST_F(Storage, struct)
+{
+    struct S
+    {
+        u32_be x;
+        u32_be y;
+        u256_be z;
+    };
+
+    StorageVariable<S> var(state, ADDRESS, bytes32_t{6000});
+
+    ASSERT_FALSE(var.load_checked().has_value());
+    var.store(S{.x = 4, .y = 5, .z = 6_u256});
+    ASSERT_TRUE(var.load_checked().has_value());
+    S s = var.load();
+    EXPECT_EQ(s.x, 4);
+    EXPECT_EQ(s.y, 5);
+    EXPECT_EQ(s.z, 6_u256);
+    s.x = s.x.native() * 2;
+    s.y = s.y.native() * 2;
+    s.z = s.z.native() * 2;
+    var.store(s);
+    ASSERT_TRUE(var.load_checked().has_value());
+    S s2 = var.load();
+    EXPECT_EQ(s2.x.native(), 8);
+    EXPECT_EQ(s2.y.native(), 10);
+    EXPECT_EQ(s2.z.native(), 12);
+    var.clear();
+    EXPECT_FALSE(var.load_checked().has_value());
+}
+
+TEST_F(Storage, array)
+{
+    struct SomeType
+    {
+        u256_be blob;
+        u32_be counter;
+    };
+
+    StorageArray<SomeType> arr(state, ADDRESS, bytes32_t{100});
+    EXPECT_EQ(arr.length(), 0);
+
+    for (uint32_t i = 0; i < 100; ++i) {
+        arr.push(SomeType{.blob = 2000_u256, .counter = i});
+        EXPECT_EQ(arr.length(), i + 1);
+    }
+
+    for (uint32_t i = 0; i < 100; ++i) {
+        auto const res = arr.get(i);
+        ASSERT_TRUE(res.load_checked().has_value())
+            << "Could not load at index: " << i << std::endl;
+        EXPECT_EQ(res.load().counter.native(), i);
+    }
+
+    for (uint32_t i = 100; i > 0; --i) {
+        arr.pop();
+        EXPECT_EQ(arr.length(), i - 1);
+    }
+}


### PR DESCRIPTION
 * StorageVariable: Takes in any trivially copyable type T, and splays it across contiguous storage slots in state.

 * StorageArray: A contiguous list of StorageVariables in state. The first element is a U256 indicating the current length of the array