### PR TITLE
fix out of bound writes to vector in `read_multiple_buffer_sender::operator()`

### DIFF
--- a/category/async/io_senders.hpp
+++ b/category/async/io_senders.hpp
@@ -210,7 +210,8 @@ public:
                 std::vector<struct iovec> temp;
                 temp.reserve(buffers_.size());
                 for (size_t n = 0; n < buffers_.size(); n++) {
-                    temp[n] = {(char *)buffers_[n].data(), buffers_[n].size()};
+                    temp.push_back(
+                        {(char *)buffers_[n].data(), buffers_[n].size()});
                 }
                 iovecs_ = std::move(temp);
                 auto &v = std::get<1>(iovecs_);


### PR DESCRIPTION
this is not active code path so the bug never manifests. We will do a clean up later.