### PR TITLE
fiber: Add support for move-only functors

### DIFF
--- a/category/core/fiber/fiber_group.hpp
+++ b/category/core/fiber/fiber_group.hpp
@@ -63,9 +63,11 @@ public:
 
     ~FiberGroup();
 
-    void submit(uint64_t const priority, std::function<void()> task)
+    template <typename F>
+    void submit(uint64_t const priority, F &&task)
     {
-        channel_.push({priority, std::move(task)});
+        channel_.push(
+            {priority, std::move_only_function<void()>(std::forward<F>(task))});
     }
 
     unsigned num_fibers() const

--- a/category/core/fiber/priority_pool.hpp
+++ b/category/core/fiber/priority_pool.hpp
@@ -55,9 +55,10 @@ public:
         return thread_pool_->num_threads();
     }
 
-    void submit(uint64_t const priority, std::function<void()> task)
+    template <typename F>
+    void submit(uint64_t const priority, F &&task)
     {
-        fiber_group_->submit(priority, std::move(task));
+        fiber_group_->submit(priority, std::forward<F>(task));
     }
 
     FiberGroup &fiber_group()

--- a/category/core/fiber/priority_task.hpp
+++ b/category/core/fiber/priority_task.hpp
@@ -25,10 +25,10 @@ MONAD_FIBER_NAMESPACE_BEGIN
 struct PriorityTask
 {
     uint64_t priority{0};
-    std::function<void()> task{};
+    std::move_only_function<void()> task{};
 };
 
-static_assert(sizeof(PriorityTask) == 40);
+static_assert(sizeof(PriorityTask) == 48);
 static_assert(alignof(PriorityTask) == 8);
 
 MONAD_FIBER_NAMESPACE_END


### PR DESCRIPTION
Changed fiber infrastructure to support move-only functors by:
- Replacing std::function<void()> with std::move_only_function<void()> in PriorityTask
- Making FiberGroup::submit() and PriorityPool::submit() templated to accept any callable type via perfect forwarding

This enables zero-copy task submission with move-only captures like unique_ptr, and eliminates potentially large copies of Transaction or similar objects.

This code was generated using Claude Sonnet 4.5