### PR TITLE
Do not put assembly functions in .eh_frame section

### DIFF
--- a/category/vm/interpreter/entry.S
+++ b/category/vm/interpreter/entry.S
@@ -7,7 +7,6 @@
 .type monad_vm_interpreter_trampoline, @function
 .align 16
 monad_vm_interpreter_trampoline:
-.cfi_startproc
     pushq %rbp
     pushq %rbx    
     pushq %r12
@@ -15,7 +14,12 @@ monad_vm_interpreter_trampoline:
     pushq %r14
     pushq %r15
     movq %rsp, (%rdi)
-    jmp monad_vm_interpreter_core_loop
-.cfi_endproc
+    pushq %rbp // for stack alignment
+    // Use the call instruction to enter the interpreter loop, so that the
+    // trampoline is the return address of the interpreter loop. Stack
+    // backtraces will deterministically end at the trampoline like this,
+    // because the trampoline is not in the `.eh_frame` unwind table.
+    call monad_vm_interpreter_core_loop
+    int3 // unreachable
 .size monad_vm_interpreter_trampoline, .-monad_vm_interpreter_trampoline
 .section .note.GNU-stack,"",@progbits

--- a/category/vm/llvm/entry.S
+++ b/category/vm/llvm/entry.S
@@ -7,7 +7,6 @@
 .type llvm_runtime_trampoline, @function
 .align 16
 llvm_runtime_trampoline:
-.cfi_startproc
     pushq %rbp
     pushq %rbx
     pushq %r12
@@ -18,6 +17,5 @@ llvm_runtime_trampoline:
     // rsi contains second argument to contract function
     movq %rsp, (%rcx) // save stack ptr (adjust rdx if args added to contract function)
     jmp *%rdx // jump to contract function (adjust rsi if args added to contract function)
-.cfi_endproc
 .size llvm_runtime_trampoline, .-llvm_runtime_trampoline
 .section .note.GNU-stack,"",@progbits

--- a/category/vm/runtime/context.S
+++ b/category/vm/runtime/context.S
@@ -27,7 +27,6 @@ monad_vm_runtime_increase_memory_raw:
 //  rax, rsp, rbp, rbx, r8, r9, ..., r15,
 //  ymm0, ymm1, ymm2, ymm3, ymm4
 // Note - no need for vzeroupper before calling this function
-.cfi_startproc
     // edi = shr_ceil<5>(edi);
     add edi, 0x1f
     shr edi, 5
@@ -110,7 +109,6 @@ monad_vm_runtime_increase_memory_raw:
     vzeroupper
     jmp monad_vm_runtime_context_error_exit
 
-.cfi_endproc
 .size monad_vm_runtime_increase_memory_raw, .-monad_vm_runtime_increase_memory_raw
 
 .globl monad_vm_runtime_increase_memory
@@ -127,13 +125,11 @@ monad_vm_runtime_increase_memory:
 //  rax, rsp, rbp, rbx, r8, r9, ..., r15,
 //  ymm0, ymm1, ymm2, ymm3, ymm4
 // Note - no need for vzeroupper before calling this function
-.cfi_startproc
 push rbx
 mov rbx, rsi
 call monad_vm_runtime_increase_memory_raw
 pop rbx
 ret
-.cfi_endproc
 .size monad_vm_runtime_increase_memory, .-monad_vm_runtime_increase_memory
 
 .section .note.GNU-stack,"",@progbits

--- a/category/vm/runtime/exit.S
+++ b/category/vm/runtime/exit.S
@@ -3,7 +3,6 @@
 .type monad_vm_runtime_exit, @function
 .align 16
 monad_vm_runtime_exit:
-.cfi_startproc
     movq %rdi, %rsp
     popq %r15
     popq %r14
@@ -12,6 +11,5 @@ monad_vm_runtime_exit:
     popq %rbx
     popq %rbp
     retq
-.cfi_endproc
 .size monad_vm_runtime_exit, .-monad_vm_runtime_exit
 .section .note.GNU-stack,"",@progbits

--- a/category/vm/runtime/math.S
+++ b/category/vm/runtime/math.S
@@ -4,7 +4,6 @@
 .type monad_vm_runtime_mul, @function
 .align 16
 monad_vm_runtime_mul:
-.cfi_startproc
     push    r13
     push    r12
     mov     r8, qword ptr [rdx]
@@ -49,14 +48,12 @@ monad_vm_runtime_mul:
     pop     r12
     pop     r13
     ret
-.cfi_endproc
 .size monad_vm_runtime_mul, .-monad_vm_runtime_mul
 
 .globl monad_vm_runtime_mul_192
 .type monad_vm_runtime_mul_192, @function
 .align 16
 monad_vm_runtime_mul_192:
-.cfi_startproc
     mov     r8, qword ptr [rdx]
     mov     r9, qword ptr [rdx + 8]
     mov     r10, qword ptr [rdx + 16]
@@ -85,7 +82,6 @@ monad_vm_runtime_mul_192:
     mov     qword ptr [rdi + 8], r11
     mov     qword ptr [rdi + 16], rcx
     ret
-.cfi_endproc
 .size monad_vm_runtime_mul_192, .-monad_vm_runtime_mul_192
 
 .section .note.GNU-stack,"",@progbits

--- a/category/vm/runtime/transmute.S
+++ b/category/vm/runtime/transmute.S
@@ -16,7 +16,6 @@ monad_vm_runtime_load_bounded_le_raw:
 //  rax, rsp, rbp, rbx, r8, r9, ..., r15,
 //  ymm0, ymm1, ..., ymm13
 // Note it is assumed that rsi <= 32 and may be negative
-.cfi_startproc
     cmp rsi, 16
     jg .g16
     cmp rsi, 8
@@ -101,7 +100,6 @@ monad_vm_runtime_load_bounded_le_raw:
     vmovd xmm15, edx
     ret
 
-.cfi_endproc
 .size monad_vm_runtime_load_bounded_le_raw, .-monad_vm_runtime_load_bounded_le_raw
 
 .globl monad_vm_runtime_load_bounded_le
@@ -119,11 +117,9 @@ monad_vm_runtime_load_bounded_le:
 //  rax, rsp, rbp, rbx, r8, r9, ..., r15,
 //  ymm1, ymm2, ..., ymm13
 // Note it is assumed that rsi <= 32 and may be negative
-.cfi_startproc
 call monad_vm_runtime_load_bounded_le_raw
 vmovups ymm0, ymm15
 ret
-.cfi_endproc
 .size monad_vm_runtime_load_bounded_le, .-monad_vm_runtime_load_bounded_le
 
 .section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Remove .cfi_startproc/.cfi_endproc directives, because behavior is not generally defined when these are not properly combined with CFI CFA directives.