### PR TITLE
[staking]: Snapshot set and consensus set have same order

### DIFF
--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -2823,6 +2823,36 @@ TEST_F(Stake, validator_exit_delegator_boundary_nz_accumulator)
     EXPECT_EQ(val_acc, epoch_acc.value.native());
 }
 
+TEST_F(Stake, snapshot_set_same_order_as_consensus_set)
+{
+    // Add five validators
+    auto const auth_address = 0xdeadbeef_address;
+    for (uint64_t i = 0; i < 5; ++i) {
+        auto const res = add_validator(
+            auth_address,
+            ACTIVE_VALIDATOR_STAKE,
+            0 /* commission */,
+            bytes32_t{i + 1} /* unique keys*/);
+        EXPECT_FALSE(res.has_error());
+    }
+
+    // validators join the consensus set
+    skip_to_next_epoch();
+
+    // consensus set copied to snapshot set. they should be the same now
+    skip_to_next_epoch();
+
+    // sets should be the same with ids in order.
+    EXPECT_EQ(
+        contract.vars.valset_consensus.length(),
+        contract.vars.valset_snapshot.length());
+    for (uint64_t i = 0; i < contract.vars.valset_consensus.length(); ++i) {
+        EXPECT_EQ(
+            contract.vars.valset_consensus.get(i).load().native(),
+            contract.vars.valset_snapshot.get(i).load().native());
+    }
+}
+
 /////////////////////
 // compound / redelegate tests
 /////////////////////


### PR DESCRIPTION
This commit constructs the snapshot set in the same order as the consensus set. Previously, we popped from the back of the consensus set. This meant the snapshot set ordering would always be the reverse of the consensus set.

There are no correctness issues. However, the ordering provides us two benefits:

1. Better UX: Ben pointed out it's confusing that the sets are ordered differently.
2. When the consensus set doesn't change over multiple epochs, we would be doing unnecessary DB writes by storing the snapshot in reverse.

The added test fails before this commit and passes after.