### PR TITLE
Fix recursion in io request resubmission

### DIFF
--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -624,7 +624,7 @@ public:
     //! the receiver
     initiation_result reinitiate() noexcept
     {
-        return do_possibly_deferred_initiate_(true, true);
+        return do_possibly_deferred_initiate_(false, true);
     }
 
     void reset()


### PR DESCRIPTION
Avoid recursion when resubmitting requests in poll_uring_.

For delayed reads, store required arguments on deferred list and submit request to iouring directly instead of going through initiate() again.

For retrying EAGAIN errors, defer initiate() if running from inside completion.
