### PR TITLE
Fixes runloop_monad

### DIFF
--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -467,12 +467,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &chain, std::filesystem::path const &ledger_dir,
     mpt::Db &raw_db, Db &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
-    fiber::PriorityPool &priority_pool, uint64_t &finalized_block_num,
+    fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
     bool const enable_tracing)
 {
     constexpr auto SLEEP_TIME = std::chrono::microseconds(100);
-    uint64_t const start_block_num = finalized_block_num;
+    uint64_t const start_block_num = block_num;
     uint256_t const chain_id = chain.get_chain_id();
     BlockHashChain block_hash_chain(block_hash_buffer);
 
@@ -550,6 +550,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
 
     std::deque<ToExecute> to_execute;
     std::deque<ToFinalize> to_finalize;
+
+    MONAD_ASSERT(start_block_num > 0);
+    uint64_t finalized_block_num = start_block_num - 1;
 
     while (finalized_block_num < end_block_num && stop == 0) {
         to_finalize.clear();
@@ -732,6 +735,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 });
         }
     }
+
+    // Increment by one to agree with the other runloops:
+    block_num = finalized_block_num + 1;
 
     return {ntxs, total_gas};
 }


### PR DESCRIPTION
Fixes off by one in monad runloop.

<details>
  <summary>Before with nblocks=1 does not run any blocks</summary>

```
2026-01-14 14:30:19.541855413 [111484] main.cpp:366 LOG_INFO	Finished initializing db at block = 0, last finalized block = 0, last verified block = 18446744073709551615, state root = 0x150622423ae5432c8ad8b4a2352bade7f9247a6e6de50d57638d1f9ef4cc32b9, time elapsed = 3134ms
2026-01-14 14:30:19.541855663 [111484] main.cpp:375 LOG_INFO	Running with block_db = /tmp/ledger, start block number = 1, number blocks = 1
2026-01-14 14:30:19.545485109 [111484] update_aux.cpp:803 LOG_INFO	Database root offsets ring buffer is configured with 16 chunks, can hold up to 268435456 historical entries.
2026-01-14 14:30:25.085893318 [111484] main.cpp:493 LOG_INFO	Finish running, finish(stopped) block number = 1, number of blocks run = 1, time_elapsed = 5s, num transactions = 0, tps = 0, gps = 0 M
```

</details>

<details>
  <summary>Before with nblocks=2 runs two blocks correctly</summary>

```
2026-01-14 14:31:17.579178969 [111508] main.cpp:366 LOG_INFO	Finished initializing db at block = 0, last finalized block = 0, last verified block = 18446744073709551615, state root = 0x150622423ae5432c8ad8b4a2352bade7f9247a6e6de50d57638d1f9ef4cc32b9, time elapsed = 27ms
2026-01-14 14:31:17.579179069 [111508] main.cpp:375 LOG_INFO	Running with block_db = /tmp/ledger, start block number = 1, number blocks = 2
2026-01-14 14:31:17.582887085 [111508] update_aux.cpp:803 LOG_INFO	Database root offsets ring buffer is configured with 16 chunks, can hold up to 268435456 historical entries.
2026-01-14 14:31:18.295172751 [111511] update_aux.cpp:1697 LOG_INFO	Version 1: nodes created or updated for upsert = 38, nodes updated for expire = 0, nreads for expire = 0

2026-01-14 14:31:18.295172993 [111511] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 121 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,24576}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 14:31:18.295486100 [111511] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 268 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,26112}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 14:31:18.295511540 [111508] runloop_monad.cpp:382 LOG_INFO	__exec_block,bl=       1,id=0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e,ts=1768401078287,tx=    3,rt=   2,rtp=66.67%,sr= 6742µs,txe=   171µs,cmt=   478µs,tot=  7660µs,tpse=17543,tps=  391,gas=    90000,gpse= 526,gps= 11,ae=   9,ane=   3,sz=   0,snz=   0,ac=       0,sc=       0
2026-01-14 14:31:18.295543979 [111508] runloop_monad.cpp:104 LOG_INFO	Run to block=    1, block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e, number of transactions      3, tps =   372, gps =   11 M, rss =   1833 MB
2026-01-14 14:31:18.302420415 [111511] update_aux.cpp:1697 LOG_INFO	Version 2: nodes created or updated for upsert = 25, nodes updated for expire = 0, nreads for expire = 0

2026-01-14 14:31:18.302420555 [111511] update_aux.cpp:1175 LOG_INFO	Finish upserting version 2. Min valid version 0. Time elapsed: 95 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,30720}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 14:31:18.302477665 [111511] update_aux.cpp:1175 LOG_INFO	Finish upserting version 2. Min valid version 0. Time elapsed: 19 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,32256}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 14:31:18.302496235 [111508] runloop_monad.cpp:382 LOG_INFO	__exec_block,bl=       2,id=0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f,ts=1768401078295,tx=    2,rt=   1,rtp=50.00%,sr= 6630µs,txe=    73µs,cmt=   175µs,tot=  6931µs,tpse=27397,tps=  288,gas=    60000,gpse= 821,gps=  8,ae=   0,ane=   0,sz=   1,snz=   0,ac=       0,sc=       0
2026-01-14 14:31:18.302510465 [111508] runloop_monad.cpp:104 LOG_INFO	Run to block=    2, block_id 0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f, number of transactions      2, tps =   287, gps =    8 M, rss =   1835 MB
2026-01-14 14:31:18.302510705 [111508] runloop_monad.cpp:712 LOG_INFO	Processing finalization for block 1 with block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e
2026-01-14 14:31:18.302565924 [111508] runloop_monad.cpp:712 LOG_INFO	Processing finalization for block 2 with block_id 0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f
2026-01-14 14:31:18.302628944 [111508] main.cpp:493 LOG_INFO	Finish running, finish(stopped) block number = 2, number of blocks run = 2, time_elapsed = 0s, num transactions = 0, tps = 0, gps = 0 M
```

</details>

<details>
  <summary>After with nblocks=1 now correctly runs one block</summary>

```
2026-01-14 15:07:06.941237725 [118172] main.cpp:366 LOG_INFO	Finished initializing db at block = 0, last finalized block = 0, last verified block = 18446744073709551615, state root = 0x150622423ae5432c8ad8b4a2352bade7f9247a6e6de50d57638d1f9ef4cc32b9, time elapsed = 3131ms
2026-01-14 15:07:06.941238075 [118172] main.cpp:375 LOG_INFO	Running with block_db = /tmp/ledger, start block number = 1, number blocks = 1
2026-01-14 15:07:06.944945439 [118172] update_aux.cpp:803 LOG_INFO	Database root offsets ring buffer is configured with 16 chunks, can hold up to 268435456 historical entries.
2026-01-14 15:07:12.507220923 [118175] update_aux.cpp:1697 LOG_INFO	Version 1: nodes created or updated for upsert = 38, nodes updated for expire = 0, nreads for expire = 0

2026-01-14 15:07:12.507221463 [118175] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 98 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,24576}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:07:12.510107791 [118175] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 2836 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,26112}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:07:12.510140831 [118172] runloop_monad.cpp:382 LOG_INFO	__exec_block,bl=       1,id=0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e,ts=1768403232500,tx=    3,rt=   2,rtp=66.67%,sr= 6734µs,txe=   170µs,cmt=  3028µs,tot= 10081µs,tpse=17647,tps=  297,gas=    90000,gpse= 529,gps=  8,ae=   9,ane=   2,sz=   0,snz=   0,ac=       0,sc=       0
2026-01-14 15:07:12.510178891 [118172] runloop_monad.cpp:104 LOG_INFO	Run to block=    1, block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e, number of transactions      3, tps =   296, gps =    8 M, rss =   5929 MB
2026-01-14 15:07:12.510179331 [118172] runloop_monad.cpp:715 LOG_INFO	Processing finalization for block 1 with block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e
2026-01-14 15:07:12.510230970 [118172] main.cpp:493 LOG_INFO	Finish running, finish(stopped) block number = 2, number of blocks run = 1, time_elapsed = 5s, num transactions = 0, tps = 0, gps = 0 M
```

</details>

<details>
  <summary>After with nblocks=2 still runs two blocks correctly</summary>

```
2026-01-14 15:07:55.709067459 [118206] main.cpp:366 LOG_INFO	Finished initializing db at block = 0, last finalized block = 0, last verified block = 18446744073709551615, state root = 0x150622423ae5432c8ad8b4a2352bade7f9247a6e6de50d57638d1f9ef4cc32b9, time elapsed = 3142ms
2026-01-14 15:07:55.709067779 [118206] main.cpp:375 LOG_INFO	Running with block_db = /tmp/ledger, start block number = 1, number blocks = 2
2026-01-14 15:07:55.712743263 [118206] update_aux.cpp:803 LOG_INFO	Database root offsets ring buffer is configured with 16 chunks, can hold up to 268435456 historical entries.
2026-01-14 15:08:01.368528400 [118209] update_aux.cpp:1697 LOG_INFO	Version 1: nodes created or updated for upsert = 38, nodes updated for expire = 0, nreads for expire = 0

2026-01-14 15:08:01.368528888 [118209] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 92 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,24576}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:08:01.371272007 [118209] update_aux.cpp:1175 LOG_INFO	Finish upserting version 1. Min valid version 0. Time elapsed: 2694 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,26112}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:08:01.371302047 [118206] runloop_monad.cpp:382 LOG_INFO	__exec_block,bl=       1,id=0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e,ts=1768403281361,tx=    3,rt=   2,rtp=66.67%,sr= 6766µs,txe=   216µs,cmt=  2879µs,tot= 10029µs,tpse=13888,tps=  299,gas=    90000,gpse= 416,gps=  8,ae=   9,ane=   3,sz=   0,snz=   0,ac=       0,sc=       0
2026-01-14 15:08:01.371338777 [118206] runloop_monad.cpp:104 LOG_INFO	Run to block=    1, block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e, number of transactions      3, tps =   297, gps =    8 M, rss =   5929 MB
2026-01-14 15:08:01.372722577 [118209] update_aux.cpp:1697 LOG_INFO	Version 2: nodes created or updated for upsert = 25, nodes updated for expire = 0, nreads for expire = 0

2026-01-14 15:08:01.372722697 [118209] update_aux.cpp:1175 LOG_INFO	Finish upserting version 2. Min valid version 0. Time elapsed: 1201 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,30720}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:08:01.372775897 [118209] update_aux.cpp:1175 LOG_INFO	Finish upserting version 2. Min valid version 0. Time elapsed: 10 us. Disk usage: 0.0003. Chunks: 1 fast, 1 slow, 7433 free. Writer offsets: fast={0,32256}, slow={0,0}. Compaction head offset fast=0, slow=0
2026-01-14 15:08:01.372794227 [118206] runloop_monad.cpp:382 LOG_INFO	__exec_block,bl=       2,id=0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f,ts=1768403281371,tx=    2,rt=   1,rtp=50.00%,sr=   60µs,txe=    32µs,cmt=  1282µs,tot=  1430µs,tpse=62500,tps= 1398,gas=    60000,gpse=1875,gps= 41,ae=   0,ane=   0,sz=   1,snz=   0,ac=       0,sc=       0
2026-01-14 15:08:01.372807317 [118206] runloop_monad.cpp:104 LOG_INFO	Run to block=    2, block_id 0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f, number of transactions      2, tps =  1374, gps =   41 M, rss =   5929 MB
2026-01-14 15:08:01.372807607 [118206] runloop_monad.cpp:715 LOG_INFO	Processing finalization for block 1 with block_id 0xbb59721984c764d0936e7abf9ef052297f1ca23475035e36de32a50893d58f0e
2026-01-14 15:08:01.372859006 [118206] runloop_monad.cpp:715 LOG_INFO	Processing finalization for block 2 with block_id 0x013b0bca99fe762452065cfa98263b8b7d1867914e8f8ff6ebefb5126edc9d9f
2026-01-14 15:08:01.373112725 [118206] main.cpp:493 LOG_INFO	Finish running, finish(stopped) block number = 3, number of blocks run = 2, time_elapsed = 5s, num transactions = 0, tps = 0, gps = 0 M
```

</details>