### PR TITLE
[call-tracer] CallFrame::Log stores receipt_index

### DIFF
--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -158,8 +158,8 @@ void EvmcHostBase::emit_log(
         for (auto i = 0u; i < num_topics; ++i) {
             log.topics.push_back({topics[i]});
         }
-        state_.store_log(log);
-        call_tracer_.on_log(std::move(log));
+        size_t const receipt_index = state_.store_log(log);
+        call_tracer_.on_log(receipt_index, std::move(log));
         return;
     }
     catch (...) {

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -574,10 +574,11 @@ std::vector<Receipt::Log> const &State::logs()
     return logs_.recent();
 }
 
-void State::store_log(Receipt::Log const &log)
+size_t State::store_log(Receipt::Log const &log)
 {
     auto &logs = logs_.current(version_);
     logs.push_back(log);
+    return logs.size() - 1;
 }
 
 void State::set_to_state_incarnation(Address const &address)

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -188,7 +188,7 @@ public:
 
     std::vector<Receipt::Log> const &logs();
 
-    void store_log(Receipt::Log const &);
+    [[nodiscard]] size_t store_log(Receipt::Log const &);
 
     ////////////////////////////////////////
 

--- a/category/execution/ethereum/trace/call_frame.hpp
+++ b/category/execution/ethereum/trace/call_frame.hpp
@@ -24,6 +24,7 @@
 #include <evmc/evmc.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstddef>
 #include <optional>
 #include <vector>
 
@@ -43,6 +44,15 @@ struct CallFrame
 {
     struct Log
     {
+        /*
+         * The receipt index is the index this log has in the receipt's log
+         * array (which has the logs in the transaction), as distinct from the
+         * CallFrame's log array (which has only the logs in this call frame).
+         * The execution events record call frame logs by referring to their
+         * receipt index to avoid copying them twice.
+         */
+        size_t receipt_index;
+
         Receipt::Log log;
 
         /*

--- a/category/execution/ethereum/trace/call_tracer.cpp
+++ b/category/execution/ethereum/trace/call_tracer.cpp
@@ -69,7 +69,7 @@ void NoopCallTracer::on_enter(evmc_message const &) {}
 
 void NoopCallTracer::on_exit(evmc::Result const &) {}
 
-void NoopCallTracer::on_log(Receipt::Log) {}
+void NoopCallTracer::on_log(size_t, Receipt::Log) {}
 
 void NoopCallTracer::on_self_destruct(Address const &, Address const &) {}
 
@@ -170,16 +170,16 @@ void CallTracer::on_exit(evmc::Result const &res)
     positions_.pop();
 }
 
-void CallTracer::on_log(Receipt::Log log)
+void CallTracer::on_log(size_t receipt_index, Receipt::Log log)
 {
     MONAD_ASSERT(!frames_.empty());
     MONAD_ASSERT(!last_.empty());
     MONAD_ASSERT(!positions_.empty());
 
-    auto &frame = frames_.at(last_.top());
+    CallFrame &frame = frames_.at(last_.top());
     MONAD_ASSERT(frame.logs.has_value());
 
-    frame.logs->emplace_back(std::move(log), positions_.top());
+    frame.logs->emplace_back(receipt_index, std::move(log), positions_.top());
 }
 
 void CallTracer::on_self_destruct(Address const &from, Address const &to)

--- a/category/execution/ethereum/trace/call_tracer.hpp
+++ b/category/execution/ethereum/trace/call_tracer.hpp
@@ -23,6 +23,7 @@
 #include <evmc/evmc.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstddef>
 #include <optional>
 #include <span>
 #include <stack>
@@ -38,7 +39,7 @@ struct CallTracerBase
 
     virtual void on_enter(evmc_message const &) = 0;
     virtual void on_exit(evmc::Result const &) = 0;
-    virtual void on_log(Receipt::Log) = 0;
+    virtual void on_log(size_t receipt_index, Receipt::Log) = 0;
     virtual void on_self_destruct(Address const &from, Address const &to) = 0;
     virtual void on_finish(uint64_t const) = 0;
     virtual void reset() = 0;
@@ -48,7 +49,7 @@ struct NoopCallTracer final : public CallTracerBase
 {
     virtual void on_enter(evmc_message const &) override;
     virtual void on_exit(evmc::Result const &) override;
-    virtual void on_log(Receipt::Log) override;
+    virtual void on_log(size_t receipt_index, Receipt::Log) override;
     virtual void on_self_destruct(Address const &, Address const &) override;
     virtual void on_finish(uint64_t const) override;
     virtual void reset() override;
@@ -70,7 +71,7 @@ public:
 
     virtual void on_enter(evmc_message const &) override;
     virtual void on_exit(evmc::Result const &) override;
-    virtual void on_log(Receipt::Log) override;
+    virtual void on_log(size_t receipt_index, Receipt::Log) override;
     virtual void
     on_self_destruct(Address const &from, Address const &to) override;
     virtual void on_finish(uint64_t const) override;

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1998,8 +1998,8 @@ std::tuple<bool, Ptr, std::vector<Ptr>> StakingContract::linked_list_traverse(
 
 void StakingContract::emit_log(Receipt::Log const &log)
 {
-    state_.store_log(log);
-    call_tracer_.on_log(log);
+    size_t const receipt_index = state_.store_log(log);
+    call_tracer_.on_log(receipt_index, log);
 }
 
 MONAD_STAKING_NAMESPACE_END


### PR DESCRIPTION
There two changes here:

- State::store_log returns the index in the receipt's log array that the log will have, and it becomes [[nodiscard]] because whomever is calling it shouldn't forget to propagate it to the call tracer

- CallTracer::on_log is passed the receipt index, and records it into the CallFrame

The rationale is to support the call frame<->log association in the execution events.

It does not make sense to record the logs twice, especially if they are large. They will instead be recorded by their receipt index, which is the same as the event recording order.