### PR TITLE
Remove llvm tests from ci

### DIFF
--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -100,7 +100,6 @@ jobs:
                   CC=${{ matrix.compiler.CC }}
                   CXX=${{ matrix.compiler.CXX }}
                   CMAKE_BUILD_TYPE=${{ matrix.build.CMAKE_BUILD_TYPE }}
-                  SKIP_LLVM_TESTS=${{ matrix.build.CMAKE_BUILD_TYPE == 'Debug' && 'true' || 'false' }}
                   TOOLCHAIN=${{ matrix.build.TOOLCHAIN }}
                 target: build_and_test_vm
                 cache-from: type=gha,scope=base

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,14 +35,13 @@ COPY . src
 ARG CC
 ARG CXX
 ARG CMAKE_BUILD_TYPE
-ARG SKIP_LLVM_TESTS
 ARG TOOLCHAIN
 
 RUN cd src && CC=${CC:?} CXX=${CXX:?} CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:?} CMAKE_TOOLCHAIN_FILE=category/core/toolchains/${TOOLCHAIN:?}.cmake ./scripts/configure.sh
-RUN cd src && cmake build -DMONAD_COMPILER_TESTING=On -DMONAD_COMPILER_LLVM=On
+RUN cd src && cmake build -DMONAD_COMPILER_TESTING=On -DMONAD_COMPILER_LLVM=Off
 
 RUN cd src && ./scripts/vm/build-tests.sh
-RUN cd src && SKIP_LLVM_TESTS=${SKIP_LLVM_TESTS:?} ./scripts/vm/test.sh
+RUN cd src && ./scripts/vm/test.sh
 
 FROM base AS code_quality
 
@@ -50,7 +49,7 @@ COPY . src
 
 RUN cd src && CMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake cmake -S . -B build           \
   -DMONAD_COMPILER_BENCHMARKS=On  \
-  -DMONAD_COMPILER_LLVM=On        \
+  -DMONAD_COMPILER_LLVM=Off       \
   -DMONAD_COMPILER_TESTING=On     \
   -DCMAKE_BUILD_TYPE=Debug        \
   -DCMAKE_C_COMPILER=clang-19     \

--- a/scripts/vm/build-tests.sh
+++ b/scripts/vm/build-tests.sh
@@ -6,5 +6,4 @@ cmake \
   --config RelWithDebInfo \
   --target vm-unit-tests \
   --target compiler-blockchain-tests \
-  --target llvm-blockchain-tests \
   --target interpreter-blockchain-tests

--- a/scripts/vm/test.sh
+++ b/scripts/vm/test.sh
@@ -5,12 +5,6 @@ set -euxo pipefail
 export UBSAN_OPTIONS="halt_on_error=1"
 ulimit -s 131072
 
-if [[ $SKIP_LLVM_TESTS == false ]]; then
-  ./build/test/vm/blockchain/llvm-blockchain-tests
-else
-  echo skipping llvm tests
-fi
-
 ./build/test/vm/unit/vm-unit-tests
 ./build/test/vm/blockchain/compiler-blockchain-tests
 ./build/test/vm/blockchain/interpreter-blockchain-tests

--- a/test/vm/execution_benchmarks/benchmarks.cpp
+++ b/test/vm/execution_benchmarks/benchmarks.cpp
@@ -85,6 +85,12 @@ namespace
                               "BlockchainTests" / "GeneralStateTests" /
                               "VMTests" / "vmPerformance";
 
+#ifdef MONAD_COMPILER_LLVM
+    static constexpr auto all_impls = {Interpreter, Compiler, LLVM, Evmone};
+#else
+    static constexpr auto all_impls = {Interpreter, Compiler, Evmone};
+#endif
+
     auto make_benchmark(
         std::string const &name, std::span<std::uint8_t const> code,
         std::span<std::uint8_t const> input)
@@ -227,7 +233,7 @@ namespace
 
     void register_benchmark(std::string_view const name, evmc_message const msg)
     {
-        for (auto const impl : {Interpreter, Compiler, LLVM, Evmone}) {
+        for (auto const impl : all_impls) {
             benchmark::RegisterBenchmark(
                 std::format(
                     "execute/{}/{}", name, BlockchainTestVM::impl_name(impl)),
@@ -301,8 +307,7 @@ namespace
                             failure_tests.end(),
                             test.name) == failure_tests.end();
 
-                    for (auto const impl :
-                         {Interpreter, Compiler, LLVM, Evmone}) {
+                    for (auto const impl : all_impls) {
                         benchmark::RegisterBenchmark(
                             std::format(
                                 "execute/{}/{}/{}/{}",

--- a/test/vm/micro_benchmarks/main.cpp
+++ b/test/vm/micro_benchmarks/main.cpp
@@ -285,7 +285,12 @@ static void run_benchmark(CommandArguments const &args, Benchmark const &bench)
         return;
     }
 
-    for (auto const impl : {Interpreter, Compiler, LLVM, Evmone}) {
+#ifdef MONAD_COMPILER_LLVM
+    static constexpr auto all_impls = {Interpreter, Compiler, LLVM, Evmone};
+#else
+    static constexpr auto all_impls = {Interpreter, Compiler, Evmone};
+#endif
+    for (auto const impl : all_impls) {
         run_implementation_benchmark(args, impl, bench);
     }
 }


### PR DESCRIPTION
* Having the llvm tests part of CI is slowing down development of production code
* Allow running benchmarks without enabling llvm