### PR TITLE
[event] export more C functions in the SDK

### DIFF
--- a/category/core/event/event_ring.c
+++ b/category/core/event/event_ring.c
@@ -26,15 +26,10 @@
 #include <unistd.h>
 
 #include <category/core/event/event_iterator.h>
+#include <category/core/event/event_recorder.h>
 #include <category/core/event/event_ring.h>
 #include <category/core/format_err.h>
 #include <category/core/srcloc.h>
-
-// The recorder is not part of the reader SDK
-#if __has_include(<category/core/event/event_recorder.h>)
-    #define HAS_EVENT_RECORDER 1
-    #include <category/core/event/event_recorder.h>
-#endif
 
 thread_local char _g_monad_event_ring_error_buf[1024];
 static size_t const PAGE_2MB = 1UL << 21, HEADER_SIZE = PAGE_2MB;
@@ -400,7 +395,6 @@ int monad_event_ring_init_recorder(
     struct monad_event_ring const *event_ring,
     struct monad_event_recorder *recorder)
 {
-#if HAS_EVENT_RECORDER
     memset(recorder, 0, sizeof *recorder);
     struct monad_event_ring_header *header = event_ring->header;
     if (header == nullptr) {
@@ -415,10 +409,6 @@ int monad_event_ring_init_recorder(
     recorder->desc_capacity_mask = header->size.descriptor_capacity - 1;
     recorder->payload_buf_mask = header->size.payload_buf_size - 1;
     return 0;
-#else
-    (void)event_ring, (void)recorder;
-    return FORMAT_ERRC(ENOSYS, "event ring recording not available in SDK");
-#endif
 }
 
 char const *monad_event_ring_get_last_error()

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -26,6 +26,8 @@ option(MONAD_EVENT_DISABLE_LIBHUGETLBFS
 
 add_library(
   monad_event
+  "../core/assert.c"
+  "../core/assert.h"
   "../core/cleanup.c"
   "../core/cleanup.h"
   "../core/format_err.c"
@@ -35,10 +37,13 @@ add_library(
   "../core/event/event_iterator.h"
   "../core/event/event_iterator_inline.h"
   "../core/event/event_metadata.h"
+  "../core/event/event_recorder.h"
+  "../core/event/event_recorder_inline.h"
   "../core/event/event_ring.c"
   "../core/event/event_ring.h"
   "../core/event/event_ring_util.c"
   "../core/event/event_ring_util.h"
+  "../core/mem/align.h"
   "../execution/ethereum/core/base_ctypes.h"
   "../execution/ethereum/core/eth_ctypes.h"
   "../execution/ethereum/event/exec_event_ctypes.h"


### PR DESCRIPTION
This exposes `core/mem/align.h` and `core/assert.{c,h}` to the SDK, allowing it to call MONAD_ASSERT and monad_round_size_to_align. This is needed by several subsequent commits. It also removes the conditional compilation cruft that excluded the event recorder from the SDK.

In addition to making the code cleaner, the Rust components (as C SDK users) are going to use this API to record their own consensus events. All of the local capture replay code in subsequent commits also needs these two files.

If the end-user ends up calling any function which can assert, they'll need to provide a `monad_stack_backtrace_capture_and_print` symbol to the linker, since this is not otherwise part of libmonad_event.a.

When used by libmonad_execution, this symbol (externally referenced by `assert.c`) pulls in libboost_stacktrace.so and the entire C++ runtime. Whomever is writing the final application should have some defined termination behavior this can hook into. We provide a shim implementation in a later commit.