### PR TITLE
[staking]: snapshot and epoch change revert on nonzero msg.value

### DIFF
--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -206,9 +206,9 @@ Result<void> ExecuteSystemTransaction<traits>::execute_staking_syscall(
     case SyscallSelector::REWARD:
         return contract.syscall_reward(calldata, value);
     case SyscallSelector::SNAPSHOT:
-        return contract.syscall_snapshot(calldata);
+        return contract.syscall_snapshot(calldata, value);
     case SyscallSelector::ON_EPOCH_CHANGE:
-        return contract.syscall_on_epoch_change(calldata);
+        return contract.syscall_on_epoch_change(calldata, value);
     }
     return staking::StakingError::MethodNotSupported;
 }

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1562,8 +1562,12 @@ Result<byte_string> StakingContract::precompile_external_reward(
 //  System Calls  //
 ////////////////////
 
-Result<void> StakingContract::syscall_on_epoch_change(byte_string_view input)
+Result<void> StakingContract::syscall_on_epoch_change(
+    byte_string_view input, uint256_t const &value)
 {
+    if (MONAD_UNLIKELY(value != 0)) {
+        return StakingError::ValueNonZero;
+    }
     BOOST_OUTCOME_TRY(u64_be const next_epoch, abi_decode_fixed<u64_be>(input));
     if (MONAD_UNLIKELY(!input.empty())) {
         return StakingError::InvalidInput;
@@ -1665,8 +1669,12 @@ Result<void> StakingContract::syscall_reward(
     return outcome::success();
 }
 
-Result<void> StakingContract::syscall_snapshot(byte_string_view const input)
+Result<void> StakingContract::syscall_snapshot(
+    byte_string_view const input, uint256_t const &value)
 {
+    if (MONAD_UNLIKELY(value != 0)) {
+        return StakingError::ValueNonZero;
+    }
     if (MONAD_UNLIKELY(!input.empty())) {
         return StakingError::InvalidInput;
     }

--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -594,9 +594,9 @@ public:
     ////////////////////
     //  System Calls  //
     ////////////////////
-    Result<void> syscall_on_epoch_change(byte_string_view);
+    Result<void> syscall_on_epoch_change(byte_string_view, uint256_t const &);
     Result<void> syscall_reward(byte_string_view, uint256_t const &);
-    Result<void> syscall_snapshot(byte_string_view);
+    Result<void> syscall_snapshot(byte_string_view, uint256_t const &);
 };
 
 MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/validate_system_transaction.cpp
+++ b/category/execution/monad/validate_system_transaction.cpp
@@ -115,7 +115,6 @@ quick_status_code_from_enum<monad::SystemTransactionError>::value_mappings()
          "system transaction before fork",
          {}},
         {SystemTransactionError::GasNonZero, "gas non zero", {}},
-        {SystemTransactionError::ValueNonZero, "value nonzero", {}},
         {SystemTransactionError::TypeNotLegacy, "type not legacy", {}},
         {SystemTransactionError::BadSender, "bad sender", {}},
         {SystemTransactionError::MissingTo, "missing to", {}},

--- a/category/execution/monad/validate_system_transaction.hpp
+++ b/category/execution/monad/validate_system_transaction.hpp
@@ -39,7 +39,6 @@ enum class SystemTransactionError
     Success = 0,
     SystemTxnBeforeFork,
     GasNonZero,
-    ValueNonZero,
     TypeNotLegacy,
     BadSender,
     MissingTo,


### PR DESCRIPTION
 * Delete unused SystemTransactionError::ValueNonZero. This is not generally applicable to system transactions, as reward has an associated msg.value

 * Crash if syscalls have nonzero msg.value

This check does not require a hardfork as consensus is already performing this check before submitting a block to execution.