### PR TITLE
Optimize MPT node allocation with custom allocator and SharedPtr

### DIFF
--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -33,9 +33,9 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-Node::UniquePtr create_node_add_new_branch(
+Node::SharedPtr create_node_add_new_branch(
     UpdateAuxImpl &aux, Node *const node, unsigned char const new_branch,
-    Node::UniquePtr new_child, uint64_t const new_version,
+    Node::SharedPtr new_child, uint64_t const new_version,
     std::optional<byte_string_view> opt_value)
 {
     uint16_t const mask =
@@ -80,9 +80,9 @@ Node::UniquePtr create_node_add_new_branch(
         static_cast<int64_t>(new_version));
 }
 
-Node::UniquePtr create_node_with_two_children(
+Node::SharedPtr create_node_with_two_children(
     UpdateAuxImpl &aux, NibblesView const path, unsigned char const branch0,
-    Node::UniquePtr child0, unsigned char const branch1, Node::UniquePtr child1,
+    Node::SharedPtr child0, unsigned char const branch1, Node::SharedPtr child1,
     uint64_t const new_version, std::optional<byte_string_view> opt_value)
 {
     // mismatch: split node's path: turn node to a branch node with two
@@ -158,7 +158,7 @@ Node::SharedPtr copy_trie_impl(
     Node *parent = nullptr;
     unsigned char branch = INVALID_BRANCH;
     Node::SharedPtr node = dest_root;
-    Node::UniquePtr new_node{};
+    Node::SharedPtr new_node{};
     unsigned prefix_index = 0;
     unsigned node_prefix_index = 0;
 
@@ -216,7 +216,7 @@ Node::SharedPtr copy_trie_impl(
         if (node->mask & (1u << nibble)) {
             auto const index = node->to_child_index(nibble);
             if (node->next(index) == nullptr) {
-                Node::UniquePtr next_node_ondisk =
+                auto next_node_ondisk =
                     read_node_blocking(aux, node->fnext(index), dest_version);
                 MONAD_ASSERT(next_node_ondisk != nullptr);
                 node->set_next(index, std::move(next_node_ondisk));

--- a/category/mpt/deserialize_node_from_receiver_result.hpp
+++ b/category/mpt/deserialize_node_from_receiver_result.hpp
@@ -54,12 +54,12 @@ namespace detail
     }
 
     template <class NodeType, class ResultType>
-    inline NodeType::UniquePtr deserialize_node_from_receiver_result(
+    inline NodeType::SharedPtr deserialize_node_from_receiver_result(
         ResultType buffer_, uint16_t buffer_off,
         MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state)
     {
         MONAD_ASSERT(buffer_);
-        typename NodeType::UniquePtr node;
+        typename NodeType::SharedPtr node;
         if constexpr (std::is_same_v<
                           std::decay_t<ResultType>,
                           typename monad::async::read_single_buffer_sender::

--- a/category/mpt/find.cpp
+++ b/category/mpt/find.cpp
@@ -52,7 +52,7 @@ find_cursor_result_type find_blocking(
                 MONAD_ASSERT(aux.is_on_disk());
                 auto g2(g.upgrade());
                 if (g2.upgrade_was_atomic() || !node->next(idx)) {
-                    Node::UniquePtr next_node_ondisk =
+                    auto next_node_ondisk =
                         read_node_blocking(aux, node->fnext(idx), version);
                     if (!next_node_ondisk) {
                         return {

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -29,7 +29,7 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-Node::UniquePtr read_node_blocking(
+Node::SharedPtr read_node_blocking(
     UpdateAuxImpl const &aux, chunk_offset_t const node_offset,
     uint64_t const version)
 {
@@ -69,7 +69,7 @@ Node::UniquePtr read_node_blocking(
     return aux.version_is_valid_ondisk(version)
                ? deserialize_node_from_buffer<Node>(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)
-               : Node::UniquePtr{};
+               : Node::SharedPtr{};
 }
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/test/node_lru_cache_test.cpp
+++ b/category/mpt/test/node_lru_cache_test.cpp
@@ -33,8 +33,9 @@ TEST(NodeCache, works)
     auto make_node = [&](uint32_t v) {
         monad::byte_string value(84, 0);
         memcpy(value.data(), &v, 4);
-        std::shared_ptr<CacheNode> node = copy_node<CacheNode>(
-            monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0).get());
+        auto temp_node =
+            monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0);
+        std::shared_ptr<CacheNode> node = copy_node<CacheNode>(temp_node.get());
         MONAD_ASSERT(node->get_mem_size() == NodeCache::AVERAGE_NODE_SIZE);
         return node;
     };
@@ -78,8 +79,9 @@ TEST(NodeCache, works)
 
     monad::byte_string large_value(84 * 3, 0);
     memcpy(large_value.data(), "hihi", 4);
-    auto node = copy_node<CacheNode>(
-        monad::mpt::make_node(0, {}, {}, std::move(large_value), 0, 0).get());
+    auto temp_large_node =
+        monad::mpt::make_node(0, {}, {}, std::move(large_value), 0, 0);
+    auto node = copy_node<CacheNode>(temp_large_node.get());
     EXPECT_EQ(node->get_mem_size(), 272);
     node_cache.insert(virtual_chunk_offset_t(6, 0, 1), std::move(node));
     // Everything else should get evicted

--- a/category/mpt/test/node_test.cpp
+++ b/category/mpt/test/node_test.cpp
@@ -65,7 +65,7 @@ auto const path = 0xabcdabcdabcdabcd_bytes;
 TEST(NodeTest, leaf)
 {
     NibblesView const path1{1, 10, path.data()};
-    Node::UniquePtr node{make_node(0, {}, path1, value, {}, 0)};
+    Node::SharedPtr node{make_node(0, {}, path1, value, {}, 0)};
 
     EXPECT_EQ(node->mask, 0);
     EXPECT_EQ(node->value(), value);
@@ -86,7 +86,7 @@ TEST(NodeTest, leaf_single_branch)
     children[0].ptr = make_node(0, {}, path1, value, {}, 0);
     NibblesView const path2{1, 10, path.data()};
     uint16_t const mask = 1u << 0xc;
-    Node::UniquePtr node{
+    Node::SharedPtr node{
         create_node_with_children(comp, mask, children, path2, value, 0)};
 
     EXPECT_EQ(node->value(), value);
@@ -111,7 +111,7 @@ TEST(NodeTest, leaf_multiple_branches)
 
     NibblesView const path2{1, 10, path.data()};
     uint16_t const mask = (1u << 0xa) | (1u << 0xc);
-    Node::UniquePtr node{
+    Node::SharedPtr node{
         create_node_with_children(comp, mask, children, path2, value, 0)};
 
     EXPECT_EQ(node->value(), value);
@@ -136,7 +136,7 @@ TEST(NodeTest, branch_node)
 
     NibblesView const path2{1, 1, path.data()}; // path2 is empty
     uint16_t const mask = (1u << 0xa) | (1u << 0xc);
-    Node::UniquePtr node{create_node_with_children(
+    Node::SharedPtr node{create_node_with_children(
         comp, mask, children, path2, std::nullopt, 0)};
 
     EXPECT_EQ(node->value_len, 0);
@@ -161,7 +161,7 @@ TEST(NodeTest, extension_node)
 
     NibblesView const path2{1, 10, path.data()};
     uint16_t const mask = (1u << 0xa) | (1u << 0xc);
-    Node::UniquePtr node{create_node_with_children(
+    Node::SharedPtr node{create_node_with_children(
         comp, mask, children, path2, std::nullopt, 0)};
 
     EXPECT_EQ(node->value_len, 0);
@@ -176,7 +176,7 @@ TEST(NodeTest, super_large_node)
     DummyCompute const comp{};
     size_t const value_len = 255 * 1024 * 1024;
     monad::byte_string value(value_len, 0);
-    Node::UniquePtr node{make_node(0, {}, {}, value, {}, 0)};
+    Node::SharedPtr node{make_node(0, {}, {}, value, {}, 0)};
     EXPECT_EQ(node->value_len, value_len);
     EXPECT_EQ(node->bitpacked.data_len, 0);
     EXPECT_EQ(node->get_mem_size(), value_len + sizeof(Node));

--- a/category/mpt/test/node_writer_test.cpp
+++ b/category/mpt/test/node_writer_test.cpp
@@ -29,7 +29,7 @@ using namespace MONAD_ASYNC_NAMESPACE;
 
 namespace
 {
-    Node::UniquePtr make_node_of_size(unsigned const node_disk_size)
+    Node::SharedPtr make_node_of_size(unsigned const node_disk_size)
     {
         MONAD_ASSERT(node_disk_size > sizeof(Node) + Node::disk_size_bytes);
         auto const node_value_size =

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -594,7 +594,7 @@ TYPED_TEST(PlainTrieTest, node_version)
     EXPECT_EQ(this->root->version, 2);
 
     auto read_child = [&](Node &parent,
-                          unsigned const index) -> Node::UniquePtr {
+                          unsigned const index) -> Node::SharedPtr {
         return read_node_blocking(this->aux, parent.fnext(index), 0);
     };
     if (this->root->next(0)) {

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -87,7 +87,7 @@ namespace detail
                     continue;
                 }
                 MONAD_ASSERT(aux.is_on_disk());
-                Node::UniquePtr next_node_ondisk =
+                auto next_node_ondisk =
                     read_node_blocking(aux, node.fnext(idx), version);
                 if (!next_node_ondisk || !preorder_traverse_blocking_impl(
                                              aux,

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -1119,10 +1119,10 @@ find_cursor_result_type find_blocking(
 
 /* This function reads a node from the specified physical offset `node_offset`,
 where the spare bits indicate the number of pages to read. It returns a valid
-`Node::UniquePtr` on success, and returns `nullptr` if the specified version
+`Node::SharedPtr` on success, and returns `nullptr` if the specified version
 becomes invalid.
 */
-Node::UniquePtr read_node_blocking(
+Node::SharedPtr read_node_blocking(
     UpdateAuxImpl const &, chunk_offset_t node_offset, uint64_t version);
 
 //////////////////////////////////////////////////////////////////////////////

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -1160,7 +1160,7 @@ Node::SharedPtr UpdateAuxImpl::do_update(
 void UpdateAuxImpl::release_unreferenced_chunks()
 {
     auto const min_valid_version = db_history_min_valid_version();
-    Node::UniquePtr min_valid_root = read_node_blocking(
+    auto min_valid_root = read_node_blocking(
         *this,
         get_root_offset_at_version(min_valid_version),
         min_valid_version);


### PR DESCRIPTION
Replace UniquePtr→SharedPtr conversions with direct SharedPtr creation using std::allocate_shared and custom variable_size_allocator. This eliminates double memory allocations (separate control block and object) by allocating both in a single block.

- Add variable_size_allocator for single-allocation SharedPtr creation
- Create make_shared Node creation functions returning SharedPtr
- Modify existing Node creation function to return SharedPtr Some functions now have both shared and unique ptr versions for optimal usage

Partially generated using Claude Sonnet 4.5