### PR TITLE
Add storage prefix nibble between account and storage keys

### DIFF
--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -127,6 +127,7 @@ TrieDb::read_storage(Address const &addr, Incarnation, bytes32_t const &key)
             prefix_,
             STATE_NIBBLE,
             NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
+            STORAGE_PREFIX_NIBBLE,
             NibblesView{keccak256({key.bytes, sizeof(key.bytes)})}),
         block_number_);
     if (res.has_error()) {
@@ -403,7 +404,8 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
                 handle_account(node);
             }
             else if (
-                path.nibble_size() == ((KECCAK256_SIZE + KECCAK256_SIZE) * 2)) {
+                path.nibble_size() ==
+                ((KECCAK256_SIZE + KECCAK256_SIZE) * 2 + 1)) {
                 handle_storage(node);
             }
             return true;
@@ -470,7 +472,7 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             auto const key = fmt::format(
                 "{}",
                 NibblesView{path}.substr(
-                    KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
+                    KECCAK256_SIZE * 2 + 1, KECCAK256_SIZE * 2));
 
             auto storage_data_json = nlohmann::json::object();
             storage_data_json["slot"] = fmt::format(

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -98,6 +98,7 @@ public:
             mpt::concat(
                 STATE_NIBBLE,
                 mpt::NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
+                STORAGE_PREFIX_NIBBLE,
                 mpt::NibblesView{keccak256({key.bytes, sizeof(key.bytes)})}),
             block_number_);
         if (!storage_leaf_res.has_value()) {

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -79,7 +79,8 @@ struct MachineBase : public mpt::StateMachine
 
     constexpr uint8_t max_depth(uint8_t const prefix_length) const
     {
-        return prefix_length + sizeof(bytes32_t) * 2 + sizeof(bytes32_t) * 2;
+        return prefix_length + sizeof(bytes32_t) * 2 + sizeof(bytes32_t) * 2 +
+               1;
     }
 };
 
@@ -115,6 +116,7 @@ inline constexpr unsigned char TX_HASH_NIBBLE = 7;
 inline constexpr unsigned char BLOCK_HASH_NIBBLE = 8;
 inline constexpr unsigned char CALL_FRAME_NIBBLE = 9;
 inline constexpr unsigned char INVALID_NIBBLE = 255;
+
 inline mpt::Nibbles const state_nibbles = mpt::concat(STATE_NIBBLE);
 inline mpt::Nibbles const code_nibbles = mpt::concat(CODE_NIBBLE);
 inline mpt::Nibbles const receipt_nibbles = mpt::concat(RECEIPT_NIBBLE);
@@ -126,6 +128,10 @@ inline mpt::Nibbles const ommer_nibbles = mpt::concat(OMMER_NIBBLE);
 inline mpt::Nibbles const withdrawal_nibbles = mpt::concat(WITHDRAWAL_NIBBLE);
 inline mpt::Nibbles const tx_hash_nibbles = mpt::concat(TX_HASH_NIBBLE);
 inline mpt::Nibbles const block_hash_nibbles = mpt::concat(BLOCK_HASH_NIBBLE);
+
+inline constexpr unsigned char STORAGE_PREFIX_NIBBLE = 0;
+inline mpt::Nibbles const storage_prefix_nibbles =
+    mpt::concat(STORAGE_PREFIX_NIBBLE);
 
 //////////////////////////////////////////////////////////
 // Proposed and finialized subtries. Active on all tables.

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -62,7 +62,7 @@ namespace detail
     // For the memory map of the first conventional chunk
     struct db_metadata
     {
-        static constexpr char const *MAGIC = "MONAD007";
+        static constexpr char const *MAGIC = "MONAD008";
         static constexpr unsigned MAGIC_STRING_LEN = 8;
 
         friend class MONAD_MPT_NAMESPACE::UpdateAuxImpl;

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -83,11 +83,20 @@ void monad_statesync_client_context::commit()
                     .version = static_cast<int64_t>(current)}));
             }
         }
+        UpdateList storage_prefix;
+        if (!storage.empty()) {
+            storage_prefix.push_front(alloc.emplace_back(Update{
+                .key = storage_prefix_nibbles,
+                .value = byte_string_view{},
+                .incarnation = false,
+                .next = std::move(storage),
+                .version = static_cast<int64_t>(current)}));
+        }
         accounts.push_front(alloc.emplace_back(Update{
             .key = hash_alloc.emplace_back(keccak256(addr.bytes)),
             .value = value,
             .incarnation = false,
-            .next = std::move(storage),
+            .next = std::move(storage_prefix),
             .version = static_cast<int64_t>(current)}));
     }
     UpdateList code_updates;

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -282,12 +282,14 @@ bool statesync_server_handle_request(
                     if (depth == HASH_SIZE) {
                         send_upsert(SYNC_TYPE_UPSERT_ACCOUNT);
                     }
-                    else {
-                        MONAD_ASSERT(depth == (HASH_SIZE * 2));
+                    else if (depth == (HASH_SIZE * 2) + 1) {
                         send_upsert(
                             SYNC_TYPE_UPSERT_STORAGE,
                             reinterpret_cast<unsigned char *>(&addr),
                             sizeof(addr));
+                    }
+                    else {
+                        MONAD_ASSERT(depth == HASH_SIZE + 1);
                     }
                 }
             }


### PR DESCRIPTION
This change introduces a storage prefix nibble to separate account and storage keys, laying the groundwork for adding a block storage trie under each account.

The storage root hash is now stored in the account leaf’s first child data instead of the account leaf’s data field. The Rust implementation must be updated accordingly when reading accounts and retrieving the storage root.

Note: this commit introduces a database format change that requires hard reset