### PR TITLE
Fuzzer: Shrink counter-examples

### DIFF
--- a/category/core/byte_string.hpp
+++ b/category/core/byte_string.hpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <cstddef>
+#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -42,6 +43,12 @@ template <class T, size_t N>
 constexpr byte_string_view to_byte_string_view(std::array<T, N> const &a)
 {
     return {a.data(), N};
+}
+
+template <class T>
+constexpr byte_string_view to_byte_string_view(std::vector<T> const &a)
+{
+    return {a.data(), a.size()};
 }
 
 inline byte_string_view to_byte_string_view(std::string const &s)

--- a/category/vm/fuzzing/CMakeLists.txt
+++ b/category/vm/fuzzing/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(monad-vm-fuzzing PRIVATE
   "generator/generator.hpp"
   "generator/instruction_data.cpp"
   "generator/instruction_data.hpp"
+  "generator/shrinker.hpp"
 )
 
 monad_compile_options(monad-vm-fuzzing)

--- a/category/vm/fuzzing/generator/choice.hpp
+++ b/category/vm/fuzzing/generator/choice.hpp
@@ -76,14 +76,19 @@ namespace monad::vm::fuzzing
         return *result;
     }
 
+    // Coin toss, biased whenever p != 0.5
+    template <typename Engine>
+    static bool toss(Engine &engine, double p)
+    {
+        std::bernoulli_distribution dist(p);
+        return dist(engine);
+    }
+
     template <typename Engine, typename Action>
     void
     with_probability(Engine &eng, double const probability, Action &&action)
     {
-        auto dist = std::uniform_real_distribution<double>(0.0, 1.0);
-        auto const cutoff = dist(eng);
-
-        if (probability >= cutoff) {
+        if (toss(eng, probability)) {
             std::forward<Action>(action)(eng);
         }
     }

--- a/category/vm/fuzzing/generator/data.hpp
+++ b/category/vm/fuzzing/generator/data.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/core/assert.h>
+
+#include <evmc/evmc.hpp>
+
+namespace monad::vm::fuzzing
+{
+    inline uint8_t num_precompiles(evmc_revision rev)
+    {
+        if (rev <= EVMC_SPURIOUS_DRAGON) {
+            return 4;
+        }
+        else if (rev <= EVMC_PETERSBURG) {
+            return 8;
+        }
+        else if (rev <= EVMC_SHANGHAI) {
+            return 9;
+        }
+        else if (rev == EVMC_CANCUN) {
+            return 10;
+        }
+        else if (rev == EVMC_PRAGUE) {
+            return 17;
+        }
+        else if (rev == EVMC_OSAKA) {
+            // TODO(BSC): handle discontinuous precompiles
+            MONAD_VM_ASSERT(false);
+        }
+        else {
+            MONAD_VM_ASSERT(false);
+        }
+    }
+}

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -1004,11 +1004,12 @@ namespace monad::vm::fuzzing
                                 }
                             },
                             [&](SmallConstant const &sc) {
-                                std::uint32_t val = sc.value;
+                                auto const *val =
+                                    reinterpret_cast<uint8_t const *>(
+                                        &sc.value);
                                 program.push_back(PUSH4);
-                                for (auto i = 0; i < 4; ++i) {
-                                    program.push_back(val & 0xFF);
-                                    val >>= 8;
+                                for (auto i = 3; i >= 0; --i) {
+                                    program.push_back(val[i]);
                                 }
                             },
                             [&](ReturnInstead const &) {

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -197,9 +197,21 @@ namespace monad::vm::fuzzing
         std::optional<evmc::address> address;
     };
 
-    struct ValidJumpDest
+    struct BlockIx
+    {
+        std::size_t index;
+    };
+
+    struct SmallConstant
+    {
+        std::uint32_t value;
+    };
+
+    struct ReturnInstead
     {
     };
+
+    using ValidJumpDest = std::variant<BlockIx, SmallConstant, ReturnInstead>;
 
     struct BasicBlockInfo
     {
@@ -321,6 +333,49 @@ namespace monad::vm::fuzzing
     }
 
     template <typename Engine>
+    ValidJumpDest generate_valid_jump_dest(
+        Engine &gen, std::vector<BlockIx> const &jumpdest_blocks,
+        std::size_t block_index)
+    {
+        // If there is only one or zero valid jump destinations,
+        // then we will likely fail due to invalid jump destination
+        // or due to generating a loop. So in this case we will generate a
+        // return instead of a jump(i) instruction with 90% probability.
+        if (jumpdest_blocks.size() <= 1 && toss(gen, 0.9)) {
+            return ValidJumpDest{ReturnInstead{}};
+        }
+
+        auto forward_dests_begin = jumpdest_blocks.begin();
+        auto const forward_dests_end = jumpdest_blocks.end();
+
+        forward_dests_begin = std::find_if(
+            forward_dests_begin, forward_dests_end, [block_index](auto jd) {
+                return jd.index > block_index;
+            });
+
+        // If there are no possible forwards jumps (i.e. we're in the last
+        // block) then we need to unconditionally sample from the full set
+        // of jumpdests.
+        auto const forward_prob =
+            (forward_dests_begin != forward_dests_end) ? 0.9 : 0.0;
+
+        return discrete_choice<ValidJumpDest>(
+            gen,
+            [&](auto &g) {
+                if (jumpdest_blocks.size() == 0) {
+                    return ValidJumpDest{SmallConstant{random_uint32(g)}};
+                }
+                else {
+                    return ValidJumpDest{uniform_sample(g, jumpdest_blocks)};
+                }
+            },
+            Choice(forward_prob, [&](auto &g) {
+                return uniform_sample(
+                    g, forward_dests_begin, forward_dests_end);
+            }));
+    }
+
+    template <typename Engine>
     evmc::address generate_precompile_address(Engine &eng, evmc_revision rev)
     {
         auto addr = [rev, &eng]() {
@@ -417,14 +472,19 @@ namespace monad::vm::fuzzing
     template <typename Engine>
     Push generate_push(
         GeneratorFocus const &focus, Engine &eng,
-        std::vector<evmc::address> const &valid_addresses)
+        std::vector<evmc::address> const &valid_addresses,
+        std::vector<BlockIx> const &jumpdest_blocks,
+        std::size_t current_block_index)
     {
         return discrete_choice<Push>(
             eng,
             [](auto &g) { return random_constant(g); },
             Choice(
                 focus.valid_jumpdest_prob,
-                [](auto &) { return ValidJumpDest{}; }),
+                [&](auto &g) {
+                    return generate_valid_jump_dest(
+                        g, jumpdest_blocks, current_block_index);
+                }),
             Choice(
                 focus.valid_address_prob,
                 [&](auto &) {
@@ -468,7 +528,7 @@ namespace monad::vm::fuzzing
             Cases{
                 [&](ValidJumpDest) -> Push { return random_constant(eng); },
                 [](Push const &x) -> Push { return x; }},
-            generate_push(focus, eng, valid_addresses));
+            generate_push(focus, eng, valid_addresses, {}, 0));
     }
 
     struct Call
@@ -652,7 +712,8 @@ namespace monad::vm::fuzzing
     std::vector<Instruction> generate_block(
         GeneratorFocus const &focus, Engine &eng, evmc_revision rev,
         std::vector<evmc::address> const &valid_addresses,
-        BasicBlockInfo const &block)
+        std::vector<BlockIx> const &jumpdest_blocks,
+        BasicBlockInfo const &block, std::size_t block_index)
     {
         static constexpr std::size_t max_block_insts = 10000;
 
@@ -719,7 +780,12 @@ namespace monad::vm::fuzzing
                 auto const main_initial_pushes = main_pushes_dist(g);
 
                 for (auto i = 0u; i < main_initial_pushes; ++i) {
-                    program.push_back(generate_push(focus, g, valid_addresses));
+                    program.push_back(generate_push(
+                        focus,
+                        g,
+                        valid_addresses,
+                        jumpdest_blocks,
+                        block_index));
                 }
             });
         }
@@ -734,8 +800,13 @@ namespace monad::vm::fuzzing
                     [](auto &g) { return generate_common_non_terminator(g); }),
                 Choice(
                     push_prob,
-                    [&focus, valid_addresses](auto &g) {
-                        return generate_push(focus, g, valid_addresses);
+                    [&](auto &g) {
+                        return generate_push(
+                            focus,
+                            g,
+                            valid_addresses,
+                            jumpdest_blocks,
+                            block_index);
                     }),
                 Choice(dup_prob, [](auto &g) { return generate_dup(g); }),
                 Choice(
@@ -767,7 +838,8 @@ namespace monad::vm::fuzzing
 
                 if (op == JUMP || op == JUMPI) {
                     with_probability(eng, focus.valid_jump_prob, [&](auto &) {
-                        program.push_back(ValidJumpDest{});
+                        program.push_back(generate_valid_jump_dest(
+                            eng, jumpdest_blocks, block_index));
                     });
                 }
                 else if (op == RETURN || op == REVERT) {
@@ -898,7 +970,7 @@ namespace monad::vm::fuzzing
 
     void compile_push(
         std::vector<std::uint8_t> &program, Push const &push,
-        std::vector<std::size_t> &jumpdest_patches)
+        std::vector<std::pair<std::size_t, BlockIx>> &jumpdest_patches)
     {
         std::visit(
             Cases{
@@ -910,13 +982,38 @@ namespace monad::vm::fuzzing
                         program.push_back(ADDRESS);
                     }
                 },
-                [&](ValidJumpDest) {
-                    jumpdest_patches.push_back(program.size());
-
-                    program.push_back(PUSH4);
-                    for (auto i = 0; i < 4; ++i) {
-                        program.push_back(0xFF);
-                    }
+                [&](ValidJumpDest const &jd) {
+                    std::visit(
+                        Cases{
+                            [&](BlockIx const &block) {
+                                // We don't know the actual jumpdest yet,
+                                // so we need to patch it later.
+                                jumpdest_patches.push_back(
+                                    std::make_pair(program.size(), block));
+                                program.push_back(PUSH4);
+                                for (auto i = 0; i < 4; ++i) {
+                                    program.push_back(0xFF);
+                                }
+                            },
+                            [&](SmallConstant const &sc) {
+                                std::uint32_t val = sc.value;
+                                program.push_back(PUSH4);
+                                for (auto i = 0; i < 4; ++i) {
+                                    program.push_back(val & 0xFF);
+                                    val >>= 8;
+                                }
+                            },
+                            [&](ReturnInstead const &) {
+                                // We will replace the jump with a return
+                                // later, so just push a dummy value here.
+                                program.push_back(PUSH1);
+                                program.push_back(0xFF);
+                                program.push_back(PUSH1);
+                                program.push_back(0xFF);
+                                program.push_back(RETURN);
+                            },
+                        },
+                        jd);
                 },
                 [&](Constant const &c) {
                     program.push_back(PUSH32);
@@ -932,7 +1029,7 @@ namespace monad::vm::fuzzing
 
     void compile_push(std::vector<std::uint8_t> &program, Push const &push)
     {
-        auto patches = std::vector<std::size_t>{};
+        auto patches = std::vector<std::pair<std::size_t, BlockIx>>{};
         compile_push(program, push, patches);
         MONAD_VM_DEBUG_ASSERT(patches.empty());
     }
@@ -940,16 +1037,14 @@ namespace monad::vm::fuzzing
     void compile_block(
         std::vector<std::uint8_t> &program,
         std::vector<Instruction> const &block,
-        std::vector<std::uint32_t> &valid_jumpdests,
-        std::vector<std::size_t> &jumpdest_patches)
+        std::vector<std::pair<std::size_t, BlockIx>> &jumpdest_patches,
+        std::vector<std::uint32_t> &block_offsets)
     {
-        auto push_op = [&](auto op, auto const &opnds) {
-            if (op == JUMPDEST) {
-                valid_jumpdests.push_back(
-                    static_cast<std::uint32_t>(program.size()));
-            }
+        // Record the starting offset of this block for patch_jumpdests
+        block_offsets.push_back(static_cast<std::uint32_t>(program.size()));
 
-            for (auto [mem_op, safe_value] : opnds) {
+        auto push_op = [&](auto op, auto const &opnds) {
+            for (auto const &[mem_op, safe_value] : opnds) {
                 auto const byte_size =
                     count_significant_bytes(safe_value.value);
                 MONAD_VM_DEBUG_ASSERT(byte_size <= 32);
@@ -988,72 +1083,24 @@ namespace monad::vm::fuzzing
         }
     }
 
-    template <typename Engine>
     void patch_jumpdests(
-        Engine &eng, std::vector<std::uint8_t> &program,
-        std::vector<std::size_t> const &jumpdest_patches,
-        std::vector<std::uint32_t> const &valid_jumpdests)
+        std::vector<std::uint8_t> &program,
+        std::vector<std::pair<std::size_t, BlockIx>> const &jumpdest_patches,
+        std::vector<std::uint32_t> const &block_offsets)
     {
-        MONAD_VM_DEBUG_ASSERT(std::ranges::is_sorted(jumpdest_patches));
-        MONAD_VM_DEBUG_ASSERT(std::ranges::is_sorted(valid_jumpdests));
-
-        // The valid jumpdests and path locations in this program appear in
-        // sorted order, so we can bias the generator towards "forwards" jumps
-        // in the CFG by simply keeping track of a pointer to the first jumpdest
-        // greater than the program offset that we're currently patching, and
-        // sampling from that range with greater probability.
-
-        auto forward_jds_begin = valid_jumpdests.begin();
-        auto const forward_jds_end = valid_jumpdests.end();
-
-        for (auto const patch : jumpdest_patches) {
+        for (auto const &[patch, block_ix] : jumpdest_patches) {
             MONAD_VM_DEBUG_ASSERT(patch + 4 < program.size());
             MONAD_VM_DEBUG_ASSERT(program[patch] == PUSH4);
+            MONAD_VM_DEBUG_ASSERT(block_ix.index < block_offsets.size());
 
-            forward_jds_begin = std::find_if(
-                forward_jds_begin, forward_jds_end, [patch](auto jd) {
-                    return jd > patch;
-                });
-
-            // If there are no possible forwards jumps (i.e. we're in the last
-            // block) then we need to unconditionally sample from the full set
-            // of jumpdests.
-            auto const forward_prob =
-                (forward_jds_begin != forward_jds_end) ? 0.9 : 0.0;
-
-            auto const jd = discrete_choice<std::size_t>(
-                eng,
-                [&](auto &g) {
-                    if (valid_jumpdests.size() == 0) {
-                        return random_uint32(g);
-                    }
-                    else {
-                        return uniform_sample(g, valid_jumpdests);
-                    }
-                },
-                Choice(forward_prob, [&](auto &g) {
-                    return uniform_sample(
-                        g, forward_jds_begin, forward_jds_end);
-                }));
-
-            auto const *bs = reinterpret_cast<uint8_t const *>(&jd);
+            auto const jd_offset = block_offsets[block_ix.index];
+            auto const *bs = reinterpret_cast<uint8_t const *>(&jd_offset);
             for (auto i = 0u; i < 4; ++i) {
                 auto &dest = program[patch + i + 1];
                 MONAD_VM_DEBUG_ASSERT(dest == 0xFF);
 
                 dest = bs[3 - i];
             }
-
-            // If there is only one or zero valid jump destinations,
-            // then we will likely fail due to invalid jump destination
-            // or due to generating a loop. So in this case we will generate a
-            // return instead of a jump(i) instruction with 90% probability.
-            auto const return_prob = valid_jumpdests.size() > 1 ? 0 : 0.9;
-            with_probability(eng, return_prob, [&](auto &) {
-                program[patch] = PUSH1;
-                program[patch + 2] = PUSH1;
-                program[patch + 4] = RETURN;
-            });
         }
     }
 
@@ -1077,6 +1124,9 @@ namespace monad::vm::fuzzing
         auto const n_exit_blocks = exit_blocks_dist(eng);
 
         auto blocks = std::vector<BasicBlockInfo>{};
+        // indices of blocks that are valid jumpdests. Used when generating push
+        // instructions to pick valid jump destinations.
+        auto jumpdest_blocks = std::vector<BlockIx>{};
 
         for (auto i = 0; i < n_blocks; ++i) {
             // main block is the first
@@ -1086,21 +1136,32 @@ namespace monad::vm::fuzzing
             // with 2/3 probability, a block is a valid jump destination
             auto const is_jump_dest = toss(eng, 0.66);
 
+            if (is_jump_dest) {
+                jumpdest_blocks.push_back(BlockIx{static_cast<size_t>(i)});
+            }
+
             blocks.push_back(BasicBlockInfo{is_main, is_exit, is_jump_dest});
         }
 
-        auto valid_jumpdests = std::vector<std::uint32_t>{};
-        auto jumpdest_patches = std::vector<std::size_t>{};
+        auto jumpdest_patches = std::vector<std::pair<std::size_t, BlockIx>>{};
+        auto block_offsets = std::vector<std::uint32_t>{};
 
-        for (auto const &block : blocks) {
-            auto const block_instructions =
-                generate_block(focus, eng, rev, valid_addresses, block);
+        for (auto block_ix = 0u; block_ix < blocks.size(); ++block_ix) {
+            auto const &block = blocks[block_ix];
+            auto const block_instructions = generate_block(
+                focus,
+                eng,
+                rev,
+                valid_addresses,
+                jumpdest_blocks,
+                block,
+                block_ix);
 
             compile_block(
-                prog, block_instructions, valid_jumpdests, jumpdest_patches);
+                prog, block_instructions, jumpdest_patches, block_offsets);
         }
 
-        patch_jumpdests(eng, prog, jumpdest_patches, valid_jumpdests);
+        patch_jumpdests(prog, jumpdest_patches, block_offsets);
         return prog;
     }
 

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -273,7 +273,8 @@ namespace monad::vm::fuzzing
         bool is_jump_dest;
     };
 
-    struct BasicBlock {
+    struct BasicBlock
+    {
         bool is_main;
         bool is_exit;
         bool is_jump_dest;
@@ -1171,13 +1172,16 @@ namespace monad::vm::fuzzing
         return contract;
     }
 
-    std::vector<std::uint8_t> compile_program(std::vector<BasicBlock> basic_blocks) {
+    std::vector<std::uint8_t>
+    compile_program(std::vector<BasicBlock> basic_blocks)
+    {
         auto prog = std::vector<std::uint8_t>{};
         auto jumpdest_patches = std::vector<std::pair<std::size_t, BlockIx>>{};
         auto block_offsets = std::vector<std::uint32_t>{};
 
         for (auto const &b : basic_blocks) {
-            compile_block(prog, b.instructions, jumpdest_patches, block_offsets);
+            compile_block(
+                prog, b.instructions, jumpdest_patches, block_offsets);
         }
         patch_jumpdests(prog, jumpdest_patches, block_offsets);
         return prog;
@@ -1188,8 +1192,8 @@ namespace monad::vm::fuzzing
         GeneratorFocus focus, Engine &eng, evmc_revision rev,
         std::vector<evmc::address> const &valid_addresses)
     {
-        auto basic_blocks = generate_basic_blocks(
-            focus, eng, rev, valid_addresses);
+        auto basic_blocks =
+            generate_basic_blocks(focus, eng, rev, valid_addresses);
         return compile_program(std::move(basic_blocks));
     }
 
@@ -1286,7 +1290,7 @@ namespace monad::vm::fuzzing
      * instantiating this lookup as appropriate.
      */
     template <typename Engine, typename LookupFunc>
-    message_ptr generate_message(
+    evmc_message generate_message(
         GeneratorFocus const &focus, Engine &eng,
         std::vector<evmc::address> const &contract_addresses,
         std::vector<evmc::address> const &known_eoas,
@@ -1344,7 +1348,9 @@ namespace monad::vm::fuzzing
 
         auto const salt = random_constant(eng).value;
 
-        return message_ptr{new evmc_message{
+        auto const &code = address_lookup(target);
+
+        return evmc_message{
             .kind = kind,
             .flags = flags,
             .depth = depth,
@@ -1360,7 +1366,7 @@ namespace monad::vm::fuzzing
             .memory_handle = nullptr,
             .memory = nullptr,
             .memory_capacity = 0,
-        }};
+        };
     }
 
 }

--- a/category/vm/fuzzing/generator/shrinker.hpp
+++ b/category/vm/fuzzing/generator/shrinker.hpp
@@ -63,8 +63,7 @@ namespace monad::vm::fuzzing
         auto const p = 1 / (mean_ratio * static_cast<double>(vec.size()));
 
         if (p >= 1.0) {
-            // Mean is greater than or equal to the vector size, so just remove
-            // one element.
+            // Invalid p, just remove a single element
             return erase_element(engine, std::move(vec)).first;
         }
         else {

--- a/category/vm/fuzzing/generator/shrinker.hpp
+++ b/category/vm/fuzzing/generator/shrinker.hpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/vm/core/assert.h>
+#include <category/vm/core/cases.hpp>
+#include <category/vm/fuzzing/generator/choice.hpp>
+#include <category/vm/fuzzing/generator/data.hpp>
+#include <category/vm/fuzzing/generator/instruction_data.hpp>
+
+#include <evmc/evmc.hpp>
+
+#include <array>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <random>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+using namespace evmc::literals;
+
+namespace monad::vm::fuzzing
+{
+    template <typename Engine, typename T>
+    std::pair<std::vector<T>, std::size_t>
+    erase_element(Engine &engine, std::vector<T> vec)
+    {
+        MONAD_VM_ASSERT(vec.size() != 0);
+
+        auto const element_to_remove = std::uniform_int_distribution<size_t>(
+            0, static_cast<size_t>(vec.size()) - 1)(engine);
+
+        vec.erase(vec.begin() + static_cast<ptrdiff_t>(element_to_remove));
+        return {vec, static_cast<std::size_t>(element_to_remove)};
+    }
+
+    template <typename Engine, typename T>
+    std::vector<T>
+    erase_range(Engine &engine, std::vector<T> vec, double mean_ratio)
+    {
+        MONAD_VM_ASSERT(vec.size() != 0);
+
+        // Generate ranges of instructions to remove.
+        // Using a geometric distribution of parameter p where mean = 1/p
+        // mean_ratio is the ratio of the mean to the total size of the vector.
+        // e.g. mean_ratio = 0.1 means the mean is 10% of the vector size.
+        // So p = 1/(mean_ratio * vec.size())
+        auto const p = 1 / (mean_ratio * static_cast<double>(vec.size()));
+
+        if (p >= 1.0) {
+            // Mean is greater than or equal to the vector size, so just remove
+            // one element.
+            return erase_element(engine, std::move(vec)).first;
+        }
+        else {
+            auto range_size_dist = std::geometric_distribution<std::size_t>(p);
+            auto range_size =
+                std::min<std::size_t>(range_size_dist(engine) + 1, vec.size() - 1);
+            auto range_start = std::uniform_int_distribution<std::size_t>(
+                0, vec.size() - range_size)(engine);
+
+            vec.erase(
+                vec.begin() + static_cast<ptrdiff_t>(range_start),
+                vec.begin() + static_cast<ptrdiff_t>(range_start + range_size));
+            return vec;
+        }
+    }
+
+    template <typename Engine>
+    std::pair<std::vector<BasicBlock>, std::size_t>
+    shrink_contract(Engine &engine, std::vector<BasicBlock> blocks)
+    {
+        MONAD_VM_ASSERT(blocks.size() != 0);
+
+        auto [new_blocks, removed_block] =
+            erase_element(engine, std::move(blocks));
+
+        // We need to adjust jump destinations so they still point to their
+        // original targets. Push instructions with a ValidJumpDest operand must
+        // be decremented if they point to a block after the removed one.
+        for (auto &block : new_blocks) {
+            for (auto &instr : block.instructions) {
+                if (auto *push = std::get_if<Push>(&instr)) {
+                    if (auto *vjd = std::get_if<ValidJumpDest>(push)) {
+                        if (auto *bix = std::get_if<BlockIx>(vjd)) {
+                            if (bix->index != 0 &&
+                                bix->index >= removed_block) {
+                                --bix->index;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return {new_blocks, removed_block};
+    }
+
+    template <typename Engine>
+    std::vector<BasicBlock> shrink_block(
+        Engine &engine, std::vector<BasicBlock> blocks,
+        std::size_t block_to_shrink)
+    {
+        MONAD_VM_ASSERT(blocks.size() != 0);
+        auto block = blocks[block_to_shrink];
+        MONAD_VM_ASSERT(block.instructions.size() != 0);
+
+        auto new_instructions =
+            erase_range(engine, std::move(block.instructions), 0.1);
+        block.instructions = new_instructions;
+        blocks[block_to_shrink] = block;
+        return blocks;
+    }
+
+    // Set the jumpdest flag of the basic block following jumpdest_block_ix
+    std::pair<std::vector<BasicBlock>, bool> propagate_jumpdest(
+        std::vector<BasicBlock> blocks, std::size_t jumpdest_block_ix)
+    {
+        bool propagated = false;
+        if (jumpdest_block_ix < blocks.size()) {
+            auto block = blocks[jumpdest_block_ix];
+            propagated = !block.is_jump_dest;
+            block.is_jump_dest = true;
+            blocks[jumpdest_block_ix] = block;
+        }
+
+        return {blocks, propagated};
+    }
+}

--- a/category/vm/fuzzing/generator/shrinker.hpp
+++ b/category/vm/fuzzing/generator/shrinker.hpp
@@ -68,8 +68,8 @@ namespace monad::vm::fuzzing
         }
         else {
             auto range_size_dist = std::geometric_distribution<std::size_t>(p);
-            auto range_size =
-                std::min<std::size_t>(range_size_dist(engine) + 1, vec.size() - 1);
+            auto range_size = std::min<std::size_t>(
+                range_size_dist(engine) + 1, vec.size() - 1);
             auto range_start = std::uniform_int_distribution<std::size_t>(
                 0, vec.size() - range_size)(engine);
 

--- a/category/vm/fuzzing/generator/shrinker.hpp
+++ b/category/vm/fuzzing/generator/shrinker.hpp
@@ -66,6 +66,9 @@ namespace monad::vm::fuzzing
             // Invalid p, just remove a single element
             return erase_element(engine, std::move(vec)).first;
         }
+        else if (vec.size() == 1) {
+            return {}; // only one element, remove it
+        }
         else {
             auto range_size_dist = std::geometric_distribution<std::size_t>(p);
             auto range_size = std::min<std::size_t>(

--- a/test/vm/fuzzer/assertions.cpp
+++ b/test/vm/fuzzer/assertions.cpp
@@ -78,18 +78,9 @@ namespace monad::vm::fuzzing
         evmc::Result const &evmone_result, evmc::Result const &compiler_result,
         bool const strict_out_of_gas)
     {
-        FUZZER_ASSERT(std::ranges::equal(
-            evmone_result.create_address.bytes,
-            compiler_result.create_address.bytes));
-
-        FUZZER_ASSERT(evmone_result.gas_left == compiler_result.gas_left);
-        FUZZER_ASSERT(evmone_result.gas_refund == compiler_result.gas_refund);
-
-        FUZZER_ASSERT(std::ranges::equal(
-            std::span(evmone_result.output_data, evmone_result.output_size),
-            std::span(
-                compiler_result.output_data, compiler_result.output_size)));
-
+        // Compare the status code before checking the rest of the fields. This
+        // is because the other fields are set to 0/NULL in case of failure,
+        // and so comparing them first produces misleading errors.
         switch (evmone_result.status_code) {
         case EVMC_SUCCESS:
         case EVMC_REVERT:
@@ -117,6 +108,18 @@ namespace monad::vm::fuzzing
             FUZZER_ASSERT(compiler_result.status_code != EVMC_REVERT);
             break;
         }
+
+        FUZZER_ASSERT(std::ranges::equal(
+            evmone_result.create_address.bytes,
+            compiler_result.create_address.bytes));
+
+        FUZZER_ASSERT(evmone_result.gas_left == compiler_result.gas_left);
+        FUZZER_ASSERT(evmone_result.gas_refund == compiler_result.gas_refund);
+
+        FUZZER_ASSERT(std::ranges::equal(
+            std::span(evmone_result.output_data, evmone_result.output_size),
+            std::span(
+                compiler_result.output_data, compiler_result.output_size)));
     }
 
 }

--- a/test/vm/fuzzer/assertions.cpp
+++ b/test/vm/fuzzer/assertions.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "account.hpp"
+#include "assertions.hpp"
 #include "state.hpp"
 
 #include <category/vm/core/assert.h>
@@ -30,35 +31,35 @@ namespace monad::vm::fuzzing
 {
     void assert_equal(StorageValue const &a, StorageValue const &b)
     {
-        MONAD_VM_ASSERT(a.current == b.current);
-        MONAD_VM_ASSERT(a.original == b.original);
-        MONAD_VM_ASSERT(a.access_status == b.access_status);
+        FUZZER_ASSERT(a.current == b.current);
+        FUZZER_ASSERT(a.original == b.original);
+        FUZZER_ASSERT(a.access_status == b.access_status);
     }
 
     void assert_equal(Account const &a, Account const &b)
     {
-        MONAD_VM_ASSERT(
+        FUZZER_ASSERT(
             a.transient_storage.size() == b.transient_storage.size());
         for (auto const &[k, v] : a.transient_storage) {
             auto const found = b.transient_storage.find(k);
-            MONAD_VM_ASSERT(found != b.transient_storage.end());
-            MONAD_VM_ASSERT(found->second == v);
+            FUZZER_ASSERT(found != b.transient_storage.end());
+            FUZZER_ASSERT(found->second == v);
         }
 
-        MONAD_VM_ASSERT(a.storage.size() == b.storage.size());
+        FUZZER_ASSERT(a.storage.size() == b.storage.size());
         for (auto const &[k, v] : a.storage) {
             auto const found = b.storage.find(k);
-            MONAD_VM_ASSERT(found != b.storage.end());
+            FUZZER_ASSERT(found != b.storage.end());
             assert_equal(v, found->second);
         }
 
-        MONAD_VM_ASSERT(a.nonce == b.nonce);
-        MONAD_VM_ASSERT(a.balance == b.balance);
-        MONAD_VM_ASSERT(a.code_hash == b.code_hash);
-        MONAD_VM_ASSERT(a.destructed == b.destructed);
-        MONAD_VM_ASSERT(a.erase_if_empty == b.erase_if_empty);
-        MONAD_VM_ASSERT(a.just_created == b.just_created);
-        MONAD_VM_ASSERT(a.access_status == b.access_status);
+        FUZZER_ASSERT(a.nonce == b.nonce);
+        FUZZER_ASSERT(a.balance == b.balance);
+        FUZZER_ASSERT(a.code_hash == b.code_hash);
+        FUZZER_ASSERT(a.destructed == b.destructed);
+        FUZZER_ASSERT(a.erase_if_empty == b.erase_if_empty);
+        FUZZER_ASSERT(a.just_created == b.just_created);
+        FUZZER_ASSERT(a.access_status == b.access_status);
     }
 
     void assert_equal(State const &a, State const &b)
@@ -66,10 +67,10 @@ namespace monad::vm::fuzzing
         auto const &a_accs = a.get_modified_accounts();
         auto const &b_accs = b.get_modified_accounts();
 
-        MONAD_VM_ASSERT(a_accs.size() == b_accs.size());
+        FUZZER_ASSERT(a_accs.size() == b_accs.size());
         for (auto const &[k, v] : a_accs) {
             auto const found = b_accs.find(k);
-            MONAD_VM_ASSERT(found != b_accs.end());
+            FUZZER_ASSERT(found != b_accs.end());
             assert_equal(v, found->second);
         }
     }
@@ -78,14 +79,14 @@ namespace monad::vm::fuzzing
         evmc::Result const &evmone_result, evmc::Result const &compiler_result,
         bool const strict_out_of_gas)
     {
-        MONAD_VM_ASSERT(std::ranges::equal(
+        FUZZER_ASSERT(std::ranges::equal(
             evmone_result.create_address.bytes,
             compiler_result.create_address.bytes));
 
-        MONAD_VM_ASSERT(evmone_result.gas_left == compiler_result.gas_left);
-        MONAD_VM_ASSERT(evmone_result.gas_refund == compiler_result.gas_refund);
+        FUZZER_ASSERT(evmone_result.gas_left == compiler_result.gas_left);
+        FUZZER_ASSERT(evmone_result.gas_refund == compiler_result.gas_refund);
 
-        MONAD_VM_ASSERT(std::ranges::equal(
+        FUZZER_ASSERT(std::ranges::equal(
             std::span(evmone_result.output_data, evmone_result.output_size),
             std::span(
                 compiler_result.output_data, compiler_result.output_size)));
@@ -93,12 +94,12 @@ namespace monad::vm::fuzzing
         switch (evmone_result.status_code) {
         case EVMC_SUCCESS:
         case EVMC_REVERT:
-            MONAD_VM_ASSERT(
+            FUZZER_ASSERT(
                 evmone_result.status_code == compiler_result.status_code);
             break;
         case EVMC_OUT_OF_GAS: {
             if (strict_out_of_gas) {
-                MONAD_VM_ASSERT(compiler_result.status_code == EVMC_OUT_OF_GAS);
+                FUZZER_ASSERT(compiler_result.status_code == EVMC_OUT_OF_GAS);
             }
             else {
                 // For the compiler, we allow a relaxed check for out-of-gas,
@@ -106,15 +107,15 @@ namespace monad::vm::fuzzing
                 // *or* an out-of-gas failure. This is because the compiler may
                 // statically produce a generic error for code that would
                 // dynamically run out of gas.
-                MONAD_VM_ASSERT(
+                FUZZER_ASSERT(
                     compiler_result.status_code == EVMC_OUT_OF_GAS ||
                     compiler_result.status_code == EVMC_FAILURE);
             }
             break;
         }
         default:
-            MONAD_VM_ASSERT(compiler_result.status_code != EVMC_SUCCESS);
-            MONAD_VM_ASSERT(compiler_result.status_code != EVMC_REVERT);
+            FUZZER_ASSERT(compiler_result.status_code != EVMC_SUCCESS);
+            FUZZER_ASSERT(compiler_result.status_code != EVMC_REVERT);
             break;
         }
     }

--- a/test/vm/fuzzer/assertions.cpp
+++ b/test/vm/fuzzer/assertions.cpp
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "account.hpp"
 #include "assertions.hpp"
+#include "account.hpp"
 #include "state.hpp"
 
 #include <category/vm/core/assert.h>
@@ -38,8 +38,7 @@ namespace monad::vm::fuzzing
 
     void assert_equal(Account const &a, Account const &b)
     {
-        FUZZER_ASSERT(
-            a.transient_storage.size() == b.transient_storage.size());
+        FUZZER_ASSERT(a.transient_storage.size() == b.transient_storage.size());
         for (auto const &[k, v] : a.transient_storage) {
             auto const found = b.transient_storage.find(k);
             FUZZER_ASSERT(found != b.transient_storage.end());

--- a/test/vm/fuzzer/assertions.hpp
+++ b/test/vm/fuzzer/assertions.hpp
@@ -24,22 +24,34 @@ namespace monad::vm::fuzzing
     class FuzzerAssertFailure : public std::runtime_error
     {
     public:
-        FuzzerAssertFailure(std::string const &msg, char const *funsig, char const *file, long line)
-          : std::runtime_error(msg), function_signature(funsig), file_name(file), line_number(line)
-        {}
+        FuzzerAssertFailure(
+            std::string const &msg, char const *funsig, char const *file,
+            long line)
+            : std::runtime_error(msg)
+            , function_signature(funsig)
+            , file_name(file)
+            , line_number(line)
+        {
+        }
 
         char const *function_signature;
         char const *file_name;
         long line_number;
     };
 
-    #define FUZZER_ASSERT(b)                                                   \
-        if (MONAD_VM_UNLIKELY(!(b))) { /* likeliest */                            \
-            throw FuzzerAssertFailure(                                         \
-                std::format("{}:{}:{} Assertion failed: {}",                  \
-                    __PRETTY_FUNCTION__, __FILE__, __LINE__, #b),              \
-                __PRETTY_FUNCTION__, __FILE__, __LINE__);                      \
-        }
+#define FUZZER_ASSERT(b)                                                       \
+    if (MONAD_VM_UNLIKELY(!(b))) { /* likeliest */                             \
+        throw FuzzerAssertFailure(                                             \
+            std::format(                                                       \
+                "{}:{}:{} Assertion failed: {}",                               \
+                __PRETTY_FUNCTION__,                                           \
+                __FILE__,                                                      \
+                __LINE__,                                                      \
+                #b),                                                           \
+            __PRETTY_FUNCTION__,                                               \
+            __FILE__,                                                          \
+            __LINE__);                                                         \
+    }
 
     void assert_equal(
         evmone::state::StorageValue const &a,

--- a/test/vm/fuzzer/assertions.hpp
+++ b/test/vm/fuzzer/assertions.hpp
@@ -20,6 +20,27 @@
 
 namespace monad::vm::fuzzing
 {
+
+    class FuzzerAssertFailure : public std::runtime_error
+    {
+    public:
+        FuzzerAssertFailure(std::string const &msg, char const *funsig, char const *file, long line)
+          : std::runtime_error(msg), function_signature(funsig), file_name(file), line_number(line)
+        {}
+
+        char const *function_signature;
+        char const *file_name;
+        long line_number;
+    };
+
+    #define FUZZER_ASSERT(b)                                                   \
+        if (MONAD_VM_UNLIKELY(!(b))) { /* likeliest */                            \
+            throw FuzzerAssertFailure(                                         \
+                std::format("{}:{}:{} Assertion failed: {}",                  \
+                    __PRETTY_FUNCTION__, __FILE__, __LINE__, #b),              \
+                __PRETTY_FUNCTION__, __FILE__, __LINE__);                      \
+        }
+
     void assert_equal(
         evmone::state::StorageValue const &a,
         evmone::state::StorageValue const &b);

--- a/test/vm/fuzzer/compiler_hook.hpp
+++ b/test/vm/fuzzer/compiler_hook.hpp
@@ -33,7 +33,7 @@ namespace monad::vm::fuzzing
      * different locations.
      */
     template <typename Engine>
-    auto compiler_emit_hook(Engine &engine)
+    auto compiler_emit_hook(Engine &engine, Engine *hook_engine)
     {
         static constexpr std::array<double, 2> artificial_swap_probs = {
             0, 0.50};
@@ -63,9 +63,11 @@ namespace monad::vm::fuzzing
                 artificial_avx_prob,
                 artificial_general_prob,
                 artificial_top2_prob,
-                &engine](vm::compiler::native::Emitter &emit) {
+                hook_engine](vm::compiler::native::Emitter &emit) {
             using monad::vm::compiler::native::GENERAL_REG_COUNT;
             using monad::vm::compiler::native::GeneralReg;
+
+            auto &engine = *hook_engine;
 
             auto &stack = emit.get_stack();
             if (stack.top_index() < stack.min_delta()) {

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -308,12 +308,12 @@ static void clean_storage(State &state)
 }
 
 using random_engine_t = std::mt19937_64;
+using seed_t = random_engine_t::result_type;
 
 namespace
 {
     struct arguments
     {
-        using seed_t = random_engine_t::result_type;
         static constexpr seed_t default_seed =
             std::numeric_limits<seed_t>::max();
 
@@ -329,6 +329,8 @@ namespace
         std::optional<GeneratorFocus> focus = std::nullopt;
         // Disable compiler hook introducing randomness in compilation
         bool deterministic_compilation = false;
+        std::size_t run_shrinking_attempts = 100;
+        std::size_t contract_shrinking_attempts = 100;
 
         void set_random_seed_if_default()
         {
@@ -386,6 +388,16 @@ static arguments parse_args(int const argc, char **const argv)
         "--deterministic-compilation",
         args.deterministic_compilation,
         "Enable deterministic compilation (no randomness)");
+
+    app.add_option(
+        "--run-shrinking-attempts",
+        args.run_shrinking_attempts,
+        "Number of run shrinking attempts (default 100)");
+
+    app.add_option(
+        "--contract-shrinking-attempts",
+        args.contract_shrinking_attempts,
+        "Number of contract shrinking attempts (default 100)");
 
     auto const rev_map = std::map<std::string, evmc_revision>{
         {"FRONTIER", EVMC_FRONTIER},
@@ -494,26 +506,70 @@ log(std::chrono::high_resolution_clock::time_point start, arguments const &args,
 }
 
 template <typename Engine>
-static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
+static evmc::VM create_monad_vm(
+    arguments const &args, Engine &engine,
+    std::unordered_map<evmc::address, seed_t> const &hook_seed_map)
 {
     using enum BlockchainTestVM::Implementation;
 
     monad::vm::compiler::native::EmitterHook hook = nullptr;
+    std::function<void(evmc_message const *msg)> execute_hook = nullptr;
 
+    // The compiler hook introduces non-determinism in the compilation process
+    // that must be controlled for the fuzzer to be effective. To do so, we
+    // assign each contract a seed, and reset the hook's RNG using that seed
+    // before each compilation so that the hook has the same influence each time
+    // that contract is compiled.
+    //
+    // This ensures that the shrinker can reliably reproduce the same
+    // compilation result for a given contract as it removes steps from the run,
+    // making the shrinking predicate deterministic when removing contracts.
+    //
+    // When shrinking individual contracts, removing instructions can shift the
+    // state of the hook RNG such that instructions following the removed
+    // instructions are compiled differently. This can lead to false negatives,
+    // where the shrinker thinks the smaller input does not reproduce the
+    // failure, when in fact it would if the hook RNG state was the same.
+    //
+    // This could be solved by assigning a seed per instruction, but that would
+    // require a more complex mechanism to track and reset the RNG state, as
+    // well as pregenerating even more values that would slow down the fuzzer in
+    // the non-shrinking case, which we want to avoid.
+    //
+    // Fortunately, most counter-examples found by the fuzzer involve only a few
+    // contracts, meaning that problem can be mitigated by increasing the number
+    // of shrinking attempts, effectively sampling the shrinking predicate
+    // multiple times.
     if (args.implementation == Compiler && !args.deterministic_compilation) {
-        hook = compiler_emit_hook(engine);
+
+        // FIXME: This is not thread-safe, but the fuzzer is single-threaded.
+        static Engine hook_engine = random_engine_t(0);
+
+        execute_hook = [&hook_seed_map](evmc_message const *msg) {
+            auto const seed_it = hook_seed_map.find(msg->recipient);
+            if (seed_it == hook_seed_map.end()) {
+                hook_engine = random_engine_t(0);
+            }
+            else {
+                auto const seed = seed_it->second;
+                hook_engine = random_engine_t(seed);
+            }
+        };
+
+        hook = compiler_emit_hook(engine, &hook_engine);
     }
 
-    return evmc::VM(new BlockchainTestVM(args.implementation, hook));
+    return evmc::VM(
+        new BlockchainTestVM(args.implementation, hook, execute_hook));
 }
 
 struct DeployContract
 {
+    seed_t contract_hook_seed;
     evmc::address contract_address;
     std::vector<BasicBlock> contract;
 };
 
-// Precompiles are deployed as contracts that
 struct DeployPrecompile
 {
     evmc::address contract_address;
@@ -589,12 +645,14 @@ static void prepare_iteration(
             continue;
         }
 
+        auto const contract_seed = engine();
         auto const contract_address = prepare_address(genesis_address, nonce);
 
         known_addresses.push_back(contract_address);
         contract_addresses.push_back(contract_address);
         contract_codes[contract_address] = compiled_contract;
-        run.push_back(DeployContract{contract_address, contract});
+        run.push_back(
+            DeployContract{contract_seed, contract_address, contract});
 
         if (args.revision >= EVMC_PRAGUE && toss(engine, 0.2)) {
             auto const delegated_contract_address =
@@ -653,15 +711,15 @@ static void do_run(
     auto engine = random_engine_t(args.seed);
 
     auto evmone_vm = evmc::VM(evmc_create_evmone());
-    // Of all the source of randomness, this is the only one that can't easily
-    // be pre-generated like the rest of the fuzzer input. The BlockchainTestVM
-    // could be extended to signal the beginning of a compilation, allowing
-    // us to reset the seed of the compiler hook to a known value, but since we
-    // don't have a clear mechanism to debug the counter-examples that depend
-    // on the compiler hook randomness, we ignore this for now.
-    // Anyway, when shrinking, the compiler hook is disabled to make the
-    // shrink predicate deterministic.
-    auto monad_vm = create_monad_vm(args, engine);
+    auto compiler_hook_seed_map = std::unordered_map<evmc::address, seed_t>{};
+    for (auto const &step : run) {
+        if (std::holds_alternative<DeployContract>(step)) {
+            auto const &d = std::get<DeployContract>(step);
+            compiler_hook_seed_map[d.contract_address] = d.contract_hook_seed;
+        }
+    }
+
+    auto monad_vm = create_monad_vm(args, engine, compiler_hook_seed_map);
 
     auto initial_state_ = initial_state();
 
@@ -826,10 +884,10 @@ static bool try_run_with_subcontract(
 {
     FUZZER_ASSERT(std::holds_alternative<DeployContract>(
         run[subcontract_iteration_index]));
-    run[subcontract_iteration_index] = DeployContract{
-        std::get<DeployContract>(run[subcontract_iteration_index])
-            .contract_address,
-        subcontract};
+    DeployContract const &d =
+        std::get<DeployContract>(run[subcontract_iteration_index]);
+    run[subcontract_iteration_index] =
+        DeployContract{d.contract_hook_seed, d.contract_address, subcontract};
     return try_run(args, run);
 }
 
@@ -881,36 +939,42 @@ static std::optional<std::vector<BasicBlock>> shrink_run_contract(
 }
 
 static Run make_singleton_run(
-    std::vector<BasicBlock> contract, evmc::address contract_address,
-    evmc_message failed_message)
+    seed_t contract_hook_seed, std::vector<BasicBlock> contract,
+    evmc::address contract_address, evmc_message failed_message)
 {
     return {
-        DeployContract{contract_address, contract},
+        DeployContract{contract_hook_seed, contract_address, contract},
         SendMessage{failed_message}};
 }
 
 static bool try_singleton_run(
-    arguments const &args, std::vector<BasicBlock> contract,
-    evmc::address contract_address, evmc_message failed_message)
+    arguments const &args, seed_t contract_hook_seed,
+    std::vector<BasicBlock> contract, evmc::address contract_address,
+    evmc_message failed_message)
 {
     auto run = make_singleton_run(
-        std::move(contract), contract_address, failed_message);
+        contract_hook_seed, contract, contract_address, failed_message);
     return try_run(args, run);
 }
 
 // A singleton run is one with a single contract and a single message.
 static Run shrink_singleton_run(
-    arguments const &args, std::vector<BasicBlock> original_contract,
-    evmc::address contract_address, evmc_message failed_message)
+    arguments const &args, seed_t contract_hook_seed,
+    std::vector<BasicBlock> original_contract, evmc::address contract_address,
+    evmc_message failed_message)
 {
     auto engine = random_engine_t(args.seed);
-    int iteration_count = 0;
-    auto run =
-        make_singleton_run(original_contract, contract_address, failed_message);
+    auto iteration_count = 0u;
+    auto run = make_singleton_run(
+        contract_hook_seed,
+        original_contract,
+        contract_address,
+        failed_message);
 
-    while (++iteration_count < 100) { // After 100 shrinker failure, give up.
+    while (++iteration_count < args.contract_shrinking_attempts) {
         if (auto new_contract = shrink_run_contract(args, engine, run, 0)) {
-            run[0] = DeployContract{contract_address, new_contract.value()};
+            run[0] = DeployContract{
+                contract_hook_seed, contract_address, new_contract.value()};
             iteration_count = 0;
         }
     }
@@ -927,22 +991,18 @@ shrink_remove_steps(arguments const &args, Engine &engine, Run const &run)
 {
     auto current_run = run;
 
-    int iteration_count = 0;
-    while (++iteration_count < 20) { // After 20 failure, give up.
+    auto iteration_count = 0u;
+    while (++iteration_count < args.run_shrinking_attempts) {
         if (current_run.size() <= 2) { // Cannot shrink further than 2 steps
             break;
         }
 
-        std::cerr << "Shrinker: Trying to remove steps, current size: "
-                  << current_run.size() << "\n";
-
         // Try to remove 10% of the steps
-        auto const new_run = erase_range(engine, current_run, 0.01);
+        auto const new_run = erase_range(engine, current_run, 0.1);
 
         if (!try_run(args, new_run)) {
             current_run = std::move(new_run);
             iteration_count = 0;
-            continue;
         }
     }
 
@@ -954,8 +1014,8 @@ static Run shrink_steps(arguments const &args, Engine &engine, Run const &run)
 {
     auto current_run = run;
 
-    int iteration_count = 0;
-    while (++iteration_count < 100) { // After 100 failure, give up.
+    auto iteration_count = 0u;
+    while (++iteration_count < args.contract_shrinking_attempts) {
 
         // Pick any of the step and try to reduce it
         auto const element_to_shrink = std::uniform_int_distribution<size_t>(
@@ -966,8 +1026,11 @@ static Run shrink_steps(arguments const &args, Engine &engine, Run const &run)
                 [&](DeployContract const &d) {
                     if (auto new_contract = shrink_run_contract(
                             args, engine, current_run, element_to_shrink)) {
+                        // 10% chance to change the seed
+                        auto const new_seed =
+                            toss(engine, 0.1) ? engine() : d.contract_hook_seed;
                         current_run[element_to_shrink] = DeployContract{
-                            d.contract_address, new_contract.value()};
+                            new_seed, d.contract_address, new_contract.value()};
                         iteration_count = 0;
                     }
                 },
@@ -1025,12 +1088,14 @@ shrink_run(arguments const &args, Run const &run, size_t failed_iteration_index)
     // form.
     // Prepare a run with only the msg.recipient contract and the message that
     // caused the failure.
-    auto contract_map =
-        std::unordered_map<evmc::address, std::vector<BasicBlock>>{};
+    auto contract_map = std::unordered_map<
+        evmc::address,
+        std::pair<std::vector<BasicBlock>, seed_t>>{};
     for (auto const &step : run) {
         if (std::holds_alternative<DeployContract>(step)) {
             auto const &d = std::get<DeployContract>(step);
-            contract_map.insert({d.contract_address, d.contract});
+            contract_map.insert(
+                {d.contract_address, {d.contract, d.contract_hook_seed}});
         }
     }
 
@@ -1051,7 +1116,8 @@ shrink_run(arguments const &args, Run const &run, size_t failed_iteration_index)
 
     if (try_singleton_run(
             args,
-            failed_contract,
+            failed_contract.second,
+            failed_contract.first,
             failed_message.code_address,
             failed_message)) {
         std::cerr << "Shrinker: Contract depends on other contracts or state\n";
@@ -1059,7 +1125,11 @@ shrink_run(arguments const &args, Run const &run, size_t failed_iteration_index)
     }
     else {
         return shrink_singleton_run(
-            args, failed_contract, failed_message.code_address, failed_message);
+            args,
+            failed_contract.second,
+            failed_contract.first,
+            failed_message.code_address,
+            failed_message);
     }
 }
 
@@ -1080,15 +1150,22 @@ static void run_loop(int argc, char **argv)
             do_run(i, args, run, iteration_index);
         }
         catch (FuzzerAssertFailure const &ex) {
-            // Disable randomness in compilation for shrinking
-            args.deterministic_compilation = true;
+            // Disable stats printing while shrinking to reduce noise.
             args.print_stats = false;
-            std::cerr << "Can reproduce the failure " << try_run(args, run)
-                      << "\n";
+            // Test whether the counter-example depends on the stack shuffling
+            // introduced by the compiler hook. If so, we increase the number of
+            // shrinking attempts by 10x to account for the non-determinism
+            // and potential false negatives when shrinking.
+            auto const deterministic_compilation_enabled =
+                args.deterministic_compilation;
+            args.deterministic_compilation = true;
+            if (!deterministic_compilation_enabled && try_run(args, run)) {
+                args.contract_shrinking_attempts *= 10;
+            }
+            args.deterministic_compilation = deterministic_compilation_enabled;
+
             auto const &shrunk_run = shrink_run(args, run, iteration_index);
-            std::cerr << "Original counter-example found by fuzzer:\n";
-            print_run(run);
-            std::cerr << "Shrunk counter-example found by fuzzer:\n";
+            std::cerr << "Counter-example found by fuzzer:\n";
             print_run(shrunk_run);
             std::exit(1);
         }

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -25,13 +25,18 @@
 #include "test_state.hpp"
 #include "transaction.hpp"
 
+#include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/core/assert.h>
 #include <category/vm/core/cases.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
 #include <category/vm/fuzzing/generator/generator.hpp>
+#include <category/vm/fuzzing/generator/shrinker.hpp>
 #include <category/vm/utils/debug.hpp>
+
+#include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/core/fmt/address_fmt.hpp>
 
 #include <evmone/constants.hpp>
 #include <evmone/evmone.h>
@@ -322,6 +327,8 @@ namespace
         evmc_revision revision = EVMC_OSAKA;
         std::optional<std::string> focus_path = std::nullopt;
         std::optional<GeneratorFocus> focus = std::nullopt;
+        // Disable compiler hook introducing randomness in compilation
+        bool deterministic_compilation = false;
 
         void set_random_seed_if_default()
         {
@@ -374,6 +381,11 @@ static arguments parse_args(int const argc, char **const argv)
         "--print-stats",
         args.print_stats,
         "Print message result statistics when logging");
+
+    app.add_flag(
+        "--deterministic-compilation",
+        args.deterministic_compilation,
+        "Enable deterministic compilation (no randomness)");
 
     auto const rev_map = std::map<std::string, evmc_revision>{
         {"FRONTIER", EVMC_FRONTIER},
@@ -454,7 +466,8 @@ static evmc_status_code fuzz_iteration(
 static void
 log(std::chrono::high_resolution_clock::time_point start, arguments const &args,
     std::unordered_map<evmc_status_code, std::size_t> const &exit_code_stats,
-    std::size_t const run_index, std::size_t const total_messages)
+    std::size_t const run_index, std::size_t const iteration_count,
+    std::size_t const total_messages)
 {
     using namespace std::chrono;
 
@@ -462,7 +475,7 @@ log(std::chrono::high_resolution_clock::time_point start, arguments const &args,
 
     auto const end = high_resolution_clock::now();
     auto const diff = (end - start).count();
-    auto const per_contract = diff / args.iterations_per_run;
+    auto const per_contract = diff / static_cast<int64_t>(iteration_count);
 
     std::cerr << std::format(
         "[{}]: {:.4f}s / iteration\n",
@@ -487,7 +500,7 @@ static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
 
     monad::vm::compiler::native::EmitterHook hook = nullptr;
 
-    if (args.implementation == Compiler) {
+    if (args.implementation == Compiler && !args.deterministic_compilation) {
         hook = compiler_emit_hook(engine);
     }
 
@@ -631,8 +644,9 @@ static Run prepare_run(arguments const &args)
     return run;
 }
 
-static void
-do_run(std::size_t const run_index, arguments const &args, Run const &run)
+static void do_run(
+    std::size_t const run_index, arguments const &args, Run const &run,
+    size_t &iteration_index)
 {
     auto const rev = args.revision;
 
@@ -640,11 +654,13 @@ do_run(std::size_t const run_index, arguments const &args, Run const &run)
 
     auto evmone_vm = evmc::VM(evmc_create_evmone());
     // Of all the source of randomness, this is the only one that can't easily
-    // be pregenerated like the rest of the fuzzer input. The BlockchainTestVM
+    // be pre-generated like the rest of the fuzzer input. The BlockchainTestVM
     // could be extended to signal the beginning of a compilation, allowing
     // us to reset the seed of the compiler hook to a known value, but since we
     // don't have a clear mechanism to debug the counter-examples that depend
-    // on the compiler hook randomness, we leave this for later.
+    // on the compiler hook randomness, we ignore this for now.
+    // Anyway, when shrinking, the compiler hook is disabled to make the
+    // shrink predicate deterministic.
     auto monad_vm = create_monad_vm(args, engine);
 
     auto initial_state_ = initial_state();
@@ -657,6 +673,7 @@ do_run(std::size_t const run_index, arguments const &args, Run const &run)
 
     auto start_time = std::chrono::high_resolution_clock::now();
 
+    iteration_index = 0;
     for (auto const &iteration : run) {
         std::visit(
             monad::vm::Cases{
@@ -695,9 +712,355 @@ do_run(std::size_t const run_index, arguments const &args, Run const &run)
                     ++exit_code_stats[ec];
                 }},
             iteration);
+
+        iteration_index++;
     }
 
-    log(start_time, args, exit_code_stats, run_index, total_messages);
+    log(start_time,
+        args,
+        exit_code_stats,
+        run_index,
+        iteration_index,
+        total_messages);
+}
+
+static bool try_run(arguments const &args, Run const &run)
+{
+    try {
+        size_t iteration_index = 0;
+        do_run(0, args, run, iteration_index);
+        return true;
+    }
+    catch (FuzzerAssertFailure const &ex) {
+        return false;
+    }
+}
+
+void print_message(evmc_message const &msg)
+{
+    static auto kind_map = std::map<evmc_call_kind, std::string>{
+        {EVMC_CALL, "CALL"},
+        {EVMC_CALLCODE, "CALLCODE"},
+        {EVMC_DELEGATECALL, "DELEGATECALL"},
+        {EVMC_CREATE, "CREATE"},
+        {EVMC_CREATE2, "CREATE2"},
+        {EVMC_EOFCREATE, "EVMC_EOFCREATE"},
+    };
+
+    std::cerr << fmt::format(
+        "  kind {}, gas {}, value {}\n",
+        kind_map[msg.kind],
+        msg.gas,
+        intx::hex(intx::be::load<intx::uint256>(msg.value)));
+
+    std::cerr << fmt::format(
+        "  code_address {}, sender {}, recipient {}\n",
+        address(msg.code_address),
+        address(msg.sender),
+        address(msg.recipient));
+
+    std::cerr << "  input_data [" << msg.input_size << " bytes]: ";
+    for (size_t i = 0; i < msg.input_size; ++i) {
+        std::cerr << fmt::format("{:02x}", msg.input_data[i]);
+    }
+    std::cerr << "\n";
+}
+
+void print_run(Run const &run)
+{
+    std::cerr << "Run with " << run.size() << " steps\n";
+    for (size_t i = 0; i < run.size(); ++i) {
+
+        std::visit(
+            monad::vm::Cases{
+                [&](DeployContract const &d) {
+                    auto const program = compile_program(d.contract);
+                    auto const code_hash =
+                        evmone::keccak256(to_byte_string_view(program));
+                    auto const code_hash_str = intx::hex(
+                        intx::be::load<intx::uint256>(code_hash.bytes));
+                    std::cerr << fmt::format(
+                        "Iteration {}: Deploy contract (hash {}) at address {} "
+                        "(size: {} bytes)\n",
+                        i,
+                        code_hash_str,
+                        d.contract_address,
+                        program.size());
+
+                    // FIXME: Use revision from args
+                    auto const &ir =
+                        monad::vm::compiler::basic_blocks::unsafe_make_ir<
+                            EvmTraits<EVMC_LATEST_STABLE_REVISION>>(program);
+                    for (auto const &block : ir.blocks()) {
+                        std::cerr << std::format("{}", block) << "\n";
+                    }
+                },
+                [&](DeployPrecompile const &d) {
+                    std::cerr << fmt::format(
+                        "Iteration {}: Deploy precompile contract at address "
+                        "{} delegating to precompile at address {}\n",
+                        i,
+                        d.contract_address,
+                        d.precompile_address);
+                },
+                [&](DeployDelegatedContract const &d) {
+                    std::cerr << fmt::format(
+                        "Iteration {}: Deploy delegated contract at address {} "
+                        "delegating to contract at address {}\n",
+                        i,
+                        d.contract_address,
+                        d.delegatee_address);
+                },
+                [&](SendMessage const &send) {
+                    std::cerr
+                        << fmt::format("Iteration {}: Send message:\n", i);
+                    print_message(send.message);
+                }},
+            run[i]);
+    }
+}
+
+static bool try_run_with_subcontract(
+    arguments const &args, Run run, std::vector<BasicBlock> subcontract,
+    std::size_t subcontract_iteration_index)
+{
+    FUZZER_ASSERT(std::holds_alternative<DeployContract>(
+        run[subcontract_iteration_index]));
+    run[subcontract_iteration_index] = DeployContract{
+        std::get<DeployContract>(run[subcontract_iteration_index])
+            .contract_address,
+        subcontract};
+    return try_run(args, run);
+}
+
+// A singleton run is one with a single contract and a single message.
+template <typename Engine>
+static std::optional<std::vector<BasicBlock>> shrink_run_contract(
+    arguments const &args, Engine &engine, Run &run,
+    std::size_t contract_iteration_index)
+{
+    FUZZER_ASSERT(
+        std::holds_alternative<DeployContract>(run[contract_iteration_index]));
+    auto contract =
+        std::get<DeployContract>(run[contract_iteration_index]).contract;
+
+    if (contract.size() == 0) {
+        return std::nullopt;
+    }
+
+    auto [new_contract, removed_block_ix] = shrink_contract(engine, contract);
+    if (!try_run_with_subcontract(
+            args, run, new_contract, contract_iteration_index)) {
+        // Block was not needed
+        return std::move(new_contract);
+    }
+    else if (contract[removed_block_ix].instructions.size() > 0) {
+        // Try to remove instructions from the block instead
+        // First try with ranges of instructions
+        // Idea if that fails: Substitute instructions with simpler ones?
+        auto new_contract2 = shrink_block(engine, contract, removed_block_ix);
+        if (!try_run_with_subcontract(
+                args, run, new_contract2, contract_iteration_index)) {
+            return std::move(new_contract2);
+        }
+    }
+    else {
+        // Block is empty but cannot be removed. This can only happen if
+        // the block is a JUMPDEST and the next block is not a JUMPDEST
+        // and depends on the fallthrough from the JUMPDEST block.
+        auto [new_contract, shrunk_contract] =
+            propagate_jumpdest(contract, removed_block_ix);
+        if (shrunk_contract &&
+            !try_run_with_subcontract(
+                args, run, new_contract, contract_iteration_index)) {
+            return std::move(new_contract);
+        }
+    }
+
+    return std::nullopt;
+}
+
+static Run make_singleton_run(
+    std::vector<BasicBlock> contract, evmc::address contract_address,
+    evmc_message failed_message)
+{
+    return {
+        DeployContract{contract_address, contract},
+        SendMessage{failed_message}};
+}
+
+static bool try_singleton_run(
+    arguments const &args, std::vector<BasicBlock> contract,
+    evmc::address contract_address, evmc_message failed_message)
+{
+    auto run = make_singleton_run(
+        std::move(contract), contract_address, failed_message);
+    return try_run(args, run);
+}
+
+// A singleton run is one with a single contract and a single message.
+static Run shrink_singleton_run(
+    arguments const &args, std::vector<BasicBlock> original_contract,
+    evmc::address contract_address, evmc_message failed_message)
+{
+    auto engine = random_engine_t(args.seed);
+    int iteration_count = 0;
+    auto run =
+        make_singleton_run(original_contract, contract_address, failed_message);
+
+    while (++iteration_count < 100) { // After 100 shrinker failure, give up.
+        if (auto new_contract = shrink_run_contract(args, engine, run, 0)) {
+            run[0] = DeployContract{contract_address, new_contract.value()};
+            iteration_count = 0;
+        }
+    }
+
+    // Make sure the final shrunken contract still fails
+    FUZZER_ASSERT(!try_run(args, run));
+
+    return run;
+}
+
+template <typename Engine>
+static Run
+shrink_remove_steps(arguments const &args, Engine &engine, Run const &run)
+{
+    auto current_run = run;
+
+    int iteration_count = 0;
+    while (++iteration_count < 20) { // After 20 failure, give up.
+        if (current_run.size() <= 2) { // Cannot shrink further than 2 steps
+            break;
+        }
+
+        std::cerr << "Shrinker: Trying to remove steps, current size: "
+                  << current_run.size() << "\n";
+
+        // Try to remove 10% of the steps
+        auto const new_run = erase_range(engine, current_run, 0.01);
+
+        if (!try_run(args, new_run)) {
+            current_run = std::move(new_run);
+            iteration_count = 0;
+            continue;
+        }
+    }
+
+    return current_run;
+}
+
+template <typename Engine>
+static Run shrink_steps(arguments const &args, Engine &engine, Run const &run)
+{
+    auto current_run = run;
+
+    int iteration_count = 0;
+    while (++iteration_count < 100) { // After 100 failure, give up.
+
+        // Pick any of the step and try to reduce it
+        auto const element_to_shrink = std::uniform_int_distribution<size_t>(
+            0, static_cast<size_t>(current_run.size()) - 1)(engine);
+
+        std::visit(
+            monad::vm::Cases{
+                [&](DeployContract const &d) {
+                    if (auto new_contract = shrink_run_contract(
+                            args, engine, current_run, element_to_shrink)) {
+                        current_run[element_to_shrink] = DeployContract{
+                            d.contract_address, new_contract.value()};
+                        iteration_count = 0;
+                    }
+                },
+                // [&](SendMessage const &send) {
+                //     // Try to replace the message with a simpler one
+                //     auto new_message =
+                //     monad::vm::fuzzing::shrink_message(engine, send.message);
+                //     if (new_message && !try_run_with_subcontract(args,
+                //     current_run,
+                //     std::get<DeployContract>(current_run[0]).contract, 0)) {
+                //         current_run[element_to_shrink] =
+                //         SendMessage{*new_message}; iteration_count = 0;
+                //     }
+                // },
+                [&](auto const &) {
+                    // Cannot shrink other steps
+                }},
+            current_run[element_to_shrink]);
+    }
+
+    return current_run;
+}
+
+static Run shrink_complete_run(
+    arguments const &args, Run const &run, size_t failed_iteration_index)
+{
+    auto engine = random_engine_t(args.seed);
+    auto current_run = run;
+
+    (void)failed_iteration_index;
+
+    // // First trim the steps after failed_iteration_index
+    // current_run.erase(current_run.begin() +
+    // static_cast<ptrdiff_t>(failed_iteration_index) + 1, current_run.end());
+
+    // // Make sure the final shrunken run still fails
+    FUZZER_ASSERT(!try_run(args, run));
+
+    current_run = shrink_remove_steps(args, engine, current_run);
+    current_run = shrink_steps(args, engine, current_run);
+    current_run = shrink_remove_steps(args, engine, current_run);
+    current_run = shrink_steps(args, engine, current_run);
+
+    // Make sure the final shrunken run still fails
+    FUZZER_ASSERT(!try_run(args, run));
+
+    return current_run;
+}
+
+static Run
+shrink_run(arguments const &args, Run const &run, size_t failed_iteration_index)
+{
+    // Assume that the contract that failed didn't depend on any of the previous
+    // contracts. This is not always true, but most counter-examples are of this
+    // form.
+    // Prepare a run with only the msg.recipient contract and the message that
+    // caused the failure.
+    auto contract_map =
+        std::unordered_map<evmc::address, std::vector<BasicBlock>>{};
+    for (auto const &step : run) {
+        if (std::holds_alternative<DeployContract>(step)) {
+            auto const &d = std::get<DeployContract>(step);
+            contract_map.insert({d.contract_address, d.contract});
+        }
+    }
+
+    auto const &failed_iteration = run[failed_iteration_index];
+    if (!std::holds_alternative<SendMessage>(failed_iteration)) {
+        std::cerr << "Failed iteration is not a message send\n";
+        return run;
+    }
+    auto const &failed_message =
+        std::get<SendMessage>(failed_iteration).message;
+    auto const &failed_contract_it =
+        contract_map.find(failed_message.code_address);
+    if (failed_contract_it == contract_map.end()) {
+        std::cerr << "Failed to find contract that caused the failure\n";
+        return run;
+    }
+    auto const &failed_contract = failed_contract_it->second;
+
+    if (try_singleton_run(
+            args,
+            failed_contract,
+            failed_message.code_address,
+            failed_message)) {
+        std::cerr << "Shrinker: Contract depends on other contracts or state\n";
+        return shrink_complete_run(args, run, failed_iteration_index);
+    }
+    else {
+        return shrink_singleton_run(
+            args, failed_contract, failed_message.code_address, failed_message);
+    }
 }
 
 static void run_loop(int argc, char **argv)
@@ -712,7 +1075,23 @@ static void run_loop(int argc, char **argv)
             "Fuzzing with seed @ {}: {}\n", msg_rev, args.seed);
 
         auto const &run = prepare_run(args);
-        do_run(i, args, run);
+        size_t iteration_index = 0;
+        try {
+            do_run(i, args, run, iteration_index);
+        }
+        catch (FuzzerAssertFailure const &ex) {
+            // Disable randomness in compilation for shrinking
+            args.deterministic_compilation = true;
+            args.print_stats = false;
+            std::cerr << "Can reproduce the failure " << try_run(args, run)
+                      << "\n";
+            auto const &shrunk_run = shrink_run(args, run, iteration_index);
+            std::cerr << "Original counter-example found by fuzzer:\n";
+            print_run(run);
+            std::cerr << "Shrunk counter-example found by fuzzer:\n";
+            print_run(shrunk_run);
+            std::exit(1);
+        }
         args.seed = random_engine_t(args.seed)();
     }
 }

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -794,6 +794,30 @@ static bool try_run(arguments const &args, Run const &run)
     }
 }
 
+static void print_run_summary(Run const &run)
+{
+    size_t basic_block_count = 0;
+    size_t deploy_count = 0;
+    size_t message_count = 0;
+    for (auto const &step : run) {
+        std::visit(
+            monad::vm::Cases{
+                [&](DeployContract const &) {
+                    deploy_count++;
+                    basic_block_count +=
+                        std::get<DeployContract>(step).contract.size();
+                },
+                [&](SendMessage const &) { message_count++; },
+                [&](auto const &) {},
+            },
+            step);
+    }
+    std::cerr << "===== Run summary =====\n";
+    std::cerr << "Contracts: " << deploy_count << "\n";
+    std::cerr << "Messages: " << message_count << "\n";
+    std::cerr << "Total basic blocks: " << basic_block_count << "\n";
+}
+
 void print_message(evmc_message const &msg)
 {
     static auto kind_map = std::map<evmc_call_kind, std::string>{
@@ -1062,17 +1086,24 @@ static Run shrink_complete_run(
 
     (void)failed_iteration_index;
 
-    // // First trim the steps after failed_iteration_index
-    // current_run.erase(current_run.begin() +
-    // static_cast<ptrdiff_t>(failed_iteration_index) + 1, current_run.end());
+    // First trim the steps after failed_iteration_index
+    current_run.erase(
+        current_run.begin() + static_cast<ptrdiff_t>(failed_iteration_index) +
+            1,
+        current_run.end());
 
     // // Make sure the final shrunken run still fails
     FUZZER_ASSERT(!try_run(args, run));
 
+    print_run_summary(current_run);
     current_run = shrink_remove_steps(args, engine, current_run);
+    print_run_summary(current_run);
     current_run = shrink_steps(args, engine, current_run);
+    print_run_summary(current_run);
     current_run = shrink_remove_steps(args, engine, current_run);
+    print_run_summary(current_run);
     current_run = shrink_steps(args, engine, current_run);
+    print_run_summary(current_run);
 
     // Make sure the final shrunken run still fails
     FUZZER_ASSERT(!try_run(args, run));

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -27,6 +27,7 @@
 
 #include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/core/assert.h>
+#include <category/vm/core/cases.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
 #include <category/vm/fuzzing/generator/generator.hpp>
@@ -218,18 +219,16 @@ static evmc::Result transition(
     return result;
 }
 
-static evmc::address deploy_contract(
-    State &state, evmc::address const &from,
+static void deploy_contract(
+    State &state, evmc::address const &to,
     std::span<std::uint8_t const> const code_)
 {
     auto code = bytes{code_.data(), code_.size()};
 
-    auto const create_address =
-        compute_create_address(from, state.get_or_insert(from).nonce++);
-    MONAD_VM_DEBUG_ASSERT(state.find(create_address) == nullptr);
+    MONAD_VM_DEBUG_ASSERT(state.find(to) == nullptr);
 
     state.insert(
-        create_address,
+        to,
         Account{
             .nonce = 0,
             .balance = 0,
@@ -238,29 +237,34 @@ static evmc::address deploy_contract(
             .transient_storage = {},
             .code = code});
 
-    MONAD_VM_ASSERT(state.find(create_address) != nullptr);
-
-    return create_address;
+    MONAD_VM_ASSERT(state.find(to) != nullptr);
 }
 
-static evmc::address deploy_delegated_contract(
-    State &state, evmc::address const &from, evmc::address const &delegatee)
+static void deploy_delegated_contract(
+    State &state, evmc::address const &to, evmc::address const &delegatee)
 {
     std::vector<uint8_t> code = {0xef, 0x01, 0x00};
     code.append_range(delegatee.bytes);
     MONAD_VM_ASSERT(code.size() == 23);
-    return deploy_contract(state, from, code);
+    deploy_contract(state, to, code);
 }
 
-static evmc::address deploy_delegated_contracts(
-    State &evmone_state, State &monad_state, evmc::address const &from,
+static void deploy_contracts(
+    State &evmone_state, State &monad_state, evmc::address const &to,
+    std::span<std::uint8_t const> const code_)
+{
+    deploy_contract(evmone_state, to, code_);
+    deploy_contract(monad_state, to, code_);
+    assert_equal(evmone_state, monad_state);
+}
+
+static void deploy_delegated_contracts(
+    State &evmone_state, State &monad_state, evmc::address const &to,
     evmc::address delegatee)
 {
-    auto const a = deploy_delegated_contract(evmone_state, from, delegatee);
-    auto const a1 = deploy_delegated_contract(monad_state, from, delegatee);
-    MONAD_VM_ASSERT(a == a1);
+    deploy_delegated_contract(evmone_state, to, delegatee);
+    deploy_delegated_contract(monad_state, to, delegatee);
     assert_equal(evmone_state, monad_state);
-    return a;
 }
 
 // It's possible for the compiler and evmone to reach equivalent-but-not-equal
@@ -490,13 +494,157 @@ static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
     return evmc::VM(new BlockchainTestVM(args.implementation, hook));
 }
 
-static void do_run(std::size_t const run_index, arguments const &args)
+struct DeployContract
+{
+    evmc::address contract_address;
+    std::vector<BasicBlock> contract;
+};
+
+// Precompiles are deployed as contracts that
+struct DeployPrecompile
+{
+    evmc::address contract_address;
+    evmc::address precompile_address;
+};
+
+struct DeployDelegatedContract
+{
+    evmc::address contract_address;
+    evmc::address delegatee_address;
+};
+
+struct SendMessage
+{
+    evmc_message message;
+};
+
+// A run is a sequence of contract deployments and messages to send.
+using RunStep = std::variant<
+    DeployContract, DeployPrecompile, DeployDelegatedContract, SendMessage>;
+
+using Run = std::vector<RunStep>;
+
+static evmc::address prepare_address(evmc::address const &from, uint64_t &nonce)
+{
+    return compute_create_address(from, nonce++);
+}
+
+// An iteration consists of the following steps:
+// 1. Optionally deploying a precompile contract
+// 2. Deploying a contract
+// 3. Optionally deploying a delegated contract
+// 4. Sending a few messages to deployed contracts
+template <typename Engine>
+static void prepare_iteration(
+    arguments const &args, Engine &engine, Run &run,
+    std::vector<evmc::address> &known_addresses,
+    std::vector<evmc::address> &contract_addresses,
+    std::unordered_map<address, std::vector<std::uint8_t>> &contract_codes,
+    uint64_t &nonce)
+{
+    auto const rev = args.revision;
+
+    using monad::vm::fuzzing::GeneratorFocus;
+    auto const &focus =
+        args.focus ? *args.focus
+                   : discrete_choice<GeneratorFocus>(
+                         engine,
+                         [](auto &) { return generic_focus; },
+                         Choice(0.60, [](auto &) { return pow2_focus; }),
+                         Choice(0.05, [](auto &) { return dyn_jump_focus; }));
+
+    if (rev >= EVMC_PRAGUE && toss(engine, 0.001)) {
+        auto precompile_address =
+            monad::vm::fuzzing::generate_precompile_address(engine, rev);
+        auto const contract_address = prepare_address(genesis_address, nonce);
+        known_addresses.push_back(contract_address);
+        run.push_back(DeployPrecompile{contract_address, precompile_address});
+    }
+
+    for (;;) {
+        std::vector<BasicBlock> contract =
+            monad::vm::fuzzing::generate_basic_blocks(
+                focus, engine, rev, known_addresses);
+
+        auto const compiled_contract = compile_program(contract);
+        if (compiled_contract.size() > evmone::MAX_CODE_SIZE) {
+            // The evmone host will fail when we attempt to deploy
+            // contracts of this size. It rarely happens that we
+            // generate contract this large.
+            std::cerr << "Skipping contract of size: "
+                      << compiled_contract.size() << " bytes" << std::endl;
+            continue;
+        }
+
+        auto const contract_address = prepare_address(genesis_address, nonce);
+
+        known_addresses.push_back(contract_address);
+        contract_addresses.push_back(contract_address);
+        contract_codes[contract_address] = compiled_contract;
+        run.push_back(DeployContract{contract_address, contract});
+
+        if (args.revision >= EVMC_PRAGUE && toss(engine, 0.2)) {
+            auto const delegated_contract_address =
+                prepare_address(genesis_address, nonce);
+            known_addresses.push_back(delegated_contract_address);
+            run.push_back(DeployDelegatedContract{
+                delegated_contract_address, contract_address});
+        }
+        break;
+    }
+
+    for (auto j = 0u; j < args.messages; ++j) {
+        auto msg = monad::vm::fuzzing::generate_message(
+            focus,
+            engine,
+            contract_addresses,
+            {genesis_address},
+            [&](auto const &address) {
+                if (auto it = contract_codes.find(address);
+                    it != contract_codes.end()) {
+                    return bytes{it->second.data(), it->second.size()};
+                }
+                return evmc::bytes{};
+            });
+        run.push_back(SendMessage{msg});
+    }
+}
+
+static Run prepare_run(arguments const &args)
+{
+    auto engine = random_engine_t(args.seed);
+    auto run = std::vector<RunStep>{};
+    auto contract_addresses = std::vector<evmc::address>{};
+    auto known_addresses = std::vector<evmc::address>{};
+    std::unordered_map<address, std::vector<std::uint8_t>> contract_codes;
+    uint64_t nonce = 0;
+    for (auto i = 0; i < args.iterations_per_run; ++i) {
+        prepare_iteration(
+            args,
+            engine,
+            run,
+            known_addresses,
+            contract_addresses,
+            contract_codes,
+            nonce);
+    }
+    return run;
+}
+
+static void
+do_run(std::size_t const run_index, arguments const &args, Run const &run)
 {
     auto const rev = args.revision;
 
     auto engine = random_engine_t(args.seed);
 
     auto evmone_vm = evmc::VM(evmc_create_evmone());
+    // Of all the source of randomness, this is the only one that can't easily
+    // be pregenerated like the rest of the fuzzer input. The BlockchainTestVM
+    // could be extended to signal the beginning of a compilation, allowing
+    // us to reset the seed of the compiler hook to a known value, but since we
+    // don't have a clear mechanism to debug the counter-examples that depend
+    // on the compiler hook randomness, we leave this for later.
     auto monad_vm = create_monad_vm(args, engine);
 
     auto initial_state_ = initial_state();
@@ -504,91 +652,49 @@ static void do_run(std::size_t const run_index, arguments const &args)
     auto evmone_state = State{initial_state_};
     auto monad_state = State{initial_state_};
 
-    auto contract_addresses = std::vector<evmc::address>{};
-    auto known_addresses = std::vector<evmc::address>{};
-
     auto exit_code_stats = std::unordered_map<evmc_status_code, std::size_t>{};
     auto total_messages = std::size_t{0};
 
     auto start_time = std::chrono::high_resolution_clock::now();
 
-    for (auto i = 0; i < args.iterations_per_run; ++i) {
-        using monad::vm::fuzzing::GeneratorFocus;
-        auto const &focus =
-            args.focus
-                ? *args.focus
-                : discrete_choice<GeneratorFocus>(
-                      engine,
-                      [](auto &) { return generic_focus; },
-                      Choice(0.60, [](auto &) { return pow2_focus; }),
-                      Choice(0.05, [](auto &) { return dyn_jump_focus; }));
+    for (auto const &iteration : run) {
+        std::visit(
+            monad::vm::Cases{
+                [&](DeployContract const &d) {
+                    deploy_contracts(
+                        evmone_state,
+                        monad_state,
+                        d.contract_address,
+                        compile_program(d.contract));
+                },
+                [&](DeployPrecompile const &d) {
+                    deploy_delegated_contracts(
+                        evmone_state,
+                        monad_state,
+                        d.contract_address,
+                        d.precompile_address);
+                },
+                [&](DeployDelegatedContract const &d) {
+                    deploy_delegated_contracts(
+                        evmone_state,
+                        monad_state,
+                        d.contract_address,
+                        d.delegatee_address);
+                },
+                [&](SendMessage const &send) {
+                    ++total_messages;
 
-        if (rev >= EVMC_PRAGUE && toss(engine, 0.001)) {
-            auto precompile =
-                monad::vm::fuzzing::generate_precompile_address(engine, rev);
-            auto const a = deploy_delegated_contracts(
-                evmone_state, monad_state, genesis_address, precompile);
-            known_addresses.push_back(a);
-        }
-
-        for (;;) {
-            auto const contract = monad::vm::fuzzing::generate_program(
-                focus, engine, rev, known_addresses);
-
-            if (contract.size() > evmone::MAX_CODE_SIZE) {
-                // The evmone host will fail when we attempt to deploy
-                // contracts of this size. It rarely happens that we
-                // generate contract this large.
-                std::cerr << "Skipping contract of size: " << contract.size()
-                          << " bytes" << std::endl;
-                continue;
-            }
-
-            auto const a =
-                deploy_contract(evmone_state, genesis_address, contract);
-            auto const a1 =
-                deploy_contract(monad_state, genesis_address, contract);
-            MONAD_VM_ASSERT(a == a1);
-
-            assert_equal(evmone_state, monad_state);
-
-            contract_addresses.push_back(a);
-            known_addresses.push_back(a);
-
-            if (args.revision >= EVMC_PRAGUE && toss(engine, 0.2)) {
-                auto const b = deploy_delegated_contracts(
-                    evmone_state, monad_state, genesis_address, a);
-                known_addresses.push_back(b);
-            }
-            break;
-        }
-
-        for (auto j = 0u; j < args.messages; ++j) {
-            auto msg = monad::vm::fuzzing::generate_message(
-                focus,
-                engine,
-                contract_addresses,
-                {genesis_address},
-                [&](auto const &address) {
-                    if (auto *found = evmone_state.find(address);
-                        found != nullptr) {
-                        return found->code;
-                    }
-
-                    return evmc::bytes{};
-                });
-            ++total_messages;
-
-            auto const ec = fuzz_iteration(
-                *msg,
-                rev,
-                evmone_state,
-                evmone_vm,
-                monad_state,
-                monad_vm,
-                args.implementation);
-            ++exit_code_stats[ec];
-        }
+                    auto const ec = fuzz_iteration(
+                        send.message,
+                        rev,
+                        evmone_state,
+                        evmone_vm,
+                        monad_state,
+                        monad_vm,
+                        args.implementation);
+                    ++exit_code_stats[ec];
+                }},
+            iteration);
     }
 
     log(start_time, args, exit_code_stats, run_index, total_messages);
@@ -604,7 +710,9 @@ static void run_loop(int argc, char **argv)
     for (auto i = 0u; i < args.runs; ++i) {
         std::cerr << std::format(
             "Fuzzing with seed @ {}: {}\n", msg_rev, args.seed);
-        do_run(i, args);
+
+        auto const &run = prepare_run(args);
+        do_run(i, args, run);
         args.seed = random_engine_t(args.seed)();
     }
 }

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -490,14 +490,6 @@ static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
     return evmc::VM(new BlockchainTestVM(args.implementation, hook));
 }
 
-// Coin toss, biased whenever p != 0.5
-template <typename Engine>
-static bool toss(Engine &engine, double p)
-{
-    std::bernoulli_distribution dist(p);
-    return dist(engine);
-}
-
 static void do_run(std::size_t const run_index, arguments const &args)
 {
     auto const rev = args.revision;

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -237,7 +237,7 @@ static void deploy_contract(
             .transient_storage = {},
             .code = code});
 
-    MONAD_VM_ASSERT(state.find(to) != nullptr);
+    FUZZER_ASSERT(state.find(to) != nullptr);
 }
 
 static void deploy_delegated_contract(
@@ -245,7 +245,7 @@ static void deploy_delegated_contract(
 {
     std::vector<uint8_t> code = {0xef, 0x01, 0x00};
     code.append_range(delegatee.bytes);
-    MONAD_VM_ASSERT(code.size() == 23);
+    FUZZER_ASSERT(code.size() == 23);
     deploy_contract(state, to, code);
 }
 

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -230,7 +230,7 @@ static void deploy_contract(
 {
     auto code = bytes{code_.data(), code_.size()};
 
-    MONAD_VM_DEBUG_ASSERT(state.find(to) == nullptr);
+    FUZZER_ASSERT(state.find(to) == nullptr);
 
     state.insert(
         to,
@@ -1130,7 +1130,8 @@ static Run shrink_steps(arguments const &args, Engine &engine, Run const &run)
                         //       second shrinking pass with this enabled?
                         auto const new_seed =
                             toss(engine, args.shrink_contract_seed ? 0.05 : 0)
-                            ? engine() : d.contract_hook_seed;
+                                ? engine()
+                                : d.contract_hook_seed;
 
                         current_run[element_to_shrink] = DeployContract{
                             new_seed, d.contract_address, new_contract.value()};
@@ -1163,8 +1164,8 @@ static Run shrink_complete_run(
             1,
         current_run.end());
 
-    // // Make sure the final shrunken run still fails
-    FUZZER_ASSERT(try_run(args, run));
+    // Make sure the final shrunken run still fails
+    FUZZER_ASSERT(try_run(args, current_run));
 
     print_run_summary(current_run);
     current_run = shrink_remove_steps(args, engine, current_run);
@@ -1177,7 +1178,7 @@ static Run shrink_complete_run(
     }
 
     // Make sure the final shrunken run still fails
-    FUZZER_ASSERT(try_run(args, run));
+    FUZZER_ASSERT(try_run(args, current_run));
 
     return current_run;
 }
@@ -1274,7 +1275,7 @@ static void run_loop(int argc, char **argv)
 
             auto const reason = try_run(args, shrunk_run);
             if (reason) {
-                std::cerr << "Final failure reason" << std::endl;
+                std::cerr << "Final failure reason:\n";
                 std::cerr << std::format(
                     "  Assertion failed: {}\n", reason->what());
             }

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -367,6 +367,9 @@ static arguments parse_args(int const argc, char **const argv)
         std::map<std::string, BlockchainTestVM::Implementation>{
             {"interpreter", BlockchainTestVM::Implementation::Interpreter},
             {"compiler", BlockchainTestVM::Implementation::Compiler},
+#ifdef MONAD_COMPILER_LLVM
+            {"llvm", BlockchainTestVM::Implementation::LLVM},
+#endif
         };
 
     app.add_option(

--- a/test/vm/vm/test_vm.cpp
+++ b/test/vm/vm/test_vm.cpp
@@ -109,7 +109,8 @@ namespace
 }
 
 BlockchainTestVM::BlockchainTestVM(
-    Implementation impl, native::EmitterHook post_hook, std::function<void(evmc_message const *msg)> execute_hook)
+    Implementation impl, native::EmitterHook post_hook,
+    std::function<void(evmc_message const *msg)> execute_hook)
     : evmc_vm{EVMC_ABI_VERSION, "monad-compiler-blockchain-test-vm", "0.0.0", ::destroy, ::execute, ::get_capabilities, nullptr}
     , impl_{impl_from_env(impl)}
     , debug_dir_{std::getenv("MONAD_COMPILER_ASM_DIR")}

--- a/test/vm/vm/test_vm.hpp
+++ b/test/vm/vm/test_vm.hpp
@@ -57,7 +57,8 @@ public:
     BlockchainTestVM(
         Implementation impl,
         monad::vm::compiler::native::EmitterHook post_instruction_emit_hook =
-            nullptr, std::function<void(evmc_message const *msg)> execute_hook = nullptr);
+            nullptr,
+        std::function<void(evmc_message const *msg)> execute_hook = nullptr);
 
     evmc::Result execute(
         evmc_host_interface const *host, evmc_host_context *context,

--- a/test/vm/vm/test_vm.hpp
+++ b/test/vm/vm/test_vm.hpp
@@ -57,7 +57,7 @@ public:
     BlockchainTestVM(
         Implementation impl,
         monad::vm::compiler::native::EmitterHook post_instruction_emit_hook =
-            nullptr);
+            nullptr, std::function<void(evmc_message const *msg)> execute_hook = nullptr);
 
     evmc::Result execute(
         evmc_host_interface const *host, evmc_host_context *context,
@@ -102,6 +102,7 @@ private:
     evmone::VM evmone_vm_;
     monad::vm::VM monad_vm_;
     char const *debug_dir_;
+    std::function<void(evmc_message const *msg)> execute_hook_;
     monad::vm::CompilerConfig base_config;
     CodeMap<evmone::baseline::CodeAnalysis> code_analyses_;
     CodeMap<monad::vm::SharedIntercode> intercodes_;


### PR DESCRIPTION
## Context

The VM fuzzer generates contracts and messages in an attempt to find inputs that cause the compiler and evmone interpreter to produce different side effects. The contracts it generates are 1000s of instructions long, with many basic blocks, which makes it difficult to isolate the exact sequence of instructions responsible for the difference.

This PR adds a shrinker to the fuzzer, so that counter-examples are reduced to only the sequence of instructions that revealed the issue. To changes can be grouped in 2 main groups:

1. Better control of random values in the fuzzer. 
- Previously, the fuzzer generated values (contracts and messages) as it executed, with the generated contracts being represented as EVM bytecode with a single random number generator. This makes replaying and shrinking fuzzer runs more or less impossible since any change would offset the random number generator and cause a cascade of different values to be generated. 
- The fuzzer now generates all of the random values ahead of time and represent contracts in a higher-level form that makes changing contracts much simpler (e.g. blocks and sequence of instructions can be removed all at once).
2. Using the reified representation of a run introduced in the previous, the different steps taken by the fuzzer (deploy X contract, send message) can be removed, reordered and simplified by the shrinker. 

The shrinker is relatively fast and has been helpful during development of the LLVM backend. Shrinking a counter-example takes a few seconds, with usually only a few instructions (<= 20) left.

Example use of the fuzzer:

When removing the dynamic gas cost of the optimized `EXP` instruction when the base is unknown and exponent = 2:

```
            else if (exp == 2) { // x ** 2 = x * x
                stack_.pop();
                stack_.pop();
                {
                    RegReserv const base_reserv{base_elem};
                    // exp_emit_gas_decrement_by_literal(2, gas_factor);
                }
                stack_.push(std::move(base_elem));
                dup(1);
                mul(remaining_base_gas);
                return true;
            }
```

the shrinker finds the following counter-example:

```
Counter-example found by fuzzer:
Run with 2 steps
Iteration 0: Deploy contract (hash 89f5a1351a0b4ed676083a7052197823779d075beb38b3c8ae4ed38759245450) at address 0x655cb46ac0378e6a78a07d313ad2a44988eb769d (size: 235 bytes)
  0x00:
      PUSH32 0x18d6d999347de3fff2a081d3272c0315c4699357a6fedbc66ad762aac60f1608
      PUSH32 0x80000000000000000000000
      PUSH32 0xa445ada6a8f4c09c9176a90d0a5f89433c81cc9cffeed6d266e8e9f48f74d25f
      PUSH32 0x100000000
      PUSH32 0x10000000000000000000000000000000000000000
      DUP5
      DUP6
      PUSH32 0xfc62b332f3b3c713f06c8eb6710daf4a0af4824c022aa33dc85ce8a7a763a768
      PUSH32 0x2
      DUP4
      EXP
    Stop

Iteration 1: Send message:
  kind DELEGATECALL, gas 4854427, value 9beab2ea26f31c9848385921d00be7a6cbf83815baa1fc66
  code_address 0x655cb46ac0378e6a78a07d313ad2a44988eb769d, sender 0xefca25b4db15773a98fae8889b0efc6bb25357ea, recipient 0xa508d306fae702242683882fa34d622165d367bd
  input_data [64 bytes]: 7f00000000000000000000000000000000000000010000000000000000000000007fffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000
Final failure reason:
  Assertion failed: void monad::vm::fuzzing::assert_equal(const evmc::Result &, const evmc::Result &, const bool):/home/lhuberdeau/monad/test/vm/fuzzer/assertions.cpp:116 Assertion failed: evmone_result.gas_left == compiler_result.gas_left

```

### Why not use a general purpose shrinking tool?

There exists off-the-shelf tools to reduce programs generated by fuzzers. One such example is [`CReduce`](https://github.com/csmith-project/creduce), which takes a file and a predicate, and removes parts of the input files to find the smallest file that match the predicate.

This approach works fine for counter-examples that fit in a single file and that are pure. The EVM environment is stateful, with the fuzzer generating the equivalent of many programs and calling them in a specific sequence. As a result, the one-file model of CReduce is a poor fit and serializing all of the fuzzer state to a single file would likely result in long shrinking times and poor counter-examples found.
