### PR TITLE
[rlp] check the length of extra_data

### DIFF
--- a/category/execution/ethereum/core/rlp/block_rlp.cpp
+++ b/category/execution/ethereum/core/rlp/block_rlp.cpp
@@ -135,6 +135,9 @@ byte_string encode_block(Block const &block)
 
 Result<BlockHeader> decode_block_header(byte_string_view &enc)
 {
+    // extraData max length is 32, see YP [4.4 - The Block]
+    constexpr size_t EXTRA_DATA_MAX_LENGTH = 32;
+
     BlockHeader block_header;
     BOOST_OUTCOME_TRY(auto payload, parse_list_metadata(enc));
 
@@ -155,6 +158,9 @@ Result<BlockHeader> decode_block_header(byte_string_view &enc)
     BOOST_OUTCOME_TRY(
         block_header.timestamp, decode_unsigned<uint64_t>(payload));
     BOOST_OUTCOME_TRY(block_header.extra_data, decode_string(payload));
+    if (block_header.extra_data.size() > EXTRA_DATA_MAX_LENGTH) {
+        return DecodeError::Overflow;
+    }
     BOOST_OUTCOME_TRY(block_header.prev_randao, decode_bytes32(payload));
     BOOST_OUTCOME_TRY(block_header.nonce, decode_byte_string_fixed<8>(payload));
 


### PR DESCRIPTION
The `extra_data` Ethereum header field is a bit different than most RLP fields in Ethereum: it is variable length but has a 32-byte maximum. We were not checking this. An Ethereum test called

```
  BlockchainTests.InvalidBlocks/bcInvalidHeaderTest/DifferentExtraData1025.json
```

is designed to detect this. I am not sure why it passed before, but this makes the rlp decode fail with DecodeError::Overflow.

Previously, the over-sized decoding would succeed (perhaps it would fail a later validation check) and then the execution event recording of BLOCK_START would memcpy outside the bounds of the 32 byte extra_data destination buffer.

This had been pointed out in the audit previously, but has surfaced now (as a real SEGFAULT) because the Ethereum test suite can record and verify the correctness of execution events.