### PR TITLE
[event] refactor exclusive writer detection

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -162,6 +162,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     PRIVATE # core
             "cpuset.c"
             "cpuset.h"
+            # event
+            "event/event_ring_util_linux.c"
             # io
             "io/buffers.cpp"
             "io/buffers.hpp"

--- a/category/core/event/event_ring_util.c
+++ b/category/core/event/event_ring_util.c
@@ -20,14 +20,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <dirent.h>
 #include <fcntl.h>
-#include <linux/magic.h>
+#include <sys/file.h>
 #include <sys/stat.h>
-#include <sys/statfs.h>
 #include <sys/types.h>
-#include <sys/vfs.h>
-#include <unistd.h>
 
 #if __has_include(<linux/limits.h>)
     #include <linux/limits.h> // NOLINT(misc-include-cleaner)
@@ -57,179 +53,6 @@ extern thread_local char _g_monad_event_ring_error_buf[1024];
 
 // Create MONAD_EVENT_DEFAULT_RING_DIR or override subpaths with rwxrwxr-x
 constexpr mode_t DIR_CREATE_MODE = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
-
-// Given a path which may not exist, walk backward until we find a parent path
-// that does exist; the caller must free(3) parent_path
-static int find_existing_parent_path(char const *path, char **parent_path)
-{
-    struct stat path_stat;
-
-    *parent_path = nullptr;
-    if (strlen(path) == 0) {
-        return FORMAT_ERRC(EINVAL, "path cannot be nullptr or empty");
-    }
-    *parent_path = strdup(path);
-
-StatAgain:
-    if (stat(*parent_path, &path_stat) == -1) {
-        if (errno != ENOENT) {
-            // stat failed for some reason other than ENOENT; we just give up
-            // in this case
-            return FORMAT_ERRC(errno, "stat of `%s` failed", *parent_path);
-        }
-
-        // For ENOENT failures, climb up the path until we find a path that
-        // does exist. If we were given an absolute path, we'll eventually
-        // succeed in stat'ing `/` (and thus won't always get ENOENT). If we
-        // were given a relative path, we'll eventually run out of `/`
-        // characters, in which case the path of interest is assumed to be
-        // the current working directory, "."
-        char *const last_path_sep = strrchr(*parent_path, '/');
-        if (last_path_sep == nullptr) {
-            strcpy(*parent_path, ".");
-        }
-        else {
-            *last_path_sep = '\0';
-            goto StatAgain;
-        }
-    }
-    return 0;
-}
-
-/*
- * The next three functions perform the following task:
- *
- * Given an inode number for a file, find the pids of all processes that have
- * opened this file with open(2) mode O_WRONLY or O_RDWR. The responsibility
- * is divided as follows:
- *
- * is_writer_fd - knows how to parse the format a single /proc/<pid>/fdinfo/<fd>
- *     entry, extracting the descriptor's inode number and open(2) flags
- *
- * scan_file_table_for_writer - given a pid for a single candidate process and
- *     the inode number of a file, walk the /proc/<pid>/fdinfo directory entries
- *     (the open file table) and call is_writer_fd on each one
- *
- * find_writer_pids_by_ino - given an inode number of a file, scan the file
- *     table of all processes we have access to by iterating through the /proc
- *     directory and calling scan_file_table_for_writer for each process
- */
-
-static bool is_writer_fd(ino_t ring_ino, int fdinfo_entry)
-{
-    // The format of an fdinfo file (as of Linux 6.16, see proc/fd.c) is:
-    //
-    //   "pos:\t%lli\nflags:\t0%o\nmnt_id:\t%i\nino:\t%lu\n"
-    //
-    // This will definitely fit in READ_BUF_SIZE bytes, if not the format
-    // must have changed somehow and we won't try to parse it.
-    constexpr char FDINFO_DELIM[] = "\t :";
-    constexpr size_t READ_BUF_SIZE = 256;
-    char read_buf[READ_BUF_SIZE];
-    char *scan = read_buf;
-    char *line;
-
-    ssize_t const n_read = read(fdinfo_entry, read_buf, sizeof read_buf);
-    if (n_read == -1 || n_read == READ_BUF_SIZE) {
-        return false;
-    }
-    bool is_write = false;
-    bool is_ino = false;
-
-    read_buf[n_read] = '\0'; // In case of a short read
-    while ((line = strsep(&scan, "\n"))) {
-        char *key = nullptr;
-        char *value = nullptr;
-        key = strsep(&line, FDINFO_DELIM);
-        while (line != nullptr) {
-            value = strsep(&line, FDINFO_DELIM);
-        }
-
-        if (key != nullptr && strcmp(key, "flags") == 0 && value != nullptr) {
-            unsigned long const flags = strtoul(value, nullptr, 0);
-            is_write = flags & O_WRONLY || flags & O_RDWR;
-        }
-        if (key != nullptr && strcmp(key, "ino") == 0 && value != nullptr) {
-            unsigned long const ino = strtoul(value, nullptr, 10);
-            is_ino = ino == ring_ino;
-        }
-    }
-
-    return is_write && is_ino;
-}
-
-static int
-scan_file_table_for_writer(ino_t ring_ino, pid_t pid, bool *writer_found)
-{
-    char fdinfo_dir_name[32];
-    struct dirent *fdinfo_dir_ent;
-    int rc = 0;
-    *writer_found = false;
-
-    snprintf(fdinfo_dir_name, sizeof fdinfo_dir_name, "/proc/%d/fdinfo", pid);
-    DIR *fdinfo_dir = opendir(fdinfo_dir_name);
-    if (fdinfo_dir == nullptr) {
-        return FORMAT_ERRC(errno, "opendir failed for %s", fdinfo_dir_name);
-    }
-    int const fdinfo_dir_fd = dirfd(fdinfo_dir);
-    if (fdinfo_dir_fd == -1) {
-        rc = FORMAT_ERRC(errno, "dirfd failed");
-        goto Done;
-    }
-    errno = 0;
-    while ((fdinfo_dir_ent = readdir(fdinfo_dir)) != nullptr &&
-           *writer_found == false) {
-        int entry = openat(fdinfo_dir_fd, fdinfo_dir_ent->d_name, O_RDONLY);
-        if (entry != -1) {
-            *writer_found = is_writer_fd(ring_ino, entry);
-        }
-        (void)close(entry);
-        errno = 0;
-    }
-    if (errno != 0) {
-        rc = FORMAT_ERRC(errno, "readdir(3) failed");
-    }
-Done:
-    (void)closedir(fdinfo_dir);
-    return rc;
-}
-
-static int find_writer_pids_by_ino(
-    ino_t const ring_ino, pid_t *pids, size_t const pid_in_size,
-    size_t *pid_out_size)
-{
-    struct dirent *proc_dir_ent;
-    DIR *proc_dir;
-    int rc = 0;
-
-    *pid_out_size = 0;
-    proc_dir = opendir("/proc");
-    if (proc_dir == nullptr) {
-        return FORMAT_ERRC(errno, "opendir(\"/proc\") failed");
-    }
-    errno = 0;
-    while ((proc_dir_ent = readdir(proc_dir)) != nullptr &&
-           *pid_out_size < pid_in_size) {
-        char *end_ptr;
-        pid_t const pid = (pid_t)strtol(proc_dir_ent->d_name, &end_ptr, 10);
-        if (*end_ptr != '\0') {
-            // The file name does not consistent entirely of numbers; this is
-            // not a process entry
-            continue;
-        }
-        bool writer_found;
-        (void)scan_file_table_for_writer(ring_ino, pid, &writer_found);
-        if (writer_found) {
-            pids[(*pid_out_size)++] = pid;
-        }
-        errno = 0;
-    }
-    if (errno != 0) {
-        rc = FORMAT_ERRC(errno, "readdir(3) failed");
-    }
-    (void)closedir(proc_dir);
-    return rc;
-}
 
 int monad_event_ring_init_simple(
     struct monad_event_ring_simple_config const *ring_config, int ring_fd,
@@ -285,46 +108,22 @@ int monad_event_ring_check_content_type(
     return 0;
 }
 
-int monad_event_ring_find_writer_pids(
-    int ring_fd, pid_t *pids, size_t *pids_size)
+int monad_event_ring_query_excl_writer_pid(int ring_fd, pid_t *pid)
 {
-    struct stat ring_stat;
-    if (pids == nullptr) {
-        return FORMAT_ERRC(EFAULT, "pids cannot be nullptr");
-    }
-    if (pids_size == nullptr) {
-        return FORMAT_ERRC(EFAULT, "pids_size cannot be nullptr");
-    }
-    if (fstat(ring_fd, &ring_stat) == -1) {
-        return FORMAT_ERRC(errno, "fstat of ring_fd %d failed", ring_fd);
-    }
-    return find_writer_pids_by_ino(
-        ring_stat.st_ino, pids, *pids_size, pids_size);
-}
-
-int monad_check_path_supports_map_hugetlb(char const *path, bool *supported)
-{
-    char *parent_path;
-    struct statfs fs_stat;
     int rc;
+    struct monad_event_flock_info fl_info;
+    size_t lock_count = 1;
 
-    *supported = false;
-    rc = find_existing_parent_path(path, &parent_path);
-    if (rc != 0 || parent_path == nullptr) {
-        goto Done;
+    *pid = 0;
+    rc = monad_event_ring_query_flocks(ring_fd, &fl_info, &lock_count);
+    if (rc != 0) {
+        return rc;
     }
-    if (statfs(parent_path, &fs_stat) == -1) {
-        rc = FORMAT_ERRC(errno, "statfs of `%s` failed", parent_path);
-        goto Done;
+    *pid = lock_count == 1 && fl_info.lock == LOCK_EX ? fl_info.pid : 0;
+    if (*pid == 0) {
+        return FORMAT_ERRC(EOWNERDEAD, "no exclusive writer process found");
     }
-    else {
-        // Only hugetlbfs supports MAP_HUGETLB
-        *supported = fs_stat.f_type == HUGETLBFS_MAGIC;
-        rc = 0;
-    }
-Done:
-    free(parent_path);
-    return rc;
+    return 0;
 }
 
 // libhugetlbfs is always present for Category Labs, but when this is compiled

--- a/category/core/event/event_ring_util_linux.c
+++ b/category/core/event/event_ring_util_linux.c
@@ -1,0 +1,196 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <linux/magic.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/vfs.h>
+
+#include <category/core/cleanup.h> // NOLINT(misc-include-cleaner)
+#include <category/core/event/event_ring_util.h>
+#include <category/core/format_err.h>
+#include <category/core/srcloc.h>
+
+// Defined in event_ring.c, so we can share monad_event_ring_get_last_error()
+extern thread_local char _g_monad_event_ring_error_buf[1024];
+
+#define FORMAT_ERRC(...)                                                       \
+    monad_format_err(                                                          \
+        _g_monad_event_ring_error_buf,                                         \
+        sizeof(_g_monad_event_ring_error_buf),                                 \
+        &MONAD_SOURCE_LOCATION_CURRENT(),                                      \
+        __VA_ARGS__)
+
+// Given a path which may not exist, walk backward until we find a parent path
+// that does exist; the caller must free(3) parent_path
+static int find_existing_parent_path(char const *path, char **parent_path)
+{
+    struct stat path_stat;
+
+    *parent_path = nullptr;
+    if (strlen(path) == 0) {
+        return FORMAT_ERRC(EINVAL, "path cannot be nullptr or empty");
+    }
+    *parent_path = strdup(path); // Freed by the caller
+    if (*parent_path == nullptr) {
+        return FORMAT_ERRC(errno, "strdup of %s failed", path);
+    }
+
+StatAgain:
+    if (stat(*parent_path, &path_stat) == -1) {
+        if (errno != ENOENT) {
+            // stat failed for some reason other than ENOENT; we just give up
+            // in this case
+            return FORMAT_ERRC(errno, "stat of `%s` failed", *parent_path);
+        }
+
+        // For ENOENT failures, climb up the path until we find a path that
+        // does exist. If we were given an absolute path, we'll eventually
+        // succeed in stat'ing `/` (and thus won't always get ENOENT). If we
+        // were given a relative path, we'll eventually run out of `/`
+        // characters, in which case the path of interest is assumed to be
+        // the current working directory, "."
+        char *const last_path_sep = strrchr(*parent_path, '/');
+        if (last_path_sep == nullptr) {
+            strcpy(*parent_path, ".");
+        }
+        else {
+            *last_path_sep = '\0';
+            goto StatAgain;
+        }
+    }
+    return 0;
+}
+
+static bool check_flock_entry(
+    char *lock_line, ino_t const ring_ino,
+    struct monad_event_flock_info *fl_info)
+{
+    char *saveptr;
+    ino_t lock_ino = 0;
+    unsigned tok_num = 0;
+
+    for (char const *tok = strtok_r(lock_line, " ", &saveptr);
+         tok != nullptr && tok_num <= 5;
+         tok = strtok_r(nullptr, " ", &saveptr), ++tok_num) {
+        switch (tok_num) {
+        case 1:
+            if (strcmp(tok, "FLOCK") != 0) {
+                return false;
+            }
+            break;
+
+        case 2:
+            if (strcmp(tok, "ADVISORY") != 0) {
+                return false;
+            }
+            break;
+
+        case 3:
+            if (strcmp(tok, "WRITE") == 0) {
+                fl_info->lock = LOCK_EX;
+            }
+            else if (strcmp(tok, "READ") == 0) {
+                fl_info->lock = LOCK_SH;
+            }
+            else {
+                return false;
+            }
+            break;
+
+        case 4:
+            if (sscanf(tok, "%d", &fl_info->pid) != 1) {
+                return false;
+            }
+            break;
+
+        case 5:
+            if (sscanf(tok, "%*x:%*x:%ju", &lock_ino) != 1) {
+                return false;
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    return lock_ino == ring_ino;
+}
+
+int monad_event_ring_query_flocks(
+    int ring_fd, struct monad_event_flock_info *flocks, size_t *size)
+{
+    struct stat ring_stat;
+    struct monad_event_flock_info fl_info_buf;
+    size_t const capacity = *size;
+    char info_buf[128];
+    FILE *lock_info_file [[gnu::cleanup(cleanup_fclose)]] = nullptr;
+
+    *size = 0;
+    if (fstat(ring_fd, &ring_stat) == -1) {
+        return FORMAT_ERRC(errno, "fstat failed");
+    }
+    lock_info_file = fopen("/proc/locks", "r");
+    if (lock_info_file == nullptr) {
+        return FORMAT_ERRC(errno, "fopen of /proc/locks failed");
+    }
+    while (fgets(info_buf, sizeof info_buf, lock_info_file) != nullptr) {
+        if (check_flock_entry(info_buf, ring_stat.st_ino, &fl_info_buf)) {
+            if (*size == capacity) {
+                return FORMAT_ERRC(ERANGE, "more flocks than copy-out space");
+            }
+            flocks[(*size)++] = fl_info_buf;
+        }
+    }
+    return 0; // NOLINT(clang-analyzer-unix.Stream)
+}
+
+int monad_check_path_supports_map_hugetlb(char const *path, bool *supported)
+{
+    char *parent_path;
+    struct statfs fs_stat;
+    int rc;
+
+    *supported = false;
+    rc = find_existing_parent_path(path, &parent_path);
+    if (rc != 0) {
+        goto Done;
+    }
+#if defined(__clang__)
+    // True when rc == 0, but clang-tidy cannot figure this out
+    __builtin_assume(parent_path != nullptr);
+#endif
+    if (statfs(parent_path, &fs_stat) == -1) {
+        rc = FORMAT_ERRC(errno, "statfs of `%s` failed", parent_path);
+        goto Done;
+    }
+    else {
+        // Only hugetlbfs supports MAP_HUGETLB
+        *supported = fs_stat.f_type == HUGETLBFS_MAGIC;
+        rc = 0;
+    }
+Done:
+    free(parent_path);
+    return rc;
+}

--- a/category/core/event/event_ring_util_posix.c
+++ b/category/core/event/event_ring_util_posix.c
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <category/core/event/event_ring_util.h>
+#include <category/core/format_err.h>
+#include <category/core/srcloc.h>
+
+// Defined in event_ring.c, so we can share monad_event_ring_get_last_error()
+extern thread_local char _g_monad_event_ring_error_buf[1024];
+
+#define FORMAT_ERRC(...)                                                       \
+    monad_format_err(                                                          \
+        _g_monad_event_ring_error_buf,                                         \
+        sizeof(_g_monad_event_ring_error_buf),                                 \
+        &MONAD_SOURCE_LOCATION_CURRENT(),                                      \
+        __VA_ARGS__)
+
+int monad_event_ring_query_flocks(
+    int, struct monad_event_flock_info *, size_t *)
+{
+    return FORMAT_ERRC(ENOSYS, "function not available on non-Linux platforms");
+}
+
+int monad_check_path_supports_map_hugetlb(char const *, bool *supported)
+{
+    *supported = false;
+    return 0;
+}

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -52,6 +52,12 @@ add_library(
   "../execution/ethereum/event/exec_event_ctypes_metadata.c"
   "../execution/ethereum/event/exec_iter_help.h")
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  target_sources(monad_event PRIVATE "../core/event/event_ring_util_linux.c")
+else()
+  target_sources(monad_event PRIVATE "../core/event/event_ring_util_posix.c")
+endif()
+
 target_include_directories(monad_event PUBLIC "../..")
 target_compile_definitions(monad_event PUBLIC _GNU_SOURCE)
 target_compile_features(monad_event PUBLIC c_std_23)


### PR DESCRIPTION
Event rings files are unlinked from the filesystem upon graceful writer shutdown, and re-created when the writer restarts. If a process exits in an ungraceful way, e.g. SIGKILL, it may leave a zombie file around. Most "ring death detection" strategies reduce to detecting when writer processes exit, which can always be done reliably, typically with pidfd_open(2) file descriptors on Linux.

Previously, the reader would discover the association of a ring with writer processes by scraping the <fcntl.h> "open flags" from the file descriptor table in the proc(5) filesystem. Whomever had the ring open with O_RDWR or O_WRONLY was considered a writer. This was done with a helper function called `monad_event_ring_find_writer_pids`.

A simpler, faster, and less brittle way is to use flock(2) to communicate the same information. flock(2) is used anyway to prevent writer processes from re-initializing a non-zombie ring when a second daemon has been started in error.

It is easier to scrape `/proc/locks` than scraping the file descriptor table of every accessible process. Also, the lock table is deliberately public, so we don't have to worry about credential differences between reader and writer wrt/ the reader's ability to read the writer's proc(5) entries.

The scheme followed here is that "exclusive writers" (single writer process for a ring) acquire exclusive locks (LOCK_EX), and a potential "multi-process writer" scenario could use shared locks (LOCK_SH). Currently we only use the exclusive writer case, for execution events and tracing rings.

The code also moved to a special Linux-specific file. Although the execution daemon cannot be run on non-Linux hosts, the event library can compile on other systems. This helps with a few workflows:

- Certain Rust workflows, e.g., building the cargo docs locally on macOS to look at them in a brower, runs enough of the build system that it tries to compile the monad-event-ring package. This in turn will run a C compiler, so it's useful for the SDK to be able to compile in more places

- Several developers have reached out about trying the SDK example program on a local macOS development laptop; in response, the first two steps of the tutorial were changed to explicitly allow this (step two uses snapshot files rather than live rings), to lower the barrier to entry for trying out the SDK

The flock-based approach is also easier to implement on any UNIX variant. flock is intended as an IPC mechanism, so it's easier to introspect compared to the more exotic data in proc(5) we were using.