### PR TITLE
[event] add block and basic txn event recording

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -107,6 +107,10 @@ add_library(
   "ethereum/event/exec_event_recorder.cpp"
   "ethereum/event/exec_event_recorder.hpp"
   "ethereum/event/exec_iter_help.h"
+  "ethereum/event/record_block_events.cpp"
+  "ethereum/event/record_block_events.hpp"
+  "ethereum/event/record_txn_events.cpp"
+  "ethereum/event/record_txn_events.hpp"
   # ethereum/execution
   "ethereum/block_hash_buffer.cpp"
   "ethereum/block_hash_buffer.hpp"
@@ -193,8 +197,12 @@ add_library(
   "monad/chain/monad_testnet2_alloc.hpp"
   # monad/core
   "monad/core/monad_block.hpp"
+  "monad/core/monad_ctypes.h"
   "monad/core/rlp/monad_block_rlp.cpp"
   "monad/core/rlp/monad_block_rlp.hpp"
+  # monad/event
+  "monad/event/record_consensus_events.cpp"
+  "monad/event/record_consensus_events.hpp"
   # monad/execution
   "monad/execute_system_transaction.cpp"
   "monad/execute_system_transaction.hpp"

--- a/category/execution/ethereum/event/record_block_events.cpp
+++ b/category/execution/ethereum/event/record_block_events.cpp
@@ -1,0 +1,132 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/event/event_recorder.h>
+#include <category/core/event/event_ring.h>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_block_events.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
+
+#include <bit>
+#include <cstring>
+#include <optional>
+
+MONAD_NAMESPACE_BEGIN
+
+void record_block_start(
+    bytes32_t const &bft_block_id, uint256_t const &chain_id,
+    BlockHeader const &eth_block_header, bytes32_t const &eth_parent_hash,
+    uint64_t block_round, uint64_t epoch, uint128_t epoch_nano_timestamp,
+    size_t txn_count,
+    std::optional<monad_c_secp256k1_pubkey> const &opt_block_author,
+    std::optional<monad_c_native_block_input> const &opt_monad_input)
+{
+    ExecutionEventRecorder *const exec_recorder = g_exec_event_recorder.get();
+    if (!exec_recorder) {
+        return;
+    }
+
+    ReservedExecEvent const block_start =
+        exec_recorder->reserve_block_start_event();
+    *block_start.payload = monad_exec_block_start{
+        .block_tag{
+            .id = bft_block_id,
+            .block_number = eth_block_header.number,
+        },
+        .round = block_round,
+        .epoch = epoch,
+        .proposal_epoch_nanos = static_cast<__uint128_t>(epoch_nano_timestamp),
+        .chain_id = chain_id,
+        .author = opt_block_author.value_or({}),
+        .parent_eth_hash = eth_parent_hash,
+        .eth_block_input =
+            {.ommers_hash = eth_block_header.ommers_hash,
+             .beneficiary = eth_block_header.beneficiary,
+             .transactions_root = eth_block_header.transactions_root,
+             .difficulty = static_cast<uint64_t>(eth_block_header.difficulty),
+             .number = eth_block_header.number,
+             .gas_limit = eth_block_header.gas_limit,
+             .timestamp = eth_block_header.timestamp,
+             .extra_data = {}, // Variable-length, set below,
+             .extra_data_length = size(eth_block_header.extra_data),
+             .prev_randao = eth_block_header.prev_randao,
+             .nonce = std::bit_cast<monad_c_b64>(eth_block_header.nonce),
+             .base_fee_per_gas = eth_block_header.base_fee_per_gas.value_or(0),
+             .withdrawals_root =
+                 eth_block_header.withdrawals_root.value_or(evmc_bytes32{}),
+             .txn_count = txn_count},
+        .monad_block_input = opt_monad_input.value_or({})};
+    memcpy(
+        block_start.payload->eth_block_input.extra_data.bytes,
+        data(eth_block_header.extra_data),
+        block_start.payload->eth_block_input.extra_data_length);
+    exec_recorder->commit(block_start);
+}
+
+Result<BlockExecOutput> record_block_result(Result<BlockExecOutput> result)
+{
+    ExecutionEventRecorder *const exec_recorder = g_exec_event_recorder.get();
+    if (!exec_recorder) {
+        return result;
+    }
+
+    if (result.has_error()) {
+        // An execution error occurred; record a BLOCK_REJECT event if block
+        // validation failed, or EVM_ERROR event for any other kind of error
+        static Result<BlockExecOutput>::error_type const ref_txn_error =
+            BlockError::GasAboveLimit;
+        static auto const &block_err_domain = ref_txn_error.domain();
+        auto const &error_domain = result.error().domain();
+        auto const error_value = result.error().value();
+        if (error_domain == block_err_domain) {
+            ReservedExecEvent const block_reject =
+                exec_recorder->reserve_block_event<monad_exec_block_reject>(
+                    MONAD_EXEC_BLOCK_REJECT);
+            *block_reject.payload = static_cast<uint32_t>(error_value);
+            exec_recorder->commit(block_reject);
+        }
+        else {
+            ReservedExecEvent const evm_error =
+                exec_recorder->reserve_block_event<monad_exec_evm_error>(
+                    MONAD_EXEC_EVM_ERROR);
+            *evm_error.payload = monad_exec_evm_error{
+                .domain_id = error_domain.id(), .status_code = error_value};
+            exec_recorder->commit(evm_error);
+        }
+    }
+    else {
+        // Record the "block execution successful" event, BLOCK_END
+        ReservedExecEvent const block_end =
+            exec_recorder->reserve_block_event<monad_exec_block_end>(
+                MONAD_EXEC_BLOCK_END);
+        BlockExecOutput const &exec_output = result.value();
+        *block_end.payload = monad_exec_block_end{
+            .eth_block_hash = exec_output.eth_block_hash,
+            .exec_output = {
+                .state_root = exec_output.eth_header.state_root,
+                .receipts_root = exec_output.eth_header.receipts_root,
+                .logs_bloom = std::bit_cast<monad_c_bloom256>(
+                    exec_output.eth_header.logs_bloom),
+                .gas_used = exec_output.eth_header.gas_used}};
+        exec_recorder->commit(block_end);
+    }
+    exec_recorder->end_current_block();
+    return result;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/event/record_block_events.hpp
+++ b/category/execution/ethereum/event/record_block_events.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/core/result.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+struct monad_c_secp256k1_pubkey;
+struct monad_c_native_block_input;
+
+MONAD_NAMESPACE_BEGIN
+
+/// Named pair holding the Ethereum block execution outputs
+struct BlockExecOutput
+{
+    BlockHeader eth_header;
+    bytes32_t eth_block_hash;
+};
+
+/// Record the start of block execution: emits a BLOCK_START event and
+/// sets the global block flow sequence number in the recorder
+void record_block_start(
+    bytes32_t const &bft_block_id, uint256_t const &chain_id,
+    BlockHeader const &, bytes32_t const &eth_parent_hash, uint64_t block_round,
+    uint64_t epoch, uint128_t epoch_nano_timestamp, size_t txn_count,
+    std::optional<monad_c_secp256k1_pubkey> const &,
+    std::optional<monad_c_native_block_input> const &);
+
+/// Record block execution output events (or an execution error event, if
+/// Result::has_error() is true); also clears the active block flow ID
+Result<BlockExecOutput> record_block_result(Result<BlockExecOutput>);
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -1,0 +1,204 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/event/event_recorder.h>
+#include <category/core/event/event_ring.h>
+#include <category/core/int.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/result.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/eth_ctypes.h>
+#include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_txn_events.hpp>
+#include <category/execution/ethereum/execute_transaction.hpp>
+#include <category/execution/ethereum/validate_transaction.hpp>
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <utility>
+
+#include <string.h>
+
+using namespace monad;
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+// Initializes the TXN_HEADER_START event payload
+void init_txn_header_start(
+    Transaction const &txn, Address const &sender,
+    monad_exec_txn_header_start *event)
+{
+    event->txn_hash = to_bytes(keccak256(rlp::encode_transaction(txn)));
+    event->sender = sender;
+    auto &header = event->txn_header;
+    header.nonce = txn.nonce;
+    header.gas_limit = txn.gas_limit;
+    header.max_fee_per_gas = txn.max_fee_per_gas;
+    header.max_priority_fee_per_gas = txn.max_priority_fee_per_gas;
+    header.value = txn.value;
+    header.to = txn.to ? *txn.to : Address{};
+    header.is_contract_creation = !txn.to;
+    header.txn_type = std::bit_cast<monad_c_transaction_type>(txn.type);
+    header.r = txn.sc.r;
+    header.s = txn.sc.s;
+    header.y_parity = txn.sc.y_parity == 1;
+    header.chain_id = txn.sc.chain_id.value_or(0);
+    header.data_length = static_cast<uint32_t>(size(txn.data));
+    header.blob_versioned_hash_length =
+        static_cast<uint32_t>(size(txn.blob_versioned_hashes));
+    header.access_list_count = static_cast<uint32_t>(size(txn.access_list));
+    header.auth_list_count =
+        static_cast<uint32_t>(size(txn.authorization_list));
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
+
+void record_txn_events(
+    uint32_t txn_num, Transaction const &transaction, Address const &sender,
+    std::span<std::optional<Address> const> authorities,
+    Result<Receipt> const &receipt_result)
+{
+    ExecutionEventRecorder *const exec_recorder = g_exec_event_recorder.get();
+    if (exec_recorder == nullptr) {
+        return;
+    }
+
+    // TXN_HEADER_START
+    ReservedExecEvent const txn_header_start =
+        exec_recorder->reserve_txn_event<monad_exec_txn_header_start>(
+            MONAD_EXEC_TXN_HEADER_START,
+            txn_num,
+            as_bytes(std::span{transaction.data}),
+            as_bytes(std::span{transaction.blob_versioned_hashes}));
+    init_txn_header_start(transaction, sender, txn_header_start.payload);
+    exec_recorder->commit(txn_header_start);
+
+    // TXN_ACCESS_LIST_ENTRY
+    for (uint32_t index = 0; AccessEntry const &e : transaction.access_list) {
+        ReservedExecEvent const access_list_entry =
+            exec_recorder->reserve_txn_event<monad_exec_txn_access_list_entry>(
+                MONAD_EXEC_TXN_ACCESS_LIST_ENTRY,
+                txn_num,
+                as_bytes(std::span{e.keys}));
+        *access_list_entry.payload = monad_exec_txn_access_list_entry{
+            .index = index,
+            .entry = {
+                .address = e.a,
+                .storage_key_count = static_cast<uint32_t>(size(e.keys))}};
+        exec_recorder->commit(access_list_entry);
+        ++index;
+    }
+
+    // TXN_AUTH_LIST_ENTRY
+    for (uint32_t index = 0;
+         AuthorizationEntry const &e : transaction.authorization_list) {
+        ReservedExecEvent const auth_list_entry =
+            exec_recorder->reserve_txn_event<monad_exec_txn_auth_list_entry>(
+                MONAD_EXEC_TXN_AUTH_LIST_ENTRY, txn_num);
+        *auth_list_entry.payload = monad_exec_txn_auth_list_entry{
+            .index = index,
+            .entry =
+                {
+                    .chain_id = e.sc.chain_id.value_or(0),
+                    .address = e.address,
+                    .nonce = e.nonce,
+                    .y_parity = e.sc.y_parity == 1,
+                    .r = e.sc.r,
+                    .s = e.sc.s,
+                },
+            .authority = authorities[index].value_or({}),
+            .is_valid_authority = authorities[index].has_value()};
+        exec_recorder->commit(auth_list_entry);
+        ++index;
+    }
+
+    // TXN_HEADER_END
+    exec_recorder->record_txn_marker_event(MONAD_EXEC_TXN_HEADER_END, txn_num);
+
+    if (receipt_result.has_error()) {
+        // Create a reference error so we can extract its domain with
+        // `ref_txn_error.domain()`, for the purpose of checking if the
+        // r.error() domain is a TransactionError. We record these as
+        // TXN_REJECT events (invalid transactions) vs. all other cases
+        // which are internal EVM errors (EVM_ERROR)
+        static Result<Receipt>::error_type const ref_txn_error =
+            TransactionError::InsufficientBalance;
+        static auto const &txn_err_domain = ref_txn_error.domain();
+        auto const &error_domain = receipt_result.error().domain();
+        auto const error_value = receipt_result.error().value();
+        if (error_domain == txn_err_domain) {
+            ReservedExecEvent const txn_reject =
+                exec_recorder->reserve_txn_event<monad_exec_txn_reject>(
+                    MONAD_EXEC_TXN_REJECT, txn_num);
+            *txn_reject.payload = static_cast<uint32_t>(error_value);
+            exec_recorder->commit(txn_reject);
+        }
+        else {
+            ReservedExecEvent const evm_error =
+                exec_recorder->reserve_txn_event<monad_exec_evm_error>(
+                    MONAD_EXEC_EVM_ERROR, txn_num);
+            *evm_error.payload = monad_exec_evm_error{
+                .domain_id = error_domain.id(), .status_code = error_value};
+            exec_recorder->commit(evm_error);
+        }
+        return;
+    }
+
+    // TXN_EVM_OUTPUT
+    Receipt const &receipt = receipt_result.value();
+    ReservedExecEvent const txn_evm_output =
+        exec_recorder->reserve_txn_event<monad_exec_txn_evm_output>(
+            MONAD_EXEC_TXN_EVM_OUTPUT, txn_num);
+    *txn_evm_output.payload = monad_exec_txn_evm_output{
+        .receipt =
+            {.status = receipt.status == 1,
+             .log_count = static_cast<uint32_t>(size(receipt.logs)),
+             .gas_used = receipt.gas_used},
+        .call_frame_count = 0};
+    exec_recorder->commit(txn_evm_output);
+
+    // TXN_LOG
+    for (uint32_t index = 0; auto const &log : receipt.logs) {
+        ReservedExecEvent const txn_log =
+            exec_recorder->reserve_txn_event<monad_exec_txn_log>(
+                MONAD_EXEC_TXN_LOG,
+                txn_num,
+                as_bytes(std::span{log.topics}),
+                as_bytes(std::span{log.data}));
+        *txn_log.payload = monad_exec_txn_log{
+            .index = index,
+            .address = log.address,
+            .topic_count = static_cast<uint8_t>(size(log.topics)),
+            .data_length = static_cast<uint32_t>(size(log.data))};
+        exec_recorder->commit(txn_log);
+        ++index;
+    }
+
+    exec_recorder->record_txn_marker_event(MONAD_EXEC_TXN_END, txn_num);
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/core/result.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+MONAD_NAMESPACE_BEGIN
+
+struct Receipt;
+struct Transaction;
+
+/// Record the transaction header events (TXN_HEADER_START, the EIP-2930
+/// and EIP-7702 events, and TXN_HEADER_END), followed by the TXN_EVM_OUTPUT,
+/// TXN_REJECT, or EVM_ERROR events, depending on what happened during
+/// transaction execution; in the TXN_EVM_OUTPUT case, also record other
+/// execution output events (TXN_LOG, etc.)
+void record_txn_events(
+    uint32_t txn_num, Transaction const &, Address const &sender,
+    std::span<std::optional<Address> const> authorities,
+    Result<Receipt> const &);
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -15,6 +15,8 @@
 
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
+#include <category/core/cpu_relax.h>
+#include <category/core/event/event_recorder.h>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
@@ -28,6 +30,9 @@
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/dao.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/vm/evm/explicit_evm_chain.hpp>
@@ -46,6 +51,7 @@
 #include <evmc/evmc.h>
 #include <intx/intx.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -231,9 +237,11 @@ Result<std::vector<Receipt>> execute_block(
 
     std::shared_ptr<std::optional<Result<Receipt>>[]> const results{
         new std::optional<Result<Receipt>>[block.transactions.size()]};
+    std::atomic<size_t> txn_exec_finished = 0;
+    size_t const txn_count = block.transactions.size();
 
     auto const tx_exec_begin = std::chrono::steady_clock::now();
-    for (unsigned i = 0; i < block.transactions.size(); ++i) {
+    for (unsigned i = 0; i < txn_count; ++i) {
         priority_pool.submit(
             i,
             [&chain = chain,
@@ -247,7 +255,9 @@ Result<std::vector<Receipt>> execute_block(
              &block_hash_buffer = block_hash_buffer,
              &block_state,
              &block_metrics,
-             &call_tracer = *call_tracers[i]] {
+             &call_tracer = *call_tracers[i],
+             &txn_exec_finished] {
+                record_txn_marker_event(MONAD_EXEC_TXN_PERF_EVM_ENTER, i);
                 try {
                     if (chain.is_system_sender(sender)) {
                         results[i] = ExecuteSystemTransaction<traits>{
@@ -276,10 +286,14 @@ Result<std::vector<Receipt>> execute_block(
                             call_tracer}();
                     }
                     promises[i + 1].set_value();
+                    record_txn_marker_event(MONAD_EXEC_TXN_PERF_EVM_EXIT, i);
+                    record_txn_events(
+                        i, transaction, sender, authorities, *results[i]);
                 }
                 catch (...) {
                     promises[i + 1].set_exception(std::current_exception());
                 }
+                txn_exec_finished.fetch_add(1, std::memory_order::relaxed);
             });
     }
 
@@ -288,6 +302,15 @@ Result<std::vector<Receipt>> execute_block(
     block_metrics.set_tx_exec_time(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - tx_exec_begin));
+
+    // All transactions have released their merge-order synchronization
+    // primitive (promises[i + 1]) but some stragglers could still be running
+    // post-execution code that occurs immediately after that, e.g.
+    // `record_txn_exec_result_events`. This waits for everything to finish
+    // so that it's safe to assume we're the only ones using `results`.
+    while (txn_exec_finished.load() < txn_count) {
+        cpu_relax();
+    }
 
     std::vector<Receipt> retvals;
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
@@ -350,7 +373,8 @@ Result<std::vector<Receipt>> execute_block(
         priority_pool,
         block_metrics,
         call_tracers);
-    MONAD_ASSERT(false);
+    MONAD_ABORT_PRINTF(
+        "unhandled evmc revision %u", static_cast<unsigned>(rev));
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/event/record_consensus_events.cpp
+++ b/category/execution/monad/event/record_consensus_events.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/monad/core/monad_block.hpp>
+#include <category/execution/monad/event/record_consensus_events.hpp>
+
+#include <cstdint>
+#include <span>
+
+MONAD_NAMESPACE_BEGIN
+
+template <class MonadConsensusBlockHeader>
+void record_block_qc(
+    MonadConsensusBlockHeader const &header, uint64_t finalized_block_num)
+{
+    // Before recording a QC for block B, we need to check if that block isn't
+    // already finalized. The reason for this check is the following sequence:
+    //
+    //   - we execute proposed block B1
+    //
+    //   - execution begins to fall behind, while consensus advances; B1
+    //     receives a QC (upon the proposal of B2) and B2 also received a QC
+    //     (upon proposal of B3), finalizing B1; the execution daemon is still
+    //     working on B1 during this time (or more likely, is restarting after
+    //     a crash that occurs immediately after B1 has executed)
+    //
+    //   - by the time execution is ready to execute another proposed block,
+    //     consensus has finalized B1; this is communicated to the execution
+    //     daemon, and finalize logic takes precedence and runs immediately,
+    //     emitting a BLOCK_FINALIZED event
+    //
+    //   - during the execution of B2, we'll see the QC for B1. Since it has
+    //     already been finalized, we'll skip it
+    if (auto *const exec_recorder = g_exec_event_recorder.get()) {
+        uint64_t const vote_block_number = header.seqno - 1;
+        if (vote_block_number <= finalized_block_num) {
+            return;
+        }
+        auto const &vote = header.qc.vote;
+        ReservedExecEvent const block_qc =
+            exec_recorder->reserve_block_event<monad_exec_block_qc>(
+                MONAD_EXEC_BLOCK_QC);
+        *block_qc.payload = monad_exec_block_qc{
+            .block_tag = {.id = vote.id, .block_number = vote_block_number},
+            .round = vote.round,
+            .epoch = vote.epoch};
+        exec_recorder->commit(block_qc);
+    }
+}
+
+#define EXPLICIT_INSTANTIATE_QC_TEMPLATE(HEADER_TYPE) \
+template void record_block_qc<HEADER_TYPE>(HEADER_TYPE const &, uint64_t);
+
+EXPLICIT_INSTANTIATE_QC_TEMPLATE(MonadConsensusBlockHeaderV0);
+EXPLICIT_INSTANTIATE_QC_TEMPLATE(MonadConsensusBlockHeaderV1);
+EXPLICIT_INSTANTIATE_QC_TEMPLATE(MonadConsensusBlockHeaderV2);
+
+#undef EXPLICIT_INSTANTIATE_QC_TEMPLATE
+
+void record_block_finalized(bytes32_t const &block_id, uint64_t block_number)
+{
+    if (auto *const exec_recorder = g_exec_event_recorder.get()) {
+        ReservedExecEvent const block_finalized =
+            exec_recorder->reserve_block_event<monad_exec_block_finalized>(
+                MONAD_EXEC_BLOCK_FINALIZED);
+        *block_finalized.payload = monad_exec_block_finalized{
+            .id = block_id, .block_number = block_number};
+        exec_recorder->commit(block_finalized);
+    }
+}
+
+void record_block_verified(std::span<uint64_t const> verified_blocks)
+{
+    if (auto *const exec_recorder = g_exec_event_recorder.get()) {
+        for (uint64_t b : verified_blocks) {
+            if (b == 0) {
+                continue;
+            }
+            ReservedExecEvent const block_verified =
+                exec_recorder->reserve_block_event<monad_exec_block_verified>(
+                    MONAD_EXEC_BLOCK_VERIFIED);
+            *block_verified.payload =
+                monad_exec_block_verified{.block_number = b};
+            exec_recorder->commit(block_verified);
+        }
+    }
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/event/record_consensus_events.hpp
+++ b/category/execution/monad/event/record_consensus_events.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <cstdint>
+#include <span>
+
+MONAD_NAMESPACE_BEGIN
+
+/// Record the BLOCK_QC event, using the QC for the parent block that is
+/// presented in a newly proposed block's header
+template <class MonadConsensusBlockHeader>
+void record_block_qc(
+    MonadConsensusBlockHeader const &, uint64_t finalized_block_num);
+
+/// Record the BLOCK_FINALIZED event
+void record_block_finalized(bytes32_t const &block_id, uint64_t block_number);
+
+/// Record a BLOCK_VERIFIED event for each of the given block numbers
+void record_block_verified(std::span<uint64_t const> verified_blocks);
+
+MONAD_NAMESPACE_END

--- a/cmd/monad/event.cpp
+++ b/cmd/monad/event.cpp
@@ -25,19 +25,15 @@
 
 #include <charconv>
 #include <concepts>
-#include <csignal>
 #include <cstdint>
-#include <cstring>
 #include <expected>
 #include <format>
 #include <memory>
-#include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <tuple>
-#include <utility>
 #include <vector>
 
 #include <errno.h>


### PR DESCRIPTION
After this, enough of the event system is present to support the WebSocket real-time data feeds in the RPC client, and almost everything needed for the SDK, except for call frames and state access records (those are left to future PRs).