### PR TITLE
[mpt] Change virtual_offset_t hasher

### DIFF
--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -18,6 +18,7 @@
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
 #include <category/core/hex_literal.hpp>
+#include <category/core/unordered_map.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/nibbles_view.hpp>
 
@@ -154,9 +155,11 @@ static_assert(INVALID_VIRTUAL_OFFSET.in_fast_list());
 
 struct virtual_chunk_offset_t_hasher
 {
-    constexpr size_t operator()(virtual_chunk_offset_t v) const noexcept
+    using is_avalanching = void;
+
+    constexpr size_t operator()(virtual_chunk_offset_t const v) const noexcept
     {
-        return fnv1a_hash<file_offset_t>()(v.hasher_raw());
+        return ankerl::unordered_dense::hash<file_offset_t>{}(v.hasher_raw());
     }
 };
 


### PR DESCRIPTION
  * Switch from fnv1 to wyhash, which ships with ankerl
  * Since virtual_chunk_offset_t is an alias for uint64, indicate to ankerl it's a primitive type with a high quality hash, and therefore doesn't require an extra mixing step.

I noticed Max is [eliding calls to the LRU](https://github.com/category-labs/monad/pull/1546) by storing it's pointer in cache in the in memory node. This implies we are CPU bound when reading data inside the LRU. Those changes are very useful, but we should also address the root cause and make sure the hashing isn't slower than it needs to be. That is the purpose of this PR.

I ran a benchmark on an LRU with 50k entries that does 10 million reads.

With these changes, the time to perform that operations goes from 1490ms to 980ms, or about 40% speedup.

I made this the default hasher for chunk_offset_t so other data structures that use the chunk_offset_t_hasher, such as the inflights map, can benefit from these improvements.