### PR TITLE
UntypedIR interpreter

### DIFF
--- a/category/vm/compiler/ir/instruction.hpp
+++ b/category/vm/compiler/ir/instruction.hpp
@@ -124,6 +124,7 @@ namespace monad::vm::compiler
 
         constexpr runtime::uint256_t const &immediate_value() const noexcept;
         constexpr std::uint32_t pc() const noexcept;
+        constexpr std::uint32_t next() const noexcept;
         constexpr std::uint32_t static_gas_cost() const noexcept;
         constexpr OpCode opcode() const noexcept;
         constexpr std::uint8_t stack_args() const noexcept;
@@ -188,6 +189,16 @@ namespace monad::vm::compiler
     constexpr std::uint32_t Instruction::pc() const noexcept
     {
         return pc_;
+    }
+
+    constexpr std::uint32_t Instruction::next() const noexcept
+    {
+        switch (opcode_) {
+        case OpCode::Push:
+            return pc_ + index_ + 1;
+        default:
+            return pc_ + 1;
+        }
     }
 
     constexpr std::uint32_t Instruction::static_gas_cost() const noexcept

--- a/category/vm/compiler/ir/untyped.cpp
+++ b/category/vm/compiler/ir/untyped.cpp
@@ -46,6 +46,26 @@ namespace monad::vm::compiler::untyped
     {
     }
 
+    byte_offset UntypedIR::UntypedIR::last_instruction_offset(Block const &b)
+    {
+        if (b.instrs.empty()) {
+            if (jumpdests.contains(b.offset)) {
+                return b.offset + 1;
+            }
+            else {
+                return b.offset;
+            }
+        }
+        else {
+            if (std::holds_alternative<FallThrough>(b.terminator)) {
+                return b.instrs.back().pc();
+            }
+            else {
+                return b.instrs.back().next();
+            }
+        }
+    }
+
     struct Ignored
     {
     };

--- a/category/vm/compiler/ir/untyped.hpp
+++ b/category/vm/compiler/ir/untyped.hpp
@@ -81,6 +81,8 @@ namespace monad::vm::compiler::untyped
         std::unordered_map<byte_offset, block_id> jumpdests;
         std::variant<std::vector<Block>, std::vector<local_stacks::Block>>
             blocks;
+
+        byte_offset last_instruction_offset(Block const &);
     };
 
     std::variant<std::vector<Block>, std::vector<local_stacks::Block>>

--- a/category/vm/interpreter/stack.hpp
+++ b/category/vm/interpreter/stack.hpp
@@ -30,9 +30,8 @@ namespace monad::vm::interpreter
 
     template <std::uint8_t Instr, Traits traits>
     [[gnu::always_inline]] inline void check_requirements(
-        runtime::Context &ctx, Intercode const &,
-        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t &gas_remaining)
+        runtime::Context &ctx, runtime::uint256_t const *stack_bottom,
+        runtime::uint256_t *stack_top, std::int64_t &gas_remaining)
     {
         static constexpr auto info = compiler::opcode_table<traits>[Instr];
 
@@ -71,6 +70,16 @@ namespace monad::vm::interpreter
                 }
             }
         }
+    }
+
+    template <std::uint8_t Instr, Traits traits>
+    [[gnu::always_inline]] inline void check_requirements(
+        runtime::Context &ctx, Intercode const &,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t &gas_remaining)
+    {
+        check_requirements<Instr, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
     }
 
     [[gnu::always_inline]] inline void

--- a/category/vm/vm.hpp
+++ b/category/vm/vm.hpp
@@ -155,6 +155,16 @@ namespace monad::vm
             return compiler_config_;
         }
 
+        runtime::EvmStackAllocator &stack_allocator()
+        {
+            return stack_allocator_;
+        }
+
+        runtime::EvmMemoryAllocator &memory_allocator()
+        {
+            return memory_allocator_;
+        };
+
         /// Execute varcode. The function will execute the nativecode in
         /// the varcode if set. Otherwise execute the intercode with
         /// interpreter and potentially start async compilation.

--- a/test/vm/CMakeLists.txt
+++ b/test/vm/CMakeLists.txt
@@ -35,6 +35,7 @@ if(MONAD_COMPILER_TESTING)
 endif()
 
 if(MONAD_COMPILER_BENCHMARKS OR MONAD_COMPILER_TESTING)
+  add_subdirectory(untyped_ir_interpreter)
   add_subdirectory(vm)
 endif()
 

--- a/test/vm/fuzzer/assertions.cpp
+++ b/test/vm/fuzzer/assertions.cpp
@@ -35,14 +35,16 @@ namespace monad::vm::fuzzing
         MONAD_VM_ASSERT(a.access_status == b.access_status);
     }
 
-    void assert_equal(Account const &a, Account const &b)
+    void assert_equal(Account const &a, Account const &b, bool check_tstorage)
     {
         MONAD_VM_ASSERT(
             a.transient_storage.size() == b.transient_storage.size());
-        for (auto const &[k, v] : a.transient_storage) {
-            auto const found = b.transient_storage.find(k);
-            MONAD_VM_ASSERT(found != b.transient_storage.end());
-            MONAD_VM_ASSERT(found->second == v);
+        if (check_tstorage) {
+            for (auto const &[k, v] : a.transient_storage) {
+                auto const found = b.transient_storage.find(k);
+                MONAD_VM_ASSERT(found != b.transient_storage.end());
+                MONAD_VM_ASSERT(found->second == v);
+            }
         }
 
         MONAD_VM_ASSERT(a.storage.size() == b.storage.size());
@@ -61,7 +63,7 @@ namespace monad::vm::fuzzing
         MONAD_VM_ASSERT(a.access_status == b.access_status);
     }
 
-    void assert_equal(State const &a, State const &b)
+    void assert_equal(State const &a, State const &b, bool check_tstorage)
     {
         auto const &a_accs = a.get_modified_accounts();
         auto const &b_accs = b.get_modified_accounts();
@@ -70,7 +72,7 @@ namespace monad::vm::fuzzing
         for (auto const &[k, v] : a_accs) {
             auto const found = b_accs.find(k);
             MONAD_VM_ASSERT(found != b_accs.end());
-            assert_equal(v, found->second);
+            assert_equal(v, found->second, check_tstorage);
         }
     }
 

--- a/test/vm/fuzzer/assertions.hpp
+++ b/test/vm/fuzzer/assertions.hpp
@@ -25,10 +25,12 @@ namespace monad::vm::fuzzing
         evmone::state::StorageValue const &b);
 
     void assert_equal(
-        evmone::state::Account const &a, evmone::state::Account const &b);
+        evmone::state::Account const &a, evmone::state::Account const &b,
+        bool check_tstorage);
 
-    void
-    assert_equal(evmone::state::State const &a, evmone::state::State const &b);
+    void assert_equal(
+        evmone::state::State const &a, evmone::state::State const &b,
+        bool check_tstorage);
 
     void assert_equal(
         evmc::Result const &evmone_result, evmc::Result const &compiler_result,

--- a/test/vm/untyped_ir_interpreter/CMakeLists.txt
+++ b/test/vm/untyped_ir_interpreter/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Copyright (C) 2025 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+option(MONAD_VM_INTERPRETER_DEBUG "Trace instructions executed by interpreter" OFF)
+
+add_library(monad-vm-untyped-ir-interpreter OBJECT)
+
+target_sources(monad-vm-untyped-ir-interpreter PRIVATE
+  "debug.hpp"
+  "execute.cpp"
+  "execute.hpp"
+  "instruction_table.hpp"
+  "instructions_fwd.hpp"
+  "intercode_untyped_ir.cpp"
+  "intercode_untyped_ir.hpp"
+  "push.hpp"
+  "types.hpp"
+)
+
+monad_compile_options(monad-vm-untyped-ir-interpreter)
+
+# Use -Og for debug build to reduce stack usage.
+target_compile_options(monad-vm-untyped-ir-interpreter PRIVATE $<$<CONFIG:Debug>:-Og>)
+
+# This is a workaround for a change made to LLVM between versions 18 and 19:
+# https://github.com/llvm/llvm-project/pull/78582
+#
+# The change in question restricts the default maximum predecessors and
+# successors that a basic block can have if it is to be duplicated (rather than
+# being shared). This affects the dispatch table of the interpreter by causing
+# the "load next instruction, indirect jump" block tail to be emitted as a
+# single shared block rather than being inlined into each opcode's dispatch
+# block. Doing so slows the interpreter down when compiled with Clang 19.
+# Because the LLVM change in question is for _compiler_ performance rather than
+# _runtime_ performance, we can safely disable the pessimisation by setting this
+# flag to a value we know to be large enough for our dispatch table.
+target_compile_options(
+  monad-vm-untyped-ir-interpreter
+  PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-mllvm -tail-dup-pred-size=256>)
+
+if(MONAD_VM_INTERPRETER_DEBUG)
+  target_compile_definitions(monad-vm-untyped-ir-interpreter PRIVATE MONAD_VM_INTERPRETER_DEBUG)
+endif()
+
+if(MONAD_VM_INTERPRETER_STATS)
+  target_compile_definitions(monad-vm-untyped-ir-interpreter PRIVATE MONAD_VM_INTERPRETER_STATS)
+endif()
+
+target_include_directories(monad-vm-untyped-ir-interpreter
+    PUBLIC .
+)
+
+target_link_libraries(monad-vm-untyped-ir-interpreter
+    PUBLIC monad-vm::monad-vm-compiler
+    PUBLIC monad-vm::monad-vm-interpreter
+)
+
+add_library(monad-vm::monad-vm-untyped-ir-interpreter ALIAS monad-vm-untyped-ir-interpreter)

--- a/test/vm/untyped_ir_interpreter/debug.hpp
+++ b/test/vm/untyped_ir_interpreter/debug.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <evmc/evmc.h>
+
+#include <format>
+#include <iostream>
+
+namespace monad::vm::interpreter
+{
+#ifdef MONAD_VM_INTERPRETER_DEBUG
+    constexpr auto debug_enabled = true;
+#else
+    constexpr auto debug_enabled = false;
+#endif
+
+    template <Traits traits>
+    void inline trace(
+        IntercodeUntypedIR const &analysis, std::int64_t gas_remaining,
+        std::uint8_t const *instr_ptr)
+    {
+        std::cerr << std::format(
+            "offset: {:#04x}  opcode: {:#x}  gas_left: {}\n",
+            instr_ptr - analysis.code(),
+            *instr_ptr,
+            gas_remaining);
+    }
+}

--- a/test/vm/untyped_ir_interpreter/execute.cpp
+++ b/test/vm/untyped_ir_interpreter/execute.cpp
@@ -1,0 +1,83 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/evm/explicit_traits.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <category/vm/runtime/uint256.hpp>
+#include <category/vm/utils/traits.hpp>
+#include <test/vm/untyped_ir_interpreter/instruction_table.hpp>
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <cstdint>
+
+/**
+ * Assembly trampoline into the interpreter's core loop (see entry.S). This
+ * function sets up the stack to be compatible with the runtime's exit ABI, then
+ * jumps to `core_loop<traits>`. It is therefore important that these two
+ * functions always maintain the same signature (so that arguments are in the
+ * expected registers when jumping to the core loop).
+ */
+extern "C" void monad_vm_interpreter_trampoline(
+    void *, ::monad::vm::runtime::Context *,
+    ::monad::vm::interpreter::IntercodeUntypedIR const *,
+    ::monad::vm::runtime::uint256_t *, void *);
+
+namespace monad::vm::interpreter::untyped_ir
+{
+    namespace
+    {
+        template <Traits traits>
+        void core_loop(
+            void *, runtime::Context *ctx, IntercodeUntypedIR const *analysis,
+            runtime::uint256_t *stack_ptr, void *)
+        {
+            static_assert(
+                utils::same_signature(
+                    monad_vm_interpreter_trampoline, core_loop<traits>),
+                "Interpreter core loop and trampoline signatures must be "
+                "identical");
+
+            auto *const stack_top = stack_ptr - 1;
+            auto const *const stack_bottom = stack_top;
+            auto const *const instr_ptr = analysis->code();
+            auto const gas_remaining = ctx->gas_remaining;
+
+            instruction_table_untyped_ir<traits>[*instr_ptr](
+                *ctx,
+                *analysis,
+                stack_bottom,
+                stack_top,
+                gas_remaining,
+                false,
+                instr_ptr);
+        }
+    }
+
+    template <Traits traits>
+    void execute(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        std::uint8_t *stack_ptr)
+    {
+        monad_vm_interpreter_trampoline(
+            static_cast<void *>(&ctx.exit_stack_ptr),
+            &ctx,
+            &analysis,
+            reinterpret_cast<runtime::uint256_t *>(stack_ptr),
+            reinterpret_cast<void *>(core_loop<traits>));
+    }
+
+    EXPLICIT_TRAITS(execute);
+}

--- a/test/vm/untyped_ir_interpreter/execute.hpp
+++ b/test/vm/untyped_ir_interpreter/execute.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/runtime/allocator.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+
+namespace monad::vm::interpreter::untyped_ir
+{
+    template <Traits traits>
+    void execute(
+        runtime::Context &, IntercodeUntypedIR const &,
+        std::uint8_t *stack_ptr);
+}

--- a/test/vm/untyped_ir_interpreter/instruction_table.hpp
+++ b/test/vm/untyped_ir_interpreter/instruction_table.hpp
@@ -1,0 +1,1883 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/interpreter/call_runtime.hpp>
+#include <category/vm/interpreter/stack.hpp>
+#include <category/vm/runtime/runtime.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <category/vm/runtime/uint256.hpp>
+#include <category/vm/utils/debug.hpp>
+#include <test/vm/untyped_ir_interpreter/debug.hpp>
+#include <test/vm/untyped_ir_interpreter/instructions_fwd.hpp>
+#include <test/vm/untyped_ir_interpreter/push.hpp>
+#include <test/vm/untyped_ir_interpreter/types.hpp>
+
+#include <evmc/evmc.h>
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+
+#if defined(__has_attribute)
+    #if __has_attribute(musttail)
+        #define MONAD_VM_MUST_TAIL __attribute__((musttail))
+    #else
+        #error "No compiler support for __attribute__((musttail))"
+    #endif
+#else
+    #error "No compiler support for __has_attribute"
+#endif
+
+#define MONAD_VM_NEXT(OP)                                                      \
+    do {                                                                       \
+        static constexpr auto delta =                                          \
+            compiler::opcode_table<traits>[(OP)].stack_increase -              \
+            compiler::opcode_table<traits>[(OP)].min_stack;                    \
+        ++instr_ptr;                                                           \
+        if constexpr (debug_enabled) {                                         \
+            trace<traits>(analysis, gas_remaining, instr_ptr);                 \
+        }                                                                      \
+        MONAD_VM_MUST_TAIL return instruction_table_untyped_ir<                \
+            traits>[*instr_ptr](                                               \
+            ctx,                                                               \
+            analysis,                                                          \
+            stack_bottom,                                                      \
+            stack_top + delta,                                                 \
+            gas_remaining,                                                     \
+            true,                                                              \
+            instr_ptr);                                                        \
+    }                                                                          \
+    while (false);
+
+#define MONAD_VM_NEXT_PUSH(OP)                                                 \
+    do {                                                                       \
+        static constexpr auto delta =                                          \
+            compiler::opcode_table<traits>[(OP)].stack_increase -              \
+            compiler::opcode_table<traits>[(OP)].min_stack;                    \
+                                                                               \
+        instr_ptr += (((OP) - PUSH0) + 1);                                     \
+        if constexpr (debug_enabled) {                                         \
+            trace<traits>(analysis, gas_remaining, instr_ptr);                 \
+        }                                                                      \
+        MONAD_VM_MUST_TAIL return instruction_table_untyped_ir<                \
+            traits>[*instr_ptr](                                               \
+            ctx,                                                               \
+            analysis,                                                          \
+            stack_bottom,                                                      \
+            stack_top + delta,                                                 \
+            gas_remaining,                                                     \
+            true,                                                              \
+            instr_ptr);                                                        \
+    }                                                                          \
+    while (false);
+
+namespace monad::vm::interpreter
+{
+    using enum runtime::StatusCode;
+    using enum compiler::EvmOpCode;
+
+    template <Traits traits>
+    consteval InstrTableUntypedIR make_instruction_table_untyped_ir()
+    {
+        constexpr auto since = [](evmc_revision first,
+                                  InstrEvalUntypedIR impl) {
+            return (traits::evm_rev() >= first) ? impl : invalid;
+        };
+
+        return {
+            stop, // 0x00
+            add<traits>, // 0x01
+            mul<traits>, // 0x02
+            sub<traits>, // 0x03
+            udiv<traits>, // 0x04,
+            sdiv<traits>, // 0x05,
+            umod<traits>, // 0x06,
+            smod<traits>, // 0x07,
+            addmod<traits>, // 0x08,
+            mulmod<traits>, // 0x09,
+            exp<traits>, // 0x0A,
+            signextend<traits>, // 0x0B,
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            lt<traits>, // 0x10,
+            gt<traits>, // 0x11,
+            slt<traits>, // 0x12,
+            sgt<traits>, // 0x13,
+            eq<traits>, // 0x14,
+            iszero<traits>, // 0x15,
+            and_<traits>, // 0x16,
+            or_<traits>, // 0x17,
+            xor_<traits>, // 0x18,
+            not_<traits>, // 0x19,
+            byte<traits>, // 0x1A,
+            since(EVMC_CONSTANTINOPLE, shl<traits>), // 0x1B,
+            since(EVMC_CONSTANTINOPLE, shr<traits>), // 0x1C,
+            since(EVMC_CONSTANTINOPLE, sar<traits>), // 0x1D,
+            invalid, //
+            invalid, //
+
+            sha3<traits>, // 0x20,
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid,
+            //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            address<traits>, // 0x30,
+            balance<traits>, // 0x31,
+            origin<traits>, // 0x32,
+            caller<traits>, // 0x33,
+            callvalue<traits>, // 0x34,
+            calldataload<traits>, // 0x35,
+            calldatasize<traits>, // 0x36,
+            calldatacopy<traits>, // 0x37,
+            codesize<traits>, // 0x38,
+            codecopy<traits>, // 0x39,
+            gasprice<traits>, // 0x3A,
+            extcodesize<traits>, // 0x3B,
+            extcodecopy<traits>, // 0x3C,
+            since(EVMC_BYZANTIUM, returndatasize<traits>), // 0x3D,
+            since(EVMC_BYZANTIUM, returndatacopy<traits>), // 0x3E,
+            since(EVMC_CONSTANTINOPLE, extcodehash<traits>), // 0x3F,
+
+            blockhash<traits>, // 0x40,
+            coinbase<traits>, // 0x41,
+            timestamp<traits>, // 0x42,
+            number<traits>, // 0x43,
+            prevrandao<traits>, // 0x44,
+            gaslimit<traits>, // 0x45,
+            since(EVMC_ISTANBUL, chainid<traits>), // 0x46,
+            since(EVMC_ISTANBUL, selfbalance<traits>), // 0x47,
+            since(EVMC_LONDON, basefee<traits>), // 0x48,
+            since(EVMC_CANCUN, blobhash<traits>), // 0x49,
+            since(EVMC_CANCUN, blobbasefee<traits>), // 0x4A,
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            pop<traits>, // 0x50,
+            mload<traits>, // 0x51,
+            mstore<traits>, // 0x52,
+            mstore8<traits>, // 0x53,
+            sload<traits>, // 0x54,
+            sstore<traits>, // 0x55,
+            jump<traits>, // 0x56,
+            jumpi<traits>, // 0x57,
+            pc<traits>, // 0x58,
+            msize<traits>, // 0x59,
+            gas<traits>, // 0x5A,
+            jumpdest<traits>, // 0x5B,
+            since(EVMC_CANCUN, tload<traits>), // 0x5C,
+            since(EVMC_CANCUN, tstore<traits>), // 0x5D,
+            since(EVMC_CANCUN, mcopy<traits>), // 0x5E,
+            since(EVMC_SHANGHAI, push<0, traits>), // 0x5F,
+
+            push<1, traits>, // 0x60,
+            push<2, traits>, // 0x61,
+            push<3, traits>, // 0x62,
+            push<4, traits>, // 0x63,
+            push<5, traits>, // 0x64,
+            push<6, traits>, // 0x65,
+            push<7, traits>, // 0x66,
+            push<8, traits>, // 0x67,
+            push<9, traits>, // 0x68,
+            push<10, traits>, // 0x69,
+            push<11, traits>, // 0x6A,
+            push<12, traits>, // 0x6B,
+            push<13, traits>, // 0x6C,
+            push<14, traits>, // 0x6D,
+            push<15, traits>, // 0x6E,
+            push<16, traits>, // 0x6F,
+
+            push<17, traits>, // 0x70,
+            push<18, traits>, // 0x71,
+            push<19, traits>, // 0x72,
+            push<20, traits>, // 0x73,
+            push<21, traits>, // 0x74,
+            push<22, traits>, // 0x75,
+            push<23, traits>, // 0x76,
+            push<24, traits>, // 0x77,
+            push<25, traits>, // 0x78,
+            push<26, traits>, // 0x79,
+            push<27, traits>, // 0x7A,
+            push<28, traits>, // 0x7B,
+            push<29, traits>, // 0x7C,
+            push<30, traits>, // 0x7D,
+            push<31, traits>, // 0x7E,
+            push<32, traits>, // 0x7F,
+
+            dup<1, traits>, // 0x80,
+            dup<2, traits>, // 0x81,
+            dup<3, traits>, // 0x82,
+            dup<4, traits>, // 0x83,
+            dup<5, traits>, // 0x84,
+            dup<6, traits>, // 0x85,
+            dup<7, traits>, // 0x86,
+            dup<8, traits>, // 0x87,
+            dup<9, traits>, // 0x88,
+            dup<10, traits>, // 0x89,
+            dup<11, traits>, // 0x8A,
+            dup<12, traits>, // 0x8B,
+            dup<13, traits>, // 0x8C,
+            dup<14, traits>, // 0x8D,
+            dup<15, traits>, // 0x8E,
+            dup<16, traits>, // 0x8F,
+
+            swap<1, traits>, // 0x90,
+            swap<2, traits>, // 0x91,
+            swap<3, traits>, // 0x92,
+            swap<4, traits>, // 0x93,
+            swap<5, traits>, // 0x94,
+            swap<6, traits>, // 0x95,
+            swap<7, traits>, // 0x96,
+            swap<8, traits>, // 0x97,
+            swap<9, traits>, // 0x98,
+            swap<10, traits>, // 0x99,
+            swap<11, traits>, // 0x9A,
+            swap<12, traits>, // 0x9B,
+            swap<13, traits>, // 0x9C,
+            swap<14, traits>, // 0x9D,
+            swap<15, traits>, // 0x9E,
+            swap<16, traits>, // 0x9F,
+
+            log<0, traits>, // 0xA0,
+            log<1, traits>, // 0xA1,
+            log<2, traits>, // 0xA2,
+            log<3, traits>, // 0xA3,
+            log<4, traits>, // 0xA4,
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+
+            create<traits>, // 0xF0,
+            call<traits>, // 0xF1,
+            callcode<traits>, // 0xF2,
+            return_<traits>, // 0xF3,
+            since(EVMC_HOMESTEAD, delegatecall<traits>), // 0xF4,
+            since(EVMC_CONSTANTINOPLE, create2<traits>), // 0xF5,
+            invalid, //
+            invalid, //
+            invalid, //
+            invalid, //
+            since(EVMC_BYZANTIUM, staticcall<traits>), // 0xFA,
+            invalid, //
+            invalid, //
+            since(EVMC_BYZANTIUM, revert<traits>), // 0xFD,
+            invalid, // 0xFE,
+            selfdestruct<traits>, // 0xFF,
+        };
+    }
+
+    template <Traits traits>
+    constexpr InstrTableUntypedIR instruction_table_untyped_ir =
+        make_instruction_table_untyped_ir<traits>();
+
+    // Instruction implementations
+    template <std::uint8_t Opcode, Traits traits, typename... FnArgs>
+    [[gnu::always_inline]] inline void checked_runtime_call(
+        void (*f)(FnArgs...), runtime::Context &ctx, IntercodeUntypedIR const &,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t &gas_remaining, std::uint8_t const *)
+    {
+        check_requirements<Opcode, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        call_runtime(f, ctx, stack_top, gas_remaining);
+    }
+
+#ifdef MONAD_COMPILER_TESTING
+    [[gnu::always_inline]]
+    inline void fuzz_tstore_stack(
+        runtime::Context const &ctx, runtime::uint256_t const *stack_bottom,
+        runtime::uint256_t const *stack_top, std::uint64_t base_offset)
+    {
+        if (!utils::is_fuzzing_monad_vm) {
+            return;
+        }
+        monad::vm::runtime::debug_tstore_stack(
+            &ctx,
+            stack_top + 1,
+            static_cast<uint64_t>(stack_top - stack_bottom),
+            0,
+            base_offset);
+    }
+#else
+    [[gnu::always_inline]] inline void fuzz_tstore_stack(
+        runtime::Context const &, runtime::uint256_t const *,
+        runtime::uint256_t const *, std::uint64_t)
+    {
+        // nop
+    }
+#endif
+
+    // Arithmetic
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    add(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<ADD, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a + b;
+
+        MONAD_VM_NEXT(ADD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    mul(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MUL, traits>(
+            monad_vm_runtime_mul,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MUL);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sub(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SUB, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a - b;
+
+        MONAD_VM_NEXT(SUB);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void udiv(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<DIV, traits>(
+            runtime::udiv,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(DIV);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sdiv(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SDIV, traits>(
+            runtime::sdiv,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SDIV);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void umod(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MOD, traits>(
+            runtime::umod,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MOD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void smod(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SMOD, traits>(
+            runtime::smod,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SMOD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void addmod(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<ADDMOD, traits>(
+            runtime::addmod,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(ADDMOD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mulmod(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MULMOD, traits>(
+            runtime::mulmod,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MULMOD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    exp(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<EXP, traits>(
+            runtime::exp<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(EXP);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void signextend(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SIGNEXTEND, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[b, x] = top_two(stack_top);
+        x = runtime::signextend(b, x);
+
+        MONAD_VM_NEXT(SIGNEXTEND);
+    }
+
+    // Boolean
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    lt(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+       runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+       std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<LT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a < b;
+
+        MONAD_VM_NEXT(LT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    gt(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+       runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+       std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<GT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a > b;
+
+        MONAD_VM_NEXT(GT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    slt(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SLT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = slt(a, b);
+
+        MONAD_VM_NEXT(SLT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sgt(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SGT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = slt(b, a); // note swapped arguments
+
+        MONAD_VM_NEXT(SGT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    eq(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+       runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+       std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<EQ, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = (a == b);
+
+        MONAD_VM_NEXT(EQ);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void iszero(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<ISZERO, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &a = *stack_top;
+        a = !a;
+
+        MONAD_VM_NEXT(ISZERO);
+    }
+
+    // Bitwise
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void and_(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<AND, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a & b;
+
+        MONAD_VM_NEXT(AND);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    or_(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<OR, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a | b;
+
+        MONAD_VM_NEXT(OR);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void xor_(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<XOR, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[a, b] = top_two(stack_top);
+        b = a ^ b;
+
+        MONAD_VM_NEXT(XOR);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void not_(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<NOT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &a = *stack_top;
+        a = ~a;
+
+        MONAD_VM_NEXT(NOT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void byte(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<BYTE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[i, x] = top_two(stack_top);
+        x = runtime::byte(i, x);
+
+        MONAD_VM_NEXT(BYTE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    shl(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SHL, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[shift, value] = top_two(stack_top);
+        value <<= shift;
+
+        MONAD_VM_NEXT(SHL);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    shr(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SHR, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[shift, value] = top_two(stack_top);
+        value >>= shift;
+
+        MONAD_VM_NEXT(SHR);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sar(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SAR, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto &&[shift, value] = top_two(stack_top);
+        value = runtime::sar(shift, value);
+
+        MONAD_VM_NEXT(SAR);
+    }
+
+    // Data
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sha3(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SHA3, traits>(
+            runtime::sha3,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SHA3);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void address(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<ADDRESS, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, runtime::uint256_from_address(ctx.env.recipient));
+
+        MONAD_VM_NEXT(ADDRESS);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void balance(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<BALANCE, traits>(
+            runtime::balance<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(BALANCE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void origin(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<ORIGIN, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_address(ctx.env.tx_context.tx_origin));
+
+        MONAD_VM_NEXT(ORIGIN);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void caller(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CALLER, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, runtime::uint256_from_address(ctx.env.sender));
+
+        MONAD_VM_NEXT(CALLER);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void callvalue(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CALLVALUE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, runtime::uint256_from_bytes32(ctx.env.value));
+
+        MONAD_VM_NEXT(CALLVALUE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldataload(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CALLDATALOAD, traits>(
+            runtime::calldataload,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CALLDATALOAD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldatasize(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CALLDATASIZE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.input_data_size);
+
+        MONAD_VM_NEXT(CALLDATASIZE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldatacopy(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CALLDATACOPY, traits>(
+            runtime::calldatacopy,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CALLDATACOPY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void codesize(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CODESIZE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.code_size);
+
+        MONAD_VM_NEXT(CODESIZE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void codecopy(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CODECOPY, traits>(
+            runtime::codecopy,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CODECOPY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void gasprice(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<GAS, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_bytes32(ctx.env.tx_context.tx_gas_price));
+
+        MONAD_VM_NEXT(GASPRICE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodesize(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<EXTCODESIZE, traits>(
+            runtime::extcodesize<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(EXTCODESIZE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodecopy(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<EXTCODECOPY, traits>(
+            runtime::extcodecopy<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(EXTCODECOPY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void returndatasize(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<RETURNDATASIZE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.return_data_size);
+
+        MONAD_VM_NEXT(RETURNDATASIZE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void returndatacopy(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<RETURNDATACOPY, traits>(
+            runtime::returndatacopy,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(RETURNDATACOPY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodehash(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<EXTCODEHASH, traits>(
+            runtime::extcodehash<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(EXTCODEHASH);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blockhash(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<BLOCKHASH, traits>(
+            runtime::blockhash,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(BLOCKHASH);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void coinbase(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<COINBASE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_address(ctx.env.tx_context.block_coinbase));
+
+        MONAD_VM_NEXT(COINBASE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void timestamp(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<TIMESTAMP, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.tx_context.block_timestamp);
+
+        MONAD_VM_NEXT(TIMESTAMP);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void number(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<NUMBER, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.tx_context.block_number);
+
+        MONAD_VM_NEXT(NUMBER);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void prevrandao(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<DIFFICULTY, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_bytes32(
+                ctx.env.tx_context.block_prev_randao));
+
+        MONAD_VM_NEXT(DIFFICULTY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void gaslimit(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<GASLIMIT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.env.tx_context.block_gas_limit);
+
+        MONAD_VM_NEXT(GASLIMIT);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void chainid(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CHAINID, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_bytes32(ctx.env.tx_context.chain_id));
+
+        MONAD_VM_NEXT(CHAINID);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void selfbalance(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SELFBALANCE, traits>(
+            runtime::selfbalance,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SELFBALANCE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void basefee(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<BASEFEE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_bytes32(ctx.env.tx_context.block_base_fee));
+
+        MONAD_VM_NEXT(BASEFEE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blobhash(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<BLOBHASH, traits>(
+            runtime::blobhash,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(BLOBHASH);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blobbasefee(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<BLOBBASEFEE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(
+            stack_top,
+            runtime::uint256_from_bytes32(ctx.env.tx_context.blob_base_fee));
+
+        MONAD_VM_NEXT(BLOBBASEFEE);
+    }
+
+    // Memory & Storage
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mload(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MLOAD, traits>(
+            runtime::mload,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MLOAD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mstore(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MSTORE, traits>(
+            runtime::mstore,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MSTORE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mstore8(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MSTORE8, traits>(
+            runtime::mstore8,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MSTORE8);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mcopy(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<MCOPY, traits>(
+            runtime::mcopy,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(MCOPY);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sstore(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SSTORE, traits>(
+            runtime::sstore<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SSTORE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sload(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<SLOAD, traits>(
+            runtime::sload<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(SLOAD);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void tstore(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<TSTORE, traits>(
+            runtime::tstore,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(TSTORE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void tload(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<TLOAD, traits>(
+            runtime::tload,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(TLOAD);
+    }
+
+    // Execution IntercodeUntypedIR
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    pc(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+       runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+       std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<PC, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, instr_ptr - analysis.code());
+
+        MONAD_VM_NEXT(PC);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void msize(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<MSIZE, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, ctx.memory.size);
+
+        MONAD_VM_NEXT(MSIZE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    gas(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<GAS, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        push(stack_top, gas_remaining);
+
+        MONAD_VM_NEXT(GAS);
+    }
+
+    // Stack
+    template <std::size_t N, Traits traits>
+        requires(N <= 32)
+    MONAD_VM_INSTRUCTION_CALL void push(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        push_impl_untyped_ir<N, traits>::push(
+            ctx, analysis, stack_bottom, stack_top, gas_remaining, instr_ptr);
+
+        MONAD_VM_NEXT_PUSH(PUSH0 + N);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    pop(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<POP, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        MONAD_VM_NEXT(POP);
+    }
+
+    template <std::size_t N, Traits traits>
+        requires(N >= 1)
+    MONAD_VM_INSTRUCTION_CALL void
+    dup(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<DUP1 + (N - 1), traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+
+        auto *const old_top = stack_top;
+        push(stack_top, *(old_top - (N - 1)));
+
+        MONAD_VM_NEXT(DUP1 + (N - 1));
+    }
+
+    template <std::size_t N, Traits traits>
+        requires(N >= 1)
+    MONAD_VM_INSTRUCTION_CALL void swap(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<SWAP1 + (N - 1), traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+
+        auto const top = stack_top->to_avx();
+        *stack_top = *(stack_top - N);
+        *(stack_top - N) = runtime::uint256_t{top};
+
+        MONAD_VM_NEXT(SWAP1 + (N - 1));
+    }
+
+    // Control Flow
+    namespace
+    {
+        inline std::uint8_t const *cast_evm_word_to_ptr(
+            IntercodeUntypedIR const &analysis,
+            runtime::uint256_t const &target)
+        {
+            if (MONAD_VM_UNLIKELY(
+                    target > std::numeric_limits<std::size_t>::max())) {
+                return nullptr;
+            }
+
+            auto const jd = static_cast<std::size_t>(target);
+            if (MONAD_VM_UNLIKELY(!analysis.is_jumpdest(jd))) {
+                return nullptr;
+            }
+
+            return analysis.code() + jd;
+        }
+
+        inline void cast_pointers(
+            IntercodeUntypedIR const &analysis, runtime::uint256_t *stack_top,
+            std::vector<std::size_t> const &coerce_list)
+        {
+            for (auto c : coerce_list) {
+                auto ptr = cast_evm_word_to_ptr(analysis, *(stack_top - c));
+                (*(stack_top - c))[0] = reinterpret_cast<uintptr_t>(ptr);
+            }
+        }
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jump(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<JUMP, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto const &target = pop(stack_top);
+
+        if (auto it = analysis.jump_coerce_map.find(
+                static_cast<std::size_t>(instr_ptr - analysis.code()));
+            it != analysis.jump_coerce_map.end()) {
+            cast_pointers(analysis, stack_top, it->second);
+        }
+
+        auto const *const new_ip = [&]() {
+            if (auto it = analysis.jumpdest_addr.find(
+                    static_cast<std::size_t>(instr_ptr - analysis.code()));
+                it != analysis.jumpdest_addr.end()) {
+                return reinterpret_cast<std::uint8_t const *>(
+                    static_cast<uintptr_t>(target[0]));
+            }
+            else {
+                return cast_evm_word_to_ptr(analysis, target);
+            }
+        }();
+
+        if (MONAD_VM_UNLIKELY(!new_ip)) {
+            ctx.exit(Error);
+        }
+
+        if constexpr (debug_enabled) {
+            trace<traits>(analysis, gas_remaining, new_ip);
+        }
+
+        MONAD_VM_MUST_TAIL return instruction_table_untyped_ir<traits>[*new_ip](
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            false,
+            new_ip);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jumpi(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<JUMPI, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        auto const &target = pop(stack_top);
+        auto const &cond = pop(stack_top);
+
+        if (cond) {
+            if (auto it = analysis.jump_coerce_map.find(
+                    static_cast<std::size_t>(instr_ptr - analysis.code()));
+                it != analysis.jump_coerce_map.end()) {
+                cast_pointers(analysis, stack_top, it->second);
+            }
+
+            auto const *const new_ip = [&]() {
+                if (auto it = analysis.jumpdest_addr.find(
+                        static_cast<std::size_t>(instr_ptr - analysis.code()));
+                    it != analysis.jumpdest_addr.end()) {
+                    return reinterpret_cast<std::uint8_t const *>(
+                        static_cast<uintptr_t>(target[0]));
+                }
+                else {
+                    return cast_evm_word_to_ptr(analysis, target);
+                }
+            }();
+
+            if (MONAD_VM_UNLIKELY(!new_ip)) {
+                ctx.exit(Error);
+            }
+
+            if constexpr (debug_enabled) {
+                trace<traits>(analysis, gas_remaining, new_ip);
+            }
+
+            MONAD_VM_MUST_TAIL return instruction_table_untyped_ir<
+                traits>[*new_ip](
+                ctx,
+                analysis,
+                stack_bottom,
+                stack_top,
+                gas_remaining,
+                false,
+                new_ip);
+        }
+        else {
+            if (auto it = analysis.fallthrough_coerce_map.find(
+                    static_cast<std::size_t>(instr_ptr - analysis.code()));
+                it != analysis.fallthrough_coerce_map.end()) {
+                cast_pointers(analysis, stack_top, it->second);
+            }
+            ++instr_ptr;
+
+            if constexpr (debug_enabled) {
+                trace<traits>(analysis, gas_remaining, instr_ptr);
+            }
+            MONAD_VM_MUST_TAIL return instruction_table_untyped_ir<
+                traits>[*instr_ptr](
+                ctx,
+                analysis,
+                stack_bottom,
+                stack_top,
+                gas_remaining,
+                false,
+                instr_ptr);
+        }
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jumpdest(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool is_fallthrough,
+        std::uint8_t const *instr_ptr)
+    {
+        fuzz_tstore_stack(
+            ctx,
+            stack_bottom,
+            stack_top,
+            static_cast<uint64_t>(instr_ptr - analysis.code()));
+        check_requirements<JUMPDEST, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+
+        if (is_fallthrough) {
+            if (auto it = analysis.fallthrough_coerce_map.find(
+                    static_cast<std::size_t>(instr_ptr - analysis.code()));
+                it != analysis.fallthrough_coerce_map.end()) {
+                cast_pointers(analysis, stack_top, it->second);
+            }
+        }
+
+        MONAD_VM_NEXT(JUMPDEST);
+    }
+
+    // Logging
+    template <std::size_t N, Traits traits>
+        requires(N <= 4)
+    MONAD_VM_INSTRUCTION_CALL void
+    log(runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        static constexpr auto impls = std::tuple{
+            &runtime::log0,
+            &runtime::log1,
+            &runtime::log2,
+            &runtime::log3,
+            &runtime::log4,
+        };
+
+        checked_runtime_call<LOG0 + N, traits>(
+            std::get<N>(impls),
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(LOG0 + N);
+    }
+
+    // Call & Create
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void create(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CREATE, traits>(
+            runtime::create<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CREATE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void call(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CALL, traits>(
+            runtime::call<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CALL);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void callcode(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CALLCODE, traits>(
+            runtime::callcode<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CALLCODE);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void delegatecall(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<DELEGATECALL, traits>(
+            runtime::delegatecall<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(DELEGATECALL);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void create2(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<CREATE2, traits>(
+            runtime::create2<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(CREATE2);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void staticcall(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        checked_runtime_call<STATICCALL, traits>(
+            runtime::staticcall<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+
+        MONAD_VM_NEXT(STATICCALL);
+    }
+
+    // VM Control
+    namespace
+    {
+        inline void return_impl [[noreturn]] (
+            runtime::StatusCode const code, runtime::Context &ctx,
+            runtime::uint256_t *stack_top, std::int64_t gas_remaining)
+        {
+            for (auto *result_loc : {&ctx.result.offset, &ctx.result.size}) {
+                std::copy_n(
+                    stack_top->as_bytes(),
+                    32,
+                    reinterpret_cast<std::uint8_t *>(result_loc));
+
+                --stack_top;
+            }
+
+            ctx.gas_remaining = gas_remaining;
+            ctx.exit(code);
+        }
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void return_(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *)
+    {
+        fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
+        check_requirements<RETURN, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        return_impl(Success, ctx, stack_top, gas_remaining);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void revert(
+        runtime::Context &ctx, IntercodeUntypedIR const &,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *)
+    {
+        check_requirements<REVERT, traits>(
+            ctx, stack_bottom, stack_top, gas_remaining);
+        return_impl(Revert, ctx, stack_top, gas_remaining);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void selfdestruct(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *instr_ptr)
+    {
+        fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
+        checked_runtime_call<SELFDESTRUCT, traits>(
+            runtime::selfdestruct<traits>,
+            ctx,
+            analysis,
+            stack_bottom,
+            stack_top,
+            gas_remaining,
+            instr_ptr);
+    }
+
+    MONAD_VM_INSTRUCTION_CALL inline void stop(
+        runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, bool, std::uint8_t const *)
+    {
+        fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
+        ctx.gas_remaining = gas_remaining;
+        ctx.exit(Success);
+    }
+
+    MONAD_VM_INSTRUCTION_CALL inline void invalid(
+        runtime::Context &ctx, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *,
+        std::int64_t gas_remaining, bool, std::uint8_t const *)
+    {
+        ctx.gas_remaining = gas_remaining;
+        ctx.exit(Error);
+    }
+}
+
+#undef MONAD_VM_MUST_TAIL
+#undef MONAD_VM_NEXT
+#undef MONAD_VM_NEXT_PUSH

--- a/test/vm/untyped_ir_interpreter/instructions_fwd.hpp
+++ b/test/vm/untyped_ir_interpreter/instructions_fwd.hpp
@@ -1,0 +1,535 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <test/vm/untyped_ir_interpreter/types.hpp>
+
+#include <evmc/evmc.h>
+
+#include <cstdint>
+
+namespace monad::vm::interpreter
+{
+    // Arithmetic
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    add(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    mul(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sub(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void udiv(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sdiv(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void umod(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void smod(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void addmod(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mulmod(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    exp(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void signextend(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Boolean
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    lt(runtime::Context &, IntercodeUntypedIR const &,
+       runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+       std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    gt(runtime::Context &, IntercodeUntypedIR const &,
+       runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+       std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    slt(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sgt(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    eq(runtime::Context &, IntercodeUntypedIR const &,
+       runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+       std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void iszero(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Bitwise
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void and_(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    or_(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void xor_(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void not_(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void byte(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    shl(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    shr(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    sar(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Data
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sha3(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void address(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void balance(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void origin(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void caller(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void callvalue(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldataload(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldatasize(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void calldatacopy(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void codesize(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void codecopy(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void gasprice(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodesize(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodecopy(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void returndatasize(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void returndatacopy(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void extcodehash(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blockhash(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void coinbase(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void timestamp(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void number(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void prevrandao(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void gaslimit(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void chainid(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void selfbalance(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void basefee(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blobhash(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void blobbasefee(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Memory & Storage
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mload(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mstore(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mstore8(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void mcopy(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sstore(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void sload(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void tstore(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void tload(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Execution IntercodeUntypedIR
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    pc(runtime::Context &, IntercodeUntypedIR const &,
+       runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+       std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void msize(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    gas(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Stack
+    template <std::size_t N, Traits traits>
+        requires(N <= 32)
+    MONAD_VM_INSTRUCTION_CALL void push(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    pop(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <std::size_t N, Traits traits>
+        requires(N >= 1)
+    MONAD_VM_INSTRUCTION_CALL void
+    dup(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <std::size_t N, Traits traits>
+        requires(N >= 1)
+    MONAD_VM_INSTRUCTION_CALL void swap(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jump(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jumpi(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void jumpdest(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Logging
+    template <std::size_t N, Traits traits>
+        requires(N <= 4)
+    MONAD_VM_INSTRUCTION_CALL void
+    log(runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // Call & Create
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void create(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void call(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void callcode(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void delegatecall(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void create2(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void staticcall(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    // VM Control
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void return_(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void revert(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void selfdestruct(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    MONAD_VM_INSTRUCTION_CALL inline void stop(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    MONAD_VM_INSTRUCTION_CALL inline void invalid(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+}

--- a/test/vm/untyped_ir_interpreter/intercode_untyped_ir.cpp
+++ b/test/vm/untyped_ir_interpreter/intercode_untyped_ir.cpp
@@ -1,0 +1,192 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/core/assert.h>
+#include <category/vm/evm/opcodes.hpp>
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+
+using namespace monad::vm::compiler;
+
+namespace monad::vm::interpreter
+{
+
+    IntercodeUntypedIR::IntercodeUntypedIR(
+        std::span<std::uint8_t const> const code)
+        : padded_code_(pad(code))
+        , code_size_(
+              code_size_t::unsafe_from(static_cast<uint32_t>(code.size())))
+        , jumpdest_map_(find_jumpdests(code))
+        , ir(untyped::UntypedIR{
+              poly_typed::PolyTypedIR{local_stacks::LocalStacksIR{
+                  basic_blocks::BasicBlocksIR{code.data(), code_size_}}}})
+        , fallthrough_coerce_map(build_fallthrough_coerce_map(ir))
+        , jump_coerce_map(build_jump_coerce_map(ir))
+        , jumpdest_addr(build_jumpdest_addr_set(ir))
+    {
+    }
+
+    IntercodeUntypedIR::~IntercodeUntypedIR()
+    {
+        delete[] (padded_code_ - start_padding_size);
+    }
+
+    std::uint8_t const *
+    IntercodeUntypedIR::pad(std::span<std::uint8_t const> const code)
+    {
+        MONAD_VM_ASSERT(code.size() <= *code_size_t::max());
+        auto *buffer = new std::uint8_t
+            [start_padding_size + code.size() + end_padding_size];
+
+        std::fill_n(&buffer[0], start_padding_size, 0);
+        std::copy(code.begin(), code.end(), &buffer[start_padding_size]);
+        std::fill_n(
+            &buffer[code.size() + start_padding_size], end_padding_size, 0);
+
+        return buffer + start_padding_size;
+    }
+
+    std::unordered_map<std::size_t, std::vector<std::size_t>>
+    IntercodeUntypedIR::build_fallthrough_coerce_map(
+        monad::vm::compiler::untyped::UntypedIR ir)
+    {
+        std::unordered_map<std::size_t, std::vector<std::size_t>>
+            fallthrough_coerce_map;
+        if (!std::holds_alternative<std::vector<untyped::Block>>(ir.blocks)) {
+            return fallthrough_coerce_map;
+        }
+
+        auto const &blocks = std::get<std::vector<untyped::Block>>(ir.blocks);
+
+        for (auto it = blocks.begin(); it != blocks.end(); ++it) {
+            auto const &b = *it;
+
+            if (std::holds_alternative<untyped::FallThrough>(b.terminator) &&
+                std::get<untyped::FallThrough>(b.terminator)
+                    .fallthrough_coerce_to_addr.size()) {
+                // if the block has a fallthrough terminator, that means the
+                // next block must begin with a jumpdest, hence we store the
+                // offset to the jumpdest instruction of the next block in the
+                // map. when we fallthrough to a new block in the interpreter
+                // (i.e. the is_fallthrough flag is set) we will check in the
+                // fallthrough map to see if any coercions fromt he previous
+                // block should be applied
+                auto next_block_it = it + 1;
+                if (next_block_it != blocks.end()) {
+                    auto next_block_offset = next_block_it->offset;
+                    fallthrough_coerce_map[next_block_offset] =
+                        std::get<untyped::FallThrough>(b.terminator)
+                            .fallthrough_coerce_to_addr;
+                }
+            }
+            else if (
+                std::holds_alternative<untyped::JumpI>(b.terminator) &&
+                std::get<untyped::JumpI>(b.terminator)
+                    .fallthrough_coerce_to_addr.size()) {
+                auto last_instr_offset = ir.last_instruction_offset(b);
+                fallthrough_coerce_map[last_instr_offset] =
+                    std::get<untyped::JumpI>(b.terminator)
+                        .fallthrough_coerce_to_addr;
+            }
+        }
+
+        return fallthrough_coerce_map;
+    }
+
+    std::unordered_map<std::size_t, std::vector<std::size_t>>
+    IntercodeUntypedIR::build_jump_coerce_map(
+        monad::vm::compiler::untyped::UntypedIR ir)
+    {
+        std::unordered_map<std::size_t, std::vector<std::size_t>>
+            jump_coerce_map;
+        if (!std::holds_alternative<std::vector<untyped::Block>>(ir.blocks)) {
+            return jump_coerce_map;
+        }
+
+        auto const &blocks = std::get<std::vector<untyped::Block>>(ir.blocks);
+
+        for (auto const &b : blocks) {
+            if (std::holds_alternative<untyped::Jump>(b.terminator) &&
+                std::get<untyped::Jump>(b.terminator).coerce_to_addr.size()) {
+                auto last_instr_offset = ir.last_instruction_offset(b);
+                jump_coerce_map[last_instr_offset] =
+                    std::get<untyped::Jump>(b.terminator).coerce_to_addr;
+            }
+            else if (
+                std::holds_alternative<untyped::JumpI>(b.terminator) &&
+                std::get<untyped::JumpI>(b.terminator).coerce_to_addr.size()) {
+                auto last_instr_offset = ir.last_instruction_offset(b);
+                jump_coerce_map[last_instr_offset] =
+                    std::get<untyped::JumpI>(b.terminator).coerce_to_addr;
+            }
+        }
+
+        return jump_coerce_map;
+    }
+
+    std::unordered_set<std::size_t> IntercodeUntypedIR::build_jumpdest_addr_set(
+        monad::vm::compiler::untyped::UntypedIR ir)
+    {
+        std::unordered_set<std::size_t> jumpdest_addr;
+        if (!std::holds_alternative<std::vector<untyped::Block>>(ir.blocks)) {
+            return jumpdest_addr;
+        }
+
+        auto const &blocks = std::get<std::vector<untyped::Block>>(ir.blocks);
+
+        for (auto const &b : blocks) {
+            if (std::holds_alternative<untyped::Jump>(b.terminator)) {
+                auto last_instr_offset = ir.last_instruction_offset(b);
+                if (std::holds_alternative<untyped::Addr>(
+                        std::get<untyped::Jump>(b.terminator).jump_dest)) {
+                    jumpdest_addr.insert(last_instr_offset);
+                }
+            }
+            else if (std::holds_alternative<untyped::JumpI>(b.terminator)) {
+                auto last_instr_offset = ir.last_instruction_offset(b);
+                if (std::holds_alternative<untyped::Addr>(
+                        std::get<untyped::JumpI>(b.terminator).jump_dest)) {
+                    jumpdest_addr.insert(last_instr_offset);
+                }
+            }
+        }
+
+        return jumpdest_addr;
+    }
+
+    auto
+    IntercodeUntypedIR::find_jumpdests(std::span<std::uint8_t const> const code)
+        -> JumpdestMap
+    {
+        auto jumpdests = JumpdestMap(code.size(), false);
+
+        for (auto i = 0u; i < code.size(); ++i) {
+            auto const op = code[i];
+
+            if (op == EvmOpCode::JUMPDEST) {
+                jumpdests[i] = true;
+            }
+
+            if (is_push_opcode(op)) {
+                i += get_push_opcode_index(op);
+            }
+        }
+
+        return jumpdests;
+    }
+}

--- a/test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp
+++ b/test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/compiler/ir/untyped.hpp>
+#include <category/vm/runtime/bin.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <unordered_set>
+#include <vector>
+
+namespace monad::vm::interpreter
+{
+    using code_size_t = runtime::Bin<20>;
+
+    class IntercodeUntypedIR
+    {
+        // 30 bytes of initial padding ensures that we can implement all
+        // PUSHN opcodes by reading data from _before_ the instruction
+        // pointer with a single 32-byte read, then cleaning up any
+        // over-read in the result value.
+        static constexpr std::size_t start_padding_size = 30;
+
+        // 32 for a truncated PUSH32, 1 for a STOP so that we don't have to
+        // worry about going off the end.
+        static constexpr std::size_t end_padding_size = 32 + 1;
+
+    public:
+        using JumpdestMap = std::vector<bool>;
+
+        explicit IntercodeUntypedIR(std::span<std::uint8_t const> const);
+
+        IntercodeUntypedIR(std::uint8_t const *code, std::size_t code_size)
+            : IntercodeUntypedIR{std::span<std::uint8_t const>{code, code_size}}
+        {
+        }
+
+        ~IntercodeUntypedIR();
+
+        std::uint8_t const *code() const noexcept
+        {
+            return padded_code_;
+        }
+
+        code_size_t code_size() const noexcept
+        {
+            return code_size_;
+        }
+
+        size_t size() const noexcept
+        {
+            return *code_size_;
+        }
+
+        std::span<uint8_t const> code_span() const noexcept
+        {
+            return {padded_code_, size_t{*code_size_}};
+        }
+
+        bool is_jumpdest(std::size_t const pc) const noexcept
+        {
+            return pc < *code_size_ && jumpdest_map_[pc];
+        }
+
+    private:
+        std::uint8_t const *padded_code_;
+        code_size_t code_size_;
+        JumpdestMap jumpdest_map_;
+        monad::vm::compiler::untyped::UntypedIR ir;
+
+    public:
+        std::unordered_map<std::size_t, std::vector<std::size_t>>
+            fallthrough_coerce_map;
+        std::unordered_map<std::size_t, std::vector<std::size_t>>
+            jump_coerce_map;
+        std::unordered_set<std::size_t> jumpdest_addr;
+
+        bool valid_ir()
+        {
+            return std::holds_alternative<
+                std::vector<monad::vm::compiler::untyped::Block>>(ir.blocks);
+        }
+
+    private:
+        static std::uint8_t const *
+        pad(std::span<std::uint8_t const> const code);
+
+        static std::unordered_map<std::size_t, std::vector<std::size_t>>
+        build_fallthrough_coerce_map(
+            monad::vm::compiler::untyped::UntypedIR ir);
+
+        static std::unordered_map<std::size_t, std::vector<std::size_t>>
+        build_jump_coerce_map(monad::vm::compiler::untyped::UntypedIR ir);
+
+        static std::unordered_set<std::size_t>
+        build_jumpdest_addr_set(monad::vm::compiler::untyped::UntypedIR ir);
+
+        static JumpdestMap
+        find_jumpdests(std::span<std::uint8_t const> const code);
+    };
+}

--- a/test/vm/untyped_ir_interpreter/push.hpp
+++ b/test/vm/untyped_ir_interpreter/push.hpp
@@ -1,0 +1,246 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/interpreter/stack.hpp>
+#include <category/vm/interpreter/types.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <category/vm/runtime/uint256.hpp>
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <evmc/evmc.h>
+
+#include <immintrin.h>
+
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+
+namespace monad::vm::interpreter
+{
+    using enum compiler::EvmOpCode;
+
+    namespace detail
+    {
+        consteval bool use_avx2_push(std::size_t const n) noexcept
+        {
+#ifdef __AVX2__
+            return n > 0;
+#else
+            (void)n;
+            return false;
+#endif
+        }
+
+        using subword_t = runtime::uint256_t::word_type;
+
+        // We need to do this memcpy dance to avoid triggering UB when
+        // reading whole words from potentially unaligned addresses in the
+        // instruction stream. The compilers seem able to optimise this out
+        // effectively, and the generated code doesn't appear different to
+        // the UB-triggering version.
+        [[gnu::always_inline]] inline subword_t
+        read_unaligned(std::uint8_t const *ptr)
+        {
+            alignas(subword_t) std::uint8_t aligned_mem[sizeof(subword_t)];
+            std::memcpy(&aligned_mem[0], ptr, sizeof(subword_t));
+            return std::byteswap(
+                *reinterpret_cast<subword_t *>(&aligned_mem[0]));
+        }
+
+        template <std::size_t N, Traits traits>
+            requires(!detail::use_avx2_push(N))
+        [[gnu::always_inline]] inline void generic_push(
+            runtime::Context &ctx, IntercodeUntypedIR const &,
+            runtime::uint256_t const *stack_bottom,
+            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
+            std::uint8_t const *instr_ptr)
+        {
+            static constexpr auto whole_words = N / 8;
+            static constexpr auto leading_part = N % 8;
+
+            check_requirements<PUSH0 + N, traits>(
+                ctx, stack_bottom, stack_top, gas_remaining);
+
+            auto const leading_word = [instr_ptr] {
+                auto word = subword_t{0};
+
+                if constexpr (leading_part == 0) {
+                    return word;
+                }
+
+                std::memcpy(
+                    reinterpret_cast<std::uint8_t *>(&word) +
+                        (8 - leading_part),
+                    instr_ptr + 1,
+                    leading_part);
+
+                return std::byteswap(word);
+            }();
+
+            if constexpr (whole_words == 0) {
+                interpreter::push(
+                    stack_top, runtime::uint256_t{leading_word, 0, 0, 0});
+            }
+            else if constexpr (whole_words == 1) {
+                interpreter::push(
+                    stack_top,
+                    runtime::uint256_t{
+                        read_unaligned(instr_ptr + 1 + leading_part),
+                        leading_word,
+                        0,
+                        0,
+                    });
+            }
+            else if constexpr (whole_words == 2) {
+                interpreter::push(
+                    stack_top,
+                    runtime::uint256_t{
+                        read_unaligned(instr_ptr + 1 + 8 + leading_part),
+                        read_unaligned(instr_ptr + 1 + leading_part),
+                        leading_word,
+                        0,
+                    });
+            }
+            else if constexpr (whole_words == 3) {
+                interpreter::push(
+                    stack_top,
+                    runtime::uint256_t{
+                        read_unaligned(instr_ptr + 1 + 16 + leading_part),
+                        read_unaligned(instr_ptr + 1 + 8 + leading_part),
+                        read_unaligned(instr_ptr + 1 + leading_part),
+                        leading_word,
+                    });
+            }
+            else {
+                static_assert(leading_part == 0);
+                interpreter::push(
+                    stack_top,
+                    runtime::uint256_t{
+                        read_unaligned(instr_ptr + 1 + 24),
+                        read_unaligned(instr_ptr + 1 + 16),
+                        read_unaligned(instr_ptr + 1 + 8),
+                        read_unaligned(instr_ptr + 1),
+                    });
+            }
+        }
+
+        template <std::size_t N, Traits traits>
+            requires(detail::use_avx2_push(N))
+        [[gnu::always_inline]] inline void avx2_push(
+            runtime::Context &ctx, IntercodeUntypedIR const &,
+            runtime::uint256_t const *stack_bottom,
+            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
+            std::uint8_t const *instr_ptr)
+        {
+            static constexpr auto whole_words = N / 8;
+            static constexpr auto leading_part = N % 8;
+
+            check_requirements<PUSH0 + N, traits>(
+                ctx, stack_bottom, stack_top, gas_remaining);
+
+            static constexpr int64_t m = ~(
+                std::numeric_limits<int64_t>::max() >> (63 - leading_part * 8));
+
+            // It is required that N > 0, otherwise we can index out of the
+            // initial 30 bytes of padding to `instr_ptr`.
+            static_assert(N > 0);
+            __m256i y;
+
+            if constexpr (N == 32) {
+                std::memcpy(&y, instr_ptr + 1, 32);
+            }
+            else {
+                std::memcpy(&y, instr_ptr - (31 - N), 32);
+            }
+
+            // y = {[y00...y07], [y10...y17], [y20...y27], [y30...y37]}
+            y = _mm256_permute4x64_epi64(y, 27);
+            // y = {[y30...y37], [y20...y27], [y10...y17], [y00...y07]}
+            static constexpr int64_t s0 =
+                0x0001020304050607LL | (whole_words == 0 ? m : 0);
+            static constexpr int64_t s1 =
+                0x08090a0b0c0d0e0fLL |
+                (whole_words == 1 ? m : (whole_words < 1 ? -1 : 0));
+            static constexpr int64_t s2 =
+                0x0001020304050607LL |
+                (whole_words == 2 ? m : (whole_words < 2 ? -1 : 0));
+            static constexpr int64_t s3 =
+                0x08090a0b0c0d0e0fLL |
+                (whole_words == 3 ? m : (whole_words < 3 ? -1 : 0));
+            y = _mm256_shuffle_epi8(y, _mm256_setr_epi64x(s0, s1, s2, s3));
+            // For N = 32:
+            // y = {[y37...y30], [y27...y20], [y17...y10], [y07...y00]}
+            std::memcpy(reinterpret_cast<uint8_t *>(stack_top + 1), &y, 32);
+        }
+    }
+
+    template <std::size_t N, Traits traits>
+    struct push_impl_untyped_ir
+    {
+        [[gnu::always_inline]] static inline void push(
+            runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+            runtime::uint256_t const *stack_bottom,
+            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
+            std::uint8_t const *instr_ptr)
+        {
+            detail::generic_push<N, traits>(
+                ctx,
+                analysis,
+                stack_bottom,
+                stack_top,
+                gas_remaining,
+                instr_ptr);
+        }
+    };
+
+    template <Traits traits>
+    struct push_impl_untyped_ir<0, traits>
+    {
+        [[gnu::always_inline]] static inline void push(
+            runtime::Context &ctx, IntercodeUntypedIR const &,
+            runtime::uint256_t const *stack_bottom,
+            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
+            std::uint8_t const *)
+        {
+            check_requirements<PUSH0, traits>(
+                ctx, stack_bottom, stack_top, gas_remaining);
+            interpreter::push(stack_top, 0);
+        }
+    };
+
+    template <std::size_t N, Traits traits>
+        requires(detail::use_avx2_push(N))
+    struct push_impl_untyped_ir<N, traits>
+    {
+        [[gnu::always_inline]] static inline void push(
+            runtime::Context &ctx, IntercodeUntypedIR const &analysis,
+            runtime::uint256_t const *stack_bottom,
+            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
+            std::uint8_t const *instr_ptr)
+        {
+            detail::avx2_push<N, traits>(
+                ctx,
+                analysis,
+                stack_bottom,
+                stack_top,
+                gas_remaining,
+                instr_ptr);
+        }
+    };
+}

--- a/test/vm/untyped_ir_interpreter/types.hpp
+++ b/test/vm/untyped_ir_interpreter/types.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/interpreter/types.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <category/vm/runtime/uint256.hpp>
+
+#include <test/vm/untyped_ir_interpreter/intercode_untyped_ir.hpp>
+
+#include <array>
+#include <cstdint>
+
+namespace monad::vm::interpreter
+{
+    using InstrEvalUntypedIR = void MONAD_VM_INSTRUCTION_CALL (*)(
+        runtime::Context &, IntercodeUntypedIR const &,
+        runtime::uint256_t const *, runtime::uint256_t *, std::int64_t, bool,
+        std::uint8_t const *);
+
+    using InstrTableUntypedIR = std::array<InstrEvalUntypedIR, 256>;
+}

--- a/test/vm/vm/CMakeLists.txt
+++ b/test/vm/vm/CMakeLists.txt
@@ -36,7 +36,9 @@ target_link_libraries(blockchain-test-vm
         evmc::evmc
         monad-vm::monad-vm
         monad-vm::monad-vm-compiler
+        monad-vm::monad-vm-evm
         monad-vm::monad-vm-interpreter
+        monad-vm::monad-vm-untyped-ir-interpreter
 )
 
 target_include_directories(blockchain-test-vm


### PR DESCRIPTION
This PR creates a copy of the monad interpeter which uses information from `UntypedIR` to convert certain stack values into pointers (see `cast_pointers` and  `cast_evm_word_to_ptr`, previously called `jump_impl`, in `test/vm/untyped_ir_interpreter/instruction_table.hpp`) at the end of each block.

Specifially, we apply coercions at the JUMP/JUMPI instruction if the current PC offset is a key in the `analysis.jump_coerce_map` or `analysis.fallthrough_coerce_map` in the "else" case of JUMPI. If a block has a fallthrough terminator (specified by a new bool flag passed through as one of the interpreter args), we apply coersions from the previous block at the start of the next one at the JUMPDEST instruction, if the current PC offset is in `analysis.fallthrough_coerce_map`.

Finally, when performing a jump, we now look up whether the stack value has already been cast into a native ptr by checking the current PC offset is in `analysis.jumpdest_addr`. If not, we call `jump_impl`/`cast_evm_word_to_ptr` like in the vanilla interpreter.