### PR TITLE
Optionally decode requests hash

### DIFF
--- a/category/execution/monad/core/rlp/monad_block_rlp.cpp
+++ b/category/execution/monad/core/rlp/monad_block_rlp.cpp
@@ -50,6 +50,14 @@ Result<BlockHeader> decode_execution_inputs(byte_string_view &enc)
         header.excess_blob_gas, decode_unsigned<uint64_t>(payload));
     BOOST_OUTCOME_TRY(header.parent_beacon_block_root, decode_bytes32(payload));
 
+    // TODO: This backwards-compatible logic should be temporary. When explicit
+    // versioning is added to this module, the following field needs to be
+    // parsed only if we're in a revision where EVMC_PRAGUE is active
+    // (MONAD_FOUR and onwards).
+    if (payload.size() > 0) {
+        BOOST_OUTCOME_TRY(header.requests_hash, decode_bytes32(payload));
+    }
+
     if (MONAD_UNLIKELY(!payload.empty())) {
         return DecodeError::InputTooLong;
     }


### PR DESCRIPTION
Consensus needs to start adding this field to blocks for Prague compatibility when they bump their version.