### PR TITLE
[staking]: Ban auth addresses that will corrupt the linked list

### DIFF
--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -504,7 +504,7 @@ private:
 
     // Low level helpers for validator and delegator lists
     template <typename Key, typename Ptr>
-    void linked_list_insert(Key const &, Ptr const &);
+    Result<void> linked_list_insert(Key const &, Ptr const &);
     template <typename Key, typename Ptr>
     void linked_list_remove(Key const &, Ptr const &);
     template <typename Key, typename Ptr>

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -817,6 +817,18 @@ TEST_F(Stake, nonpayable_functions_revert)
         StakingError::ValueNonZero);
 }
 
+TEST_F(Stake, auth_address_conflicts_with_linked_list)
+{
+    // empty pointer
+    Address empty{};
+    EXPECT_TRUE(add_validator(empty, ACTIVE_VALIDATOR_STAKE).has_error());
+
+    // sentinel
+    Address sentinel{};
+    std::memset(sentinel.bytes, 0xFF, sizeof(Address));
+    EXPECT_TRUE(add_validator(sentinel, ACTIVE_VALIDATOR_STAKE).has_error());
+}
+
 /////////////////////////
 // Add Validator Tests //
 /////////////////////////


### PR DESCRIPTION
The linked list for get_delegators_for_validator requires that two addresses are unused.
  * Empty Address: all 0x00
  * Sentinel Address: all 0xFF

For flexibility, validators have complete control over what they set their auth address to. But if they set it to either of these values, the linked list mappings will be corrupted. This diff bans those addresses.

While the same is true for validator IDs, those start at 1 and will take billions of years to reach u64 max, so this would not happen.

Just to note, the impact of this is basically zero. Someone would be burning `MIN_VALIDATE_STAKE` to corrupt the list for their validator only, which they are now locked out of.

Reported by Zellic