### PR TITLE
Basic event testing during monad-ethereum-test

### DIFF
--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -109,6 +109,11 @@ public:
     /// Record a transaction-level event with no payload in one step
     void record_txn_marker_event(monad_exec_event_type, uint32_t txn_num);
 
+    monad_event_ring const *get_event_ring() const
+    {
+        return &exec_ring_;
+    }
+
 private:
     static constexpr size_t RECORD_ERROR_TRUNCATED_SIZE = 1UL << 13;
 

--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -46,10 +46,12 @@ target_sources(
   monad-ethereum-test
   PRIVATE include/blockchain_test.hpp
           include/ethereum_test.hpp
+          include/event.hpp
           include/from_json.hpp
           include/transaction_test.hpp
           src/blockchain_test.cpp
           src/ethereum_test.cpp
+          src/event.cpp
           src/main.cpp
           src/transaction_test.cpp)
 
@@ -77,7 +79,7 @@ function(add_ethereum_test)
 
   add_test(NAME ${ADD_ETHEREUM_TEST_FORK}_monad_ethereum_test
            COMMAND monad-ethereum-test --fork ${ADD_ETHEREUM_TEST_FORK}
-                   --gtest_filter=${FILTER})
+                   --record-exec-events --gtest_filter=${FILTER})
 endfunction()
 
 add_ethereum_test(FORK frontier)

--- a/test/ethereum_test/include/blockchain_test.hpp
+++ b/test/ethereum_test/include/blockchain_test.hpp
@@ -37,6 +37,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct Block;
+struct BlockExecOutput;
 class BlockHashBuffer;
 struct Receipt;
 
@@ -53,12 +54,17 @@ class BlockchainTest : public testing::Test
     bool enable_tracing_;
 
     template <Traits traits>
-    static Result<std::vector<Receipt>>
-    execute(Block &, test::db_t &, vm::VM &, BlockHashBuffer const &, bool);
+    static Result<std::vector<Receipt>> execute_and_record(
+        Block &, test::db_t &, vm::VM &, BlockHashBuffer const &, bool);
+
+    template <Traits traits>
+    static Result<BlockExecOutput> execute(
+        Block &, test::db_t &, vm::VM &, BlockHashBuffer const &, bool,
+        std::vector<Receipt> &, std::vector<std::vector<CallFrame>> &);
 
     static Result<std::vector<Receipt>> execute_dispatch(
-        evmc_revision, Block &, test::db_t &, vm::VM &,
-        BlockHashBuffer const &, bool);
+        evmc_revision, Block &, test::db_t &, vm::VM &, BlockHashBuffer const &,
+        bool);
 
     static void
     validate_post_state(nlohmann::json const &json, nlohmann::json const &db);
@@ -69,7 +75,8 @@ public:
 
     BlockchainTest(
         std::filesystem::path const &file,
-        std::optional<evmc_revision> const &revision, bool enable_tracing) noexcept
+        std::optional<evmc_revision> const &revision,
+        bool enable_tracing) noexcept
         : file_{file}
         , revision_{revision}
         , enable_tracing_{enable_tracing}

--- a/test/ethereum_test/include/event.hpp
+++ b/test/ethereum_test/include/event.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/event/event_ring.h>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+
+#include <monad/test/config.hpp>
+
+#include <vector>
+
+MONAD_TEST_NAMESPACE_BEGIN
+
+// Smart pointer to an execution event whose payload stays resident in event
+// ring memory
+template <typename T>
+struct RingEvent
+{
+    monad_event_descriptor event;
+    T const *payload;
+    monad_event_ring const *event_ring;
+
+    explicit operator bool() const
+    {
+        return event_ring != nullptr &&
+               monad_event_ring_payload_check(event_ring, &event);
+    }
+
+    T const *operator->() const
+    {
+        return static_cast<bool>(*this) ? payload : nullptr;
+    }
+};
+
+// Captured execution events in a block; we don't capture everything, because
+// the tests don't have enough information to check most of it (no call frames,
+// etc.)
+struct ExecutionEvents
+{
+    RingEvent<monad_exec_block_start> block_start;
+    RingEvent<monad_exec_block_end> block_end;
+    RingEvent<monad_exec_block_reject> block_reject_code;
+    RingEvent<monad_exec_txn_reject> txn_reject_code;
+    std::vector<RingEvent<monad_exec_txn_header_start>> txn_inputs;
+    std::vector<RingEvent<monad_exec_txn_evm_output>> txn_evm_outputs;
+};
+
+// After a block is executed, iterate through the recorded events and
+// populate the ExecutionEvents structure with any events discovered
+void find_execution_events(
+    monad_event_ring const *, monad_event_iterator *, ExecutionEvents *);
+
+void init_exec_event_recorder();
+
+MONAD_TEST_NAMESPACE_END

--- a/test/ethereum_test/src/event.cpp
+++ b/test/ethereum_test/src/event.cpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <event.hpp>
+
+#include <category/core/assert.h>
+#include <category/core/cleanup.h>
+#include <category/core/config.hpp>
+#include <category/core/event/event_iterator.h>
+#include <category/core/event/event_ring.h>
+#include <category/core/event/event_ring_util.h>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+
+#include <gtest/gtest.h>
+#include <monad/test/config.hpp>
+
+#include <cstdint>
+#include <memory>
+
+#include <sys/mman.h>
+
+MONAD_NAMESPACE_BEGIN
+
+// Links against the global object in libmonad_execution_ethereum; remains
+// uninitialized if recording is disabled
+extern std::unique_ptr<ExecutionEventRecorder> g_exec_event_recorder;
+
+MONAD_NAMESPACE_END
+
+MONAD_TEST_NAMESPACE_BEGIN
+
+void find_execution_events(
+    monad_event_ring const *event_ring, monad_event_iterator *iter,
+    ExecutionEvents *exec_events)
+{
+    monad_event_descriptor event;
+
+ConsumeMore:
+    ASSERT_EQ(monad_event_iterator_try_next(iter, &event), MONAD_EVENT_SUCCESS);
+    ASSERT_NE(event.event_type, MONAD_EXEC_EVM_ERROR);
+    ASSERT_TRUE(monad_event_ring_payload_check(event_ring, &event));
+    void const *const payload =
+        monad_event_ring_payload_peek(event_ring, &event);
+
+    switch (event.event_type) {
+    case MONAD_EXEC_BLOCK_START:
+        ASSERT_FALSE(exec_events->block_start);
+        exec_events->block_start = {
+            event,
+            reinterpret_cast<monad_exec_block_start const *>(payload),
+            event_ring};
+        break;
+
+    case MONAD_EXEC_BLOCK_END:
+        ASSERT_FALSE(exec_events->block_end);
+        exec_events->block_end = {
+            event,
+            reinterpret_cast<monad_exec_block_end const *>(payload),
+            event_ring};
+        return;
+
+    case MONAD_EXEC_BLOCK_REJECT:
+        ASSERT_FALSE(exec_events->block_reject_code);
+        exec_events->block_reject_code = {
+            event,
+            reinterpret_cast<monad_exec_block_reject const *>(payload),
+            event_ring};
+        return;
+
+    case MONAD_EXEC_TXN_REJECT:
+        ASSERT_FALSE(exec_events->txn_reject_code);
+        exec_events->txn_reject_code = {
+            event,
+            reinterpret_cast<monad_exec_txn_reject const *>(payload),
+            event_ring};
+        return;
+
+    case MONAD_EXEC_TXN_HEADER_START:
+        exec_events->txn_inputs.emplace_back(
+            event,
+            reinterpret_cast<monad_exec_txn_header_start const *>(payload),
+            event_ring);
+        break;
+
+    case MONAD_EXEC_TXN_EVM_OUTPUT:
+        exec_events->txn_evm_outputs.emplace_back(
+            event,
+            reinterpret_cast<monad_exec_txn_evm_output const *>(payload),
+            event_ring);
+        break;
+    }
+
+    // Look for more events until we find the end of the block (either
+    // BLOCK_END or one of the other terminating events, e.g. BLOCK_REJECT)
+    goto ConsumeMore;
+}
+
+void init_exec_event_recorder()
+{
+    constexpr uint8_t DESCRIPTORS_SHIFT = 20;
+    constexpr uint8_t PAYLOAD_BUF_SHIFT = 28; // 256 MiB
+    constexpr char MEMFD_NAME[] = "memfd:exec_event_test";
+
+    int ring_fd [[gnu::cleanup(cleanup_close)]] = memfd_create(MEMFD_NAME, 0);
+    MONAD_ASSERT(ring_fd != -1);
+
+    // We're the exclusive owner; initialize the event ring file
+    monad_event_ring_simple_config const simple_cfg = {
+        .descriptors_shift = DESCRIPTORS_SHIFT,
+        .payload_buf_shift = PAYLOAD_BUF_SHIFT,
+        .context_large_pages = 0,
+        .content_type = MONAD_EVENT_CONTENT_TYPE_EXEC,
+        .schema_hash = g_monad_exec_event_schema_hash};
+    int rc = monad_event_ring_init_simple(&simple_cfg, ring_fd, 0, MEMFD_NAME);
+    MONAD_ASSERT_PRINTF(
+        rc == 0,
+        "event library error -- %s",
+        monad_event_ring_get_last_error());
+
+    // mmap the event ring into this process' address space
+    monad_event_ring exec_ring;
+    rc = monad_event_ring_mmap(
+        &exec_ring,
+        PROT_READ | PROT_WRITE,
+        MAP_POPULATE,
+        ring_fd,
+        0,
+        MEMFD_NAME);
+    MONAD_ASSERT_PRINTF(
+        rc == 0,
+        "event library error -- %s",
+        monad_event_ring_get_last_error());
+
+    // Create the execution recorder object
+    g_exec_event_recorder = std::make_unique<ExecutionEventRecorder>(
+        ring_fd, MEMFD_NAME, exec_ring);
+}
+
+MONAD_TEST_NAMESPACE_END

--- a/test/ethereum_test/src/main.cpp
+++ b/test/ethereum_test/src/main.cpp
@@ -20,6 +20,8 @@
 
 #include <blockchain_test.hpp>
 #include <ethereum_test.hpp>
+#include <event.hpp>
+#include <monad/test/config.hpp>
 #include <transaction_test.hpp>
 
 #include <evmc/evmc.h>
@@ -52,6 +54,7 @@ int main(int argc, char *argv[])
     std::optional<evmc_revision> revision = std::nullopt;
     std::optional<size_t> txn_index = std::nullopt;
     bool trace_calls = false;
+    bool record_exec_events = false;
 
     CLI::App app{"monad ethereum tests runner"};
     app.add_option("--log_level", log_level, "Logging level")
@@ -61,6 +64,8 @@ int main(int argc, char *argv[])
             CLI::CheckedTransformer(test::revision_map, CLI::ignore_case));
     app.add_option("--txn", txn_index, "Index of transaction to run");
     app.add_flag("--trace_calls", trace_calls, "Enable call tracing");
+    app.add_flag(
+        "--record-exec-events", record_exec_events, "Record execution events");
     CLI11_PARSE(app, argc, argv);
 
     quill::start(true);


### PR DESCRIPTION
This will record execution events when `--record-exec-event is passed`, and will do some basic checking of the contents. There is a lot that is not tested by this, since the Ethereum tests we run don't appear to cover execution outputs like logs.

For correctness, we still rely on the full system CVT test in Rust, but this should catch basic recording problems.