### PR TITLE
Add a README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Monad Execution
+
+## Overview
+
+This repository contains the execution component of a Monad node. It
+handles the transaction processing for new blocks, and keeps track of
+the state of the blockchain. Consequently, this repository contains
+the source code for Category Labs' custom
+[EVM implementation](https://docs.monad.xyz/monad-arch/execution/native-compilation),
+its [database implementation](https://docs.monad.xyz/monad-arch/execution/monaddb),
+and the high-level [transaction scheduling](https://docs.monad.xyz/monad-arch/execution/parallel-execution).
+The other main repository is [monad-bft](https://github.com/category-labs/monad-bft),
+which contains the source code for the consensus component.
+
+## Building the source code
+
+### Package requirements
+
+Execution has two kinds of dependencies on third-party libraries:
+
+1. **Self-managed**: execution's CMake build system will checkout most of
+   its third-party dependencies as git submodules, and build them as part
+   of its own build process, as CMake subprojects; this will happen
+   automatically during the build, but you must run:
+
+   ```shell
+   git submodule update --init --recursive
+   ```
+
+   after checking out this repository.
+
+2. **System**: some dependencies are expected to already be part of the
+   system in a default location, i.e., they are expected to come from the
+   system's package manager. The primary development platform is Ubuntu, so
+   the required packages use the Debian/Ubuntu package names; an up-to-date
+   list of the required system dependencies can be found in the docker
+   configuration file `docker/release.Dockerfile` (you will need all
+   the packages installed via the `apt install` commands)
+
+### Minimum development tool requirements
+
+- gcc-15 or clang-19
+- CMake 3.27
+- Even when using clang, the only standard library supported is libstdc++;
+  libc++ may work but it is not a tested platform
+
+### CPU compilation requirements
+
+As explained in the [hardware requirements](https://docs.monad.xyz/monad-arch/hardware-requirements),
+a Monad node requires a relatively recent CPU. Execution explicitly
+requires this to compile: it needs to emit machine code that is only
+supported on recent CPU models, for fast cryptographic operations.
+
+The minimum ISA support corresponds to the [x86-64-v3](https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels)
+feature level. Consequently, the minimum flag you must pass to the compiler
+is `-march=x86-64-v3`, or alternatively `-march=haswell` ("Haswell" was
+the codename of the first Intel CPU to support all of these features).
+
+You may also pass any higher architecture level if you wish, although
+the compiled binary may not work on older CPUs. The execution docker
+files use `-march=haswell` because it tries to maximize the number of
+systems the resulting binary can run on. If you are only running locally
+(i.e., the binary does not need to run anywhere else) use `-march=native`.
+
+### Compiling the execution code
+
+First, change your working directory to the root directory of the execution
+git repository root and then run:
+
+```shell
+CC=gcc-15 CXX=g++-15 CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" \
+./scripts/configure.sh && ./scripts/build.sh
+```
+
+The above command will do several things:
+
+- Use gcc-15 instead of the system's default compiler
+
+- Emit machine code using Haswell-era CPU extensions
+
+- Run CMake, and generate a [ninja](https://ninja-build.org/) build
+  system in the `<path-to-execution-repo>/build` directory with
+  the [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+  set to `RelWithDebInfo` by default
+
+- Build the CMake `all` target, which builds everything
+
+The compiler and CPU options are injected via environment variables that
+are read by CMake.  If you want debug binaries instead, you can also pass
+`CMAKE_BUILD_TYPE=Debug` via the environment.
+
+When finished, this will build all of the execution binaries. The main one is
+the execution daemon, `build/cmd/monad`. This binary can provide block
+execution services for different EVM-compatible blockchains:
+
+- When used as part of a Monad blockchain node, it behaves as the block
+  execution service for the Category Labs consensus daemon (for details, see
+  [here](docs/overview.md#how-is-execution-used)); when running in this mode,
+  Monad EVM extensions (e.g., Monad-style staking) are enabled
+
+- It can also replay the history of other EVM-compatible blockchains, by
+  executing their historical blocks as inputs; a common developer workflow
+  (and a good full system test) is to replay the history of the original
+  Ethereum mainnet and verify that the computed Merkle roots match after
+  each block
+
+You can also run the full test suite in parallel with:
+
+```
+CTEST_PARALLEL_LEVEL=$(nproc) ctest
+```
+
+## A tour of execution
+
+To understand how the source code is organized, you should start by reading
+the execution [developer overview](docs/overview.md), which explains how
+execution and consensus fit together, and where in the source tree you can
+find different pieces of functionality.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,133 @@
+# Monad execution overview
+
+## Consensus and execution
+
+The most common kind of blockchain architecture separates the operation of a
+node into two distinct components, which are typically called "consensus" and
+"execution."
+
+The consensus component gets its name from the distributed consensus algorithm
+it implements; this algorithm allows the network to reach agreement about new
+blocks (bundles of transactions) to be appended to the blockchain. The
+execution component performs the actual transaction processing, and keeps
+track of the state of the blockchain in a database.
+
+In the Category Labs architecture, the two components are developed
+separately, and live in separate source code repositories. They produce
+two separate binaries, which are also called "consensus" and "execution"
+throughout the documentation. These binaries typically run as Linux daemons,
+and are managed as systemd services.
+
+Although the two components are typically called "consensus" and "execution",
+their source code repositories and command names are different for historical
+reasons:
+
+- The consensus repository is called [monad-bft](https://github.com/category-labs/monad-bft),
+  because its distributed consensus algorithm belongs to the Byzantine Fault
+  Tolerant family; the name of the consensus daemon binary is `monad-node`
+
+- The execution repository is just called [monad](https://github.com/category-labs/monad),
+  and the name of the execution daemon binary is also just `monad`
+
+## How is execution used?
+
+Most of the source code in this repository is compiled into a single library,
+called `libmonad_execution.a` (or `libmonad_execution.so`, if you compile
+using shared libraries).
+
+This library is used in a few different ways:
+
+1. **Stand-alone/daemon mode**: the execution daemon (source code in the
+   `cmd/monad` directory) is run as a systemd service; it is small
+   wrapper around the `libmonad_execution` functionality that looks for
+   new blocks written to disk by the consensus daemon and executes them
+   immediately, updating the local state database after successful execution
+
+2. **Hosted mode**: the consensus daemon and the RPC server also use some
+   execution APIs directly; they do this by compiling the execution library
+   as a shared object (`libmonad_execution.so`), and loading it into their
+   processes; they can then call execution functions directly
+
+3. **Interactive mode**: `cmd/monad` can also be run interactively from the
+   command line; this is not typically done when participating in the
+   blockchain network, but it is useful for developers, e.g., to manually
+   replay a sequence of blocks
+
+The way the two daemons fit together is shown in the diagram below. It is
+a simple loop that starts and ends with the consensus client:
+
+```
+                       ╔════════════════════════════════╗
+                       ║                                ║      Reads new blocks
+  Writes new blocks    ║         The "ledger":          ║       written by the
+     proposed by   ┌──▶║ a directory on the filesystem  ║────┐ consensus daemon
+   consensus peers │   ║    containing recent blocks    ║    │ and executes them
+                   │   ║                                ║    │
+                   │   ╚════════════════════════════════╝    │
+                   │                                         │
+                   │                                         ▼
+   ┌─Consensus daemon──────────────┐        ┌─Execution daemon───────────────┐
+   │                               │        │                                │
+   │┌─────────────────────────────┐│        │ ┌────────────────────────────┐ │
+   ││                             ││        │ │       runloop_monad        │ │
+   ││       Monad consensus       ││        │ ├────────────────────────────┤ │
+   ││          algorithm          ││        │ │                            │ │
+   ││                             ││        │ │    libmonad_execution.a    │ │
+   │├─────────────────────────────┤│        │ │  static library functions  │ │
+   ││                             ││        │ │ (including EVM and triedb) │ │
+   ││    libmonad_execution.so    ││        │ │                            │ │
+   ││ (including triedb read API) ││        │ └──────────────┬─────────────┘ │
+   ││                             ││        └────────────────┼───────────────┘
+   │└──────────────▲──────────────┘│                         │
+   └───────────────┼───────────────┘                         │
+                   │                                         │
+                   │                                         │
+                   │  ╔════════════════════════════════╗     │
+                   │  ║                                ║     │
+                   │  ║     TrieDB database file:      ║     │
+                   └──╣     typically a dedicated      ║◀────┘
+   Hosted execution   ║       NVMe block device        ║     Execution results
+   library can read   ║                                ║    (e.g., state roots)
+  results from triedb ╚════════════════════════════════╝    are written to the
+                                                              triedb database
+```
+
+This organization helps explain why the consensus binary is called
+`monad-node`: even though a "Monad node" is really both daemons operating
+together, it's clear in the diagram that execution is a local service that
+provides EVM and database services to consensus.
+
+In particular, the execution daemon has no networking of any kind, nor is it
+configured with any kind of public/private key identity. The "network" identity
+of a node -- and all of the related code and configuration files -- are part
+of the consensus daemon. To an external observer, the consensus daemon alone
+_appears_ to be "the node." In reality, during normal operation of the Monad
+blockchain protocol, neither daemon can do much of anything without the other.
+
+## Organization of the source code
+
+The source code for `libmonad_execution` is in the `category` subdirectory.
+It is organized into several components, each in its own directory:
+
+| Directory | Contains |
+| --------- | -------- |
+| async     | A library for asynchronous IO using `io_uring`, used by triedb                                               |
+| core      | Common functionality shared by multiple components                                                           |
+| execution | High-level transaction scheduling; Ethereum utilities (e.g. RLP decoding); "glue" between triedb and the EVM |
+| mpt       | The triedb database; stands for "Merkle-Patricia Trie", the central state data structure of Ethereum         |
+| rpc       | `extern "C"` interface to execute a single transaction; used by the RPC server to implement `eth_call`       |
+| statesync | Distributed database state synchronization protocol; an `extern "C"` interface used by consensus during sync |
+| vm        | Ethereum Virtual Machine implementation (interpreter and native code compiler, with Monad extensions)        |
+
+There is also a directory called `event`, which is not listed above. This
+directory is related to the "execution event SDK", which is used by third-party
+applications to consume real-time blockchain data published by execution. It
+produces a separate library called `libmonad_event`, which is only meant for
+third parties.
+
+All of the execution event SDK source code is actually contained in the
+`category/core/event` subdirectory, so its API is also available in the
+`libmonad_execution` library. `libmonad_event` is a separate CMake target in
+order to simplify the build system integration of third-party users, so that
+they do not need to integrate with the much larger and complex build system
+of the full execution project.


### PR DESCRIPTION
A typical README.md file just explains what a project is and how to compile it, so that is what this file does.

However, you cannot make much sense of execution without understanding how it integrates with consensus, so a general overview for developers is provided in a different file.