### PR TITLE
disable CREATE and CREATE2 when executing delegated code

### DIFF
--- a/category/execution/ethereum/chain/chain.hpp
+++ b/category/execution/ethereum/chain/chain.hpp
@@ -51,6 +51,8 @@ struct Chain
     get_max_code_size(uint64_t block_number, uint64_t timestamp) const = 0;
 
     virtual GenesisState get_genesis_state() const = 0;
+
+    virtual bool get_create_inside_delegated() const = 0;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -171,4 +171,9 @@ GenesisState EthereumMainnet::get_genesis_state() const
     return {header, ETHEREUM_MAINNET_ALLOC};
 }
 
+bool EthereumMainnet::get_create_inside_delegated() const
+{
+    return true;
+}
+
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/chain/ethereum_mainnet.hpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.hpp
@@ -53,6 +53,8 @@ struct EthereumMainnet : Chain
     get_max_code_size(uint64_t block_number, uint64_t timestamp) const override;
 
     virtual GenesisState get_genesis_state() const override;
+
+    virtual bool get_create_inside_delegated() const override;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -20,8 +20,8 @@
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
-#include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -35,12 +35,13 @@ MONAD_NAMESPACE_BEGIN
 EvmcHostBase::EvmcHostBase(
     CallTracerBase &call_tracer, evmc_tx_context const &tx_context,
     BlockHashBuffer const &block_hash_buffer, State &state,
-    size_t const max_code_size) noexcept
+    size_t const max_code_size, bool const create_inside_delegated) noexcept
     : tx_context_{tx_context}
     , block_hash_buffer_{block_hash_buffer}
     , state_{state}
     , call_tracer_{call_tracer}
     , max_code_size_{max_code_size}
+    , create_inside_delegated_{create_inside_delegated}
 {
 }
 

--- a/category/execution/ethereum/evmc_host_test.cpp
+++ b/category/execution/ethereum/evmc_host_test.cpp
@@ -142,7 +142,8 @@ TEST(EvmcHost, emit_log)
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,
-        MAX_CODE_SIZE_EIP170};
+        MAX_CODE_SIZE_EIP170,
+        true};
 
     host.emit_log(
         from,
@@ -175,7 +176,8 @@ TEST(EvmcHost, access_precompile)
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,
-        MAX_CODE_SIZE_EIP170};
+        MAX_CODE_SIZE_EIP170,
+        true};
 
     EXPECT_EQ(
         host.access_account(0x0000000000000000000000000000000000000001_address),

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -203,7 +203,8 @@ Result<evmc::Result> ExecuteTransaction<rev>::execute_impl2(
         tx_context,
         block_hash_buffer_,
         state,
-        chain_.get_max_code_size(header_.number, header_.timestamp)};
+        chain_.get_max_code_size(header_.number, header_.timestamp),
+        chain_.get_create_inside_delegated()};
 
     return ExecuteTransactionNoValidation<rev>::operator()(state, host);
 }

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -149,7 +149,7 @@ TEST(CallTrace, execute_success)
     BlockHashBufferFinalized buffer{};
     CallTracer call_tracer{tx};
     EvmcHost<EVMC_SHANGHAI> host(
-        call_tracer, tx_context, buffer, s, MAX_CODE_SIZE_EIP170);
+        call_tracer, tx_context, buffer, s, MAX_CODE_SIZE_EIP170, true);
 
     auto const result = ExecuteTransactionNoValidation<EVMC_SHANGHAI>(
         EthereumMainnet{}, tx, sender, BlockHeader{.beneficiary = beneficiary})(
@@ -219,7 +219,7 @@ TEST(CallTrace, execute_reverted_insufficient_balance)
     BlockHashBufferFinalized buffer{};
     CallTracer call_tracer{tx};
     EvmcHost<EVMC_SHANGHAI> host(
-        call_tracer, tx_context, buffer, s, MAX_CODE_SIZE_EIP170);
+        call_tracer, tx_context, buffer, s, MAX_CODE_SIZE_EIP170, true);
 
     auto const result = ExecuteTransactionNoValidation<EVMC_SHANGHAI>(
         EthereumMainnet{}, tx, sender, BlockHeader{.beneficiary = beneficiary})(

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -17,15 +17,15 @@
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/chain/genesis_state.hpp>
-#include <category/execution/monad/chain/monad_devnet.hpp>
-#include <category/execution/monad/chain/monad_mainnet.hpp>
-#include <category/execution/monad/chain/monad_testnet.hpp>
-#include <category/execution/monad/chain/monad_testnet2.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_mainnet.hpp>
+#include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/chain/monad_testnet2.hpp>
 #include <category/mpt/db.hpp>
 
 #include <gtest/gtest.h>
@@ -119,4 +119,13 @@ TEST(MonadChain, Genesis)
             0xFE557D7B2B42D6352B985949AA37EDA10FB02C90FEE62EB29E68839F2FB72B31_bytes32);
         EXPECT_TRUE(static_validate_header<EVMC_CANCUN>(header).has_value());
     }
+}
+
+TEST(MonadChain, create_inside_delegated)
+{
+    EXPECT_FALSE(MonadMainnet{}.get_create_inside_delegated());
+    EXPECT_FALSE(MonadDevnet{}.get_create_inside_delegated());
+    EXPECT_FALSE(MonadTestnet{}.get_create_inside_delegated());
+    EXPECT_FALSE(MonadTestnet2{}.get_create_inside_delegated());
+    EXPECT_TRUE(EthereumMainnet{}.get_create_inside_delegated());
 }

--- a/category/execution/monad/chain/monad_chain.cpp
+++ b/category/execution/monad/chain/monad_chain.cpp
@@ -85,4 +85,9 @@ size_t MonadChain::get_max_code_size(
     }
 }
 
+bool MonadChain::get_create_inside_delegated() const
+{
+    return false;
+}
+
 MONAD_NAMESPACE_END

--- a/category/execution/monad/chain/monad_chain.hpp
+++ b/category/execution/monad/chain/monad_chain.hpp
@@ -15,10 +15,10 @@
 
 #pragma once
 
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/monad/chain/monad_revision.h>
-#include <category/core/config.hpp>
-#include <category/core/bytes.hpp>
 
 #include <evmc/evmc.h>
 
@@ -44,6 +44,8 @@ struct MonadChain : Chain
 
     virtual size_t
     get_max_code_size(uint64_t block_number, uint64_t timestamp) const override;
+
+    virtual bool get_create_inside_delegated() const override;
 };
 
 MONAD_NAMESPACE_END

--- a/category/rpc/eth_call.cpp
+++ b/category/rpc/eth_call.cpp
@@ -225,7 +225,12 @@ namespace
         }();
 
         EvmcHost<rev> host{
-            *call_tracer, tx_context, buffer, state, max_code_size};
+            *call_tracer,
+            tx_context,
+            buffer,
+            state,
+            max_code_size,
+            chain.get_create_inside_delegated()};
         auto execution_result = ExecuteTransactionNoValidation<rev>{
             chain, enriched_txn, sender, header}(state, host);
 


### PR DESCRIPTION
Revived version of https://github.com/category-labs/monad/pull/1367