### PR TITLE
Disable compilation when call tracing is active

### DIFF
--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -415,7 +415,11 @@ try {
             ? std::numeric_limits<uint64_t>::max()
             : block_num + nblocks - 1;
 
-    vm::VM vm;
+    // If call tracing is enabled, we need to correspondingly disable native
+    // compilation: the compiler does not expose the full fidelity of error exit
+    // codes that are required to serve RPC responses that include call traces.
+    vm::VM vm{!trace_calls};
+
     DbCache db_cache = ctx ? DbCache{*ctx} : DbCache{triedb};
     auto const result = [&] {
         switch (chain_config) {


### PR DESCRIPTION
We need to disable compilation when call tracing is active; if we don't then the persisted traces may not contain full-fidelity out-of-gas error codes, which produces RPC errors.