### PR TITLE
[test/unit]: Have TraitsTest play nicer with fixtures

### DIFF
--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -66,10 +66,9 @@ namespace
 }
 
 template <typename MonadRevisionT>
-struct StakeTraits : public ::testing::Test
+struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
 {
-    static constexpr monad_revision REV = MonadRevisionT::value;
-    using Trait = MonadTraits<REV>;
+    using Trait = MonadTraitsTest<MonadRevisionT>::Trait;
 
     OnDiskMachine machine;
     vm::VM vm;
@@ -341,9 +340,7 @@ using StakeBeforeActiveValidatorStakeFork =
 template <typename MonadRevisionT>
 using StakeAllRevisions = StakeTraits<MonadRevisionT>;
 
-TYPED_TEST_SUITE(
-    StakeAllRevisions, ::detail::MonadRevisionTypes,
-    ::detail::RevisionTestNameGenerator);
+DEFINE_MONAD_TRAITS_FIXTURE(StakeAllRevisions);
 
 TEST_F(StakeLatest, invoke_fallback)
 {

--- a/test/unit/common/include/monad/test/traits_test.hpp
+++ b/test/unit/common/include/monad/test/traits_test.hpp
@@ -87,6 +87,24 @@ namespace detail
     };
 }
 
+#define DEFINE_MONAD_TRAITS_FIXTURE(FIXTURE_NAME)                              \
+    TYPED_TEST_SUITE(                                                          \
+        FIXTURE_NAME,                                                          \
+        ::detail::MonadRevisionTypes,                                          \
+        ::detail::RevisionTestNameGenerator)
+
+#define DEFINE_ETHEREUM_TRAITS_FIXTURE(FIXTURE_NAME)                           \
+    TYPED_TEST_SUITE(                                                          \
+        FIXTURE_NAME,                                                          \
+        ::detail::EvmRevisionTypes,                                            \
+        ::detail::RevisionTestNameGenerator)
+
+#define DEFINE_TRAITS_FIXTURE(FIXTURE_NAME)                                    \
+    TYPED_TEST_SUITE(                                                          \
+        FIXTURE_NAME,                                                          \
+        ::detail::MonadEvmRevisionTypes,                                       \
+        ::detail::RevisionTestNameGenerator)
+
 template <typename MonadRevisionT>
 struct MonadTraitsTest : public ::testing::Test
 {
@@ -94,9 +112,7 @@ struct MonadTraitsTest : public ::testing::Test
     using Trait = monad::MonadTraits<REV>;
 };
 
-TYPED_TEST_SUITE(
-    MonadTraitsTest, ::detail::MonadRevisionTypes,
-    ::detail::RevisionTestNameGenerator);
+DEFINE_MONAD_TRAITS_FIXTURE(MonadTraitsTest);
 
 template <typename EvmRevisionT>
 struct EvmTraitsTest : public ::testing::Test
@@ -105,9 +121,7 @@ struct EvmTraitsTest : public ::testing::Test
     using Trait = monad::EvmTraits<REV>;
 };
 
-TYPED_TEST_SUITE(
-    EvmTraitsTest, ::detail::EvmRevisionTypes,
-    ::detail::RevisionTestNameGenerator);
+DEFINE_ETHEREUM_TRAITS_FIXTURE(EvmTraitsTest);
 
 template <typename T>
 struct TraitsTest : public ::testing::Test
@@ -147,6 +161,4 @@ std::vector<std::variant<evmc_revision, monad_revision>> monad_evm_revisions()
     return result;
 }
 
-TYPED_TEST_SUITE(
-    TraitsTest, ::detail::MonadEvmRevisionTypes,
-    ::detail::RevisionTestNameGenerator);
+DEFINE_TRAITS_FIXTURE(TraitsTest);


### PR DESCRIPTION
 * Define helper macros for defining a TYPED_TEST suite so users don't have to reach into the detail namespace.
 * Have existing suites inherit from the relevant TraitsTest instead of duplicating that logic inside their own suite.