### PR TITLE
reserve balance checks now use the final state code hash

### DIFF
--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -37,7 +37,7 @@ bool revert_monad_transaction(
     MonadChainContext const &);
 
 bool can_sender_dip_into_reserve(
-    Address const &sender, uint64_t i, bytes32_t const &orig_code_hash,
+    Address const &sender, uint64_t i, bool sender_is_delegated,
     MonadChainContext const &);
 
 uint256_t get_max_reserve(monad_revision, Address const &);


### PR DESCRIPTION
This makes the checks more liberal (less likely to revert transactions during execution), and also makes the implementation closer to the Coq [model](https://category-labs.github.io/category-research/reserve-balance-coq-proofs/monad.proofs.reservebal.html#execValidatedTx) that was proven correct (under some assumptions).

When this change was done in the Coq model months ago, IIRC, the Coq proofs did not require making any additional assumption.  The Coq proofs already assumed that the senders of the transactions accepted by consensus cannot be smart contract (SC) addresses. This is a cryptographic hardness assumption whose proof is beyond the scope of the planned Coq proofs about monad.  SC addresses are based on hashes of code/nonces and thus having a corresponding private key seems to be cryptographically impossible. Formally, the following assumptions sufficed for the [Coq proof](https://category-labs.github.io/category-research/reserve-balance-coq-proofs/monad.proofs.reservebal.html#fullBlockStep2), as listed in the linked theorem statement:

```
(∀ ac, ac ∈ (map sender blocks) → isSC latestState.1 ac = false)
```
This assumption says that the senders of the transactions are not smart contracts in the last fully executed state from which consensus is building the proposals (list of transactions, possibly spanning multiple blocks). However, the above is not sufficient. The Coq proofs also assume the following so that the above property can be preserved while executing the proposed transactions during the proof steps:

```
(∀ txext, txext ∈ blocks → txCannotCreateContractAtAddrs txext (map sender blocks))
```
where `txCannotCreateContractAtAddrs` is [defined](https://category-labs.github.io/category-research/reserve-balance-coq-proofs/monad.proofs.reservebal.html#txCannotCreateContractAtAddrs) as:
```
Definition txCannotCreateContractAtAddrs tx (eoasWithPrivateKey: list EvmAddr) := 
  ∀ s, let sf := (execValidatedTx s tx) in 
          ∀ addr, addr ∈ eoasWithPrivateKey 
                       → isSC s.1 addr = false 
                        → isSC sf.1 addr = false.
```




The test case in this PR was mainly written by codex-cli