### PR TITLE
Enhance exec events recording during tests

### DIFF
--- a/test/ethereum_test/include/event.hpp
+++ b/test/ethereum_test/include/event.hpp
@@ -18,6 +18,7 @@
 
 #include <monad/test/config.hpp>
 
+#include <string>
 #include <vector>
 
 MONAD_TEST_NAMESPACE_BEGIN
@@ -61,6 +62,6 @@ struct ExecutionEvents
 void find_execution_events(
     monad_event_ring const *, monad_event_iterator *, ExecutionEvents *);
 
-void init_exec_event_recorder();
+void init_exec_event_recorder(std::string event_ring_path);
 
 MONAD_TEST_NAMESPACE_END


### PR DESCRIPTION
This commit does a few things:

 - The call to the initialization function somehow got lost in a rebase and the recording tests never ran at all; this was fixed

 - If the user passes a file name after the --record-exec-events, it will create the event ring file with `open(<filename>, O_CREAT | O_EXCL)` instead of the default, which creates an anonymous memfd_create(2) descriptor

 - The CLI also gains a --sleep option, to put the process to sleep for a specified number of seconds after the event ring is created but before the tests are run

The purpose of the two latter enhancements is to give the user time to run an eventcap process, to capture all the execution events that are written by the tests. For example, this was used to capture the output of the all the EIP-7702 tests, to ensure they're recorded correctly.

Terminal 1:

```shell
test/ethereum_test/monad-ethereum-test --fork prague --gtest_filter=\*7702\* \
      --trace_calls --record-exec-events /tmp/test-ring --sleep 10
```

Terminal 2:

```shell
cmd/eventcap snap -r /tmp/test-ring -o- | zstd -19 > /tmp/snapshot-7702.zst
```