### PR TITLE
[event] explicitly clear flow info that doesn't apply

### DIFF
--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -290,6 +290,8 @@ inline void ExecutionEventRecorder::record_block_marker_event(
         monad_event_recorder_reserve(&exec_recorder_, 0, &seqno, &payload_buf);
     event->event_type = std::to_underlying(event_type);
     event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = cur_block_start_seqno_;
+    event->content_ext[MONAD_FLOW_TXN_ID] = 0;
+    event->content_ext[MONAD_FLOW_ACCOUNT_INDEX] = 0;
     monad_event_recorder_commit(event, seqno);
 }
 
@@ -303,6 +305,7 @@ inline void ExecutionEventRecorder::record_txn_marker_event(
     event->event_type = std::to_underlying(event_type);
     event->content_ext[MONAD_FLOW_BLOCK_SEQNO] = cur_block_start_seqno_;
     event->content_ext[MONAD_FLOW_TXN_ID] = txn_num + 1;
+    event->content_ext[MONAD_FLOW_ACCOUNT_INDEX] = 0;
     monad_event_recorder_commit(event, seqno);
 }
 


### PR DESCRIPTION
Poorly written clients might try to unconditionally read these for event types they don't apply to, so always clear them. For an explanation of what these are, see:

> https://docs.monad.xyz/execution-events/event-ring#flow-tags-the-content_ext-fields-in-execution-event-rings