### PR TITLE
Add support for broken-down intrinsic gas, change execution event gas recording

### DIFF
--- a/category/execution/ethereum/core/eth_ctypes.h
+++ b/category/execution/ethereum/core/eth_ctypes.h
@@ -95,6 +95,17 @@ struct monad_c_eth_txn_header
     uint32_t auth_list_count;            ///< # of EIP-7702 AuthorizationList entries
 };
 
+/// Components of intrinsic gas (g_0)
+struct monad_c_eth_intrinsic_gas
+{
+    uint64_t base;           ///< Base cost of transaction
+    uint64_t data;           ///< Cost of calldata
+    uint64_t creation;       ///< Cost of contract creation
+    uint64_t init_code;      ///< Cost of EIP-3860 initcode metering
+    uint64_t access_list;    ///< Cost of EIP-2930 access list entries
+    uint64_t authorizations; ///< Cost of EIP-7702 authorizations
+};
+
 /// Result of executing a valid transaction
 ///
 /// This type is designed for incremental, out-of-order reporting of transaction

--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -33,6 +33,7 @@
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/state3/version_stack.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 
 #include <bit>
@@ -358,7 +359,9 @@ void record_txn_header_events(
 }
 
 void record_txn_output_events(
-    uint32_t const txn_num, Receipt const &receipt,
+    uint32_t const txn_num, Transaction const &transaction,
+    Receipt const &receipt, uint64_t gas_left,
+    monad_c_eth_intrinsic_gas const &intrinsic_gas,
     std::span<CallFrame const> const call_frames, State const &txn_state)
 {
     ExecutionEventRecorder *const exec_recorder = g_exec_event_recorder.get();
@@ -402,6 +405,40 @@ void record_txn_output_events(
         std::span const return_bytes{
             call_frame.output.data(), call_frame.output.size()};
 
+        // The execution event publisher handles message call frame gas
+        // accounting differently than the CallTracer API, for the top-level
+        // message call.
+        //
+        // The RLP-encoded form of the CallFrame was designed around answering
+        // RPC queries, and contains some unfortunate adjustments for the sake
+        // of compatibility with popular JSON-RPC systems.
+        //
+        // For the top-level frame:
+        //
+        //   - TXN_CALL_FRAME shows the gas available to the top-level message
+        //     _net of_ (after subtracting) the intrinsic gas; this is
+        //     reasonable, since the intrinsic gas is not "available to" the
+        //     message anymore, and because the user knows the gas limit so
+        //     can compute the intrinsic gas if they want to
+        //
+        //   - CallFrame shows the gas available to the message _gross of_
+        //     (before subtracting) the intrinsic gas; this makes it harder
+        //     for them to compute the intrinsic gas
+        //
+        //   - TXN_CALL_FRAME shows the gas used by the top-level message to
+        //     be the gas used by the EVM until the point where the message
+        //     call exits
+        //
+        //   - CallFrame shows the gas used by the top-level message to be
+        //     whatever the Receipt said it was, which for the Monad chain
+        //     family, is the entire gas_limit; this makes it harder to see
+        //     what the true EVM gas cost was
+        uint64_t const gas_available =
+            index == 0 ? transaction.gas_limit - sum(intrinsic_gas)
+                       : call_frame.gas;
+        uint64_t const gas_used =
+            index == 0 ? gas_available - gas_left : call_frame.gas_used;
+
         ReservedExecEvent const txn_call_frame =
             exec_recorder->reserve_txn_event<monad_exec_txn_call_frame>(
                 MONAD_EXEC_TXN_CALL_FRAME,
@@ -415,8 +452,8 @@ void record_txn_output_events(
             .opcode = std::to_underlying(
                 get_call_frame_opcode(call_frame.type, call_frame.flags)),
             .value = call_frame.value,
-            .gas = call_frame.gas,
-            .gas_used = call_frame.gas_used,
+            .gas = gas_available,
+            .gas_used = gas_used,
             .evmc_status = std::to_underlying(call_frame.status),
             .depth = call_frame.depth,
             .input_length = call_frame.input.size(),

--- a/category/execution/ethereum/event/record_txn_events.hpp
+++ b/category/execution/ethereum/event/record_txn_events.hpp
@@ -25,6 +25,8 @@
 
 enum monad_exec_account_access_context : uint8_t;
 
+struct monad_c_eth_intrinsic_gas;
+
 MONAD_NAMESPACE_BEGIN
 
 struct CallFrame;
@@ -42,7 +44,8 @@ void record_txn_header_events(
 /// Record TXN_EVM_OUTPUT, and all subsequent execution output events
 /// (TXN_LOG, TXN_CALL_FRAME, etc.)
 void record_txn_output_events(
-    uint32_t txn_num, Receipt const &, std::span<CallFrame const>,
+    uint32_t txn_num, Transaction const &, Receipt const &, uint64_t gas_left,
+    monad_c_eth_intrinsic_gas const &, std::span<CallFrame const>,
     State const &);
 
 /// Record TXN_REJECT or EVM_ERROR events depending on what happened during

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -96,6 +96,7 @@ ExecuteTransactionNoValidation<traits>::ExecuteTransactionNoValidation(
     , sender_{sender}
     , authorities_{authorities}
     , header_{header}
+    , intrinsic_gas_{intrinsic_gas_breakdown<traits>(tx)}
 {
 }
 
@@ -211,7 +212,7 @@ evmc_message ExecuteTransactionNoValidation<traits>::to_message(
         .kind = to_address.first,
         .flags = 0,
         .depth = 0,
-        .gas = static_cast<int64_t>(tx_.gas_limit - intrinsic_gas<traits>(tx_)),
+        .gas = static_cast<int64_t>(tx_.gas_limit - sum(this->intrinsic_gas_)),
         .recipient = to_address.second,
         .sender = sender_,
         .input_data = tx_.data.data(),
@@ -417,7 +418,10 @@ Receipt ExecuteTransaction<traits>::execute_final(
     trace::run_tracer<traits>(state_tracer_, state);
     record_txn_output_events(
         static_cast<uint32_t>(this->i_),
+        this->tx_,
         receipt,
+        static_cast<uint64_t>(result.gas_left),
+        this->intrinsic_gas_,
         call_tracer_.get_call_frames(),
         state);
 

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/core/eth_ctypes.h>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/traits.hpp>
@@ -56,6 +57,7 @@ protected:
     Address const &sender_;
     std::span<std::optional<Address> const> const authorities_;
     BlockHeader const &header_;
+    monad_c_eth_intrinsic_gas intrinsic_gas_;
 
 public:
     ExecuteTransactionNoValidation(

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -16,6 +16,7 @@
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
+#include <category/execution/ethereum/core/eth_ctypes.h>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -107,26 +108,47 @@ uint64_t g_data(Transaction const &tx) noexcept
 EXPLICIT_TRAITS(g_data);
 
 template <Traits traits>
-uint64_t intrinsic_gas(Transaction const &tx) noexcept
+monad_c_eth_intrinsic_gas
+intrinsic_gas_breakdown(Transaction const &tx) noexcept
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_TANGERINE_WHISTLE);
 
-    uint64_t gas = 21'000 + g_data<traits>(tx) + g_txn_create(tx);
+    monad_c_eth_intrinsic_gas gas = {
+        .base = 21'000,
+        .data = g_data<traits>(tx),
+        .creation = g_txn_create(tx),
+        .init_code = 0,
+        .access_list = 0,
+        .authorizations = 0};
 
     // EIP-2930: access-list and storage-key cost (Berlin)
     if constexpr (traits::evm_rev() >= MONAD_ETH_BERLIN) {
-        gas += g_access_and_storage(tx);
+        gas.access_list = g_access_and_storage(tx);
     }
     // EIP-3860: per-word initcode cost (Shanghai)
     if constexpr (traits::evm_rev() >= MONAD_ETH_SHANGHAI) {
-        gas += g_extra_cost_init(tx);
+        gas.init_code = g_extra_cost_init(tx);
     }
     // EIP-7702: authorization-list cost (Prague)
     if constexpr (traits::evm_rev() >= MONAD_ETH_PRAGUE) {
-        gas += g_authorization(tx);
+        gas.authorizations += g_authorization(tx);
     }
 
     return gas;
+}
+
+EXPLICIT_TRAITS(intrinsic_gas_breakdown);
+
+uint64_t sum(monad_c_eth_intrinsic_gas const &g) noexcept
+{
+    return g.base + g.data + g.creation + g.init_code + g.access_list +
+           g.authorizations;
+}
+
+template <Traits traits>
+uint64_t intrinsic_gas(Transaction const &tx) noexcept
+{
+    return sum(intrinsic_gas_breakdown<traits>(tx));
 }
 
 EXPLICIT_TRAITS(intrinsic_gas);

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -25,6 +25,8 @@
 
 #include <cstdint>
 
+struct monad_c_eth_intrinsic_gas;
+
 MONAD_NAMESPACE_BEGIN
 
 struct Transaction;
@@ -32,6 +34,11 @@ struct BlockHeader;
 
 template <Traits traits>
 uint64_t g_data(Transaction const &) noexcept;
+
+template <Traits traits>
+monad_c_eth_intrinsic_gas intrinsic_gas_breakdown(Transaction const &) noexcept;
+
+uint64_t sum(monad_c_eth_intrinsic_gas const &) noexcept;
 
 template <Traits traits>
 uint64_t intrinsic_gas(Transaction const &) noexcept;

--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -23,6 +23,7 @@
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/core/eth_ctypes.h>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -194,7 +195,10 @@ Receipt ExecuteSystemTransaction<traits>::execute_final(State &state)
     trace::run_tracer<traits>(state_tracer_, state);
     record_txn_output_events(
         static_cast<uint32_t>(this->i_),
+        this->tx_,
         receipt,
+        /*gas_left=*/0,
+        monad_c_eth_intrinsic_gas{},
         call_tracer_.get_call_frames(),
         state);
     return receipt;


### PR DESCRIPTION
There are several related things happening in this PR. First we add a new C type, for representing the broken-down sources of intrinsic gas cost:

```C
/// Components of intrinsic gas (g_0)
struct monad_c_eth_intrinsic_gas
{
    uint64_t base;           ///< Base cost of transaction
    uint64_t data;           ///< Cost of calldata
    uint64_t creation;       ///< Cost of contract creation
    uint64_t init_code;      ///< Cost of EIP-3860 initcode metering
    uint64_t access_list;    ///< Cost of EIP-2930 access list entries
    uint64_t authorizations; ///< Cost of EIP-7702 authorizations
};
```

There are a few changes:

- The sole function which computes intrinsic gas (`intrinsic_gas_breakdown`) now produces one of the above structures. The `sum` function, whose overload for this type is found via argument dependent lookup, aggregates a breakdown structure to produce the total intrinsic gas; the old `intrinsic_gas` function is now a convenience wrapper for `sum(intrinsic_gas_breakdown<traits>(tx))`

- `static_validate_transaction` no longer computes the intrinsic gas itself, but requires the caller to pass it in. This was done for two reasons (1) it removes a hack for system transactions, where we used to pass a (temporary) fake `gas_limit` to trick the intrinsic validation step and (2) now we're computing this once and passing it around, no need to keep recomputing it (although sometimes we re-sum it)

- The broken down `intrinsic_gas_` is stored in the `ExecuteTransaction` functor, so that it can be passed in full to the event recording; eventually it will be exposed publicly via both RPC and the exec event ring, but this is an API (for RPC) and ABI (for events) affecting change, so it will happen later

- Top-level call frame gas accounting is changed for execution events; eventually when we break the ABI, we'll report the intrinsic gas breakdown too