### PR TITLE
[execution/monad] Failsafe sanity checks for reward system txs

### DIFF
--- a/category/execution/monad/validate_monad_block.hpp
+++ b/category/execution/monad/validate_monad_block.hpp
@@ -17,10 +17,11 @@
 
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
+#include <category/execution/ethereum/core/address.hpp>
 #include <category/vm/evm/monad/revision.h>
 #include <category/vm/evm/traits.hpp>
 
-#include <vector>
+#include <span>
 
 // TODO unstable paths between versions
 #if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
@@ -33,12 +34,16 @@
 
 MONAD_NAMESPACE_BEGIN
 
+struct Transaction;
+
 enum class MonadBlockError
 {
     Success = 0,
     TimestampMismatch,
     BaseFeeMismatch,
     SystemTransactionNotFirstInBlock,
+    MultipleRewardTransactions,
+    InvalidRewardValue,
 };
 
 template <class MonadConsensusBlockHeader>
@@ -46,7 +51,8 @@ Result<void>
 static_validate_consensus_header(MonadConsensusBlockHeader const &);
 
 template <Traits traits>
-Result<void> static_validate_monad_senders(std::vector<Address> const &);
+Result<void> static_validate_monad_body(
+    std::span<Address const>, std::span<Transaction const>);
 
 MONAD_NAMESPACE_END
 

--- a/category/execution/monad/validate_monad_block_test.cpp
+++ b/category/execution/monad/validate_monad_block_test.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/monad/staking/util/constants.hpp>
+#include <category/execution/monad/system_sender.hpp>
+#include <category/execution/monad/validate_monad_block.hpp>
+#include <monad/test/traits_test.hpp>
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+
+TYPED_TEST(MonadTraitsTest, no_system_txns)
+{
+    std::vector<Address> senders{
+        0xaaaa_address,
+        0xbbbb_address,
+        0xcccc_address,
+    };
+    std::vector<Transaction> txns(senders.size());
+    auto const res =
+        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    EXPECT_FALSE(res.has_error());
+}
+
+TYPED_TEST(MonadTraitsTest, multiple_system_txns_ok)
+{
+    std::vector<Address> senders{
+        SYSTEM_SENDER,
+        SYSTEM_SENDER,
+        0xaaaa_address,
+        0xbbbb_address,
+    };
+    std::vector<Transaction> txns(senders.size());
+    txns[1].value = 25 * staking::MON;
+    auto const res =
+        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    EXPECT_FALSE(res.has_error());
+}
+
+TYPED_TEST(MonadTraitsTest, system_txn_comes_after_user_txn)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<Address> senders{
+        0xaaaa_address,
+        0xbbbb_address,
+        SYSTEM_SENDER,
+        0xcccc_address,
+    };
+    std::vector<Transaction> txns(senders.size());
+    auto const res =
+        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+        EXPECT_FALSE(res.has_error());
+    }
+    else {
+        ASSERT_TRUE(res.has_error());
+        EXPECT_EQ(
+            res.error(), MonadBlockError::SystemTransactionNotFirstInBlock);
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, multiple_reward_txns_error)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<Address> senders{
+        SYSTEM_SENDER,
+        SYSTEM_SENDER,
+        0xaaaa_address,
+        0xbbbb_address,
+    };
+    std::vector<Transaction> txns(senders.size());
+    txns[0].value = 25 * staking::MON;
+    txns[1].value = 1 * staking::MON;
+    auto const res =
+        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+        EXPECT_FALSE(res.has_error());
+    }
+    else {
+        ASSERT_TRUE(res.has_error());
+        EXPECT_EQ(res.error(), MonadBlockError::MultipleRewardTransactions);
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, reward_txn_exceeds_maximum)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<Address> senders{
+        SYSTEM_SENDER,
+        0xaaaa_address,
+    };
+    std::vector<Transaction> txns(senders.size());
+    txns[0].value = 26 * staking::MON;
+    auto const res =
+        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+        EXPECT_FALSE(res.has_error());
+    }
+    else {
+        ASSERT_TRUE(res.has_error());
+        EXPECT_EQ(res.error(), MonadBlockError::InvalidRewardValue);
+    }
+}

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -204,7 +204,8 @@ Result<BlockExecOutput> propose_block(
                              .senders_and_authorities =
                                  std::move(senders_and_authorities)})
                      .second);
-    BOOST_OUTCOME_TRY(static_validate_monad_senders<traits>(senders));
+    BOOST_OUTCOME_TRY(
+        static_validate_monad_body<traits>(senders, block.transactions));
 
     // Create call frames vectors for tracers
     std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -132,7 +132,8 @@ Result<void> process_monad_block(
             }
         }
     }
-    BOOST_OUTCOME_TRY(static_validate_monad_senders<traits>(senders));
+    BOOST_OUTCOME_TRY(
+        static_validate_monad_body<traits>(senders, block.transactions));
 
     // Call tracer initialization
     std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};


### PR DESCRIPTION
* assert there's max 1 reward system tx per block
* assert that the value of it if it exists is <= 25 MON

Adds unit test suite to verify expected behavior.