### PR TITLE
event_interator_inline: replace local const with macro for MAX_SYNC_SPIN

### DIFF
--- a/category/core/event/event_iterator_inline.h
+++ b/category/core/event/event_iterator_inline.h
@@ -37,10 +37,11 @@ extern "C"
 {
 #endif
 
+constexpr uint64_t MAX_SYNC_SPIN = 100;
+
 static inline uint64_t
 monad_event_iterator_sync_wait(struct monad_event_iterator *iter)
 {
-    uint64_t const MAX_SYNC_SPIN = 100;
     uint64_t write_last_seqno =
         __atomic_load_n(&iter->control->last_seqno, __ATOMIC_ACQUIRE);
     // `write_last_seqno` is the last sequence number the writer has allocated.


### PR DESCRIPTION
the current version creates an uint64_t everytime the function runs, which is just a waste of memory