### PR TITLE
[test/util]: TraitsTest: Add missing include

### DIFF
--- a/test/unit/common/include/monad/test/traits_test.hpp
+++ b/test/unit/common/include/monad/test/traits_test.hpp
@@ -19,6 +19,7 @@
 #include <category/vm/evm/traits.hpp>
 
 #include <evmc/evmc.h>
+#include <evmc/helpers.h>
 #include <gtest/gtest.h>
 
 #include <format>


### PR DESCRIPTION
`evmc_revision_to_string()` is declared in evmc/helpers.h