### PR TITLE
[uint256] Force intermediate results of bitwise operations to avoid AVX stalls

### DIFF
--- a/category/vm/runtime/uint256.hpp
+++ b/category/vm/runtime/uint256.hpp
@@ -438,10 +438,10 @@ namespace monad::vm::runtime
         uint256_t const &x, uint256_t const &y) noexcept                       \
     {                                                                          \
         return uint256_t{                                                      \
-            x[0] op_name y[0],                                                 \
-            x[1] op_name y[1],                                                 \
-            x[2] op_name y[2],                                                 \
-            x[3] op_name y[3]};                                                \
+            force(x[0] op_name y[0]),                                          \
+            force(x[1] op_name y[1]),                                          \
+            force(x[2] op_name y[2]),                                          \
+            force(x[3] op_name y[3])};                                         \
     }
         BITWISE_BINOP(uint256_t, &);
         BITWISE_BINOP(uint256_t, |);
@@ -469,7 +469,11 @@ namespace monad::vm::runtime
         [[gnu::always_inline]] inline constexpr uint256_t
         operator~() const noexcept
         {
-            return uint256_t{~words_[0], ~words_[1], ~words_[2], ~words_[3]};
+            return uint256_t{
+                force(~words_[0]),
+                force(~words_[1]),
+                force(~words_[2]),
+                force(~words_[3])};
         }
 
         template <typename T>


### PR DESCRIPTION
As noted in #1602, bitwise operations on `uint256_t` are vectorized by GCC/Clang and incur store forwarding stalls when mixed with non-vectorized operations. This can be fixed by forcing the intermediate results.