### PR TITLE
[staking]: Add external rewards precompile

### DIFF
--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -492,6 +492,11 @@ private:
     // stake.
     Result<void> pull_delegator_up_to_date(u64_be, Delegator &);
 
+    // Updates a validator's additive accumulator with the new reward, which
+    // goes to every active delegator in the pool.
+    Result<void> apply_reward(
+        ValExecution &, uint256_t const &reward, uint256_t const &active_stake);
+
     // helper function for delegate. used by three compiles:
     //  1. add_validator
     //  2. delegate
@@ -555,6 +560,8 @@ public:
     Result<byte_string> precompile_claim_rewards(
         byte_string_view, evmc_address const &, evmc_uint256be const &);
     Result<byte_string> precompile_change_commission(
+        byte_string_view, evmc_address const &, evmc_uint256be const &);
+    Result<byte_string> precompile_external_reward(
         byte_string_view, evmc_address const &, evmc_uint256be const &);
 
     ////////////////////

--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -40,6 +40,8 @@ inline constexpr uint256_t ACTIVE_VALIDATOR_STAKE{50'000'000 * MON};
 inline constexpr uint256_t UNIT_BIAS{
     1000000000000000000000000000000000000_u256}; // 1e36
 inline constexpr uint256_t DUST_THRESHOLD{1000000000}; // 1e9
+inline constexpr uint256_t MAX_EXTERNAL_REWARD{
+    1000000000000000000000000_u256}; // 1e24
 
 inline constexpr Address STAKING_CA{0x1000};
 inline constexpr uint64_t ACTIVE_VALSET_SIZE{200};

--- a/category/execution/monad/staking/util/staking_error.cpp
+++ b/category/execution/monad/staking/util/staking_error.cpp
@@ -57,7 +57,7 @@ quick_status_code_from_enum<monad::staking::StakingError>::value_mappings()
         {StakingError::BlsSignatureVerificationFailed,
          "bls signature verification failed",
          {}},
-        {StakingError::BlockAuthorNotInSet, "block author not in set", {}},
+        {StakingError::NotInValidatorSet, "not in validator set", {}},
         {StakingError::SolvencyError, "solvency error", {}},
         {StakingError::SnapshotInBoundary,
          "called snapshot while in boundary",
@@ -67,6 +67,8 @@ quick_status_code_from_enum<monad::staking::StakingError>::value_mappings()
         {StakingError::CommissionTooHigh, "commission too high", {}},
         {StakingError::ValueNonZero, "value is nonzero", {}},
         {StakingError::DelegationTooSmall, "delegation is too small", {}},
+        {StakingError::ExternalRewardTooSmall, "external reward too small", {}},
+        {StakingError::ExternalRewardTooLarge, "external reward too large", {}},
     };
 
     return v;

--- a/category/execution/monad/staking/util/staking_error.hpp
+++ b/category/execution/monad/staking/util/staking_error.hpp
@@ -49,7 +49,7 @@ enum class StakingError
     InvalidBlsSignature,
     SecpSignatureVerificationFailed,
     BlsSignatureVerificationFailed,
-    BlockAuthorNotInSet,
+    NotInValidatorSet,
     SolvencyError,
     SnapshotInBoundary,
     InvalidEpochChange,
@@ -57,6 +57,8 @@ enum class StakingError
     CommissionTooHigh,
     ValueNonZero,
     DelegationTooSmall,
+    ExternalRewardTooSmall,
+    ExternalRewardTooLarge,
 };
 
 MONAD_STAKING_NAMESPACE_END


### PR DESCRIPTION
This precompile supports adding rewards to the validator pool outside of the standard block rewards.