### PR TITLE
[event] record events synchronously, as they occur

### DIFF
--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -30,13 +30,19 @@ struct Receipt;
 struct Transaction;
 
 /// Record the transaction header events (TXN_HEADER_START, the EIP-2930
-/// and EIP-7702 events, and TXN_HEADER_END), followed by the TXN_EVM_OUTPUT,
-/// TXN_REJECT, or EVM_ERROR events, depending on what happened during
-/// transaction execution; in the TXN_EVM_OUTPUT case, also record other
-/// execution output events (TXN_LOG, TXN_CALL_FRAME, etc.)
-void record_txn_events(
+/// and EIP-7702 events, and TXN_HEADER_END)
+void record_txn_header_events(
     uint32_t txn_num, Transaction const &, Address const &sender,
-    std::span<std::optional<Address> const> authorities,
-    Result<Receipt> const &, std::span<CallFrame const>);
+    std::span<std::optional<Address> const> authorities);
+
+/// Record TXN_EVM_OUTPUT, and all subsequent execution output events
+/// (TXN_LOG, TXN_CALL_FRAME, etc.)
+void record_txn_output_events(
+    uint32_t txn_num, Receipt const &, std::span<CallFrame const>);
+
+/// Record TXN_REJECT or EVM_ERROR events depending on what happened during
+/// transaction execution
+void record_txn_error_event(
+    uint32_t txn_num, Result<Receipt>::error_type const &);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -270,14 +270,10 @@ Result<std::vector<Receipt>> execute_block_transactions(
                         state_tracer,
                         revert_transaction);
                     promises[i + 1].set_value();
+                    if (results[i]->has_error()) {
+                        record_txn_error_event(i, results[i]->error());
+                    }
                     record_txn_marker_event(MONAD_EXEC_TXN_PERF_EVM_EXIT, i);
-                    record_txn_events(
-                        i,
-                        transaction,
-                        sender,
-                        authorities,
-                        *results[i],
-                        call_tracer.get_call_frames());
                 }
                 catch (...) {
                     promises[i + 1].set_exception(std::current_exception());

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -20,6 +20,7 @@
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/evm.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
@@ -296,6 +297,7 @@ ExecuteTransaction<traits>::ExecuteTransaction(
     , call_tracer_{call_tracer}
     , state_tracer_{state_tracer}
 {
+    record_txn_header_events(static_cast<uint32_t>(i), tx, sender, authorities);
 }
 
 template <Traits traits>
@@ -416,6 +418,10 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             call_tracer_.on_finish(receipt.gas_used);
             trace::run_tracer<traits>(state_tracer_, state);
             block_state_.merge(state);
+            record_txn_output_events(
+                static_cast<uint32_t>(this->i_),
+                receipt,
+                call_tracer_.get_call_frames());
             return receipt;
         }
     }
@@ -437,6 +443,10 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         call_tracer_.on_finish(receipt.gas_used);
         trace::run_tracer<traits>(state_tracer_, state);
         block_state_.merge(state);
+        record_txn_output_events(
+            static_cast<uint32_t>(this->i_),
+            receipt,
+            call_tracer_.get_call_frames());
         return receipt;
     }
 }


### PR DESCRIPTION
This does not remove the recording of the marker events MONAD_EXEC_TXN_PERF_EVM_{ENTER,EXIT} yet, nor the `txn_exec_finished` check. Both should no longer be necessary, and will be removed in a later commit.