### PR TITLE
Search for `libcrypto++` using pkg_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ endfunction()
 find_package(Boost REQUIRED COMPONENTS fiber json)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
+pkg_check_modules(crypto++ REQUIRED IMPORTED_TARGET libcrypto++)
 
 # asmjit
 set(ASMJIT_STATIC ON)

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -220,8 +220,8 @@ target_link_libraries(
   PRIVATE Boost::fiber
   PRIVATE Boost::json
   PUBLIC c-kzg-4844
-  PRIVATE cryptopp
   PRIVATE PkgConfig::brotli
+  PRIVATE PkgConfig::crypto++
   PUBLIC ethash::keccak
   PUBLIC evmc
   PUBLIC intx::intx


### PR DESCRIPTION
Previously we were just letting this fail at build time; this PR pushes the check to configure time.