### PR TITLE
[event] add call frame recording to execution

### DIFF
--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -25,6 +25,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
+struct CallFrame;
 struct Receipt;
 struct Transaction;
 
@@ -32,10 +33,10 @@ struct Transaction;
 /// and EIP-7702 events, and TXN_HEADER_END), followed by the TXN_EVM_OUTPUT,
 /// TXN_REJECT, or EVM_ERROR events, depending on what happened during
 /// transaction execution; in the TXN_EVM_OUTPUT case, also record other
-/// execution output events (TXN_LOG, etc.)
+/// execution output events (TXN_LOG, TXN_CALL_FRAME, etc.)
 void record_txn_events(
     uint32_t txn_num, Transaction const &, Address const &sender,
     std::span<std::optional<Address> const> authorities,
-    Result<Receipt> const &);
+    Result<Receipt> const &, std::span<CallFrame const>);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -243,7 +243,12 @@ Result<std::vector<Receipt>> execute_block_transactions(
                     promises[i + 1].set_value();
                     record_txn_marker_event(MONAD_EXEC_TXN_PERF_EVM_EXIT, i);
                     record_txn_events(
-                        i, transaction, sender, authorities, *results[i]);
+                        i,
+                        transaction,
+                        sender,
+                        authorities,
+                        *results[i],
+                        call_tracer.get_call_frames());
                 }
                 catch (...) {
                     promises[i + 1].set_exception(std::current_exception());

--- a/category/execution/ethereum/trace/call_frame.cpp
+++ b/category/execution/ethereum/trace/call_frame.cpp
@@ -18,10 +18,18 @@
 #include <category/core/config.hpp>
 #include <category/core/likely.h>
 #include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/vm/evm/opcodes.hpp>
 
+#include <evmc/hex.hpp>
+#include <intx/intx.hpp>
 #include <nlohmann/json.hpp>
 
-MONAD_NAMESPACE_BEGIN
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <utility>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
 constexpr std::string_view call_kind_to_string(CallType const &type)
 {
@@ -42,6 +50,10 @@ constexpr std::string_view call_kind_to_string(CallType const &type)
         MONAD_ASSERT(false);
     }
 }
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
 
 nlohmann::json to_json(CallFrame const &f)
 {
@@ -75,6 +87,27 @@ nlohmann::json to_json(CallFrame const &f)
     res["calls"] = nlohmann::json::array();
 
     return res;
+}
+
+vm::compiler::EvmOpCode
+get_call_frame_opcode(CallType const type, uint32_t const call_flags)
+{
+    using enum vm::compiler::EvmOpCode;
+    switch (type) {
+    case CallType::CALL:
+        return call_flags & EVMC_STATIC ? STATICCALL : CALL;
+    case CallType::CALLCODE:
+        return CALLCODE;
+    case CallType::DELEGATECALL:
+        return DELEGATECALL;
+    case CallType::CREATE:
+        return CREATE;
+    case CallType::CREATE2:
+        return CREATE2;
+    case CallType::SELFDESTRUCT:
+        return SELFDESTRUCT;
+    }
+    std::unreachable();
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/trace/call_frame.hpp
+++ b/category/execution/ethereum/trace/call_frame.hpp
@@ -24,8 +24,14 @@
 #include <evmc/evmc.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstdint>
 #include <optional>
 #include <vector>
+
+namespace monad::vm::compiler
+{
+    enum EvmOpCode : uint8_t;
+}
 
 MONAD_NAMESPACE_BEGIN
 
@@ -86,5 +92,7 @@ static_assert(sizeof(CallFrame) == 216);
 static_assert(alignof(CallFrame) == 8);
 
 nlohmann::json to_json(CallFrame const &);
+
+vm::compiler::EvmOpCode get_call_frame_opcode(CallType, uint32_t call_flags);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/trace/call_tracer.cpp
+++ b/category/execution/ethereum/trace/call_tracer.cpp
@@ -77,6 +77,11 @@ void NoopCallTracer::on_finish(uint64_t const) {}
 
 void NoopCallTracer::reset() {}
 
+std::span<CallFrame const> NoopCallTracer::get_call_frames() const
+{
+    return {};
+}
+
 CallTracer::CallTracer(Transaction const &tx, std::vector<CallFrame> &frames)
     : frames_(frames)
     , tx_(tx)
@@ -219,6 +224,11 @@ void CallTracer::reset()
 
     positions_ = std::stack<size_t>{};
     positions_.push(0);
+}
+
+std::span<CallFrame const> CallTracer::get_call_frames() const
+{
+    return frames_;
 }
 
 nlohmann::json CallTracer::to_json() const

--- a/category/execution/ethereum/trace/call_tracer.hpp
+++ b/category/execution/ethereum/trace/call_tracer.hpp
@@ -42,6 +42,7 @@ struct CallTracerBase
     virtual void on_self_destruct(Address const &from, Address const &to) = 0;
     virtual void on_finish(uint64_t const) = 0;
     virtual void reset() = 0;
+    virtual std::span<CallFrame const> get_call_frames() const = 0;
 };
 
 struct NoopCallTracer final : public CallTracerBase
@@ -52,6 +53,7 @@ struct NoopCallTracer final : public CallTracerBase
     virtual void on_self_destruct(Address const &, Address const &) override;
     virtual void on_finish(uint64_t const) override;
     virtual void reset() override;
+    virtual std::span<CallFrame const> get_call_frames() const override;
 };
 
 class CallTracer final : public CallTracerBase
@@ -75,6 +77,7 @@ public:
     on_self_destruct(Address const &from, Address const &to) override;
     virtual void on_finish(uint64_t const) override;
     virtual void reset() override;
+    virtual std::span<CallFrame const> get_call_frames() const override;
 
     nlohmann::json to_json() const;
 };


### PR DESCRIPTION
The only thing that's not obvious in this PR is the rationale for this function:

```c++
vm::compiler::EvmOpCode
get_call_frame_opcode(CallType type, uint32_t call_flags)
```

Rather than record the CallType enum and flags, we instead map them back to an EVM opcode and record the opcode numerical value to imply the call type.

The reason for doing this is the CallType enum is something we made up. Execution events are consumed outside of our codebase by third parties, where this enum is not defined. Rather than publicly export this implementation detail and its specific encoding, we instead represent the needed data using a method based on an independent and rigid standard which has meaning to everyone: an EVM opcode.