### PR TITLE
Convert debug asserts in category/async to MONAD_ASSERT

### DIFF
--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -97,9 +97,9 @@ struct chunk_offset_t
         , spare{spare_ & max_spare}
         , bits_format{0x1}
     {
-        MONAD_DEBUG_ASSERT(id_ <= max_id);
-        MONAD_DEBUG_ASSERT(offset_ <= max_offset);
-        MONAD_DEBUG_ASSERT(spare_ <= max_spare);
+        MONAD_ASSERT(id_ <= max_id);
+        MONAD_ASSERT(offset_ <= max_offset);
+        MONAD_ASSERT(spare_ <= max_spare);
     }
 
     constexpr bool operator==(chunk_offset_t const &o) const noexcept
@@ -122,7 +122,7 @@ struct chunk_offset_t
     {
         chunk_offset_t ret(*this);
         offset_ += ret.offset;
-        MONAD_DEBUG_ASSERT(offset_ <= max_offset);
+        MONAD_ASSERT(offset_ <= max_offset);
         ret.offset = offset_ & max_offset;
         return ret;
     }
@@ -149,7 +149,7 @@ struct chunk_offset_t
 
     void set_spare(uint16_t value) noexcept
     {
-        MONAD_DEBUG_ASSERT(value < max_spare);
+        MONAD_ASSERT(value < max_spare);
         spare = value & max_spare;
     }
 };

--- a/category/async/detail/connected_operation_storage.hpp
+++ b/category/async/detail/connected_operation_storage.hpp
@@ -46,7 +46,7 @@ namespace detail
 
         bool am_within_completions() const noexcept
         {
-            MONAD_DEBUG_ASSERT(within_completions_count >= 0);
+            MONAD_ASSERT(within_completions_count >= 0);
             return within_completions_count > 0;
         }
 
@@ -157,7 +157,7 @@ namespace detail
             // You must initiate operations on the same kernel thread as
             // the AsyncIO instance associated with this operation state
             // (except for threadsafeop)
-            MONAD_DEBUG_ASSERT(
+            MONAD_ASSERT(
                 this->executor() == nullptr || this->is_threadsafeop() ||
                 this->executor()->owning_thread_id() == get_tl_tid());
             this->being_executed_ = true;

--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -44,7 +44,7 @@ namespace detail
         constexpr explicit read_buffer_deleter(AsyncIO *parent)
             : parent_(parent)
         {
-            MONAD_DEBUG_ASSERT(parent != nullptr);
+            MONAD_ASSERT(parent != nullptr);
         }
 
         inline void operator()(std::byte *b);
@@ -60,7 +60,7 @@ namespace detail
         constexpr explicit write_buffer_deleter(AsyncIO *parent)
             : parent_(parent)
         {
-            MONAD_DEBUG_ASSERT(parent != nullptr);
+            MONAD_ASSERT(parent != nullptr);
         }
 
         inline void operator()(std::byte *b);
@@ -352,7 +352,7 @@ protected:
         , io_(&io)
     {
 #ifndef __clang__
-        MONAD_DEBUG_ASSERT(&io != nullptr);
+        MONAD_ASSERT(&io != nullptr);
 #endif
     }
 
@@ -432,9 +432,9 @@ public:
         static void set_key(node_ptr n, file_offset_t v)
         {
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
-            MONAD_DEBUG_ASSERT(v <= max_key);
+            MONAD_ASSERT(v <= max_key);
             n->key = v & max_key;
-            MONAD_DEBUG_ASSERT(n->key == v);
+            MONAD_ASSERT(n->key == v);
         }
 
         static erased_connected_operation *
@@ -481,9 +481,9 @@ public:
         static void set_key(erased_connected_operation *n, file_offset_t v)
         {
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
-            MONAD_DEBUG_ASSERT(v <= max_key);
+            MONAD_ASSERT(v <= max_key);
             n->rbtree_.key = v & max_key;
-            MONAD_DEBUG_ASSERT(n->rbtree_.key == v);
+            MONAD_ASSERT(n->rbtree_.key == v);
         }
 
         static node_ptr to_node_ptr(erased_connected_operation *n)

--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -305,9 +305,9 @@ void AsyncIO::submit_request_sqe_(
     std::span<std::byte> buffer, chunk_offset_t chunk_and_offset,
     void *uring_data, enum erased_connected_operation::io_priority prio)
 {
-    MONAD_DEBUG_ASSERT(uring_data != nullptr);
-    MONAD_DEBUG_ASSERT((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
-    MONAD_DEBUG_ASSERT(buffer.size() <= READ_BUFFER_SIZE);
+    MONAD_ASSERT(uring_data != nullptr);
+    MONAD_ASSERT((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
+    MONAD_ASSERT(buffer.size() <= READ_BUFFER_SIZE);
 
 #ifndef NDEBUG
     memset(buffer.data(), 0xff, buffer.size());
@@ -354,7 +354,7 @@ void AsyncIO::submit_request_(
     std::span<const struct iovec> buffers, chunk_offset_t chunk_and_offset,
     void *uring_data, enum erased_connected_operation::io_priority prio)
 {
-    MONAD_DEBUG_ASSERT(uring_data != nullptr);
+    MONAD_ASSERT(uring_data != nullptr);
     assert((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
 #ifndef NDEBUG
     for (auto const &buffer : buffers) {
@@ -405,10 +405,10 @@ void AsyncIO::submit_request_(
     std::span<std::byte const> buffer, chunk_offset_t chunk_and_offset,
     void *uring_data, enum erased_connected_operation::io_priority prio)
 {
-    MONAD_DEBUG_ASSERT(uring_data != nullptr);
+    MONAD_ASSERT(uring_data != nullptr);
     MONAD_ASSERT(!rwbuf_.is_read_only());
-    MONAD_DEBUG_ASSERT((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
-    MONAD_DEBUG_ASSERT(buffer.size() <= WRITE_BUFFER_SIZE);
+    MONAD_ASSERT((chunk_and_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
+    MONAD_ASSERT(buffer.size() <= WRITE_BUFFER_SIZE);
 
     auto const &ci = seq_chunks_[chunk_and_offset.id];
     auto offset = ci.chunk.write_fd(buffer.size()).second;
@@ -494,9 +494,9 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
 {
     // bit 0 in poll_rings_mask blocks read completions, bit 1 blocks write
     // completions
-    MONAD_DEBUG_ASSERT((poll_rings_mask & 3) != 3);
+    MONAD_ASSERT((poll_rings_mask & 3) != 3);
     auto h = detail::AsyncIO_per_thread_state().enter_completions();
-    MONAD_DEBUG_ASSERT(owning_tid_ == get_tl_tid());
+    MONAD_ASSERT(owning_tid_ == get_tl_tid());
 
     struct io_uring_cqe *cqe = nullptr;
     auto *const other_ring = &uring_.get_ring();

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -151,13 +151,13 @@ public:
 
     class storage_pool &storage_pool() noexcept
     {
-        MONAD_DEBUG_ASSERT(storage_pool_ != nullptr);
+        MONAD_ASSERT(storage_pool_ != nullptr);
         return *storage_pool_;
     }
 
     const class storage_pool &storage_pool() const noexcept
     {
-        MONAD_DEBUG_ASSERT(storage_pool_ != nullptr);
+        MONAD_ASSERT(storage_pool_ != nullptr);
         return *storage_pool_;
     }
 
@@ -475,7 +475,7 @@ public:
 
     read_buffer_ptr get_read_buffer(size_t bytes) noexcept
     {
-        MONAD_DEBUG_ASSERT(bytes <= READ_BUFFER_SIZE);
+        MONAD_ASSERT(bytes <= READ_BUFFER_SIZE);
         unsigned char *mem = rd_pool_.alloc();
         if (mem == nullptr) {
             mem = poll_uring_while_no_io_buffers_(false);
@@ -508,22 +508,22 @@ private:
             connected_operation_storage_pool_, 1);
         MONAD_ASSERT_PRINTF(
             mem != nullptr, "failed due to %s", strerror(errno));
-        MONAD_DEBUG_ASSERT(((void)mem[0], true));
+        MONAD_ASSERT(((void)mem[0], true));
         auto ret = std::unique_ptr<
             connected_type,
             io_connected_operation_unique_ptr_deleter>(
             new (mem) connected_type(connect()));
         // Did you accidentally pass in a foreign buffer to use?
         // Can't do that, must use buffer returned.
-        MONAD_DEBUG_ASSERT(ret->sender().buffer().data() == nullptr);
+        MONAD_ASSERT(ret->sender().buffer().data() == nullptr);
         if constexpr (is_write) {
-            MONAD_DEBUG_ASSERT(rwbuf_.get_write_size() >= WRITE_BUFFER_SIZE);
+            MONAD_ASSERT(rwbuf_.get_write_size() >= WRITE_BUFFER_SIZE);
             auto buffer = std::move(ret->sender()).buffer();
             buffer.set_write_buffer(get_write_buffer());
             ret->sender().reset(ret->sender().offset(), std::move(buffer));
         }
         else {
-            MONAD_DEBUG_ASSERT(rwbuf_.get_read_size() >= READ_BUFFER_SIZE);
+            MONAD_ASSERT(rwbuf_.get_read_size() >= READ_BUFFER_SIZE);
         }
         return ret;
     }
@@ -593,7 +593,7 @@ public:
                     state);
             erased_connected_operation::rbtree_node_traits::set_key(
                 p, state->sender().offset().raw());
-            MONAD_DEBUG_ASSERT(p->key == state->sender().offset().raw());
+            MONAD_ASSERT(p->key == state->sender().offset().raw());
             extant_write_operations_::init(p);
             auto pred = [](auto const *a, auto const *b) {
                 auto get_key = [](auto const *a) {

--- a/category/async/io_senders.hpp
+++ b/category/async/io_senders.hpp
@@ -351,7 +351,7 @@ public:
 
     result<void> operator()(erased_connected_operation *io_state) noexcept
     {
-        MONAD_DEBUG_ASSERT(!!buffer_);
+        MONAD_ASSERT(!!buffer_);
         buffer_.set_bytes_transferred(size_t(append_ - buffer_.data()));
         io_state->executor()->submit_write_request(buffer_, offset_, io_state);
         return success();
@@ -379,14 +379,14 @@ public:
 
     constexpr size_t written_buffer_bytes() const noexcept
     {
-        MONAD_DEBUG_ASSERT(buffer_.data() <= append_);
+        MONAD_ASSERT(buffer_.data() <= append_);
         return static_cast<size_t>(append_ - buffer_.data());
     }
 
     constexpr size_t remaining_buffer_bytes() const noexcept
     {
         auto const *end = buffer_.data() + buffer_.size();
-        MONAD_DEBUG_ASSERT(end >= append_);
+        MONAD_ASSERT(end >= append_);
         return static_cast<size_t>(end - append_);
     }
 

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -174,7 +174,7 @@ protected:
         const noexcept override
     {
         (void)code;
-        MONAD_DEBUG_ASSERT(code.domain() == *this);
+        MONAD_ASSERT(code.domain() == *this);
         return true;
     }
 
@@ -183,7 +183,7 @@ protected:
         const BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::status_code<void> &code2)
         const noexcept override
     {
-        MONAD_DEBUG_ASSERT(code1.domain() == *this);
+        MONAD_ASSERT(code1.domain() == *this);
         auto const &c1 =
             static_cast<sender_errc_with_payload_code const &>(code1);
         if (code2.domain() == *this) {
@@ -208,7 +208,7 @@ protected:
         const noexcept override
     {
         (void)code;
-        MONAD_DEBUG_ASSERT(code.domain() == *this);
+        MONAD_ASSERT(code.domain() == *this);
         return errc::unknown;
     }
 
@@ -216,7 +216,7 @@ protected:
         const BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::status_code<void> &code)
         const noexcept override
     {
-        MONAD_DEBUG_ASSERT(code.domain() == *this);
+        MONAD_ASSERT(code.domain() == *this);
         auto const &c =
             static_cast<sender_errc_with_payload_code const &>(code);
         switch (sender_errc(c.value().code)) {
@@ -234,7 +234,7 @@ protected:
         const BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::status_code<void> &code)
         const override
     {
-        MONAD_DEBUG_ASSERT(code.domain() == *this);
+        MONAD_ASSERT(code.domain() == *this);
         auto const &c =
             static_cast<sender_errc_with_payload_code const &>(code);
         throw BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::status_error<

--- a/category/async/test/sender_receiver.cpp
+++ b/category/async/test/sender_receiver.cpp
@@ -353,7 +353,7 @@ struct cpp_suspend_resume_io_receiver
         MONAD_ASYNC_NAMESPACE::erased_connected_operation *rawstate,
         MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type buffer)
     {
-        MONAD_DEBUG_ASSERT(!res.has_value());
+        MONAD_ASSERT(!res.has_value());
         res = {rawstate, std::move(buffer)};
         _h.resume();
     }
@@ -373,13 +373,13 @@ struct cpp_suspend_resume_io_receiver
 
     void await_suspend(std::coroutine_handle<> h)
     {
-        MONAD_DEBUG_ASSERT(!res.has_value());
+        MONAD_ASSERT(!res.has_value());
         _h = h;
     }
 
     result_type await_resume()
     {
-        MONAD_DEBUG_ASSERT(res.has_value());
+        MONAD_ASSERT(res.has_value());
         auto ret = std::move(res).value();
         res.reset();
         return ret;


### PR DESCRIPTION
The modified asserts seem to be simple and should not have significant performance impact.