### PR TITLE
Merge CacheNode and Node back to single class

### DIFF
--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -34,7 +34,7 @@ class TrieRODb final : public ::monad::Db
 {
     ::monad::mpt::RODb &db_;
     uint64_t block_number_;
-    ::monad::mpt::CacheNodeCursor prefix_cursor_;
+    ::monad::mpt::NodeCursor prefix_cursor_;
 
 public:
     explicit TrieRODb(mpt::RODb &db)

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -68,14 +68,14 @@ public:
     RODb &operator=(RODb const &) = delete;
     RODb &operator=(RODb &&) = delete;
 
-    Result<CacheNodeCursor>
-    find(CacheNodeCursor const &, NibblesView, uint64_t block_id) const;
-    Result<CacheNodeCursor> find(NibblesView prefix, uint64_t block_id) const;
+    Result<NodeCursor>
+    find(NodeCursor const &, NibblesView, uint64_t block_id) const;
+    Result<NodeCursor> find(NibblesView prefix, uint64_t block_id) const;
 
     uint64_t get_latest_version() const;
     uint64_t get_earliest_version() const;
     bool traverse(
-        CacheNodeCursor const &, TraverseMachine &, uint64_t block_id,
+        NodeCursor const &, TraverseMachine &, uint64_t block_id,
         size_t concurrency_limit = 4096);
 };
 
@@ -169,7 +169,7 @@ public:
 struct AsyncContext
 {
     using inflight_root_t = ankerl::unordered_dense::segmented_map<
-        uint64_t, std::vector<std::function<void(std::shared_ptr<CacheNode>)>>>;
+        uint64_t, std::vector<std::function<void(std::shared_ptr<Node>)>>>;
 
     UpdateAux<> &aux;
     NodeCache node_cache;
@@ -203,12 +203,12 @@ namespace detail
             op_get_node2
         } op_type;
 
-        std::shared_ptr<CacheNode> root;
-        CacheNodeCursor cur;
+        std::shared_ptr<Node> root;
+        NodeCursor cur;
         Nibbles const nv;
         uint64_t const block_id;
 
-        find_result_type<CacheNodeCursor> res_root;
+        find_result_type<NodeCursor> res_root;
         find_result_type<T> get_result;
 
         constexpr DbGetSender(
@@ -219,13 +219,13 @@ namespace detail
             , nv(n)
             , block_id(block_id_)
         {
-            if constexpr (std::same_as<T, std::shared_ptr<CacheNode>>) {
+            if constexpr (std::same_as<T, std::shared_ptr<Node>>) {
                 MONAD_ASSERT(op_type == op_t::op_get_node1);
             }
         }
 
         constexpr DbGetSender(
-            AsyncContext &context_, op_t const op_type_, CacheNodeCursor cur_,
+            AsyncContext &context_, op_t const op_type_, NodeCursor cur_,
             NibblesView const n, uint64_t const block_id_)
             : context(context_)
             , op_type(op_type_)
@@ -233,7 +233,7 @@ namespace detail
             , nv(n)
             , block_id(block_id_)
         {
-            if constexpr (std::same_as<T, std::shared_ptr<CacheNode>>) {
+            if constexpr (std::same_as<T, std::shared_ptr<Node>>) {
                 MONAD_ASSERT(op_type == op_t::op_get_node1);
             }
         }
@@ -283,13 +283,13 @@ inline detail::DbGetSender<byte_string> make_get_data_sender(
         block_id};
 }
 
-inline detail::DbGetSender<std::shared_ptr<CacheNode>> make_get_node_sender(
+inline detail::DbGetSender<std::shared_ptr<Node>> make_get_node_sender(
     AsyncContext *const context, NibblesView const nv, uint64_t const block_id)
 {
     MONAD_ASSERT(context);
     return {
         *context,
-        detail::DbGetSender<std::shared_ptr<CacheNode>>::op_t::op_get_node1,
+        detail::DbGetSender<std::shared_ptr<Node>>::op_t::op_get_node1,
         nv,
         block_id};
 }

--- a/category/mpt/deserialize_node_from_receiver_result.hpp
+++ b/category/mpt/deserialize_node_from_receiver_result.hpp
@@ -53,20 +53,20 @@ namespace detail
         }
     }
 
-    template <class NodeType, class ResultType>
-    inline NodeType::SharedPtr deserialize_node_from_receiver_result(
+    template <class ResultType>
+    inline Node::SharedPtr deserialize_node_from_receiver_result(
         ResultType buffer_, uint16_t buffer_off,
         MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state)
     {
         MONAD_ASSERT(buffer_);
-        typename NodeType::SharedPtr node;
+        Node::SharedPtr node;
         if constexpr (std::is_same_v<
                           std::decay_t<ResultType>,
                           typename monad::async::read_single_buffer_sender::
                               result_type>) {
             auto &buffer = std::move(buffer_).assume_value().get();
             MONAD_ASSERT(buffer.size() > buffer_off);
-            node = deserialize_node_from_buffer<NodeType>(
+            node = deserialize_node_from_buffer(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);
             buffer.reset();
@@ -82,7 +82,7 @@ namespace detail
             MONAD_ASSERT(buffer.size() > buffer_off);
             // Did the Receiver forget to set lifetime_managed_internally?
             MONAD_DEBUG_ASSERT(io_state->lifetime_is_managed_internally());
-            node = deserialize_node_from_buffer<NodeType>(
+            node = deserialize_node_from_buffer(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);
         }

--- a/category/mpt/node_cache.hpp
+++ b/category/mpt/node_cache.hpp
@@ -28,13 +28,12 @@ MONAD_MPT_NAMESPACE_BEGIN
 // Memory bounded node cache
 class NodeCache final
     : private static_lru_cache<
-          virtual_chunk_offset_t,
-          std::pair<std::shared_ptr<CacheNode>, unsigned>,
+          virtual_chunk_offset_t, std::pair<std::shared_ptr<Node>, unsigned>,
           virtual_chunk_offset_t_hasher>
 {
     // second in value is node size
     using Base = static_lru_cache<
-        virtual_chunk_offset_t, std::pair<std::shared_ptr<CacheNode>, unsigned>,
+        virtual_chunk_offset_t, std::pair<std::shared_ptr<Node>, unsigned>,
         virtual_chunk_offset_t_hasher>;
 
     size_t max_bytes_;
@@ -78,7 +77,7 @@ public:
 
     Map::iterator insert(
         virtual_chunk_offset_t const &virt_offset,
-        std::shared_ptr<CacheNode> const &sp) noexcept
+        std::shared_ptr<Node> const &sp) noexcept
     {
         MONAD_ASSERT(virt_offset != virtual_chunk_offset_t::invalid_value());
 

--- a/category/mpt/node_cursor.hpp
+++ b/category/mpt/node_cursor.hpp
@@ -22,21 +22,20 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-template <node_type NodeType>
-struct NodeCursorBase
+struct NodeCursor
 {
-    std::shared_ptr<NodeType> node{nullptr};
+    std::shared_ptr<Node> node{nullptr};
     unsigned prefix_index{0};
 
-    constexpr NodeCursorBase()
+    constexpr NodeCursor()
         : node{nullptr}
         , prefix_index{0}
     {
     }
 
     // NOLINTNEXTLINE(google-explicit-constructor)
-    constexpr NodeCursorBase(
-        std::shared_ptr<NodeType> node_, unsigned prefix_index_ = 0)
+    constexpr NodeCursor(
+        std::shared_ptr<Node> node_, unsigned prefix_index_ = 0)
         : node{std::move(node_)}
         , prefix_index{prefix_index_}
     {
@@ -48,13 +47,7 @@ struct NodeCursorBase
     }
 };
 
-using NodeCursor = NodeCursorBase<Node>;
-using CacheNodeCursor = NodeCursorBase<CacheNode>;
-
 static_assert(sizeof(NodeCursor) == 24);
 static_assert(alignof(NodeCursor) == 8);
-
-static_assert(sizeof(CacheNodeCursor) == 24);
-static_assert(alignof(CacheNodeCursor) == 8);
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -67,7 +67,7 @@ Node::SharedPtr read_node_blocking(
             strerror(errno));
     }
     return aux.version_is_valid_ondisk(version)
-               ? deserialize_node_from_buffer<Node>(
+               ? deserialize_node_from_buffer(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)
                : Node::SharedPtr{};
 }

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -628,10 +628,10 @@ TEST_F(OnDiskDbWithFileAsyncFixture, read_only_db_single_thread_async)
                 ASSERT_TRUE(res.has_value());
                 EXPECT_EQ(res.value(), kv[1].second);
             });
-        async_get<std::shared_ptr<CacheNode>>(
+        async_get<std::shared_ptr<Node>>(
             make_get_node_sender(
                 ctx.get(), prefix + kv[0].first, starting_block_id),
-            [&](result_t<std::shared_ptr<CacheNode>> res) {
+            [&](result_t<std::shared_ptr<Node>> res) {
                 ASSERT_TRUE(res.has_value());
                 EXPECT_EQ(res.value()->value(), kv[0].second);
             });
@@ -643,9 +643,9 @@ TEST_F(OnDiskDbWithFileAsyncFixture, read_only_db_single_thread_async)
                     res.value(),
                     0x05a697d6698c55ee3e4d472c4907bca2184648bcfdd0e023e7ff7089dc984e7e_bytes);
             });
-        async_get<std::shared_ptr<CacheNode>>(
+        async_get<std::shared_ptr<Node>>(
             make_get_node_sender(ctx.get(), prefix, starting_block_id),
-            [&](result_t<std::shared_ptr<CacheNode>> res) {
+            [&](result_t<std::shared_ptr<Node>> res) {
                 ASSERT_TRUE(res.has_value());
                 EXPECT_EQ(
                     res.value()->data(),
@@ -1084,7 +1084,7 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
     // async get traverse root
     struct GetNodeReceiver
     {
-        using ResultType = monad::async::result<std::shared_ptr<CacheNode>>;
+        using ResultType = monad::async::result<std::shared_ptr<Node>>;
 
         detail::TraverseSender traverse_sender;
         TraverseResult &result;
@@ -1102,8 +1102,7 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
                 result.traverse_success = false;
             }
             else {
-                traverse_sender.traverse_root =
-                    copy_node<Node>(res.assume_value().get());
+                traverse_sender.traverse_root = res.assume_value();
                 // issue async traverse
                 auto *traverse_state = new auto(monad::async::connect(
                     std::move(traverse_sender), TraverseReceiver{result}));

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -69,13 +69,13 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
     monad::mpt::AsyncInflightNodes inflights;
     monad::mpt::NodeCache node_cache{
         1000 * monad::mpt::NodeCache::AVERAGE_NODE_SIZE};
-    std::shared_ptr<CacheNode> cache_root = copy_node<CacheNode>(root.get());
+    std::shared_ptr<Node> cache_root = root;
     auto state = monad::async::connect(
         monad::mpt::find_request_sender<>(
             aux,
             node_cache,
             inflights,
-            CacheNodeCursor{cache_root},
+            NodeCursor{cache_root},
             latest_version,
             key,
             true),

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -708,13 +708,13 @@ int main(int argc, char *argv[])
                     bool &done;
                     unsigned const n_slices;
                     find_bytes_request_sender *sender{nullptr};
-                    CacheNodeCursor state_start;
+                    NodeCursor state_start;
                     monad::small_prng rand;
                     monad::byte_string key;
 
                     explicit receiver_t(
                         uint64_t &ops_, bool &done_, unsigned n_slices_,
-                        CacheNodeCursor begin, uint32_t id)
+                        NodeCursor begin, uint32_t id)
                         : ops(ops_)
                         , done(done_)
                         , n_slices(n_slices_)
@@ -755,8 +755,7 @@ int main(int argc, char *argv[])
                 NodeCache node_cache{1000 * NodeCache::AVERAGE_NODE_SIZE};
                 std::vector<std::unique_ptr<connected_state_type>> states;
                 states.reserve(random_read_benchmark_threads);
-                std::shared_ptr<CacheNode> start_node =
-                    copy_node<CacheNode>(state_start.node.get());
+                std::shared_ptr<Node> start_node = state_start.node;
                 for (uint32_t n = 0; n < random_read_benchmark_threads; n++) {
                     states.emplace_back(new auto(connect(
                         *aux.io,
@@ -764,7 +763,7 @@ int main(int argc, char *argv[])
                             aux,
                             node_cache,
                             inflights,
-                            CacheNodeCursor{start_node},
+                            NodeCursor{start_node},
                             aux.db_history_max_version(),
                             NibblesView{},
                             true},
@@ -772,7 +771,7 @@ int main(int argc, char *argv[])
                             ops,
                             signal_done,
                             n_slices,
-                            CacheNodeCursor{start_node},
+                            NodeCursor{start_node},
                             n))));
                 }
 

--- a/category/mpt/test/node_lru_cache_test.cpp
+++ b/category/mpt/test/node_lru_cache_test.cpp
@@ -33,9 +33,8 @@ TEST(NodeCache, works)
     auto make_node = [&](uint32_t v) {
         monad::byte_string value(84, 0);
         memcpy(value.data(), &v, 4);
-        auto temp_node =
+        std::shared_ptr<Node> node =
             monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0);
-        std::shared_ptr<CacheNode> node = copy_node<CacheNode>(temp_node.get());
         MONAD_ASSERT(node->get_mem_size() == NodeCache::AVERAGE_NODE_SIZE);
         return node;
     };
@@ -79,9 +78,7 @@ TEST(NodeCache, works)
 
     monad::byte_string large_value(84 * 3, 0);
     memcpy(large_value.data(), "hihi", 4);
-    auto temp_large_node =
-        monad::mpt::make_node(0, {}, {}, std::move(large_value), 0, 0);
-    auto node = copy_node<CacheNode>(temp_large_node.get());
+    auto node = monad::mpt::make_node(0, {}, {}, std::move(large_value), 0, 0);
     EXPECT_EQ(node->get_mem_size(), 272);
     node_cache.insert(virtual_chunk_offset_t(6, 0, 1), std::move(node));
     // Everything else should get evicted

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -174,7 +174,7 @@ namespace detail
                 }
                 else { // version is valid after reading the buffer
                     auto const next_node_on_disk =
-                        deserialize_node_from_receiver_result<Node>(
+                        deserialize_node_from_receiver_result(
                             std::move(buffer_), buffer_off, io_state);
                     sender->within_recursion_count++;
                     async_parallel_preorder_traverse_impl(

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -236,7 +236,7 @@ struct load_all_impl_
                 MONAD_ASSERT(root.node->next(branch_index) == nullptr);
                 root.node->set_next(
                     branch_index,
-                    detail::deserialize_node_from_receiver_result<Node>(
+                    detail::deserialize_node_from_receiver_result(
                         std::move(buffer_), buffer_off, io_state));
                 impl->nodes_loaded++;
             }
@@ -333,7 +333,7 @@ public:
     void set_value(erased_connected_operation *io_state_, Result buffer_)
     {
         MONAD_ASSERT(buffer_);
-        auto as_node = detail::deserialize_node_from_receiver_result<Node>(
+        auto as_node = detail::deserialize_node_from_receiver_result(
             std::move(buffer_), buffer_offset, io_state_);
         cont(std::move(as_node));
     }

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -1092,7 +1092,7 @@ template <class T>
 using find_result_type = std::pair<T, find_result>;
 
 using find_cursor_result_type = find_result_type<NodeCursor>;
-using find_owning_cursor_result_type = find_result_type<CacheNodeCursor>;
+using find_owning_cursor_result_type = find_result_type<NodeCursor>;
 
 using inflight_map_t = ankerl::unordered_dense::segmented_map<
     chunk_offset_t,
@@ -1102,8 +1102,8 @@ using inflight_map_t = ankerl::unordered_dense::segmented_map<
 
 using inflight_map_owning_t = ankerl::unordered_dense::segmented_map<
     virtual_chunk_offset_t,
-    std::vector<std::function<MONAD_ASYNC_NAMESPACE::result<void>(
-        CacheNodeCursor const &)>>,
+    std::vector<
+        std::function<MONAD_ASYNC_NAMESPACE::result<void>(NodeCursor const &)>>,
     virtual_chunk_offset_t_hasher>;
 
 // The request type to put to the fiber buffered channel for triedb thread
@@ -1132,7 +1132,7 @@ void find_notify_fiber_future(
 void find_owning_notify_fiber_future(
     UpdateAuxImpl &, NodeCache &, inflight_map_owning_t &,
     threadsafe_boost_fibers_promise<find_owning_cursor_result_type> &promise,
-    CacheNodeCursor const &start, NibblesView, uint64_t version);
+    NodeCursor const &start, NibblesView, uint64_t version);
 
 // rodb load root
 void load_root_notify_fiber_future(


### PR DESCRIPTION
Remove using next pointers in rodb cache, always use hash, since using a shared ptr can keep nodes that should be recycled.