### PR TITLE
Tweaking runtime signextend for better codegen

### DIFF
--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -510,9 +510,11 @@ static_assert(std::is_trivially_copyable_v<uint256_t>);
 [[gnu::always_inline]]
 inline uint256_t signextend(uint256_t const &byte_index_256, uint256_t const &x)
 {
+    uint256_t ret = x;
     if (byte_index_256 >= 31) {
-        return x;
+        return ret;
     }
+
     uint64_t const byte_index = byte_index_256[0];
     uint64_t const word_index = byte_index >> 3;
     uint64_t const word = x[word_index];
@@ -526,10 +528,6 @@ inline uint256_t signextend(uint256_t const &byte_index_256, uint256_t const &x)
         ~(std::numeric_limits<int64_t>::min() >> (63 - bit_index));
     uint64_t const lower = static_cast<uint64_t>(signed_lower);
     uint64_t const sign_bits = static_cast<uint64_t>(signed_byte >> 63);
-    uint256_t ret;
-    for (uint64_t j = 0; j < word_index; ++j) {
-        ret[j] = x[j];
-    }
     ret[word_index] = upper | lower;
     for (uint64_t j = word_index + 1; j < 4; ++j) {
         ret[j] = sign_bits;


### PR DESCRIPTION
Minor tweak produces significantly better codegen in both gcc and clang. Speedup ~2x for clang and ~3x for gcc (as measured in microbenchmarks). This appears consistent with the change to the code produced.

# Previous codegen
clang:
<img width="7030" height="8640" alt="signextend-clang-baseline" src="https://github.com/user-attachments/assets/ce73dd93-3641-46d4-ae9c-8a7cebff863e" />

gcc:
<img width="5985" height="7270" alt="signextend-gcc-baseline" src="https://github.com/user-attachments/assets/61d5657e-538c-4480-a973-df542925230c" />

# New codegen
clang:
<img width="3425" height="4680" alt="signextend-clang-opt" src="https://github.com/user-attachments/assets/dd956a64-be2a-45fd-87b9-7df5cae4ed64" />

gcc:
<img width="3005" height="4575" alt="signextend-gcc-opt" src="https://github.com/user-attachments/assets/88702e7e-6ca3-410a-af33-ebb3597c3687" />
