### PR TITLE
Add dump_concurrency_limit parameter to monad_cli for snapshot dump

### DIFF
--- a/category/execution/ethereum/db/db_snapshot.h
+++ b/category/execution/ethereum/db/db_snapshot.h
@@ -40,7 +40,7 @@ bool monad_db_dump_snapshot(
     uint64_t (*write)(
         uint64_t shard, enum monad_snapshot_type, unsigned char const *bytes,
         size_t len, void *user),
-    void *user);
+    void *user, unsigned dump_concurrency_limit);
 
 struct monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t block, char const *const *dbname_paths, size_t len,

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -118,7 +118,9 @@ TEST(DbBinarySnapshot, Basic)
             static_cast<unsigned>(-1),
             100,
             monad_db_snapshot_write_filesystem,
-            context));
+            context,
+            2048 // dump_concurrency_limit
+            ));
 
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
 

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -797,6 +797,7 @@ int main(int argc, char *argv[])
     std::optional<std::filesystem::path> dump_binary_snapshot;
     std::optional<std::filesystem::path> load_binary_snapshot;
     uint64_t version;
+    unsigned dump_concurrency_limit = 2048;
 
     CLI::App cli{"monad_cli"};
     cli.add_option(
@@ -823,6 +824,10 @@ int main(int argc, char *argv[])
         "--dump_binary_snapshot",
         dump_binary_snapshot,
         "Dump a binary snapshot to directory");
+    cli_group->add_option(
+        "--dump_concurrency_limit",
+        dump_concurrency_limit,
+        "Read concurrency limit for snapshot dump");
     cli_group
         ->add_option(
             "--load_binary_snapshot",
@@ -889,7 +894,8 @@ int main(int argc, char *argv[])
             sq_thread_cpu.value_or(std::numeric_limits<unsigned>::max()),
             version,
             monad_db_snapshot_write_filesystem,
-            context);
+            context,
+            dump_concurrency_limit);
         LOG_INFO(
             "snapshot dump success={} version={} directory={} elapsed={}",
             success,


### PR DESCRIPTION
Add a single parameter dump_concurrency_limit that sets all queue sizes (rd_buffers, uring_entries, concurrent_read_io_limit, and traverse concurrency_limit) to the same value. This avoids double-queueing bottlenecks where operations queue at multiple levels in the I/O stack.

Default value: 2048

This code was generated using Claude Sonnet 4.5