### PR TITLE
Verify version after reading node from disk

### DIFF
--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1599,6 +1599,7 @@ namespace detail
                     context.node_cache,
                     context.inflight_nodes,
                     cur,
+                    block_id,
                     nv,
                     op_type == op_t::op_get2),
                 find_request_receiver_t<T>{

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -76,6 +76,7 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
             node_cache,
             inflights,
             OwningNodeCursor{cache_root},
+            latest_version,
             key,
             true),
         receiver_t{});

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -770,6 +770,7 @@ int main(int argc, char *argv[])
                             node_cache,
                             inflights,
                             OwningNodeCursor{start_node},
+                            aux.db_history_max_version(),
                             NibblesView{},
                             true},
                         receiver_t(


### PR DESCRIPTION
Verify version after translating physical address to virtual.

Verify that translation remains the same after reading node from disk. This guarantees that the node was read from the valid disk location and version remains valid.