### PR TITLE
Fix dangling pointers to intercode

### DIFF
--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -104,7 +104,7 @@ namespace
             .input_size = 32,
             .code_address = blockhash_opcode_addr};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         return state.vm().execute<Prague>(host, &msg, hash, code);
     }
 
@@ -246,7 +246,7 @@ TEST_F(BlockHistoryFixture, read_from_block_hash_history_contract)
             .input_size = 32,
             .code_address = BLOCK_HISTORY_ADDRESS};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         evmc::Result const result =
             state.vm().execute<Prague>(host, &msg, hash, code);
         if (expect_success) {
@@ -305,7 +305,7 @@ TEST_F(BlockHistoryFixture, read_write_block_hash_history_contract)
             .input_size = 32,
             .code_address = BLOCK_HISTORY_ADDRESS};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         evmc::Result const result =
             state.vm().execute<Prague>(host, &msg, hash, code);
         ASSERT_EQ(result.status_code, EVMC_SUCCESS);
@@ -337,7 +337,7 @@ TEST_F(BlockHistoryFixture, read_write_block_hash_history_contract)
             .input_size = 32,
             .code_address = BLOCK_HISTORY_ADDRESS};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         evmc::Result const result =
             state.vm().execute<Prague>(host, &msg, hash, code);
         if (expect_success) {
@@ -418,7 +418,7 @@ TEST_F(BlockHistoryFixture, unauthorized_set)
             .input_size = 32,
             .code_address = BLOCK_HISTORY_ADDRESS};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         evmc::Result result =
             state.vm().execute<Prague>(host, &msg, hash, code);
         if (expect_success) {
@@ -455,7 +455,7 @@ TEST_F(BlockHistoryFixture, unauthorized_set)
             .input_size = 32,
             .code_address = BLOCK_HISTORY_ADDRESS};
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         evmc::Result const result =
             state.vm().execute<Prague>(host, &msg, hash, code);
         if (expect_success) {

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -120,7 +120,7 @@ Result<void> EthereumMainnet::validate_transaction(
 {
     evmc_revision const rev = get_revision(block_number, timestamp);
     auto const sender_account = state.recent_account(sender);
-    auto const &icode = state.get_code(sender)->intercode();
+    auto const icode = state.get_code(sender)->intercode();
     return ::monad::validate_transaction(
         rev, tx, sender_account, {icode->code(), icode->size()});
 }

--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -310,7 +310,7 @@ evmc::Result call(
     }
     else {
         auto const hash = state.get_code_hash(msg.code_address);
-        auto const &code = state.read_code(hash);
+        auto const code = state.read_code(hash);
         result = state.vm().execute<traits>(*host, &msg, hash, code);
     }
 

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -136,7 +136,7 @@ uint64_t ExecuteTransactionNoValidation<traits>::process_authorizations(
         state.access_account(*authority);
 
         // 5. Verify the code of authority is empty or already delegated.
-        auto const &icode = state.get_code(*authority)->intercode();
+        auto const icode = state.get_code(*authority)->intercode();
         auto const code = std::span{icode->code(), *icode->code_size()};
         if (!(code.empty() || vm::evm::is_delegated(code))) {
             continue;

--- a/category/execution/monad/validate_monad_transaction.cpp
+++ b/category/execution/monad/validate_monad_transaction.cpp
@@ -35,7 +35,7 @@ Result<void> validate_monad_transaction(
     std::span<std::optional<Address> const> const authorities)
 {
     auto const acct = state.recent_account(sender);
-    auto const &icode = state.get_code(sender)->intercode();
+    auto const icode = state.get_code(sender)->intercode();
     auto res = ::monad::validate_transaction(
         rev, tx, acct, {icode->code(), icode->size()});
     if (MONAD_LIKELY(monad_rev >= MONAD_FOUR)) {


### PR DESCRIPTION
I have searched the monad code for uses of the `get_code` and `read_code` functions, to find locations where we are taking a reference to an `Intercode` inside a `Varcode` rvalue. I have found 3 such occurrences.

Some places we are taking const reference of a `Varcode` rvalue, which is not strictly wrong, but seems weird because reference has no effect.

This issue was raised by Gustavo Grieco.