### PR TITLE
[vm/utils] Add `clz` to the microbenchmark suite

### DIFF
--- a/test/vm/micro_benchmarks/main.cpp
+++ b/test/vm/micro_benchmarks/main.cpp
@@ -32,7 +32,7 @@ using namespace monad::vm;
 using namespace monad::vm::runtime;
 using namespace monad::vm::utils::evm_as;
 
-using traits = EvmTraits<EVMC_PRAGUE>;
+using traits = EvmTraits<EVMC_OSAKA>;
 
 struct CommandArguments
 {
@@ -291,7 +291,9 @@ static void run_benchmark(CommandArguments const &args, Benchmark const &bench)
 }
 
 static std::vector<EvmBuilder<traits>> const basic_una_math_builders = {
-    EvmBuilder<traits>{}.iszero(), EvmBuilder<traits>{}.not_()};
+    EvmBuilder<traits>{}.iszero(),
+    EvmBuilder<traits>{}.not_(),
+    EvmBuilder<traits>{}.clz()};
 
 static std::vector<EvmBuilder<traits>> const basic_bin_math_builders = {
     EvmBuilder<traits>{}.add(),


### PR DESCRIPTION
Needs #1970 for full compatibility.