### PR TITLE
Make Prague fuzzing the default

### DIFF
--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -315,7 +315,7 @@ namespace
         bool print_stats = false;
         BlockchainTestVM::Implementation implementation =
             BlockchainTestVM::Implementation::Compiler;
-        evmc_revision revision = EVMC_CANCUN;
+        evmc_revision revision = EVMC_PRAGUE;
 
         void set_random_seed_if_default()
         {


### PR DESCRIPTION
Previously, we were fuzzing at Cancun by default in CI. Now that `MONAD_FOUR` onwards are being rolled out to live networks, we should be fuzzing against Prague by default to ensure that the new Ethereum features added in those revisions are correct.