### PR TITLE
Convert `execute_block` call tree to use spans

### DIFF
--- a/category/execution/ethereum/chain/chain.hpp
+++ b/category/execution/ethereum/chain/chain.hpp
@@ -25,6 +25,7 @@
 #include <evmc/evmc.hpp>
 
 #include <optional>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -52,7 +53,7 @@ struct Chain
     virtual Result<void> validate_transaction(
         uint64_t block_number, uint64_t timestamp, Transaction const &,
         Address const &sender, State &, uint256_t const &base_fee_per_gas,
-        std::vector<std::optional<Address>> const &authorities) const = 0;
+        std::span<std::optional<Address> const> authorities) const = 0;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -162,7 +162,7 @@ GenesisState EthereumMainnet::get_genesis_state() const
 Result<void> EthereumMainnet::validate_transaction(
     uint64_t const block_number, uint64_t const timestamp,
     Transaction const &tx, Address const &sender, State &state,
-    uint256_t const &, std::vector<std::optional<Address>> const &) const
+    uint256_t const &, std::span<std::optional<Address> const>) const
 {
     evmc_revision const rev = get_revision(block_number, timestamp);
     auto const sender_account = state.recent_account(sender);

--- a/category/execution/ethereum/chain/ethereum_mainnet.hpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.hpp
@@ -24,6 +24,8 @@
 
 #include <evmc/evmc.h>
 
+#include <span>
+
 MONAD_NAMESPACE_BEGIN
 
 struct BlockHeader;
@@ -52,7 +54,7 @@ struct EthereumMainnet : Chain
     virtual Result<void> validate_transaction(
         uint64_t block_number, uint64_t timestamp, Transaction const &,
         Address const &sender, State &, uint256_t const &base_fee_per_gas,
-        std::vector<std::optional<Address>> const &authorities) const override;
+        std::span<std::optional<Address> const> authorities) const override;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -112,7 +112,7 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 std::vector<std::optional<Address>> recover_senders(
-    std::vector<Transaction> const &transactions,
+    std::span<Transaction const> const transactions,
     fiber::PriorityPool &priority_pool)
 {
     std::vector<std::optional<Address>> senders{transactions.size()};
@@ -140,7 +140,7 @@ std::vector<std::optional<Address>> recover_senders(
 }
 
 std::vector<std::vector<std::optional<Address>>> recover_authorities(
-    std::vector<Transaction> const &transactions,
+    std::span<Transaction const> const transactions,
     fiber::PriorityPool &priority_pool)
 {
     std::vector<std::vector<std::optional<Address>>> authorities{
@@ -213,12 +213,12 @@ template <Traits traits>
 Result<std::vector<Receipt>> execute_block_transactions(
     Chain const &chain, BlockHeader const &header,
     std::span<Transaction const> const transactions,
-    std::vector<Address> const &senders,
-    std::vector<std::vector<std::optional<Address>>> const &authorities,
+    std::span<Address const> const senders,
+    std::span<std::vector<std::optional<Address>> const> const authorities,
     BlockState &block_state, BlockHashBuffer const &block_hash_buffer,
     fiber::PriorityPool &priority_pool, BlockMetrics &block_metrics,
-    std::vector<std::unique_ptr<CallTracerBase>> &call_tracers,
-    std::vector<std::unique_ptr<trace::StateTracer>> &state_tracers,
+    std::span<std::unique_ptr<CallTracerBase>> const call_tracers,
+    std::span<std::unique_ptr<trace::StateTracer>> const state_tracers,
     RevertTransactionFn const &revert_transaction)
 {
     MONAD_ASSERT(senders.size() == transactions.size());
@@ -329,12 +329,13 @@ EXPLICIT_TRAITS(execute_block_transactions);
 
 template <Traits traits>
 Result<std::vector<Receipt>> execute_block(
-    Chain const &chain, Block const &block, std::vector<Address> const &senders,
-    std::vector<std::vector<std::optional<Address>>> const &authorities,
+    Chain const &chain, Block const &block,
+    std::span<Address const> const senders,
+    std::span<std::vector<std::optional<Address>> const> const authorities,
     BlockState &block_state, BlockHashBuffer const &block_hash_buffer,
     fiber::PriorityPool &priority_pool, BlockMetrics &block_metrics,
-    std::vector<std::unique_ptr<CallTracerBase>> &call_tracers,
-    std::vector<std::unique_ptr<trace::StateTracer>> &state_tracers,
+    std::span<std::unique_ptr<CallTracerBase>> const call_tracers,
+    std::span<std::unique_ptr<trace::StateTracer>> const state_tracers,
     RevertTransactionFn const &revert_transaction)
 {
     TRACE_BLOCK_EVENT(StartBlock);

--- a/category/execution/ethereum/execute_block.hpp
+++ b/category/execution/ethereum/execute_block.hpp
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <vector>
 
 MONAD_NAMESPACE_BEGIN
@@ -42,28 +43,28 @@ struct Chain;
 template <Traits traits>
 Result<std::vector<Receipt>> execute_block_transactions(
     Chain const &, BlockHeader const &, std::span<Transaction const>,
-    std::vector<Address> const &senders,
-    std::vector<std::vector<std::optional<Address>>> const &authorities,
+    std::span<Address const> senders,
+    std::span<std::vector<std::optional<Address>> const> authorities,
     BlockState &, BlockHashBuffer const &, fiber::PriorityPool &,
-    BlockMetrics &, std::vector<std::unique_ptr<CallTracerBase>> &,
-    std::vector<std::unique_ptr<trace::StateTracer>> &state_tracers,
+    BlockMetrics &, std::span<std::unique_ptr<CallTracerBase>>,
+    std::span<std::unique_ptr<trace::StateTracer>> state_tracers,
     RevertTransactionFn const & = [](Address const &, Transaction const &,
                                      uint64_t, State &) { return false; });
 
 template <Traits traits>
 Result<std::vector<Receipt>> execute_block(
-    Chain const &, Block const &, std::vector<Address> const &senders,
-    std::vector<std::vector<std::optional<Address>>> const &authorities,
+    Chain const &, Block const &, std::span<Address const> senders,
+    std::span<std::vector<std::optional<Address>> const> authorities,
     BlockState &, BlockHashBuffer const &, fiber::PriorityPool &,
-    BlockMetrics &, std::vector<std::unique_ptr<CallTracerBase>> &,
-    std::vector<std::unique_ptr<trace::StateTracer>> &state_tracers,
+    BlockMetrics &, std::span<std::unique_ptr<CallTracerBase>>,
+    std::span<std::unique_ptr<trace::StateTracer>> state_tracers,
     RevertTransactionFn const & = [](Address const &, Transaction const &,
                                      uint64_t, State &) { return false; });
 
 std::vector<std::optional<Address>>
-recover_senders(std::vector<Transaction> const &, fiber::PriorityPool &);
+recover_senders(std::span<Transaction const>, fiber::PriorityPool &);
 
 std::vector<std::vector<std::optional<Address>>>
-recover_authorities(std::vector<Transaction> const &, fiber::PriorityPool &);
+recover_authorities(std::span<Transaction const>, fiber::PriorityPool &);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -77,7 +77,7 @@ MONAD_NAMESPACE_BEGIN
 template <Traits traits>
 ExecuteTransactionNoValidation<traits>::ExecuteTransactionNoValidation(
     Chain const &chain, Transaction const &tx, Address const &sender,
-    std::vector<std::optional<Address>> const &authorities,
+    std::span<std::optional<Address> const> const authorities,
     BlockHeader const &header, uint64_t const i,
     RevertTransactionFn const &revert_transaction)
     : chain_{chain}
@@ -281,7 +281,7 @@ template <Traits traits>
 ExecuteTransaction<traits>::ExecuteTransaction(
     Chain const &chain, uint64_t const i, Transaction const &tx,
     Address const &sender,
-    std::vector<std::optional<Address>> const &authorities,
+    std::span<std::optional<Address> const> const authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
     BlockState &block_state, BlockMetrics &block_metrics,
     boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -26,7 +26,7 @@
 #include <evmc/evmc.hpp>
 
 #include <cstdint>
-#include <vector>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -56,7 +56,7 @@ protected:
     Chain const &chain_;
     Transaction const &tx_;
     Address const &sender_;
-    std::vector<std::optional<Address>> const &authorities_;
+    std::span<std::optional<Address> const> const authorities_;
     BlockHeader const &header_;
     uint64_t i_;
     RevertTransactionFn revert_transaction_;
@@ -64,7 +64,7 @@ protected:
 public:
     ExecuteTransactionNoValidation(
         Chain const &, Transaction const &, Address const &,
-        std::vector<std::optional<Address>> const &, BlockHeader const &,
+        std::span<std::optional<Address> const>, BlockHeader const &,
         uint64_t i,
         RevertTransactionFn const & = [](Address const &, Transaction const &,
                                          uint64_t, State &) { return false; });
@@ -96,7 +96,7 @@ class ExecuteTransaction : public ExecuteTransactionNoValidation<traits>
 public:
     ExecuteTransaction(
         Chain const &, uint64_t i, Transaction const &, Address const &,
-        std::vector<std::optional<Address>> const &, BlockHeader const &,
+        std::span<std::optional<Address> const>, BlockHeader const &,
         BlockHashBuffer const &, BlockState &, BlockMetrics &,
         boost::fibers::promise<void> &prev, CallTracerBase &,
         trace::StateTracer &,

--- a/category/execution/monad/chain/monad_chain.cpp
+++ b/category/execution/monad/chain/monad_chain.cpp
@@ -73,7 +73,7 @@ Result<void> MonadChain::validate_transaction(
     uint64_t const block_number, uint64_t const timestamp,
     Transaction const &tx, Address const &sender, State &state,
     uint256_t const &base_fee_per_gas,
-    std::vector<std::optional<Address>> const &authorities) const
+    std::span<std::optional<Address> const> const authorities) const
 {
 
     monad_revision const monad_rev = get_monad_revision(timestamp);

--- a/category/execution/monad/chain/monad_chain.hpp
+++ b/category/execution/monad/chain/monad_chain.hpp
@@ -25,6 +25,7 @@
 #include <evmc/evmc.h>
 
 #include <optional>
+#include <span>
 #include <vector>
 
 MONAD_NAMESPACE_BEGIN
@@ -62,7 +63,7 @@ struct MonadChain : Chain
     virtual Result<void> validate_transaction(
         uint64_t block_number, uint64_t timestamp, Transaction const &,
         Address const &sender, State &, uint256_t const &base_fee_per_gas,
-        std::vector<std::optional<Address>> const &authorities) const override;
+        std::span<std::optional<Address> const> authorities) const override;
 
     bool revert_transaction(
         uint64_t block_number, uint64_t timestamp, Address const &sender,

--- a/category/execution/monad/validate_monad_transaction.cpp
+++ b/category/execution/monad/validate_monad_transaction.cpp
@@ -32,7 +32,7 @@ Result<void> validate_monad_transaction(
     monad_revision const monad_rev, evmc_revision const rev,
     Transaction const &tx, Address const &sender, State &state,
     uint256_t const &base_fee_per_gas,
-    std::vector<std::optional<Address>> const &authorities)
+    std::span<std::optional<Address> const> const authorities)
 {
     auto const acct = state.recent_account(sender);
     auto const &icode = state.get_code(sender)->intercode();

--- a/category/execution/monad/validate_monad_transaction.hpp
+++ b/category/execution/monad/validate_monad_transaction.hpp
@@ -34,7 +34,7 @@
 
 #include <initializer_list>
 #include <optional>
-#include <vector>
+#include <span>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -52,7 +52,7 @@ enum class MonadTransactionError
 Result<void> validate_monad_transaction(
     monad_revision, evmc_revision, Transaction const &, Address const &sender,
     State &, uint256_t const &base_fee_per_gas,
-    std::vector<std::optional<Address>> const &authorities);
+    std::span<std::optional<Address> const> authorities);
 
 MONAD_NAMESPACE_END
 

--- a/category/rpc/eth_call.cpp
+++ b/category/rpc/eth_call.cpp
@@ -600,7 +600,8 @@ struct monad_eth_call_executor
             return;
         }
 
-        auto const authorities = recover_authorities({txn}, active_pool.pool);
+        auto const authorities =
+            recover_authorities(std::span{&txn, 1}, active_pool.pool);
         MONAD_ASSERT(authorities.size() == 1);
 
         active_pool.pool.submit(


### PR DESCRIPTION
Follow up to https://github.com/category-labs/monad/pull/1848 to convert the rest of the arguments to `execute_block` (and downstream code) to use `std::span<T const>` instead of `std::vector<T> const&`