### PR TITLE
Add UntypedIR

### DIFF
--- a/category/vm/compiler/CMakeLists.txt
+++ b/category/vm/compiler/CMakeLists.txt
@@ -41,6 +41,9 @@ target_sources(monad-vm-compiler PRIVATE
     "ir/poly_typed/subst_map.hpp"
     "ir/poly_typed/unify.cpp"
     "ir/poly_typed/unify.hpp"
+    # untyped ir
+    "ir/untyped.hpp"
+    "ir/untyped.cpp"
     # x86 backend
     "ir/x86.hpp"
     "ir/x86.cpp"

--- a/category/vm/compiler/ir/untyped.cpp
+++ b/category/vm/compiler/ir/untyped.cpp
@@ -1,0 +1,466 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/compiler/ir/basic_blocks.hpp>
+#include <category/vm/compiler/ir/local_stacks.hpp>
+#include <category/vm/compiler/ir/poly_typed.hpp>
+#include <category/vm/compiler/ir/poly_typed/block.hpp>
+#include <category/vm/compiler/ir/poly_typed/kind.hpp>
+#include <category/vm/compiler/ir/untyped.hpp>
+#include <category/vm/compiler/types.hpp>
+#include <category/vm/core/assert.h>
+#include <category/vm/core/cases.hpp>
+
+#include <cstddef>
+#include <format>
+#include <limits>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+using namespace monad::vm::compiler;
+
+using monad::vm::Cases;
+
+namespace monad::vm::compiler::untyped
+{
+    UntypedIR::UntypedIR(poly_typed::PolyTypedIR &&ir)
+        : codesize{ir.codesize}
+        , jumpdests{std::move(ir.jumpdests)}
+        , blocks{build_untyped(jumpdests, std::move(ir.blocks))}
+    {
+    }
+
+    struct Ignored
+    {
+    };
+
+    std::variant<Addr, Word, Ignored> expected_jumpdest_type(
+        std::vector<poly_typed::Kind> const &dest_block_kind,
+        std::vector<poly_typed::Kind> const &output_stack_kind, size_t i)
+    {
+        if (i >= output_stack_kind.size()) {
+            return Ignored{};
+        }
+        if (std::holds_alternative<poly_typed::Cont>(*output_stack_kind[i])) {
+            if (i < dest_block_kind.size()) {
+                MONAD_VM_ASSERT(
+                    std::holds_alternative<poly_typed::Cont>(
+                        *dest_block_kind[i]) ||
+                    std::holds_alternative<poly_typed::KindVar>(
+                        *dest_block_kind[i]));
+            }
+            return Addr{};
+        }
+        else if (std::holds_alternative<poly_typed::WordCont>(
+                     *output_stack_kind[i])) {
+            if (i < dest_block_kind.size() &&
+                std::holds_alternative<poly_typed::Cont>(*dest_block_kind[i])) {
+                return Addr{};
+            }
+            else {
+                return Word{};
+            }
+        }
+        else {
+            if (i < dest_block_kind.size()) {
+                MONAD_VM_ASSERT(!std::holds_alternative<poly_typed::Cont>(
+                    *dest_block_kind[i]));
+                MONAD_VM_ASSERT(!std::holds_alternative<poly_typed::WordCont>(
+                    *dest_block_kind[i]));
+            }
+
+            return Ignored{};
+        }
+    }
+
+    std::vector<poly_typed::Value> pad_output_stack(
+        std::vector<poly_typed::Kind> const &output_stack_kind,
+        std::span<poly_typed::Value> output_stack, size_t min_params)
+    {
+        auto stack = std::vector<poly_typed::Value>(
+            output_stack.begin(), output_stack.end());
+        // We need to pad out the output stack in case the inferred output type
+        // refers to output stack items past the min_params number actually used
+        // by the block.
+        if (output_stack.size() < output_stack_kind.size()) {
+            for (size_t i = 0, param = min_params;
+                 i < output_stack_kind.size() - output_stack.size();
+                 ++i, ++param) {
+                stack.emplace_back(poly_typed::ValueIs::PARAM_ID, param);
+            }
+        }
+        return stack;
+    }
+
+    std::variant<Addr, Word> current_type(
+        std::vector<poly_typed::Kind> const &input_stack_kind,
+        std::vector<poly_typed::Value> const &output_stack, size_t i)
+    {
+        switch (output_stack[i].is) {
+        case poly_typed::ValueIs::LITERAL:
+            return Word{};
+        case poly_typed::ValueIs::PARAM_ID: {
+            MONAD_VM_ASSERT(output_stack[i].param < input_stack_kind.size());
+            poly_typed::Kind const &kind =
+                input_stack_kind[output_stack[i].param];
+
+            if (std::holds_alternative<poly_typed::Cont>(*kind)) {
+                return Addr{};
+            }
+            else {
+                return Word{};
+            }
+        }
+        default:
+            return Word{};
+        }
+    }
+
+    std::vector<size_t> collect_coercions(
+        std::vector<poly_typed::Kind> const &input_stack_kind,
+        std::vector<poly_typed::Kind> const &dest_block_kind,
+        std::vector<poly_typed::Kind> const &output_stack_kind,
+        std::vector<poly_typed::Value> const &output_stack)
+    {
+        std::vector<size_t> coersions;
+        for (size_t i = 0; i < output_stack_kind.size(); i++) {
+            auto current = current_type(input_stack_kind, output_stack, i);
+            auto expected =
+                expected_jumpdest_type(dest_block_kind, output_stack_kind, i);
+            if (!std::holds_alternative<Ignored>(expected)) {
+                if (std::holds_alternative<Word>(current) &&
+                    std::holds_alternative<Addr>(expected)) {
+                    coersions.push_back(i);
+                }
+                else if (
+                    std::holds_alternative<Addr>(current) &&
+                    std::holds_alternative<Word>(expected)) {
+                    MONAD_VM_ASSERT(false);
+                }
+                // current == Addr, jumpdest_type_may == Addr - nothing to do
+                // current == Word, jumpdest_type_may == Word - nothing to do
+            }
+        }
+        return coersions;
+    }
+
+    std::variant<std::vector<Block>, std::vector<local_stacks::Block>>
+    build_untyped(
+        std::unordered_map<byte_offset, block_id> const &jumpdests,
+        std::vector<poly_typed::Block> &&typed_blocks)
+    {
+        auto const &pre_cont = typed_blocks.front().kind;
+        if (!(pre_cont->front.size() == 0 &&
+              std::holds_alternative<poly_typed::ContVar>(pre_cont->tail))) {
+            std::vector<local_stacks::Block> untyped_blocks;
+            untyped_blocks.reserve(typed_blocks.size());
+            for (auto &tb : typed_blocks) {
+                block_id fallthrough_dest = INVALID_BLOCK_ID;
+                basic_blocks::Terminator terminator;
+                std::visit<void>(
+                    Cases{
+                        [&](poly_typed::JumpI const &t) {
+                            terminator = basic_blocks::Terminator::JumpI;
+                            fallthrough_dest = t.fallthrough_dest;
+                        },
+                        [&](poly_typed::Jump const &) {
+                            terminator = basic_blocks::Terminator::Jump;
+                        },
+                        [&](poly_typed::FallThrough const &t) {
+                            terminator = basic_blocks::Terminator::FallThrough;
+                            fallthrough_dest = t.fallthrough_dest;
+                        },
+                        [&](poly_typed::Return const &) {
+                            terminator = basic_blocks::Terminator::Return;
+                        },
+                        [&](poly_typed::Revert const &) {
+                            terminator = basic_blocks::Terminator::Revert;
+                        },
+                        [&](poly_typed::SelfDestruct const &) {
+                            terminator = basic_blocks::Terminator::SelfDestruct;
+                        },
+                        [&](poly_typed::Stop const &) {
+                            terminator = basic_blocks::Terminator::Stop;
+                        },
+                        [&](poly_typed::InvalidInstruction const &) {
+                            terminator =
+                                basic_blocks::Terminator::InvalidInstruction;
+                        },
+                    },
+                    tb.terminator);
+
+                untyped_blocks.push_back(
+                    {tb.min_params,
+                     std::move(tb.output),
+                     std::move(tb.instrs),
+                     terminator,
+                     fallthrough_dest,
+                     tb.offset});
+            }
+            return untyped_blocks;
+        }
+
+        std::vector<Block> blocks;
+        blocks.reserve(typed_blocks.size());
+
+        for (auto &tb : typed_blocks) {
+            if (std::holds_alternative<poly_typed::ContWords>(tb.kind->tail)) {
+                // If the inferred kind is Word... -> Exit
+                // this block cannot be reachable from the entry-point
+                // and can thus be marked as dead code
+                blocks.push_back({tb.offset, tb.min_params, {}, DeadCode{}});
+                continue;
+            }
+
+            Terminator t;
+            if (std::holds_alternative<poly_typed::Return>(tb.terminator)) {
+                t = Terminator{std::get<poly_typed::Return>(tb.terminator)};
+            }
+            else if (std::holds_alternative<poly_typed::Stop>(tb.terminator)) {
+                t = Terminator{std::get<poly_typed::Stop>(tb.terminator)};
+            }
+            else if (std::holds_alternative<poly_typed::Revert>(
+                         tb.terminator)) {
+                t = Terminator{std::get<poly_typed::Revert>(tb.terminator)};
+            }
+            else if (std::holds_alternative<poly_typed::SelfDestruct>(
+                         tb.terminator)) {
+                t = Terminator{
+                    std::get<poly_typed::SelfDestruct>(tb.terminator)};
+            }
+            else if (std::holds_alternative<poly_typed::InvalidInstruction>(
+                         tb.terminator)) {
+                t = Terminator{
+                    std::get<poly_typed::InvalidInstruction>(tb.terminator)};
+            }
+            else if (std::holds_alternative<poly_typed::FallThrough>(
+                         tb.terminator)) {
+                poly_typed::FallThrough const &fallthrough =
+                    std::get<poly_typed::FallThrough>(tb.terminator);
+
+                auto padded_output_stack = pad_output_stack(
+                    fallthrough.fallthrough_kind->front,
+                    tb.output,
+                    tb.min_params);
+
+                auto coerce_to_addr = collect_coercions(
+                    tb.kind->front,
+                    typed_blocks[fallthrough.fallthrough_dest].kind->front,
+                    fallthrough.fallthrough_kind->front,
+                    padded_output_stack);
+
+                t = FallThrough{coerce_to_addr, fallthrough.fallthrough_dest};
+            }
+            else {
+                MONAD_VM_ASSERT(tb.output.size() > 0);
+                auto &jump_dest_value = tb.output.front();
+                std::optional<poly_typed::ContKind> jump_dest_kind;
+                JumpDest jump_dest;
+
+                switch (jump_dest_value.is) {
+                case poly_typed::ValueIs::COMPUTED: {
+                    MONAD_VM_ASSERT(false);
+                }
+                case poly_typed::ValueIs::PARAM_ID: {
+                    MONAD_VM_ASSERT(
+                        jump_dest_value.param < tb.kind->front.size());
+                    poly_typed::Kind const &kind =
+                        tb.kind->front[jump_dest_value.param];
+                    if (std::holds_alternative<poly_typed::Cont>(*kind)) {
+                        jump_dest_kind = std::get<poly_typed::Cont>(*kind).cont;
+                        jump_dest = Addr{};
+                    }
+                    else if (std::holds_alternative<poly_typed::WordCont>(
+                                 *kind)) {
+                        jump_dest_kind =
+                            std::get<poly_typed::WordCont>(*kind).cont;
+                        jump_dest = Word{};
+                    }
+                    else {
+                        // If the block kind is not Word... -> Exit
+                        // then the jump dest can only be a Cont or a
+                        // WordCont
+                        MONAD_VM_ASSERT(false);
+                    }
+                    break;
+                }
+                default: {
+                    if (jump_dest_value.literal >
+                        std::numeric_limits<size_t>::max()) {
+                        jump_dest = Invalid{};
+                        jump_dest_kind = std::nullopt;
+                    }
+                    else {
+                        if (auto block_offset_id = jumpdests.find(
+                                static_cast<size_t>(jump_dest_value.literal));
+                            block_offset_id != jumpdests.end()) {
+                            jump_dest = block_offset_id->second;
+                            MONAD_VM_ASSERT(
+                                block_offset_id->second < typed_blocks.size());
+                            jump_dest_kind =
+                                typed_blocks[block_offset_id->second].kind;
+                        }
+                        else {
+                            jump_dest = Invalid{};
+                            jump_dest_kind = std::nullopt;
+                        }
+                    }
+                }
+                }
+
+                if (std::holds_alternative<poly_typed::Jump>(tb.terminator)) {
+                    poly_typed::Jump const &jump =
+                        std::get<poly_typed::Jump>(tb.terminator);
+                    std::span<poly_typed::Value> const output_tail(
+                        tb.output.data() + 1, tb.output.size() - 1);
+                    auto padded_output_stack = pad_output_stack(
+                        jump.jump_kind->front, output_tail, tb.min_params);
+                    auto coerce_to_addr = jump_dest_kind
+                                              ? collect_coercions(
+                                                    tb.kind->front,
+                                                    (*jump_dest_kind)->front,
+                                                    jump.jump_kind->front,
+                                                    padded_output_stack)
+                                              : std::vector<size_t>{};
+
+                    t = Jump{coerce_to_addr, jump_dest};
+                }
+                else {
+                    poly_typed::JumpI const &jumpi =
+                        std::get<poly_typed::JumpI>(tb.terminator);
+                    std::span<poly_typed::Value> const output_tail(
+                        tb.output.data() + 2, tb.output.size() - 2);
+                    auto padded_output_stack = pad_output_stack(
+                        jumpi.jump_kind->front, output_tail, tb.min_params);
+                    auto coerce_to_addr = jump_dest_kind
+                                              ? collect_coercions(
+                                                    tb.kind->front,
+                                                    (*jump_dest_kind)->front,
+                                                    jumpi.jump_kind->front,
+                                                    padded_output_stack)
+                                              : std::vector<size_t>{};
+                    MONAD_VM_ASSERT(
+                        jumpi.fallthrough_dest < typed_blocks.size());
+
+                    auto padded_output_stack_fallthrough = pad_output_stack(
+                        jumpi.fallthrough_kind->front,
+                        output_tail,
+                        tb.min_params);
+                    auto fallthrough_coerce_to_addr = collect_coercions(
+                        tb.kind->front,
+                        typed_blocks[jumpi.fallthrough_dest].kind->front,
+                        jumpi.fallthrough_kind->front,
+                        padded_output_stack_fallthrough);
+
+                    t = JumpI{
+                        coerce_to_addr,
+                        jump_dest,
+                        fallthrough_coerce_to_addr,
+                        jumpi.fallthrough_dest};
+                }
+            }
+
+            blocks.push_back(
+                {tb.offset, tb.min_params, std::move(tb.instrs), t});
+        }
+
+        return blocks;
+    }
+
+}
+
+std::format_context::iterator std::formatter<untyped::UntypedIR>::format(
+    untyped::UntypedIR const &ir, std::format_context &ctx) const
+{
+    if (std::holds_alternative<std::vector<untyped::Block>>(ir.blocks)) {
+        auto const &blocks = std::get<std::vector<untyped::Block>>(ir.blocks);
+        for (auto const &b : blocks) {
+            std::format_to(ctx.out(), "0x{:x}:\n", b.offset);
+            if (ir.jumpdests.contains(b.offset)) {
+                std::format_to(ctx.out(), "  JUMPDEST\n", b.offset);
+            }
+            for (auto const &ins : b.instrs) {
+                std::format_to(ctx.out(), "  {}\n", ins);
+            }
+            std::format_to(ctx.out(), "\n");
+            std::visit<void>(
+                Cases{
+                    [&](untyped::JumpI const &t) {
+                        std::format_to(
+                            ctx.out(),
+                            "  JUMPI {} BLOCK_{}\n",
+                            t.jump_dest,
+                            t.fallthrough_dest);
+                        std::format_to(ctx.out(), "  coerce to addr if:");
+                        for (auto const &v : t.coerce_to_addr) {
+                            std::format_to(ctx.out(), " {}", v);
+                        }
+                        std::format_to(ctx.out(), "\n  coerce to addr else :");
+                        for (auto const &v : t.fallthrough_coerce_to_addr) {
+                            std::format_to(ctx.out(), " {}", v);
+                        }
+                        std::format_to(ctx.out(), "\n");
+                    },
+                    [&](untyped::Jump const &t) {
+                        std::format_to(ctx.out(), "  JUMP {}\n", t.jump_dest);
+                        std::format_to(ctx.out(), "  coerce to addr:");
+                        for (auto const &v : t.coerce_to_addr) {
+                            std::format_to(ctx.out(), " {}", v);
+                        }
+                        std::format_to(ctx.out(), "\n");
+                    },
+                    [&](untyped::FallThrough const &t) {
+                        std::format_to(
+                            ctx.out(),
+                            "  FALLTHROUGH 0x{}\n",
+                            t.fallthrough_dest);
+                        std::format_to(ctx.out(), "  coerce to addr:");
+                        for (auto const &v : t.fallthrough_coerce_to_addr) {
+                            std::format_to(ctx.out(), " {}", v);
+                        }
+                        std::format_to(ctx.out(), "\n");
+                    },
+                    [&](poly_typed::Return const &) {
+                        std::format_to(ctx.out(), "  RETURN\n");
+                    },
+                    [&](poly_typed::Revert const &) {
+                        std::format_to(ctx.out(), "  REVERT\n");
+                    },
+                    [&](poly_typed::SelfDestruct const &) {
+                        std::format_to(ctx.out(), "  SELFDESTRUCT\n");
+                    },
+                    [&](poly_typed::Stop const &) {
+                        std::format_to(ctx.out(), "  STOP\n");
+                    },
+                    [&](poly_typed::InvalidInstruction const &) {
+                        std::format_to(ctx.out(), "  INVALIDINSTRUCTION\n");
+                    },
+                    [&](untyped::DeadCode const &) {
+                        std::format_to(ctx.out(), "  DEAD CODE\n");
+                    },
+                },
+                b.terminator);
+        }
+    }
+    else {
+        std::format_to(ctx.out(), "Invalid type\n");
+    }
+
+    return ctx.out();
+}

--- a/category/vm/compiler/ir/untyped.hpp
+++ b/category/vm/compiler/ir/untyped.hpp
@@ -1,0 +1,134 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/compiler/ir/poly_typed.hpp>
+#include <category/vm/compiler/ir/poly_typed/block.hpp>
+#include <category/vm/interpreter/intercode.hpp>
+
+namespace monad::vm::compiler::untyped
+{
+
+    struct Word
+    {
+    };
+
+    struct Addr
+    {
+    };
+
+    struct Invalid
+    {
+    };
+
+    using JumpDest = std::variant<block_id, Word, Addr, Invalid>;
+
+    struct FallThrough
+    {
+        std::vector<size_t> fallthrough_coerce_to_addr;
+        block_id fallthrough_dest;
+    };
+
+    struct JumpI
+    {
+        std::vector<size_t> coerce_to_addr;
+        JumpDest jump_dest;
+        std::vector<size_t> fallthrough_coerce_to_addr;
+        block_id fallthrough_dest;
+    };
+
+    struct Jump
+    {
+        std::vector<size_t> coerce_to_addr;
+        JumpDest jump_dest;
+    };
+
+    struct DeadCode
+    {
+    };
+
+    using Terminator = std::variant<
+        FallThrough, JumpI, Jump, poly_typed::Return, poly_typed::Stop,
+        poly_typed::Revert, poly_typed::SelfDestruct,
+        poly_typed::InvalidInstruction, DeadCode>;
+
+    struct Block
+    {
+        byte_offset offset;
+        size_t min_params;
+        std::vector<Instruction> instrs;
+        Terminator terminator;
+    };
+
+    struct UntypedIR
+    {
+        explicit UntypedIR(poly_typed::PolyTypedIR &&ir);
+
+        interpreter::code_size_t codesize;
+        std::unordered_map<byte_offset, block_id> jumpdests;
+        std::variant<std::vector<Block>, std::vector<local_stacks::Block>>
+            blocks;
+    };
+
+    std::variant<std::vector<Block>, std::vector<local_stacks::Block>>
+    build_untyped(
+        std::unordered_map<byte_offset, block_id> const &jumpdests,
+        std::vector<poly_typed::Block> &&typed_blocks);
+
+}
+
+template <>
+struct std::formatter<monad::vm::compiler::untyped::UntypedIR>
+{
+    constexpr auto parse(std::format_parse_context &ctx)
+    {
+        return ctx.begin();
+    }
+
+    std::format_context::iterator format(
+        monad::vm::compiler::untyped::UntypedIR const &ir,
+        std::format_context &ctx) const;
+};
+
+template <>
+struct std::formatter<monad::vm::compiler::untyped::JumpDest>
+{
+    constexpr auto parse(std::format_parse_context &ctx)
+    {
+        return ctx.begin();
+    }
+
+    auto format(
+        monad::vm::compiler::untyped::JumpDest const &jd,
+        std::format_context &ctx) const
+    {
+        using monad::vm::Cases;
+        using namespace monad::vm::compiler::untyped;
+
+        std::visit<void>(
+            Cases{
+                [&](Word const &) { std::format_to(ctx.out(), "WORD"); },
+                [&](Addr const &) { std::format_to(ctx.out(), "ADDR"); },
+                [&](Invalid const &) { std::format_to(ctx.out(), "INVALID"); },
+                [&](monad::vm::compiler::block_id id) {
+                    std::format_to(ctx.out(), "BLOCK_{}", id);
+                },
+            },
+            jd);
+
+        return ctx.out();
+    }
+};

--- a/test/vm/unit/CMakeLists.txt
+++ b/test/vm/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(vm-unit-tests PRIVATE
     unify_tests.cpp
     infer_tests.cpp
     type_check_tests.cpp
+    untyped_tests.cpp
     stack_tests.cpp
     emitter_tests.cpp
     interpreter_tests.cpp

--- a/test/vm/unit/untyped_tests.cpp
+++ b/test/vm/unit/untyped_tests.cpp
@@ -1,0 +1,268 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/compiler/ir/basic_blocks.hpp>
+#include <category/vm/compiler/ir/local_stacks.hpp>
+#include <category/vm/compiler/ir/poly_typed.hpp>
+#include <category/vm/compiler/ir/untyped.hpp>
+
+#include <category/vm/evm/opcodes.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+using namespace monad::vm::compiler;
+using namespace monad::vm::compiler::untyped;
+
+TEST(untyped, test_invalid)
+{
+    auto ir = poly_typed::PolyTypedIR(local_stacks::LocalStacksIR(
+        basic_blocks::BasicBlocksIR::unsafe_from({ADD})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_FALSE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+}
+
+TEST(untyped, dead_code)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {PUSH0, STOP, JUMPDEST, PUSH0, SLOAD, JUMP})));
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 2);
+    ASSERT_TRUE(std::holds_alternative<DeadCode>(blocks[1].terminator));
+}
+
+TEST(untyped, unsupported_sload_jump)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {JUMPDEST, PUSH0, SLOAD, JUMP})));
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_FALSE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+}
+
+TEST(untyped, test_computed_literal_jump)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {PUSH1, 5, PUSH1, 1, ADD, JUMP, JUMPDEST, STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 2);
+    ASSERT_TRUE(std::holds_alternative<Jump>(blocks[0].terminator));
+
+    auto const &jump = std::get<Jump>(blocks[0].terminator);
+    ASSERT_TRUE(std::holds_alternative<block_id>(jump.jump_dest));
+}
+
+TEST(untyped, test_jumpi_word_cont)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {JUMPDEST, PUSH1, 0xc,    PUSH0, PUSH1,    0xe,      JUMPI,
+             JUMPDEST, PUSH1, 0x12,   SWAP1, JUMP,     JUMPDEST, JUMP,
+             JUMPDEST, PUSH0, SSTORE, STOP,  JUMPDEST, STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 5);
+    ASSERT_TRUE(std::holds_alternative<JumpI>(blocks[0].terminator));
+
+    // in the fallthrough case, we coerce the evm word to address
+    // as it will be jumped to.
+    // but in the if case, the address will be SSTOREd, so it should not
+    // be coerced
+    auto const &jumpi = std::get<JumpI>(blocks[0].terminator);
+    ASSERT_EQ(jumpi.coerce_to_addr.size(), 0);
+    ASSERT_EQ(jumpi.fallthrough_coerce_to_addr.size(), 1);
+    ASSERT_EQ(jumpi.fallthrough_coerce_to_addr[0], 0);
+}
+
+TEST(untyped, test_jump_coerce_multiple)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {JUMPDEST, PUSH1, 0xe,      DUP1,  PUSH1,  0x9,   PUSH1,
+             0xe,      JUMP,  JUMPDEST, PUSH1, 0x10,   SWAP1, JUMP,
+             JUMPDEST, JUMP,  JUMPDEST, PUSH0, SSTORE, STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 4);
+    ASSERT_TRUE(std::holds_alternative<Jump>(blocks[0].terminator));
+
+    auto const &jump = std::get<Jump>(blocks[0].terminator);
+    ASSERT_EQ(jump.coerce_to_addr.size(), 2);
+    ASSERT_EQ(jump.coerce_to_addr[0], 0);
+    ASSERT_EQ(jump.coerce_to_addr[1], 1);
+}
+
+TEST(untyped, test_jump_word)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {JUMPDEST,
+             PUSH1,
+             0xb,
+             PUSH1,
+             0x6,
+             JUMP,
+             JUMPDEST,
+             DUP1,
+             DUP1,
+             SSTORE,
+             JUMP,
+             JUMPDEST,
+             STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<Jump>(blocks[1].terminator));
+
+    auto const &jump = std::get<Jump>(blocks[1].terminator);
+    // because the top of the stack value passed into this block
+    // is used both as a jump destination and as
+    // an EVM word for sstore, it must be an EVM word and cannot be
+    // cast to an address until the JUMP
+    ASSERT_TRUE(std::holds_alternative<Word>(jump.jump_dest));
+}
+
+TEST(untyped, test_jump_addr)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {// 0x0:
+             JUMPDEST,
+             PUSH1,
+             0xf,
+             PUSH1,
+             0x6,
+             JUMP,
+
+             // 0x6 : (Word : s0 -> Exit),s0 -> Exit
+             JUMPDEST,
+             DUP1,
+             PUSH1,
+             0xb,
+             JUMP, // : Word,(s0 -> Exit),s0 -> Exit <- we must coerce here
+                   // because the duplicated input changed from a WordCont to
+                   // Cont, due to the jump to 0xb
+
+             // 0xb : Word,(s0 -> Exit),s0 -> Exit
+             JUMPDEST,
+             DUP1,
+             SSTORE,
+             JUMP,
+
+             // 0xf: s0 -> Exit
+             JUMPDEST,
+             STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 4);
+    ASSERT_TRUE(std::holds_alternative<Jump>(blocks[1].terminator));
+
+    auto const &jump = std::get<Jump>(blocks[1].terminator);
+    ASSERT_EQ(jump.coerce_to_addr.size(), 1);
+    ASSERT_EQ(jump.coerce_to_addr[0], 1);
+
+    ASSERT_TRUE(std::holds_alternative<Jump>(blocks[2].terminator));
+
+    auto const &jump2 = std::get<Jump>(blocks[2].terminator);
+    ASSERT_TRUE(std::holds_alternative<Addr>(jump2.jump_dest));
+}
+
+TEST(untyped, dead_cont_words)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {STOP,
+             JUMPDEST, // this block has type Word... -> Exit, hence we mark it
+                       // as dead code because the entry-point has a valid type
+                       // of s0 -> Exit
+             DUP1,
+             DUP1,
+             SSTORE,
+             DUP1,
+             DUP1,
+             JUMPI,
+             JUMP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<DeadCode>(blocks[1].terminator));
+}
+
+TEST(untyped, pad_output_stack)
+{
+    auto ir = poly_typed::PolyTypedIR(
+        local_stacks::LocalStacksIR(basic_blocks::BasicBlocksIR::unsafe_from(
+            {PUSH1,
+             0xf,
+             PUSH1,
+             0xf,
+             PUSH1,
+             0x7,
+             JUMP,
+
+             // 0x7 : Word,(Word : s1 -> Exit),s1 -> Exit
+             JUMPDEST,
+             PUSH1,
+             0xb,
+             JUMP, // here the output stack is only a single value, but the
+                   // output stack type is Word,(Word : s1 -> Exit),s1 -> Exit,
+                   // hence we need to pad out theoutput stack to 0xb, %p0, %p1
+
+             // 0xb : Word,(Word : s0 -> Exit),s0 -> Exit
+             JUMPDEST,
+             DUP2,
+             SSTORE,
+             JUMP,
+
+             // 0xf : s0 -> Exit
+             JUMPDEST,
+             STOP})));
+
+    auto blocks_may = build_untyped(ir.jumpdests, std::move(ir.blocks));
+    ASSERT_TRUE(
+        std::holds_alternative<std::vector<untyped::Block>>(blocks_may));
+    auto const &blocks = std::get<std::vector<untyped::Block>>(blocks_may);
+    ASSERT_EQ(blocks.size(), 4);
+}


### PR DESCRIPTION
The purpose of this IR is to aid generating code that takes advantage of statically known JUMP/JUMPI destinations via constant propagation. 
Another optimisation which this IR enables is storing block labels/addresses on the stack. This allows jumping to another block by directly loading an x86 address from the top of the stack and jumping to it, as opposed to doign a lookup in the jump table (that is, if the `JumpDest` is an `Addr{}`).
Further, the vector of coerce stack offsets should allow us to emit code to convert any EVM words which are know to be continuations/pointers into machine addresses when it is safe to do so, i.e. when the type from PolyTypedIR guarantees that the given stack element will only ever be used as an address via JUMP/JUMPI.