### PR TITLE
Remove some redundant asserts

### DIFF
--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -434,7 +434,6 @@ public:
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
             MONAD_ASSERT(v <= max_key);
             n->key = v & max_key;
-            MONAD_ASSERT(n->key == v);
         }
 
         static erased_connected_operation *
@@ -483,7 +482,6 @@ public:
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
             MONAD_ASSERT(v <= max_key);
             n->rbtree_.key = v & max_key;
-            MONAD_ASSERT(n->rbtree_.key == v);
         }
 
         static node_ptr to_node_ptr(erased_connected_operation *n)

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -508,7 +508,6 @@ private:
             connected_operation_storage_pool_, 1);
         MONAD_ASSERT_PRINTF(
             mem != nullptr, "failed due to %s", strerror(errno));
-        MONAD_ASSERT(((void)mem[0], true));
         auto ret = std::unique_ptr<
             connected_type,
             io_connected_operation_unique_ptr_deleter>(


### PR DESCRIPTION
Second assert after bitmask is always true because of the first one and not necessary.

Assertion for memory accessible is not necessary, memory will be accessed by constructor.