### PR TITLE
Remove unused cross-thread pipe messaging infrastructure

### DIFF
--- a/category/async/detail/connected_operation_storage.hpp
+++ b/category/async/detail/connected_operation_storage.hpp
@@ -156,9 +156,8 @@ namespace detail
                 is_retry; // useful to know how this initiation is coming about
             // You must initiate operations on the same kernel thread as
             // the AsyncIO instance associated with this operation state
-            // (except for threadsafeop)
             MONAD_ASSERT(
-                this->executor() == nullptr || this->is_threadsafeop() ||
+                this->executor() == nullptr ||
                 this->executor()->owning_thread_id() == get_tl_tid());
             this->being_executed_ = true;
             // Prevent compiler reordering write of being_executed_ after this
@@ -369,17 +368,6 @@ namespace detail
             return sender_operation_type<Sender> == operation_type::write;
         }
 
-        static constexpr bool is_timeout() noexcept
-        {
-            return sender_operation_type<Sender> == operation_type::timeout;
-        }
-
-        static constexpr bool is_threadsafeop() noexcept
-        {
-            return sender_operation_type<Sender> ==
-                   operation_type::threadsafeop;
-        }
-
         //! Initiates the operation, calling the Receiver with any failure,
         //! returning if deferred or if immediate failure occurred.
         //! If successful do NOT modify anything after
@@ -392,12 +380,9 @@ namespace detail
             //
             // It is safe to not defer write op, because no write receivers do
             // recursion in current use cases thus no risk of stack exhaustion.
-            // The threadsafe op is special, it isn't for this AsyncIO
-            // instance and therefore never needs deferring
             return this->do_possibly_deferred_initiate_(
                 detail::sender_operation_type<sender_type> ==
-                        operation_type::write ||
-                    this->is_threadsafeop(),
+                    operation_type::write,
                 false);
         }
 

--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -75,8 +75,6 @@ enum class operation_type : uint8_t
     unknown,
     read,
     write,
-    timeout,
-    threadsafeop,
     read_scatter
 };
 
@@ -542,16 +540,6 @@ public:
         return operation_type_ == operation_type::write;
     }
 
-    bool is_timeout() const noexcept
-    {
-        return operation_type_ == operation_type::timeout;
-    }
-
-    bool is_threadsafeop() const noexcept
-    {
-        return operation_type_ == operation_type::threadsafeop;
-    }
-
     bool is_currently_being_executed() const noexcept
     {
         return being_executed_;
@@ -612,10 +600,7 @@ public:
         //
         // It is safe to not defer write op, because no write receivers do
         // recursion in current use cases thus no risk of stack exhaustion.
-        // The threadsafe op is special, it isn't for this AsyncIO
-        // instance and therefore never needs deferring
-        return do_possibly_deferred_initiate_(
-            is_write() || is_threadsafeop(), false);
+        return do_possibly_deferred_initiate_(is_write(), false);
     }
 
     //! Invoke re-initiation after temporary failutre, sending any failure to

--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -31,7 +31,6 @@
 
 #include <ankerl/unordered_dense.h>
 
-#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -89,10 +88,6 @@ MONAD_ASYNC_NAMESPACE_BEGIN
 
 namespace detail
 {
-    // diseased dead beef in hex, last bit set so won't be a pointer
-    static void *const ASYNC_IO_MSG_PIPE_READY_IO_URING_DATA_MAGIC =
-        (void *)(uintptr_t)0xd15ea5eddeadbeef;
-
     struct AsyncIO_per_thread_state_t::within_completions_holder
     {
         AsyncIO_per_thread_state_t *parent;
@@ -156,7 +151,6 @@ AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
     : owning_tid_(get_tl_tid())
     , storage_pool_{std::addressof(pool)}
     , cnv_chunk_{pool.chunk(storage_pool::cnv, 0)}
-    , fds_{-1, -1}
     , uring_(rwbuf.ring())
     , wr_uring_(rwbuf.wr_ring())
     , rwbuf_(rwbuf)
@@ -180,26 +174,6 @@ AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
         ts.instance == nullptr,
         "currently cannot create more than one AsyncIO per thread at a time");
     ts.instance = this;
-
-    // create and register the message type pipe for threadsafe communications
-    // read side is nonblocking, write side is blocking
-    auto *ring = &uring_.get_ring();
-    if (!(ring->flags & IORING_SETUP_IOPOLL)) {
-        MONAD_ASSERT_PRINTF(
-            ::pipe2((int *)&fds_, O_NONBLOCK | O_DIRECT | O_CLOEXEC) != -1,
-            "failed due to %s",
-            std::strerror(errno));
-        MONAD_ASSERT_PRINTF(
-            ::fcntl(fds_.msgwrite, F_SETFL, O_DIRECT | O_CLOEXEC) != -1,
-            "failed due to %s",
-            std::strerror(errno));
-        struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-        MONAD_ASSERT(sqe);
-        io_uring_prep_poll_multishot(sqe, fds_.msgread, POLLIN);
-        io_uring_sqe_set_data(
-            sqe, detail::ASYNC_IO_MSG_PIPE_READY_IO_URING_DATA_MAGIC);
-        MONAD_ASYNC_IO_URING_RETRYABLE(io_uring_submit(ring));
-    }
 
     auto const count = pool.chunks(storage_pool::seq);
     std::vector<int> fds;
@@ -297,9 +271,6 @@ AsyncIO::~AsyncIO()
         MONAD_ASSERT(!io_uring_unregister_files(&wr_uring_->get_ring()));
     }
     MONAD_ASSERT(!io_uring_unregister_files(&uring_.get_ring()));
-
-    ::close(fds_.msgread);
-    ::close(fds_.msgwrite);
 }
 
 void AsyncIO::account_read_(size_t size)
@@ -533,9 +504,6 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
     erased_connected_operation *state = nullptr;
     result<size_t> res(success(0));
     auto get_cqe = [&] {
-        auto const inflight_ts =
-            records_.inflight_ts.load(std::memory_order_acquire);
-
         if (wr_ring != nullptr && records_.inflight_wr > 0 &&
             (poll_rings_mask & 2) == 0) {
             ring = wr_ring;
@@ -550,8 +518,7 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
             }
             io_uring_peek_cqe(wr_ring, &cqe);
             if ((poll_rings_mask & 1) != 0) {
-                if (blocking && inflight_ts == 0 &&
-                    detail::AsyncIO_per_thread_state().empty()) {
+                if (blocking && detail::AsyncIO_per_thread_state().empty()) {
                     MONAD_ASYNC_IO_URING_RETRYABLE(
                         io_uring_wait_cqe(ring, &cqe));
                 }
@@ -571,65 +538,23 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
                 // code, this will do it.
                 MONAD_ASYNC_IO_URING_RETRYABLE(io_uring_submit(other_ring));
             }
-            if (blocking && inflight_ts == 0 && records_.inflight_wr == 0 &&
+            if (blocking && records_.inflight_wr == 0 &&
                 detail::AsyncIO_per_thread_state().empty()) {
                 MONAD_ASYNC_IO_URING_RETRYABLE(io_uring_wait_cqe(ring, &cqe));
             }
             else {
-                // If nothing in io_uring and there are no threadsafe ops in
-                // flight, return false
-                if (0 != io_uring_peek_cqe(ring, &cqe) && inflight_ts == 0) {
+                // If nothing in io_uring, return false
+                if (0 != io_uring_peek_cqe(ring, &cqe)) {
                     return false;
                 }
             }
         }
 
-        void *data = (cqe != nullptr)
-                         ? io_uring_cqe_get_data(cqe)
-                         : detail::ASYNC_IO_MSG_PIPE_READY_IO_URING_DATA_MAGIC;
+        void *data = io_uring_cqe_get_data(cqe);
         MONAD_ASSERT(data);
-        if (data == detail::ASYNC_IO_MSG_PIPE_READY_IO_URING_DATA_MAGIC) {
-            // MSG_READ pipe has a message for us. It is simply the pointer to
-            // the connected operation state for us to complete.
-            MONAD_ASSERT(cqe == nullptr || cqe->res == POLLIN);
-            if (cqe != nullptr && !(cqe->flags & IORING_CQE_F_MORE)) {
-                // Rearm the poll
-                struct io_uring_sqe *sqe = io_uring_get_sqe(ring);
-                MONAD_ASSERT(sqe);
-                io_uring_prep_poll_multishot(sqe, fds_.msgread, POLLIN);
-                io_uring_sqe_set_data(
-                    sqe, detail::ASYNC_IO_MSG_PIPE_READY_IO_URING_DATA_MAGIC);
-                MONAD_ASYNC_IO_URING_RETRYABLE(io_uring_submit(ring));
-            }
-            auto const readed = ::read(
-                fds_.msgread,
-                static_cast<void *>(&state),
-                sizeof(erased_connected_operation *));
-            if (readed >= 0) {
-                MONAD_ASSERT(sizeof(erased_connected_operation *) == readed);
-                // Writes flushed in the submitting thread must be acquired now
-                // before state can be dereferenced
-                std::atomic_thread_fence(std::memory_order_acquire);
-            }
-            else {
-                if (EAGAIN == errno || EWOULDBLOCK == errno) {
-                    // Spurious wakeup
-                    if (cqe != nullptr) {
-                        io_uring_cqe_seen(ring, cqe);
-                        cqe = nullptr;
-                    }
-                    return true;
-                }
-                else {
-                    MONAD_ASSERT(readed >= 0);
-                }
-            }
-        }
-        else {
-            state = reinterpret_cast<erased_connected_operation *>(data);
-            res = (cqe->res < 0) ? result<size_t>(posix_code(-cqe->res))
-                                 : result<size_t>(cqe->res);
-        }
+        state = reinterpret_cast<erased_connected_operation *>(data);
+        res = (cqe->res < 0) ? result<size_t>(posix_code(-cqe->res))
+                             : result<size_t>(cqe->res);
         if (cqe != nullptr) {
             io_uring_cqe_seen(ring, cqe);
             cqe = nullptr;
@@ -677,12 +602,6 @@ size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
         else if (state->is_write()) {
             --records_.inflight_wr;
             is_read_or_write = true;
-        }
-        else if (state->is_timeout()) {
-            --records_.inflight_tm;
-        }
-        else if (state->is_threadsafeop()) {
-            records_.inflight_ts.fetch_sub(1, std::memory_order_acq_rel);
         }
         else if (state->is_read_scatter()) {
             --records_.inflight_rd_scatter;


### PR DESCRIPTION
The pipe-based cross-thread communication mechanism in AsyncIO has been unused since the threadsafe_sender was removed.

Remove the relevant code from async io.