### PR TITLE
[execution/ethereum]: Remove validate_output_header from chain

### DIFF
--- a/category/execution/ethereum/chain/chain.hpp
+++ b/category/execution/ethereum/chain/chain.hpp
@@ -45,9 +45,6 @@ struct Chain
 
     virtual Result<void> static_validate_header(BlockHeader const &) const;
 
-    virtual Result<void> validate_output_header(
-        BlockHeader const &input, BlockHeader const &output) const = 0;
-
     virtual GenesisState get_genesis_state() const = 0;
 
     virtual Result<void> validate_transaction(

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -101,52 +101,6 @@ EthereumMainnet::static_validate_header(BlockHeader const &header) const
     return success();
 }
 
-Result<void> EthereumMainnet::validate_output_header(
-    BlockHeader const &input, BlockHeader const &output) const
-{
-    // First, validate execution inputs.
-    if (MONAD_UNLIKELY(input.ommers_hash != output.ommers_hash)) {
-        return BlockError::WrongOmmersHash;
-    }
-    if (MONAD_UNLIKELY(input.transactions_root != output.transactions_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-    if (MONAD_UNLIKELY(input.withdrawals_root != output.withdrawals_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-
-    // Second, validate execution outputs known before commit.
-
-    // YP eq. 170
-    if (MONAD_UNLIKELY(input.gas_used != output.gas_used)) {
-        return BlockError::InvalidGasUsed;
-    }
-
-    // YP eq. 56
-    if (MONAD_UNLIKELY(output.gas_used > output.gas_limit)) {
-        return BlockError::GasAboveLimit;
-    }
-
-    // YP eq. 33
-    if (MONAD_UNLIKELY(input.logs_bloom != output.logs_bloom)) {
-        return BlockError::WrongLogsBloom;
-    }
-
-    if (MONAD_UNLIKELY(input.parent_hash != output.parent_hash)) {
-        return BlockError::WrongParentHash;
-    }
-
-    // Lastly, validate execution outputs only known after commit.
-    if (MONAD_UNLIKELY(input.state_root != output.state_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-    if (MONAD_UNLIKELY(input.receipts_root != output.receipts_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-
-    return success();
-}
-
 GenesisState EthereumMainnet::get_genesis_state() const
 {
     BlockHeader header;

--- a/category/execution/ethereum/chain/ethereum_mainnet.hpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.hpp
@@ -46,9 +46,6 @@ struct EthereumMainnet : Chain
     virtual Result<void>
     static_validate_header(BlockHeader const &) const override;
 
-    virtual Result<void> validate_output_header(
-        BlockHeader const &input, BlockHeader const &output) const override;
-
     virtual GenesisState get_genesis_state() const override;
 
     virtual Result<void> validate_transaction(

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -254,6 +254,52 @@ Result<void> static_validate_block(evmc_revision const rev, Block const &block)
     MONAD_ASSERT(false);
 }
 
+Result<void>
+validate_output_header(BlockHeader const &input, BlockHeader const &output)
+{
+    // First, validate execution inputs.
+    if (MONAD_UNLIKELY(input.ommers_hash != output.ommers_hash)) {
+        return BlockError::WrongOmmersHash;
+    }
+    if (MONAD_UNLIKELY(input.transactions_root != output.transactions_root)) {
+        return BlockError::WrongMerkleRoot;
+    }
+    if (MONAD_UNLIKELY(input.withdrawals_root != output.withdrawals_root)) {
+        return BlockError::WrongMerkleRoot;
+    }
+
+    // Second, validate execution outputs known before commit.
+
+    // YP eq. 170
+    if (MONAD_UNLIKELY(input.gas_used != output.gas_used)) {
+        return BlockError::InvalidGasUsed;
+    }
+
+    // YP eq. 56
+    if (MONAD_UNLIKELY(output.gas_used > output.gas_limit)) {
+        return BlockError::GasAboveLimit;
+    }
+
+    // YP eq. 33
+    if (MONAD_UNLIKELY(input.logs_bloom != output.logs_bloom)) {
+        return BlockError::WrongLogsBloom;
+    }
+
+    if (MONAD_UNLIKELY(input.parent_hash != output.parent_hash)) {
+        return BlockError::WrongParentHash;
+    }
+
+    // Lastly, validate execution outputs only known after commit.
+    if (MONAD_UNLIKELY(input.state_root != output.state_root)) {
+        return BlockError::WrongMerkleRoot;
+    }
+    if (MONAD_UNLIKELY(input.receipts_root != output.receipts_root)) {
+        return BlockError::WrongMerkleRoot;
+    }
+
+    return success();
+}
+
 MONAD_NAMESPACE_END
 
 BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_BEGIN

--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -73,6 +73,9 @@ Result<void> static_validate_block(Block const &);
 
 Result<void> static_validate_block(evmc_revision, Block const &);
 
+Result<void>
+validate_output_header(BlockHeader const &input, BlockHeader const &output);
+
 MONAD_NAMESPACE_END
 
 BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_BEGIN

--- a/category/execution/monad/chain/monad_chain.cpp
+++ b/category/execution/monad/chain/monad_chain.cpp
@@ -49,26 +49,6 @@ evmc_revision MonadChain::get_revision(
     return EVMC_CANCUN;
 }
 
-Result<void> MonadChain::validate_output_header(
-    BlockHeader const &input, BlockHeader const &output) const
-{
-    if (MONAD_UNLIKELY(input.ommers_hash != output.ommers_hash)) {
-        return BlockError::WrongOmmersHash;
-    }
-    if (MONAD_UNLIKELY(input.transactions_root != output.transactions_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-    if (MONAD_UNLIKELY(input.withdrawals_root != output.withdrawals_root)) {
-        return BlockError::WrongMerkleRoot;
-    }
-
-    // YP eq. 56
-    if (MONAD_UNLIKELY(output.gas_used > output.gas_limit)) {
-        return BlockError::GasAboveLimit;
-    }
-    return success();
-}
-
 Result<void> MonadChain::validate_transaction(
     uint64_t const block_number, uint64_t const timestamp,
     Transaction const &tx, Address const &sender, State &state,

--- a/category/execution/monad/chain/monad_chain.hpp
+++ b/category/execution/monad/chain/monad_chain.hpp
@@ -55,9 +55,6 @@ struct MonadChain : Chain
     virtual evmc_revision
     get_revision(uint64_t block_number, uint64_t timestamp) const override;
 
-    virtual Result<void> validate_output_header(
-        BlockHeader const &input, BlockHeader const &output) const override;
-
     virtual monad_revision get_monad_revision(uint64_t timestamp) const = 0;
 
     virtual Result<void> validate_transaction(

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -170,8 +170,7 @@ Result<void> process_ethereum_block(
     }
     // Post-commit validation of header, with Merkle root fields filled in
     auto const output_header = db.read_eth_header();
-    BOOST_OUTCOME_TRY(
-        chain.validate_output_header(block.header, output_header));
+    BOOST_OUTCOME_TRY(validate_output_header(block.header, output_header));
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -222,8 +222,7 @@ Result<void> process_monad_block(
     }
     // Post-commit validation of header, with Merkle root fields filled in
     auto const output_header = db.read_eth_header();
-    BOOST_OUTCOME_TRY(
-        chain.validate_output_header(block.header, output_header));
+    BOOST_OUTCOME_TRY(validate_output_header(block.header, output_header));
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -340,7 +340,7 @@ Result<BlockExecOutput> BlockchainTest::execute(
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
 
     BOOST_OUTCOME_TRY(
-        chain.validate_output_header(block.header, exec_output.eth_header));
+        validate_output_header(block.header, exec_output.eth_header));
 
     return exec_output;
 }


### PR DESCRIPTION
Having this method on the Chain object is holdover from a time when the replay ethereum and live execution had the same entrypoint.

With the runloops, this is no longer necessary.

Header validation on the chain is a bit of a footgun. Replaying monad from ethereum blocks uses the Monad chain with only live execution validation. Replay monad now checks the state root.