### PR TITLE
Apply relaxed merge to reserve balance and validate transaction. Enable relaxed merge.

### DIFF
--- a/category/execution/ethereum/execute_message.cpp
+++ b/category/execution/ethereum/execute_message.cpp
@@ -48,10 +48,7 @@ namespace
     bool sender_has_balance(State &state, evmc_message const &msg) noexcept
     {
         uint256_t const value = load_be<uint256_t>(msg.value);
-        // for optimistic execution, we do NOT require the original balance to
-        // match exactly, just add a lower bound constraint to suffice for this
-        // debit
-        return state.record_balance_constraint_for_debit(msg.sender, value);
+        return state.check_min_balance(msg.sender, value);
     }
 
     template <Traits traits>

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -451,7 +451,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
     {
         TRACE_TXN_EVENT(StartExecution);
 
-        State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        State state{block_state_, Incarnation{header_.number, i_ + 1}, true};
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -454,7 +454,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
     {
         TRACE_TXN_EVENT(StartExecution);
 
-        State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        State state{block_state_, Incarnation{header_.number, i_ + 1}, true};
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -358,7 +358,7 @@ void State::subtract_from_balance(
         account = Account{.incarnation = incarnation_};
     }
 
-    MONAD_ASSERT_THROW(delta <= account.value().balance, "balance underflow");
+    MONAD_ASSERT_THROW(check_min_balance(address, delta), "balance underflow");
 
     account.value().balance -= delta;
     account_state.touch();
@@ -683,12 +683,17 @@ bool State::try_fix_account_mismatch(
             return false;
         }
         if (actual->balance > original->balance) {
-            recent->balance += actual->balance - original->balance;
+            uint256_t const delta = actual->balance - original->balance;
+            if (std::numeric_limits<uint256_t>::max() - recent->balance <
+                delta) {
+                return false;
+            }
+            recent->balance += delta;
         }
         else {
-            MONAD_ASSERT(
-                recent->balance >= (original->balance - actual->balance));
-            recent->balance -= original->balance - actual->balance;
+            uint256_t const delta = original->balance - actual->balance;
+            MONAD_ASSERT(recent->balance >= delta);
+            recent->balance -= delta;
         }
     }
     original->balance = actual->balance;
@@ -700,13 +705,26 @@ bool State::try_fix_account_mismatch(
     return true;
 }
 
-bool State::record_balance_constraint_for_debit(
-    Address const &address, uint256_t const &debit)
+bool State::check_min_original_balance(
+    Address const &address, uint256_t const &value)
+{
+    auto &orig_state = original_account_state(address);
+    auto const &account = orig_state.account_;
+    return check_account_min_balance(orig_state, account, value);
+}
+
+bool State::check_min_balance(Address const &address, uint256_t const &value)
 {
     auto const &account = recent_account(address);
-    uint256_t const balance = account.has_value() ? account->balance : 0;
+    OriginalAccountState &orig_state = original_account_state(address);
+    return check_account_min_balance(orig_state, account, value);
+}
 
-    auto &original_state = original_account_state(address);
+bool State::check_account_min_balance(
+    OriginalAccountState &original_state, std::optional<Account> const &account,
+    uint256_t const &debit)
+{
+    uint256_t const balance = account ? account->balance : 0;
     // RELAXED MERGE
     // if current balance  >= `debit`, then:
     // 1. compute the amount that current balance exceeds `debit`

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -369,7 +369,7 @@ void State::subtract_from_balance(
         account = Account{.incarnation = incarnation_};
     }
 
-    MONAD_ASSERT_THROW(delta <= account.value().balance, "balance underflow");
+    MONAD_ASSERT_THROW(check_min_balance(address, delta), "balance underflow");
 
     account.value().balance -= delta;
     account_state.touch();
@@ -694,12 +694,17 @@ bool State::try_fix_account_mismatch(
             return false;
         }
         if (actual->balance > original->balance) {
-            recent->balance += actual->balance - original->balance;
+            uint256_t const delta = actual->balance - original->balance;
+            if (std::numeric_limits<uint256_t>::max() - recent->balance <
+                delta) {
+                return false;
+            }
+            recent->balance += delta;
         }
         else {
-            MONAD_ASSERT(
-                recent->balance >= (original->balance - actual->balance));
-            recent->balance -= original->balance - actual->balance;
+            uint256_t const delta = original->balance - actual->balance;
+            MONAD_ASSERT(recent->balance >= delta);
+            recent->balance -= delta;
         }
     }
     original->balance = actual->balance;
@@ -711,13 +716,26 @@ bool State::try_fix_account_mismatch(
     return true;
 }
 
-bool State::record_balance_constraint_for_debit(
-    Address const &address, uint256_t const &debit)
+bool State::check_min_original_balance(
+    Address const &address, uint256_t const &value)
+{
+    auto &orig_state = original_account_state(address);
+    auto const &account = orig_state.account_;
+    return check_account_min_balance(orig_state, account, value);
+}
+
+bool State::check_min_balance(Address const &address, uint256_t const &value)
 {
     auto const &account = recent_account(address);
-    uint256_t const balance = account.has_value() ? account->balance : 0;
+    OriginalAccountState &orig_state = original_account_state(address);
+    return check_account_min_balance(orig_state, account, value);
+}
 
-    auto &original_state = original_account_state(address);
+bool State::check_account_min_balance(
+    OriginalAccountState &original_state, std::optional<Account> const &account,
+    uint256_t const &debit)
+{
+    uint256_t const balance = account ? account->balance : 0;
     // RELAXED MERGE
     // if current balance  >= `debit`, then:
     // 1. compute the amount that current balance exceeds `debit`

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -233,17 +233,16 @@ public:
     bool try_fix_account_mismatch(
         Address const &, std::optional<Account> const &actual);
 
-    /**
-     * Checks whether the account currently has enough balance to cover `debit`
-     * and records the relaxed-merge constraints needed for that debit.
-     *
-     * NOTE: This method mutates the account's OriginalAccountState by either
-     * tightening the recorded `min_balance` or demanding exact balance
-     * validation when the balance is insufficient. Callers should treat it as
-     * a stateful helper rather than a pure predicate.
-     */
-    bool record_balance_constraint_for_debit(
-        Address const &, uint256_t const &debit);
+    // These functions check whether the account associated with the input
+    // address has enough balance to cover the input amount and record the
+    // corresponding relaxed-merge validation requirements.
+    bool check_min_original_balance(Address const &, uint256_t const &);
+    bool check_min_balance(Address const &, uint256_t const &);
+
+private:
+    bool check_account_min_balance(
+        OriginalAccountState &, std::optional<Account> const &,
+        uint256_t const &);
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -235,17 +235,16 @@ public:
     bool try_fix_account_mismatch(
         Address const &, std::optional<Account> const &actual);
 
-    /**
-     * Checks whether the account currently has enough balance to cover `debit`
-     * and records the relaxed-merge constraints needed for that debit.
-     *
-     * NOTE: This method mutates the account's OriginalAccountState by either
-     * tightening the recorded `min_balance` or demanding exact balance
-     * validation when the balance is insufficient. Callers should treat it as
-     * a stateful helper rather than a pure predicate.
-     */
-    bool record_balance_constraint_for_debit(
-        Address const &, uint256_t const &debit);
+    // These functions check whether the account associated with the input
+    // address has enough balance to cover the input amount and record the
+    // corresponding relaxed-merge validation requirements.
+    bool check_min_original_balance(Address const &, uint256_t const &);
+    bool check_min_balance(Address const &, uint256_t const &);
+
+private:
+    bool check_account_min_balance(
+        OriginalAccountState &, std::optional<Account> const &,
+        uint256_t const &);
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/validate_transaction.hpp
+++ b/category/execution/ethereum/validate_transaction.hpp
@@ -117,12 +117,7 @@ template <Traits traits>
         return TransactionError::BadNonce;
     }
 
-    // YP (71)
-    // RELAXED MERGE
-    // note this passes because `v0` includes gas which is later deducted in
-    // `irrevocable_change` before relaxed merge logic in `sender_has_balance`
-    // this is fragile as it depends on values in two locations matching
-    if (MONAD_UNLIKELY(state.get_balance(sender) < v0)) {
+    if (MONAD_UNLIKELY(!state.check_min_balance(sender, v0))) {
         return TransactionError::InsufficientBalance;
     }
 

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -102,9 +102,11 @@ bool dipped_into_reserve(
         // Check if dipped into reserve
         std::optional<uint256_t> const violation_threshold =
             [&] -> std::optional<uint256_t> {
-            uint256_t const orig_balance = state.get_original_balance(addr);
+            uint256_t const max_reserve = get_max_reserve<traits>(addr);
             uint256_t const reserve =
-                std::min(get_max_reserve<traits>(addr), orig_balance);
+                state.check_min_original_balance(addr, max_reserve)
+                    ? max_reserve
+                    : state.get_original_balance(addr);
             if (addr == sender) {
                 if (gas_fees > reserve) { // must be dipping
                     return std::nullopt;
@@ -113,9 +115,8 @@ bool dipped_into_reserve(
             }
             return reserve;
         }();
-        uint256_t const curr_balance = state.get_balance(addr);
         if (!violation_threshold.has_value() ||
-            curr_balance < violation_threshold.value()) {
+            !state.check_min_balance(addr, violation_threshold.value())) {
             if (addr == sender) {
                 if (!can_sender_dip_into_reserve(
                         sender, i, effective_is_delegated, ctx)) {
@@ -209,7 +210,9 @@ uint256_t ReserveBalance::pretx_reserve(Address const &address)
 {
     MONAD_ASSERT(get_max_reserve_);
     uint256_t const max_reserve = get_max_reserve_(address);
-    return std::min(max_reserve, state_->get_original_balance(address));
+    return state_->check_min_original_balance(address, max_reserve)
+               ? max_reserve
+               : state_->get_original_balance(address);
 }
 
 void ReserveBalance::update_violation_status(Address const &address)
@@ -266,7 +269,7 @@ void ReserveBalance::update_violation_status(Address const &address)
         return;
     }
 
-    if (state_->get_balance(address) < *violation_threshold) {
+    if (!state_->check_min_balance(address, *violation_threshold)) {
         failed_.insert(address);
     }
     else {

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -103,9 +103,11 @@ bool dipped_into_reserve(
         // Check if dipped into reserve
         std::optional<uint256_t> const violation_threshold =
             [&] -> std::optional<uint256_t> {
-            uint256_t const orig_balance = state.get_original_balance(addr);
+            uint256_t const max_reserve = get_max_reserve<traits>(addr);
             uint256_t const reserve =
-                std::min(get_max_reserve<traits>(addr), orig_balance);
+                state.check_min_original_balance(addr, max_reserve)
+                    ? max_reserve
+                    : state.get_original_balance(addr);
             if (addr == sender) {
                 if (gas_fees > reserve) { // must be dipping
                     return std::nullopt;
@@ -114,9 +116,8 @@ bool dipped_into_reserve(
             }
             return reserve;
         }();
-        uint256_t const curr_balance = state.get_balance(addr);
         if (!violation_threshold.has_value() ||
-            curr_balance < violation_threshold.value()) {
+            !state.check_min_balance(addr, violation_threshold.value())) {
             if (addr == sender) {
                 if (!can_sender_dip_into_reserve(
                         sender, i, effective_is_delegated, ctx)) {
@@ -210,7 +211,9 @@ uint256_t ReserveBalance::pretx_reserve(Address const &address)
 {
     MONAD_ASSERT(get_max_reserve_);
     uint256_t const max_reserve = get_max_reserve_(address);
-    return std::min(max_reserve, state_->get_original_balance(address));
+    return state_->check_min_original_balance(address, max_reserve)
+               ? max_reserve
+               : state_->get_original_balance(address);
 }
 
 void ReserveBalance::update_violation_status(Address const &address)
@@ -267,7 +270,7 @@ void ReserveBalance::update_violation_status(Address const &address)
         return;
     }
 
-    if (state_->get_balance(address) < *violation_threshold) {
+    if (!state_->check_min_balance(address, *violation_threshold)) {
         failed_.insert(address);
     }
     else {

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1514,9 +1514,9 @@ Result<byte_string> StakingContract::precompile_withdraw(
 
     BOOST_OUTCOME_TRY(
         withdrawal_amount, checked_add(withdrawal_amount, rewards));
-    uint256_t const contract_balance = state_.get_balance(STAKING_CA);
     MONAD_ASSERT_THROW(
-        contract_balance >= withdrawal_amount, "withdrawal insolvent");
+        state_.check_min_balance(STAKING_CA, withdrawal_amount),
+        "withdrawal insolvent");
     send_tokens(msg_sender, withdrawal_amount);
 
     emit_withdraw_event(val_id, msg_sender, withdrawal_id, withdrawal_amount);

--- a/category/execution/monad/validate_monad_transaction.cpp
+++ b/category/execution/monad/validate_monad_transaction.cpp
@@ -46,7 +46,7 @@ Result<void> validate_transaction(
 
         uint256_t const gas_fee =
             uint256_t{tx.gas_limit} * gas_price<traits>(tx, base_fee_per_gas);
-        if (MONAD_UNLIKELY(state.get_balance(sender) < gas_fee)) {
+        if (MONAD_UNLIKELY(!state.check_min_balance(sender, gas_fee))) {
             return MonadTransactionError::InsufficientBalanceForFee;
         }
 


### PR DESCRIPTION
This PR:
- Adds to State variants of check min balance functions (to support relaxing reserve balance and validate transaction)
- Relaxes reserve balance
- Relaxed validate transaction
- Enables relaxed merge validation

[Updated 2025-12-23]
- Relaxes staking [2026-03-24]