### PR TITLE
[event] use MONAD_{LIKELY,UNLIKELY}

### DIFF
--- a/category/core/event/event_iterator_inline.h
+++ b/category/core/event/event_iterator_inline.h
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include <category/core/event/event_ring.h>
+#include <category/core/likely.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -83,17 +84,17 @@ inline enum monad_event_iter_result monad_event_iterator_try_copy(
         &iter->descriptors[iter->read_last_seqno & iter->desc_capacity_mask];
     uint64_t const seqno =
         __atomic_load_n(&ring_event->seqno, __ATOMIC_ACQUIRE);
-    if (__builtin_expect(seqno == iter->read_last_seqno + 1, 1)) {
+    if (MONAD_LIKELY(seqno == iter->read_last_seqno + 1)) {
         // Copy the structure, then reload sequence number with
         // __ATOMIC_ACQUIRE to make sure it still matches after the copy
         *event = *ring_event;
         __atomic_load(&ring_event->seqno, &event->seqno, __ATOMIC_ACQUIRE);
-        if (__builtin_expect(event->seqno == seqno, 1)) {
+        if (MONAD_LIKELY(event->seqno == seqno)) {
             return MONAD_EVENT_SUCCESS;
         }
         return MONAD_EVENT_GAP;
     }
-    if (__builtin_expect(seqno < iter->read_last_seqno, 1)) {
+    if (MONAD_LIKELY(seqno < iter->read_last_seqno)) {
         return MONAD_EVENT_NOT_READY;
     }
     return seqno == iter->read_last_seqno && seqno == 0 ? MONAD_EVENT_NOT_READY
@@ -105,7 +106,7 @@ inline enum monad_event_iter_result monad_event_iterator_try_next(
 {
     enum monad_event_iter_result const r =
         monad_event_iterator_try_copy(iter, event);
-    if (__builtin_expect(r == MONAD_EVENT_SUCCESS, 1)) {
+    if (MONAD_LIKELY(r == MONAD_EVENT_SUCCESS)) {
         ++iter->read_last_seqno;
     }
     return r;

--- a/category/core/event/event_ring.h
+++ b/category/core/event/event_ring.h
@@ -31,6 +31,8 @@
 
 #include <sys/types.h>
 
+#include <category/core/likely.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -247,7 +249,7 @@ inline bool monad_event_ring_try_copy(
     struct monad_event_ring const *event_ring, uint64_t seqno,
     struct monad_event_descriptor *event)
 {
-    if (__builtin_expect(seqno == 0, 0)) {
+    if (MONAD_UNLIKELY(seqno == 0)) {
         return false;
     }
     struct monad_event_descriptor const *const ring_event =
@@ -255,7 +257,7 @@ inline bool monad_event_ring_try_copy(
     *event = *ring_event;
     uint64_t const ring_seqno =
         __atomic_load_n(&ring_event->seqno, __ATOMIC_ACQUIRE);
-    if (__builtin_expect(ring_seqno != seqno, 0)) {
+    if (MONAD_UNLIKELY(ring_seqno != seqno)) {
         return false;
     }
     return true;
@@ -283,14 +285,12 @@ inline void *monad_event_ring_payload_memcpy(
     struct monad_event_ring const *event_ring,
     struct monad_event_descriptor const *event, void *dst, size_t n)
 {
-    if (__builtin_expect(
-            !monad_event_ring_payload_check(event_ring, event), 0)) {
+    if (MONAD_UNLIKELY(!monad_event_ring_payload_check(event_ring, event))) {
         return nullptr;
     }
     void const *const src = monad_event_ring_payload_peek(event_ring, event);
     memcpy(dst, src, n);
-    if (__builtin_expect(
-            !monad_event_ring_payload_check(event_ring, event), 0)) {
+    if (MONAD_UNLIKELY(!monad_event_ring_payload_check(event_ring, event))) {
         return nullptr; // Payload expired
     }
     return dst;

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
   "../core/cleanup.h"
   "../core/format_err.c"
   "../core/format_err.h"
+  "../core/likely.h"
   "../core/srcloc.h"
   "../core/event/event_iterator.h"
   "../core/event/event_iterator_inline.h"


### PR DESCRIPTION
Previously we tried to limit the number of C source files that the SDK exposed, preferring __builtin_expect to the MONAD_LIKELY. Be less strict about this.