### PR TITLE
[vm] Facility to lazily construct `SharedIntercode`

### DIFF
--- a/category/vm/compiler.hpp
+++ b/category/vm/compiler.hpp
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <span>
 #include <thread>
 
 namespace monad::vm
@@ -186,6 +187,12 @@ namespace monad::vm
             evmc::bytes32 const &code_hash, SharedIntercode const &icode)
         {
             return varcode_cache_.try_set(code_hash, icode);
+        }
+
+        SharedVarcode try_insert_varcode_raw(
+            evmc::bytes32 const &code_hash, std::span<uint8_t const> code)
+        {
+            return varcode_cache_.try_set_raw(code_hash, code);
         }
 
         bool is_varcode_cache_warm()

--- a/category/vm/varcode_cache.cpp
+++ b/category/vm/varcode_cache.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
 
 namespace monad::vm
 {
@@ -68,5 +69,15 @@ namespace monad::vm
         auto vcode = std::make_shared<Varcode>(icode);
         (void)weight_cache_.try_insert(code_hash, vcode, weight);
         return vcode;
+    }
+
+    SharedVarcode VarcodeCache::try_set_raw(
+        evmc::bytes32 const &code_hash, std::span<uint8_t const> code)
+    {
+        WeightCache::ConstAccessor acc;
+        if (!weight_cache_.find(acc, code_hash)) {
+            return try_set(code_hash, make_shared_intercode(code));
+        }
+        return acc->second.value_;
     }
 }

--- a/category/vm/varcode_cache.hpp
+++ b/category/vm/varcode_cache.hpp
@@ -19,6 +19,8 @@
 #include <category/vm/utils/evmc_utils.hpp>
 #include <category/vm/utils/lru_weight_cache.hpp>
 
+#include <span>
+
 namespace monad::vm
 {
     class VarcodeCache
@@ -48,6 +50,12 @@ namespace monad::vm
         /// Find varcode under `code_hash`, otherwise insert into cache.
         SharedVarcode
         try_set(evmc::bytes32 const &code_hash, SharedIntercode const &);
+
+        /// Find varcode under `code_hash`, otherwise construct a
+        /// `SharedVarcode` object from the given bytecodes and insert it into
+        /// cache.
+        SharedVarcode try_set_raw(
+            evmc::bytes32 const &code_hash, std::span<uint8_t const> code);
 
         /// Whether the cache is warmed up.
         bool is_warm()

--- a/category/vm/vm.hpp
+++ b/category/vm/vm.hpp
@@ -145,6 +145,12 @@ namespace monad::vm
             return compiler_.try_insert_varcode(code_hash, icode);
         }
 
+        SharedVarcode try_insert_varcode_raw(
+            evmc::bytes32 const &code_hash, std::span<uint8_t const> code)
+        {
+            return compiler_.try_insert_varcode_raw(code_hash, code);
+        }
+
         Compiler &compiler()
         {
             return compiler_;


### PR DESCRIPTION
This patch adds the method `VarcodeCache::try_set_raw` (and corresponding methods in `VM` and `Compiler`) which given a bytecode checks whether a suitable `SharedIntercode` object exists already in the cache before constructing it.

Resolves #2000.