### PR TITLE
[staking]: Reduce pagination on inverse mappings from 100 to 50

### DIFF
--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -575,8 +575,10 @@ public:
         byte_string_view, evmc_address const &, evmc_uint256be const &);
     Result<byte_string> precompile_get_execution_valset(
         byte_string_view, evmc_address const &, evmc_uint256be const &);
+    template <Traits traits>
     Result<byte_string> precompile_get_delegations(
         byte_string_view, evmc_address const &, evmc_uint256be const &);
+    template <Traits traits>
     Result<byte_string> precompile_get_delegators(
         byte_string_view, evmc_address const &, evmc_uint256be const &);
     Result<byte_string> precompile_get_epoch(

--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -85,11 +85,21 @@ namespace limits
         return 200;
     }
 
-    // Results for get_valset, get_delegators_for_validator, and
-    // get_validators_for_delegator are paginated
-    constexpr uint64_t paginated_results_size()
+    constexpr uint32_t array_pagination()
     {
         return 100;
+    };
+
+    template <Traits traits>
+    constexpr uint32_t linked_list_pagination()
+    {
+        if constexpr (traits::monad_rev() < MONAD_EIGHT) {
+            return 100;
+        }
+
+        // The relation to array pagination is each list node occupies two
+        // slots.
+        return 50;
     };
 
     constexpr uint64_t withdrawal_delay()


### PR DESCRIPTION
This includes:
  * precompile_get_delegations()
  * precompile_get_delegators()