### PR TITLE
[staking]: Increase unit bias and disallow dust delegators

### DIFF
--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -39,6 +39,7 @@ inline constexpr uint256_t MIN_VALIDATE_STAKE{1'000'000 * MON};
 inline constexpr uint256_t ACTIVE_VALIDATOR_STAKE{50'000'000 * MON};
 inline constexpr uint256_t UNIT_BIAS{
     1000000000000000000000000000000000000_u256}; // 1e36
+inline constexpr uint256_t DUST_THRESHOLD{1000000000}; // 1e9
 
 inline constexpr Address STAKING_CA{0x1000};
 inline constexpr uint64_t ACTIVE_VALSET_SIZE{200};

--- a/category/execution/monad/staking/util/staking_error.cpp
+++ b/category/execution/monad/staking/util/staking_error.cpp
@@ -66,6 +66,7 @@ quick_status_code_from_enum<monad::staking::StakingError>::value_mappings()
         {StakingError::RequiresAuthAddress, "requires auth address", {}},
         {StakingError::CommissionTooHigh, "commission too high", {}},
         {StakingError::ValueNonZero, "value is nonzero", {}},
+        {StakingError::DelegationTooSmall, "delegation is too small", {}},
     };
 
     return v;

--- a/category/execution/monad/staking/util/staking_error.hpp
+++ b/category/execution/monad/staking/util/staking_error.hpp
@@ -56,6 +56,7 @@ enum class StakingError
     RequiresAuthAddress,
     CommissionTooHigh,
     ValueNonZero,
+    DelegationTooSmall,
 };
 
 MONAD_STAKING_NAMESPACE_END


### PR DESCRIPTION
[staking]: Increase unit bias to 1e36. Note that the accumulator slightly underestimates the "true" amount of rewards. There is a rounding error every time there is a division. For example, 3 people get 10 wei rewards equally. So each would get 3.3333... wei, but fixed point maths means we are truncating these subwei decimal places. Increasing the unit bias means less wei is lost each division.

Higher precision reduces rounding errors and reduces the amount of dust in the contract

[staking]: Disallow dust delegators
    
A new constant is added called `DUST_THRESHOLD`. This is set to 1 MON.
All delegations must be greater than the dust threshold. Should a
delegator have less in his balance than the dust threshold after
undelegating, the dust is sent to him automatically as part of that
delegation.
    
Tests added:
  * dust hunter: Searches for the minimum amount of active stake that produces nonzero rewards for a delegator. It is asserted that the dust threshold is greater than this value.
   * delegate: Delegations under the dust threshold are rejected.
   * undelegate: Dust left after an undelegation is included in the withdrawal.
