### PR TITLE
[staking]: Return early if start_ptr is bogus

### DIFF
--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1876,6 +1876,11 @@ std::tuple<bool, Ptr, std::vector<Ptr>> StakingContract::linked_list_traverse(
     else {
         ptr = start_ptr;
     }
+    if (MONAD_UNLIKELY(
+            Trait::prev(Trait::load_node(*this, key, ptr)) == Trait::empty())) {
+        // bogus pointer, not in list.
+        return {true, ptr, {}};
+    }
 
     std::vector<Ptr> results;
     uint32_t nodes_read = 0;

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -4165,18 +4165,56 @@ TEST_F(Stake, get_valset_empty)
 
 TEST_F(Stake, empty_get_delegators_for_validator_getter)
 {
-    auto const [done, _, delegators] = contract.get_delegators_for_validator(
-        u64_be{1}, Address{}, std::numeric_limits<uint32_t>::max());
-    EXPECT_TRUE(done);
-    EXPECT_TRUE(delegators.empty());
+    {
+        // validator doesn't exist
+        auto const [done, _, delegators] =
+            contract.get_delegators_for_validator(
+                u64_be{1}, Address{}, std::numeric_limits<uint32_t>::max());
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(delegators.empty());
+    }
+
+    {
+        // validator exists, bogus delegator start pointer provided
+        auto const res =
+            add_validator(0xdeadbeef_address, ACTIVE_VALIDATOR_STAKE);
+        ASSERT_FALSE(res.has_error());
+        auto const [done, _, delegators] =
+            contract.get_delegators_for_validator(
+                res.value().id,
+                0x1337_address,
+                std::numeric_limits<uint32_t>::max());
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(delegators.empty());
+    }
 }
 
 TEST_F(Stake, empty_get_validators_for_delegator_getter)
 {
-    auto const [done, _, validators] = contract.get_validators_for_delegator(
-        Address{0x1337}, u64_be{}, std::numeric_limits<uint32_t>::max());
-    EXPECT_TRUE(done);
-    EXPECT_TRUE(validators.empty());
+    {
+        // validator doesn't exist
+        auto const [done, _, validators] =
+            contract.get_validators_for_delegator(
+                Address{0x1337},
+                u64_be{},
+                std::numeric_limits<uint32_t>::max());
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(validators.empty());
+    }
+
+    {
+        // validator exists, bogus val_id start pointer provided
+        auto const res =
+            add_validator(0xdeadbeef_address, ACTIVE_VALIDATOR_STAKE);
+        ASSERT_FALSE(res.has_error());
+        auto const [done, _, delegators] =
+            contract.get_validators_for_delegator(
+                0xdeadbeef_address,
+                u64_be{200},
+                std::numeric_limits<uint32_t>::max());
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(delegators.empty());
+    }
 }
 
 TEST_F(Stake, get_delegators_for_validator)


### PR DESCRIPTION
A node can be determined to be in the linked list if it's "prev" pointer is not empty. To prevent a single iteration, return early if the start pointer is not in the list.

The impact of this issue is very low, because a user would be providing bad input and get bad output as a result.  I can't imagine a use case where this would actually happen, as users would be using the output from a previous call as the input to the next one. However, it's a simple enough fix that we should do it for UX purposes.

This issue was reported by spearbit.

Closes https://github.com/category-labs/monad/issues/1651