### PR TITLE
Unify single buffer and scatter read handling in AsyncIO

### DIFF
--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -20,8 +20,10 @@
 #include <cassert>
 #include <compare>
 #include <cstdint>
+#include <span>
 
 #include <linux/types.h> // for __u64
+#include <sys/uio.h> // for struct iovec
 
 #define MONAD_ASYNC_NAMESPACE_BEGIN                                            \
     namespace monad                                                            \
@@ -190,6 +192,16 @@ static constexpr uint16_t DISK_PAGE_SIZE = (1U << DISK_PAGE_BITS);
 //! The DMA friendly page size and bits
 static constexpr uint16_t DMA_PAGE_BITS = 6;
 static constexpr uint16_t DMA_PAGE_SIZE = (1U << DMA_PAGE_BITS);
+
+//! Calculate total byte length from an array of iovec buffers
+inline size_t iov_length(std::span<const struct iovec> iovecs)
+{
+    size_t total = 0;
+    for (auto const &iov : iovecs) {
+        total += iov.iov_len;
+    }
+    return total;
+}
 
 MONAD_ASYNC_NAMESPACE_END
 

--- a/category/async/io_senders.hpp
+++ b/category/async/io_senders.hpp
@@ -85,7 +85,7 @@ public:
         buffer_ = std::move(buffer);
     }
 
-    result<void> operator()(erased_connected_operation *io_state) noexcept
+    result<void> operator()(erased_connected_operation *io_state)
     {
         if (!buffer_) {
             buffer_.set_read_buffer(


### PR DESCRIPTION
Previously, single buffer reads and scatter reads had inconsistent behavior for limit checking, queueing, and statistics tracking:
- Separate counters (inflight_rd vs inflight_rd_scatter)
- Only single buffer reads were queued when over limit
- Only single buffer reads tracked bytes_read

This commit unifies the handling so both read types share:
- Single inflight_rd counter for all reads
- Same concurrent_read_io_limit_ and queueing mechanism
- Consistent bytes_read tracking
- Same dequeue behavior on completion

Implementation changes:
- deferred read queue now stores sqe entries directly
- Removed inflight_rd_scatter and max_inflight_rd_scatter counters
- Scatter reads now check limit and queue when over limit
- Scatter reads now track bytes_read by summing iovec lengths

This code was generated using Claude Sonnet 4.5