### PR TITLE
[staking]: Making staking CA access warm

### DIFF
--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -171,9 +171,6 @@ struct EvmcHost final : public EvmcHostBase
     access_account(Address const &address) noexcept override
     {
         try {
-            // NOTE: we deliberately do not check the monad precompiles here.
-            // They are stateful and stateful precompiles should pay the COLD
-            // account access like any other contract.
             if (is_precompile<traits>(address)) {
                 return EVMC_ACCESS_WARM;
             }

--- a/category/execution/ethereum/precompiles.cpp
+++ b/category/execution/ethereum/precompiles.cpp
@@ -109,9 +109,17 @@ std::optional<PrecompiledContract> resolve_precompile(Address const &address)
 EXPLICIT_TRAITS(resolve_precompile);
 
 template <Traits traits>
-bool is_precompile(Address const &address)
+bool is_eth_precompile(Address const &address)
 {
     return resolve_precompile<traits>(address).has_value();
+}
+
+EXPLICIT_TRAITS(is_eth_precompile);
+
+template <Traits traits>
+bool is_precompile(Address const &address)
+{
+    return is_eth_precompile<traits>(address);
 }
 
 EXPLICIT_TRAITS(is_precompile);

--- a/category/execution/ethereum/precompiles.hpp
+++ b/category/execution/ethereum/precompiles.hpp
@@ -33,6 +33,9 @@ bool init_trusted_setup();
 inline constexpr Address ripemd_address{3};
 
 template <Traits traits>
+bool is_eth_precompile(Address const &);
+
+template <Traits traits>
 bool is_precompile(Address const &);
 
 template <Traits traits>

--- a/category/execution/monad/monad_precompiles.cpp
+++ b/category/execution/monad/monad_precompiles.cpp
@@ -70,6 +70,15 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 template <Traits traits>
+bool is_precompile(Address const &address)
+{
+    return is_eth_precompile<traits>(address) ||
+           (address == staking::STAKING_CA);
+}
+
+EXPLICIT_MONAD_TRAITS(is_precompile);
+
+template <Traits traits>
 std::optional<evmc::Result>
 check_call_precompile(State &state, evmc_message const &msg)
 {

--- a/category/execution/monad/monad_precompiles.hpp
+++ b/category/execution/monad/monad_precompiles.hpp
@@ -30,6 +30,9 @@ MONAD_NAMESPACE_BEGIN
 class State;
 
 template <Traits traits>
+bool is_precompile(Address const &);
+
+template <Traits traits>
 std::optional<evmc::Result>
 check_call_precompile(State &, evmc_message const &msg);
 


### PR DESCRIPTION
After discussion with the team, it was decided that the staking account access charge should always be warm. The first transaction in every block is a reward, and the system has already paid for the cold access by loading it into the DB cache. Note that this deviates from traditonal ethereum pricing, which is per transaction. We are pricing this based on a DbCache.