### PR TITLE
Remove operator() from BytesHashCompare

### DIFF
--- a/category/core/bytes_hash_compare.hpp
+++ b/category/core/bytes_hash_compare.hpp
@@ -36,11 +36,6 @@ struct BytesHashCompare
     {
         return memcmp(a.bytes, b.bytes, sizeof(Bytes)) == 0;
     }
-
-    bool operator()(Bytes const &a) const
-    {
-        return hash(a);
-    }
 };
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
Removing unused incorrect BytesHashCompare operator().