### PR TITLE
Store delegated code inline in `Account`

### DIFF
--- a/category/core/bytes.hpp
+++ b/category/core/bytes.hpp
@@ -59,6 +59,11 @@ constexpr bytes32_t to_bytes(byte_string_view const data) noexcept
     return byte;
 }
 
+constexpr byte_string to_byte_string(bytes32_t const &n) noexcept
+{
+    return {n.bytes, sizeof(n.bytes)};
+}
+
 using namespace evmc::literals;
 inline constexpr bytes32_t NULL_HASH{
     0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32};

--- a/category/execution/ethereum/core/fmt/account_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/account_fmt.hpp
@@ -36,12 +36,12 @@ struct fmt::formatter<monad::Account> : public monad::BasicFormatter
             ctx.out(),
             "Account{{"
             "balance={}, "
-            "code_hash={}, "
+            "code_or_hash={}, "
             "nonce={}, "
             "incarnation={}"
             "}}",
             a.balance,
-            a.code_hash,
+            monad::to_bytes(a.code_view()),
             a.nonce,
             a.incarnation);
         return ctx.out();

--- a/category/execution/ethereum/core/rlp/account_rlp.cpp
+++ b/category/execution/ethereum/core/rlp/account_rlp.cpp
@@ -40,7 +40,7 @@ encode_account(Account const &account, bytes32_t const &storage_root)
         encode_unsigned(account.nonce),
         encode_unsigned(account.balance),
         encode_bytes32(storage_root),
-        encode_bytes32(account.code_hash));
+        encode_bytes32(account.get_code_hash()));
 }
 
 Result<Account> decode_account(bytes32_t &storage_root, byte_string_view &enc)
@@ -51,7 +51,7 @@ Result<Account> decode_account(bytes32_t &storage_root, byte_string_view &enc)
     BOOST_OUTCOME_TRY(acct.nonce, decode_unsigned<uint64_t>(payload));
     BOOST_OUTCOME_TRY(acct.balance, decode_unsigned<uint256_t>(payload));
     BOOST_OUTCOME_TRY(storage_root, decode_bytes32(payload));
-    BOOST_OUTCOME_TRY(acct.code_hash, decode_bytes32(payload));
+    BOOST_OUTCOME_TRY(acct.code_or_hash, decode_bytes32(payload));
 
     if (MONAD_UNLIKELY(!payload.empty())) {
         return DecodeError::InputTooLong;

--- a/category/execution/ethereum/core/test/test_account_rlp.cpp
+++ b/category/execution/ethereum/core/test/test_account_rlp.cpp
@@ -36,7 +36,7 @@ TEST(Rlp_Account, Encode)
         0xbea34dd04b09ad3b6014251ee24578074087ee60fda8c391cf466dfe5d687d7b_bytes32};
     static constexpr bytes32_t code_hash{
         0x6b8cebdc2590b486457bbb286e96011bdd50ccc1d8580c1ffb3c89e828462283_bytes32};
-    Account const a{.balance = b, .code_hash = code_hash};
+    Account const a{.balance = b, .code_or_hash = code_hash};
     byte_string const rlp_account{
         0xf8, 0x48, 0x80, 0x84, 0x01, 0x6e, 0x36, 0x00, 0xa0, 0xbe, 0xa3,
         0x4d, 0xd0, 0x4b, 0x09, 0xad, 0x3b, 0x60, 0x14, 0x25, 0x1e, 0xe2,
@@ -57,5 +57,5 @@ TEST(Rlp_Account, Encode)
 
     EXPECT_EQ(storage_root, decoded_storage_root);
     EXPECT_EQ(a.balance, decoded_account.value().balance);
-    EXPECT_EQ(a.code_hash, decoded_account.value().code_hash);
+    EXPECT_EQ(a.code_or_hash, decoded_account.value().code_or_hash);
 }

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -283,7 +283,7 @@ TYPED_TEST(DBTest, read_storage)
 
 TYPED_TEST(DBTest, read_code)
 {
-    Account acct_a{.balance = 1, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account acct_a{.balance = 1, .code_or_hash = A_CODE_HASH, .nonce = 1};
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
@@ -294,7 +294,7 @@ TYPED_TEST(DBTest, read_code)
     auto const a_icode = tdb.read_code(A_CODE_HASH);
     EXPECT_EQ(byte_string_view(a_icode->code(), a_icode->size()), A_CODE);
 
-    Account acct_b{.balance = 0, .code_hash = B_CODE_HASH, .nonce = 1};
+    Account acct_b{.balance = 0, .code_or_hash = B_CODE_HASH, .nonce = 1};
     commit_sequential(
         tdb,
         StateDeltas{{ADDR_B, StateDelta{.account = {std::nullopt, acct_b}}}},
@@ -358,7 +358,8 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
 
 TYPED_TEST(DBTest, ModifyStorageOfAccount)
 {
-    Account acct{.balance = 1'000'000, .code_hash = {}, .nonce = 1337};
+    Account acct{
+        .balance = 1'000'000, .code_or_hash = bytes32_t{}, .nonce = 1337};
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
@@ -404,7 +405,8 @@ TYPED_TEST(DBTest, touch_without_modify_regression)
 
 TYPED_TEST(DBTest, delete_account_modify_storage_regression)
 {
-    Account acct{.balance = 1'000'000, .code_hash = {}, .nonce = 1337};
+    Account acct{
+        .balance = 1'000'000, .code_or_hash = bytes32_t{}, .nonce = 1337};
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
@@ -436,7 +438,8 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
 
 TYPED_TEST(DBTest, storage_deletion)
 {
-    Account acct{.balance = 1'000'000, .code_hash = {}, .nonce = 1337};
+    Account acct{
+        .balance = 1'000'000, .code_or_hash = bytes32_t{}, .nonce = 1337};
 
     TrieDb tdb{this->db};
     commit_sequential(

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -444,11 +444,17 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
                 fmt::format("{}", acct.value().second.balance);
             json[key]["nonce"] =
                 fmt::format("0x{:x}", acct.value().second.nonce);
-
-            auto const icode = db.read_code(acct.value().second.code_hash);
-            MONAD_ASSERT(icode);
-            json[key]["code"] = "0x" + to_hex({icode->code(), icode->size()});
-
+            if (acct.value().second.inline_delegated_code()) {
+                json[key]["code"] =
+                    "0x" + to_hex(acct.value().second.code_view());
+            }
+            else {
+                auto const icode =
+                    db.read_code(acct.value().second.get_code_hash());
+                MONAD_ASSERT(icode);
+                json[key]["code"] =
+                    "0x" + to_hex({icode->code(), icode->size()});
+            }
             if (!json[key].contains("storage")) {
                 json[key]["storage"] = nlohmann::json::object();
             }

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/monad_exception.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/mpt/db.hpp>

--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -198,7 +198,7 @@ void record_account_events(
     initial_state.nonce = prestate_valid ? prestate_account->nonce : 0;
     initial_state.balance = prestate_valid ? prestate_account->balance : 0;
     initial_state.code_hash =
-        prestate_valid ? prestate_account->code_hash : NULL_HASH;
+        prestate_valid ? prestate_account->get_code_hash() : NULL_HASH;
 
     auto const [modified_balance, is_balance_modified] =
         account_info.get_balance_modification();

--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -326,7 +326,7 @@ evmc::Result execute_call_message(
     }
     else {
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const code = state.read_code(hash);
+        auto const code = state.get_code(msg.code_address);
         result = state.vm().execute<traits>(*host, &msg, hash, code);
     }
 

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -233,7 +233,8 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
                       Account{.balance = 10'000'000'000, .nonce = 7}}}},
             {to,
              StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = code_hash}}}}},
+                 .account =
+                     {std::nullopt, Account{.code_or_hash = code_hash}}}}},
         Code{},
         BlockHeader{});
 
@@ -506,7 +507,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = good_code_hash,
+                          .code_or_hash = good_code_hash,
                       }}}},
             {bad_code_address,
              StateDelta{
@@ -514,7 +515,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = bad_code_hash,
+                          .code_or_hash = bad_code_hash,
                       }}}},
         },
         Code{
@@ -629,7 +630,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = good_code_hash,
+                          .code_or_hash = good_code_hash,
                       }}}},
             {bad_code_address,
              StateDelta{
@@ -637,7 +638,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = bad_code_hash,
+                          .code_or_hash = bad_code_hash,
                       }}}},
         },
         Code{
@@ -836,7 +837,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_validation)
     }
 }
 
-TYPED_TEST(TraitsTest, create_inside_delegated_call)
+TYPED_TEST(TraitsTest, create_inside_delegated_call_old_account_format)
 {
     InMemoryMachine machine;
     mpt::Db db{machine};
@@ -873,7 +874,7 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
+                          .code_or_hash = eoa_code_hash,
                       }}}},
             {from,
              StateDelta{
@@ -888,10 +889,113 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = delegated_code_hash,
+                          .code_or_hash = delegated_code_hash,
                       }}}}},
         Code{
             {eoa_code_hash, eoa_icode},
+            {delegated_code_hash, delegated_icode},
+        },
+        BlockHeader{});
+
+    auto msg_memory = vm.message_memory_ref();
+    evmc_message const m{
+        .kind = EVMC_CALL,
+        .flags = EVMC_DELEGATED,
+        .gas = 1'000'000,
+        .recipient = eoa,
+        .sender = from,
+        .code_address = delegated,
+        .memory_handle = msg_memory.get(),
+        .memory = msg_memory.get(),
+        .memory_capacity = vm.message_memory_capacity(),
+    };
+
+    BlockHashBufferFinalized const block_hash_buffer;
+    NoopCallTracer call_tracer;
+    Transaction tx{};
+    auto const chain_ctx =
+        ChainContext<typename TestFixture::Trait>::debug_empty();
+    uint256_t base_fee{0};
+    EvmcHost<typename TestFixture::Trait> h{
+        call_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
+
+    if constexpr (TestFixture::Trait::evm_rev() >= EVMC_PRAGUE) {
+        auto const result = h.call(m);
+        // CREATE should fail on Monad chains and succeed on Ethereum chains
+        if constexpr (TestFixture::Trait::can_create_inside_delegated()) {
+            static_assert(TestFixture::is_evm_trait());
+            EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        }
+        else {
+            static_assert(TestFixture::is_monad_trait());
+            EXPECT_EQ(result.status_code, EVMC_FAILURE);
+        }
+    }
+}
+
+TYPED_TEST(TraitsTest, create_inside_delegated_call)
+{
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    db_t tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+    State s{bs, Incarnation{0, 0}};
+
+    static constexpr auto eoa{
+        0x00000000000000000000000000000000aaaaaaaa_address};
+
+    static constexpr auto from{
+        0x00000000000000000000000000000000bbbbbbbb_address};
+
+    static constexpr auto delegated{
+        0x00000000000000000000000000000000cccccccc_address};
+
+    uint8_t eoa_code[23] = {0xEF, 0x01, 0x00};
+    std::copy_n(delegated.bytes, 20, &eoa_code[3]);
+    auto const eoa_icode = vm::make_shared_intercode(eoa_code);
+
+    // PUSH0; PUSH0; PUSH0; CREATE
+    auto const delegated_code = from_hex("0x5F5F5FF0").value();
+    auto const delegated_icode = vm::make_shared_intercode(delegated_code);
+    auto const delegated_code_hash = to_bytes(keccak256(delegated_code));
+
+    commit_sequential(
+        tdb,
+        StateDeltas{
+            {eoa,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 10'000'000'000,
+                          .code_or_hash =
+                              byte_string_view{eoa_code, sizeof(eoa_code)},
+                      }}}},
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 10'000'000'000,
+                      }}}},
+            {delegated,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 10'000'000'000,
+                          .code_or_hash = delegated_code_hash,
+                      }}}}},
+        Code{
             {delegated_code_hash, delegated_icode},
         },
         BlockHeader{});
@@ -966,7 +1070,6 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
     uint8_t eoa_code[23] = {0xEF, 0x01, 0x00};
     std::copy_n(delegated.bytes, 20, &eoa_code[3]);
     auto const eoa_icode = vm::make_shared_intercode(eoa_code);
-    auto const eoa_code_hash = to_bytes(keccak256(eoa_code));
 
     // Make a delegatecall to the creator contract, and fail execution if that
     // call failed.
@@ -994,7 +1097,8 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
+                          .code_or_hash =
+                              byte_string_view{eoa_code, sizeof(eoa_code)},
                       }}}},
             {from,
              StateDelta{
@@ -1009,7 +1113,7 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = delegated_code_hash,
+                          .code_or_hash = delegated_code_hash,
                       }}}},
             {creator,
              StateDelta{
@@ -1017,10 +1121,9 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = creator_code_hash,
+                          .code_or_hash = creator_code_hash,
                       }}}}},
         Code{
-            {eoa_code_hash, eoa_icode},
             {delegated_code_hash, delegated_icode},
             {creator_code_hash, creator_icode},
         },
@@ -1094,7 +1197,6 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
     auto const eoa_code =
         from_hex("0xEF01000000000000000000000000000000000000000001").value();
     auto const eoa_icode = vm::make_shared_intercode(eoa_code);
-    auto const eoa_code_hash = to_bytes(keccak256(eoa_code));
 
     // Make a delegatecall to the EOA account with 100 gas, and fail execution
     // if that call failed.
@@ -1117,7 +1219,7 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
+                          .code_or_hash = eoa_code,
                       }}}},
             {from,
              StateDelta{
@@ -1132,10 +1234,9 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = contract_code_hash,
+                          .code_or_hash = contract_code_hash,
                       }}}}},
         Code{
-            {eoa_code_hash, eoa_icode},
             {contract_code_hash, contract_icode},
         },
         BlockHeader{});
@@ -1213,7 +1314,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
                  .account =
                      {std::nullopt,
                       Account{
-                          .code_hash = code_hash,
+                          .code_or_hash = code_hash,
                       }}}}},
         Code{
             {code_hash, icode},
@@ -1334,7 +1435,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = short_code_hash,
+                          .code_or_hash = short_code_hash,
                       }}}},
             {falsely_delegated_2,
              StateDelta{
@@ -1342,7 +1443,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = bad_code_hash2,
+                          .code_or_hash = bad_code_hash2,
                       }}}},
             {falsely_delegated_3,
              StateDelta{
@@ -1350,7 +1451,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = bad_code_hash,
+                          .code_or_hash = bad_code_hash,
                       }}}},
             {correctly_delegated,
              StateDelta{
@@ -1358,7 +1459,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
                      {std::nullopt,
                       Account{
                           .balance = 10'000'000'000,
-                          .code_hash = good_code_hash,
+                          .code_or_hash = good_code_hash,
                       }}}}},
         Code{
             {bad_code_hash, bad_icode},

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -134,7 +134,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
                      {std::nullopt,
                       Account{
                           .balance = 0xffffffffffffffffffffffffffffffff_u128,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {to,
              StateDelta{
@@ -142,12 +142,12 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
                      {std::nullopt,
                       Account{
                           .balance = 0x0fffffffffffff,
-                          .code_hash = STRESS_TEST_CODE_HASH}}}},
+                          .code_or_hash = STRESS_TEST_CODE_HASH}}}},
             {ca,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = NULL_HASH}}}}},
+                      Account{.balance = 0x1b58, .code_or_hash = NULL_HASH}}}}},
         Code{{STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE}},
         BlockHeader{.number = 0});
 
@@ -282,7 +282,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {to,
              StateDelta{
@@ -290,7 +290,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = STRESS_TEST_CODE_HASH}}}}},
+                          .code_or_hash = STRESS_TEST_CODE_HASH}}}}},
         Code{{STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE}},
         BlockHeader{.number = 0});
 
@@ -403,7 +403,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
                      {std::nullopt,
                       Account{
                           .balance = 0x989680,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {to,
              StateDelta{
@@ -411,7 +411,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
                      {std::nullopt,
                       Account{
                           .balance = 0x0,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x01}}}},
             {ca,
              StateDelta{
@@ -419,7 +419,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
                      {std::nullopt,
                       Account{
                           .balance = 0x1b58,
-                          .code_hash = REFUND_TEST_CODE_HASH}},
+                          .code_or_hash = REFUND_TEST_CODE_HASH}},
                  .storage =
                      {{bytes32_t{0x01}, {bytes32_t{}, bytes32_t{0x01}}},
                       {bytes32_t{0x02}, {bytes32_t{}, bytes32_t{0x01}}},

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -196,8 +196,9 @@ void BlockState::merge(State const &state)
         MONAD_ASSERT(stack.version() == 0);
         auto const &account_state = stack.recent();
         auto const &account = account_state.account_;
-        if (account.has_value()) {
-            code_hashes.insert(account.value().code_hash);
+        if (account.has_value() && account.value().code_or_hash.is_hash()) {
+            // Ignore empty and inline code
+            code_hashes.insert(account.value().get_code_hash());
         }
     }
 

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -262,7 +262,7 @@ TEST_F(InMemoryStateTest, get_code_hash)
         StateDeltas{
             {a,
              StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = hash1}}}}},
+                 .account = {std::nullopt, Account{.code_or_hash = hash1}}}}},
         Code{},
         BlockHeader{});
 
@@ -1026,7 +1026,7 @@ TEST_F(InMemoryStateTest, set_storage_modified_restored)
 TEST_F(InMemoryStateTest, get_code_size)
 {
     BlockState bs{this->tdb, this->vm};
-    Account acct{.code_hash = code_hash1};
+    Account acct{.code_or_hash = code_hash1};
     commit_sequential(
         this->tdb,
         StateDeltas{{a, StateDelta{.account = {std::nullopt, acct}}}},
@@ -1040,8 +1040,8 @@ TEST_F(InMemoryStateTest, get_code_size)
 TEST_F(InMemoryStateTest, copy_code)
 {
     BlockState bs{this->tdb, this->vm};
-    Account acct_a{.code_hash = code_hash1};
-    Account acct_b{.code_hash = code_hash2};
+    Account acct_a{.code_or_hash = code_hash1};
+    Account acct_b{.code_or_hash = code_hash2};
 
     commit_sequential(
         this->tdb,
@@ -1100,7 +1100,8 @@ TEST_F(InMemoryStateTest, get_code)
         StateDeltas{
             {a,
              StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = code_hash1}}}}},
+                 .account =
+                     {std::nullopt, Account{.code_or_hash = code_hash1}}}}},
         Code{{code_hash1, vm::make_shared_intercode(contract)}},
         BlockHeader{});
 

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -103,7 +103,7 @@ public:
     [[nodiscard]] bytes32_t get_code_hash() const
     {
         if (MONAD_LIKELY(account_.has_value())) {
-            return account_->code_hash;
+            return account_->get_code_hash();
         }
         return NULL_HASH;
     }
@@ -114,6 +114,11 @@ public:
             return account_->nonce;
         }
         return 0;
+    }
+
+    [[nodiscard]] bool inline_delegated_code() const noexcept
+    {
+        return account_.has_value() && account_->inline_delegated_code();
     }
 
     [[nodiscard]] std::optional<Incarnation> get_incarnation() const

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -31,6 +31,7 @@
 #include <category/execution/ethereum/state3/version_stack.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/vm/code.hpp>
+#include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
@@ -234,7 +235,7 @@ bytes32_t State::get_code_hash(Address const &address)
 {
     auto const &account = recent_account(address);
     if (MONAD_LIKELY(account.has_value())) {
-        return account.value().code_hash;
+        return account.value().get_code_hash();
     }
     return NULL_HASH;
 }
@@ -507,7 +508,12 @@ vm::SharedVarcode State::get_code(Address const &address)
     if (MONAD_UNLIKELY(!account.has_value())) {
         return block_state_.read_code(NULL_HASH);
     }
-    return read_code(account.value().code_hash);
+    if (account.value().inline_delegated_code()) {
+        auto const code = account.value().code_view();
+        MONAD_DEBUG_ASSERT(vm::evm::is_delegated(code));
+        return std::make_shared<vm::Varcode>(vm::make_shared_intercode(code));
+    }
+    return read_code(account.value().get_code_hash());
 }
 
 size_t State::get_code_size(Address const &address)
@@ -516,7 +522,14 @@ size_t State::get_code_size(Address const &address)
     if (MONAD_UNLIKELY(!account.has_value())) {
         return 0;
     }
-    bytes32_t const &code_hash = account.value().code_hash;
+    if (!account.value().has_code()) {
+        return 0;
+    }
+    if (account.value().inline_delegated_code()) {
+        return CodeStorage::DELEGATED_CODE_SIZE;
+    }
+    bytes32_t const &code_hash = account.value().get_code_hash();
+    MONAD_ASSERT(code_hash != NULL_HASH);
     {
         auto const it = code_.find(code_hash);
         if (it != code_.end()) {
@@ -538,7 +551,12 @@ size_t State::copy_code(
     if (MONAD_UNLIKELY(!account.has_value())) {
         return 0;
     }
-    bytes32_t const &code_hash = account.value().code_hash;
+    if (account.value().inline_delegated_code()) {
+        auto const code = account.value().code_view();
+        std::copy_n(code.data(), code.size(), buffer);
+        return CodeStorage::DELEGATED_CODE_SIZE;
+    }
+    bytes32_t const &code_hash = account.value().get_code_hash();
     vm::SharedVarcode vcode{};
     {
         auto const it = code_.find(code_hash);
@@ -566,10 +584,13 @@ void State::set_code(Address const &address, byte_string_view const code)
     if (MONAD_UNLIKELY(!account.has_value())) {
         return;
     }
-
+    if (code.empty() || vm::evm::is_delegated(code)) {
+        account.value().code_or_hash = code;
+        return;
+    }
     auto const code_hash = to_bytes(keccak256(code));
     code_[code_hash] = vm().try_insert_varcode_raw(code_hash, code);
-    account.value().code_hash = code_hash;
+    account.value().code_or_hash = code_hash;
     rb_.on_set_code(address, code);
 }
 
@@ -579,7 +600,7 @@ void State::create_contract(Address const &address)
     if (MONAD_UNLIKELY(account.has_value())) {
         // EIP-684
         MONAD_ASSERT(account->nonce == 0);
-        MONAD_ASSERT(account->code_hash == NULL_HASH);
+        MONAD_ASSERT(account->has_code() == false);
         // keep the balance, per chapter 7 of the YP
         account->incarnation = incarnation_;
     }
@@ -648,7 +669,7 @@ bool State::try_fix_account_mismatch(
     if (is_dead(actual)) {
         return false;
     }
-    if (original->code_hash != actual->code_hash) {
+    if (original->code_or_hash != actual->code_or_hash) {
         return false;
     }
     if (original->incarnation != actual->incarnation) {

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -84,9 +84,9 @@ class State
 public:
     OriginalAccountState &original_account_state(Address const &);
 
-private:
     AccountState const &recent_account_state(Address const &);
 
+private:
     AccountState &current_account_state(Address const &);
 
     std::optional<Account> const &recent_account(Address const &);

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -129,13 +129,13 @@ TYPED_TEST(TraitsTest, execute_success)
                      {std::nullopt,
                       Account{
                           .balance = 0x200000,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {ADDR_B,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                      Account{.balance = 0, .code_or_hash = NULL_HASH}}}}},
         Code{},
         BlockHeader{});
 
@@ -206,13 +206,13 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
                      {std::nullopt,
                       Account{
                           .balance = 0x10000,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {ADDR_B,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                      Account{.balance = 0, .code_or_hash = NULL_HASH}}}}},
         Code{},
         BlockHeader{});
 
@@ -292,7 +292,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = code_hash}}}}},
+                      Account{.balance = 0, .code_or_hash = code_hash}}}}},
         Code{
             {code_hash, icode},
         },
@@ -407,7 +407,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_or_hash = code_hash}}}}},
         Code{
             {code_hash, icode},
         },
@@ -488,7 +488,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_or_hash = code_hash}}}}},
         Code{
             {code_hash, icode},
         },
@@ -757,7 +757,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_or_hash = code_hash}}}}},
         Code{
             {code_hash, icode},
         },
@@ -860,7 +860,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0u, .code_hash = code_hash}}}}},
+                      Account{.balance = 0u, .code_or_hash = code_hash}}}}},
         Code{
             {code_hash, icode},
         },
@@ -995,14 +995,14 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000'000u,
-                          .code_hash = intermediary_code_hash}}}},
+                          .code_or_hash = intermediary_code_hash}}}},
             {SELFDESTRUCT_CONTRACT_ADDR,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000,
-                          .code_hash = selfdestruct_code_hash}}}}}
+                          .code_or_hash = selfdestruct_code_hash}}}}}
 
         ,
         Code{
@@ -1218,7 +1218,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000UL,
-                          .code_hash = selfdestruct_code_hash}}}}}
+                          .code_or_hash = selfdestruct_code_hash}}}}}
 
         ,
         Code{
@@ -1370,7 +1370,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000'000'000UL,
-                          .code_hash = a_code_hash}}}},
+                          .code_or_hash = a_code_hash}}}},
             {ADDR_B,
              StateDelta{.account = {std::nullopt, Account{.balance = 1UL}}}}}
 

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -16,6 +16,8 @@
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/keccak.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/db_snapshot_filesystem.h>
@@ -24,10 +26,11 @@
 #include <category/execution/monad/core/monad_block.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/vm/evm/delegation.hpp>
 
-#include <ankerl/unordered_dense.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <filesystem>
 
 namespace
@@ -60,6 +63,16 @@ TEST(DbBinarySnapshot, Basic)
 
     auto const src_db = tmp_dbname();
 
+    constexpr uint64_t delegated_idx = 88;
+    static constexpr Address delegated_addr{delegated_idx};
+    byte_string const delegated_code = from_hex("0x5F5F5FF0").value();
+    bytes32_t const delegated_code_hash = to_bytes(keccak256(delegated_code));
+    // Accounts with an index that is a multiple of 100 are EOAs with delegation
+    uint8_t eoa_code_data[23] = {0xEF, 0x01, 0x00};
+    std::copy_n(delegated_addr.bytes, 20, &eoa_code_data[3]);
+    byte_string const eoa_code{eoa_code_data, sizeof(eoa_code_data)};
+    ASSERT_TRUE(vm::evm::is_delegated({eoa_code_data, sizeof(eoa_code_data)}));
+
     bytes32_t root_hash;
     Code code_delta;
     BlockHeader last_header;
@@ -74,19 +87,26 @@ TEST(DbBinarySnapshot, Basic)
         StateDeltas deltas;
         for (uint64_t i = 0; i < 100'000; ++i) {
             StorageDeltas storage;
+            Account acct{.balance = i, .nonce = i};
             if ((i % 100) == 0) {
+                acct.code_or_hash = eoa_code;
                 for (uint64_t j = 0; j < 10; ++j) {
                     storage.emplace(
                         bytes32_t{j}, StorageDelta{bytes32_t{}, bytes32_t{j}});
                 }
             }
+            else if (i == delegated_idx) {
+                acct.code_or_hash = delegated_code_hash;
+            }
             deltas.emplace(
                 Address{i},
                 StateDelta{
-                    .account =
-                        {std::nullopt, Account{.balance = i, .nonce = i}},
-                    .storage = storage});
+                    .account = {std::nullopt, acct}, .storage = storage});
         }
+
+        code_delta.emplace(
+            to_bytes(delegated_code_hash),
+            vm::make_shared_intercode(delegated_code));
         for (uint64_t i = 0; i < 1'000; ++i) {
             std::vector<uint64_t> const bytes(100, i);
             byte_string_view const code{
@@ -144,6 +164,18 @@ TEST(DbBinarySnapshot, Basic)
         tdb.set_block_and_prefix(100);
         EXPECT_EQ(tdb.read_eth_header(), last_header);
         EXPECT_EQ(tdb.state_root(), root_hash);
+
+        for (uint64_t i = 100; i < 100'000; i += 100) {
+            auto const acct = tdb.read_account(Address{i});
+            ASSERT_TRUE(acct.has_value());
+            EXPECT_EQ(acct->code_or_hash, eoa_code);
+            EXPECT_TRUE(acct->inline_delegated_code());
+        }
+        auto const acct = tdb.read_account(delegated_addr);
+        ASSERT_TRUE(acct.has_value());
+        EXPECT_EQ(acct->code_or_hash, delegated_code_hash);
+        EXPECT_FALSE(acct->inline_delegated_code());
+
         for (auto const &[hash, icode] : code_delta) {
             auto const from_db = tdb.read_code(hash);
             ASSERT_TRUE(from_db);

--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -286,11 +286,16 @@ namespace trace
         else {
             res["balance"] =
                 std::format("0x{}", intx::to_string(account->balance, 16));
-            if (account->code_hash != NULL_HASH) {
-                auto const icode =
-                    state.read_code(account->code_hash)->intercode();
-                res["code"] = byte_string_to_hex(
-                    byte_string_view(icode->code(), *icode->code_size()));
+            if (account->has_code()) {
+                if (account->inline_delegated_code()) {
+                    res["code"] = byte_string_to_hex(account->code_view());
+                }
+                else {
+                    auto const icode =
+                        state.read_code(account->get_code_hash())->intercode();
+                    res["code"] = byte_string_to_hex(
+                        byte_string_view(icode->code(), *icode->code_size()));
+                }
             }
             // nonce == 0 is not included in the output.
             if (account->nonce != 0) {
@@ -424,14 +429,21 @@ namespace trace
                             "0x{}",
                             intx::to_string(current_account->balance, 16));
                     }
-                    if (original_account->code_hash !=
-                        current_account->code_hash) {
-                        auto const icode =
-                            state.read_code(current_account->code_hash)
-                                ->intercode();
-                        post[address_key]["code"] =
-                            byte_string_to_hex(byte_string_view(
-                                icode->code(), *icode->code_size()));
+                    if (original_account->code_or_hash !=
+                        current_account->code_or_hash) {
+                        if (current_account->inline_delegated_code()) {
+                            post[address_key]["code"] = byte_string_to_hex(
+                                current_account->code_view());
+                        }
+                        else {
+                            auto const icode =
+                                state
+                                    .read_code(current_account->get_code_hash())
+                                    ->intercode();
+                            post[address_key]["code"] =
+                                byte_string_to_hex(byte_string_view(
+                                    icode->code(), *icode->code_size()));
+                        }
                     }
                     // TODO: Geth has begun including code_hash aswell.
                     if (original_account->nonce != current_account->nonce) {

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -73,7 +73,7 @@ namespace
 
 TEST(PrestateTracer, pre_state_to_json)
 {
-    Account const a{.balance = 1000, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account const a{.balance = 1000, .code_or_hash = A_CODE_HASH, .nonce = 1};
     OriginalAccountState as{a};
     as.storage_ = as.storage_.insert({key1, value1});
     as.storage_ = as.storage_.insert({key2, value2});
@@ -119,7 +119,7 @@ TEST(PrestateTracer, pre_state_to_json)
 
 TEST(PrestateTracer, zero_nonce)
 {
-    Account const a{.balance = 1000, .code_hash = NULL_HASH, .nonce = 0};
+    Account const a{.balance = 1000, .code_or_hash = NULL_HASH, .nonce = 0};
     OriginalAccountState as{a};
 
     trace::Map<Address, OriginalAccountState> prestate{};
@@ -151,7 +151,7 @@ TEST(PrestateTracer, zero_nonce)
 
 TEST(PrestateTracer, state_deltas_to_json)
 {
-    Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account a{.balance = 500, .code_or_hash = A_CODE_HASH, .nonce = 1};
 
     InMemoryMachine machine;
     mpt::Db db{machine};
@@ -198,7 +198,7 @@ TEST(PrestateTracer, state_deltas_to_json)
 
 TEST(PrestateTracer, statediff_account_creation)
 {
-    Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account a{.balance = 500, .code_or_hash = A_CODE_HASH, .nonce = 1};
 
     InMemoryMachine machine;
     mpt::Db db{machine};
@@ -235,7 +235,7 @@ TEST(PrestateTracer, statediff_account_creation)
 
 TEST(PrestateTracer, statediff_balance_nonce_update)
 {
-    Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account a{.balance = 500, .code_or_hash = A_CODE_HASH, .nonce = 1};
     Account b = a;
     b.nonce += 1;
     b.balance -= 100;
@@ -280,7 +280,7 @@ TEST(PrestateTracer, statediff_balance_nonce_update)
 
 TEST(PrestateTracer, statediff_delete_storage)
 {
-    Account const a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account const a{.balance = 500, .code_or_hash = A_CODE_HASH, .nonce = 1};
     Account b = a;
     b.nonce += 1;
     b.balance -= 100;
@@ -338,8 +338,8 @@ TEST(PrestateTracer, statediff_delete_storage)
 
 TEST(PrestateTracer, statediff_multiple_fields_update)
 {
-    Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
-    Account b{.balance = 42, .code_hash = B_CODE_HASH, .nonce = 2};
+    Account a{.balance = 500, .code_or_hash = A_CODE_HASH, .nonce = 1};
+    Account b{.balance = 42, .code_or_hash = B_CODE_HASH, .nonce = 2};
 
     InMemoryMachine machine;
     mpt::Db db{machine};
@@ -398,7 +398,7 @@ TEST(PrestateTracer, statediff_multiple_fields_update)
 
 TEST(PrestateTracer, statediff_account_deletion)
 {
-    Account a{.balance = 32, .code_hash = NULL_HASH, .nonce = 1};
+    Account a{.balance = 32, .code_or_hash = NULL_HASH, .nonce = 1};
 
     InMemoryMachine machine;
     mpt::Db db{machine};
@@ -442,7 +442,7 @@ TEST(PrestateTracer, geth_example_prestate)
     // The only difference between this test and the Geth prestate tracer
     // example is the code/codehash. Here we use one from our test resources,
     // because the code in the Geth example is truncated.
-    Account const a{.balance = 0, .code_hash = A_CODE_HASH, .nonce = 1};
+    Account const a{.balance = 0, .code_or_hash = A_CODE_HASH, .nonce = 1};
     OriginalAccountState as{a};
     as.storage_ = as.storage_.insert({key4, value4});
     as.storage_ = as.storage_.insert({key5, value5});
@@ -450,14 +450,14 @@ TEST(PrestateTracer, geth_example_prestate)
     as.storage_ = as.storage_.insert({key7, value7});
 
     Account const b{
-        .balance = 0x7a48734599f7284, .code_hash = NULL_HASH, .nonce = 1133};
+        .balance = 0x7a48734599f7284, .code_or_hash = NULL_HASH, .nonce = 1133};
     OriginalAccountState bs{b};
     Account const c{
         .balance = intx::from_string<uint256_t>("0x2638035a26d133809"),
-        .code_hash = NULL_HASH,
+        .code_or_hash = NULL_HASH,
         .nonce = 0};
     OriginalAccountState cs{c};
-    Account const d{.balance = 0x0, .code_hash = NULL_HASH, .nonce = 0};
+    Account const d{.balance = 0x0, .code_or_hash = NULL_HASH, .nonce = 0};
     OriginalAccountState ds{d};
 
     trace::Map<Address, OriginalAccountState> prestate{};
@@ -514,9 +514,9 @@ TEST(PrestateTracer, geth_example_prestate)
 TEST(PrestateTracer, geth_example_statediff)
 {
     Account const a{
-        .balance = 0x7a48429e177130a, .code_hash = NULL_HASH, .nonce = 1134};
+        .balance = 0x7a48429e177130a, .code_or_hash = NULL_HASH, .nonce = 1134};
     Account const b{
-        .balance = 0x7a48429e177130a, .code_hash = NULL_HASH, .nonce = 1135};
+        .balance = 0x7a48429e177130a, .code_or_hash = NULL_HASH, .nonce = 1135};
 
     StateDeltas state_deltas{
         {addr3, StateDelta{.account = {a, b}, .storage = {}}},

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -69,11 +69,10 @@ bool dipped_into_reserve(
     auto const &orig = state.original();
     for (auto const &[addr, cur_account] : state.current()) {
         MONAD_ASSERT(orig.contains(addr));
-        bytes32_t const orig_code_hash = orig.at(addr).get_code_hash();
-        bytes32_t const effective_code_hash =
-            (traits::monad_rev() >= MONAD_EIGHT)
-                ? cur_account.recent().get_code_hash()
-                : orig_code_hash;
+        auto const &effective_state = (traits::monad_rev() >= MONAD_EIGHT)
+                                          ? cur_account.recent()
+                                          : orig.at(addr);
+        bytes32_t const effective_code_hash = effective_state.get_code_hash();
         bool effective_is_delegated = false;
 
         // the balance of the staking contract address can decrease but that
@@ -85,12 +84,16 @@ bool dipped_into_reserve(
 
         // Skip if not EOA
         if (effective_code_hash != NULL_HASH) {
-            vm::SharedIntercode const intercode =
-                state.read_code(effective_code_hash)->intercode();
-            effective_is_delegated = monad::vm::evm::is_delegated(
-                {intercode->code(), intercode->size()});
-            if (!effective_is_delegated) {
-                continue;
+            effective_is_delegated = effective_state.inline_delegated_code();
+            if (!effective_is_delegated) { // if not inlined code, read code to
+                                           // to check delegation status
+                vm::SharedIntercode const intercode =
+                    state.read_code(effective_code_hash)->intercode();
+                effective_is_delegated = monad::vm::evm::is_delegated(
+                    {intercode->code(), intercode->size()});
+                if (!effective_is_delegated) {
+                    continue; // skip if account has code and is not delegated
+                }
             }
         }
         else if (
@@ -136,8 +139,12 @@ bool dipped_into_reserve(
     return false;
 }
 
-bool is_delegated(State &state, bytes32_t const &code_hash)
+bool is_delegated(State &state, AccountState const &account_state)
 {
+    if (account_state.inline_delegated_code()) {
+        return true;
+    }
+    bytes32_t const code_hash = account_state.get_code_hash();
     if (MONAD_UNLIKELY(code_hash == NULL_HASH)) {
         return false;
     }
@@ -192,14 +199,14 @@ bool ReserveBalance::subject_account(Address const &address)
         return false;
     }
 
-    OriginalAccountState &orig_state = state_->original_account_state(address);
-    bytes32_t const effective_code_hash = use_recent_code_hash_
-                                              ? state_->get_code_hash(address)
-                                              : orig_state.get_code_hash();
-    if (effective_code_hash == NULL_HASH) {
+    AccountState const &account_state =
+        use_recent_code_ ? state_->recent_account_state(address)
+                         : state_->original_account_state(address);
+    bytes32_t const code_hash = account_state.get_code_hash();
+    if (code_hash == NULL_HASH) {
         return true;
     }
-    return is_delegated(*state_, effective_code_hash);
+    return is_delegated(*state_, account_state);
 }
 
 uint256_t ReserveBalance::pretx_reserve(Address const &address)
@@ -303,7 +310,7 @@ void ReserveBalance::on_set_code(
     if (!tracking_enabled_) {
         return;
     }
-    if (!use_recent_code_hash_) {
+    if (!use_recent_code_) {
         return;
     }
     auto &violation_threshold = violation_thresholds_[address];
@@ -333,7 +340,7 @@ void ReserveBalance::init_from_tx(
 
     if constexpr (tracking_disabled) {
         tracking_enabled_ = false;
-        use_recent_code_hash_ = false;
+        use_recent_code_ = false;
         allow_init_selfdestruct_exemption_ = false;
         sender_ = {};
         sender_gas_fees_ = 0;
@@ -346,14 +353,13 @@ void ReserveBalance::init_from_tx(
     MONAD_ASSERT(i < ctx.senders.size());
     MONAD_ASSERT(i < ctx.authorities.size());
     MONAD_ASSERT(ctx.senders.size() == ctx.authorities.size());
-    use_recent_code_hash_ = traits::monad_rev() >= MONAD_EIGHT;
+    use_recent_code_ = traits::monad_rev() >= MONAD_EIGHT;
     allow_init_selfdestruct_exemption_ = traits::monad_rev() >= MONAD_NINE;
-    bytes32_t const sender_code_hash =
-        use_recent_code_hash_
-            ? state_->get_code_hash(sender)
-            : state_->original_account_state(sender).get_code_hash();
+    AccountState const &sender_account_state =
+        use_recent_code_ ? state_->recent_account_state(sender)
+                         : state_->original_account_state(sender);
     bool const sender_can_dip = can_sender_dip_into_reserve<traits>(
-        sender, i, is_delegated(*state_, sender_code_hash), ctx);
+        sender, i, is_delegated(*state_, sender_account_state), ctx);
     tracking_enabled_ = true;
     sender_ = sender;
     sender_gas_fees_ = uint256_t{tx.gas_limit} *

--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -46,7 +46,7 @@ class ReserveBalance
 
     State *state_;
     bool tracking_enabled_{false};
-    bool use_recent_code_hash_{false};
+    bool use_recent_code_{false};
     bool allow_init_selfdestruct_exemption_{false};
     Address sender_{};
     uint256_t sender_gas_fees_{0};

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -195,13 +195,13 @@ namespace
                          {std::nullopt,
                           Account{
                               .balance = 20'000'000u,
-                              .code_hash = NULL_HASH,
+                              .code_or_hash = NULL_HASH,
                               .nonce = 0x0}}}},
                 {ADDR_B,
                  StateDelta{
                      .account =
                          {std::nullopt,
-                          Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                          Account{.balance = 0, .code_or_hash = {}}}}}},
             Code{},
             header);
 
@@ -691,14 +691,14 @@ TEST_F(EthCallFixture, assertion_exception_depth1)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1, .code_hash = NULL_HASH}}}},
+                      Account{.balance = 1, .code_or_hash = {}}}}},
             {to,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}}},
+                          .code_or_hash = {}}}}}},
         Code{},
         BlockHeader{.number = 0});
 
@@ -782,19 +782,19 @@ TEST_F(EthCallFixture, assertion_exception_depth2)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1, .code_hash = NULL_HASH}}}},
+                      Account{.balance = 1, .code_or_hash = {}}}}},
             {addr2,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1, .code_hash = hash2}}}},
+                      Account{.balance = 1, .code_or_hash = hash2}}}},
             {addr3,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max() - 1,
-                          .code_hash = NULL_HASH}}}}},
+                          .code_or_hash = {}}}}}},
         Code{{hash2, icode2}},
         BlockHeader{.number = 0});
 
@@ -863,7 +863,7 @@ TEST_F(EthCallFixture, loop_out_of_gas)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+                      Account{.balance = 0x1b58, .code_or_hash = code_hash}}}}},
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -982,7 +982,7 @@ TEST_F(EthCallFixture, expensive_read_out_of_gas)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+                      Account{.balance = 0x1b58, .code_or_hash = code_hash}}}}},
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -1049,7 +1049,7 @@ TEST_F(EthCallFixture, from_contract_account)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+                      Account{.balance = 0x1b58, .code_or_hash = code_hash}}}}},
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -1119,7 +1119,7 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
                              {std::nullopt,
                               Account{
                                   .balance = 0x1b58,
-                                  .code_hash = code_hash}}}}},
+                                  .code_or_hash = code_hash}}}}},
                 Code{{code_hash, icode}},
                 BlockHeader{.number = i});
         }
@@ -1243,27 +1243,27 @@ TEST_F(EthCallFixture, call_trace_with_logs)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
+                          .code_or_hash = NULL_HASH}}}},
             {a_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = a_code_hash}}}},
+                      Account{.balance = 0, .code_or_hash = a_code_hash}}}},
             {b_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}},
+                      Account{.balance = 0, .code_or_hash = b_code_hash}}}},
             {c_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = c_code_hash}}}},
+                      Account{.balance = 0, .code_or_hash = c_code_hash}}}},
             {d_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = d_code_hash}}}}},
+                      Account{.balance = 0, .code_or_hash = d_code_hash}}}}},
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -1448,7 +1448,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
                      {std::nullopt,
                       Account{
                           .balance = 22000,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = {},
                           .nonce = 0x0}}}},
             {precompile_address,
              StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}}},
@@ -1541,7 +1541,7 @@ TEST_F(EthCallFixture, transfer_success_with_state_trace)
 
     Account const acct_from{
         .balance = 0x200000,
-        .code_hash = NULL_HASH,
+        .code_or_hash = {},
         .nonce = 0x0,
     };
 
@@ -2809,13 +2809,13 @@ TEST_F(EthCallFixture, access_list_trace)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
+                          .code_or_hash = NULL_HASH}}}},
             {contract_address,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}},
+                          .balance = 0, .code_or_hash = contract_code_hash}}}}},
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -2911,13 +2911,13 @@ TEST_F(EthCallFixture, access_list_trace_empty)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
+                          .code_or_hash = NULL_HASH}}}},
             {contract_address,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}},
+                          .balance = 0, .code_or_hash = contract_code_hash}}}}},
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -3000,17 +3000,17 @@ TEST_F(EthCallFixture, access_list_trace_nested)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
+                          .code_or_hash = NULL_HASH}}}},
             {a_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = a_code_hash}}}},
+                      Account{.balance = 0, .code_or_hash = a_code_hash}}}},
             {b_address,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}}},
+                      Account{.balance = 0, .code_or_hash = b_code_hash}}}}},
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -3276,7 +3276,7 @@ TEST_F(EthCallFixture, prestate_override_state)
                      std::nullopt,
                      Account{
                          .balance = 0x0,
-                         .code_hash = code_hash,
+                         .code_or_hash = code_hash,
                          .nonce = 1,
                      }},
              .storage =
@@ -3539,7 +3539,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                      {std::nullopt,
                       Account{
                           .balance = uint256_t{1'000'000'000'000'000'000} * 100,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0}}}},
             {delegated_eoa,
              StateDelta{
@@ -3547,7 +3547,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                      {std::nullopt,
                       Account{
                           .balance = uint256_t{1'000'000'000'000'000'000} * 7,
-                          .code_hash = delegated_eoa_code_hash,
+                          .code_or_hash = delegated_eoa_code_hash,
                           .nonce = 0}}}},
             {contract,
              StateDelta{
@@ -3555,14 +3555,16 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                      {std::nullopt,
                       Account{
                           .balance = 0,
-                          .code_hash = contract_code_hash,
+                          .code_or_hash = contract_code_hash,
                           .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
+                          .balance = 0,
+                          .code_or_hash = NULL_HASH,
+                          .nonce = 0}}}},
         },
         Code{
             {contract_code_hash, contract_icode},
@@ -3639,14 +3641,16 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
                      {std::nullopt,
                       Account{
                           .balance = uint256_t{1'000'000'000'000'000'000} * 12,
-                          .code_hash = NULL_HASH,
+                          .code_or_hash = NULL_HASH,
                           .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
+                          .balance = 0,
+                          .code_or_hash = NULL_HASH,
+                          .nonce = 0}}}},
         },
         Code{},
         header);
@@ -3739,7 +3743,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
                      {std::nullopt,
                       Account{
                           .balance = uint256_t{1'000'000'000'000'000'000} * 12,
-                          .code_hash = delegated_eoa_code_hash,
+                          .code_or_hash = delegated_eoa_code_hash,
                           .nonce = 0}}}},
             {contract,
              StateDelta{
@@ -3747,14 +3751,16 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
                      {std::nullopt,
                       Account{
                           .balance = 0,
-                          .code_hash = contract_code_hash,
+                          .code_or_hash = contract_code_hash,
                           .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
+                          .balance = 0,
+                          .code_or_hash = NULL_HASH,
+                          .nonce = 0}}}},
         },
         Code{
             {delegated_eoa_code_hash, delegated_eoa_icode},

--- a/category/statesync/statesync_protocol.cpp
+++ b/category/statesync/statesync_protocol.cpp
@@ -43,9 +43,8 @@ void account_update(
     using StorageDeltas = monad_statesync_client_context::StorageDeltas;
 
     if (acct.has_value()) {
-        auto const &hash = acct.value().code_hash;
-        if (hash != NULL_HASH) {
-            ctx.seen_code.emplace(hash);
+        if (acct.value().code_or_hash.is_hash()) { // code is not null or inline
+            ctx.seen_code.emplace(to_bytes(acct.value().get_code_hash()));
         }
     }
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/trie_rodb.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_client.h>
@@ -31,6 +32,7 @@
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
 #include <category/statesync/statesync_version.h>
+#include <category/vm/evm/delegation.hpp>
 #include <test_resource_data.h>
 
 #include <ethash/keccak.hpp>
@@ -185,6 +187,13 @@ namespace
                 &statesync_server_recv,
                 &statesync_server_send_upsert,
                 &statesync_server_send_done);
+        }
+
+        void reinit()
+        {
+            monad_statesync_client_context_destroy(cctx);
+            monad_statesync_server_destroy(server);
+            init();
         }
 
         void run()
@@ -389,7 +398,7 @@ TEST_F(StateSyncFixture, sync_from_some)
                       {std::nullopt,
                        Account{
                            .balance = 1337,
-                           .code_hash = code_hash,
+                           .code_or_hash = code_hash,
                            .nonce = 1,
                            .incarnation = Incarnation{3, 0}}},
                   .storage =
@@ -502,6 +511,128 @@ TEST_F(StateSyncFixture, sync_from_some)
         EXPECT_FALSE(cdb.find(concat(FINALIZED_NIBBLE, nibble), hdr6.number)
                          .has_value());
     }
+}
+
+TEST_F(StateSyncFixture, sync_with_account_delegation)
+{
+    init();
+
+    mpt::RODb cro{ReadOnlyOnDiskDbConfig{.dbname_paths = {cdbname}}};
+    TrieRODb ctdb{cro};
+
+    BlockHeader hdr{.parent_hash = NULL_HASH, .number = 0};
+    commit_sequential(sctx, StateDeltas{}, Code{}, hdr);
+
+    constexpr auto DELEGATED =
+        0x001762430ea9c3a26e5749afdb70da5f78ddbb8c_address;
+    constexpr auto EOA = 0x000d836201318ec6899a67540690382780743280_address;
+
+    auto const delegated_code = from_hex("0x5F5F5FF0").value();
+    auto const delegated_code_hash = to_bytes(keccak256(delegated_code));
+    auto const delegated_icode = vm::make_shared_intercode(delegated_code);
+
+    uint8_t eoa_code[23] = {0xEF, 0x01, 0x00};
+    std::copy_n(DELEGATED.bytes, 20, &eoa_code[3]);
+    auto const eoa_icode = vm::make_shared_intercode(eoa_code);
+    auto const eoa_code_hash = to_bytes(keccak256(eoa_code));
+    byte_string const eoa_code_bytes{eoa_code, sizeof(eoa_code)};
+
+    // Delegate b using old format with inserted code
+    Account const a{
+        .balance = 1337,
+        .code_or_hash = delegated_code_hash,
+        .nonce = 1,
+        .incarnation = Incarnation{1, 0}};
+    Account b{.balance = 1000, .code_or_hash = eoa_code_hash, .nonce = 1};
+
+    hdr.parent_hash =
+        to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    hdr.state_root =
+        0x1f8baedbafa3cbbdf6353bc564dac7e0536045096b6cd9296baeb533de1fbbda_bytes32;
+    hdr.number = 1;
+    commit_sequential(
+        sctx,
+        StateDeltas{
+            {DELEGATED,
+             {.account = {std::nullopt, a},
+              .storage =
+                  {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                    {{},
+                     0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}},
+            {EOA, {.account = {std::nullopt, b}}}},
+        Code{
+            {delegated_code_hash, delegated_icode}, {eoa_code_hash, eoa_icode}},
+        hdr);
+    ASSERT_EQ(sctx.state_root(), hdr.state_root);
+    handle_target(cctx, hdr);
+    run();
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    ctdb.set_block_and_prefix(hdr.number);
+    auto acct_b = ctdb.read_account(EOA);
+    ASSERT_TRUE(acct_b.has_value());
+    EXPECT_FALSE(acct_b->inline_delegated_code());
+    EXPECT_EQ(acct_b->code_view(), eoa_code_hash);
+    auto const code_b = ctdb.read_code(eoa_code_hash);
+    EXPECT_TRUE(vm::evm::is_delegated(code_b->code_span())) << code_b;
+    EXPECT_FALSE(ctdb.read_account(DELEGATED)->inline_delegated_code());
+
+    reinit();
+
+    // undelegate b
+    hdr.parent_hash =
+        to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    hdr.number = 2;
+    hdr.state_root =
+        0xcf92aa7edc9ba86eabc6c161913bf51762a6e480df4ea8d45fe9cdcdb5331265_bytes32;
+    acct_b = stdb.read_account(EOA);
+    ASSERT_TRUE(acct_b.has_value());
+    ASSERT_EQ(*acct_b, b);
+    b.code_or_hash = NULL_HASH;
+    b.nonce++;
+    ASSERT_FALSE(b.has_code());
+    commit_sequential(
+        sctx, StateDeltas{{EOA, {.account = {acct_b, b}}}}, Code{}, hdr);
+    ASSERT_EQ(sctx.state_root(), hdr.state_root);
+
+    handle_target(cctx, hdr);
+    run();
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    ctdb.set_block_and_prefix(hdr.number);
+    acct_b = ctdb.read_account(EOA);
+    ASSERT_TRUE(acct_b.has_value());
+    EXPECT_FALSE(acct_b->inline_delegated_code());
+    EXPECT_FALSE(acct_b->has_code());
+    EXPECT_FALSE(ctdb.read_account(DELEGATED)->inline_delegated_code());
+
+    reinit();
+
+    // redelegate b using the new format with inline code
+    hdr.parent_hash =
+        to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    hdr.number = 3;
+    hdr.state_root =
+        0x40d8efbe3c45a76df73fbbfdfc293e752b7428f013571ccbf2cca7215cd36c57_bytes32;
+    acct_b = stdb.read_account(EOA);
+    ASSERT_TRUE(acct_b.has_value());
+    ASSERT_EQ(*acct_b, b);
+    b.code_or_hash = eoa_code_bytes;
+    b.nonce++;
+    commit_sequential(
+        sctx, StateDeltas{{EOA, {.account = {acct_b, b}}}}, Code{}, hdr);
+    ASSERT_EQ(sctx.state_root(), hdr.state_root);
+
+    handle_target(cctx, hdr);
+    run();
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    ctdb.set_block_and_prefix(hdr.number);
+    acct_b = ctdb.read_account(EOA);
+    ASSERT_TRUE(acct_b.has_value());
+    EXPECT_TRUE(acct_b->inline_delegated_code());
+    EXPECT_EQ(acct_b->code_view(), eoa_code_bytes);
+    EXPECT_FALSE(ctdb.read_account(DELEGATED)->inline_delegated_code());
 }
 
 TEST_F(StateSyncFixture, deletion_proposal)
@@ -964,7 +1095,7 @@ TEST_F(StateSyncFixture, update_contract_twice)
 
     Account const a{
         .balance = 1337,
-        .code_hash = code_hash,
+        .code_or_hash = code_hash,
         .nonce = 1,
         .incarnation = Incarnation{1, 0}};
 

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -136,7 +136,7 @@ inline void load_db(TrieDb &db, uint64_t const n)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = A_CODE_HASH}},
+                          .code_or_hash = A_CODE_HASH}},
                  .storage =
                      {{bytes32_t{},
                        {bytes32_t{},
@@ -147,28 +147,28 @@ inline void load_db(TrieDb &db, uint64_t const n)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = B_CODE_HASH}}}},
+                          .code_or_hash = B_CODE_HASH}}}},
             {0x0000000000000000000000000000000000000102_address,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = C_CODE_HASH}}}},
+                          .code_or_hash = C_CODE_HASH}}}},
             {0x0000000000000000000000000000000000000103_address,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = D_CODE_HASH}}}},
+                          .code_or_hash = D_CODE_HASH}}}},
             {0x0000000000000000000000000000000000000104_address,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = E_CODE_HASH}}}},
+                          .code_or_hash = E_CODE_HASH}}}},
             {0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 0x7024c}}}},
@@ -183,7 +183,7 @@ inline void load_db(TrieDb &db, uint64_t const n)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9cf,
-                          .code_hash = H_CODE_HASH}}}}},
+                          .code_or_hash = H_CODE_HASH}}}}},
         Code{
             {A_CODE_HASH, A_ICODE},
             {B_CODE_HASH, B_ICODE},


### PR DESCRIPTION
**Account changes:**

Introduce `CodeStorage` class in `Account`, which can hold either inline delegated code or a code hash.
Preserve backward compatibility: legacy accounts in Db always store a 32-byte code hash 

**Account encoding changes:**
Update `encode_account_db()` to support inline delegated code. `Account::code_or_hash` is still encoded as an RLP string but not always 32 bytes anymore, its length determines the representation:
- `len = 0`: account has no code
- `len = 23`: inline delegated code (new format)
- `len = 32`: code hash (old or new format, both valid)

**Reader-side delegation check**
```python
def is_delegated_eoa:
     if (!account.has_code()): return False;
     if (account.inline_delegated_code()): return True;
     code = db.read_code(account.get_code_hash());
     return is_code_delegated(code);
```