### PR TITLE
Use regular lru cache for async reads instead of level limited

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ function(monad_compile_options target)
   target_compile_definitions(${target} PUBLIC "JSON_HAS_RANGES=0")
 endfunction()
 
-find_package(Boost REQUIRED COMPONENTS fiber json)
+find_package(Boost REQUIRED COMPONENTS fiber json CONFIG)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
 pkg_check_modules(crypto++ REQUIRED IMPORTED_TARGET libcrypto++)

--- a/category/mpt/bench/async_read_bench.cpp
+++ b/category/mpt/bench/async_read_bench.cpp
@@ -92,13 +92,14 @@ struct Stats
 
 int main(int argc, char *const argv[])
 {
-    unsigned num_async_reader_threads = 0;
+    unsigned num_async_reader_threads = 1;
     size_t num_async_reads_inflight = 100;
     unsigned num_traverse_threads = 0;
     double prng_bias = 1.66;
     size_t num_nodes_per_version = 1;
     uint32_t runtime_seconds = std::numeric_limits<uint32_t>::max();
     unsigned update_delay_ms = 500;
+    uint64_t cache_size = 1 * 1024 * 1024;
 
     Stats total_stats;
 
@@ -136,6 +137,10 @@ int main(int argc, char *const argv[])
             "--update-delay",
             update_delay_ms,
             "Delay between upserts in the RWDb in milliseconds");
+        cli.add_option(
+            "--cache-size",
+            cache_size,
+            "Size of the node cache (in number of nodes)");
         cli.add_option(
                "--db",
                dbname_paths,
@@ -275,7 +280,7 @@ int main(int argc, char *const argv[])
                 .dbname_paths = {dbname_paths}};
             AsyncIOContext io_ctx{ro_config};
             Db ro_db{io_ctx};
-            auto async_ctx = async_context_create(ro_db);
+            auto async_ctx = async_context_create(ro_db, cache_size);
 
             struct ThreadStats
             {

--- a/category/mpt/deserialize_node_from_receiver_result.hpp
+++ b/category/mpt/deserialize_node_from_receiver_result.hpp
@@ -53,20 +53,20 @@ namespace detail
         }
     }
 
-    template <class ResultType>
-    inline Node::UniquePtr deserialize_node_from_receiver_result(
+    template <class NodeType, class ResultType>
+    inline NodeType::UniquePtr deserialize_node_from_receiver_result(
         ResultType buffer_, uint16_t buffer_off,
         MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state)
     {
         MONAD_ASSERT(buffer_);
-        Node::UniquePtr node;
+        typename NodeType::UniquePtr node;
         if constexpr (std::is_same_v<
                           std::decay_t<ResultType>,
                           typename monad::async::read_single_buffer_sender::
                               result_type>) {
             auto &buffer = std::move(buffer_).assume_value().get();
             MONAD_ASSERT(buffer.size() > buffer_off);
-            node = deserialize_node_from_buffer(
+            node = deserialize_node_from_buffer<NodeType>(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);
             buffer.reset();
@@ -82,7 +82,7 @@ namespace detail
             MONAD_ASSERT(buffer.size() > buffer_off);
             // Did the Receiver forget to set lifetime_managed_internally?
             MONAD_DEBUG_ASSERT(io_state->lifetime_is_managed_internally());
-            node = deserialize_node_from_buffer(
+            node = deserialize_node_from_buffer<NodeType>(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);
         }

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -94,7 +94,7 @@ namespace
             if (node == nullptr) {
                 parent->set_next(
                     branch_index,
-                    detail::deserialize_node_from_receiver_result(
+                    detail::deserialize_node_from_receiver_result<Node>(
                         std::move(buffer_), buffer_off, io_state));
                 node = parent->next(branch_index);
             }
@@ -161,8 +161,8 @@ namespace
                     NodeCache::ConstAccessor acc;
                     MONAD_ASSERT(node_cache.find(acc, virtual_offset) == false);
                 }
-                std::shared_ptr<Node> node =
-                    detail::deserialize_node_from_receiver_result(
+                std::shared_ptr<CacheNode> node =
+                    detail::deserialize_node_from_receiver_result<CacheNode>(
                         std::move(buffer_), buffer_off, io_state);
                 node_cache.insert(virtual_offset, node);
                 start_cursor = OwningNodeCursor{node};

--- a/category/mpt/nibbles_view.hpp
+++ b/category/mpt/nibbles_view.hpp
@@ -151,6 +151,7 @@ class NibblesView
 private:
     friend class Nibbles;
     friend class Node;
+    friend class NodeBase;
     using size_type = Nibbles::size_type;
     unsigned char const *data_{nullptr};
     bool begin_nibble_{false};

--- a/category/mpt/node_cursor.hpp
+++ b/category/mpt/node_cursor.hpp
@@ -50,7 +50,7 @@ static_assert(std::is_trivially_copyable_v<NodeCursor> == true);
 
 struct OwningNodeCursor
 {
-    std::shared_ptr<Node> node{nullptr};
+    std::shared_ptr<CacheNode> node;
     unsigned prefix_index{0};
 
     constexpr OwningNodeCursor()
@@ -59,7 +59,8 @@ struct OwningNodeCursor
     {
     }
 
-    OwningNodeCursor(std::shared_ptr<Node> node_, unsigned prefix_index_ = 0)
+    OwningNodeCursor(
+        std::shared_ptr<CacheNode> node_, unsigned prefix_index_ = 0)
         : node{node_}
         , prefix_index{prefix_index_}
     {

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -67,7 +67,7 @@ Node::UniquePtr read_node_blocking(
             strerror(errno));
     }
     return aux.version_is_valid_ondisk(version)
-               ? deserialize_node_from_buffer(
+               ? deserialize_node_from_buffer<Node>(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)
                : Node::UniquePtr{};
 }

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -165,7 +165,7 @@ namespace detail
                 }
                 else { // version is valid after reading the buffer
                     auto next_node_on_disk =
-                        deserialize_node_from_receiver_result(
+                        deserialize_node_from_receiver_result<Node>(
                             std::move(buffer_), buffer_off, io_state);
                     sender->within_recursion_count++;
                     async_parallel_preorder_traverse_impl(
@@ -402,7 +402,11 @@ inline bool preorder_traverse_ondisk(
 
     auto *const state = new auto(async::connect(
         detail::TraverseSender(
-            aux, copy_node(&node), machine.clone(), version, concurrency_limit),
+            aux,
+            copy_node<Node>(&node),
+            machine.clone(),
+            version,
+            concurrency_limit),
         TraverseReceiver{version_expired_before_traverse_complete}));
     state->initiate();
 

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -232,7 +232,7 @@ struct load_all_impl_
                 MONAD_ASSERT(root.node->next(branch_index) == nullptr);
                 root.node->set_next(
                     branch_index,
-                    detail::deserialize_node_from_receiver_result(
+                    detail::deserialize_node_from_receiver_result<Node>(
                         std::move(buffer_), buffer_off, io_state));
                 impl->nodes_loaded++;
             }
@@ -343,7 +343,7 @@ struct update_receiver
     void set_value(erased_connected_operation *io_state, ResultType buffer_)
     {
         MONAD_ASSERT(buffer_);
-        Node::UniquePtr old = detail::deserialize_node_from_receiver_result(
+        auto old = detail::deserialize_node_from_receiver_result<Node>(
             std::move(buffer_), buffer_off, io_state);
         // continue recurse down the trie starting from `old`
         upsert_(
@@ -404,7 +404,7 @@ struct read_single_child_expire_receiver
     void set_value(erased_connected_operation *io_state, ResultType buffer_)
     {
         MONAD_ASSERT(buffer_);
-        auto single_child = detail::deserialize_node_from_receiver_result(
+        auto single_child = detail::deserialize_node_from_receiver_result<Node>(
             std::move(buffer_), buffer_off, io_state);
         auto new_node = make_node(
             *single_child,
@@ -497,7 +497,7 @@ struct read_single_child_receiver
         auto &child = tnode->children[bitmask_index(
             tnode->orig_mask,
             static_cast<unsigned>(std::countr_zero(tnode->mask)))];
-        child.ptr = detail::deserialize_node_from_receiver_result(
+        child.ptr = detail::deserialize_node_from_receiver_result<Node>(
             std::move(buffer_), buffer_off, io_state);
         auto const path_size = tnode->path.nibble_size();
         create_node_compute_data_possibly_async(
@@ -555,7 +555,7 @@ struct compaction_receiver
     {
         MONAD_ASSERT(buffer_);
         tnode->update_after_async_read(
-            detail::deserialize_node_from_receiver_result(
+            detail::deserialize_node_from_receiver_result<Node>(
                 std::move(buffer_), buffer_off, io_state));
         auto *parent = tnode->parent;
         compact_(
@@ -625,7 +625,7 @@ struct expire_receiver
     {
         MONAD_ASSERT(buffer_);
         tnode->update_after_async_read(
-            detail::deserialize_node_from_receiver_result(
+            detail::deserialize_node_from_receiver_result<Node>(
                 std::move(buffer_), buffer_off, io_state));
         auto *parent = tnode->parent;
         MONAD_ASSERT(parent);

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -1084,7 +1084,7 @@ static_assert(alignof(fiber_find_request_t) == 8);
 static_assert(std::is_trivially_copyable_v<fiber_find_request_t> == true);
 
 using NodeCache = static_lru_cache<
-    virtual_chunk_offset_t, std::shared_ptr<Node>,
+    virtual_chunk_offset_t, std::shared_ptr<CacheNode>,
     virtual_chunk_offset_t_hasher>;
 
 //! \warning this is not threadsafe, should only be called from triedb thread


### PR DESCRIPTION
Replace caching limited by level with lru cache for async reads.

Add benchmark for async reads.

Add CacheNode type for using in lru cache. This allows following pointers to child nodes with a single indirection without going through hash table. The child pointer is 'weak' pointer and can point to a recycled node, it is verified on use by comparing the cache key (virtual address).