### PR TITLE
Re-enable monad interpreter debug output

### DIFF
--- a/category/vm/interpreter/debug.hpp
+++ b/category/vm/interpreter/debug.hpp
@@ -36,36 +36,15 @@ namespace monad::vm::interpreter
     /**
      * Debug trace printing compatible with the JSON format emitted by evmone.
      */
-    template <Traits traits>
-    void trace(
-        std::uint8_t const instr, runtime::Context const &ctx,
-        Intercode const &analysis, runtime::uint256_t const *stack_bottom,
-        runtime::uint256_t const *stack_top, std::int64_t gas_remaining,
+    [[gnu::always_inline]]
+    inline void trace(
+        Intercode const &analysis, std::int64_t gas_remaining,
         std::uint8_t const *instr_ptr)
     {
-        auto const &info = compiler::opcode_table<traits>[instr];
-        auto const stack_size = stack_top - stack_bottom;
-
         std::cerr << std::format(
-            "{{\"pc\":{},\"op\":{},\"gas\":\"0x{:x}\",\"gasCost\":\"0x{"
-            ":x}\",\"memSize\":{},\"stack\":[",
+            "offset: 0x{:02x}  opcode: 0x{:x}  gas_left: {}\n",
             instr_ptr - analysis.code(),
-            instr,
-            gas_remaining,
-            info.dynamic_gas ? 0 : info.min_gas,
-            ctx.memory.size);
-
-        auto const *comma = "";
-        for (auto i = stack_size - 1; i >= 0; --i) {
-            std::cerr << std::format(
-                "{}\"0x{}\"", comma, (stack_top - i)->to_string(16));
-            comma = ",";
-        }
-
-        std::cerr << std::format(
-            "],\"depth\":{},\"refund\":{},\"opName\":\"{}\"}}\n",
-            ctx.env.depth,
-            ctx.gas_refund,
-            info.name);
+            *instr_ptr,
+            gas_remaining);
     }
 }

--- a/category/vm/interpreter/execute.cpp
+++ b/category/vm/interpreter/execute.cpp
@@ -15,6 +15,7 @@
 
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
+#include <category/vm/interpreter/debug.hpp>
 #include <category/vm/interpreter/instruction_table.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 #include <category/vm/runtime/types.hpp>
@@ -55,6 +56,9 @@ namespace monad::vm::interpreter
             auto const *const instr_ptr = analysis->code();
             auto const gas_remaining = ctx->gas_remaining;
 
+            if constexpr (debug_enabled) {
+                trace(*analysis, gas_remaining, instr_ptr);
+            }
             instruction_table<traits>[*instr_ptr](
                 *ctx,
                 *analysis,


### PR DESCRIPTION
This re-enables debug printing into cerr and outputs the same format as produced by our custom evmone's `EVMONE_DEBUG_TRACE` flag, namely:

```
offset: 0x00  opcode: 0x5b  gas_left: 69539
offset: 0x01  opcode: 0x34  gas_left: 69538
offset: 0x02  opcode: 0x3a  gas_left: 69536
offset: 0x03  opcode: 0x81  gas_left: 69534
```

Ths should make it easy to diff the two vm's when running the fuzzer.