### PR TITLE
Support CLZ opcode

### DIFF
--- a/category/vm/compiler/ir/instruction.hpp
+++ b/category/vm/compiler/ir/instruction.hpp
@@ -57,6 +57,7 @@ namespace monad::vm::compiler
         Shl = 0x1B,
         Shr = 0x1C,
         Sar = 0x1D,
+        Clz = 0x1E,
         Sha3 = 0x20,
         Address = 0x30,
         Balance = 0x31,
@@ -302,6 +303,8 @@ namespace monad::vm::compiler
             return "SHR";
         case Sar:
             return "SAR";
+        case Clz:
+            return "CLZ";
         case Sha3:
             return "KECCAK256";
         case Address:

--- a/category/vm/compiler/ir/local_stacks.cpp
+++ b/category/vm/compiler/ir/local_stacks.cpp
@@ -224,6 +224,11 @@ namespace
         case Sar:
             eval_binary_instruction(tok, stack, sar);
             break;
+        case Clz:
+            eval_unary_instruction(tok, stack, [](auto &x) {
+                return monad::vm::runtime::countl_zero(x);
+            });
+            break;
         case CodeSize:
             stack.emplace_front(ValueIs::LITERAL, uint256_t{codesize});
             break;

--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -124,6 +124,9 @@ namespace
         case Sar:
             emit.sar();
             break;
+        case Clz:
+            emit.clz();
+            break;
         case Sha3:
             emit.sha3<traits>(remaining_base_gas);
             break;

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -306,6 +306,7 @@ namespace monad::vm::compiler::native
         void shl();
         void shr();
         void sar();
+        void clz();
 
         void and_();
         void or_();
@@ -350,6 +351,8 @@ namespace monad::vm::compiler::native
         bool mulmod_opt();
         void mulmod(int64_t remaining_base_gas);
 
+        template <typename T, size_t N>
+        void array_leading_zeros(std::array<T, N> const &);
         template <typename T, size_t N>
         void array_byte_width(std::array<T, N> const &);
 

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -127,6 +127,7 @@ namespace monad::vm::compiler
         SHL = 0x1B,
         SHR = 0x1C,
         SAR = 0x1D,
+        CLZ = 0x1E,
         SHA3 = 0x20,
         ADDRESS = 0x30,
         BALANCE = 0x31,
@@ -760,8 +761,12 @@ namespace monad::vm::compiler
     consteval std::array<OpCodeInfo, 256>
     make_opcode_table<EvmTraits<EVMC_OSAKA>>()
     {
-        return make_opcode_table<
-            EvmTraits<previous_evm_revision(EVMC_OSAKA)>>();
+        auto table =
+            make_opcode_table<EvmTraits<previous_evm_revision(EVMC_OSAKA)>>();
+
+        // https://eips.ethereum.org/EIPS/eip-7939
+        add_opcode(0x1E, table, {"CLZ", 0, 1, 1, false, 5, 0});
+        return table;
     }
 
     template <>

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -128,7 +128,7 @@ namespace monad::vm::interpreter
             since(EVMC_CONSTANTINOPLE, shl<traits>), // 0x1B,
             since(EVMC_CONSTANTINOPLE, shr<traits>), // 0x1C,
             since(EVMC_CONSTANTINOPLE, sar<traits>), // 0x1D,
-            invalid, //
+            since(EVMC_OSAKA, clz<traits>), // 0x1E,
             invalid, //
 
             sha3<traits>, // 0x20,
@@ -795,6 +795,20 @@ namespace monad::vm::interpreter
         value = runtime::sar(shift, value);
 
         MONAD_VM_NEXT(SAR);
+    }
+
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    clz(runtime::Context &ctx, Intercode const &analysis,
+        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
+        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+    {
+        check_requirements<CLZ, traits>(
+            ctx, analysis, stack_bottom, stack_top, gas_remaining);
+        auto &a = *stack_top;
+        a = runtime::countl_zero(a);
+
+        MONAD_VM_NEXT(CLZ);
     }
 
     // Data

--- a/category/vm/interpreter/instructions_fwd.hpp
+++ b/category/vm/interpreter/instructions_fwd.hpp
@@ -151,6 +151,11 @@ namespace monad::vm::interpreter
     sar(runtime::Context &, Intercode const &, runtime::uint256_t const *,
         runtime::uint256_t *, std::int64_t, std::uint8_t const *);
 
+    template <Traits traits>
+    MONAD_VM_INSTRUCTION_CALL void
+    clz(runtime::Context &, Intercode const &, runtime::uint256_t const *,
+        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+
     // Data
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void sha3(

--- a/category/vm/utils/evm-as/builder.hpp
+++ b/category/vm/utils/evm-as/builder.hpp
@@ -326,6 +326,11 @@ namespace monad::vm::utils::evm_as
             return ins(compiler::EvmOpCode::SAR);
         }
 
+        EvmBuilder &clz() noexcept
+        {
+            return ins(compiler::EvmOpCode::CLZ);
+        }
+
         EvmBuilder &sha3() noexcept
         {
             return ins(compiler::EvmOpCode::SHA3);

--- a/test/ethereum_test/exclude/osaka.cmake
+++ b/test/ethereum_test/exclude/osaka.cmake
@@ -11,6 +11,5 @@ set(osaka_excluded_tests
     "BlockchainTests.osaka/eip7823_modexp_upper_bounds/*"
     "BlockchainTests.osaka/eip7934_block_rlp_limit/*"
     "BlockchainTests.osaka/eip7825_transaction_gas_limit_cap/*"
-    "BlockchainTests.osaka/eip7939_count_leading_zeros/*"
     "BlockchainTests.osaka/eip7883_modexp_gas_increase/*"
 )


### PR DESCRIPTION
## Context

Follow-up to https://github.com/category-labs/monad/pull/1939

To be compatible with the Ethereum Fusaka network upgrade, we must support the following features:

- [EIP-7939](https://eips.ethereum.org/EIPS/eip-7939): Count leading zeros (CLZ) opcode
- [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823): Set upper bounds for MODEXP
- [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883): ModExp Gas Cost Increase
- [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918): Blob base fee bounded by execution cost

This PR adds support for the CLZ opcode, gated by the `EVMC_OSAKA` revision.
