### PR TITLE
[staking]: Prep for fork by templating contract by revision

### DIFF
--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -193,7 +193,7 @@ Result<void> ExecuteSystemTransaction<traits>::execute_staking_syscall(
     // creates staking account in state if it doesn't exist
     state.add_to_balance(staking::STAKING_CA, 0);
 
-    staking::StakingContract contract(state, call_tracer_);
+    staking::StakingContract<traits> contract(state, call_tracer_);
     if (MONAD_UNLIKELY(calldata.size() < 4)) {
         return staking::StakingError::InvalidInput;
     }

--- a/category/execution/monad/monad_precompiles.cpp
+++ b/category/execution/monad/monad_precompiles.cpp
@@ -41,12 +41,12 @@ std::optional<evmc::Result> check_call_monad_precompile(
 
     byte_string_view input{msg.input_data, msg.input_size};
     auto const [method, cost] =
-        staking::StakingContract::precompile_dispatch(input);
+        staking::StakingContract<traits>::precompile_dispatch(input);
     if (MONAD_UNLIKELY(std::cmp_less(msg.gas, cost))) {
         return evmc::Result{evmc_status_code::EVMC_OUT_OF_GAS};
     }
 
-    staking::StakingContract contract(state, call_tracer);
+    staking::StakingContract<traits> contract(state, call_tracer);
     auto const res = (contract.*method)(input, msg.sender, msg.value);
     if (MONAD_LIKELY(res.has_value())) {
         int64_t const gas_left = msg.gas - static_cast<int64_t>(cost);

--- a/category/execution/monad/staking/read_valset.hpp
+++ b/category/execution/monad/staking/read_valset.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <category/execution/monad/staking/config.hpp>
+#include <category/vm/evm/monad/revision.h>
 
 #include <optional>
 #include <vector>
@@ -41,7 +42,8 @@ struct Validator
     evmc_uint256be stake;
 };
 
-std::optional<std::vector<Validator>>
-read_valset(mpt::Db &db, size_t block_num, uint64_t requested_epoch);
+std::optional<std::vector<Validator>> read_valset(
+    monad_revision rev, mpt::Db &db, size_t block_num,
+    uint64_t requested_epoch);
 
 MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -29,6 +29,7 @@
 #include <category/execution/monad/staking/util/delegator.hpp>
 #include <category/execution/monad/staking/util/staking_error.hpp>
 #include <category/execution/monad/staking/util/val_execution.hpp>
+#include <category/vm/evm/traits.hpp>
 
 #include <evmc/evmc.h>
 
@@ -44,6 +45,7 @@ MONAD_NAMESPACE_END
 
 MONAD_STAKING_NAMESPACE_BEGIN
 
+template <Traits traits>
 class StakingContract
 {
     State &state_;

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -21,6 +21,7 @@
 #include <category/execution/monad/staking/read_valset.hpp>
 #include <category/execution/monad/staking/staking_contract.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/vm/evm/traits.hpp>
 
 #include <test_resource_data.h>
 #include <utility>
@@ -83,7 +84,7 @@ protected:
         BlockState bs{tdb, vm};
         State state{bs, Incarnation{0, 0}};
         NoopCallTracer call_tracer{};
-        StakingContract contract{state, call_tracer};
+        StakingContract<MonadTraits<MONAD_FOUR>> contract{state, call_tracer};
 
         state.add_to_balance(STAKING_CA, 0);
 
@@ -130,7 +131,7 @@ class ReadValsetBeforeBoundary : public ReadValsetBase
 
 TEST_F(ReadValsetBeforeBoundary, get_this_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH);
+    auto const set = read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH);
     ASSERT_TRUE(set.has_value());
     EXPECT_EQ(set.value().size(), CONSENSUS_VALSET_LENGTH);
     for (auto const &validator : set.value()) {
@@ -140,19 +141,22 @@ TEST_F(ReadValsetBeforeBoundary, get_this_epoch_valset)
 
 TEST_F(ReadValsetBeforeBoundary, get_next_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
     EXPECT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetBeforeBoundary, asking_for_expired_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
     ASSERT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetBeforeBoundary, asking_for_future_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
     ASSERT_FALSE(set.has_value());
 }
 
@@ -166,7 +170,7 @@ class ReadValsetAfterBoundary : public ReadValsetBase
 
 TEST_F(ReadValsetAfterBoundary, get_this_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH);
+    auto const set = read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH);
 
     // expect the snapshot view when requesting current epoch valset
     ASSERT_TRUE(set.has_value());
@@ -178,7 +182,8 @@ TEST_F(ReadValsetAfterBoundary, get_this_epoch_valset)
 
 TEST_F(ReadValsetAfterBoundary, get_next_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
 
     // expect the consensus view when requesting current epoch valset
     ASSERT_TRUE(set.has_value());
@@ -190,12 +195,14 @@ TEST_F(ReadValsetAfterBoundary, get_next_epoch_valset)
 
 TEST_F(ReadValsetAfterBoundary, asking_for_expired_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
     EXPECT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetAfterBoundary, asking_for_future_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
+    auto const set =
+        read_valset(MONAD_FOUR, ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
     EXPECT_FALSE(set.has_value());
 }

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -35,6 +35,7 @@
 #include <category/execution/monad/staking/util/secp256k1.hpp>
 #include <category/execution/monad/staking/util/staking_error.hpp>
 #include <category/execution/monad/system_sender.hpp>
+#include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
 
 #include <test_resource_data.h>
@@ -251,7 +252,7 @@ struct Stake : public ::testing::Test
     BlockState bs{tdb, vm};
     State state{bs, Incarnation{0, 0}};
     NoopCallTracer call_tracer{};
-    StakingContract contract{state, call_tracer};
+    StakingContract<MonadTraits<MONAD_FOUR>> contract{state, call_tracer};
 
     void SetUp() override
     {


### PR DESCRIPTION
 * This PR only sets up the boilerplate. The tests still need to be migrated to a the new revision-aware harness

 * read valset consensus API has a parameter change and must include a revision.