### PR TITLE
[ethereum/db]: Add CommitBuilder API

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(
   # ethereum/db
   "ethereum/db/block_db.cpp"
   "ethereum/db/block_db.hpp"
+  "ethereum/db/commit_builder.cpp"
+  "ethereum/db/commit_builder.hpp"
   "ethereum/db/db.hpp"
   "ethereum/db/db_cache.hpp"
   "ethereum/db/db_snapshot.cpp"

--- a/category/execution/ethereum/db/commit_builder.cpp
+++ b/category/execution/ethereum/db/commit_builder.cpp
@@ -1,0 +1,351 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "commit_builder.hpp"
+
+#include <category/core/assert.h>
+#include <category/core/keccak.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/rlp/address_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/block_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/int_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/receipt_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/withdrawal_rlp.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/trace/rlp/call_frame_rlp.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/mpt/update.hpp>
+#include <category/mpt/util.hpp>
+
+#include <limits>
+
+MONAD_NAMESPACE_BEGIN
+
+using namespace monad::mpt;
+
+namespace
+{
+    byte_string
+    encode_receipt_db(Receipt const &receipt, size_t const log_index_begin)
+    {
+        return rlp::encode_list2(
+            rlp::encode_string2(rlp::encode_receipt(receipt)),
+            rlp::encode_unsigned(log_index_begin));
+    }
+
+    byte_string encode_transaction_db(
+        byte_string_view const encoded_tx, Address const &sender)
+    {
+        return rlp::encode_list2(
+            rlp::encode_string2(encoded_tx), rlp::encode_address(sender));
+    }
+}
+
+CommitBuilder::CommitBuilder(uint64_t const block_number)
+    : block_number_{block_number}
+{
+}
+
+CommitBuilder &CommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
+{
+    UpdateList account_updates;
+    for (auto const &[addr, delta] : state_deltas) {
+        UpdateList storage_updates;
+        std::optional<byte_string_view> value;
+        auto const &account = delta.account.second;
+        if (account.has_value()) {
+            for (auto const &[key, delta] : delta.storage) {
+                if (delta.first != delta.second) {
+                    storage_updates.push_front(
+                        update_alloc_.emplace_back(Update{
+                            .key = hash_alloc_.emplace_back(
+                                keccak256({key.bytes, sizeof(key.bytes)})),
+                            .value = delta.second == bytes32_t{}
+                                         ? std::nullopt
+                                         : std::make_optional<byte_string_view>(
+                                               bytes_alloc_.emplace_back(
+                                                   encode_storage_db(
+                                                       key, delta.second))),
+                            .incarnation = false,
+                            .next = UpdateList{},
+                            .version = static_cast<int64_t>(block_number_)}));
+                }
+            }
+            value = bytes_alloc_.emplace_back(
+                encode_account_db(addr, account.value()));
+        }
+
+        if (!storage_updates.empty() || delta.account.first != account) {
+            bool const incarnation =
+                account.has_value() && delta.account.first.has_value() &&
+                delta.account.first->incarnation != account->incarnation;
+            account_updates.push_front(update_alloc_.emplace_back(Update{
+                .key = hash_alloc_.emplace_back(
+                    keccak256({addr.bytes, sizeof(addr.bytes)})),
+                .value = value,
+                .incarnation = incarnation,
+                .next = std::move(storage_updates),
+                .version = static_cast<int64_t>(block_number_)}));
+        }
+    }
+
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = state_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(account_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_code(Code const &code)
+{
+    UpdateList code_updates;
+    for (auto const &[hash, icode] : code) {
+        MONAD_ASSERT(icode);
+        code_updates.push_front(update_alloc_.emplace_back(Update{
+            .key = NibblesView{to_byte_string_view(hash.bytes)},
+            .value = {{icode->code(), icode->size()}},
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
+    }
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = code_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(code_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_receipts(std::vector<Receipt> const &receipts)
+{
+    UpdateList receipt_updates;
+    MONAD_ASSERT(receipts.size() <= std::numeric_limits<uint32_t>::max());
+
+    size_t log_index_begin = 0;
+    for (uint32_t i = 0; i < static_cast<uint32_t>(receipts.size()); ++i) {
+        auto const &rlp_index =
+            bytes_alloc_.emplace_back(rlp::encode_unsigned(i));
+        auto const &receipt = receipts[i];
+        auto const &encoded_receipt = bytes_alloc_.emplace_back(
+            encode_receipt_db(receipt, log_index_begin));
+        log_index_begin += receipt.logs.size();
+
+        receipt_updates.push_front(update_alloc_.emplace_back(Update{
+            .key = NibblesView{rlp_index},
+            .value = encoded_receipt,
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
+    }
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = receipt_nibbles,
+        .value = byte_string_view{},
+        .incarnation = true,
+        .next = std::move(receipt_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_transactions(
+    std::vector<Transaction> const &transactions,
+    std::vector<Address> const &senders)
+{
+    UpdateList txn_updates;
+    UpdateList txn_hash_updates;
+
+    MONAD_ASSERT(transactions.size() <= std::numeric_limits<uint32_t>::max());
+    MONAD_ASSERT(transactions.size() == senders.size());
+
+    auto const encoded_block_number =
+        bytes_alloc_.emplace_back(rlp::encode_unsigned(block_number_));
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(transactions.size()); ++i) {
+        auto const &rlp_index =
+            bytes_alloc_.emplace_back(rlp::encode_unsigned(i));
+
+        auto const encoded_tx = rlp::encode_transaction(transactions[i]);
+        txn_updates.push_front(update_alloc_.emplace_back(Update{
+            .key = NibblesView{rlp_index},
+            .value = bytes_alloc_.emplace_back(
+                encode_transaction_db(encoded_tx, senders[i])),
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
+
+        txn_hash_updates.push_front(update_alloc_.emplace_back(Update{
+            .key = NibblesView{hash_alloc_.emplace_back(keccak256(encoded_tx))},
+            .value = bytes_alloc_.emplace_back(
+                rlp::encode_list2(encoded_block_number, rlp_index)),
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
+    }
+
+    // txns subtrie
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = transaction_nibbles,
+        .value = byte_string_view{},
+        .incarnation = true,
+        .next = std::move(txn_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    // txns hash subtrie
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = tx_hash_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(txn_hash_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_call_frames(
+    std::vector<std::vector<CallFrame>> const &call_frames)
+{
+    UpdateList call_frame_updates;
+
+    MONAD_ASSERT(call_frames.size() <= std::numeric_limits<uint32_t>::max());
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(call_frames.size()); ++i) {
+        byte_string_view frame_view =
+            bytes_alloc_.emplace_back(rlp::encode_call_frames(call_frames[i]));
+        uint8_t chunk_index = 0;
+        auto const call_frame_prefix =
+            serialize_as_big_endian<sizeof(uint32_t)>(i);
+
+        while (!frame_view.empty()) {
+            MONAD_ASSERT(chunk_index <= std::numeric_limits<uint8_t>::max());
+            byte_string_view chunk =
+                frame_view.substr(0, MAX_VALUE_LEN_OF_LEAF);
+            frame_view.remove_prefix(chunk.size());
+            byte_string const chunk_key =
+                byte_string{&chunk_index, sizeof(uint8_t)};
+            call_frame_updates.push_front(update_alloc_.emplace_back(Update{
+                .key = bytes_alloc_.emplace_back(call_frame_prefix + chunk_key),
+                .value = chunk,
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(block_number_)}));
+            ++chunk_index;
+        }
+    }
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = call_frame_nibbles,
+        .value = byte_string_view{},
+        .incarnation = true,
+        .next = std::move(call_frame_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_ommers(std::vector<BlockHeader> const &ommers)
+{
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = ommer_nibbles,
+        .value = bytes_alloc_.emplace_back(rlp::encode_ommers(ommers)),
+        .incarnation = true,
+        .next = UpdateList{},
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &
+CommitBuilder::add_withdrawals(std::vector<Withdrawal> const &withdrawals)
+{
+    UpdateList withdrawal_updates;
+
+    for (size_t i = 0; i < withdrawals.size(); ++i) {
+        auto const &rlp_index =
+            bytes_alloc_.emplace_back(rlp::encode_unsigned(i));
+
+        withdrawal_updates.push_front(update_alloc_.emplace_back(Update{
+            .key = NibblesView{rlp_index},
+            .value = bytes_alloc_.emplace_back(
+                rlp::encode_withdrawal(withdrawals[i])),
+            .incarnation = false,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(block_number_)}));
+    }
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = withdrawal_nibbles,
+        .value = byte_string_view{},
+        .incarnation = true,
+        .next = std::move(withdrawal_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+CommitBuilder &CommitBuilder::add_block_header(BlockHeader const &header)
+{
+    auto const eth_header_rlp = rlp::encode_block_header(header);
+
+    UpdateList block_hash_nested_updates;
+    block_hash_nested_updates.push_front(update_alloc_.emplace_back(Update{
+        .key = hash_alloc_.emplace_back(keccak256(eth_header_rlp)),
+        .value = bytes_alloc_.emplace_back(rlp::encode_unsigned(header.number)),
+        .incarnation = false,
+        .next = UpdateList{},
+        .version = static_cast<int64_t>(block_number_)}));
+
+    // block header subtrie
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = block_header_nibbles,
+        .value = bytes_alloc_.emplace_back(eth_header_rlp),
+        .incarnation = true,
+        .next = UpdateList{},
+        .version = static_cast<int64_t>(block_number_)}));
+
+    // block hash subtrie
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = block_hash_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(block_hash_nested_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+UpdateList CommitBuilder::build(NibblesView const prefix)
+{
+    UpdateList root_update;
+    root_update.push_front(update_alloc_.emplace_back(Update{
+        .key = prefix,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(updates_),
+        .version = static_cast<int64_t>(block_number_)}));
+    return root_update;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/commit_builder.hpp
+++ b/category/execution/ethereum/db/commit_builder.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/mpt/update.hpp>
+
+#include <deque>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+struct CallFrame;
+struct Transaction;
+struct BlockHeader;
+struct Receipt;
+struct Withdrawal;
+
+class CommitBuilder
+{
+    std::deque<mpt::Update> update_alloc_;
+    std::deque<byte_string> bytes_alloc_;
+    std::deque<hash256> hash_alloc_;
+    mpt::UpdateList updates_;
+    uint64_t block_number_;
+
+public:
+    explicit CommitBuilder(uint64_t block_number);
+
+    CommitBuilder &add_state_deltas(StateDeltas const &);
+
+    CommitBuilder &add_code(Code const &);
+
+    CommitBuilder &add_receipts(std::vector<Receipt> const &);
+
+    CommitBuilder &add_transactions(
+        std::vector<Transaction> const &, std::vector<Address> const &);
+
+    CommitBuilder &add_call_frames(std::vector<std::vector<CallFrame>> const &);
+
+    CommitBuilder &add_ommers(std::vector<BlockHeader> const &);
+
+    CommitBuilder &add_withdrawals(std::vector<Withdrawal> const &);
+
+    CommitBuilder &add_block_header(BlockHeader const &);
+
+    mpt::UpdateList build(mpt::NibblesView);
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -75,24 +75,6 @@ MONAD_NAMESPACE_BEGIN
 
 using namespace monad::mpt;
 
-namespace
-{
-    byte_string
-    encode_receipt_db(Receipt const &receipt, size_t const log_index_begin)
-    {
-        return rlp::encode_list2(
-            rlp::encode_string2(rlp::encode_receipt(receipt)),
-            rlp::encode_unsigned(log_index_begin));
-    }
-
-    byte_string encode_transaction_db(
-        byte_string_view const encoded_tx, Address const &sender)
-    {
-        return rlp::encode_list2(
-            rlp::encode_string2(encoded_tx), rlp::encode_address(sender));
-    }
-}
-
 TrieDb::TrieDb(mpt::Db &db)
     : db_{db}
     , block_number_{db.get_latest_finalized_version()}
@@ -204,211 +186,24 @@ void TrieDb::commit(
     }
     block_number_ = header.number;
 
-    UpdateList account_updates;
-    for (auto const &[addr, delta] : state_deltas) {
-        UpdateList storage_updates;
-        std::optional<byte_string_view> value;
-        auto const &account = delta.account.second;
-        if (account.has_value()) {
-            for (auto const &[key, delta] : delta.storage) {
-                if (delta.first != delta.second) {
-                    storage_updates.push_front(
-                        update_alloc_.emplace_back(Update{
-                            .key = hash_alloc_.emplace_back(
-                                keccak256({key.bytes, sizeof(key.bytes)})),
-                            .value = delta.second == bytes32_t{}
-                                         ? std::nullopt
-                                         : std::make_optional<byte_string_view>(
-                                               bytes_alloc_.emplace_back(
-                                                   encode_storage_db(
-                                                       key, delta.second))),
-                            .incarnation = false,
-                            .next = UpdateList{},
-                            .version = static_cast<int64_t>(block_number_)}));
-                }
-            }
-            value = bytes_alloc_.emplace_back(
-                encode_account_db(addr, account.value()));
-        }
-
-        if (!storage_updates.empty() || delta.account.first != account) {
-            bool const incarnation =
-                account.has_value() && delta.account.first.has_value() &&
-                delta.account.first->incarnation != account->incarnation;
-            account_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = hash_alloc_.emplace_back(
-                    keccak256({addr.bytes, sizeof(addr.bytes)})),
-                .value = value,
-                .incarnation = incarnation,
-                .next = std::move(storage_updates),
-                .version = static_cast<int64_t>(block_number_)}));
-        }
-    }
-
-    UpdateList code_updates;
-    for (auto const &[hash, icode] : code) {
-        // TODO write intercode object
-        MONAD_ASSERT(icode);
-        code_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{to_byte_string_view(hash.bytes)},
-            .value = {{icode->code(), icode->size()}},
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
-    }
-
-    UpdateList receipt_updates;
-    UpdateList transaction_updates;
-    UpdateList tx_hash_updates;
-    UpdateList call_frame_updates;
-    MONAD_ASSERT(receipts.size() == transactions.size());
-    MONAD_ASSERT(transactions.size() == senders.size());
-    MONAD_ASSERT(receipts.size() == call_frames.size());
-    MONAD_ASSERT(receipts.size() <= std::numeric_limits<uint32_t>::max());
-    auto const &encoded_block_number =
-        bytes_alloc_.emplace_back(rlp::encode_unsigned(header.number));
-    std::vector<byte_string> index_alloc;
-    index_alloc.reserve(std::max(
-        receipts.size(),
-        withdrawals.transform(&std::vector<Withdrawal>::size).value_or(0)));
-    size_t log_index_begin = 0;
-    for (uint32_t i = 0; i < static_cast<uint32_t>(receipts.size()); ++i) {
-        auto const &rlp_index =
-            index_alloc.emplace_back(rlp::encode_unsigned(i));
-        auto const &receipt = receipts[i];
-        auto const &encoded_receipt = bytes_alloc_.emplace_back(
-            encode_receipt_db(receipt, log_index_begin));
-        log_index_begin += receipt.logs.size();
-        receipt_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{rlp_index},
-            .value = encoded_receipt,
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
-
-        auto const encoded_tx = rlp::encode_transaction(transactions[i]);
-        transaction_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{rlp_index},
-            .value = bytes_alloc_.emplace_back(
-                encode_transaction_db(encoded_tx, senders[i])),
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
-        tx_hash_updates.push_front(update_alloc_.emplace_back(Update{
-            .key = NibblesView{hash_alloc_.emplace_back(keccak256(encoded_tx))},
-            .value = bytes_alloc_.emplace_back(
-                rlp::encode_list2(encoded_block_number, rlp_index)),
-            .incarnation = false,
-            .next = UpdateList{},
-            .version = static_cast<int64_t>(block_number_)}));
-
-        // Call frames
-        std::span<CallFrame const> frames{call_frames[i]};
-        byte_string_view frame_view =
-            bytes_alloc_.emplace_back(rlp::encode_call_frames(frames));
-        uint8_t chunk_index = 0;
-        auto const call_frame_prefix =
-            serialize_as_big_endian<sizeof(uint32_t)>(i);
-        while (!frame_view.empty()) {
-            byte_string_view chunk =
-                frame_view.substr(0, mpt::MAX_VALUE_LEN_OF_LEAF);
-            frame_view.remove_prefix(chunk.size());
-            byte_string const chunk_key =
-                byte_string{&chunk_index, sizeof(uint8_t)};
-            call_frame_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = bytes_alloc_.emplace_back(call_frame_prefix + chunk_key),
-                .value = chunk,
-                .incarnation = false,
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(block_number_)}));
-            ++chunk_index;
-        }
-    }
-
-    UpdateList updates;
-
-    auto state_update = Update{
-        .key = state_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(account_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    auto code_update = Update{
-        .key = code_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(code_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    auto receipt_update = Update{
-        .key = receipt_nibbles,
-        .value = byte_string_view{},
-        .incarnation = true,
-        .next = std::move(receipt_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    auto call_frame_update = Update{
-        .key = call_frame_nibbles,
-        .value = byte_string_view{},
-        .incarnation = true,
-        .next = std::move(call_frame_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    auto transaction_update = Update{
-        .key = transaction_nibbles,
-        .value = byte_string_view{},
-        .incarnation = true,
-        .next = std::move(transaction_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    auto ommer_update = Update{
-        .key = ommer_nibbles,
-        .value = bytes_alloc_.emplace_back(rlp::encode_ommers(ommers)),
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(block_number_)};
-    auto tx_hash_update = Update{
-        .key = tx_hash_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(tx_hash_updates),
-        .version = static_cast<int64_t>(block_number_)};
-    updates.push_front(state_update);
-    updates.push_front(code_update);
-    updates.push_front(receipt_update);
-    updates.push_front(call_frame_update);
-    updates.push_front(transaction_update);
-    updates.push_front(ommer_update);
-    updates.push_front(tx_hash_update);
-    UpdateList withdrawal_updates;
+    CommitBuilder builder(block_number_);
+    builder.add_state_deltas(state_deltas)
+        .add_code(code)
+        .add_receipts(receipts)
+        .add_transactions(transactions, senders)
+        .add_call_frames(call_frames)
+        .add_ommers(ommers);
     if (withdrawals.has_value()) {
-        // only commit withdrawals when the optional has value
-        for (size_t i = 0; i < withdrawals.value().size(); ++i) {
-            if (i >= index_alloc.size()) {
-                index_alloc.emplace_back(rlp::encode_unsigned(i));
-            }
-            withdrawal_updates.push_front(update_alloc_.emplace_back(Update{
-                .key = NibblesView{index_alloc[i]},
-                .value = bytes_alloc_.emplace_back(
-                    rlp::encode_withdrawal(withdrawals.value()[i])),
-                .incarnation = false,
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(block_number_)}));
-        }
-        updates.push_front(update_alloc_.emplace_back(Update{
-            .key = withdrawal_nibbles,
-            .value = byte_string_view{},
-            .incarnation = true,
-            .next = std::move(withdrawal_updates),
-            .version = static_cast<int64_t>(block_number_)}));
+        builder.add_withdrawals(withdrawals.value());
     }
-
-    UpdateList ls;
-    ls.push_front(update_alloc_.emplace_back(Update{
-        .key = prefix_,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates),
-        .version = static_cast<int64_t>(block_number_)}));
 
     curr_root_ = db_.upsert(
-        std::move(curr_root_), std::move(ls), block_number_, true, true, false);
+        std::move(curr_root_),
+        builder.build(prefix_),
+        block_number_,
+        true,
+        true,
+        false);
 
     BlockHeader complete_header = header;
     if (MONAD_LIKELY(header.receipts_root == NULL_ROOT)) {
@@ -427,52 +222,14 @@ void TrieDb::commit(
     complete_header.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
     complete_header.logs_bloom = compute_bloom(receipts);
     complete_header.ommers_hash = compute_ommers_hash(ommers);
-    auto const eth_header_rlp = rlp::encode_block_header(complete_header);
 
-    UpdateList block_hash_nested_updates;
-    block_hash_nested_updates.push_front(update_alloc_.emplace_back(Update{
-        .key = hash_alloc_.emplace_back(keccak256(eth_header_rlp)),
-        .value = encoded_block_number,
-        .incarnation = false,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(block_number_)}));
-
-    UpdateList updates2;
-
-    auto block_header_update = Update{
-        .key = block_header_nibbles,
-        .value = eth_header_rlp,
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(block_number_)};
-    auto block_hash_update = Update{
-        .key = block_hash_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(block_hash_nested_updates),
-        .version = static_cast<int64_t>(block_number_)};
-
-    updates2.push_front(block_header_update);
-    updates2.push_front(block_hash_update);
-
-    UpdateList ls2;
-    ls2.push_front(update_alloc_.emplace_back(Update{
-        .key = prefix_,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates2),
-        .version = static_cast<int64_t>(block_number_)}));
-
+    builder.add_block_header(complete_header);
     bool const enable_compaction = false;
     curr_root_ = db_.upsert(
         std::move(curr_root_),
-        std::move(ls2),
+        builder.build(prefix_),
         block_number_,
         enable_compaction);
-
-    update_alloc_.clear();
-    bytes_alloc_.clear();
-    hash_alloc_.clear();
 }
 
 void TrieDb::set_block_and_prefix(

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -21,6 +21,7 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
@@ -44,9 +45,6 @@ MONAD_NAMESPACE_BEGIN
 class TrieDb final : public ::monad::Db
 {
     ::monad::mpt::Db &db_;
-    std::deque<mpt::Update> update_alloc_;
-    std::deque<byte_string> bytes_alloc_;
-    std::deque<hash256> hash_alloc_;
     uint64_t block_number_;
     // bytes32_t{} represent finalized
     bytes32_t proposal_block_id_;
@@ -67,6 +65,7 @@ public:
     virtual void set_block_and_prefix(
         uint64_t block_number,
         bytes32_t const &block_id = bytes32_t{}) override;
+
     virtual void commit(
         StateDeltas const &, Code const &, bytes32_t const &block_id,
         BlockHeader const &, std::vector<Receipt> const & = {},
@@ -75,6 +74,7 @@ public:
         std::vector<Transaction> const & = {},
         std::vector<BlockHeader> const &ommers = {},
         std::optional<std::vector<Withdrawal>> const & = std::nullopt) override;
+
     virtual void
     finalize(uint64_t block_number, bytes32_t const &block_id) override;
     virtual void update_verified_block(uint64_t block_number) override;


### PR DESCRIPTION
TrieDb::commit() has become a large function that will continue to grow as new features are added. The CommitBuilder API contains the logic for building a coherent UpdateList to TrieDb, and commit becomes a small shim around db.upsert().

This is the first step in a larger refactor. Ideally, we should be passing an UpdateList into commit(), and the caller should use the CommitBuilder API to construct a set of Updates without adding many lines of code.

This has two benefits:

* Test cases that only commit a subset of the tables don't need to build every field.

* This lends well to future upgrades where Monad will diverge from Ethereum. The caller can construct the relevant set of updates for a chain.