### PR TITLE
expand clang-tidy checks to category/async

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@
                     clang-analyzer*,
                     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
                     -clang-analyzer-security.insecureAPI.strcpy,
+                    -clang-analyzer-optin.core.EnumCastOutOfRange,
                     google-build-explicit-make-pair,
                     google-explicit-constructor,
                     llvm-include-order,
@@ -59,7 +60,7 @@
     - key:          bugprone-string-constructor.StringNames
       value:        ::std::basic_string;::std::basic_string_view;::absl::string_view
     - key:          misc-include-cleaner.IgnoreHeaders
-      value:        gtest/|gmock/|sys/|CLI/|boost/|llvm/
+      value:        gtest/.*|gmock/.*|sys/.*|CLI/.*|boost/.*|llvm/.*|quill/.*
     - key:          modernize-use-default-member-init.UseAssignment
       value:        1
     - key:          modernize-use-transparent-functors.SafeMode
@@ -68,7 +69,7 @@
       value:        1
     - key:          modernize-loop-convert.UseCxx20ReverseRanges
       value:        false
-    - key:          misc-include-cleaner.IgnoreHeaders
-      value:        'quill/.*'
+    - key:          bugprone-unused-return-value.AllowCastToVoid
+      value:        true
 ...
 

--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -208,7 +208,7 @@ namespace std
             return v_.is_lock_free();
         }
 
-        constexpr atomic(value_type v) noexcept
+        constexpr explicit atomic(value_type v) noexcept
             : v_(std::bit_cast<uint64_t>(v))
         {
         }

--- a/category/async/detail/connected_operation_storage.hpp
+++ b/category/async/detail/connected_operation_storage.hpp
@@ -102,7 +102,7 @@ namespace detail
 
     inline AsyncIO *AsyncIO_thread_instance() noexcept
     {
-        auto &ts = AsyncIO_per_thread_state();
+        auto const &ts = AsyncIO_per_thread_state();
         return ts.instance;
     }
 
@@ -149,8 +149,8 @@ namespace detail
         Sender sender_;
         Receiver receiver_;
 
-        virtual initiation_result do_possibly_deferred_initiate_(
-            bool never_defer, bool is_retry) noexcept override
+        virtual initiation_result
+        do_possibly_deferred_initiate_(bool never_defer, bool is_retry) override
         {
             (void)
                 is_retry; // useful to know how this initiation is coming about
@@ -385,7 +385,7 @@ namespace detail
         //! If successful do NOT modify anything after
         //! this until after completion, it may cause a silent page
         //! copy-on-write.
-        initiation_result initiate() noexcept
+        initiation_result initiate()
         {
             // NOTE Keep this in sync with the one in
             // erased_connected_operation. This is here to aid devirtualisation.

--- a/category/async/detail/scope_polyfill.hpp
+++ b/category/async/detail/scope_polyfill.hpp
@@ -153,7 +153,7 @@ namespace monad
                         return;
                     }
     #if __cplusplus >= 201700 || _HAS_CXX17
-                    bool unwind_is_due_to_throw =
+                    bool const unwind_is_due_to_throw =
                         (std::uncaught_exceptions() > uncaught_exceptions_);
     #else
                     bool unwind_is_due_to_throw = std::uncaught_exception();

--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -115,7 +115,7 @@ public:
     using base_::size_bytes;
     using base_::subspan;
 
-    constexpr filled_read_buffer() {}
+    constexpr filled_read_buffer() = default;
 
     filled_read_buffer(filled_read_buffer const &) = delete;
     filled_read_buffer(filled_read_buffer &&) = default;
@@ -206,7 +206,7 @@ public:
     using base_::size_bytes;
     using base_::subspan;
 
-    constexpr filled_write_buffer() {}
+    constexpr filled_write_buffer() = default;
 
     filled_write_buffer(filled_write_buffer const &) = delete;
     filled_write_buffer(filled_write_buffer &&) = default;
@@ -356,8 +356,8 @@ protected:
 #endif
     }
 
-    virtual initiation_result do_possibly_deferred_initiate_(
-        bool never_defer, bool is_retry) noexcept = 0;
+    virtual initiation_result
+    do_possibly_deferred_initiate_(bool never_defer, bool is_retry) = 0;
 
 public:
     union

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -73,7 +73,7 @@ private:
         chunk_t &chunk;
         int io_uring_read_fd{-1}, io_uring_write_fd{-1}; // NOT POSIX fds!
 
-        constexpr chunk_ref_(chunk_t &chunk_)
+        constexpr explicit chunk_ref_(chunk_t &chunk_)
             : chunk{chunk_}
             , io_uring_read_fd{chunk.read_fd().first}
             , io_uring_write_fd{chunk.write_fd(0).first}
@@ -422,7 +422,7 @@ public:
         ConnectedOperationType state[0];
 #pragma GCC diagnostic pop
 
-        constexpr registered_io_buffer_with_connected_operation() {}
+        constexpr registered_io_buffer_with_connected_operation() = default;
     };
     friend struct io_connected_operation_unique_ptr_deleter;
 
@@ -473,7 +473,7 @@ public:
     using read_buffer_ptr = detail::read_buffer_ptr;
     using write_buffer_ptr = detail::write_buffer_ptr;
 
-    read_buffer_ptr get_read_buffer(size_t bytes) noexcept
+    read_buffer_ptr get_read_buffer(size_t bytes)
     {
         MONAD_ASSERT(bytes <= READ_BUFFER_SIZE);
         unsigned char *mem = rd_pool_.alloc();
@@ -484,7 +484,7 @@ public:
             (std::byte *)mem, detail::read_buffer_deleter(this));
     }
 
-    write_buffer_ptr get_write_buffer() noexcept
+    write_buffer_ptr get_write_buffer()
     {
         unsigned char *mem = wr_pool_.alloc();
         if (mem == nullptr) {
@@ -544,7 +544,9 @@ public:
         return make_connected_impl_ < Sender::my_operation_type ==
                operation_type::write > ([&] {
                    return connect<Sender, Receiver>(
-                       *this, std::move(sender), std::move(receiver));
+                       *this,
+                       std::forward<Sender>(sender),
+                       std::forward<Receiver>(receiver));
                });
     }
 

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -97,9 +97,9 @@ public:
             std::reference_wrapper<filled_write_buffer>>
             payload;
 
-        constexpr value_type() noexcept {}
+        constexpr value_type() noexcept = default;
 
-        constexpr value_type(sender_errc code_) noexcept
+        constexpr explicit value_type(sender_errc code_) noexcept
             : code(code_)
         {
         }
@@ -275,11 +275,14 @@ namespace detail
 
         thread_local_sender_errc_with_payload_code_allocator() = default;
 
+        // NOLINTBEGIN(google-explicit-constructor)
         template <class U>
         constexpr thread_local_sender_errc_with_payload_code_allocator(
             thread_local_sender_errc_with_payload_code_allocator<U> const &)
         {
         }
+
+        // NOLINTEND(google-explicit-constructor)
 
         [[nodiscard]] value_type *allocate(size_type n)
         {

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -35,7 +35,6 @@
 #include <limits>
 #include <mutex>
 #include <span>
-#include <sstream>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -503,7 +502,7 @@ storage_pool::device_t storage_pool::make_device_(
 void storage_pool::fill_chunks_(creation_flags const &flags)
 {
     auto hashshouldbe = fnv1a_hash<uint32_t>::begin();
-    for (auto &device : devices_) {
+    for (auto const &device : devices_) {
         fnv1a_hash<uint32_t>::add(hashshouldbe, uint32_t(device.unique_hash_));
         fnv1a_hash<uint32_t>::add(
             hashshouldbe, uint32_t(device.unique_hash_ >> 32));
@@ -609,7 +608,7 @@ void storage_pool::fill_chunks_(creation_flags const &flags)
         }
 #ifndef NDEBUG
         for (size_t n = 0; n < chunks.size(); n++) {
-            auto devicechunks = devices_[n].chunks();
+            auto const devicechunks = devices_[n].chunks();
             MONAD_ASSERT(chunks[n] == devicechunks);
         }
 #endif
@@ -789,7 +788,7 @@ storage_pool::~storage_pool()
     cleanupchunks_(seq);
     for (auto const &device : devices_) {
         if (device.metadata_ != nullptr) {
-            auto total_size =
+            auto const total_size =
                 device.metadata_->total_size(device.size_of_file_);
             ::munmap(
                 reinterpret_cast<void *>(round_down_align<CPU_PAGE_BITS>(
@@ -821,7 +820,7 @@ storage_pool::chunk_t storage_pool::activate_chunk(
 #ifndef __clang__
     MONAD_ASSERT(this != nullptr);
 #endif
-    std::unique_lock g(lock_);
+    std::unique_lock const g(lock_);
     chunk_t const ret = [&]() {
         switch (which) {
         case chunk_type::cnv:

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -103,13 +103,13 @@ public:
             size_t chunks(file_offset_t end_of_this_offset) const noexcept
             {
                 end_of_this_offset -= sizeof(metadata_t);
-                auto ret =
+                auto const ret =
                     end_of_this_offset / (chunk_capacity + sizeof(uint32_t));
                 // We need the front CPU_PAGE_SIZE of this metadata to not
                 // include any chunk
-                auto endofchunks =
+                auto const endofchunks =
                     round_down_align<CPU_PAGE_BITS>(ret * chunk_capacity);
-                auto startofmetadata = round_down_align<CPU_PAGE_BITS>(
+                auto const startofmetadata = round_down_align<CPU_PAGE_BITS>(
                     end_of_this_offset - ret * sizeof(uint32_t));
                 if (startofmetadata == endofchunks) {
                     return ret - 1;
@@ -123,7 +123,7 @@ public:
             {
                 static_assert(
                     sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));
-                auto count = chunks(end_of_this_offset);
+                auto const count = chunks(end_of_this_offset);
                 return {
                     start_lifetime_as_array<std::atomic<uint32_t>>(
                         const_cast<std::byte *>(
@@ -136,7 +136,7 @@ public:
             // Bytes used by the pool metadata on this device
             size_t total_size(file_offset_t end_of_this_offset) const noexcept
             {
-                auto count = chunks(end_of_this_offset);
+                auto const count = chunks(end_of_this_offset);
                 return sizeof(metadata_t) + count * sizeof(uint32_t);
             }
         } *const metadata_;

--- a/category/async/test/benchmark_io_test.cpp
+++ b/category/async/test/benchmark_io_test.cpp
@@ -186,11 +186,12 @@ struct shared_state_t
             max_ns = elapsed_ns;
         }
         acc_ns += elapsed_ns;
-        auto r = rand();
+        auto const r = rand();
         auto [chunk_id, chunk_size_div_disk_page_size] =
             chunk_sizes_div_disk_page_size
                 [r % uint32_t(chunk_sizes_div_disk_page_size.size())];
-        auto offset_into_chunk = (r >> 16) % chunk_size_div_disk_page_size;
+        auto const offset_into_chunk =
+            (r >> 16) % chunk_size_div_disk_page_size;
         return MONAD_ASYNC_NAMESPACE::chunk_offset_t(
             chunk_id,
             offset_into_chunk * MONAD_ASYNC_NAMESPACE::DISK_PAGE_SIZE);
@@ -246,292 +247,314 @@ inline void receiver_t::set_value(
 
 int main(int argc, char *argv[])
 {
-    CLI::App cli("Tool for benchmarking the i/o engine", "benchmark_io_test");
-    cli.footer(R"(Suitable sources of block storage:
+    try {
+        CLI::App cli(
+            "Tool for benchmarking the i/o engine", "benchmark_io_test");
+        cli.footer(R"(Suitable sources of block storage:
 
 1. Raw partitions on a storage device.
 2. The storage device itself.
 3. A file on a filing system (use 'truncate -s 1T sparsefile' to create and
 set it to the desired size beforehand).
 )");
-    try {
-        bool destroy_and_fill = false;
-        unsigned destroy_and_really_fill_count = 0;
-        std::vector<std::filesystem::path> storage_paths;
-        monad::io::RingConfig ringconfig{128};
-        unsigned concurrent_io = 2048;
-        unsigned concurrent_read_io_limit = 0;
-        bool eager_completions = false;
-        bool highest_io_priority = false;
-        unsigned workload_us = 5;
-        unsigned duration_secs = 30;
-        cli.add_option(
-               "--storage",
-               storage_paths,
-               "one or more sources of block storage (must be at least 256Mb + "
-               "4Kb long).")
-            ->required();
-        cli.add_flag(
-            "--fill",
-            destroy_and_fill,
-            "destroy all existing contents, mark all chunks as full before "
-            "doing test.");
-        cli.add_option(
-            "--really-fill",
-            destroy_and_really_fill_count,
-            "destroy all existing contents, actually fill percentage of total "
-            "chunks specified before doing test.");
-        cli.add_option(
-            "--concurrent-io",
-            concurrent_io,
-            "how many i/o this test program should do concurrently. Default is "
-            "2048.");
+        try {
+            bool destroy_and_fill = false;
+            unsigned destroy_and_really_fill_count = 0;
+            std::vector<std::filesystem::path> storage_paths;
+            monad::io::RingConfig ringconfig{128};
+            unsigned concurrent_io = 2048;
+            unsigned concurrent_read_io_limit = 0;
+            bool eager_completions = false;
+            bool highest_io_priority = false;
+            unsigned workload_us = 5;
+            unsigned duration_secs = 30;
+            cli.add_option(
+                   "--storage",
+                   storage_paths,
+                   "one or more sources of block storage (must be at least "
+                   "256Mb + "
+                   "4Kb long).")
+                ->required();
+            cli.add_flag(
+                "--fill",
+                destroy_and_fill,
+                "destroy all existing contents, mark all chunks as full before "
+                "doing test.");
+            cli.add_option(
+                "--really-fill",
+                destroy_and_really_fill_count,
+                "destroy all existing contents, actually fill percentage of "
+                "total "
+                "chunks specified before doing test.");
+            cli.add_option(
+                "--concurrent-io",
+                concurrent_io,
+                "how many i/o this test program should do concurrently. "
+                "Default is "
+                "2048.");
 
-        cli.add_option(
-            "--ring-entries",
-            ringconfig.entries,
-            "how many submission entries io_uring should have. Default is "
-            "128.");
-        cli.add_flag(
-            "--enable-io-polling",
-            ringconfig.enable_io_polling,
-            "whether to enable i/o polling within the kernel. Default is no "
-            "i/o polling.");
-        cli.add_option(
-            "--kernel-poll-thread",
-            ringconfig.sq_thread_cpu,
-            "on what CPU to run a spin polling thread within the kernel. "
-            "Default is no kernel thread.");
-        cli.add_option(
-            "--concurrent-read-io-limit",
-            concurrent_read_io_limit,
-            "maximum number of read i/o to issue at a time. This differs from "
-            "--concurrent-io because it tells AsyncIO to ensure concurrent i/o "
-            "does not exceed this, whereas --concurrent-io tells this test "
-            "program how many i/o to do. Default is no "
-            "limit.");
-        cli.add_flag(
-            "--eager-completions",
-            eager_completions,
-            "whether to reap completions as eagerly as possible. Default is "
-            "reaping as needed.");
-        cli.add_flag(
-            "--highest-io-priority",
-            highest_io_priority,
-            "whether to set highest i/o priority possible, which is sent on to "
-            "the storage device and may encourage it to minimise latency. "
-            "Default is not set.");
-        cli.add_option(
-            "--workload",
-            workload_us,
-            "how long the simulated workload should last each time in "
-            "microseconds. Default is five microseconds.");
-        cli.add_option(
-            "--duration",
-            duration_secs,
-            "how long the benchmark should run for in seconds. Default is "
-            "thirty seconds.");
-        cli.parse(argc, argv);
+            cli.add_option(
+                "--ring-entries",
+                ringconfig.entries,
+                "how many submission entries io_uring should have. Default is "
+                "128.");
+            cli.add_flag(
+                "--enable-io-polling",
+                ringconfig.enable_io_polling,
+                "whether to enable i/o polling within the kernel. Default is "
+                "no "
+                "i/o polling.");
+            cli.add_option(
+                "--kernel-poll-thread",
+                ringconfig.sq_thread_cpu,
+                "on what CPU to run a spin polling thread within the kernel. "
+                "Default is no kernel thread.");
+            cli.add_option(
+                "--concurrent-read-io-limit",
+                concurrent_read_io_limit,
+                "maximum number of read i/o to issue at a time. This differs "
+                "from "
+                "--concurrent-io because it tells AsyncIO to ensure concurrent "
+                "i/o "
+                "does not exceed this, whereas --concurrent-io tells this test "
+                "program how many i/o to do. Default is no "
+                "limit.");
+            cli.add_flag(
+                "--eager-completions",
+                eager_completions,
+                "whether to reap completions as eagerly as possible. Default "
+                "is "
+                "reaping as needed.");
+            cli.add_flag(
+                "--highest-io-priority",
+                highest_io_priority,
+                "whether to set highest i/o priority possible, which is sent "
+                "on to "
+                "the storage device and may encourage it to minimise latency. "
+                "Default is not set.");
+            cli.add_option(
+                "--workload",
+                workload_us,
+                "how long the simulated workload should last each time in "
+                "microseconds. Default is five microseconds.");
+            cli.add_option(
+                "--duration",
+                duration_secs,
+                "how long the benchmark should run for in seconds. Default is "
+                "thirty seconds.");
+            cli.parse(argc, argv);
 
 #if MONAD_HAVE_LIBCAP
-        if (highest_io_priority) {
-            // We will need the CAP_SYS_NICE capability for this to work
-            MONAD_ASSERT(CAP_IS_SUPPORTED(CAP_SYS_NICE));
-            auto *caps = cap_get_proc();
-            MONAD_ASSERT(caps != nullptr);
-            auto uncaps =
-                monad::make_scope_exit([&]() noexcept { cap_free(caps); });
-            cap_value_t const cap_list[] = {CAP_SYS_NICE};
-            if (cap_set_flag(caps, CAP_EFFECTIVE, 1, cap_list, CAP_SET) == -1 ||
-                cap_set_proc(caps) == -1) {
-                std::cerr
-                    << "FATAL: To use --highest-io-priority the process needs "
-                       "the CAP_SYS_NICE capability. To assign that, "
-                       "do:\n\nsudo setcap cap_sys_nice+ep "
-                       "benchmark_io_test\n\nAnd run it again."
-                    << std::endl;
-                return 1;
+            if (highest_io_priority) {
+                // We will need the CAP_SYS_NICE capability for this to work
+                MONAD_ASSERT(CAP_IS_SUPPORTED(CAP_SYS_NICE));
+                auto *caps = cap_get_proc();
+                MONAD_ASSERT(caps != nullptr);
+                auto const uncaps =
+                    monad::make_scope_exit([&]() noexcept { cap_free(caps); });
+                cap_value_t const cap_list[] = {CAP_SYS_NICE};
+                if (cap_set_flag(caps, CAP_EFFECTIVE, 1, cap_list, CAP_SET) ==
+                        -1 ||
+                    cap_set_proc(caps) == -1) {
+                    std::cerr << "FATAL: To use --highest-io-priority the "
+                                 "process needs "
+                                 "the CAP_SYS_NICE capability. To assign that, "
+                                 "do:\n\nsudo setcap cap_sys_nice+ep "
+                                 "benchmark_io_test\n\nAnd run it again."
+                              << std::endl;
+                    return 1;
+                }
             }
-        }
 #else // MONAD_HAVE_LIBCAP
-        MONAD_ASSERT(!highest_io_priority); // Not supported without libcap
+            MONAD_ASSERT(!highest_io_priority); // Not supported without libcap
 #endif
-        if (destroy_and_really_fill_count > 0) {
-            destroy_and_fill = true;
-            if (destroy_and_really_fill_count > 100) {
-                destroy_and_really_fill_count = 100;
-            }
-        }
-
-        auto const mode =
-            destroy_and_fill
-                ? MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate
-                : MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
-        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags{};
-        flags.interleave_chunks_evenly = true;
-        MONAD_ASYNC_NAMESPACE::storage_pool pool{{storage_paths}, mode, flags};
-
-        monad::io::Ring ring(ringconfig);
-        monad::io::Buffers rwbuf = monad::io::make_buffers_for_read_only(
-            ring,
-            concurrent_io,
-            MONAD_ASYNC_NAMESPACE::AsyncIO::READ_BUFFER_SIZE);
-        auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{pool, rwbuf};
-        if (destroy_and_really_fill_count > 0) {
-            uint32_t const tofill =
-                (uint32_t)(100.0 * double(io.chunk_count()) /
-                           double(destroy_and_really_fill_count));
-            std::cout << "Destroying storage and filling " << tofill
-                      << " chunks with random bytes ..." << std::endl;
-            monad::small_prng rand;
-            std::span<uint32_t> buffer;
-            monad::HugeMem storage;
-            auto make_storage = [&](size_t bytes) {
-                storage = monad::HugeMem{bytes};
-                buffer = {
-                    (uint32_t *)storage.get_data(),
-                    storage.get_size() / sizeof(uint32_t)};
-                for (auto &p : buffer) {
-                    p = rand();
+            if (destroy_and_really_fill_count > 0) {
+                destroy_and_fill = true;
+                if (destroy_and_really_fill_count > 100) {
+                    destroy_and_really_fill_count = 100;
                 }
-            };
-            for (uint32_t n = 0; n < tofill; n++) {
-                auto const bytes = uint32_t(io.chunk_capacity(n));
-                auto [fd, offset] = pool.chunk(pool.seq, n).write_fd(bytes);
-                if (buffer.size_bytes() < bytes) {
-                    make_storage(bytes);
-                }
-                auto const written =
-                    ::pwrite(fd, buffer.data(), bytes, off_t(offset));
-                if (written < 0) {
-                    throw std::system_error(errno, std::system_category());
-                }
-                MONAD_ASSERT(written > 0);
-            }
-        }
-        else if (destroy_and_fill) {
-            for (uint32_t n = 0; n < io.chunk_count(); n++) {
-                pool.chunk(pool.seq, n)
-                    .write_fd(uint32_t(io.chunk_capacity(n)));
-            }
-        }
-        io.set_capture_io_latencies(true);
-        io.set_concurrent_read_io_limit(concurrent_read_io_limit);
-
-        shared_state_t shared_state{io};
-        if (auto bytes = shared_state.test_surface_available(); bytes < 1024) {
-            std::stringstream ss;
-            ss << "Storage used for test has " << bytes
-               << " bytes allocated, this is too little to run the test. "
-                  "Consider using --fill or --really-fill.";
-            throw std::runtime_error(std::move(ss).str());
-        }
-        if (auto bytes = shared_state.test_surface_available();
-            bytes < 100ULL * 1024 * 1024 * 1024) {
-            std::cerr << "WARNING: Storage used for test has "
-                      << (double(bytes) / 1024.0 / 1024.0 / 1024.0)
-                      << " Gb allocated, it is recommended at least 100 Gb is "
-                         "available for the random read test."
-                      << std::endl;
-        }
-        else {
-            std::cout << "NOTE: Test surface will be "
-                      << (double(bytes) / 1024.0 / 1024.0 / 1024.0) << " Gb"
-                      << std::endl;
-        }
-
-        struct statistics_t
-        {
-            uint32_t ops_per_sec{0};
-            float mean_latency{0};
-            float min_latency{0};
-            float max_latency{0};
-        } statistics;
-
-        std::cout << "\nBeginning random read test, printing performance every "
-                     "second from now ..."
-                  << std::endl;
-        auto begin = std::chrono::steady_clock::now();
-        auto print_statistics = [&] {
-            auto const now = std::chrono::steady_clock::now();
-            auto const elapsed =
-                double(std::chrono::duration_cast<std::chrono::milliseconds>(
-                           now - begin)
-                           .count());
-            statistics.ops_per_sec =
-                uint32_t(1000.0 * double(shared_state.ops) / elapsed);
-            statistics.mean_latency =
-                float(double(shared_state.acc_ns) / double(shared_state.ops));
-            statistics.min_latency = float(shared_state.min_ns);
-            statistics.max_latency = float(shared_state.max_ns);
-            std::cout << "\nTotal ops/sec: " << statistics.ops_per_sec
-                      << " mean latency: " << statistics.mean_latency
-                      << " min: " << statistics.min_latency
-                      << " max: " << statistics.max_latency << std::endl;
-        };
-
-        {
-            std::vector<connected_state_ptr_type> states;
-            states.reserve(concurrent_io);
-            for (size_t n = 0; n < concurrent_io; n++) {
-                states.push_back(io.make_connected(
-                    MONAD_ASYNC_NAMESPACE::read_single_buffer_sender({0, 0}, 0),
-                    receiver_t{&shared_state}));
             }
 
-            begin = std::chrono::steady_clock::now();
-            for (auto &i : states) {
-                MONAD_ASYNC_NAMESPACE::filled_read_buffer res;
-                if (highest_io_priority) {
-                    i->set_io_priority(
-                        MONAD_ASYNC_NAMESPACE::erased_connected_operation::
-                            io_priority::highest);
-                }
-                i->receiver().set_value(
-                    i.get(),
-                    MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::
-                        result_type{res});
-            }
-            io.set_eager_completions(eager_completions);
-            shared_state.acc_ns = 0;
-            shared_state.max_ns = 0;
-            shared_state.min_ns = UINT64_MAX;
-            std::chrono::seconds elapsed_secs(2);
-            do {
-                auto diff = std::chrono::duration_cast<std::chrono::seconds>(
-                    std::chrono::steady_clock::now() - begin);
-                if (diff > elapsed_secs) {
-                    print_statistics();
-                    elapsed_secs = diff;
-                }
-                io.poll_nonblocking(1);
-                if (workload_us > 0) {
-                    auto const begin2 = std::chrono::steady_clock::now();
-                    do {
-                        /* deliberately occupy the CPU fully */
+            auto const mode =
+                destroy_and_fill
+                    ? MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate
+                    : MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
+            MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags{};
+            flags.interleave_chunks_evenly = true;
+            MONAD_ASYNC_NAMESPACE::storage_pool pool{
+                {storage_paths}, mode, flags};
+
+            monad::io::Ring ring(ringconfig);
+            monad::io::Buffers rwbuf = monad::io::make_buffers_for_read_only(
+                ring,
+                concurrent_io,
+                MONAD_ASYNC_NAMESPACE::AsyncIO::READ_BUFFER_SIZE);
+            auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{pool, rwbuf};
+            if (destroy_and_really_fill_count > 0) {
+                uint32_t const tofill =
+                    (uint32_t)(100.0 * double(io.chunk_count()) /
+                               double(destroy_and_really_fill_count));
+                std::cout << "Destroying storage and filling " << tofill
+                          << " chunks with random bytes ..." << std::endl;
+                monad::small_prng rand;
+                std::span<uint32_t> buffer;
+                monad::HugeMem storage;
+                auto make_storage = [&](size_t bytes) {
+                    storage = monad::HugeMem{bytes};
+                    buffer = {
+                        (uint32_t *)storage.get_data(),
+                        storage.get_size() / sizeof(uint32_t)};
+                    for (auto &p : buffer) {
+                        p = rand();
                     }
-                    while (std::chrono::steady_clock::now() - begin2 <
-                           std::chrono::microseconds(workload_us));
+                };
+                for (uint32_t n = 0; n < tofill; n++) {
+                    auto const bytes = uint32_t(io.chunk_capacity(n));
+                    auto [fd, offset] = pool.chunk(pool.seq, n).write_fd(bytes);
+                    if (buffer.size_bytes() < bytes) {
+                        make_storage(bytes);
+                    }
+                    auto const written =
+                        ::pwrite(fd, buffer.data(), bytes, off_t(offset));
+                    if (written < 0) {
+                        throw std::system_error(errno, std::system_category());
+                    }
+                    MONAD_ASSERT(written > 0);
                 }
             }
-            while (std::chrono::steady_clock::now() - begin <
-                   std::chrono::seconds(duration_secs));
-            shared_state.done = true;
-            io.wait_until_done();
+            else if (destroy_and_fill) {
+                for (uint32_t n = 0; n < io.chunk_count(); n++) {
+                    pool.chunk(pool.seq, n)
+                        .write_fd(uint32_t(io.chunk_capacity(n)));
+                }
+            }
+            io.set_capture_io_latencies(true);
+            io.set_concurrent_read_io_limit(concurrent_read_io_limit);
+
+            shared_state_t shared_state{io};
+            if (auto const bytes = shared_state.test_surface_available();
+                bytes < 1024) {
+                std::stringstream ss;
+                ss << "Storage used for test has " << bytes
+                   << " bytes allocated, this is too little to run the test. "
+                      "Consider using --fill or --really-fill.";
+                throw std::runtime_error(std::move(ss).str());
+            }
+            if (auto const bytes = shared_state.test_surface_available();
+                bytes < 100ULL * 1024 * 1024 * 1024) {
+                std::cerr
+                    << "WARNING: Storage used for test has "
+                    << (double(bytes) / 1024.0 / 1024.0 / 1024.0)
+                    << " Gb allocated, it is recommended at least 100 Gb is "
+                       "available for the random read test."
+                    << std::endl;
+            }
+            else {
+                std::cout << "NOTE: Test surface will be "
+                          << (double(bytes) / 1024.0 / 1024.0 / 1024.0) << " Gb"
+                          << std::endl;
+            }
+
+            struct statistics_t
+            {
+                uint32_t ops_per_sec{0};
+                float mean_latency{0};
+                float min_latency{0};
+                float max_latency{0};
+            } statistics;
+
+            std::cout
+                << "\nBeginning random read test, printing performance every "
+                   "second from now ..."
+                << std::endl;
+            auto begin = std::chrono::steady_clock::now();
+            auto print_statistics = [&] {
+                auto const now = std::chrono::steady_clock::now();
+                auto const elapsed = double(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - begin)
+                        .count());
+                statistics.ops_per_sec =
+                    uint32_t(1000.0 * double(shared_state.ops) / elapsed);
+                statistics.mean_latency = float(
+                    double(shared_state.acc_ns) / double(shared_state.ops));
+                statistics.min_latency = float(shared_state.min_ns);
+                statistics.max_latency = float(shared_state.max_ns);
+                std::cout << "\nTotal ops/sec: " << statistics.ops_per_sec
+                          << " mean latency: " << statistics.mean_latency
+                          << " min: " << statistics.min_latency
+                          << " max: " << statistics.max_latency << std::endl;
+            };
+
+            {
+                std::vector<connected_state_ptr_type> states;
+                states.reserve(concurrent_io);
+                for (size_t n = 0; n < concurrent_io; n++) {
+                    states.push_back(io.make_connected(
+                        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender(
+                            {0, 0}, 0),
+                        receiver_t{&shared_state}));
+                }
+
+                begin = std::chrono::steady_clock::now();
+                for (auto &i : states) {
+                    MONAD_ASYNC_NAMESPACE::filled_read_buffer res;
+                    if (highest_io_priority) {
+                        i->set_io_priority(
+                            MONAD_ASYNC_NAMESPACE::erased_connected_operation::
+                                io_priority::highest);
+                    }
+                    i->receiver().set_value(
+                        i.get(),
+                        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::
+                            result_type{res});
+                }
+                io.set_eager_completions(eager_completions);
+                shared_state.acc_ns = 0;
+                shared_state.max_ns = 0;
+                shared_state.min_ns = UINT64_MAX;
+                std::chrono::seconds elapsed_secs(2);
+                do {
+                    auto const diff =
+                        std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::steady_clock::now() - begin);
+                    if (diff > elapsed_secs) {
+                        print_statistics();
+                        elapsed_secs = diff;
+                    }
+                    io.poll_nonblocking(1);
+                    if (workload_us > 0) {
+                        auto const begin2 = std::chrono::steady_clock::now();
+                        do {
+                            /* deliberately occupy the CPU fully */
+                        }
+                        while (std::chrono::steady_clock::now() - begin2 <
+                               std::chrono::microseconds(workload_us));
+                    }
+                }
+                while (std::chrono::steady_clock::now() - begin <
+                       std::chrono::seconds(duration_secs));
+                shared_state.done = true;
+                io.wait_until_done();
+            }
+            print_statistics();
         }
-        print_statistics();
-    }
 
-    catch (const CLI::CallForHelp &e) {
-        std::cout << cli.help() << std::flush;
-    }
+        catch (const CLI::CallForHelp &e) {
+            std::cout << cli.help() << std::flush;
+        }
 
-    catch (const CLI::RequiredError &e) {
-        std::cerr << "FATAL: " << e.what() << "\n\n";
-        std::cerr << cli.help() << std::flush;
-        return 1;
-    }
+        catch (const CLI::RequiredError &e) {
+            std::cerr << "FATAL: " << e.what() << "\n\n";
+            std::cerr << cli.help() << std::flush;
+            return 1;
+        }
 
+        catch (std::exception const &e) {
+            std::cerr << "FATAL: " << e.what() << std::endl;
+            return 1;
+        }
+    }
     catch (std::exception const &e) {
         std::cerr << "FATAL: " << e.what() << std::endl;
         return 1;

--- a/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
@@ -52,7 +52,7 @@ namespace
             monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testrwbuf);
         std::vector<monad::async::read_single_buffer_sender::buffer_type> bufs;
-        auto empty_testio = monad::make_scope_exit(
+        auto const empty_testio = monad::make_scope_exit(
             [&]() noexcept { testio.wait_until_done(); });
 
         struct empty_receiver
@@ -76,7 +76,7 @@ namespace
                     {0, 0}, monad::async::DISK_PAGE_SIZE),
                 empty_receiver{bufs}));
             state->initiate(); // will reap completions if no buffers free
-            state.release();
+            (void)state.release();
         };
         for (size_t n = 0; n < 512; n++) {
             make();

--- a/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
@@ -51,7 +51,7 @@ namespace
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testrwbuf);
         std::vector<monad::async::erased_connected_operation_ptr> states;
-        auto empty_testio = monad::make_scope_exit(
+        auto const empty_testio = monad::make_scope_exit(
             [&]() noexcept { testio.wait_until_done(); });
 
         struct empty_receiver

--- a/category/async/test/storage_pool.cpp
+++ b/category/async/test/storage_pool.cpp
@@ -27,11 +27,11 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
-#include <stdexcept>
-#include <system_error>
+#include <stdio.h>
 #include <utility>
 #include <vector>
 
@@ -47,7 +47,7 @@ namespace
         std::cout << "Pool has " << pool.devices().size() << " devices:";
         for (size_t n = 0; n < pool.devices().size(); n++) {
             auto const &device = pool.devices()[n];
-            auto capacity = device.capacity();
+            auto const capacity = device.capacity();
             std::cout << "\n   " << (n + 1) << ". chunks = " << device.chunks()
                       << " capacity = " << capacity.first
                       << " used = " << capacity.second
@@ -59,13 +59,13 @@ namespace
                   << pool.chunks(storage_pool::seq);
         std::cout << "\n   First conventional chunk ";
         {
-            auto &chunk = pool.chunk(storage_pool::cnv, 0);
+            auto const &chunk = pool.chunk(storage_pool::cnv, 0);
             std::cout << "has capacity = " << chunk.capacity()
                       << " used = " << chunk.size();
         }
         std::cout << "\n   First sequential chunk ";
         {
-            auto &chunk = pool.chunk(storage_pool::seq, 0);
+            auto const &chunk = pool.chunk(storage_pool::seq, 0);
             std::cout << "has capacity = " << chunk.capacity()
                       << " used = " << chunk.size();
         }
@@ -168,7 +168,7 @@ namespace
 
         std::vector<std::byte> buffer2(buffer.size());
         auto check = [&](auto &chunk, int a, int b) {
-            auto fd = chunk.read_fd();
+            auto const fd = chunk.read_fd();
             MONAD_ASSERT(
                 -1 != ::pread(
                           fd.first,
@@ -246,7 +246,7 @@ namespace
             ({
                 std::filesystem::path const devs[] = {
                     "/dev/mapper/raid0-rawblk0", "/dev/mapper/raid0-rawblk1"};
-                storage_pool pool(devs, storage_pool::mode::truncate);
+                storage_pool const pool(devs, storage_pool::mode::truncate);
             }),
             "open failed");
     }
@@ -275,8 +275,8 @@ namespace
                 create_temp_file(22 * BLKSIZE),
                 create_temp_file(12 * BLKSIZE),
                 create_temp_file(7 * BLKSIZE)};
-            auto undevs = monad::make_scope_exit([&]() noexcept {
-                for (auto &p : devs) {
+            auto const undevs = monad::make_scope_exit([&]() noexcept {
+                for (auto const &p : devs) {
                     std::filesystem::remove(p);
                 }
             });
@@ -388,8 +388,8 @@ namespace
             create_temp_file(20 * BLKSIZE),
             create_temp_file(10 * BLKSIZE),
             create_temp_file(5 * BLKSIZE)};
-        auto undevs = monad::make_scope_exit([&]() noexcept {
-            for (auto &p : devs) {
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
                 std::filesystem::remove(p);
             }
         });
@@ -413,7 +413,7 @@ namespace
         memset(buffer1.data(), 0xee, buffer1.size());
         auto chunk1 = pool1.chunk(storage_pool::seq, 0);
         {
-            auto fd = chunk1.write_fd(buffer1.size());
+            auto const fd = chunk1.write_fd(buffer1.size());
             MONAD_ASSERT(
                 -1 != ::pwrite(
                           fd.first,
@@ -426,9 +426,9 @@ namespace
         memset(buffer2.data(), 0xcc, buffer2.size());
         auto chunk2 = pool2.chunk(storage_pool::seq, 0);
         {
-            auto cloned = chunk1.clone_contents_into(chunk2, UINT32_MAX);
+            auto const cloned = chunk1.clone_contents_into(chunk2, UINT32_MAX);
             EXPECT_EQ(cloned, buffer1.size());
-            auto fd = chunk2.read_fd();
+            auto const fd = chunk2.read_fd();
             MONAD_ASSERT(
                 -1 != ::pread(
                           fd.first,

--- a/category/async/test/test_fixture.hpp
+++ b/category/async/test/test_fixture.hpp
@@ -63,8 +63,8 @@ namespace monad::test
             std::unique_ptr<monad::async::AsyncIO> testio = [this] {
                 auto ret =
                     std::make_unique<monad::async::AsyncIO>(pool, testrwbuf);
-                auto fd = pool.chunk(monad::async::storage_pool::seq, 0)
-                              .write_fd(TEST_FILE_SIZE);
+                auto const fd = pool.chunk(monad::async::storage_pool::seq, 0)
+                                    .write_fd(TEST_FILE_SIZE);
                 MONAD_ASSERT(
                     TEST_FILE_SIZE == ::pwrite(
                                           fd.first,

--- a/category/async/util.cpp
+++ b/category/async/util.cpp
@@ -29,8 +29,8 @@
 
 #include <fcntl.h> // for open
 #include <linux/magic.h> // for TMPFS_MAGIC
+#include <sys/statfs.h> // for statfs
 #include <sys/user.h> // for PAGE_SIZE
-#include <sys/vfs.h> // for statfs
 #include <unistd.h> // for unlink
 
 #if PAGE_SIZE != 4096
@@ -47,7 +47,7 @@ std::filesystem::path const &working_temporary_directory()
         auto test_path = [&](std::filesystem::path const &path) -> bool {
             int fd = ::open(path.c_str(), O_RDWR | O_DIRECT | O_TMPFILE, 0600);
             if (-1 == fd && ENOTSUP == errno) {
-                auto path2 = path / "monad_XXXXXX";
+                auto const path2 = path / "monad_XXXXXX";
                 std::string path2_str = path2.native();
                 fd = mkostemp(path2_str.data(), O_DIRECT);
                 if (-1 != fd) {
@@ -139,7 +139,7 @@ int make_temporary_inode() noexcept
     if (-1 == fd && ENOTSUP == errno) {
         // O_TMPFILE is not supported on ancient Linux kernels
         // of the kind apparently Github like to run :(
-        auto buffer = working_temporary_directory() / "monad_XXXXXX";
+        auto const buffer = working_temporary_directory() / "monad_XXXXXX";
         fd = mkstemp(const_cast<char *>(buffer.native().c_str()));
         if (-1 != fd) {
             unlink(buffer.c_str());

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1451,10 +1451,7 @@ namespace detail
         uint64_t const version;
         UpdateAux<> &aux;
 
-        enum : bool
-        {
-            lifetime_managed_internally = true
-        };
+        static constexpr bool lifetime_managed_internally = true;
 
         void set_value(
             async::erased_connected_operation *const this_io_state,

--- a/category/mpt/test/fiber_future_wrapped_read.cpp
+++ b/category/mpt/test/fiber_future_wrapped_read.cpp
@@ -40,13 +40,13 @@
 
 using namespace MONAD_ASYNC_NAMESPACE;
 
-struct FiberFutureWrappedFind
-    : public monad::test::AsyncTestFixture<::testing::Test>
+namespace
 {
-};
+    struct FiberFutureWrappedFind
+        : public monad::test::AsyncTestFixture<::testing::Test>
+    {
+    };
 
-TEST_F(FiberFutureWrappedFind, single_thread_fibers_read)
-{
     struct receiver_t
     {
         FiberFutureWrappedFind::shared_state_t *const fixture_shared_state;
@@ -55,10 +55,8 @@ TEST_F(FiberFutureWrappedFind, single_thread_fibers_read)
             promise;
         chunk_offset_t offset;
 
-        enum : bool
-        {
-            lifetime_managed_internally = false // we manage state lifetime
-        };
+        static constexpr bool lifetime_managed_internally =
+            false; // we manage state lifetime
 
         bool done{false};
 
@@ -89,7 +87,10 @@ TEST_F(FiberFutureWrappedFind, single_thread_fibers_read)
             done = true;
         }
     };
+}
 
+TEST_F(FiberFutureWrappedFind, single_thread_fibers_read)
+{
     // impl_sender: request read thru an io sender
     auto impl_sender = [&]() -> result<std::vector<std::byte>> {
         // This initiates the i/o reading DISK_PAGE_SIZE bytes from a

--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -47,10 +47,12 @@ if [ -f $CONST_CORRECTNESS_PLUGIN ]; then
                         -checks='-misc-const-correctness,misc-auto-const-correctness' )
 fi
 
+
 mapfile -t inputs < <(\
   find \
-    category/core \
-    category/vm   \
+    category/async      \
+    category/core       \
+    category/vm         \
     \( -name '*.cpp' -or -name '*.c' \))
 
 "${RUN_CLANG_TIDY}"                               \


### PR DESCRIPTION
`async` directory now passes `clang-tidy` checks