### PR TITLE
[event] SDK helper to seek to a sequence number

### DIFF
--- a/category/core/event/event_iterator.h
+++ b/category/core/event/event_iterator.h
@@ -59,6 +59,12 @@ static enum monad_event_iter_result monad_event_iterator_try_next(
 static enum monad_event_iter_result monad_event_iterator_try_copy(
     struct monad_event_iterator const *, struct monad_event_descriptor *);
 
+/// Set the iterator so that the next call to `monad_event_iterator_try_next`
+/// or `monad_event_iterator_try_copy` will read the event descriptor with the
+/// specified sequence number; this performs no checking
+static void
+monad_event_iterator_set_seqno(struct monad_event_iterator *, uint64_t seqno);
+
 /// Reset the iterator to point to the latest event produced; used for gap
 /// recovery
 static uint64_t monad_event_iterator_reset(struct monad_event_iterator *);

--- a/category/core/event/event_iterator_inline.h
+++ b/category/core/event/event_iterator_inline.h
@@ -111,6 +111,12 @@ inline enum monad_event_iter_result monad_event_iterator_try_next(
     return r;
 }
 
+inline void monad_event_iterator_set_seqno(
+    struct monad_event_iterator *iter, uint64_t seqno)
+{
+    iter->read_last_seqno = seqno - 1;
+}
+
 inline uint64_t monad_event_iterator_reset(struct monad_event_iterator *iter)
 {
     uint64_t const last_available_seqno = monad_event_iterator_sync_wait(iter);

--- a/category/execution/ethereum/event/exec_iter_help_inline.h
+++ b/category/execution/ethereum/event/exec_iter_help_inline.h
@@ -69,7 +69,8 @@ static inline bool _monad_exec_iter_copy_consensus_event(
     if (event->content_ext[MONAD_FLOW_BLOCK_SEQNO] != 0 &&
         event->event_type != MONAD_EXEC_BLOCK_START) {
         uint64_t const iter_save = iter->read_last_seqno;
-        iter->read_last_seqno = event->content_ext[MONAD_FLOW_BLOCK_SEQNO] - 1;
+        monad_event_iterator_set_seqno(
+            iter, event->content_ext[MONAD_FLOW_BLOCK_SEQNO]);
         if (__builtin_expect(
                 monad_event_iterator_try_copy(iter, event) !=
                     MONAD_EVENT_SUCCESS,


### PR DESCRIPTION
This is a somewhat common thing to do in more advanced applications, and manually writing `last_read_seqno = seqno - 1` directly is very confusing about its intent, since it is written in terms of how the event ring works, rather than what is happening