### PR TITLE
log: move long db commit warning to execution

### DIFF
--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -1155,12 +1155,6 @@ Node::SharedPtr UpdateAuxImpl::do_update(
         curr_slow_writer_offset.offset,
         (uint32_t)compact_offset_fast,
         (uint32_t)compact_offset_slow);
-    if (duration > std::chrono::microseconds(500'000)) {
-        LOG_WARNING_CFORMAT(
-            "Upsert version %lu takes longer than 0.5 s, time elapsed: %ld us.",
-            version,
-            duration.count());
-    }
     return root;
 }
 

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -162,7 +162,12 @@ Result<void> process_ethereum_block(
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
-
+    if (commit_time > std::chrono::milliseconds(500)) {
+        LOG_WARNING(
+            "Slow block commit detected - block {}: {}",
+            block.header.number,
+            commit_time);
+    }
     // Post-commit validation of header, with Merkle root fields filled in
     auto const output_header = db.read_eth_header();
     BOOST_OUTCOME_TRY(

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -303,6 +303,12 @@ Result<BlockExecOutput> propose_block(
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
+    if (commit_time > std::chrono::milliseconds(500)) {
+        LOG_WARNING(
+            "Slow block commit detected - block {}: {}",
+            block.header.number,
+            commit_time);
+    }
 
     // Post-commit validation of header, with Merkle root fields filled in
     exec_output.eth_header = db.read_eth_header();


### PR DESCRIPTION
so it does not warn when restoring db from binary snapshot, where long db upsert time is expected