### PR TITLE
[event] record state access events

### DIFF
--- a/category/execution/ethereum/dispatch_transaction.cpp
+++ b/category/execution/ethereum/dispatch_transaction.cpp
@@ -25,7 +25,7 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
+    BlockState &block_state, BlockMetrics &block_metrics, State &state,
     boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
     trace::StateTracer &state_tracer,
     RevertTransactionFn const &revert_transaction)
@@ -40,6 +40,7 @@ Result<Receipt> dispatch_transaction(
         block_hash_buffer,
         block_state,
         block_metrics,
+        state,
         prev,
         call_tracer,
         state_tracer,

--- a/category/execution/ethereum/dispatch_transaction.hpp
+++ b/category/execution/ethereum/dispatch_transaction.hpp
@@ -51,7 +51,7 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
+    BlockState &block_state, BlockMetrics &block_metrics, State &state,
     boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
     trace::StateTracer &state_tracer,
     RevertTransactionFn const &revert_transaction);

--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -23,11 +23,15 @@
 #include <optional>
 #include <span>
 
+enum monad_exec_account_access_context : uint8_t;
+
 MONAD_NAMESPACE_BEGIN
 
 struct CallFrame;
 struct Receipt;
 struct Transaction;
+
+class State;
 
 /// Record the transaction header events (TXN_HEADER_START, the EIP-2930
 /// and EIP-7702 events, and TXN_HEADER_END), followed by the TXN_EVM_OUTPUT,
@@ -37,6 +41,11 @@ struct Transaction;
 void record_txn_events(
     uint32_t txn_num, Transaction const &, Address const &sender,
     std::span<std::optional<Address> const> authorities,
-    Result<Receipt> const &, std::span<CallFrame const>);
+    Result<Receipt> const &, std::span<CallFrame const>, State const &);
+
+/// Record all account state accesses (both reads and writes) described by a
+/// State object
+void record_account_access_events(
+    monad_exec_account_access_context, State const &);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -86,6 +86,7 @@ class ExecuteTransaction : public ExecuteTransactionNoValidation<traits>
     BlockHashBuffer const &block_hash_buffer_;
     BlockState &block_state_;
     BlockMetrics &block_metrics_;
+    State &state_;
     boost::fibers::promise<void> &prev_;
     CallTracerBase &call_tracer_;
     trace::StateTracer &state_tracer_;
@@ -97,7 +98,7 @@ public:
     ExecuteTransaction(
         Chain const &, uint64_t i, Transaction const &, Address const &,
         std::span<std::optional<Address> const>, BlockHeader const &,
-        BlockHashBuffer const &, BlockState &, BlockMetrics &,
+        BlockHashBuffer const &, BlockState &, BlockMetrics &, State &,
         boost::fibers::promise<void> &prev, CallTracerBase &,
         trace::StateTracer &,
         RevertTransactionFn const & = [](Address const &, Transaction const &,

--- a/category/execution/ethereum/execute_transaction_test.cpp
+++ b/category/execution/ethereum/execute_transaction_test.cpp
@@ -102,6 +102,7 @@ TYPED_TEST(TraitsTest, irrevocable_gas_and_refund_new_contract)
     NoopCallTracer noop_call_tracer;
     trace::StateTracer noop_state_tracer = std::monostate{};
 
+    State state{bs, Incarnation{header.number, 1}};
     auto const receipt = ExecuteTransaction<typename TestFixture::Trait>(
         EthereumMainnet{},
         0,
@@ -112,6 +113,7 @@ TYPED_TEST(TraitsTest, irrevocable_gas_and_refund_new_contract)
         block_hash_buffer,
         bs,
         metrics,
+        state,
         prev,
         noop_call_tracer,
         noop_state_tracer)();
@@ -210,6 +212,7 @@ TYPED_TEST(TraitsTest, TopLevelCreate)
     boost::fibers::promise<void> prev{};
     prev.set_value();
 
+    State state{bs, Incarnation{header.number, 1}};
     auto const receipt = ExecuteTransaction<typename TestFixture::Trait>(
         MonadTestnet{},
         0,
@@ -220,6 +223,7 @@ TYPED_TEST(TraitsTest, TopLevelCreate)
         block_hash_buffer,
         bs,
         metrics,
+        state,
         prev,
         noop_call_tracer,
         noop_state_tracer)();
@@ -363,6 +367,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
         NoopCallTracer noop_call_tracer;
         trace::StateTracer noop_state_tracer = std::monostate{};
 
+        State state{bs, Incarnation{header.number, 1}};
         auto const receipt = ExecuteTransaction<typename TestFixture::Trait>(
             MonadDevnet{},
             0,
@@ -373,6 +378,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
             block_hash_buffer,
             bs,
             metrics,
+            state,
             prev,
             noop_call_tracer,
             noop_state_tracer)();
@@ -418,6 +424,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
         NoopCallTracer noop_call_tracer;
         trace::StateTracer noop_state_tracer = std::monostate{};
 
+        State state{bs, Incarnation{header.number, 1}};
         auto const receipt = ExecuteTransaction<typename TestFixture::Trait>(
             MonadDevnet{},
             0,
@@ -428,6 +435,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
             block_hash_buffer,
             bs,
             metrics,
+            state,
             prev,
             noop_call_tracer,
             noop_state_tracer)();
@@ -520,6 +528,7 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
         NoopCallTracer noop_call_tracer;
         trace::StateTracer noop_state_tracer = std::monostate{};
 
+        State state{bs, Incarnation{header.number, 1}};
         auto const receipt = ExecuteTransaction<typename TestFixture::Trait>(
             MonadDevnet{},
             0,
@@ -530,6 +539,7 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
             block_hash_buffer,
             bs,
             metrics,
+            state,
             prev,
             noop_call_tracer,
             noop_state_tracer)();

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -57,11 +57,11 @@ private:
     friend class State;
     friend class BlockState;
 
-    // the classes below can access the account_ field just for logging but
-    // CANNOT use it to make decisions affecting the final state (state of
-    // accounts) of execution.
-    friend struct trace::PrestateTracer;
-    friend struct trace::StateDiffTracer;
+    friend std::optional<Account> const &
+    get_account_for_trace(AccountState const &as)
+    {
+        return as.account_;
+    }
 
 public:
     Map<bytes32_t, bytes32_t> storage_{};

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -120,6 +120,15 @@ State::Map<bytes32_t, vm::SharedVarcode> const &State::code() const
     return code_;
 }
 
+void State::clear()
+{
+    original_.clear();
+    current_.clear();
+    logs_.reset({});
+    code_.clear();
+    version_ = 0;
+}
+
 void State::push()
 {
     ++version_;

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -87,6 +87,8 @@ public:
 
     Map<bytes32_t, vm::SharedVarcode> const &code() const;
 
+    void clear();
+
     void push();
 
     void pop_accept();

--- a/category/execution/ethereum/state3/version_stack.hpp
+++ b/category/execution/ethereum/state3/version_stack.hpp
@@ -39,6 +39,12 @@ public:
     VersionStack &operator=(VersionStack &&) = default;
     VersionStack &operator=(VersionStack const &) = delete;
 
+    void reset(T value, unsigned version = 0)
+    {
+        stack_.clear();
+        stack_.emplace_back(version, std::move(value));
+    }
+
     size_t size() const
     {
         return stack_.size();

--- a/category/execution/ethereum/trace/prestate_tracer.cpp
+++ b/category/execution/ethereum/trace/prestate_tracer.cpp
@@ -81,10 +81,12 @@ namespace trace
 
             // Possible diff.
             auto const &current_account_state = current_stack.recent();
-            auto const &current_account = current_account_state.account_;
+            auto const &current_account =
+                get_account_for_trace(current_account_state);
             auto const &current_storage = current_account_state.storage_;
             auto const &original_account_state = it->second;
-            auto const &original_account = original_account_state.account_;
+            auto const &original_account =
+                get_account_for_trace(original_account_state);
             auto const &original_storage = original_account_state.storage_;
 
             // Nothing to do if the account has been created and destructed
@@ -161,7 +163,7 @@ namespace trace
     json PrestateTracer::account_state_to_json(
         OriginalAccountState const &as, State &state)
     {
-        auto const &account = as.account_;
+        auto const &account = get_account_for_trace(as);
         auto const &storage = as.storage_;
         json res = account_to_json(account, state);
         if (!storage.empty() && account.has_value()) {

--- a/category/execution/monad/dispatch_transaction.cpp
+++ b/category/execution/monad/dispatch_transaction.cpp
@@ -27,7 +27,7 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
+    BlockState &block_state, BlockMetrics &block_metrics, State &state,
     boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
     trace::StateTracer &state_tracer,
     RevertTransactionFn const &revert_transaction)
@@ -44,6 +44,7 @@ Result<Receipt> dispatch_transaction(
             header,
             block_state,
             block_metrics,
+            state,
             prev,
             call_tracer}();
     }
@@ -58,6 +59,7 @@ Result<Receipt> dispatch_transaction(
             block_hash_buffer,
             block_state,
             block_metrics,
+            state,
             prev,
             call_tracer,
             state_tracer,

--- a/category/execution/monad/dispatch_transaction.hpp
+++ b/category/execution/monad/dispatch_transaction.hpp
@@ -26,7 +26,7 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
+    BlockState &block_state, BlockMetrics &block_metrics, State &state,
     boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
     trace::StateTracer &, RevertTransactionFn const &revert_transaction);
 

--- a/category/execution/monad/execute_system_transaction.hpp
+++ b/category/execution/monad/execute_system_transaction.hpp
@@ -34,13 +34,14 @@ class ExecuteSystemTransaction
     BlockHeader const &header_;
     BlockState &block_state_;
     BlockMetrics &block_metrics_;
+    State &state_;
     boost::fibers::promise<void> &prev_;
     CallTracerBase &call_tracer_;
 
 public:
     ExecuteSystemTransaction(
         Chain const &, uint64_t i, Transaction const &, Address const &,
-        BlockHeader const &, BlockState &, BlockMetrics &,
+        BlockHeader const &, BlockState &, BlockMetrics &, State &,
         boost::fibers::promise<void> &prev, CallTracerBase &);
 
     Result<Receipt> operator()();


### PR DESCRIPTION
There are a few changes here:

- The ExecuteTransaction and ExecuteSystemTransaction functors are given a State object rather than creating one, so it can be owned by the outer transaction fiber. After the functor is done executing the transaction, this outer fiber gives the State to the recording code

- `class State` gains the `State::clear` method, so that it can be reset when re-execution is needed

- record_txn_events.cpp gains functions for recording State objects as `ACCOUNT_ACCESS_LIST_HEADER`, `ACCOUNT_ACCESS`, and `STORAGE_ACCESS` events

- All state-affecting changes to the block that occur before transaction and after the transaction are also recorded