### PR TITLE
Fuzzer focus flag

### DIFF
--- a/test/vm/fuzzer/typechecker_fuzzer.cpp
+++ b/test/vm/fuzzer/typechecker_fuzzer.cpp
@@ -176,9 +176,9 @@ static void do_run(std::size_t const run_index, arguments const &args)
         using monad::vm::fuzzing::GeneratorFocus;
         auto focus = discrete_choice<GeneratorFocus>(
             engine,
-            [](auto &) { return GeneratorFocus::Generic; },
-            Choice(0.05, [](auto &) { return GeneratorFocus::Pow2; }),
-            Choice(0.8, [](auto &) { return GeneratorFocus::DynJump; }));
+            [](auto &) { return generic_focus; },
+            Choice(0.05, [](auto &) { return pow2_focus; }),
+            Choice(0.8, [](auto &) { return dyn_jump_focus; }));
 
         auto const contract =
             monad::vm::fuzzing::generate_program(focus, engine, rev, {});


### PR DESCRIPTION
Refactor the fuzzer, pulling all the generator parameters into a single GeneratorFocus struct. This should make it a lot easier to tweak parameters when testing generation of different programs as I've added a `--focus` flag which can parse parameters dynamically from a JSON file. THis saves a lot of recompiling when tweaking thenumbers.

This PR will be likely followed up by some more tweaks and cleanup to the generator, for now just trying to keep the diff as small as possible.