### PR TITLE
testnet2 MONAD_FOUR fork

### DIFF
--- a/category/execution/monad/chain/monad_testnet2.cpp
+++ b/category/execution/monad/chain/monad_testnet2.cpp
@@ -24,10 +24,10 @@ MONAD_NAMESPACE_BEGIN
 
 monad_revision MonadTestnet2::get_monad_revision(uint64_t const timestamp) const
 {
-    if (MONAD_LIKELY(timestamp >= 1753795800)) { // 2025-07-29T13:30:00.000Z
-        return MONAD_THREE;
+    if (MONAD_LIKELY(timestamp >= 1758029400)) { // 2025-09-16T13:30:00.000Z
+        return MONAD_FOUR;
     }
-    return MONAD_TWO;
+    return MONAD_THREE;
 }
 
 uint256_t MonadTestnet2::get_chain_id() const


### PR DESCRIPTION
testnet2 is being reset with an earlier release which is MONAD_THREE before the upgrade to MONAD_FOUR