### PR TITLE
Tag x86 emitter stack offset locations with AVX or GPR

### DIFF
--- a/test/vm/unit/stack_tests.cpp
+++ b/test/vm/unit/stack_tests.cpp
@@ -37,9 +37,9 @@ namespace
         {
         }
 
-        StackElemTestData &with_stack_offset(StackOffset x)
+        StackElemTestData &with_stack_offset(std::int32_t offset)
         {
-            stack_offset = x;
+            stack_offset = {offset, PrevLoc::Unknown};
             return *this;
         }
 
@@ -86,9 +86,9 @@ TEST(VirtualStack, ctor_test_1)
     ASSERT_EQ(stack.max_delta(), 0);
     ASSERT_EQ(stack.delta(), -1);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset(-2)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
 }
 
 TEST(VirtualStack, ctor_test_2)
@@ -100,11 +100,11 @@ TEST(VirtualStack, ctor_test_2)
     ASSERT_EQ(stack.max_delta(), 0);
     ASSERT_EQ(stack.delta(), -4);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-3), StackElemTestData{{-3}}.with_stack_offset({-3})));
+        stack.get(-3), StackElemTestData{{-3}}.with_stack_offset(-3)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset(-2)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
 }
 
 TEST(VirtualStack, ctor_test_3)
@@ -127,9 +127,9 @@ TEST(VirtualStack, ctor_test_4)
     ASSERT_EQ(stack.max_delta(), 0);
     ASSERT_EQ(stack.delta(), 0);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset(-2)));
 }
 
 TEST(VirtualStack, ctor_test_5)
@@ -142,7 +142,7 @@ TEST(VirtualStack, ctor_test_5)
     ASSERT_EQ(stack.delta(), 0);
     for (int32_t i = -1; i >= -17; --i) {
         ASSERT_TRUE(test_stack_element(
-            stack.get(i), StackElemTestData{{i}}.with_stack_offset({i})));
+            stack.get(i), StackElemTestData{{i}}.with_stack_offset(i)));
     }
 }
 
@@ -155,7 +155,7 @@ TEST(VirtualStack, ctor_test_6)
     ASSERT_EQ(stack.max_delta(), 1);
     ASSERT_EQ(stack.delta(), 1);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
 }
 
 TEST(VirtualStack, ctor_test_7)
@@ -168,7 +168,7 @@ TEST(VirtualStack, ctor_test_7)
     ASSERT_EQ(stack.delta(), 1);
     for (int32_t i = -1; i >= -16; --i) {
         ASSERT_TRUE(test_stack_element(
-            stack.get(i), StackElemTestData{{i}}.with_stack_offset({i})));
+            stack.get(i), StackElemTestData{{i}}.with_stack_offset(i)));
     }
 }
 
@@ -182,9 +182,9 @@ TEST(VirtualStack, ctor_test_8)
     ASSERT_EQ(stack.max_delta(), 3);
     ASSERT_EQ(stack.delta(), 1);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset(-2)));
 }
 
 TEST(VirtualStack, push_test)
@@ -210,7 +210,7 @@ TEST(VirtualStack, pop_test)
     ASSERT_EQ(stack.max_delta(), 0);
     ASSERT_EQ(stack.delta(), 0);
     ASSERT_TRUE(
-        test_stack_element(e, StackElemTestData{{}}.with_stack_offset({-1})));
+        test_stack_element(e, StackElemTestData{{}}.with_stack_offset(-1)));
 }
 
 TEST(VirtualStack, swap_test)
@@ -223,11 +223,11 @@ TEST(VirtualStack, swap_test)
     ASSERT_EQ(stack.max_delta(), 0);
     ASSERT_EQ(stack.delta(), 0);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-3), StackElemTestData{{-3}}.with_stack_offset({-1})));
+        stack.get(-3), StackElemTestData{{-3}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{-2}}.with_stack_offset(-2)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-3})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-3)));
 }
 
 TEST(VirtualStack, dup_test)
@@ -240,11 +240,11 @@ TEST(VirtualStack, dup_test)
     ASSERT_EQ(stack.max_delta(), 1);
     ASSERT_EQ(stack.delta(), 1);
     ASSERT_TRUE(test_stack_element(
-        stack.get(-2), StackElemTestData{{0, -2}}.with_stack_offset({-2})));
+        stack.get(-2), StackElemTestData{{0, -2}}.with_stack_offset(-2)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(0), StackElemTestData{{0, -2}}.with_stack_offset({-2})));
+        stack.get(0), StackElemTestData{{0, -2}}.with_stack_offset(-2)));
 }
 
 TEST(VirtualStack, push_pop_dup_swap_test_1)
@@ -264,9 +264,9 @@ TEST(VirtualStack, push_pop_dup_swap_test_1)
     ASSERT_TRUE(
         test_stack_element(e, StackElemTestData{{1}}.with_literal({0})));
     ASSERT_TRUE(test_stack_element(
-        stack.get(-1), StackElemTestData{{-1, 0}}.with_stack_offset({-1})));
+        stack.get(-1), StackElemTestData{{-1, 0}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
-        stack.get(0), StackElemTestData{{-1, 0}}.with_stack_offset({-1})));
+        stack.get(0), StackElemTestData{{-1, 0}}.with_stack_offset(-1)));
     ASSERT_TRUE(test_stack_element(
         stack.get(1), StackElemTestData{{1}}.with_literal({0})));
 }
@@ -276,10 +276,10 @@ TEST(VirtualStack, insert_stack_offset_test_1)
     auto ir = basic_blocks::BasicBlocksIR::unsafe_from({PUSH0});
     Stack stack{ir.blocks()[0]};
     stack.push_literal(0);
-    stack.insert_stack_offset(stack.get(0));
+    stack.insert_stack_offset(stack.get(0), PrevLoc::Unknown);
     ASSERT_TRUE(test_stack_element(
         stack.get(0),
-        StackElemTestData{{0}}.with_literal({0}).with_stack_offset({0})));
+        StackElemTestData{{0}}.with_literal({0}).with_stack_offset(0)));
 }
 
 TEST(VirtualStack, insert_stack_offset_test_2)
@@ -289,18 +289,18 @@ TEST(VirtualStack, insert_stack_offset_test_2)
     stack.push_literal(0);
     stack.push_literal(0);
     stack.push_literal(0);
-    stack.insert_stack_offset(stack.get(0), 1);
-    stack.insert_stack_offset(stack.get(1));
-    stack.insert_stack_offset(stack.get(2));
+    stack.insert_stack_offset(stack.get(0), 1, PrevLoc::Unknown);
+    stack.insert_stack_offset(stack.get(1), PrevLoc::Unknown);
+    stack.insert_stack_offset(stack.get(2), PrevLoc::Unknown);
     ASSERT_TRUE(test_stack_element(
         stack.get(0),
-        StackElemTestData{{0}}.with_literal({0}).with_stack_offset({1})));
+        StackElemTestData{{0}}.with_literal({0}).with_stack_offset(1)));
     ASSERT_TRUE(test_stack_element(
         stack.get(1),
-        StackElemTestData{{1}}.with_literal({0}).with_stack_offset({0})));
+        StackElemTestData{{1}}.with_literal({0}).with_stack_offset(0)));
     ASSERT_TRUE(test_stack_element(
         stack.get(2),
-        StackElemTestData{{2}}.with_literal({0}).with_stack_offset({2})));
+        StackElemTestData{{2}}.with_literal({0}).with_stack_offset(2)));
 }
 
 TEST(VirtualStack, insert_stack_offset_test_3)
@@ -310,18 +310,18 @@ TEST(VirtualStack, insert_stack_offset_test_3)
     stack.push_literal(0);
     stack.push_literal(0);
     stack.push_literal(0);
-    stack.insert_stack_offset(stack.get(0), 1);
-    stack.insert_stack_offset(stack.get(2));
-    stack.insert_stack_offset(stack.get(1));
+    stack.insert_stack_offset(stack.get(0), 1, PrevLoc::Unknown);
+    stack.insert_stack_offset(stack.get(2), PrevLoc::Unknown);
+    stack.insert_stack_offset(stack.get(1), PrevLoc::Unknown);
     ASSERT_TRUE(test_stack_element(
         stack.get(0),
-        StackElemTestData{{0}}.with_literal({0}).with_stack_offset({1})));
+        StackElemTestData{{0}}.with_literal({0}).with_stack_offset(1)));
     ASSERT_TRUE(test_stack_element(
         stack.get(1),
-        StackElemTestData{{1}}.with_literal({0}).with_stack_offset({0})));
+        StackElemTestData{{1}}.with_literal({0}).with_stack_offset(0)));
     ASSERT_TRUE(test_stack_element(
         stack.get(2),
-        StackElemTestData{{2}}.with_literal({0}).with_stack_offset({2})));
+        StackElemTestData{{2}}.with_literal({0}).with_stack_offset(2)));
 }
 
 TEST(VirtualStack, alloc_stack_offset_test_1)
@@ -330,18 +330,18 @@ TEST(VirtualStack, alloc_stack_offset_test_1)
     Stack stack{ir.blocks()[0]};
     stack.pop();
     stack.pop();
-    auto e1 = stack.alloc_stack_offset(-2);
-    auto e2 = stack.alloc_stack_offset(-2);
+    auto e1 = stack.alloc_stack_offset(-2, PrevLoc::Unknown);
+    auto e2 = stack.alloc_stack_offset(-2, PrevLoc::Unknown);
     ASSERT_TRUE(
-        test_stack_element(e1, StackElemTestData{{}}.with_stack_offset({-2})));
+        test_stack_element(e1, StackElemTestData{{}}.with_stack_offset(-2)));
     ASSERT_TRUE(
-        test_stack_element(e2, StackElemTestData{{}}.with_stack_offset({-1})));
+        test_stack_element(e2, StackElemTestData{{}}.with_stack_offset(-1)));
     stack.push(e1);
     stack.push(e2);
-    ASSERT_TRUE(test_stack_element(
-        e1, StackElemTestData{{-2}}.with_stack_offset({-2})));
-    ASSERT_TRUE(test_stack_element(
-        e2, StackElemTestData{{-1}}.with_stack_offset({-1})));
+    ASSERT_TRUE(
+        test_stack_element(e1, StackElemTestData{{-2}}.with_stack_offset(-2)));
+    ASSERT_TRUE(
+        test_stack_element(e2, StackElemTestData{{-1}}.with_stack_offset(-1)));
 }
 
 TEST(VirtualStack, insert_avx_reg_test_1)


### PR DESCRIPTION
Track where stack offset was moved from, to help prevent store forwarding stalls. Fixes #1864.
The new microbenchmark shows the stall disappearing:

main:
```
compiler
	store forwarding stall, constant input, throughput

	baseline:  0.104079 ms
	best:      0.114349 ms
	seq delta: 1.04053 ns
	total:     24 ms

compiler
	store forwarding stall, constant input, latency

	baseline:  0.118239 ms
	best:      0.153188 ms
	seq delta: 3.54093 ns
	total:     30 ms
```

feature:
```
compiler
	store forwarding stall, constant input, throughput

	baseline:  0.104739 ms
	best:      0.105049 ms
	seq delta: 0.0314083 ns
	total:     23 ms

compiler
	store forwarding stall, constant input, latency

	baseline:  0.118699 ms
	best:      0.118269 ms
	seq delta: -0.0435664 ns
	total:     27 ms
```

These are the results for other microbenchmarks, namely pairing of BASIC_BIN_MATH; BASIC_BIN_MATH, only showing pairs where the difference in the sequence deltas between main and feature branch was >0.5ns:

throughput:
<img width="6160" height="1158" alt="throughput" src="https://github.com/user-attachments/assets/964ef5ad-0e5b-4dd3-a6e5-7c0ff4e39cda" />

latency:
<img width="4360" height="1157" alt="latency" src="https://github.com/user-attachments/assets/8f6735d5-5e99-4c0b-930b-7abf44f22f70" />

Note: It appears that the results with DIV are quite noisy based on multiple measurements. This is probably due to the relative complexity of the div runtime function comparted to the other bin math operations