### PR TITLE
Add sharding support for distributed snapshot creation in monad_cli

### DIFF
--- a/category/execution/ethereum/db/db_snapshot.h
+++ b/category/execution/ethereum/db/db_snapshot.h
@@ -20,6 +20,12 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
+
+inline constexpr unsigned MONAD_SNAPSHOT_SHARD_NIBBLES = 2;
+inline constexpr unsigned MONAD_SNAPSHOT_SHARDS =
+    1 << (MONAD_SNAPSHOT_SHARD_NIBBLES * 4);
+static_assert(MONAD_SNAPSHOT_SHARDS == 256);
+
 extern "C"
 {
 #endif
@@ -40,7 +46,8 @@ bool monad_db_dump_snapshot(
     uint64_t (*write)(
         uint64_t shard, enum monad_snapshot_type, unsigned char const *bytes,
         size_t len, void *user),
-    void *user, unsigned dump_concurrency_limit);
+    void *user, unsigned dump_concurrency_limit, uint64_t total_shards,
+    uint64_t shard_number);
 
 struct monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t block, char const *const *dbname_paths, size_t len,


### PR DESCRIPTION
Enables splitting snapshot creation across multiple nodes by adding --total_shards and --shard_number CLI parameters. Each node processes a subset of the 256 existing shards (accounts, storage, code) and Ethereum headers, enabling parallel snapshot generation.

Key changes:
- Add --total_shards and --shard_number CLI arguments to monad_cli
- Filter snapshot traversal by shard assignment (shard % total_shards == shard_number)
- Optimize traversal by skipping entire subtrees for unassigned shards

Example usage to split across 4 nodes:
  node0: monad_cli --dump_binary_snapshot /snap --version 1000 --db /data --total_shards 4 --shard_number 0 node1: monad_cli --dump_binary_snapshot /snap --version 1000 --db /data --total_shards 4 --shard_number 1 node2: monad_cli --dump_binary_snapshot /snap --version 1000 --db /data --total_shards 4 --shard_number 2 node3: monad_cli --dump_binary_snapshot /snap --version 1000 --db /data --total_shards 4 --shard_number 3

This code was generated using Claude Sonnet 4.5