### PR TITLE
Fix depth bug in selfdestructing call frames

### DIFF
--- a/category/execution/ethereum/trace/call_tracer.hpp
+++ b/category/execution/ethereum/trace/call_tracer.hpp
@@ -61,7 +61,6 @@ class CallTracer final : public CallTracerBase
     std::vector<CallFrame> &frames_;
     std::stack<size_t> last_{};
     std::stack<size_t> positions_{};
-    uint64_t depth_{0};
     Transaction const &tx_;
 
 public:


### PR DESCRIPTION
Previously, the call tracer tracked the depth of selfdestructing call frames with a separate variable. This produced a bug whereby successive selfdestructs would appear at the lowest depth for any of them, rather than as children of their respective parents. The regression test added explains this diagrammatically.

Fixes #1975 