### PR TITLE
Only emit jump table if contract has indirect jump

### DIFF
--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -591,7 +591,7 @@ namespace monad::vm::compiler::native
         , as_{init_code_holder(rt, config.asm_log_path)}
         , epilogue_label_{as_.newNamedLabel("ContractEpilogue")}
         , error_label_{as_.newNamedLabel("Error")}
-        , jump_table_label_{as_.newNamedLabel("JumpTable")}
+        , jump_table_label_{std::nullopt}
         , keep_stack_in_next_block_{}
         , gpq256_regs_{Gpq256{x86::r12, x86::r13, x86::r14, x86::r15}, Gpq256{x86::r8, x86::r9, x86::r10, x86::r11}, Gpq256{x86::rcx, x86::rsi, x86::rdx, x86::rdi}}
         , bytecode_size_{codesize}
@@ -642,29 +642,32 @@ namespace monad::vm::compiler::native
         // relative label distance ourselves, instead of asmjit doing the
         // same calculation again and again for `as_.embedLabelDelta`.
         as_.align(asmjit::AlignMode::kData, 4);
-        as_.bind(jump_table_label_);
-        int32_t const error_offset = [&] {
-            int64_t const x = std::bit_cast<int64_t>(
-                code_holder_.labelOffset(error_label_) -
-                code_holder_.labelOffset(jump_table_label_));
-            MONAD_VM_DEBUG_ASSERT(
-                x <= std::numeric_limits<int32_t>::max() &&
-                x >= std::numeric_limits<int32_t>::min());
-            return static_cast<int32_t>(x);
-        }();
-        size_t error_offset_repeat_count = 0;
-        for (size_t bid = 0; bid < *bytecode_size_; ++bid) {
-            auto lbl = jump_dests_.find(bid);
-            if (lbl != jump_dests_.end()) {
-                as_.embedInt32(error_offset, error_offset_repeat_count);
-                error_offset_repeat_count = 0;
-                as_.embedLabelDelta(lbl->second, jump_table_label_, 4);
+        if (jump_table_label_) {
+            as_.bind(jump_table_label_.value());
+            int32_t const error_offset = [&] {
+                int64_t const x = std::bit_cast<int64_t>(
+                    code_holder_.labelOffset(error_label_) -
+                    code_holder_.labelOffset(jump_table_label_.value()));
+                MONAD_VM_DEBUG_ASSERT(
+                    x <= std::numeric_limits<int32_t>::max() &&
+                    x >= std::numeric_limits<int32_t>::min());
+                return static_cast<int32_t>(x);
+            }();
+            size_t error_offset_repeat_count = 0;
+            for (size_t bid = 0; bid < *bytecode_size_; ++bid) {
+                auto lbl = jump_dests_.find(bid);
+                if (lbl != jump_dests_.end()) {
+                    as_.embedInt32(error_offset, error_offset_repeat_count);
+                    error_offset_repeat_count = 0;
+                    as_.embedLabelDelta(
+                        lbl->second, jump_table_label_.value(), 4);
+                }
+                else {
+                    ++error_offset_repeat_count;
+                }
             }
-            else {
-                ++error_offset_repeat_count;
-            }
+            as_.embedInt32(error_offset, error_offset_repeat_count);
         }
-        as_.embedInt32(error_offset, error_offset_repeat_count);
 
         static char const *const ro_section_name = "ro";
         static auto const ro_section_name_len = 2;
@@ -3452,6 +3455,8 @@ namespace monad::vm::compiler::native
                 stack_.remove_general_reg(*dest);
             }
         }
+        jump_table_label_ = jump_table_label_ ? jump_table_label_
+                                              : as_.newNamedLabel("JumpTable");
         if (std::holds_alternative<Gpq256>(dest_op)) {
             Gpq256 const &gpq = std::get<Gpq256>(dest_op);
             as_.cmp(gpq[0], *bytecode_size_);
@@ -3460,7 +3465,7 @@ namespace monad::vm::compiler::native
             as_.or_(gpq[1], gpq[3]);
             as_.jnz(error_label_);
 
-            as_.lea(x86::rax, x86::ptr(jump_table_label_));
+            as_.lea(x86::rax, x86::ptr(jump_table_label_.value()));
             as_.movsxd(x86::rcx, x86::dword_ptr(x86::rax, gpq[0], 2));
             as_.add(x86::rax, x86::rcx);
             as_.jmp(x86::rax);
@@ -3486,7 +3491,7 @@ namespace monad::vm::compiler::native
             as_.or_(x86::rdx, m);
             as_.jnz(error_label_);
 
-            as_.lea(x86::rax, x86::ptr(jump_table_label_));
+            as_.lea(x86::rax, x86::ptr(jump_table_label_.value()));
             as_.movsxd(x86::rcx, x86::dword_ptr(x86::rax, x86::rcx, 2));
             as_.add(x86::rax, x86::rcx);
             as_.jmp(x86::rax);

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -1090,7 +1090,7 @@ namespace monad::vm::compiler::native
         asmjit::x86::Assembler as_;
         asmjit::Label epilogue_label_;
         asmjit::Label error_label_;
-        asmjit::Label jump_table_label_;
+        std::optional<asmjit::Label> jump_table_label_;
         Stack stack_;
         bool keep_stack_in_next_block_;
         std::array<Gpq256, 3> gpq256_regs_;


### PR DESCRIPTION
## Context

On the 20425 contracts executed at least 5 times between block 15M to ~19M, around 9365 have only direct jumps. Other contracts have a mix of direct and indirect jumps. For the contracts with only direct jumps, the jump table occupies around 5% of the total compiled code size, which can be removed.

```
 avg_jt | p10_jt | p50_jt | p90_jt | p99_jt 
--------+--------+--------+--------+--------
    4.9 |    3.8 |    4.5 |    5.6 |    7.4
(1 row)
```