### PR TITLE
[mpt] Refactor compute interface for clarity and safety

### DIFF
--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -422,20 +422,20 @@ namespace
     struct StorageRootMerkleCompute : public StorageMerkleCompute
     {
         virtual unsigned
-        compute(unsigned char *const buffer, Node *const node) override
+        compute(unsigned char *const buffer, Node const &node) override
         {
-            MONAD_ASSERT(node->has_value());
+            MONAD_ASSERT(node.has_value());
             return encode_two_pieces(
                 buffer,
-                node->path_nibble_view(),
-                AccountLeafProcessor::process(*node),
+                node.path_nibble_view(),
+                AccountLeafProcessor::process(node),
                 true);
         }
     };
 
     struct AccountRootMerkleCompute : public AccountMerkleCompute
     {
-        virtual unsigned compute(unsigned char *const, Node *const) override
+        virtual unsigned compute(unsigned char *const, Node const &) override
         {
             return 0;
         }

--- a/category/mpt/compute.cpp
+++ b/category/mpt/compute.cpp
@@ -101,25 +101,25 @@ std::span<unsigned char> encode_16_children(
 }
 
 std::span<unsigned char>
-encode_16_children(Node *node, std::span<unsigned char> result)
+encode_16_children(Node const &node, std::span<unsigned char> result)
 {
 
     for (unsigned i = 0, bit = 1; i < 16; ++i, bit <<= 1) {
-        if (node->mask & bit) {
-            auto const child_index = node->to_child_index(i);
+        if (node.mask & bit) {
+            auto const child_index = node.to_child_index(i);
             MONAD_DEBUG_ASSERT(
-                node->child_data_len(child_index) <= KECCAK256_SIZE);
+                node.child_data_len(child_index) <= KECCAK256_SIZE);
             result =
-                (node->child_data_len(child_index) < KECCAK256_SIZE)
+                (node.child_data_len(child_index) < KECCAK256_SIZE)
                     ? [&] {
                           memcpy(
                               result.data(),
-                              node->child_data(child_index),
-                              node->child_data_len(child_index));
+                              node.child_data(child_index),
+                              node.child_data_len(child_index));
                           return result.subspan(
-                              node->child_data_len(child_index));
+                              node.child_data_len(child_index));
                       }()
-                    : rlp::encode_string(result, node->child_data_view(child_index));
+                    : rlp::encode_string(result, node.child_data_view(child_index));
         }
         else {
             result = encode_empty_string(result);

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -336,6 +336,12 @@ unsigned char *Node::child_data(unsigned const index) noexcept
     return child_data() + child_data_offset(index);
 }
 
+unsigned char const *Node::child_data(unsigned const index) const noexcept
+{
+    MONAD_DEBUG_ASSERT(index < number_of_children());
+    return child_data() + child_data_offset(index);
+}
+
 void Node::set_child_data(unsigned const index, byte_string_view data) noexcept
 {
     // called after data_off array is calculated
@@ -433,7 +439,7 @@ void ChildData::finalize(
 {
     MONAD_DEBUG_ASSERT(is_valid());
     ptr = std::move(node);
-    auto const length = compute.compute(data, ptr.get());
+    auto const length = compute.compute(data, *ptr);
     MONAD_DEBUG_ASSERT(length <= std::numeric_limits<uint8_t>::max());
     len = static_cast<uint8_t>(length);
     cache_node = cache;

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -295,6 +295,7 @@ public:
     unsigned char const *child_data() const noexcept;
     byte_string_view child_data_view(unsigned index) const noexcept;
     unsigned char *child_data(unsigned index) noexcept;
+    unsigned char const *child_data(unsigned index) const noexcept;
     void set_child_data(unsigned index, byte_string_view data) noexcept;
 
     //! next pointers

--- a/category/mpt/test/node_test.cpp
+++ b/category/mpt/test/node_test.cpp
@@ -52,7 +52,7 @@ struct DummyCompute final : Compute
         return 0;
     }
 
-    virtual unsigned compute(unsigned char *buffer, Node *) override
+    virtual unsigned compute(unsigned char *buffer, Node const &) override
     {
         buffer[0] = 0xa;
         return 1;

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -45,7 +45,7 @@ namespace monad::test
 
     struct RootMerkleCompute : public MerkleCompute
     {
-        virtual unsigned compute(unsigned char *const, Node *const) override
+        virtual unsigned compute(unsigned char *const, Node const &) override
         {
             return 0;
         }
@@ -395,8 +395,8 @@ namespace monad::test
         {
             if (this->root.get()) {
                 monad::byte_string res(32, 0);
-                auto const len = this->sm->get_compute().compute(
-                    res.data(), this->root.get());
+                auto const len =
+                    this->sm->get_compute().compute(res.data(), *this->root);
                 if (len < KECCAK256_SIZE) {
                     keccak256(res.data(), len, res.data());
                 }
@@ -648,8 +648,7 @@ namespace monad::test
             {
                 if (this->root.get()) {
                     monad::byte_string res(32, 0);
-                    this->sm.get_compute().compute(
-                        res.data(), this->root.get());
+                    this->sm.get_compute().compute(res.data(), *this->root);
                     return res;
                 }
                 return empty_trie_hash;


### PR DESCRIPTION
  - Refactor `Compute` interface methods for improved clarity:
    - Rename `compute_len()` → `compute_node_data_len()` to better reflect its purpose
    - Rename `compute_branch()` → `set_node_data()` and add size validation
    - Change `compute()` and `encode_16_children()` to use `Node const&` instead of `Node*` to enforce immutability
  - Unify leaf processor concepts:
    - Standardize all leaf processors to use `process(Node const&)` signature
    - Rename concept from `compute_leaf_data` to `leaf_processor`
    - Rename structs for consistency (e.g., `ComputeAccountLeaf` → `AccountLeafProcessor`, `TransactionLeafProcess` → `TransactionLeafProcessor`)
  - Move `EmptyCompute` from implementation files to compute.hpp as a reusable base type

  These changes are refactoring-only with no functional behavior changes to the MPT computation logic.