### PR TITLE
[event] record state access events

### DIFF
--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -13,10 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/result.hpp>
+#include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/eth_ctypes.h>
 #include <category/execution/ethereum/core/receipt.hpp>
@@ -26,11 +29,16 @@
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
 #include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
+#include <category/execution/ethereum/state3/account_state.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/state3/version_stack.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 
 #include <bit>
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <span>
 #include <utility>
@@ -65,6 +73,216 @@ void init_txn_header_start(
     header.access_list_count = static_cast<uint32_t>(txn.access_list.size());
     header.auth_list_count =
         static_cast<uint32_t>(txn.authorization_list.size());
+}
+
+// Tracks information about an accessed account, including (1) the prestate and
+// the (2) the modified state if a write access modified anything, with helper
+// functions to determine what was modified
+struct AccountAccessInfo
+{
+    Address const *address;
+    OriginalAccountState const *prestate; // State as it existed in original
+    AccountState const *modified_state; // Last state as it existed in current
+
+    bool is_read_only_access() const
+    {
+        return modified_state == nullptr;
+    }
+
+    std::pair<uint64_t, bool> get_nonce_modification() const
+    {
+        if (is_read_only_access()) {
+            return {0, false};
+        }
+
+        std::optional<Account> const &prestate_account =
+            get_account_for_trace(*prestate);
+        std::optional<Account> const &modified_account =
+            get_account_for_trace(*modified_state);
+
+        uint64_t const prestate_nonce =
+            is_dead(prestate_account) ? 0 : prestate_account->nonce;
+        uint64_t const modified_nonce =
+            is_dead(modified_account) ? 0 : modified_account->nonce;
+        return {modified_nonce, prestate_nonce != modified_nonce};
+    }
+
+    std::pair<uint256_t, bool> get_balance_modification() const
+    {
+        if (is_read_only_access()) {
+            return {0, false};
+        }
+
+        std::optional<Account> const &prestate_account =
+            get_account_for_trace(*prestate);
+        std::optional<Account> const &modified_account =
+            get_account_for_trace(*modified_state);
+
+        uint256_t const prestate_balance =
+            is_dead(prestate_account) ? 0 : prestate_account->balance;
+        uint256_t const modified_balance =
+            is_dead(modified_account) ? 0 : modified_account->balance;
+        return {modified_balance, prestate_balance != modified_balance};
+    }
+};
+
+/// Reserves either a block-level or transaction-level event, depending on
+/// whether opt_txn_num is set or not; the account access events are allocated
+/// this way, as some of them occur at system scope
+template <typename T>
+ReservedExecEvent<T> reserve_event(
+    ExecutionEventRecorder *exec_recorder, monad_exec_event_type event_type,
+    std::optional<uint32_t> opt_txn_num)
+{
+    return opt_txn_num
+               ? exec_recorder->reserve_txn_event<T>(event_type, *opt_txn_num)
+               : exec_recorder->reserve_block_event<T>(event_type);
+}
+
+// Records a MONAD_EXEC_STORAGE_ACCESS event for all reads and writes in the
+// AccountState prestate and modified maps
+void record_storage_events(
+    ExecutionEventRecorder *exec_recorder,
+    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
+    uint32_t account_index, Address const *address,
+    AccountState::StorageMap const *prestate_storage,
+    AccountState::StorageMap const *modified_storage, bool is_transient)
+{
+    for (size_t index = 0; auto const &[key, value] : *prestate_storage) {
+        bool is_modified = false;
+        bytes32_t end_value = {};
+
+        if (modified_storage) {
+            if (bytes32_t const *const v = modified_storage->find(key)) {
+                end_value = *v;
+                is_modified = end_value != value;
+            }
+        }
+
+        ReservedExecEvent const storage_access =
+            reserve_event<monad_exec_storage_access>(
+                exec_recorder, MONAD_EXEC_STORAGE_ACCESS, opt_txn_num);
+        *storage_access.payload = monad_exec_storage_access{
+            .address = *address,
+            .index = static_cast<uint32_t>(index),
+            .access_context = ctx,
+            .modified = is_modified,
+            .transient = is_transient,
+            .key = key,
+            .start_value = value,
+            .end_value = end_value,
+        };
+        storage_access.event->content_ext[MONAD_FLOW_ACCOUNT_INDEX] =
+            account_index;
+        exec_recorder->commit(storage_access);
+        ++index;
+    }
+}
+
+// Records an MONAD_EXEC_ACCOUNT_ACCESS event, and delegates to
+// record_storage_events to record both the ordinary and transient storage
+// accesses
+void record_account_events(
+    ExecutionEventRecorder *exec_recorder,
+    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
+    uint32_t index, AccountAccessInfo const &account_info)
+{
+    MONAD_ASSERT(account_info.prestate);
+    monad_c_eth_account_state initial_state;
+    std::optional<Account> const &prestate_account =
+        get_account_for_trace(*account_info.prestate);
+    bool const prestate_valid = !is_dead(prestate_account);
+
+    initial_state.nonce = prestate_valid ? prestate_account->nonce : 0;
+    initial_state.balance = prestate_valid ? prestate_account->balance : 0;
+    initial_state.code_hash =
+        prestate_valid ? prestate_account->code_hash : NULL_HASH;
+
+    auto const [modified_balance, is_balance_modified] =
+        account_info.get_balance_modification();
+    auto const [modified_nonce, is_nonce_modified] =
+        account_info.get_nonce_modification();
+
+    ReservedExecEvent const account_access =
+        reserve_event<monad_exec_account_access>(
+            exec_recorder, MONAD_EXEC_ACCOUNT_ACCESS, opt_txn_num);
+    *account_access.payload = monad_exec_account_access{
+        .index = index,
+        .address = *account_info.address,
+        .access_context = ctx,
+        .is_balance_modified = is_balance_modified,
+        .is_nonce_modified = is_nonce_modified,
+        .prestate = initial_state,
+        .modified_balance = modified_balance,
+        .modified_nonce = modified_nonce,
+        .storage_key_count =
+            static_cast<uint32_t>(size(account_info.prestate->storage_)),
+        .transient_count = static_cast<uint32_t>(
+            size(account_info.prestate->transient_storage_))};
+    exec_recorder->commit(account_access);
+
+    auto const *const post_state_storage_map =
+        account_info.is_read_only_access()
+            ? nullptr
+            : &account_info.modified_state->storage_;
+    record_storage_events(
+        exec_recorder,
+        ctx,
+        opt_txn_num,
+        index,
+        account_info.address,
+        &account_info.prestate->storage_,
+        post_state_storage_map,
+        false);
+
+    auto const *const post_state_transient_map =
+        account_info.is_read_only_access()
+            ? nullptr
+            : &account_info.modified_state->transient_storage_;
+    record_storage_events(
+        exec_recorder,
+        ctx,
+        opt_txn_num,
+        index,
+        account_info.address,
+        &account_info.prestate->transient_storage_,
+        post_state_transient_map,
+        true);
+}
+
+// Function that records all state accesses and changes that occurred in some
+// scope, either the block prologue, block epilogue, or in the scope of some
+// transaction
+void record_account_access_events_internal(
+    ExecutionEventRecorder *exec_recorder,
+    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
+    State const &state)
+{
+    auto const &prestate_map = state.original();
+
+    ReservedExecEvent const list_header =
+        reserve_event<monad_exec_account_access_list_header>(
+            exec_recorder, MONAD_EXEC_ACCOUNT_ACCESS_LIST_HEADER, opt_txn_num);
+    *list_header.payload = monad_exec_account_access_list_header{
+        .entry_count = static_cast<uint32_t>(prestate_map.size()),
+        .access_context = ctx};
+    exec_recorder->commit(list_header);
+
+    auto const &current_state_map = state.current();
+    for (uint32_t index = 0; auto const &[address, prestate] : prestate_map) {
+        AccountState const *current_state = nullptr;
+        if (auto const i = current_state_map.find(address);
+            i != end(current_state_map)) {
+            current_state = std::addressof(i->second.recent());
+        }
+        record_account_events(
+            exec_recorder,
+            ctx,
+            opt_txn_num,
+            index,
+            AccountAccessInfo{&address, &prestate, current_state});
+        index++;
+    }
 }
 
 MONAD_ANONYMOUS_NAMESPACE_END
@@ -136,7 +354,7 @@ void record_txn_header_events(
 
 void record_txn_output_events(
     uint32_t const txn_num, Receipt const &receipt,
-    std::span<CallFrame const> const call_frames)
+    std::span<CallFrame const> const call_frames, State const &txn_state)
 {
     ExecutionEventRecorder *const exec_recorder = g_exec_event_recorder.get();
     if (exec_recorder == nullptr) {
@@ -203,6 +421,10 @@ void record_txn_output_events(
         ++index;
     }
 
+    // Account access records for the transaction
+    record_account_access_events_internal(
+        exec_recorder, MONAD_ACCT_ACCESS_TRANSACTION, txn_num, txn_state);
+
     exec_recorder->record_txn_marker_event(MONAD_EXEC_TXN_END, txn_num);
 }
 
@@ -238,6 +460,18 @@ void record_txn_error_event(
         *evm_error.payload = monad_exec_evm_error{
             .domain_id = error_domain.id(), .status_code = error_value};
         exec_recorder->commit(evm_error);
+    }
+}
+
+// The externally-visible wrapper of the account-access-recording function that
+// is called from execute_block.cpp, to record prologue and epilogue accesses;
+// transaction-scope state accesses use record_txn_output_events instead
+void record_account_access_events(
+    monad_exec_account_access_context ctx, State const &state)
+{
+    if (ExecutionEventRecorder *const e = g_exec_event_recorder.get()) {
+        return record_account_access_events_internal(
+            e, ctx, std::nullopt, state);
     }
 }
 

--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -23,11 +23,15 @@
 #include <optional>
 #include <span>
 
+enum monad_exec_account_access_context : uint8_t;
+
 MONAD_NAMESPACE_BEGIN
 
 struct CallFrame;
 struct Receipt;
 struct Transaction;
+
+class State;
 
 /// Record the transaction header events (TXN_HEADER_START, the EIP-2930
 /// and EIP-7702 events, and TXN_HEADER_END)
@@ -38,11 +42,17 @@ void record_txn_header_events(
 /// Record TXN_EVM_OUTPUT, and all subsequent execution output events
 /// (TXN_LOG, TXN_CALL_FRAME, etc.)
 void record_txn_output_events(
-    uint32_t txn_num, Receipt const &, std::span<CallFrame const>);
+    uint32_t txn_num, Receipt const &, std::span<CallFrame const>,
+    State const &);
 
 /// Record TXN_REJECT or EVM_ERROR events depending on what happened during
 /// transaction execution
 void record_txn_error_event(
     uint32_t txn_num, Result<Receipt>::error_type const &);
+
+/// Record all account state accesses (both reads and writes) described by a
+/// State object
+void record_account_access_events(
+    monad_exec_account_access_context, State const &);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -205,6 +205,7 @@ void execute_block_header(
 
     MONAD_ASSERT(block_state.can_merge(state));
     block_state.merge(state);
+    record_account_access_events(MONAD_ACCT_ACCESS_BLOCK_PROLOGUE, state);
 }
 
 EXPLICIT_TRAITS(execute_block_header);
@@ -373,6 +374,7 @@ Result<std::vector<Receipt>> execute_block(
 
     MONAD_ASSERT(block_state.can_merge(state));
     block_state.merge(state);
+    record_account_access_events(MONAD_ACCT_ACCESS_BLOCK_EPILOGUE, state);
 
     return retvals;
 }

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -421,7 +421,8 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             record_txn_output_events(
                 static_cast<uint32_t>(this->i_),
                 receipt,
-                call_tracer_.get_call_frames());
+                call_tracer_.get_call_frames(),
+                state);
             return receipt;
         }
     }
@@ -446,7 +447,8 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         record_txn_output_events(
             static_cast<uint32_t>(this->i_),
             receipt,
-            call_tracer_.get_call_frames());
+            call_tracer_.get_call_frames(),
+            state);
         return receipt;
     }
 }

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -61,11 +61,11 @@ private:
     friend class State;
     friend class BlockState;
 
-    // the classes below can access the account_ field just for logging but
-    // CANNOT use it to make decisions affecting the final state (state of
-    // accounts) of execution.
-    friend struct trace::PrestateTracer;
-    friend struct trace::StateDiffTracer;
+    friend std::optional<Account> const &
+    get_account_for_trace(AccountState const &as)
+    {
+        return as.account_;
+    }
 
 public:
     StorageMap storage_{};

--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -83,10 +83,12 @@ namespace trace
 
             // Possible diff.
             auto const &current_account_state = current_stack.recent();
-            auto const &current_account = current_account_state.account_;
+            auto const &current_account =
+                get_account_for_trace(current_account_state);
             auto const &current_storage = current_account_state.storage_;
             auto const &original_account_state = it->second;
-            auto const &original_account = original_account_state.account_;
+            auto const &original_account =
+                get_account_for_trace(original_account_state);
             auto const &original_storage = original_account_state.storage_;
 
             // Nothing to do if the account has been created and destructed
@@ -228,7 +230,7 @@ namespace trace
     json PrestateTracer::account_state_to_json(
         OriginalAccountState const &as, State &state)
     {
-        auto const &account = as.account_;
+        auto const &account = get_account_for_trace(as);
         auto const &storage = as.storage_;
         json res = account_to_json(account, state);
         if (!storage.empty() && account.has_value()) {


### PR DESCRIPTION
There are two changes here:

- record_txn_events.cpp gains functions for recording State objects as `ACCOUNT_ACCESS_LIST_HEADER`, `ACCOUNT_ACCESS`, and `STORAGE_ACCESS` events

- All state-affecting changes to the block that occur before transaction and after the transaction are also recorded