### PR TITLE
Osaka fuzzer support

### DIFF
--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -848,6 +848,12 @@ namespace monad::vm::compiler
         return info == unknown_opcode_info;
     }
 
+    template <Traits traits>
+    constexpr bool is_unknown_opcode_info(uint8_t const opcode)
+    {
+        return is_unknown_opcode_info<traits>(opcode_table<traits>[opcode]);
+    }
+
     /**
      * Returns `true` if `opcode` belongs to the `PUSHN` family of EVM opcodes.
      */

--- a/category/vm/fuzzing/generator/instruction_data.hpp
+++ b/category/vm/fuzzing/generator/instruction_data.hpp
@@ -25,7 +25,8 @@ namespace monad::vm::fuzzing
     using enum monad::vm::compiler::EvmOpCode;
 
     template <auto in, auto f>
-    consteval auto filter() {
+    consteval auto filter()
+    {
         static constexpr auto new_size = std::count_if(in.begin(), in.end(), f);
         auto out = std::array<typename decltype(in)::value_type, new_size>{};
         std::copy_if(in.begin(), in.end(), out.begin(), f);
@@ -127,21 +128,16 @@ namespace monad::vm::fuzzing
         JUMPDEST,
     };
 
-    template <Traits traits>
     constexpr auto uncommon_non_terminators = make_opcode_array<
-        traits, uncommon_non_terminators_all>();
-    template <Traits traits>
-    constexpr auto common_non_terminators = make_opcode_array<
-        traits, common_non_terminators_all>();
-    template <Traits traits>
-    constexpr auto terminators = make_opcode_array<
-        traits, terminators_all>();
-    template <Traits traits>
-    constexpr auto exit_terminators = make_opcode_array<
-        traits, exit_terminators_all>();
-    template <Traits traits>
-    constexpr auto jump_terminators = make_opcode_array<
-        traits, jump_terminators_all>();
+        EvmTraits<EVMC_OSAKA>, uncommon_non_terminators_all>();
+    constexpr auto common_non_terminators =
+        make_opcode_array<EvmTraits<EVMC_OSAKA>, common_non_terminators_all>();
+    constexpr auto terminators =
+        make_opcode_array<EvmTraits<EVMC_OSAKA>, terminators_all>();
+    constexpr auto exit_terminators =
+        make_opcode_array<EvmTraits<EVMC_OSAKA>, exit_terminators_all>();
+    constexpr auto jump_terminators =
+        make_opcode_array<EvmTraits<EVMC_OSAKA>, jump_terminators_all>();
 
     constexpr bool is_exit_terminator(std::uint8_t opcode) noexcept
     {

--- a/category/vm/fuzzing/generator/instruction_data.hpp
+++ b/category/vm/fuzzing/generator/instruction_data.hpp
@@ -102,7 +102,7 @@ namespace monad::vm::fuzzing
         SWAP7,      SWAP8,       SWAP9,
         SWAP10,     SWAP11,      SWAP12,
         SWAP13,     SWAP14,      SWAP15,
-        SWAP16,
+        SWAP16,     CLZ,
     };
 
     constexpr auto terminators_all = std::array{

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -315,7 +315,7 @@ namespace
         bool print_stats = false;
         BlockchainTestVM::Implementation implementation =
             BlockchainTestVM::Implementation::Compiler;
-        evmc_revision revision = EVMC_PRAGUE;
+        evmc_revision revision = EVMC_OSAKA;
         std::optional<std::string> focus_path = std::nullopt;
         std::optional<GeneratorFocus> focus = std::nullopt;
 

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -28,6 +28,8 @@
 #include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/core/assert.h>
 #include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/switch_traits.hpp>
+#include <category/vm/evm/traits.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
 #include <category/vm/fuzzing/generator/generator.hpp>
 #include <category/vm/utils/debug.hpp>
@@ -410,9 +412,10 @@ static arguments parse_args(int const argc, char **const argv)
     return args;
 }
 
+template <Traits traits>
 static evmc_status_code fuzz_iteration(
-    evmc_message const &msg, evmc_revision const rev, State &evmone_state,
-    evmc::VM &evmone_vm, State &monad_state, evmc::VM &monad_vm,
+    evmc_message const &msg, State &evmone_state, evmc::VM &evmone_vm,
+    State &monad_state, evmc::VM &monad_vm,
     BlockchainTestVM::Implementation const impl)
 {
     for (State &state : {std::ref(evmone_state), std::ref(monad_state)}) {
@@ -421,12 +424,12 @@ static evmc_status_code fuzz_iteration(
     }
 
     auto const evmone_checkpoint = evmone_state.checkpoint();
-    auto const evmone_result =
-        transition(evmone_state, msg, rev, evmone_vm, block_gas_limit);
+    auto const evmone_result = transition(
+        evmone_state, msg, traits::evm_rev(), evmone_vm, block_gas_limit);
 
     auto const monad_checkpoint = monad_state.checkpoint();
-    auto const monad_result =
-        transition(monad_state, msg, rev, monad_vm, block_gas_limit);
+    auto const monad_result = transition(
+        monad_state, msg, traits::evm_rev(), monad_vm, block_gas_limit);
 
     assert_equal(
         evmone_result,
@@ -498,10 +501,9 @@ static bool toss(Engine &engine, double p)
     return dist(engine);
 }
 
+template <Traits traits>
 static void do_run(std::size_t const run_index, arguments const &args)
 {
-    auto const rev = args.revision;
-
     auto engine = random_engine_t(args.seed);
 
     auto evmone_vm = evmc::VM(evmc_create_evmone());
@@ -531,17 +533,18 @@ static void do_run(std::size_t const run_index, arguments const &args)
                       Choice(0.60, [](auto &) { return pow2_focus; }),
                       Choice(0.05, [](auto &) { return dyn_jump_focus; }));
 
-        if (rev >= EVMC_PRAGUE && toss(engine, 0.001)) {
-            auto precompile =
-                monad::vm::fuzzing::generate_precompile_address(engine, rev);
+        if (traits::evm_rev() >= EVMC_PRAGUE && toss(engine, 0.001)) {
+            auto precompile = monad::vm::fuzzing::
+                generate_precompile_address<random_engine_t, traits>(engine);
             auto const a = deploy_delegated_contracts(
                 evmone_state, monad_state, genesis_address, precompile);
             known_addresses.push_back(a);
         }
 
         for (;;) {
-            auto const contract = monad::vm::fuzzing::generate_program(
-                focus, engine, rev, known_addresses);
+            auto const contract =
+                monad::vm::fuzzing::generate_program<random_engine_t, traits>(
+                    focus, engine, known_addresses);
 
             if (contract.size() > evmone::MAX_CODE_SIZE) {
                 // The evmone host will fail when we attempt to deploy
@@ -587,9 +590,8 @@ static void do_run(std::size_t const run_index, arguments const &args)
                 });
             ++total_messages;
 
-            auto const ec = fuzz_iteration(
+            auto const ec = fuzz_iteration<traits>(
                 *msg,
-                rev,
                 evmone_state,
                 evmone_vm,
                 monad_state,
@@ -600,6 +602,12 @@ static void do_run(std::size_t const run_index, arguments const &args)
     }
 
     log(start_time, args, exit_code_stats, run_index, total_messages);
+}
+
+static void do_run(std::size_t const run_index, arguments const &args)
+{
+    auto const rev = args.revision;
+    SWITCH_EVM_TRAITS(do_run, run_index, args);
 }
 
 static void run_loop(int argc, char **argv)

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -535,7 +535,7 @@ static void do_run(std::size_t const run_index, arguments const &args)
 
         if (traits::evm_rev() >= EVMC_PRAGUE && toss(engine, 0.001)) {
             auto precompile = monad::vm::fuzzing::
-                generate_precompile_address<random_engine_t, traits>(engine);
+                generate_precompile_address(engine, traits::evm_rev());
             auto const a = deploy_delegated_contracts(
                 evmone_state, monad_state, genesis_address, precompile);
             known_addresses.push_back(a);

--- a/test/vm/fuzzer/typechecker_fuzzer.cpp
+++ b/test/vm/fuzzer/typechecker_fuzzer.cpp
@@ -181,7 +181,7 @@ static void do_run(std::size_t const run_index, arguments const &args)
             Choice(0.8, [](auto &) { return dyn_jump_focus; }));
 
         auto const contract =
-            monad::vm::fuzzing::generate_program(focus, engine, {});
+            monad::vm::fuzzing::generate_program(focus, engine, rev, {});
 
         fuzz_iteration(contract, rev);
     }

--- a/test/vm/fuzzer/typechecker_fuzzer.cpp
+++ b/test/vm/fuzzer/typechecker_fuzzer.cpp
@@ -181,7 +181,7 @@ static void do_run(std::size_t const run_index, arguments const &args)
             Choice(0.8, [](auto &) { return dyn_jump_focus; }));
 
         auto const contract =
-            monad::vm::fuzzing::generate_program(focus, engine, rev, {});
+            monad::vm::fuzzing::generate_program(focus, engine, {});
 
         fuzz_iteration(contract, rev);
     }


### PR DESCRIPTION
## Context

Add support for Osaka to the VM fuzzer. Because Osaka adds support for a new opcode, I needed to put `Traits` template parameters on the `common_non_terminators` opcode array so that the fuzzer only generates `CLZ` operations when passed `--revision OSAKA`.

Targeting https://github.com/category-labs/monad/pull/1940 for a nicer diff, but this PR will be rebased once https://github.com/category-labs/monad/pull/1940 is merged.

## Fuzzer stats

<details>
  <summary>On main (Prague)</summary>

```
Fuzzing with seed @ Prague: 25
Skipping contract of size: 44889 bytes
Skipping contract of size: 43909 bytes
Skipping contract of size: 48730 bytes
Skipping contract of size: 47125 bytes
[1]: 0.0054s / iteration
  BAD_JUMP_DESTINATION : 1.25%
  STACK_UNDERFLOW      : 1.75%
  STATIC_MODE_VIOLATION: 1.50%
  REVERT               : 6.00%
  INVALID_MEMORY_ACCESS: 2.25%
  OUT_OF_GAS           : 7.25%
  INSUFFICIENT_BALANCE : 2.25%
  STACK_OVERFLOW       : 14.50%
  SUCCESS              : 63.25%
Fuzzing with seed @ Prague: 13519535848783852808
Skipping contract of size: 50447 bytes
Skipping contract of size: 27509 bytes
Skipping contract of size: 117909 bytes
Skipping contract of size: 124990 bytes
[2]: 0.0079s / iteration
  BAD_JUMP_DESTINATION : 0.75%
  INVALID_MEMORY_ACCESS: 2.75%
  REVERT               : 12.75%
  INSUFFICIENT_BALANCE : 2.00%
  SUCCESS              : 49.00%
  STACK_OVERFLOW       : 11.00%
  STATIC_MODE_VIOLATION: 1.25%
  OUT_OF_GAS           : 20.50%
Fuzzing with seed @ Prague: 28984892454251406
Skipping contract of size: 111351 bytes
Skipping contract of size: 29495 bytes
Skipping contract of size: 45318 bytes
Skipping contract of size: 40487 bytes
Skipping contract of size: 24655 bytes
Skipping contract of size: 61471 bytes
[3]: 0.0095s / iteration
  REVERT               : 3.50%
  INVALID_MEMORY_ACCESS: 2.00%
  STATIC_MODE_VIOLATION: 1.25%
  INSUFFICIENT_BALANCE : 4.25%
  STACK_OVERFLOW       : 19.75%
  SUCCESS              : 53.00%
  OUT_OF_GAS           : 12.00%
  BAD_JUMP_DESTINATION : 4.25%
Fuzzing with seed @ Prague: 2421158388134208676
Skipping contract of size: 28207 bytes
Skipping contract of size: 64710 bytes
[4]: 0.0058s / iteration
  STACK_OVERFLOW       : 1.00%
  STACK_UNDERFLOW      : 0.75%
  STATIC_MODE_VIOLATION: 1.00%
  BAD_JUMP_DESTINATION : 2.50%
  INVALID_MEMORY_ACCESS: 3.00%
  OUT_OF_GAS           : 17.00%
  INSUFFICIENT_BALANCE : 2.50%
  REVERT               : 10.75%
  SUCCESS              : 61.50%
Fuzzing with seed @ Prague: 1480329314561705367
Skipping contract of size: 60870 bytes
Skipping contract of size: 103810 bytes
Skipping contract of size: 29922 bytes
[5]: 0.0075s / iteration
  BAD_JUMP_DESTINATION : 3.00%
  STACK_UNDERFLOW      : 3.25%
  INVALID_MEMORY_ACCESS: 3.00%
  STACK_OVERFLOW       : 3.00%
  STATIC_MODE_VIOLATION: 1.25%
  INSUFFICIENT_BALANCE : 3.00%
  REVERT               : 13.75%
  OUT_OF_GAS           : 10.25%
  SUCCESS              : 59.50%
```
</details>

<details>
  <summary>On main (Cancun)</summary>

```
Fuzzing with seed @ Cancun: 25
Skipping contract of size: 56723 bytes
Skipping contract of size: 27748 bytes
Skipping contract of size: 27281 bytes
Skipping contract of size: 29506 bytes
Skipping contract of size: 27925 bytes
[1]: 0.0067s / iteration
  INVALID_MEMORY_ACCESS: 0.50%
  STATIC_MODE_VIOLATION: 1.00%
  STACK_UNDERFLOW      : 0.75%
  INSUFFICIENT_BALANCE : 2.00%
  BAD_JUMP_DESTINATION : 3.00%
  OUT_OF_GAS           : 8.00%
  STACK_OVERFLOW       : 9.75%
  REVERT               : 9.50%
  SUCCESS              : 65.50%
Fuzzing with seed @ Cancun: 13519535848783852808
Skipping contract of size: 30577 bytes
Skipping contract of size: 24760 bytes
[2]: 0.0061s / iteration
  INVALID_MEMORY_ACCESS: 2.25%
  REVERT               : 4.50%
  BAD_JUMP_DESTINATION : 2.25%
  STACK_OVERFLOW       : 3.75%
  INSUFFICIENT_BALANCE : 1.50%
  STATIC_MODE_VIOLATION: 1.75%
  STACK_UNDERFLOW      : 3.00%
  SUCCESS              : 57.50%
  OUT_OF_GAS           : 23.50%
Fuzzing with seed @ Cancun: 28984892454251406
Skipping contract of size: 45880 bytes
[3]: 0.0096s / iteration
  STACK_UNDERFLOW      : 0.50%
  BAD_JUMP_DESTINATION : 1.00%
  STATIC_MODE_VIOLATION: 1.00%
  REVERT               : 2.75%
  STACK_OVERFLOW       : 9.25%
  INSUFFICIENT_BALANCE : 2.00%
  OUT_OF_GAS           : 15.25%
  SUCCESS              : 68.25%
Fuzzing with seed @ Cancun: 2421158388134208676
Skipping contract of size: 43793 bytes
Skipping contract of size: 34733 bytes
Skipping contract of size: 32584 bytes
Skipping contract of size: 45448 bytes
Skipping contract of size: 35886 bytes
[4]: 0.0066s / iteration
  INVALID_MEMORY_ACCESS: 0.75%
  REVERT               : 2.75%
  STACK_UNDERFLOW      : 4.50%
  STACK_OVERFLOW       : 13.50%
  OUT_OF_GAS           : 14.50%
  INSUFFICIENT_BALANCE : 1.50%
  BAD_JUMP_DESTINATION : 3.50%
  STATIC_MODE_VIOLATION: 1.00%
  SUCCESS              : 58.00%
Fuzzing with seed @ Cancun: 1480329314561705367
Skipping contract of size: 29696 bytes
Skipping contract of size: 51949 bytes
Skipping contract of size: 28096 bytes
[5]: 0.0065s / iteration
  INVALID_MEMORY_ACCESS: 1.50%
  BAD_JUMP_DESTINATION : 2.00%
  STACK_UNDERFLOW      : 4.75%
  STATIC_MODE_VIOLATION: 0.50%
  OUT_OF_GAS           : 11.25%
  REVERT               : 13.00%
  INSUFFICIENT_BALANCE : 4.00%
  STACK_OVERFLOW       : 11.50%
  SUCCESS              : 51.50%
```
</details>

<details>
  <summary>This branch (Osaka)</summary>

```
Fuzzing with seed @ Osaka: 25
Skipping contract of size: 44889 bytes
Skipping contract of size: 48292 bytes
Skipping contract of size: 38384 bytes
Skipping contract of size: 77884 bytes
Skipping contract of size: 82387 bytes
Skipping contract of size: 28769 bytes
[1]: 0.0056s / iteration
  BAD_JUMP_DESTINATION : 0.50%
  INVALID_MEMORY_ACCESS: 1.50%
  STACK_UNDERFLOW      : 2.75%
  STATIC_MODE_VIOLATION: 0.50%
  OUT_OF_GAS           : 16.25%
  INSUFFICIENT_BALANCE : 2.50%
  REVERT               : 13.25%
  STACK_OVERFLOW       : 9.50%
  SUCCESS              : 53.25%
Fuzzing with seed @ Osaka: 13519535848783852808
Skipping contract of size: 29000 bytes
[2]: 0.0074s / iteration
  REVERT               : 1.75%
  BAD_JUMP_DESTINATION : 2.00%
  INSUFFICIENT_BALANCE : 3.00%
  STACK_OVERFLOW       : 6.25%
  STATIC_MODE_VIOLATION: 1.50%
  SUCCESS              : 63.25%
  OUT_OF_GAS           : 22.25%
Fuzzing with seed @ Osaka: 28984892454251406
Skipping contract of size: 111351 bytes
Skipping contract of size: 29495 bytes
Skipping contract of size: 39853 bytes
Skipping contract of size: 45504 bytes
[3]: 0.0106s / iteration
  INVALID_MEMORY_ACCESS: 1.25%
  STATIC_MODE_VIOLATION: 1.25%
  INSUFFICIENT_BALANCE : 2.00%
  STACK_UNDERFLOW      : 1.75%
  REVERT               : 5.25%
  STACK_OVERFLOW       : 12.50%
  SUCCESS              : 54.00%
  OUT_OF_GAS           : 14.75%
  BAD_JUMP_DESTINATION : 7.25%
Fuzzing with seed @ Osaka: 2421158388134208676
Skipping contract of size: 91555 bytes
Skipping contract of size: 114972 bytes
Skipping contract of size: 32821 bytes
[4]: 0.0068s / iteration
  UNDEFINED_INSTRUCTION: 0.50%
  BAD_JUMP_DESTINATION : 1.25%
  INVALID_MEMORY_ACCESS: 2.00%
  REVERT               : 5.25%
  INSUFFICIENT_BALANCE : 3.00%
  STATIC_MODE_VIOLATION: 1.00%
  STACK_UNDERFLOW      : 2.25%
  OUT_OF_GAS           : 20.25%
  STACK_OVERFLOW       : 9.50%
  SUCCESS              : 55.00%
Fuzzing with seed @ Osaka: 1480329314561705367
Skipping contract of size: 30142 bytes
Skipping contract of size: 28412 bytes
Skipping contract of size: 87763 bytes
[5]: 0.0083s / iteration
  STACK_OVERFLOW       : 3.50%
  REVERT               : 2.25%
  INVALID_MEMORY_ACCESS: 2.25%
  STATIC_MODE_VIOLATION: 1.50%
  STACK_UNDERFLOW      : 3.25%
  INSUFFICIENT_BALANCE : 3.00%
  OUT_OF_GAS           : 10.00%
  BAD_JUMP_DESTINATION : 4.50%
  SUCCESS              : 69.75%
```
</details>

<details>
  <summary>This branch (Cancun)</summary>

```
Fuzzing with seed @ Cancun: 25
Skipping contract of size: 25381 bytes
[1]: 0.0036s / iteration
  STATIC_MODE_VIOLATION: 0.75%
  REVERT               : 2.50%
  INVALID_MEMORY_ACCESS: 1.00%
  INSUFFICIENT_BALANCE : 1.50%
  STACK_UNDERFLOW      : 2.50%
  OUT_OF_GAS           : 4.50%
  STACK_OVERFLOW       : 7.25%
  UNDEFINED_INSTRUCTION: 33.75%
  SUCCESS              : 46.25%
Fuzzing with seed @ Cancun: 13519535848783852808
Skipping contract of size: 32497 bytes
[2]: 0.0043s / iteration
  REVERT               : 0.25%
  INVALID_MEMORY_ACCESS: 0.50%
  STATIC_MODE_VIOLATION: 0.75%
  INSUFFICIENT_BALANCE : 2.25%
  STACK_UNDERFLOW      : 4.00%
  BAD_JUMP_DESTINATION : 2.25%
  UNDEFINED_INSTRUCTION: 38.25%
  STACK_OVERFLOW       : 5.25%
  SUCCESS              : 37.75%
  OUT_OF_GAS           : 8.75%
Fuzzing with seed @ Cancun: 28984892454251406
Skipping contract of size: 25890 bytes
Skipping contract of size: 31550 bytes
Skipping contract of size: 30216 bytes
Skipping contract of size: 80007 bytes
Skipping contract of size: 64674 bytes
Skipping contract of size: 39180 bytes
Skipping contract of size: 112656 bytes
Skipping contract of size: 33134 bytes
[3]: 0.0058s / iteration
  OUT_OF_GAS           : 0.50%
  BAD_JUMP_DESTINATION : 0.50%
  INVALID_MEMORY_ACCESS: 0.75%
  STACK_UNDERFLOW      : 0.75%
  STATIC_MODE_VIOLATION: 1.00%
  STACK_OVERFLOW       : 5.50%
  REVERT               : 3.75%
  INSUFFICIENT_BALANCE : 2.25%
  UNDEFINED_INSTRUCTION: 35.50%
  SUCCESS              : 49.50%
Fuzzing with seed @ Cancun: 2421158388134208676
Skipping contract of size: 57163 bytes
Skipping contract of size: 55169 bytes
Skipping contract of size: 27418 bytes
Skipping contract of size: 26183 bytes
Skipping contract of size: 24604 bytes
Skipping contract of size: 46774 bytes
Skipping contract of size: 48180 bytes
[4]: 0.0050s / iteration
  BAD_JUMP_DESTINATION : 0.50%
  INVALID_MEMORY_ACCESS: 0.75%
  STACK_UNDERFLOW      : 0.50%
  STACK_OVERFLOW       : 2.00%
  REVERT               : 1.25%
  STATIC_MODE_VIOLATION: 1.50%
  INSUFFICIENT_BALANCE : 1.00%
  UNDEFINED_INSTRUCTION: 37.00%
  OUT_OF_GAS           : 7.50%
  SUCCESS              : 48.00%
Fuzzing with seed @ Cancun: 1480329314561705367
Skipping contract of size: 29696 bytes
Skipping contract of size: 47192 bytes
[5]: 0.0045s / iteration
  INVALID_MEMORY_ACCESS: 0.25%
  BAD_JUMP_DESTINATION : 1.75%
  INSUFFICIENT_BALANCE : 0.50%
  STATIC_MODE_VIOLATION: 0.75%
  STACK_UNDERFLOW      : 6.25%
  OUT_OF_GAS           : 7.25%
  STACK_OVERFLOW       : 2.75%
  SUCCESS              : 33.00%
  UNDEFINED_INSTRUCTION: 47.50%
```
</details>
