### PR TITLE
[event] refactor ExecutionEventRecorder (and a few other fixes)

### DIFF
--- a/category/core/event/event_recorder_inline.h
+++ b/category/core/event/event_recorder_inline.h
@@ -83,7 +83,8 @@ static inline struct monad_event_descriptor *monad_event_recorder_reserve(
     uint64_t const sliding_window_width =
         payload_buf_size - MONAD_EVENT_WINDOW_INCR;
     struct monad_event_ring_control *const rctl = recorder->control;
-    size_t const alloc_size = monad_round_size_to_align(payload_size, 8);
+    size_t const alloc_size =
+        monad_round_size_to_align(payload_size, MONAD_EVENT_PAYLOAD_ALIGN);
 
     if (MONAD_UNLIKELY(alloc_size > UINT32_MAX)) {
         *seqno = 0;

--- a/category/core/event/event_ring.h
+++ b/category/core/event/event_ring.h
@@ -73,7 +73,7 @@ struct monad_event_descriptor
     uint32_t payload_size;       ///< Size of event payload
     uint64_t record_epoch_nanos; ///< Time event was recorded
     uint64_t payload_buf_offset; ///< Unwrapped offset of payload in p. buf
-    uint64_t user[4];            ///< Meaning defined by the writer
+    uint64_t content_ext[4];     ///< Extensions for particular content types
 };
 
 static_assert(sizeof(struct monad_event_descriptor) == 64);
@@ -207,7 +207,11 @@ constexpr uint8_t MONAD_EVENT_MAX_DESCRIPTORS_SHIFT = 32;
 constexpr uint8_t MONAD_EVENT_MIN_PAYLOAD_BUF_SHIFT = 27;
 constexpr uint8_t MONAD_EVENT_MAX_PAYLOAD_BUF_SHIFT = 40;
 
+/// Sliding window increment, see `event_recorder.md` documentation
 constexpr uint64_t MONAD_EVENT_WINDOW_INCR = 1UL << 24;
+
+/// Allocations from an event ring payload buffer have this alignment
+constexpr size_t MONAD_EVENT_PAYLOAD_ALIGN = 16;
 
 /*
  * Record error event payload definitions; in any event domain, the event_type
@@ -218,7 +222,7 @@ constexpr uint64_t MONAD_EVENT_WINDOW_INCR = 1UL << 24;
 
 struct monad_event_record_error
 {
-    enum monad_event_record_error_type
+    alignas(16) enum monad_event_record_error_type
         error_type;                  ///< Kind of recording error that occurred
     uint16_t dropped_event_type;     ///< What kind of event was discarded
     uint32_t truncated_payload_size; ///< Size of truncated trailing payload

--- a/category/event/example/eventwatch.c
+++ b/category/event/example/eventwatch.c
@@ -185,16 +185,16 @@ static void print_event(
         event->seqno,
         event->payload_size,
         event->payload_buf_offset);
-    if (event->user[MONAD_FLOW_BLOCK_SEQNO] != 0) {
-        // When `event->user[MONAD_FLOW_BLOCK_SEQNO]` is non-zero, it is set to
-        // the sequence number of the MONAD_EXEC_BLOCK_START event that started
-        // the block that this event is part of. This code tries to read the
-        // payload of that event, to print the block number.
+    if (event->content_ext[MONAD_FLOW_BLOCK_SEQNO] != 0) {
+        // When `event->content_ext[MONAD_FLOW_BLOCK_SEQNO]` is non-zero, it
+        // is set to the sequence number of the MONAD_EXEC_BLOCK_START event
+        // that started the block that this event is part of. This code tries
+        // to read the payload of that event, to print the block number.
         struct monad_event_descriptor start_block_event;
         struct monad_exec_block_start const *block_start = nullptr;
         if (monad_event_ring_try_copy(
                 event_ring,
-                event->user[MONAD_FLOW_BLOCK_SEQNO],
+                event->content_ext[MONAD_FLOW_BLOCK_SEQNO],
                 &start_block_event)) {
             block_start =
                 monad_event_ring_payload_peek(event_ring, &start_block_event);
@@ -210,8 +210,8 @@ static void print_event(
             }
         }
     }
-    if (event->user[MONAD_FLOW_TXN_ID] != 0) {
-        o += sprintf(o, " TXN: %lu", event->user[MONAD_FLOW_TXN_ID] - 1);
+    if (event->content_ext[MONAD_FLOW_TXN_ID] != 0) {
+        o += sprintf(o, " TXN: %lu", event->content_ext[MONAD_FLOW_TXN_ID] - 1);
     }
     *o++ = '\n';
     fwrite(event_buf, (size_t)(o - event_buf), 1, out);

--- a/category/execution/ethereum/event/exec_event_ctypes.h
+++ b/category/execution/ethereum/event/exec_event_ctypes.h
@@ -108,7 +108,7 @@ struct monad_exec_block_start
     uint64_t round;                   ///< Round when block was proposed
     uint64_t epoch;                   ///< Epoch when block was proposed
     __uint128_t proposal_epoch_nanos; ///< UNIX epoch nanosecond timestamp
-    monad_c_uint256_ne chain_id;      ///< Block chain we're associated with
+    monad_c_uint256_ne chain_id;      ///< Blockchain we're associated with
     struct monad_c_secp256k1_pubkey
         author;                       ///< Public key of block author
     monad_c_bytes32 parent_eth_hash;  ///< Hash of Ethereum parent block

--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -30,18 +30,16 @@
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 
 #include <array>
-#include <atomic>
-#include <bit>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -49,11 +47,23 @@
 
 MONAD_NAMESPACE_BEGIN
 
-/// All execution event recording goes through this object; it owns the
-/// `monad_event_recorder` object, the execution event ring memory mapping, and
-/// holds the event ring's file descriptor open (so that the flock(2) remains in
-/// place); it also keeps track of the block flow ID -- the sequence number of
-/// the BLOCK_START event, copied into all subsequent block-level events
+/// Event recording works in three steps: (1) reserving descriptor and payload
+/// buffer space in the event ring, then (2) the user performs zero-copy
+/// initialization of the payload directly in ring memory, then (3) the result
+/// is committed to the event ring; this structure connects all three steps
+template <typename T>
+struct ReservedExecEvent
+{
+    monad_event_descriptor *event;
+    T *payload;
+    uint64_t seqno;
+};
+
+/// All execution event recording goes through this class; it owns the
+/// `monad_event_recorder` object, the event ring memory mapping, and holds the
+/// event ring's file descriptor open (so that the flock(2) remains in place);
+/// it also keeps track of the block flow ID -- the sequence number of the
+/// BLOCK_START event, copied into all subsequent block-level events
 class ExecutionEventRecorder
 {
 public:
@@ -62,174 +72,232 @@ public:
 
     ~ExecutionEventRecorder();
 
-    uint64_t get_block_start_seqno() const
-    {
-        return block_start_seqno_;
-    }
+    /// Reserve resources to record a BLOCK_START event; also sets the
+    /// current block flow ID
+    ReservedExecEvent<monad_exec_block_start> reserve_block_start_event();
 
-    uint64_t set_block_start_seqno(uint64_t seqno)
-    {
-        std::swap(block_start_seqno_, seqno);
-        return seqno;
-    }
-
-    monad_event_ring const *get_event_ring() const
-    {
-        return &exec_ring_;
-    }
-
-    // Some events need "customized" recording (e.g., they need to modify
-    // the event descriptor manually, or do some time-sensitive work between
-    // descriptor reservation and a potentially-expensive payload memcpy);
-    // such customized recording calls this method and manually finishes the
-    // recording process; in the general case, recording should instead call
-    // one of the "all-in-one" `record` overloads below, when possible
-    monad_event_descriptor *
-    record_reserve(size_t payload_size, uint64_t *seqno, uint8_t **payload)
-    {
-        return monad_event_recorder_reserve(
-            &exec_recorder_, payload_size, seqno, payload);
-    }
-
-    /*
-     * `record` overloads; these differ in how the event payload is specified
-     */
-
-    /// Record an execution event with a payload specified by a C-style
-    /// (pointer, length) pair
-    void record(
-        std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type,
-        void const *payload, size_t payload_size)
-    {
-        uint64_t seqno;
-        uint8_t *payload_buf;
-
-        if (payload_size > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
-            return record_error_event(
-                opt_txn_num,
-                event_type,
-                MONAD_EVENT_RECORD_ERROR_OVERFLOW_4GB,
-                payload,
-                payload_size);
-        }
-
-        monad_event_descriptor *const event =
-            record_reserve(payload_size, &seqno, &payload_buf);
-        // Reservation failure should only happen in the > UINT32_MAX case,
-        // which was handled above
-        MONAD_DEBUG_ASSERT(event != nullptr);
-
-        if (!monad_event_ring_payload_check(&exec_ring_, event)) [[unlikely]] {
-            // The payload buffer expired immediately after it was allocated;
-            // because this happened so quickly, this is typically not a "real"
-            // expiration but means we tried to allocate space for a payload
-            // that was smaller than the 4 GiB limit, but still larger than the
-            // maximum size that the payload buffer was able to handle. For
-            // example, suppose we tried to allocate 300 MiB from a 256 MiB
-            // payload buffer.
-            //
-            // The event ring C API does not handle this as a special case;
-            // instead, the payload buffer's normal ring buffer expiration logic
-            // allows the allocation to "succeed" but it appears as expired
-            // immediately upon allocation (for the expiration logic, see the
-            // "Sliding window buffer" section of event_recorder.md).
-            //
-            // We treat this as a formal error so that the operator will know
-            // to allocate a (much) larger event ring buffer.
-            return record_error_event(
-                opt_txn_num,
-                event_type,
-                MONAD_EVENT_RECORD_ERROR_OVERFLOW_EXPIRE,
-                payload,
-                payload_size);
-        }
-        if (payload_size > 0) {
-            // This guard is here because sometimes payload == nullptr when
-            // payload_size == 0, and ASAN doesn't like it
-            memcpy(payload_buf, payload, payload_size);
-        }
-        event->event_type = event_type;
-        event->user[MONAD_FLOW_BLOCK_SEQNO] = block_start_seqno_;
-        event->user[MONAD_FLOW_TXN_ID] = opt_txn_num.value_or(-1) + 1;
-        monad_event_recorder_commit(event, seqno);
-    }
-
-    /// Record an execution event with no payload
-    void record(
-        std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type)
-    {
-        return record(opt_txn_num, event_type, nullptr, 0);
-    }
-
-    /// Record an execution event whose payload is described by some
-    /// memcpy-able type T
-    template <typename T>
-        requires std::is_trivially_copyable_v<T>
-    void record(
-        std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type,
-        T const &payload)
-    {
-        return record(opt_txn_num, event_type, &payload, sizeof payload);
-    }
-
-    /// Record an execution event whose payload is described by a memcpy-able
-    /// type T, followed by a variadic number of byte buffer arguments, each
-    /// described by a `std::span<std::byte const>` (gather I/O). The type T is
-    /// called a "header event", and describes the size of the trailing length
-    /// data to be parsed by the reader (e.g., the `data` field of a TXN_LOG,
-    /// or the `input` and `return` values of a TXN_CALL_FRAME)
+    /// Reserve resources to record an event that occurs at block scope; T is
+    /// the type of the "header" payload, and U... is a variadic sequence of
+    /// trailing payload buffers of type `std::span<std::byte const>`, e.g.,
+    /// TXN_LOG records the log header structure `struct monad_exec_txn_log`
+    /// and two variadic byte sequences (for topics and log data)
     template <typename T, std::same_as<std::span<std::byte const>>... U>
-        requires std::is_trivially_copyable_v<T>
-    void record(
-        std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type,
-        T const &payload, U... bufs)
+    ReservedExecEvent<T> reserve_block_event(monad_exec_event_type, U...);
+
+    /// Reserve resources to record a transaction-level event
+    template <typename T, std::same_as<std::span<std::byte const>>... U>
+    ReservedExecEvent<T> reserve_txn_event(
+        monad_exec_event_type event_type, uint32_t txn_num,
+        U &&...trailing_bufs)
     {
-        uint64_t seqno;
-        uint8_t *payload_buf;
-        size_t const payload_size = (size(bufs) + ... + sizeof payload);
-
-        if (payload_size > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
-            return record_error_event(
-                opt_txn_num,
-                event_type,
-                MONAD_EVENT_RECORD_ERROR_OVERFLOW_4GB,
-                payload,
-                payload_size);
-        }
-
-        monad_event_descriptor *const event =
-            record_reserve(payload_size, &seqno, &payload_buf);
-        MONAD_DEBUG_ASSERT(event != nullptr);
-        if (!monad_event_ring_payload_check(&exec_ring_, event)) [[unlikely]] {
-            return record_error_event(
-                opt_txn_num,
-                event_type,
-                MONAD_EVENT_RECORD_ERROR_OVERFLOW_EXPIRE,
-                payload,
-                payload_size);
-        }
-        else {
-            void *p = mempcpy(payload_buf, &payload, sizeof payload);
-            ((p = mempcpy(p, data(bufs), size(bufs))), ...);
-        }
-        event->event_type = event_type;
-        event->user[MONAD_FLOW_BLOCK_SEQNO] = block_start_seqno_;
-        event->user[MONAD_FLOW_TXN_ID] = opt_txn_num.value_or(-1) + 1;
-        monad_event_recorder_commit(event, seqno);
+        auto r = reserve_block_event<T>(
+            event_type, std::forward<U>(trailing_bufs)...);
+        r.event->content_ext[MONAD_FLOW_TXN_ID] = txn_num + 1;
+        return r;
     }
 
-    void record_error_event(
-        std::optional<uint32_t> opt_txn_num, monad_exec_event_type,
-        monad_event_record_error_type, void const *payload,
-        size_t original_payload_size);
+    /// Mark that the current block has ended
+    void end_current_block();
+
+    /// Commit the previously reserved event resources to the event ring
+    template <typename T>
+    void commit(ReservedExecEvent<T> const &);
+
+    /// Record a block-level event with no payload in one step
+    void record_block_marker_event(monad_exec_event_type);
+
+    /// Record a transaction-level event with no payload in one step
+    void record_txn_marker_event(monad_exec_event_type, uint32_t txn_num);
 
 private:
+    static constexpr size_t RECORD_ERROR_TRUNCATED_SIZE = 1UL << 13;
+
+    /// Helper for creating a RECORD_ERROR event in place of the requested
+    /// event, which could not be recorded
+    std::tuple<monad_event_descriptor *, std::byte *, uint64_t>
+    setup_record_error_event(
+        monad_exec_event_type, monad_event_record_error_type,
+        size_t header_payload_size,
+        std::span<std::span<std::byte const> const> payload_bufs,
+        size_t original_payload_size);
+
     alignas(64) monad_event_recorder exec_recorder_;
     monad_event_ring exec_ring_;
-    uint64_t block_start_seqno_;
+    uint64_t cur_block_start_seqno_;
     std::string ring_path_;
     int ring_fd_;
 };
+
+inline ReservedExecEvent<monad_exec_block_start>
+ExecutionEventRecorder::reserve_block_start_event()
+{
+    ReservedExecEvent const block_start =
+        reserve_block_event<monad_exec_block_start>(MONAD_EXEC_BLOCK_START);
+    cur_block_start_seqno_ = block_start.seqno;
+    block_start.event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = block_start.seqno;
+    return block_start;
+}
+
+template <typename T, std::same_as<std::span<std::byte const>>... U>
+ReservedExecEvent<T> ExecutionEventRecorder::reserve_block_event(
+    monad_exec_event_type event_type, U... trailing_bufs)
+{
+    // This is checking that, in the event of a recorder error, we could still
+    // fit the entire header event type T and the error reporting type in the
+    // maximum "truncated buffer" size allocated to report errors
+    static_assert(
+        sizeof(T) + sizeof(monad_exec_record_error) <=
+        RECORD_ERROR_TRUNCATED_SIZE);
+
+    // This function does the following:
+    //
+    //   - Reserves an event descriptor
+    //
+    //   - Reserves payload buffer space to hold the event payload data type,
+    //     which is a fixed-size, C-layout-compatible structure of type `T`;
+    //     the caller will later initialize this memory, constructing their T
+    //     instance within it
+    //
+    //   - Also reserves (as part of the above allocation) payload buffer space
+    //     for variable-length arrays that follow the `T` object in the event
+    //     payload. For example, the topics and log data arrays for TXN_LOG
+    //     are variable-length data that is copied immediately following the
+    //     main `T = monad_c_eth_txn_log` payload structure; in this kind of
+    //     event, the payload type `monad_c_eth_txn_log` is called the "header"
+    //
+    // All variable-length trailing data segments are passed to this function
+    // via the variadic list of arguments. They are treated as unstructured
+    // data and have type `std::span<std::byte const>`. After payload space is
+    // reserved for these byte arrays, they are also memcpy'd immediately.
+    //
+    // Events that do not have variable-length trailing data also use this
+    // function, with an empty `U` parameter pack.
+    //
+    // The reason variable-length data is memcpy'd immediately but the fixed
+    // sized part of the event payload (of type `T`) is not, is best explained
+    // by example. Consider this C++ type that models an Ethereum log:
+    //
+    //    struct Log
+    //    {
+    //        byte_string data{};
+    //        std::vector<bytes32_t> topics{};
+    //        Address address{};
+    //    }
+    //
+    // This type is not trivially copyable, but the underlying array elements
+    // in the `data` and `topics` array can be trivially copied.
+    //
+    // The corresponding C-layout-compatible type describing the log,
+    // `T = monad_c_eth_txn_log`, has to be manually initialized by the caller,
+    // so this function returns a `monad_c_eth_txn_log *` pointing to the
+    // payload buffer space for the caller to perform zero-copy initialization.
+    //
+    // We need to know the total size of the variable-length trailing data in
+    // order to reserve enough space for it; since the caller always knows what
+    // this data is, this function asks for the complete span rather than just
+    // the size, and also does the memcpy now. This simplifies the recording
+    // calls, and also the handling of the RECORD_ERROR type, which writes
+    // diagnostic truncated payloads on overflow
+
+    size_t const payload_size = (size(trailing_bufs) + ... + sizeof(T));
+    if (payload_size > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+        std::array<std::span<std::byte const>, sizeof...(trailing_bufs)> const
+            trailing_bufs_array = {trailing_bufs...};
+        auto const [event, header_buf, seqno] = setup_record_error_event(
+            event_type,
+            MONAD_EVENT_RECORD_ERROR_OVERFLOW_4GB,
+            sizeof(T),
+            trailing_bufs_array,
+            payload_size);
+        return {event, reinterpret_cast<T *>(header_buf), seqno};
+    }
+    if (payload_size >=
+        exec_ring_.payload_buf_mask + 1 - 2 * MONAD_EVENT_WINDOW_INCR) {
+        // The payload is smaller than the maximum possible size, but still
+        // cannot fit entirely in the event ring's payload buffer. For example,
+        // suppose we tried to allocate 300 MiB from a 256 MiB payload buffer.
+        //
+        // The event ring C API does not handle this as a special case;
+        // instead, the payload buffer's normal ring buffer expiration logic
+        // allows the allocation to "succeed" but it appears as expired
+        // immediately upon allocation (for the expiration logic, see the
+        // "Sliding window buffer" section of event_recorder.md).
+        //
+        // We treat this as a formal error so that the operator will know
+        // to allocate a (much) larger event ring buffer.
+        std::array<std::span<std::byte const>, sizeof...(trailing_bufs)> const
+            trailing_bufs_array = {trailing_bufs...};
+        auto const [event, header_buf, seqno] = setup_record_error_event(
+            event_type,
+            MONAD_EVENT_RECORD_ERROR_OVERFLOW_EXPIRE,
+            sizeof(T),
+            trailing_bufs_array,
+            payload_size);
+        return {event, reinterpret_cast<T *>(header_buf), seqno};
+    }
+
+    uint64_t seqno;
+    uint8_t *payload_buf;
+    monad_event_descriptor *const event = monad_event_recorder_reserve(
+        &exec_recorder_, payload_size, &seqno, &payload_buf);
+    MONAD_DEBUG_ASSERT(event != nullptr);
+    if constexpr (sizeof...(trailing_bufs) > 0) {
+        // Copy the variable-length trailing buffers; GCC issues a false
+        // positive warning about this memcpy that must be disabled
+#if !defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-overflow"
+    #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+        void *p = payload_buf + sizeof(T);
+        ((p = mempcpy(p, data(trailing_bufs), size(trailing_bufs))), ...);
+#if !defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif
+    }
+    event->event_type = event_type;
+    event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = cur_block_start_seqno_;
+    event->content_ext[MONAD_FLOW_TXN_ID] = 0;
+    event->content_ext[MONAD_FLOW_ACCOUNT_INDEX] = 0;
+
+    return {event, reinterpret_cast<T *>(payload_buf), seqno};
+}
+
+inline void ExecutionEventRecorder::end_current_block()
+{
+    cur_block_start_seqno_ = 0;
+}
+
+template <typename T>
+void ExecutionEventRecorder::commit(ReservedExecEvent<T> const &exec_event)
+{
+    monad_event_recorder_commit(exec_event.event, exec_event.seqno);
+}
+
+inline void ExecutionEventRecorder::record_block_marker_event(
+    monad_exec_event_type event_type)
+{
+    uint64_t seqno;
+    uint8_t *payload_buf;
+    monad_event_descriptor *const event =
+        monad_event_recorder_reserve(&exec_recorder_, 0, &seqno, &payload_buf);
+    event->event_type = std::to_underlying(event_type);
+    event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = cur_block_start_seqno_;
+    monad_event_recorder_commit(event, seqno);
+}
+
+inline void ExecutionEventRecorder::record_txn_marker_event(
+    monad_exec_event_type event_type, uint32_t txn_num)
+{
+    uint64_t seqno;
+    uint8_t *payload_buf;
+    monad_event_descriptor *const event =
+        monad_event_recorder_reserve(&exec_recorder_, 0, &seqno, &payload_buf);
+    event->event_type = std::to_underlying(event_type);
+    event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = cur_block_start_seqno_;
+    event->content_ext[MONAD_FLOW_TXN_ID] = txn_num + 1;
+    monad_event_recorder_commit(event, seqno);
+}
 
 // Declare the global recorder object; this is initialized by the driver
 // process if it wants execution event recording, and is left uninitialized to
@@ -244,34 +312,18 @@ extern std::unique_ptr<ExecutionEventRecorder> g_exec_event_recorder;
  * Helper free functions for execution event recording
  */
 
-inline void record_exec_event(
-    std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type)
+inline void record_block_marker_event(monad_exec_event_type event_type)
 {
     if (auto *const e = g_exec_event_recorder.get()) {
-        return e->record(opt_txn_num, event_type);
+        e->record_block_marker_event(event_type);
     }
 }
 
-template <typename T>
-    requires std::is_trivially_copyable_v<T>
-void record_exec_event(
-    std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type,
-    T const &payload)
+inline void
+record_txn_marker_event(monad_exec_event_type event_type, uint32_t txn_num)
 {
     if (auto *const e = g_exec_event_recorder.get()) {
-        return e->record(opt_txn_num, event_type, payload);
-    }
-}
-
-template <typename T, std::same_as<std::span<std::byte const>>... U>
-    requires std::is_trivially_copyable_v<T>
-void record_exec_event(
-    std::optional<uint32_t> opt_txn_num, monad_exec_event_type event_type,
-    T const &payload, U &&...bufs)
-{
-    if (auto *const e = g_exec_event_recorder.get()) {
-        return e->record(
-            opt_txn_num, event_type, payload, std::forward<U...>(bufs...));
+        e->record_txn_marker_event(event_type, txn_num);
     }
 }
 

--- a/category/execution/ethereum/event/exec_iter_help_inline.h
+++ b/category/execution/ethereum/event/exec_iter_help_inline.h
@@ -36,12 +36,14 @@ static inline bool _monad_exec_ring_ensure_block(
     struct monad_event_descriptor *buf)
 {
     if (__builtin_expect(
-            (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+            (*event_p)->content_ext[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
                 (*event_p)->event_type != MONAD_EXEC_BLOCK_START,
             0)) {
         if (__builtin_expect(
                 !monad_event_ring_try_copy(
-                    event_ring, (*event_p)->user[MONAD_FLOW_BLOCK_SEQNO], buf),
+                    event_ring,
+                    (*event_p)->content_ext[MONAD_FLOW_BLOCK_SEQNO],
+                    buf),
                 0)) {
             return false;
         }
@@ -64,10 +66,10 @@ static inline bool _monad_exec_iter_copy_consensus_event(
             0)) {
         return false;
     }
-    if (event->user[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
+    if (event->content_ext[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
         event->event_type != MONAD_EXEC_BLOCK_START) {
         uint64_t const iter_save = iter->read_last_seqno;
-        iter->read_last_seqno = event->user[MONAD_FLOW_BLOCK_SEQNO] - 1;
+        iter->read_last_seqno = event->content_ext[MONAD_FLOW_BLOCK_SEQNO] - 1;
         if (__builtin_expect(
                 monad_event_iterator_try_copy(iter, event) !=
                     MONAD_EVENT_SUCCESS,


### PR DESCRIPTION
There are a few changes here:

- Now all the event initialization is zero-copy: the reservation step returns a pointer into the event ring payload buffer, rather than memcpy'ing into it

- Fixes a bug in the event recorder which under-aligned payload structures that required 16-byte alignment. These occur when we use the GNU native 128-bit integer type `__uint128_t`, whose counterpart `u128` is used in Rust for proposal epoch nanosecond timestamp. These appear for the first time in #1573 

- Renames the event descriptor's `user` field to `content_ext` (content extensions) to match the SDK documentation