### PR TITLE
[event] add monad_event_resolve_ring_file

### DIFF
--- a/category/core/event/event_ring_util.h
+++ b/category/core/event/event_ring_util.h
@@ -33,6 +33,11 @@ extern "C"
 #endif
 
 enum monad_event_content_type : uint16_t;
+struct monad_event_ring;
+
+/// Value passed to monad_event_resolve_ring_file's `default_path` parameter,
+/// to request the hugetlbfs path that is dynamically computed by libhugetlbfs
+constexpr char const *MONAD_EVENT_DEFAULT_HUGETLBFS = nullptr;
 
 /// Arguments for the `monad_event_ring_init_simple` function
 struct monad_event_ring_simple_config
@@ -71,8 +76,18 @@ int monad_check_path_supports_map_hugetlb(char const *path, bool *supported);
 /// a hugetlbfs filesystem that is used to hold event ring files; also computes
 /// the full path to this directory; this is a wrapper around the generic API
 /// function `monad_hugetlbfs_open_dir_fd`
-int monad_event_open_ring_dir_fd(
-    int *dirfd, char *namebuf, size_t namebuf_size);
+int monad_event_open_hugetlbfs_dir_fd(
+    int *dirfd, char *pathbuf, size_t pathbuf_size);
+
+/// Given an event ring file input (typically from the command line), resolve it
+/// to a file relative to the directory `default_path` if it does not contain
+/// any '/' characters, i.e., if it is a "pure" filename; if it contains a '/'
+/// character then copy it as-is, so that it will resolve relative to getcwd(2),
+/// similar to how a UNIX shell resolves command names; if `default_path` is
+/// MONAD_EVENT_DEFAULT_HUGETLBFS, this calls monad_event_open_hugetlbfs_dir_fd
+int monad_event_resolve_ring_file(
+    char const *default_path, char const *file, char *pathbuf,
+    size_t pathbuf_size);
 
 constexpr char MONAD_EVENT_DEFAULT_RING_DIR[] = "event-rings";
 

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -22,7 +22,7 @@
 project(monad_event)
 
 option(MONAD_EVENT_DISABLE_LIBHUGETLBFS
-  "Disable the `monad_event_open_ring_dir_fd` API function (removes dependency on libhugetlbfs" OFF)
+  "Disable the default value in the `monad_event_open_hugetlbfs_dir_fd` API function (removes dependency on libhugetlbfs)" OFF)
 
 add_library(
   monad_event

--- a/cmd/monad/event.hpp
+++ b/cmd/monad/event.hpp
@@ -24,7 +24,6 @@
 
 #include <category/core/config.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <string>
@@ -36,7 +35,7 @@ MONAD_NAMESPACE_BEGIN
 
 struct EventRingConfig
 {
-    std::string event_ring_spec; ///< File name or path to shared memory file
+    std::string event_ring_file; ///< Path to event ring file
     uint8_t descriptors_shift;   ///< Descriptor capacity = 2^descriptors_shift
     uint8_t payload_buf_shift;   ///< Payload buffer size = 2^payload_buf_shift
 };


### PR DESCRIPTION
The logic of what this does was duplicated across all programs, now it happens in only one place. The rationale for the mechanism and how it functions is part of the public SDK documentation here:

> https://docs.monad.xyz/execution-events/advanced#location-of-event-ring-files

As a drive-by change, we use posix_fallocate instead of the Linux-specific fallocate, whose advanced features we didn't need