### PR TITLE
Infer bounds for stack element

### DIFF
--- a/category/vm/compiler/CMakeLists.txt
+++ b/category/vm/compiler/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(monad-vm-compiler PRIVATE
     "ir/poly_typed/subst_map.hpp"
     "ir/poly_typed/unify.cpp"
     "ir/poly_typed/unify.hpp"
+    # bound inference
+    "ir/bound_inference.hpp"
     # untyped ir
     "ir/untyped.hpp"
     "ir/untyped.cpp"

--- a/category/vm/compiler/ir/bound_inference.hpp
+++ b/category/vm/compiler/ir/bound_inference.hpp
@@ -1,0 +1,339 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/runtime/uint256.hpp>
+#include <category/vm/compiler/ir/instruction.hpp>
+#include <category/vm/compiler/ir/x86.hpp>
+#include <category/vm/compiler/ir/x86/emitter.hpp>
+
+#include <evmc/evmc.h>
+
+#include <cstdint>
+
+namespace monad::vm::compiler::bound_inference
+{
+    using namespace monad::vm::compiler;
+    using namespace monad::vm::compiler::native;
+
+    // Compute bounds on the result of an instruction.
+    // It may not compute the tightest possible bound for instructions that are
+    // constant folded, i.e. composed only of literals.
+    std::uint32_t compute_result_bound(Instruction instr, Emitter &emit)
+    {
+        auto &stack = emit.get_stack();
+        auto const top_index = stack.top_index();
+        using enum OpCode;
+        if (instr.opcode() == Add) {
+            return std::min(
+                256u,
+                std::max(
+                    stack.get(top_index)->bit_upper_bound(),
+                    stack.get(top_index - 1)->bit_upper_bound()) +
+                    1);
+        }
+        else if (instr.opcode() == Mul) {
+            return std::min(
+                256u,
+                stack.get(top_index)->bit_upper_bound() +
+                    stack.get(top_index - 1)->bit_upper_bound());
+        }
+        else if (instr.opcode() == Div || instr.opcode() == SDiv) {
+            // When both sides are non-negative, SDiv is the same as Div
+            auto const lhs_bound = stack.get(top_index)->bit_upper_bound();
+            auto const rhs_bound = stack.get(top_index - 1)->bit_upper_bound();
+            if (instr.opcode() == Div || (lhs_bound < 256 && rhs_bound < 256)) {
+                // Worst case: negative number divided by 1
+                return lhs_bound;
+            }
+            else {
+                // Signed division with possible negative numbers
+                return 256;
+            }
+        }
+        else if (instr.opcode() == Mod || instr.opcode() == SMod) {
+            // When both sides are non-negative, SMod is the same as Mod
+            auto const lhs_bound = stack.get(top_index)->bit_upper_bound();
+            auto const rhs_bound = stack.get(top_index - 1)->bit_upper_bound();
+            if (instr.opcode() == Mod || (lhs_bound < 256 && rhs_bound < 256)) {
+                // Result is always less than the modulus.
+                return rhs_bound;
+            }
+            else {
+                // Signed modulus with possible negative numbers
+                return 256;
+            }
+        }
+        else if (instr.opcode() == Sub) {
+            // No bound can be inferred because of negative numbers unless
+            // the lhs is a literal and rhs is bounded by lhs.
+            auto const lhs = stack.get(top_index);
+            auto const lhs_bound = lhs->bit_upper_bound();
+            auto const rhs_bound = stack.get(top_index - 1)->bit_upper_bound();
+            if (lhs->literal() && lhs_bound > rhs_bound) {
+                // Result will not go negative, worst case is subtracting 0
+                return lhs_bound;
+            }
+            else {
+                return 256;
+            }
+        }
+        else if (instr.opcode() == AddMod || instr.opcode() == MulMod) {
+            // Result is always less than the modulus.
+            return stack.get(top_index - 2)->bit_upper_bound();
+        }
+        else if (instr.opcode() == Exp || instr.opcode() == SignExtend) {
+            // No bound can be inferred.
+            return 256;
+        }
+        else if (
+            instr.opcode() == Lt || instr.opcode() == Gt ||
+            instr.opcode() == SLt || instr.opcode() == SGt ||
+            instr.opcode() == Eq || instr.opcode() == IsZero) {
+            // Boolean result (0 or 1)
+            return 1;
+        }
+        else if (instr.opcode() == And) {
+            // Bitwise and: result bound is min of operand bounds
+            return std::min(
+                stack.get(top_index)->bit_upper_bound(),
+                stack.get(top_index - 1)->bit_upper_bound());
+        }
+        else if (instr.opcode() == Or || instr.opcode() == XOr) {
+            // Bitwise or/xor: result bound is max of operand bounds
+            return std::max(
+                stack.get(top_index)->bit_upper_bound(),
+                stack.get(top_index - 1)->bit_upper_bound());
+        }
+        else if (instr.opcode() == Not) {
+            // Worst case value == 0 => result = 2^256 - 1
+            return 256;
+        }
+        else if (instr.opcode() == Byte) {
+            // Extracts one byte
+            return 8;
+        }
+        else if (instr.opcode() == Shl) {
+            // if the shift amount is a literal, we shift the bound
+            // accordingly. Otherwise, assume a shl with the maximum shift
+            // amount.
+            auto const shift = stack.get(top_index);
+            auto const shift_bound = shift->bit_upper_bound();
+            auto const val = stack.get(top_index - 1);
+            auto const val_bound = val->bit_upper_bound();
+            if (shift->literal()) {
+                auto const shift_lit = shift->literal()->value;
+                if (shift_lit >= 256) {
+                    return 0; // all bits shifted out of range
+                }
+                else {
+                    // shift_lit < 256 ^ val_bound < 256 => no overflow
+                    return val_bound + static_cast<std::uint32_t>(shift_lit);
+                }
+            }
+            else {
+                // shift is not a literal, assume maximum shift (bounded by
+                // 2**16 - 1) to prevent overflows.
+                auto const max_shift = (1u << std::min(16u, shift_bound)) - 1;
+                return val_bound + max_shift;
+            }
+        }
+        else if (instr.opcode() == Shr || instr.opcode() == Sar) {
+            // If we can bound the value to be non-negative, we can treat
+            // sar like shr for the purpose of upper bound computation.
+            auto const shift = stack.get(top_index);
+            auto const val = stack.get(top_index - 1);
+            auto const val_bound = val->bit_upper_bound();
+            // Whether sign bits are involved in the shift
+            auto const signed_shift = instr.opcode() == Sar && val_bound == 256;
+            if (!signed_shift && shift->literal()) {
+                // Unsigned shift with a literal shift amount
+                auto const shift_lit = shift->literal()->value;
+                if (shift_lit >= 256 ||
+                    static_cast<std::uint32_t>(shift_lit) >= val_bound) {
+                    return 0; // All bits shifted out of range
+                }
+                else {
+                    // Difference with SHL: subtract the shift amount
+                    return val_bound - static_cast<std::uint32_t>(shift_lit);
+                }
+            }
+            else {
+                // Shift is either not a literal or the value is negative.
+                // In both cases, we cannot infer a tighter bound than the
+                // original value's bound
+                return val_bound;
+            }
+        }
+
+        else if (instr.opcode() == Clz) {
+            return 9; // max 256 leading zeros
+        }
+        else if (instr.opcode() == Sha3) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == Address) {
+            return 160; // address
+        }
+        else if (instr.opcode() == Balance) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == Origin) {
+            return 160; // address
+        }
+        else if (instr.opcode() == Caller) {
+            return 160; // address
+        }
+        else if (instr.opcode() == CallValue) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == CallDataLoad) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == CallDataSize) {
+            return sizeof(monad::vm::runtime::Environment::input_data_size) * 8;
+        }
+        else if (instr.opcode() == CallDataCopy) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == CodeSize) {
+            return sizeof(monad::vm::runtime::Environment::code_size) * 8;
+        }
+        else if (instr.opcode() == CodeCopy) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == GasPrice) {
+            return sizeof(evmc_tx_context::tx_gas_price) * 8;
+        }
+        else if (instr.opcode() == ExtCodeSize) {
+            return sizeof(monad::vm::runtime::Environment::code_size) * 8;
+        }
+        else if (instr.opcode() == ExtCodeCopy) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == ReturnDataSize) {
+            return sizeof(monad::vm::runtime::Environment::return_data_size) *
+                   8;
+        }
+        else if (instr.opcode() == ReturnDataCopy) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == ExtCodeHash) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == BlockHash) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == Coinbase) {
+            return 160; // address
+        }
+        else if (instr.opcode() == Timestamp) {
+            return sizeof(evmc_tx_context::block_timestamp) * 8;
+        }
+        else if (instr.opcode() == Number) {
+            return sizeof(evmc_tx_context::block_number) * 8;
+        }
+        else if (instr.opcode() == Difficulty) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == GasLimit) {
+            return sizeof(evmc_tx_context::block_gas_limit) * 8;
+        }
+        else if (instr.opcode() == ChainId) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == SelfBalance) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == BaseFee) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == BlobHash) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == BlobBaseFee) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == Pop) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == MLoad) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == MStore) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == MStore8) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == SLoad) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == SStore) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == Pc) {
+            return sizeof(monad::vm::runtime::Environment::code_size) * 8;
+        }
+        else if (instr.opcode() == MSize) {
+            return sizeof(monad::vm::runtime::Memory::size) * 8;
+        }
+        else if (instr.opcode() == Gas) {
+            return sizeof(monad::vm::runtime::Context::gas_remaining) * 8;
+        }
+        else if (instr.opcode() == TLoad) {
+            return 256; // full word
+        }
+        else if (instr.opcode() == TStore) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == MCopy) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == Push) {
+            return instr.index() * 8; // number of bits pushed
+        }
+        else if (instr.opcode() == Dup) {
+            return stack.get(top_index + 1 - instr.index())->bit_upper_bound();
+        }
+        else if (instr.opcode() == Swap) {
+            return stack.get(top_index - instr.index())->bit_upper_bound();
+        }
+        else if (instr.opcode() == Log) {
+            return 256; // no result pushed
+        }
+        else if (instr.opcode() == Create) {
+            return 160; // address
+        }
+        else if (instr.opcode() == Call) {
+            return 1; // success flag
+        }
+        else if (instr.opcode() == CallCode) {
+            return 1; // success flag
+        }
+        else if (instr.opcode() == DelegateCall) {
+            return 1; // success flag
+        }
+        else if (instr.opcode() == Create2) {
+            return 160; // address
+        }
+        else if (instr.opcode() == StaticCall) {
+            return 1; // success flag
+        }
+        else {
+            // Default case: assume full 256-bit bound for unhandled opcodes
+            return 256;
+        }
+    }
+}

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -7258,7 +7258,7 @@ namespace monad::vm::compiler::native
             // multiplication instruction.
             stack_.pop();
             stack_.pop();
-            StackElemRef res = mul_with_bit_size(256, std::move(b_elem), a, {});
+            StackElemRef res = mul_with_bit_size(result_bound, std::move(b_elem), a, {});
             res->set_bit_upper_bound(result_bound);
             stack_.push(std::move(res));
             return true;

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -6148,6 +6148,43 @@ namespace monad::vm::compiler::native
         as_.adc(gpq[3], 0);
     }
 
+    // OR together elements of an array and set flags.
+    // The operands in `arr` must be ordered from least to most significant.
+    //
+    // If `count` is provided, only the first `count` elements are checked.
+    // This allows skipping elements known to be zero based on bound information.
+    template <typename T, size_t N>
+    void Emitter::array_or(bool inplace, std::array<T, N> const &arr, size_t count)
+    {
+        MONAD_VM_DEBUG_ASSERT(count > 0 && count <= N);
+
+        if (count == 1) {
+            // Single element: need explicit test to set flags
+            as_.mov(x86::rax, arr[0]);
+            as_.test(x86::rax, x86::rax);
+        }
+        else if (inplace) {
+            // If T is a register, arr[0] is mutated. Otherwise, use rax
+            if constexpr (std::is_same_v<T, x86::Gpq>) {
+                for (size_t i = 1; i < count; ++i) {
+                    as_.or_(arr[0], arr[i]);
+                }
+            }
+            else {
+                as_.mov(x86::rax, arr[0]);
+                for (size_t i = 1; i < count; ++i) {
+                    as_.or_(x86::rax, arr[i]);
+                }
+            }
+        }
+        else {
+            as_.mov(x86::rax, arr[0]);
+            for (size_t i = 1; i < count; ++i) {
+                as_.or_(x86::rax, arr[i]);
+            }
+        }
+    }
+
     // Will not mutate the lower 64 bits, even when `elem` is not live.
     template <typename... LiveSet>
     void Emitter::test_high_bits192(
@@ -6155,17 +6192,21 @@ namespace monad::vm::compiler::native
     {
         MONAD_VM_DEBUG_ASSERT(!stack_.has_deferred_comparison());
         MONAD_VM_DEBUG_ASSERT(!elem->literal());
+
+        auto const bound = elem->bit_upper_bound();
+
+        // If we know the value fits in 64 bits, the upper 192 bits are zero.
+        // Set ZF=1 and return.
+        if (bound <= 64) {
+            as_.xor_(x86::eax, x86::eax);
+            return;
+        }
+
         if (elem->general_reg()) {
             auto const &gpq = general_reg_to_gpq256(*elem->general_reg());
-            if (is_live(elem, live)) {
-                as_.mov(x86::rax, gpq[1]);
-                as_.or_(x86::rax, gpq[2]);
-                as_.or_(x86::rax, gpq[3]);
-            }
-            else {
-                as_.or_(gpq[1], gpq[2]);
-                as_.or_(gpq[1], gpq[3]);
-            }
+            size_t const count = bound > 192 ? 3 : (bound > 128 ? 2 : 1);
+            std::array<asmjit::x86::Gpq, 3> const &gpq_r64 = {gpq[1], gpq[2], gpq[3]};
+            array_or(!is_live(elem, live), gpq_r64, count);
         }
         else if (elem->avx_reg()) {
             uint256_t const mask{
@@ -6177,13 +6218,12 @@ namespace monad::vm::compiler::native
         }
         else {
             MONAD_VM_DEBUG_ASSERT(elem->stack_offset().has_value());
-            auto mem = stack_offset_to_mem(*elem->stack_offset());
-            mem.addOffset(8);
-            as_.mov(x86::rax, mem);
-            mem.addOffset(8);
-            as_.or_(x86::rax, mem);
-            mem.addOffset(8);
-            as_.or_(x86::rax, mem);
+            auto const mem256 = stack_offset_to_mem256(*elem->stack_offset());
+
+            // Use bound information to skip upper bits above bound.
+            size_t const count = bound > 192 ? 3 : (bound > 128 ? 2 : 1);
+            std::array<x86::Mem, 3> const mems = {mem256[1], mem256[2], mem256[3]};
+            array_or(false, mems, count);
         }
     }
 

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -233,6 +233,7 @@ namespace monad::vm::compiler::native
         void checked_debug_comment(std::string const &msg);
         void swap_general_regs(StackElem &, StackElem &);
         void swap_general_reg_indices(GeneralReg, uint8_t, uint8_t);
+        void assert_runtime_result_bound();
 
         uint32_t exponential_constant_fold_counter() const
         {

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -358,6 +358,8 @@ namespace monad::vm::compiler::native
         template <typename T, size_t N>
         void array_leading_zeros(std::array<T, N> const &);
         template <typename T, size_t N>
+        void array_bit_width(std::array<T, N> const &);
+        template <typename T, size_t N>
         void array_byte_width(std::array<T, N> const &);
 
         bool exp_optimized(int64_t, uint32_t);
@@ -414,6 +416,7 @@ namespace monad::vm::compiler::native
         {
             call_runtime(
                 remaining_base_gas, true, runtime::extcodesize<traits>);
+            stack_.top()->set_bit_upper_bound(32);
         }
 
         template <Traits traits>
@@ -519,18 +522,21 @@ namespace monad::vm::compiler::native
         void create(int64_t remaining_base_gas)
         {
             call_runtime(remaining_base_gas, true, runtime::create<traits>);
+            stack_.top()->set_bit_upper_bound(160);
         }
 
         template <Traits traits>
         void call(int64_t remaining_base_gas)
         {
             call_runtime(remaining_base_gas, true, runtime::call<traits>);
+            stack_.top()->set_bit_upper_bound(1);
         }
 
         template <Traits traits>
         void callcode(int64_t remaining_base_gas)
         {
             call_runtime(remaining_base_gas, true, runtime::callcode<traits>);
+            stack_.top()->set_bit_upper_bound(1);
         }
 
         template <Traits traits>
@@ -538,18 +544,21 @@ namespace monad::vm::compiler::native
         {
             call_runtime(
                 remaining_base_gas, true, runtime::delegatecall<traits>);
+            stack_.top()->set_bit_upper_bound(1);
         }
 
         template <Traits traits>
         void create2(int64_t remaining_base_gas)
         {
             call_runtime(remaining_base_gas, true, runtime::create2<traits>);
+            stack_.top()->set_bit_upper_bound(160);
         }
 
         template <Traits traits>
         void staticcall(int64_t remaining_base_gas)
         {
             call_runtime(remaining_base_gas, true, runtime::staticcall<traits>);
+            stack_.top()->set_bit_upper_bound(1);
         }
 
         template <Traits traits>

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -751,7 +751,7 @@ namespace monad::vm::compiler::native
         void negate_gpq256(Gpq256 const &);
 
         template <typename T, size_t N>
-        void array_or(bool, std::array<T, N> const &, size_t count);
+        void array_or(asmjit::x86::Gpq, std::array<T, N> const &, size_t count);
 
         template <typename... LiveSet>
         void test_high_bits192(StackElemRef, std::tuple<LiveSet...> const &);

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -983,7 +983,8 @@ namespace monad::vm::compiler::native
         void general_bin_instr(
             StackElemRef dst, LocationType dst_loc, StackElemRef src,
             LocationType src_loc,
-            std::function<bool(size_t, uint64_t)> is_no_operation);
+            std::function<bool(size_t, uint64_t)> is_no_operation,
+            unsigned bit_bound);
 
         template <typename... LiveSet>
         std::tuple<StackElemRef, StackElemRef, LocationType> get_una_arguments(
@@ -1012,7 +1013,8 @@ namespace monad::vm::compiler::native
         void avx_or_general_bin_instr(
             StackElemRef dst, StackElemRef left, LocationType left_loc,
             StackElemRef right, LocationType right_loc,
-            std::function<bool(size_t, uint64_t)> is_no_operation);
+            std::function<bool(size_t, uint64_t)> is_no_operation,
+            unsigned bit_bound);
 
         template <typename... LiveSet>
         std::tuple<

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -750,6 +750,9 @@ namespace monad::vm::compiler::native
         StackElemRef negate_by_sub(StackElemRef);
         void negate_gpq256(Gpq256 const &);
 
+        template <typename T, size_t N>
+        void array_or(bool, std::array<T, N> const &, size_t count);
+
         template <typename... LiveSet>
         void test_high_bits192(StackElemRef, std::tuple<LiveSet...> const &);
 

--- a/category/vm/compiler/ir/x86/types.hpp
+++ b/category/vm/compiler/ir/x86/types.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/vm/compiler/ir/instruction.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 #include <category/vm/runtime/bin.hpp>
 #include <category/vm/runtime/runtime.hpp>
@@ -130,7 +131,8 @@ namespace monad::vm::compiler::native
 
     class Emitter;
 
-    using EmitterHook = std::function<void(Emitter &)>;
+    using PreEmitterHook = std::function<void(Emitter &, Instruction const &)>;
+    using PostEmitterHook = std::function<void(Emitter &, Instruction const &)>;
 
     struct CompilerConfig
     {
@@ -138,6 +140,7 @@ namespace monad::vm::compiler::native
         bool runtime_debug_trace{};
         interpreter::code_size_t max_code_size_offset =
             monad::vm::runtime::bin<10 * 1024>;
-        EmitterHook post_instruction_emit_hook{};
+        PreEmitterHook pre_instruction_emit_hook{};
+        PostEmitterHook post_instruction_emit_hook{};
     };
 }

--- a/category/vm/compiler/ir/x86/virtual_stack.cpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86/virtual_stack.hpp>
 #include <category/vm/compiler/types.hpp>
@@ -107,6 +108,7 @@ namespace monad::vm::compiler::native
         MONAD_VM_DEBUG_ASSERT(
             !stack_offset_ && !avx_reg_ && !general_reg_ && !literal_);
         stack_.deferred_comparison_.set(this, c);
+        bit_upper_bound_ = 1u; // Result of comparison is either 0 or 1.
     }
 
     void StackElem::deferred_comparison()
@@ -118,6 +120,7 @@ namespace monad::vm::compiler::native
         MONAD_VM_DEBUG_ASSERT(
             !stack_offset_ && !avx_reg_ && !general_reg_ && !literal_);
         stack_.deferred_comparison_.stack_elem = this;
+        bit_upper_bound_ = 1u; // Result of comparison is either 0 or 1.
     }
 
     void StackElem::negated_deferred_comparison()
@@ -128,6 +131,7 @@ namespace monad::vm::compiler::native
         MONAD_VM_DEBUG_ASSERT(
             !stack_offset_ && !avx_reg_ && !general_reg_ && !literal_);
         stack_.deferred_comparison_.negated_stack_elem = this;
+        bit_upper_bound_ = 1u; // Result of comparison is either 0 or 1.
     }
 
     void StackElem::discharge_deferred_comparison()
@@ -151,6 +155,7 @@ namespace monad::vm::compiler::native
     {
         MONAD_VM_ASSERT(!literal_.has_value());
         literal_ = x;
+        bit_upper_bound_ = static_cast<std::uint32_t>(bit_width(x.value));
     }
 
     void StackElem::insert_stack_offset(StackOffset x)

--- a/category/vm/compiler/ir/x86/virtual_stack.hpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/utils/rc_ptr.hpp>
 
@@ -213,6 +214,22 @@ namespace monad::vm::compiler::native
             return !stack_indices_.empty();
         }
 
+        uint32_t bit_upper_bound() const
+        {
+            return bit_upper_bound_;
+        }
+
+        void set_bit_upper_bound(std::uint32_t bits)
+        {
+            MONAD_VM_ASSERT(bits <= 256u);
+            // If the stack element is a literal, don't change the bit upper
+            // bound, since it is already correctly set when the literal was
+            // inserted.
+            if (!literal_) {
+                bit_upper_bound_ = bits;
+            }
+        }
+
         // Remember to match this with a call to `unreserve_avx_reg`.
         void reserve_avx_reg()
         {
@@ -264,6 +281,7 @@ namespace monad::vm::compiler::native
         std::optional<AvxReg> avx_reg_;
         std::optional<GeneralReg> general_reg_;
         std::optional<Literal> literal_;
+        uint32_t bit_upper_bound_ = 256u; // Bounded by 2^{256} by default.
     };
 
     using StackElemRef = utils::RcPtr<StackElem, StackElemDeleter>;

--- a/compile-and-fuzz.sh
+++ b/compile-and-fuzz.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+set -e
+
+./scripts/vm/tmux-fuzzer.sh kill
+cmake --build build -j$(nproc)
+./scripts/vm/tmux-fuzzer.sh start
+
+# Every second, for 5 seconds, call ./scripts/vm/tmux-fuzzer.sh status
+for i in $(seq 1 5); do
+  sleep 1
+  if ./scripts/vm/tmux-fuzzer.sh status | grep -q "TERMINATED"; then
+    echo "Fuzzer has found a bug!"
+    ./scripts/vm/tmux-fuzzer.sh status
+    exit 1
+  fi
+done
+
+echo "All good after 5 seconds of fuzzing, probably good to go!"

--- a/test/vm/fuzzer/compiler_hook.hpp
+++ b/test/vm/fuzzer/compiler_hook.hpp
@@ -63,9 +63,12 @@ namespace monad::vm::fuzzing
                 artificial_avx_prob,
                 artificial_general_prob,
                 artificial_top2_prob,
-                &engine](vm::compiler::native::Emitter &emit) {
+                &engine](
+                   vm::compiler::native::Emitter &emit, auto const &instr) {
             using monad::vm::compiler::native::GENERAL_REG_COUNT;
             using monad::vm::compiler::native::GeneralReg;
+
+            (void)instr;
 
             auto &stack = emit.get_stack();
             if (stack.top_index() < stack.min_delta()) {

--- a/test/vm/vm/test_vm.cpp
+++ b/test/vm/vm/test_vm.cpp
@@ -109,11 +109,12 @@ namespace
 }
 
 BlockchainTestVM::BlockchainTestVM(
-    Implementation impl, native::EmitterHook post_hook)
+    Implementation impl, native::PreEmitterHook pre_hook,
+    native::PostEmitterHook post_hook)
     : evmc_vm{EVMC_ABI_VERSION, "monad-compiler-blockchain-test-vm", "0.0.0", ::destroy, ::execute, ::get_capabilities, nullptr}
     , impl_{impl_from_env(impl)}
     , debug_dir_{std::getenv("MONAD_COMPILER_ASM_DIR")}
-    , base_config{.runtime_debug_trace = is_compiler_runtime_debug_trace_enabled(), .max_code_size_offset = code_size_t::max(), .post_instruction_emit_hook = post_hook}
+    , base_config{.runtime_debug_trace = is_compiler_runtime_debug_trace_enabled(), .max_code_size_offset = code_size_t::max(), .pre_instruction_emit_hook = pre_hook, .post_instruction_emit_hook = post_hook}
     , rt_ctx_{nullptr}
 {
     MONAD_VM_ASSERT(!debug_dir_ || fs::is_directory(debug_dir_));

--- a/test/vm/vm/test_vm.hpp
+++ b/test/vm/vm/test_vm.hpp
@@ -58,8 +58,10 @@ public:
 
     BlockchainTestVM(
         Implementation impl,
-        monad::vm::compiler::native::EmitterHook post_instruction_emit_hook =
-            nullptr);
+        monad::vm::compiler::native::PreEmitterHook pre_instruction_emit_hook =
+            nullptr,
+        monad::vm::compiler::native::PostEmitterHook
+            post_instruction_emit_hook = nullptr);
 
     evmc::Result execute(
         evmc_host_interface const *host, evmc_host_context *context,


### PR DESCRIPTION
## Context

For https://github.com/category-labs/monad/issues/1888

A possible performance improvement comes from the observation that some instructions produce values that will never exceed a certain bound. `IsZero`, `Byte`, `Clz` are examples of such instructions, whose result always fit in 1, 8 and 9 bits, respectively. The current implementation of the compiler treats the results of these operations as unknown 256-bit values (stored either in a register or in memory), but instructions that consume these operands could avoid doing the full 256-bit operation since we know that the upper N bits are all 0. Non-arithmetic operations also produce results that only use some of the 256 bits. For example, `CallDataSize`, which is frequently used in the function selector dispatch, produces a value that fits in 32-bit, and `Caller`’s output is a 160-bit address.

This PR implements a local abstract interpretation over the bit width of stack elements, so that future PRs can use that information to generate faster and more compact machine code.

Examples of code generation optimizations:

- Instructions using `test_high_bits192`, such as `byte` and shifts, could avoid testing the upper 192 bits.
- Instructions using `GENERAL_BIN_INSTR`, such as `add`, can avoid doing `op_with_carry` over the full 256-bit range.
- Logical operations, comparison operations and `CLZ` can skip some comparisons when the result is known to be 0/false.
- More accurate “fast `MUL`” logic to fallback to runtime implementation less often if we know that an unknown stack element is small enough.

## Testing

Ran the fuzzer, found and fixed an issue with `SUB` and then it found nothing while running for 10-15 minutes. One thing the fuzzer doesn't test is that the bounds are as small as possible (i.e. the fuzzer would be happy if `compute_result_bound` always returned 256).