### PR TITLE
Fix allocator to throw if allocation fails, remove assertion

### DIFF
--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -506,8 +506,6 @@ private:
             std::allocator_traits<connected_operation_storage_allocator_type_>;
         unsigned char *mem = (unsigned char *)traits::allocate(
             connected_operation_storage_pool_, 1);
-        MONAD_ASSERT_PRINTF(
-            mem != nullptr, "failed due to %s", strerror(errno));
         auto ret = std::unique_ptr<
             connected_type,
             io_connected_operation_unique_ptr_deleter>(

--- a/category/core/mem/allocators.hpp
+++ b/category/core/mem/allocators.hpp
@@ -89,22 +89,30 @@ namespace allocators
         [[nodiscard]] constexpr T *allocate(size_t const no)
         {
             MONAD_ASSERT(no < size_t(-1) / sizeof(T));
+            void *p;
             if constexpr (alignof(T) > alignof(max_align_t)) {
-                return reinterpret_cast<T *>(
-                    std::aligned_alloc(alignof(T), no * sizeof(T)));
+                p = std::aligned_alloc(alignof(T), no * sizeof(T));
             }
-            return reinterpret_cast<T *>(std::malloc(no * sizeof(T)));
+            else {
+                p = std::malloc(no * sizeof(T));
+            }
+            MONAD_ASSERT(p != nullptr);
+            return reinterpret_cast<T *>(p);
         }
 
         template <class U>
         [[nodiscard]] constexpr T *allocate_overaligned(size_t const no)
         {
             MONAD_ASSERT(no < size_t(-1) / sizeof(T));
+            void *p;
             if constexpr (alignof(U) > alignof(max_align_t)) {
-                return reinterpret_cast<T *>(
-                    std::aligned_alloc(alignof(U), no * sizeof(T)));
+                p = std::aligned_alloc(alignof(U), no * sizeof(T));
             }
-            return reinterpret_cast<T *>(std::malloc(no * sizeof(T)));
+            else {
+                p = std::malloc(no * sizeof(T));
+            }
+            MONAD_ASSERT(p != nullptr);
+            return reinterpret_cast<T *>(p);
         }
 
         constexpr void deallocate(T *const p, size_t const)


### PR DESCRIPTION
Allocator is supposed to return valid memory or throw so checking for allocation success is not necessary in the callers.

This change also fixes the cases where we used the allocator without checking return value.