### PR TITLE
[copyright] remove Category Labs copyright notices from third_party

### DIFF
--- a/.github/workflows/license.sh
+++ b/.github/workflows/license.sh
@@ -38,9 +38,14 @@ exit_code=0
 
 for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp'); do
     contents=$(head -c $C_LICENSE_HEADER_LEN "$file")
+    directory=$(dirname "$file")
 
-    if [ $(dirname "$file") == "utils/clang-tidy-auto-const" ]; then
-       continue
+    if [ "$directory" == "utils/clang-tidy-auto-const" ]; then
+        continue
+    fi
+
+    if [ "${directory#third_party}" != "$directory" ]; then
+        continue
     fi
 
     if [ "$contents" == "$C_LICENSE_HEADER" ]; then

--- a/third_party/ankerl/robin_hood.h
+++ b/third_party/ankerl/robin_hood.h
@@ -1,18 +1,3 @@
-// Copyright (C) 2025 Category Labs, Inc.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 //                 ______  _____                 ______                _________
 //  ______________ ___  /_ ___(_)_______         ___  /_ ______ ______ ______  /
 //  __  ___/_  __ \__  __ \__  / __  __ \        __  __ \_  __ \_  __ \_  __  /

--- a/third_party/openssl/crypto/sha/keccak1600.c
+++ b/third_party/openssl/crypto/sha/keccak1600.c
@@ -1,18 +1,3 @@
-// Copyright (C) 2025 Category Labs, Inc.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 /*
  * Copyright 2016-2023 The OpenSSL Project Authors. All Rights Reserved.
  *


### PR DESCRIPTION
These were added by accident, the license.sh CI script should not check for our copyrights in the third_party directory tree