### PR TITLE
db: use shared ptr

### DIFF
--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -34,7 +34,7 @@ class TrieRODb final : public ::monad::Db
 {
     ::monad::mpt::RODb &db_;
     uint64_t block_number_;
-    ::monad::mpt::OwningNodeCursor prefix_cursor_;
+    ::monad::mpt::CacheNodeCursor prefix_cursor_;
 
 public:
     TrieRODb(mpt::RODb &db)

--- a/category/mpt/node_cache.hpp
+++ b/category/mpt/node_cache.hpp
@@ -56,7 +56,7 @@ class NodeCache final
     }
 
 public:
-    static constexpr size_t AVERAGE_NODE_SIZE = 100;
+    static constexpr size_t AVERAGE_NODE_SIZE = 104;
 
     using Base::ConstAccessor;
     using Base::list_node;

--- a/category/mpt/node_cursor.hpp
+++ b/category/mpt/node_cursor.hpp
@@ -18,22 +18,25 @@
 #include <category/mpt/node.hpp>
 
 #include <cstdint>
+#include <memory>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-struct NodeCursor
+template <node_type NodeType>
+struct NodeCursorBase
 {
-    Node *node{nullptr};
+    std::shared_ptr<NodeType> node{nullptr};
     unsigned prefix_index{0};
 
-    constexpr NodeCursor()
+    constexpr NodeCursorBase()
         : node{nullptr}
         , prefix_index{0}
     {
     }
 
-    constexpr NodeCursor(Node &node_, unsigned prefix_index_ = 0)
-        : node{&node_}
+    constexpr NodeCursorBase(
+        std::shared_ptr<NodeType> node_, unsigned prefix_index_ = 0)
+        : node{std::move(node_)}
         , prefix_index{prefix_index_}
     {
     }
@@ -44,40 +47,13 @@ struct NodeCursor
     }
 };
 
-static_assert(sizeof(NodeCursor) == 16);
+using NodeCursor = NodeCursorBase<Node>;
+using CacheNodeCursor = NodeCursorBase<CacheNode>;
+
+static_assert(sizeof(NodeCursor) == 24);
 static_assert(alignof(NodeCursor) == 8);
-static_assert(std::is_trivially_copyable_v<NodeCursor> == true);
 
-struct OwningNodeCursor
-{
-    std::shared_ptr<CacheNode> node;
-    unsigned prefix_index{0};
-
-    constexpr OwningNodeCursor()
-        : node{nullptr}
-        , prefix_index{0}
-    {
-    }
-
-    OwningNodeCursor(
-        std::shared_ptr<CacheNode> node_, unsigned prefix_index_ = 0)
-        : node{node_}
-        , prefix_index{prefix_index_}
-    {
-    }
-
-    constexpr bool is_valid() const noexcept
-    {
-        return node != nullptr;
-    }
-
-    OwningNodeCursor(OwningNodeCursor &) = default;
-    OwningNodeCursor &operator=(OwningNodeCursor &) = default;
-    OwningNodeCursor(OwningNodeCursor &&) = default;
-    OwningNodeCursor &operator=(OwningNodeCursor &&) = default;
-};
-
-static_assert(sizeof(OwningNodeCursor) == 24);
-static_assert(alignof(OwningNodeCursor) == 8);
+static_assert(sizeof(CacheNodeCursor) == 24);
+static_assert(alignof(CacheNodeCursor) == 8);
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/test/blocking_read_concurrency_test.cpp
+++ b/category/mpt/test/blocking_read_concurrency_test.cpp
@@ -88,7 +88,7 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
 {
     // Load root of most recent version
     auto const latest_version = state()->aux.db_history_max_version();
-    Node::UniquePtr root = read_node_blocking(
+    Node::SharedPtr root = read_node_blocking(
         state()->aux,
         state()->aux.get_root_offset_at_version(latest_version),
         latest_version);
@@ -118,7 +118,7 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
                 root->move_next(idx).reset();
             }
             auto [node_cursor, res] =
-                find_blocking(ro_aux, *root, key, latest_version);
+                find_blocking(ro_aux, NodeCursor{root}, key, latest_version);
             if (res != find_result::success) {
                 ASSERT_EQ(res, find_result::version_no_longer_exist);
                 completion_promise.set_value(count);
@@ -168,7 +168,7 @@ TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
 {
     // Load root of most recent version
     auto const latest_version = state()->aux.db_history_max_version();
-    Node::UniquePtr root = read_node_blocking(
+    Node::SharedPtr root = read_node_blocking(
         state()->aux,
         state()->aux.get_root_offset_at_version(latest_version),
         latest_version);

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -223,11 +223,11 @@ struct cli_tool_fixture
                         monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                 monad::async::AsyncIO testio(pool, testrwbuf);
                 monad::mpt::UpdateAux<> const aux{&testio};
-                monad::mpt::Node::UniquePtr root_ptr{read_node_blocking(
+                monad::mpt::Node::SharedPtr root_ptr{read_node_blocking(
                     aux,
                     aux.get_latest_root_offset(),
                     aux.db_history_max_version())};
-                monad::mpt::NodeCursor const root(*root_ptr);
+                monad::mpt::NodeCursor const root(root_ptr);
 
                 for (auto &key : this->state()->keys) {
                     auto ret = monad::mpt::find_blocking(
@@ -326,11 +326,11 @@ struct cli_tool_fixture
                             monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                     monad::async::AsyncIO testio(pool, testrwbuf);
                     monad::mpt::UpdateAux<> const aux{&testio};
-                    monad::mpt::Node::UniquePtr root_ptr{read_node_blocking(
+                    monad::mpt::Node::SharedPtr root_ptr{read_node_blocking(
                         aux,
                         aux.get_latest_root_offset(),
                         aux.db_history_max_version())};
-                    monad::mpt::NodeCursor const root(*root_ptr);
+                    monad::mpt::NodeCursor const root(root_ptr);
 
                     for (auto &key : this->state()->keys) {
                         auto ret = monad::mpt::find_blocking(

--- a/category/mpt/test/load_all_test.cpp
+++ b/category/mpt/test/load_all_test.cpp
@@ -33,14 +33,14 @@ TEST_F(LoadAllTest, works)
 {
     monad::test::UpdateAux<void> aux{&state()->io};
     monad::test::StateMachineAlwaysMerkle sm;
-    monad::mpt::Node::UniquePtr root{monad::mpt::read_node_blocking(
+    monad::mpt::Node::SharedPtr root{monad::mpt::read_node_blocking(
         state()->aux,
         aux.get_latest_root_offset(),
         aux.db_history_max_version())};
-    auto nodes_loaded = monad::mpt::load_all(aux, sm, *root);
+    auto nodes_loaded = monad::mpt::load_all(aux, sm, root);
     EXPECT_GE(nodes_loaded, state()->keys.size());
     std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;
-    nodes_loaded = monad::mpt::load_all(aux, sm, *root);
+    nodes_loaded = monad::mpt::load_all(aux, sm, root);
     EXPECT_EQ(nodes_loaded, 0);
     std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;
 }

--- a/category/mpt/test/locking_trie_test.cpp
+++ b/category/mpt/test/locking_trie_test.cpp
@@ -162,7 +162,7 @@ struct LockingTrieTest
 TEST_F(LockingTrieTest, works)
 {
     auto &aux = this->state()->aux;
-    auto *root = this->state()->root.get();
+    auto &root = this->state()->root;
     auto const version = aux.db_history_max_version();
     auto &keys = this->state()->keys;
     // Appending blocks only does exclusive lock and unlock and nothing else
@@ -213,7 +213,7 @@ TEST_F(LockingTrieTest, works)
     {
         aux.lock().clear();
         auto [leaf_it, res] =
-            find_blocking(aux, *root, keys.back().first, version);
+            find_blocking(aux, root, keys.back().first, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());
@@ -231,7 +231,7 @@ TEST_F(LockingTrieTest, works)
     {
         aux.lock().clear();
         auto [leaf_it, res] =
-            find_blocking(aux, *root, keys.back().first, version);
+            find_blocking(aux, root, keys.back().first, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_NE(leaf_it.node, nullptr);
         EXPECT_TRUE(leaf_it.node->has_value());

--- a/category/mpt/test/merkle_trie_test.cpp
+++ b/category/mpt/test/merkle_trie_test.cpp
@@ -243,28 +243,28 @@ TYPED_TEST(TrieTest, insert_unrelated_leaves_then_read)
         0xd339cf4033aca65996859d35da4612b642664cc40734dbdd40738aa47f1e3e44_hex);
 
     auto [leaf_it, res] =
-        find_blocking(this->aux, *this->root, kv[0].first, version);
+        find_blocking(this->aux, this->root, kv[0].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[0].second);
     std::tie(leaf_it, res) =
-        find_blocking(this->aux, *this->root, kv[1].first, version);
+        find_blocking(this->aux, this->root, kv[1].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[1].second);
     std::tie(leaf_it, res) =
-        find_blocking(this->aux, *this->root, kv[2].first, version);
+        find_blocking(this->aux, this->root, kv[2].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[2].second);
     std::tie(leaf_it, res) =
-        find_blocking(this->aux, *this->root, kv[3].first, version);
+        find_blocking(this->aux, this->root, kv[3].first, version);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
@@ -541,7 +541,7 @@ TYPED_TEST(TrieTest, verify_correct_compute_at_section_edge)
     EXPECT_EQ(this->root->child_data_len(), 0);
 
     // leaf is the end of prefix2 section, also root of account trie
-    Node *const prefix2_leaf = this->root->next(1);
+    auto &prefix2_leaf = this->root->next(1);
     EXPECT_EQ(prefix2_leaf->has_value(), true);
     EXPECT_EQ(prefix2_leaf->path_nibbles_len(), 0);
     EXPECT_EQ(prefix2_leaf->child_data_len(0), 10);
@@ -598,7 +598,7 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
             block_id,
             true /*compaction*/);
         auto [state_it, res] =
-            find_blocking(this->aux, *this->root, prefix, block_id);
+            find_blocking(this->aux, this->root, prefix, block_id);
         EXPECT_EQ(res, find_result::success);
         EXPECT_EQ(
             state_it.node->data(),
@@ -681,15 +681,14 @@ TYPED_TEST(TrieTest, variable_length_trie)
 
     // find
     {
-        auto [node0, res] =
-            find_blocking(this->aux, *this->root, key0, version);
+        auto [node0, res] = find_blocking(this->aux, this->root, key0, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), long_value);
     }
 
     {
         auto [node_long, res] =
-            find_blocking(this->aux, *this->root, keylong, version);
+            find_blocking(this->aux, this->root, keylong, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), long_value);
     }
@@ -734,14 +733,14 @@ TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
     // find
     {
         auto [node0, res] =
-            find_blocking(this->aux, *this->root, prefix + key0, version);
+            find_blocking(this->aux, this->root, prefix + key0, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), value);
     }
 
     {
         auto [node_long, res] =
-            find_blocking(this->aux, *this->root, prefix + keylong, version);
+            find_blocking(this->aux, this->root, prefix + keylong, version);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), value);
     }

--- a/category/mpt/test/min_truncated_offsets_test.cpp
+++ b/category/mpt/test/min_truncated_offsets_test.cpp
@@ -208,11 +208,10 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                 TraverseCalculateAndVerifyMinTruncatedOffsets>(*this);
         }
 
-    } traverse{this->aux};
+    } traverse{aux};
 
     // WARNING: test will fail and there are memory leak using parallel traverse
-    ASSERT_TRUE(
-        preorder_traverse_blocking(this->aux, *this->root, traverse, block_id));
+    ASSERT_TRUE(preorder_traverse_blocking(aux, *root, traverse, block_id));
     EXPECT_EQ(traverse.level, 0);
     EXPECT_EQ(traverse.root_to_node_records.empty(), true);
 }

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -40,7 +40,7 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
     monad::test::StateMachineAlwaysMerkle sm;
     // Load its root
     auto const latest_version = aux.db_history_max_version();
-    monad::mpt::Node::UniquePtr root{monad::mpt::read_node_blocking(
+    monad::mpt::Node::SharedPtr root{monad::mpt::read_node_blocking(
         aux, aux.get_root_offset_at_version(latest_version), latest_version)};
     auto const &key = state()->keys.front().first;
     auto const &value = state()->keys.front().first;
@@ -75,7 +75,7 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
             aux,
             node_cache,
             inflights,
-            OwningNodeCursor{cache_root},
+            CacheNodeCursor{cache_root},
             latest_version,
             key,
             true),
@@ -84,7 +84,8 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
 
     // Synchronously load the same key
     EXPECT_EQ(
-        find_blocking(aux, *root, key, latest_version).first.node->value(),
+        find_blocking(aux, NodeCursor{root}, key, latest_version)
+            .first.node->value(),
         value);
 
     // Let the async find of that key complete

--- a/category/mpt/test/node_lru_cache_test.cpp
+++ b/category/mpt/test/node_lru_cache_test.cpp
@@ -80,7 +80,7 @@ TEST(NodeCache, works)
     memcpy(large_value.data(), "hihi", 4);
     auto node = copy_node<CacheNode>(
         monad::mpt::make_node(0, {}, {}, std::move(large_value), 0, 0).get());
-    EXPECT_EQ(node->get_mem_size(), 268);
+    EXPECT_EQ(node->get_mem_size(), 272);
     node_cache.insert(virtual_chunk_offset_t(6, 0, 1), std::move(node));
     // Everything else should get evicted
     EXPECT_EQ(node_cache.size(), 1);

--- a/category/mpt/test/node_test.cpp
+++ b/category/mpt/test/node_test.cpp
@@ -71,7 +71,7 @@ TEST(NodeTest, leaf)
     EXPECT_EQ(node->mask, 0);
     EXPECT_EQ(node->value(), value);
     EXPECT_EQ(node->path_nibble_view(), path1);
-    EXPECT_EQ(node->get_mem_size(), 25);
+    EXPECT_EQ(node->get_mem_size(), 32);
     EXPECT_EQ(node->get_disk_size(), 29);
 }
 
@@ -93,7 +93,7 @@ TEST(NodeTest, leaf_single_branch)
     EXPECT_EQ(node->value(), value);
     EXPECT_EQ(node->path_nibble_view(), path2);
     EXPECT_EQ(node->bitpacked.data_len, 1);
-    EXPECT_EQ(node->get_mem_size(), 61);
+    EXPECT_EQ(node->get_mem_size(), 72);
     EXPECT_EQ(node->get_disk_size(), 57);
 }
 
@@ -118,7 +118,7 @@ TEST(NodeTest, leaf_multiple_branches)
     EXPECT_EQ(node->value(), value);
     EXPECT_EQ(node->path_nibble_view(), path2);
     EXPECT_EQ(node->bitpacked.data_len, 2);
-    EXPECT_EQ(node->get_mem_size(), 97);
+    EXPECT_EQ(node->get_mem_size(), 120);
     EXPECT_EQ(node->get_disk_size(), 85);
 }
 
@@ -143,7 +143,7 @@ TEST(NodeTest, branch_node)
     EXPECT_EQ(node->value_len, 0);
     EXPECT_EQ(node->bitpacked.data_len, 0);
     EXPECT_EQ(node->path_nibble_view(), path2);
-    EXPECT_EQ(node->get_mem_size(), 86);
+    EXPECT_EQ(node->get_mem_size(), 104);
     EXPECT_EQ(node->get_disk_size(), 74);
 }
 
@@ -168,7 +168,7 @@ TEST(NodeTest, extension_node)
     EXPECT_EQ(node->value_len, 0);
     EXPECT_EQ(node->path_nibble_view(), path2);
     EXPECT_EQ(node->bitpacked.data_len, 0);
-    EXPECT_EQ(node->get_mem_size(), 91);
+    EXPECT_EQ(node->get_mem_size(), 112);
     EXPECT_EQ(node->get_disk_size(), 79);
 }
 

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -125,53 +125,53 @@ TYPED_TEST(PlainTrieTest, var_length_trie)
         make_update(kv[7].first, kv[7].second));
 
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
+        find_blocking(this->aux, this->root, kv[0].first, version)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version)
+        find_blocking(this->aux, this->root, kv[2].first, version)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first, version)
+        find_blocking(this->aux, this->root, kv[3].first, version)
             .first.node->value(),
         kv[3].second);
 
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
+        find_blocking(this->aux, this->root, kv[0].first, version)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version)
+        find_blocking(this->aux, this->root, kv[2].first, version)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first, version)
+        find_blocking(this->aux, this->root, kv[3].first, version)
             .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[4].first, version)
+        find_blocking(this->aux, this->root, kv[4].first, version)
             .first.node->value(),
         kv[4].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[5].first, version)
+        find_blocking(this->aux, this->root, kv[5].first, version)
             .first.node->value(),
         kv[5].second);
 
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[6].first, version)
+        find_blocking(this->aux, this->root, kv[6].first, version)
             .first.node->value(),
         kv[6].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[7].first, version)
+        find_blocking(this->aux, this->root, kv[7].first, version)
             .first.node->value(),
         kv[7].second);
 
@@ -179,8 +179,8 @@ TYPED_TEST(PlainTrieTest, var_length_trie)
     EXPECT_FALSE(this->root->has_value());
     EXPECT_EQ(this->root->bitpacked.data_len, 0);
     EXPECT_EQ(this->root->path_nibbles_len(), 0);
-    Node *const node0 = this->root->next(0);
-    Node *const node1 = this->root->next(1); // 1111... 111a... 111b...
+    auto node0 = this->root->next(0);
+    auto node1 = this->root->next(1); // 1111... 111a... 111b...
     EXPECT_EQ(node0->mask, 0);
     EXPECT_EQ(node1->mask, 1u << 1 | 1u << 0xa | 1u << 0xb);
     EXPECT_EQ(
@@ -189,12 +189,12 @@ TYPED_TEST(PlainTrieTest, var_length_trie)
     EXPECT_EQ(
         node1->path_nibble_view(), (NibblesView{1, 3, kv[1].first.data()}));
 
-    Node *const node1111 = node1->next(0);
-    Node *const node111a = node1->next(1);
-    Node *const node111b = node1->next(2);
+    auto node1111 = node1->next(0);
+    auto node111a = node1->next(1);
+    auto node111b = node1->next(2);
     EXPECT_EQ(node1111->value(), kv[1].second);
     EXPECT_EQ(node1111->mask, 1u << 0xa);
-    Node *const node1111_aa = node1111->next(0);
+    auto node1111_aa = node1111->next(0);
     EXPECT_EQ(node1111_aa->mask, 1u << 0xa | 1u << 0xc);
     EXPECT_EQ(node1111_aa->next(0)->value(), kv[2].second);
     EXPECT_EQ(node1111_aa->next(1)->value(), kv[3].second);
@@ -241,15 +241,15 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[1].first, kv[1].second),
         make_update(kv[2].first, kv[2].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
+        find_blocking(this->aux, this->root, kv[0].first, version)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version)
+        find_blocking(this->aux, this->root, kv[2].first, version)
             .first.node->value(),
         kv[2].second);
 
@@ -258,7 +258,7 @@ TYPED_TEST(PlainTrieTest, mismatch)
         this->root->path_nibble_view(),
         (NibblesView{0, 2, kv[0].first.data()}));
     EXPECT_EQ(this->root->next(1)->value(), kv[2].second);
-    Node *left_leaf = this->root->next(0)->next(0);
+    auto left_leaf = this->root->next(0)->next(0);
     EXPECT_EQ(left_leaf->value(), kv[0].second);
     /* insert 12347678, 123aabcd
                   12
@@ -276,19 +276,19 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[3].first, kv[3].second),
         make_update(kv[4].first, kv[4].second));
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[2].first, version)
+        find_blocking(this->aux, this->root, kv[2].first, version)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[3].first, version)
+        find_blocking(this->aux, this->root, kv[3].first, version)
             .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[4].first, version)
+        find_blocking(this->aux, this->root, kv[4].first, version)
             .first.node->value(),
         kv[4].second);
 
@@ -296,11 +296,11 @@ TYPED_TEST(PlainTrieTest, mismatch)
     EXPECT_EQ(
         this->root->path_nibble_view(),
         (NibblesView{0, 2, kv[0].first.data()}));
-    Node *node3 = this->root->next(0);
+    auto node3 = this->root->next(0);
     EXPECT_EQ(node3->mask, 1u << 4 | 1u << 0xa);
     EXPECT_EQ(node3->bitpacked.data_len, 0);
     EXPECT_EQ(node3->path_bytes(), 0);
-    Node *node34 = node3->next(0);
+    auto node34 = node3->next(0);
     EXPECT_EQ(node34->mask, 0b11100000);
     EXPECT_EQ(node34->bitpacked.data_len, 0);
     EXPECT_EQ(node34->path_bytes(), 0);
@@ -386,16 +386,16 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
                 std::move(nested)));
     }
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
+        find_blocking(this->aux, this->root, kv[0].first, version)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, *this->root, kv[1].first + nested_kv[0].first, version)
+            this->aux, this->root, kv[1].first + nested_kv[0].first, version)
             .first.node->value(),
         nested_kv[0].second);
 
@@ -411,21 +411,21 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
             make_update(kv[1].first, kv[1].second, true, std::move(nested)));
     }
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[0].first, version)
+        find_blocking(this->aux, this->root, kv[0].first, version)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, *this->root, kv[1].first, version)
+        find_blocking(this->aux, this->root, kv[1].first, version)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, *this->root, kv[1].first + nested_kv[1].first, version)
+            this->aux, this->root, kv[1].first + nested_kv[1].first, version)
             .first.node->value(),
         nested_kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, *this->root, kv[1].first + nested_kv[0].first, version)
+            this->aux, this->root, kv[1].first + nested_kv[0].first, version)
             .second,
         find_result::key_mismatch_failure);
 }
@@ -451,8 +451,8 @@ TYPED_TEST(PlainTrieTest, large_values)
     same_upsert_to_clear_nodes_outside_cache_level();
     {
         auto [leaf_it, res] =
-            find_blocking(this->aux, *this->root, key1, version);
-        auto *leaf = leaf_it.node;
+            find_blocking(this->aux, this->root, key1, version);
+        auto &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
@@ -462,8 +462,8 @@ TYPED_TEST(PlainTrieTest, large_values)
     same_upsert_to_clear_nodes_outside_cache_level();
     {
         auto [leaf_it, res] =
-            find_blocking(this->aux, *this->root, key2, version);
-        auto *leaf = leaf_it.node;
+            find_blocking(this->aux, this->root, key2, version);
+        auto &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
@@ -475,13 +475,13 @@ TYPED_TEST(PlainTrieTest, large_values)
         monad::threadsafe_boost_fibers_promise<find_cursor_result_type> p;
         auto fut = p.get_future();
         inflight_map_t inflights;
-        find_notify_fiber_future(this->aux, inflights, p, *this->root, key1);
+        find_notify_fiber_future(this->aux, inflights, p, this->root, key1);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
             this->aux.io->wait_until_done();
         }
         auto [leaf_it, res] = fut.get();
-        auto *leaf = leaf_it.node;
+        auto &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
@@ -493,13 +493,13 @@ TYPED_TEST(PlainTrieTest, large_values)
         monad::threadsafe_boost_fibers_promise<find_cursor_result_type> p;
         auto fut = p.get_future();
         inflight_map_t inflights;
-        find_notify_fiber_future(this->aux, inflights, p, *this->root, key2);
+        find_notify_fiber_future(this->aux, inflights, p, this->root, key2);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
             this->aux.io->wait_until_done();
         }
         auto [leaf_it, res] = fut.get();
-        auto *leaf = leaf_it.node;
+        auto &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
         EXPECT_TRUE(leaf->has_value());
@@ -540,7 +540,7 @@ TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
             make_update(prefix, top_value, false, std::move(updates)));
         // find blocking on multi-level trie
         auto [begin, errc] =
-            find_blocking(this->aux, *this->root, prefix, version);
+            find_blocking(this->aux, this->root, prefix, version);
         EXPECT_EQ(errc, find_result::success);
         EXPECT_EQ(begin.node->number_of_children(), 2);
         EXPECT_EQ(begin.node->value(), top_value);

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -256,8 +256,8 @@ namespace monad::test
     using StateMachinePlainVarLen = StateMachineAlways<
         EmptyCompute, StateMachineConfig{.variable_length_start_depth = 0}>;
 
-    Node::UniquePtr upsert_vector(
-        UpdateAuxImpl &aux, StateMachine &sm, Node::UniquePtr old,
+    Node::SharedPtr upsert_vector(
+        UpdateAuxImpl &aux, StateMachine &sm, Node::SharedPtr old,
         std::vector<Update> &&update_vec, uint64_t const version = 0)
     {
         UpdateList update_ls;
@@ -268,8 +268,8 @@ namespace monad::test
     }
 
     template <class... Updates>
-    [[nodiscard]] constexpr Node::UniquePtr upsert_updates_with_version(
-        UpdateAuxImpl &aux, StateMachine &sm, Node::UniquePtr old,
+    [[nodiscard]] constexpr Node::SharedPtr upsert_updates_with_version(
+        UpdateAuxImpl &aux, StateMachine &sm, Node::SharedPtr old,
         uint64_t const version, Updates... updates)
     {
         UpdateList update_ls;
@@ -278,8 +278,8 @@ namespace monad::test
     }
 
     template <class... Updates>
-    [[nodiscard]] constexpr Node::UniquePtr upsert_updates(
-        UpdateAuxImpl &aux, StateMachine &sm, Node::UniquePtr old,
+    [[nodiscard]] constexpr Node::SharedPtr upsert_updates(
+        UpdateAuxImpl &aux, StateMachine &sm, Node::SharedPtr old,
         Updates... updates)
     {
         return upsert_updates_with_version(
@@ -336,7 +336,7 @@ namespace monad::test
     class InMemoryTrieBase : public Base
     {
     public:
-        Node::UniquePtr root;
+        Node::SharedPtr root;
         UpdateAux<LockType> aux;
 
         InMemoryTrieBase()
@@ -372,7 +372,7 @@ namespace monad::test
         MONAD_ASYNC_NAMESPACE::AsyncIO io;
 
     public:
-        Node::UniquePtr root;
+        Node::SharedPtr root;
         UpdateAux<LockType> aux;
 
         OnDiskTrieBase()
@@ -512,7 +512,7 @@ namespace monad::test
                         MONAD_IO_BUFFERS_WRITE_SIZE)};
             MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rwbuf};
             MerkleCompute comp;
-            Node::UniquePtr root;
+            Node::SharedPtr root;
             StateMachineAlwaysMerkle sm;
             UpdateAux<LockType> aux{
                 &io, Config.history_len}; // trie section starts from account

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -1057,8 +1057,8 @@ version + 1. However, we do not assume that the version history is continuous
 because user can move_trie_version_forward(), which can invalidate versions in
 the middle of a continuous history.
 */
-Node::UniquePtr UpdateAuxImpl::do_update(
-    Node::UniquePtr prev_root, StateMachine &sm, UpdateList &&updates,
+Node::SharedPtr UpdateAuxImpl::do_update(
+    Node::SharedPtr prev_root, StateMachine &sm, UpdateList &&updates,
     uint64_t const version, bool const compaction, bool const can_write_to_fast,
     bool const write_root)
 {


### PR DESCRIPTION
## Motivation
The switch to shared_ptr makes lifetime management much easier, and lays groundwork for enhanced caching capabilities.
This change also helps remove the restriction of reading only a single database version during execution, allowing concurrent access to different versions (this part will be in a follow-up PR). 

## Description
- Use unique ptr -> shared ptr for in memory trie representation
- NodeCursor now shares ownership of node.
- Rename OwningNodeCursor to CacheNodeCursor

## Benchmark 
Not much performance impact. See specific result in #benchmark channel 

