### PR TITLE
Gather compile-time instruction inputs/outputs

### DIFF
--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -309,31 +309,56 @@ namespace
     }
 
     [[gnu::always_inline]]
-    inline void
-    post_instruction_emit(Emitter &emit, CompilerConfig const &config)
+    inline void pre_instruction_emit(
+        Emitter &emit, CompilerConfig const &config, size_t block_id,
+        size_t instr_index, Instruction const &instr)
     {
         (void)emit;
         (void)config;
+        (void)block_id;
+        (void)instr_index;
+        (void)instr;
+#ifdef MONAD_COMPILER_TESTING
+        if (config.pre_instruction_emit_hook) {
+            config.pre_instruction_emit_hook(
+                emit, block_id, instr_index, instr);
+        }
+#endif
+    }
+
+    [[gnu::always_inline]]
+    inline void post_instruction_emit(
+        Emitter &emit, CompilerConfig const &config, size_t block_id,
+        size_t instr_index, Instruction const &instr)
+    {
+        (void)emit;
+        (void)config;
+        (void)block_id;
+        (void)instr_index;
+        (void)instr;
 #ifdef MONAD_COMPILER_TESTING
         if (config.post_instruction_emit_hook) {
-            config.post_instruction_emit_hook(emit);
+            config.post_instruction_emit_hook(
+                emit, block_id, instr_index, instr);
         }
 #endif
     }
 
     template <Traits traits>
     void emit_instrs(
-        Emitter &emit, Block const &block, int64_t instr_gas,
+        Emitter &emit, size_t block_id, Block const &block, int64_t instr_gas,
         native_code_size_t max_native_size, CompilerConfig const &config)
     {
         int64_t remaining_base_gas = instr_gas;
-        for (auto const &instr : block.instrs) {
+        for (size_t i = 0; i < block.instrs.size(); ++i) {
+            auto const &instr = block.instrs[i];
             MONAD_VM_DEBUG_ASSERT(
                 remaining_base_gas >= instr.static_gas_cost());
+            pre_instruction_emit(emit, config, block_id, i, instr);
             remaining_base_gas -= instr.static_gas_cost();
             emit_instr<traits>(emit, instr, remaining_base_gas);
             require_code_size_in_bound(emit, max_native_size);
-            post_instruction_emit(emit, config);
+            post_instruction_emit(emit, config, block_id, i, instr);
         }
     }
 
@@ -435,13 +460,14 @@ namespace monad::vm::compiler::native
         }
         native_code_size_t const max_native_size =
             max_code_size(config.max_code_size_offset, ir.codesize);
-        for (Block const &block : ir.blocks()) {
+        for (size_t block_id = 0; block_id < ir.blocks().size(); ++block_id) {
+            Block const &block = ir.blocks()[block_id];
             bool const can_enter_block = emit.begin_new_block(block);
             if (can_enter_block) {
                 int64_t const base_gas = block_base_gas<traits>(block);
                 emit_gas_decrement(emit, ir, block, base_gas);
                 emit_instrs<traits>(
-                    emit, block, base_gas, max_native_size, config);
+                    emit, block_id, block, base_gas, max_native_size, config);
                 emit_terminator<traits>(emit, ir, block);
             }
             require_code_size_in_bound(emit, max_native_size);

--- a/category/vm/compiler/ir/x86/types.hpp
+++ b/category/vm/compiler/ir/x86/types.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <category/vm/compiler/ir/basic_blocks.hpp>
+#include <category/vm/compiler/ir/instruction.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 #include <category/vm/runtime/bin.hpp>
 #include <category/vm/runtime/runtime.hpp>
@@ -130,7 +132,10 @@ namespace monad::vm::compiler::native
 
     class Emitter;
 
-    using EmitterHook = std::function<void(Emitter &)>;
+    using PreEmitterHook =
+        std::function<void(Emitter &, size_t, size_t, Instruction const &)>;
+    using PostEmitterHook =
+        std::function<void(Emitter &, size_t, size_t, Instruction const &)>;
 
     struct CompilerConfig
     {
@@ -138,6 +143,7 @@ namespace monad::vm::compiler::native
         bool runtime_debug_trace{};
         interpreter::code_size_t max_code_size_offset =
             monad::vm::runtime::bin<10 * 1024>;
-        EmitterHook post_instruction_emit_hook{};
+        PreEmitterHook pre_instruction_emit_hook{};
+        PostEmitterHook post_instruction_emit_hook{};
     };
 }

--- a/category/vm/compiler/ir/x86/virtual_stack.cpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.cpp
@@ -101,6 +101,12 @@ namespace monad::vm::compiler::native
                    : *stack_indices_.begin();
     }
 
+    bool StackElem::is_deferred_comparison() const
+    {
+        return stack_.deferred_comparison_.stack_elem == this ||
+               stack_.deferred_comparison_.negated_stack_elem == this;
+    }
+
     void StackElem::deferred_comparison(Comparison c)
     {
         MONAD_VM_ASSERT(stack_.deferred_comparison_.stack_elem == nullptr);

--- a/cmd/vm/mce/mce.cpp
+++ b/cmd/vm/mce/mce.cpp
@@ -18,6 +18,7 @@
 #include <instrumentable_parser.hpp>
 #include <instrumentable_vm.hpp>
 #include <instrumentation_device.hpp>
+#include <operands_logger.hpp>
 #include <stopwatch.hpp>
 
 #include <category/core/runtime/uint256.hpp>
@@ -61,6 +62,8 @@ struct arguments
     bool instrument_parse = false;
     bool instrument_compile = false;
     bool instrument_execute = false;
+    bool instrument_compile_operands = false;
+    bool compile_only = false;
     std::optional<std::string> asm_log_file;
     bool wall_clock_time = false;
     bool report_result = false;
@@ -96,6 +99,16 @@ static arguments parse_args(int const argc, char **const argv)
         args.instrument_execute,
         std::format(
             "Instrument execution (default: {})", args.instrument_execute));
+    app.add_flag(
+        "-o",
+        args.instrument_compile_operands,
+        std::format(
+            "Instrument compilation of operands (default: {})",
+            args.instrument_compile_operands));
+    app.add_flag(
+        "--compile-only",
+        args.compile_only,
+        "Parse bytecode and compile only, skip execution");
     app.add_option(
         "--dump-asm", args.asm_log_file, "Dump assembly output to file");
     app.add_flag(
@@ -211,8 +224,17 @@ int mce_main(arguments const &args)
 
     asmjit::JitRuntime rt{};
     native::CompilerConfig config{};
+    OperandsLoggerState operands_logger_state(ir->blocks().size());
+
     if (args.asm_log_file) {
         config.asm_log_path = args.asm_log_file->c_str();
+    }
+    if (args.instrument_compile_operands) {
+        // This will log the operands of each instruction
+        std::tie(
+            config.pre_instruction_emit_hook,
+            config.post_instruction_emit_hook) =
+            operands_logger_make_hooks(operands_logger_state);
     }
     std::shared_ptr<native::Nativecode> const ncode = [&]() {
         if (args.instrument_compile) {
@@ -230,22 +252,32 @@ int mce_main(arguments const &args)
         return 1;
     }
 
-    evmc::Result const result = [&]() {
-        if (args.instrument_execute) {
-            InstrumentableVM<true> vm(rt);
-            return vm.execute<traits>(ncode->entrypoint(), device);
-        }
-        else {
-            InstrumentableVM<false> vm(rt);
-            return vm.execute<traits>(ncode->entrypoint(), device);
-        }
-    }();
+    if (args.instrument_compile_operands) {
+        std::cout << operands_logger_state.to_json(ir.value()).dump()
+                  << std::endl;
+    }
 
-    dump_result(args, result);
+    if (!args.compile_only) {
+        evmc::Result const result = [&]() {
+            if (args.instrument_execute) {
+                InstrumentableVM<true> vm(rt);
+                return vm.execute<traits>(ncode->entrypoint(), device);
+            }
+            else {
+                InstrumentableVM<false> vm(rt);
+                return vm.execute<traits>(ncode->entrypoint(), device);
+            }
+        }();
 
-    auto status_code = result.status_code;
+        dump_result(args, result);
 
-    return status_code == EVMC_SUCCESS ? 0 : 1;
+        auto status_code = result.status_code;
+
+        return status_code == EVMC_SUCCESS ? 0 : 1;
+    }
+    else {
+        return 0;
+    }
 }
 
 static std::string uppercase(std::string s)

--- a/cmd/vm/mce/scripts/compile-smart-contracts.sh
+++ b/cmd/vm/mce/scripts/compile-smart-contracts.sh
@@ -1,0 +1,55 @@
+#! /bin/sh
+#
+# compile-smart-contracts.sh: Gather statistics on the compilation of smart
+#                             contracts in directory using mce's -o option.
+# Usage: compile-smart-contracts.sh <directory>
+
+set -e -u
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <directory> <output_dir>"
+  exit 1
+fi
+
+log() {
+  printf "%s\n" "$1" 2>&1
+}
+
+DIR="$1"
+OUT_DIR="$2"
+N=64 # Number of parallel mce processes to run
+
+# Count number of non-empty files to process
+N_FILES=0
+for file in "$DIR"/*; do
+  # Skip if file is empty
+  if [ ! -s "$file" ]; then
+    continue
+  fi
+  N_FILES=$((N_FILES + 1))
+done
+
+go() {
+  HEX_FILE="$OUT_DIR/$(basename "$file").hex"
+  JSON_FILE="$OUT_DIR/$(basename "$file").json"
+  xxd -c 0 -ps "$file" > "$HEX_FILE"
+  ./build/cmd/vm/mce/mce --compile-only -o "$HEX_FILE" > "$JSON_FILE"
+}
+
+# Process files
+ix=0
+for file in "$DIR"/*; do
+  # Skip if file is empty
+  if [ ! -s "$file" ]; then
+    log "Skipping empty file: $file"
+    continue
+  else
+    : $((ix = ix + 1))
+    log "Processing file: $file ($ix/$N_FILES)"
+  fi
+
+  go "$file" &
+
+  # If we've started N tasks, wait for them to finish
+  [ $((ix % N)) -eq 0 ] && wait
+done

--- a/cmd/vm/mce/src/operands_logger.hpp
+++ b/cmd/vm/mce/src/operands_logger.hpp
@@ -114,17 +114,19 @@ namespace
                 auto const &block_metadata = blocks_metadata[i];
                 nlohmann::json block_json;
                 block_json["instructions"] = nlohmann::json::array();
-                block_json["is_jump_dest"] = ir.jump_dests().contains(block.offset);
+                block_json["is_jump_dest"] =
+                    ir.jump_dests().contains(block.offset);
                 block_json["offset"] = block.offset;
-                block_json["terminator"] =
-                    std::format("{}", block.terminator);
+                block_json["terminator"] = std::format("{}", block.terminator);
                 size_t start_contract_code_size = contract_code_size;
 
                 if (block.fallthrough_dest != INVALID_BLOCK_ID) {
                     block_json["fallthrough_dest"] = block.fallthrough_dest;
                 }
 
-                for (auto const &[instr, opnds, outputs, before_size, after_size] : block_metadata) {
+                for (auto const
+                         &[instr, opnds, outputs, before_size, after_size] :
+                     block_metadata) {
                     nlohmann::json instr_json;
                     auto opcode = instr.opcode();
                     instr_json["opcode"] = opcode;
@@ -143,7 +145,8 @@ namespace
                     block_json["instructions"].push_back(instr_json);
                     contract_code_size = after_size;
                 }
-                block_json["code_size"] = contract_code_size - start_contract_code_size;
+                block_json["code_size"] =
+                    contract_code_size - start_contract_code_size;
                 basic_blocks.push_back(block_json);
             }
             nlohmann::json contract_json;
@@ -173,45 +176,51 @@ namespace
 
     auto operands_logger_make_hooks(OperandsLoggerState &state)
     {
-        auto pre_hook =
-            [&state](auto &emitter, auto block_ix, auto instr_ix, auto &instr) {
-                (void)instr_ix; // Avoid unused variable warning
+        auto pre_hook = [&state](
+                            auto &emitter,
+                            auto block_ix,
+                            auto instr_ix,
+                            auto &instr) {
+            (void)instr_ix; // Avoid unused variable warning
 
-                std::optional<std::vector<OperandLocations>> instr_args =
-                    peek_stack(emitter, instr.stack_args());
+            std::optional<std::vector<OperandLocations>> instr_args =
+                peek_stack(emitter, instr.stack_args());
 
-                if (!instr_args) {
-                    std::cerr << "Error: peek_stack returned nullopt. "
-                                 "instr.stack_args() = "
-                              << instr.stack_args()
-                              << ", emit.get_stack().top_index() = "
-                              << emitter.get_stack().top_index() << std::endl;
-                }
-                else {
-                    state.blocks_metadata[block_ix].push_back(
-                        InstructionMetadata{instr, instr_args.value(), {}, emitter.estimate_size(), 0});
-                }
-            };
+            if (!instr_args) {
+                std::cerr << "Error: peek_stack returned nullopt. "
+                             "instr.stack_args() = "
+                          << instr.stack_args()
+                          << ", emit.get_stack().top_index() = "
+                          << emitter.get_stack().top_index() << std::endl;
+            }
+            else {
+                state.blocks_metadata[block_ix].push_back(InstructionMetadata{
+                    instr, instr_args.value(), {}, emitter.estimate_size(), 0});
+            }
+        };
 
-        auto post_hook =
-            [&state](auto &emitter, auto block_ix, auto instr_ix, auto &instr) {
-                std::optional<std::vector<OperandLocations>> instr_results =
-                    peek_stack(emitter, instr.stack_increase());
+        auto post_hook = [&state](
+                             auto &emitter,
+                             auto block_ix,
+                             auto instr_ix,
+                             auto &instr) {
+            std::optional<std::vector<OperandLocations>> instr_results =
+                peek_stack(emitter, instr.stack_increase());
 
-                if (!instr_results) {
-                    std::cerr << "Error: peek_stack returned nullopt. "
-                                 "instr.stack_increase() = "
-                              << instr.stack_increase()
-                              << ", emit.get_stack().top_index() = "
-                              << emitter.get_stack().top_index() << std::endl;
-                }
-                else {
-                    state.blocks_metadata[block_ix][instr_ix].result_locations =
-                        instr_results.value();
-                    state.blocks_metadata[block_ix][instr_ix].contract_size_after =
-                        emitter.estimate_size();
-                }
-            };
+            if (!instr_results) {
+                std::cerr << "Error: peek_stack returned nullopt. "
+                             "instr.stack_increase() = "
+                          << instr.stack_increase()
+                          << ", emit.get_stack().top_index() = "
+                          << emitter.get_stack().top_index() << std::endl;
+            }
+            else {
+                state.blocks_metadata[block_ix][instr_ix].result_locations =
+                    instr_results.value();
+                state.blocks_metadata[block_ix][instr_ix].contract_size_after =
+                    emitter.estimate_size();
+            }
+        };
         return std::tuple{pre_hook, post_hook};
     }
 }

--- a/cmd/vm/mce/src/operands_logger.hpp
+++ b/cmd/vm/mce/src/operands_logger.hpp
@@ -1,0 +1,202 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/runtime/uint256.hpp>
+#include <category/vm/compiler/ir/basic_blocks.hpp>
+#include <category/vm/compiler/ir/x86/emitter.hpp>
+
+#include <nlohmann/json.hpp>
+
+using namespace monad::vm;
+
+namespace
+{
+    using OperandLocations = compiler::native::OperandLocations;
+
+    struct InstructionMetadata
+    {
+        Instruction instruction;
+        std::vector<OperandLocations> operand_locations;
+        std::vector<OperandLocations> result_locations;
+    };
+
+    struct OperandsLoggerState
+    {
+        // Reference to the original IR so we can map instructions back to their
+        // original locations.
+        // basic_blocks::BasicBlocksIR const &ir;
+        // Metadata accumulated as the instructions are compiled.
+        std::vector<std::vector<InstructionMetadata>> blocks_metadata;
+
+        OperandsLoggerState(size_t blocks_count)
+            : blocks_metadata(blocks_count)
+        {
+        }
+
+        // Output JSON format
+        //
+        // type Obj = [Block]
+        //
+        // type Block = {
+        //   instructions: [Instruction]
+        //   offset: number,
+        //   terminator: "JumpI" | "Return" | "Revert" | "Jump" | "SelfDestruct"
+        //                       | "Stop" | "FallThrough" | "InvalidInstruction"
+        //   fallthrough_dest: number?
+        // }
+        //
+        // type OpCode = uint8
+        //
+        // type Instruction = {
+        //   opcode: OpCode,
+        //   immediate?: string,  // For push instructions
+        //   index?: number,      // For push, swap, dup and log instructions
+        //   opcode_name: string, // Name of the opcode
+        //   operands: [Operand],
+        //   outputs: [Operand]
+        // }
+        //
+        // type Operand = {
+        //   literal: string?,
+        //   general_reg: number?,
+        //   avx_reg: number?,
+        //   stack_offset: number?,
+        //   deferred_comparison: boolean?
+        // }
+        nlohmann::json to_json(std::vector<OperandLocations> locations)
+        {
+            auto obj = nlohmann::json::array();
+            for (auto const &opnd : locations) {
+                nlohmann::json opnd_json;
+                if (opnd.literal) {
+                    opnd_json["literal"] =
+                        std::format("{}", opnd.literal->value);
+                }
+                if (opnd.general_reg) {
+                    opnd_json["general_reg"] = opnd.general_reg->reg;
+                }
+                if (opnd.avx_reg) {
+                    opnd_json["avx_reg"] = opnd.avx_reg->reg;
+                }
+                if (opnd.stack_offset) {
+                    opnd_json["stack_offset"] = opnd.stack_offset->offset;
+                }
+                if (opnd.is_deferred_comparison) {
+                    opnd_json["deferred_comparison"] = true;
+                }
+                obj.push_back(opnd_json);
+            }
+            return obj;
+        }
+
+        nlohmann::json to_json(basic_blocks::BasicBlocksIR const &ir)
+        {
+            auto blocks = ir.blocks();
+            nlohmann::json object = nlohmann::json::array();
+
+            for (size_t i = 0; i < blocks_metadata.size(); ++i) {
+                auto const &block_metadata = blocks_metadata[i];
+                nlohmann::json block_json;
+                block_json["instructions"] = nlohmann::json::array();
+                block_json["offset"] = blocks[i].offset;
+                block_json["terminator"] =
+                    std::format("{}", blocks[i].terminator);
+
+                if (blocks[i].fallthrough_dest != INVALID_BLOCK_ID) {
+                    block_json["fallthrough_dest"] = blocks[i].fallthrough_dest;
+                }
+
+                for (auto const &[instr, opnds, outputs] : block_metadata) {
+                    nlohmann::json instr_json;
+                    auto opcode = instr.opcode();
+                    instr_json["opcode"] = opcode;
+                    if (opcode == OpCode::Push) {
+                        instr_json["immediate"] =
+                            std::format("{}", instr.immediate_value());
+                    }
+                    if (opcode == OpCode::Push || opcode == OpCode::Swap ||
+                        opcode == OpCode::Dup || opcode == OpCode::Log) {
+                        instr_json["index"] = instr.index();
+                    }
+                    instr_json["opcode_name"] = opcode_name(opcode);
+                    instr_json["operands"] = to_json(opnds);
+                    instr_json["outputs"] = to_json(outputs);
+                    block_json["instructions"].push_back(instr_json);
+                }
+                object.push_back(block_json);
+            }
+            return object;
+        }
+    };
+
+    std::optional<std::vector<OperandLocations>>
+    peek_stack(compiler::native::Emitter &emit, uint8_t length)
+    {
+        // Stack underflow check
+        if (emit.get_stack().top_index() - emit.get_stack().bottom_index() <
+            length) {
+            return std::nullopt;
+        }
+        std::vector<OperandLocations> elems;
+        elems.reserve(length);
+        for (size_t i = 0; i < length; ++i) {
+            elems.push_back(emit.get_stack().get_stack_elem_locations(
+                emit.get_stack().top_index() - static_cast<int32_t>(i)));
+        }
+        return elems;
+    }
+
+    auto operands_logger_make_hooks(OperandsLoggerState &state)
+    {
+        auto pre_hook =
+            [&state](auto &emitter, auto block_ix, auto instr_ix, auto &instr) {
+                (void)instr_ix; // Avoid unused variable warning
+
+                std::optional<std::vector<OperandLocations>> instr_args =
+                    peek_stack(emitter, instr.stack_args());
+
+                if (!instr_args) {
+                    std::cerr << "Error: peek_stack returned nullopt. "
+                                 "instr.stack_args() = "
+                              << instr.stack_args()
+                              << ", emit.get_stack().top_index() = "
+                              << emitter.get_stack().top_index() << std::endl;
+                }
+                else {
+                    state.blocks_metadata[block_ix].push_back(
+                        InstructionMetadata{instr, instr_args.value(), {}});
+                }
+            };
+
+        auto post_hook =
+            [&state](auto &emitter, auto block_ix, auto instr_ix, auto &instr) {
+                std::optional<std::vector<OperandLocations>> instr_results =
+                    peek_stack(emitter, instr.stack_increase());
+
+                if (!instr_results) {
+                    std::cerr << "Error: peek_stack returned nullopt. "
+                                 "instr.stack_increase() = "
+                              << instr.stack_increase()
+                              << ", emit.get_stack().top_index() = "
+                              << emitter.get_stack().top_index() << std::endl;
+                }
+                else {
+                    state.blocks_metadata[block_ix][instr_ix].result_locations =
+                        instr_results.value();
+                }
+            };
+        return std::tuple{pre_hook, post_hook};
+    }
+}

--- a/test/vm/fuzzer/compiler_hook.hpp
+++ b/test/vm/fuzzer/compiler_hook.hpp
@@ -63,7 +63,14 @@ namespace monad::vm::fuzzing
                 artificial_avx_prob,
                 artificial_general_prob,
                 artificial_top2_prob,
-                &engine](vm::compiler::native::Emitter &emit) {
+                &engine](
+                   vm::compiler::native::Emitter &emit,
+                   auto block_id,
+                   auto instr_ix,
+                   auto instr) {
+            (void)block_id;
+            (void)instr_ix;
+            (void)instr; // Unused
             using monad::vm::compiler::native::GENERAL_REG_COUNT;
             using monad::vm::compiler::native::GeneralReg;
 

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -481,13 +481,15 @@ static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
 {
     using enum BlockchainTestVM::Implementation;
 
-    monad::vm::compiler::native::EmitterHook hook = nullptr;
+    monad::vm::compiler::native::PreEmitterHook pre_hook = nullptr;
+    monad::vm::compiler::native::PostEmitterHook post_hook = nullptr;
 
     if (args.implementation == Compiler) {
-        hook = compiler_emit_hook(engine);
+        post_hook = compiler_emit_hook(engine);
     }
 
-    return evmc::VM(new BlockchainTestVM(args.implementation, hook));
+    return evmc::VM(
+        new BlockchainTestVM(args.implementation, pre_hook, post_hook));
 }
 
 // Coin toss, biased whenever p != 0.5

--- a/test/vm/vm/test_vm.cpp
+++ b/test/vm/vm/test_vm.cpp
@@ -107,13 +107,15 @@ namespace
 }
 
 BlockchainTestVM::BlockchainTestVM(
-    Implementation impl, native::EmitterHook post_hook)
+    Implementation impl, native::PreEmitterHook pre_hook,
+    native::PostEmitterHook post_hook)
     : evmc_vm{EVMC_ABI_VERSION, "monad-compiler-blockchain-test-vm", "0.0.0", ::destroy, ::execute, ::get_capabilities, nullptr}
     , impl_{impl_from_env(impl)}
     , debug_dir_{std::getenv("MONAD_COMPILER_ASM_DIR")}
     , base_config{
           .runtime_debug_trace = is_compiler_runtime_debug_trace_enabled(),
           .max_code_size_offset = code_size_t::max(),
+          .pre_instruction_emit_hook = pre_hook,
           .post_instruction_emit_hook = post_hook}
 {
     MONAD_VM_ASSERT(!debug_dir_ || fs::is_directory(debug_dir_));

--- a/test/vm/vm/test_vm.hpp
+++ b/test/vm/vm/test_vm.hpp
@@ -56,8 +56,10 @@ public:
 
     BlockchainTestVM(
         Implementation impl,
-        monad::vm::compiler::native::EmitterHook post_instruction_emit_hook =
-            nullptr);
+        monad::vm::compiler::native::PreEmitterHook pre_instruction_emit_hook =
+            nullptr,
+        monad::vm::compiler::native::PostEmitterHook
+            post_instruction_emit_hook = nullptr);
 
     evmc::Result execute(
         evmc_host_interface const *host, evmc_host_context *context,


### PR DESCRIPTION
## Context

I've been using these changes for some time to gather the inputs and outputs of instructions during the compilation of smart contracts. It looks at the virtual stack based on the number of arguments (`Instruction::stack_args`) and outputs (`Instruction::stack_increase`), and writes the result to a json file. The json file is then consumed by a python script that converts the data in whatever format we need (csv/sql for now) that I intend to create a separate PR for.

~"nice-to-have" that could be added:~
- ~Identify basic blocks that are jump destinations (could be used to check if `jumpi_keep_fallthrough_stack` is used)~ Done
- ~Keep track of native code size, and maybe of compiled instruction code size?~ Done