### PR TITLE
Improve statesync shutdown and fix protocol corruption

### DIFF
--- a/category/statesync/CMakeLists.txt
+++ b/category/statesync/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(
   "statesync_server.h"
   "statesync_server_context.cpp"
   "statesync_server_context.hpp"
-  "statesync_server_context.hpp"
+  "statesync_thread.cpp"
+  "statesync_thread.hpp"
   "statesync_version.cpp"
   "statesync_version.h")
 

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -517,15 +517,10 @@ void monad_statesync_server_run_once(struct monad_statesync_server *const sync)
         return;
     }
     MONAD_ASSERT(buf[0] == SYNC_TYPE_REQUEST);
-    unsigned char *ptr = buf;
-    uint64_t n = sizeof(monad_sync_request);
-    while (n != 0) {
-        auto const res = sync->statesync_server_recv(sync->net, ptr, n);
-        if (res == -1) {
-            continue;
-        }
-        ptr += res;
-        n -= static_cast<size_t>(res);
+    if (sync->statesync_server_recv(
+            sync->net, buf, sizeof(monad_sync_request)) !=
+        static_cast<ssize_t>(sizeof(monad_sync_request))) {
+        return;
     }
     auto const &rq = unaligned_load<monad_sync_request>(buf);
     monad_statesync_server_handle_request(sync, rq);

--- a/category/statesync/statesync_server.h
+++ b/category/statesync/statesync_server.h
@@ -17,6 +17,8 @@
 
 #include <category/statesync/statesync_messages.h>
 
+#include <sys/types.h>
+
 struct monad_statesync_server;
 struct monad_statesync_server_context;
 struct monad_statesync_server_network;

--- a/category/statesync/statesync_thread.cpp
+++ b/category/statesync/statesync_thread.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/statesync/statesync_thread.hpp>
+
+#include <category/mpt/ondisk_db_config.hpp>
+
+#include <pthread.h>
+
+MONAD_NAMESPACE_BEGIN
+
+StateSyncServer::StateSyncServer(StateSyncServerConfig const &config)
+    : ctx{std::make_unique<monad_statesync_server_context>(*config.triedb)}
+    , server{monad_statesync_server_create(
+          ctx.get(), config.network, &monad::statesync_server_recv,
+          &monad::statesync_server_send_upsert,
+          &monad::statesync_server_send_done)}
+    , thread{[this, config](std::stop_token const token) {
+        pthread_setname_np(pthread_self(), "statesync");
+
+        mpt::AsyncIOContext io_ctx{mpt::ReadOnlyOnDiskDbConfig{
+            .sq_thread_cpu = config.ro_sq_thread_cpu,
+            .dbname_paths = config.dbname_paths}};
+        mpt::Db ro{io_ctx};
+        ctx->ro = &ro;
+
+        std::stop_callback stop_cb(
+            token, [config]() { config.network->signal_shutdown(); });
+
+        while (!token.stop_requested()) {
+            monad_statesync_server_run_once(server.get());
+        }
+
+        ctx->ro = nullptr;
+    }}
+{
+}
+
+std::unique_ptr<StateSyncServer>
+make_statesync_server(StateSyncServerConfig const &config)
+{
+    return std::make_unique<StateSyncServer>(config);
+}
+
+MONAD_NAMESPACE_END

--- a/category/statesync/statesync_thread.hpp
+++ b/category/statesync/statesync_thread.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/statesync/statesync_server.h>
+#include <category/statesync/statesync_server_context.hpp>
+#include <category/statesync/statesync_server_network.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+struct StateSyncServerConfig
+{
+    monad::TrieDb *triedb;
+    monad_statesync_server_network *network;
+    std::optional<int> ro_sq_thread_cpu;
+    std::vector<std::filesystem::path> dbname_paths;
+};
+
+struct monad_statesync_server_deleter
+{
+    void operator()(monad_statesync_server *server) const
+    {
+        if (server != nullptr) {
+            monad_statesync_server_destroy(server);
+        }
+    }
+};
+
+struct StateSyncServer
+{
+    std::unique_ptr<monad_statesync_server_context> ctx;
+    std::unique_ptr<monad_statesync_server, monad_statesync_server_deleter>
+        server;
+    std::jthread thread;
+
+    explicit StateSyncServer(StateSyncServerConfig const &config);
+
+    StateSyncServer(StateSyncServer const &) = delete;
+    StateSyncServer &operator=(StateSyncServer const &) = delete;
+    StateSyncServer(StateSyncServer &&) = delete;
+    StateSyncServer &operator=(StateSyncServer &&) = delete;
+};
+
+std::unique_ptr<StateSyncServer>
+make_statesync_server(StateSyncServerConfig const &config);
+
+MONAD_NAMESPACE_END

--- a/category/statesync/test/test_network_shutdown.cpp
+++ b/category/statesync/test/test_network_shutdown.cpp
@@ -1,0 +1,216 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/basic_formatter.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/ondisk_db_config.hpp>
+#include <category/statesync/statesync_server_network.hpp>
+#include <category/statesync/statesync_thread.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/scope_exit.hpp>
+
+#include <array>
+#include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <optional>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <thread>
+#include <unistd.h>
+
+TEST(StateSyncThread, shutdown_via_jthread_stop_token)
+{
+    // Tests production shutdown: request_stop() → stop_callback →
+    // signal_shutdown() → eventfd → poll() wakes → thread exits
+
+    std::filesystem::path const socket_path =
+        std::filesystem::temp_directory_path() / "test_statesync_prod.sock";
+    std::filesystem::remove(socket_path);
+    BOOST_SCOPE_EXIT(&socket_path)
+    {
+        std::filesystem::remove(socket_path);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    int const listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0) << "Failed to create socket: " << strerror(errno);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path.c_str(), sizeof(addr.sun_path) - 1);
+
+    ASSERT_EQ(bind(listen_fd, (struct sockaddr *)&addr, sizeof(addr)), 0)
+        << "Failed to bind socket: " << strerror(errno);
+    ASSERT_EQ(listen(listen_fd, 1), 0)
+        << "Failed to listen on socket: " << strerror(errno);
+
+    std::filesystem::path const dbname =
+        std::filesystem::temp_directory_path() / "test_triedb_shutdown.mdb";
+    std::filesystem::remove(dbname);
+    BOOST_SCOPE_EXIT(&dbname)
+    {
+        std::filesystem::remove(dbname);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    int const fd =
+        ::open(dbname.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    ASSERT_GE(fd, 0) << "Failed to create db file: " << strerror(errno);
+    ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)), 0)
+        << "Failed to truncate db file: " << strerror(errno);
+    ::close(fd);
+
+    monad::mpt::AsyncIOContext io_ctx{
+        monad::mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}};
+    monad::mpt::Db db{io_ctx};
+    monad::TrieDb triedb(db);
+
+    std::optional<monad_statesync_server_network> net;
+    std::thread connect_thread([&]() { net.emplace(socket_path.c_str()); });
+
+    int const client_fd = accept(listen_fd, nullptr, nullptr);
+    ASSERT_GE(client_fd, 0)
+        << "Failed to accept connection: " << strerror(errno);
+    BOOST_SCOPE_EXIT(&client_fd)
+    {
+        if (client_fd >= 0) {
+            close(client_fd);
+        }
+    }
+    BOOST_SCOPE_EXIT_END
+
+    connect_thread.join();
+    close(listen_fd);
+
+    std::unique_ptr<monad::StateSyncServer> sync_server =
+        monad::make_statesync_server(monad::StateSyncServerConfig{
+            .triedb = &triedb,
+            .network = &*net,
+            .ro_sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname}});
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    auto const stop_start = std::chrono::steady_clock::now();
+    sync_server->thread.request_stop();
+    sync_server->thread.join();
+
+    auto const stop_elapsed = std::chrono::steady_clock::now() - stop_start;
+    auto const stop_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(stop_elapsed)
+            .count();
+
+    EXPECT_LT(stop_ms, 5000)
+        << "Thread should exit quickly, took " << stop_ms << "ms";
+}
+
+TEST(StateSyncThread, shutdown_during_reconnect)
+{
+    // Tests shutdown works when connect() is stuck in retry loop
+
+    std::filesystem::path const socket_path =
+        std::filesystem::temp_directory_path() /
+        "test_statesync_reconnect.sock";
+    std::filesystem::remove(socket_path);
+    BOOST_SCOPE_EXIT(&socket_path)
+    {
+        std::filesystem::remove(socket_path);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    int const listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0) << "Failed to create socket: " << strerror(errno);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path.c_str(), sizeof(addr.sun_path) - 1);
+
+    ASSERT_EQ(bind(listen_fd, (struct sockaddr *)&addr, sizeof(addr)), 0)
+        << "Failed to bind socket: " << strerror(errno);
+    ASSERT_EQ(listen(listen_fd, 1), 0)
+        << "Failed to listen on socket: " << strerror(errno);
+
+    std::filesystem::path const dbname =
+        std::filesystem::temp_directory_path() / "test_triedb_reconnect.mdb";
+    std::filesystem::remove(dbname);
+    BOOST_SCOPE_EXIT(&dbname)
+    {
+        std::filesystem::remove(dbname);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    int const fd =
+        ::open(dbname.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    ASSERT_GE(fd, 0) << "Failed to create db file: " << strerror(errno);
+    ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)), 0)
+        << "Failed to truncate db file: " << strerror(errno);
+    ::close(fd);
+
+    monad::mpt::AsyncIOContext io_ctx{
+        monad::mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}};
+    monad::mpt::Db db{io_ctx};
+    monad::TrieDb triedb(db);
+
+    std::optional<monad_statesync_server_network> net;
+    std::thread connect_thread([&]() { net.emplace(socket_path.c_str()); });
+
+    int client_fd = accept(listen_fd, nullptr, nullptr);
+    ASSERT_GE(client_fd, 0)
+        << "Failed to accept connection: " << strerror(errno);
+    BOOST_SCOPE_EXIT(&client_fd)
+    {
+        if (client_fd >= 0) {
+            close(client_fd);
+        }
+    }
+    BOOST_SCOPE_EXIT_END
+
+    connect_thread.join();
+    close(listen_fd);
+
+    std::unique_ptr<monad::StateSyncServer> sync_server =
+        monad::make_statesync_server(monad::StateSyncServerConfig{
+            .triedb = &triedb,
+            .network = &*net,
+            .ro_sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname}});
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    close(client_fd);
+    client_fd = -1;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto const stop_start = std::chrono::steady_clock::now();
+    sync_server->thread.request_stop();
+    sync_server->thread.join();
+
+    auto const stop_elapsed = std::chrono::steady_clock::now() - stop_start;
+    auto const stop_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(stop_elapsed)
+            .count();
+
+    EXPECT_LT(stop_ms, 5000)
+        << "Thread should exit from reconnect loop, took " << stop_ms << "ms";
+}


### PR DESCRIPTION
This commit improves the statesync shutdown mechanism and fixes a protocol corruption issue and busy recv loop.

Key changes:

1. Modified statesync_server_recv() to guarantee complete reads:
   - Now always returns exactly the requested number of bytes or -1
   - Accumulates data internally until the full message is received
   - Prevents protocol corruption from partial reads + reconnection
   - Uses poll() instead of busy-waiting, eliminating CPU spinning

2. Removed retry loop in monad_statesync_server_run_once():
   - Simplified to two simple recv() calls (type + request)
   - No longer needed since recv() guarantees complete reads

3. Fixed shutdown handling during reconnect:
   - connect() now polls shutdown_eventfd during retry loop
   - Prevents infinite hang when connection keeps failing
   - recv() reconnects and returns error on connection loss

This code was generated using Claude Sonnet 4.5