### PR TITLE
add transaction lock to claim rewards

### DIFF
--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -118,6 +118,11 @@ public:
         //  Constants //
         ////////////////
 
+        // A non-zero value to indicate a transaction level lock. This value is
+        // never written to storage. It is maintained in transient storage.
+        bytes32_t LOOPING_TSTORE_LOCK_KEY =
+            0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+
         // The current epoch, which is incremented by syscall_on_epoch_change()
         StorageVariable<u64_be> epoch{state_, STAKING_CA, AddressEpoch};
 

--- a/category/execution/monad/staking/util/staking_error.cpp
+++ b/category/execution/monad/staking/util/staking_error.cpp
@@ -69,6 +69,7 @@ quick_status_code_from_enum<monad::staking::StakingError>::value_mappings()
         {StakingError::DelegationTooSmall, "delegation is too small", {}},
         {StakingError::ExternalRewardTooSmall, "external reward too small", {}},
         {StakingError::ExternalRewardTooLarge, "external reward too large", {}},
+        {StakingError::LockedFunction, "locked function", {}},
     };
 
     return v;

--- a/category/execution/monad/staking/util/staking_error.hpp
+++ b/category/execution/monad/staking/util/staking_error.hpp
@@ -59,6 +59,7 @@ enum class StakingError
     DelegationTooSmall,
     ExternalRewardTooSmall,
     ExternalRewardTooLarge,
+    LockedFunction,
 };
 
 MONAD_STAKING_NAMESPACE_END


### PR DESCRIPTION
Add a transaction level lock mechanism to prevent flash loans from interacting with the staking contracts reward calculation. 