### PR TITLE
[async] Optimize poll_uring_ with stack allocation and fix cq_ready bug

### DIFF
--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -27,6 +27,8 @@
 #include <category/core/tl_tid.h>
 #include <category/core/unordered_map.hpp>
 
+#include <boost/container/small_vector.hpp>
+
 #include <atomic>
 #include <cassert>
 #include <cerrno>
@@ -720,10 +722,12 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
         result<size_t> res{success(0)};
     };
 
-    std::vector<completion_t> completions;
+    constexpr size_t COMPLETIONS_STACK_CAPACITY = 64;
+    boost::container::small_vector<completion_t, COMPLETIONS_STACK_CAPACITY>
+        completions;
     completions.reserve(
-        2 + io_uring_sq_ready(other_ring) +
-        ((wr_ring != nullptr) ? io_uring_sq_ready(wr_ring) : 0));
+        2 + io_uring_cq_ready(other_ring) +
+        ((wr_ring != nullptr) ? io_uring_cq_ready(wr_ring) : 0));
     for (;;) {
         ring = nullptr;
         state = nullptr;


### PR DESCRIPTION
Use boost::container::small_vector to allocate up to 64 completion entries on the stack, avoiding heap allocation in the common case.

Fix bug where io_uring_sq_ready() was incorrectly used instead of io_uring_cq_ready() when reserving capacity for the completions vector. The code processes completion queue entries, not submission queue entries, so it should check completion queue readiness.

- Add COMPLETIONS_STACK_CAPACITY constant (64) for stack capacity
- Replace std::vector with small_vector for stack allocation
- Fix io_uring_sq_ready() → io_uring_cq_ready() in reserve() call

This code was generated using Claude Sonnet 4.5