### PR TITLE
db_metadata: remove `using_chunks_for_root_offsets` now that root offsets must use chunk

### DIFF
--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -43,8 +43,7 @@ namespace detail
         constexpr struct
         {
             uint64_t chunk_info_count : 20;
-            uint64_t using_chunks_for_root_offsets : 1;
-            uint64_t unused0_ : 35;
+            uint64_t unused0_ : 36;
             uint64_t reserved0_ : 8;
         } v{.reserved0_ = 1};
 
@@ -75,8 +74,7 @@ namespace detail
 
         char magic[MAGIC_STRING_LEN];
         uint64_t chunk_info_count : 20; // items in chunk_info below
-        uint64_t using_chunks_for_root_offsets : 1;
-        uint64_t unused0_ : 35; // next item MUST be on a byte boundary
+        uint64_t unused0_ : 36; // next item MUST be on a byte boundary
         uint64_t reserved_for_is_dirty_ : 8; // for is_dirty below
         // DO NOT INSERT ANYTHING IN HERE
         uint64_t capacity_in_free_list; // used to detect when free space is
@@ -91,32 +89,23 @@ namespace detail
         struct root_offsets_ring_t
         {
             static constexpr size_t SIZE_ = 65536;
-            static_assert(
-                (SIZE_ & (SIZE_ - 1)) == 0,
-                "root offsets must be a power of 2");
 
             uint64_t version_lower_bound_;
             uint64_t
                 next_version_; // all bits zero turns into INVALID_BLOCK_NUM
 
-            union
+            struct
             {
+                uint32_t high_bits_all_set; // All bits one to deliberately
+                                            // break older codebases
+                uint32_t cnv_chunks_len; // How long the following list is
+
                 struct
                 {
                     uint32_t high_bits_all_set; // All bits one to deliberately
                                                 // break older codebases
-                    uint32_t cnv_chunks_len; // How long the following list is
-
-                    struct
-                    {
-                        uint32_t
-                            high_bits_all_set; // All bits one to deliberately
-                                               // break older codebases
-                        uint32_t cnv_chunk_id; // The read-write chunk id
-                    } cnv_chunks[SIZE_ - 1];
-                };
-
-                chunk_offset_t arr[SIZE_];
+                    uint32_t cnv_chunk_id; // The read-write chunk id
+                } cnv_chunks[SIZE_ - 1];
             } storage_;
         } root_offsets;
 

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -234,7 +234,6 @@ TEST(update_aux_test, configurable_root_offset_chunks)
 
         // Verify that exactly 4 chunks were allocated to hold two copies of
         // root offsets, since chunk 0 is used for metadata
-        EXPECT_TRUE(aux.db_metadata()->using_chunks_for_root_offsets);
         EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
         EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
     }
@@ -247,7 +246,6 @@ TEST(update_aux_test, configurable_root_offset_chunks)
         EXPECT_EQ(pool.chunks(monad::async::storage_pool::cnv), 5);
         monad::async::AsyncIO testio(pool, testbuf);
         monad::mpt::UpdateAux<> aux(testio);
-        EXPECT_TRUE(aux.db_metadata()->using_chunks_for_root_offsets);
         EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
         EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
     }

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -188,8 +188,7 @@ class UpdateAuxImpl
     struct db_metadata_
     {
         detail::db_metadata *main{nullptr};
-        std::span<chunk_offset_t>
-            root_offsets; // if not-null, mmap of DB version ring buffer storage
+        std::span<chunk_offset_t> root_offsets;
     } db_metadata_[2]; // two copies, to prevent sudden process
                        // exits making the DB irretrievable
 
@@ -630,16 +629,15 @@ public:
                       m->main->root_offsets.version_lower_bound_)
                 , next_version_(m->main->root_offsets.next_version_)
                 , root_offsets_chunks_(
-                      m->root_offsets.empty()
-                          ? std::span<chunk_offset_t>(
-                                m->main->root_offsets.storage_.arr)
-                          : std::span<chunk_offset_t>(m->root_offsets))
+                      std::span<chunk_offset_t>(m->root_offsets))
             {
-                MONAD_DEBUG_ASSERT(
+                MONAD_ASSERT_PRINTF(
                     root_offsets_chunks_.size() ==
-                    1ULL
-                        << (63 -
-                            std::countl_zero(root_offsets_chunks_.size())));
+                        1ULL
+                            << (63 -
+                                std::countl_zero(root_offsets_chunks_.size())),
+                    "root offsets chunks size is %lu, not a power of 2",
+                    root_offsets_chunks_.size());
             }
 
             size_t capacity() const noexcept


### PR DESCRIPTION
on top of #1937  , will rebase after that one is merged