### PR TITLE
Accept --hyphen-style long options

### DIFF
--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -147,21 +147,21 @@ try {
     cli.add_option("--chain", chain_config, "select which chain config to run")
         ->transform(CLI::CheckedTransformer(CHAIN_CONFIG_MAP, CLI::ignore_case))
         ->required();
-    cli.add_option("--block_db", block_db_path, "block_db directory")
+    cli.add_option("--block-db,--block_db", block_db_path, "block_db directory")
         ->required();
     cli.add_option("--nblocks", nblocks, "number of blocks to execute");
-    cli.add_option("--log_level", log_level, "level of logging")
+    cli.add_option("--log-level,--log_level", log_level, "level of logging")
         ->transform(CLI::CheckedTransformer(log_level_map, CLI::ignore_case));
     cli.add_option("--nthreads", nthreads, "number of threads");
     cli.add_option("--nfibers", nfibers, "number of fibers");
     cli.add_flag("--no-compaction", no_compaction, "disable compaction");
     cli.add_option(
-        "--sq_thread_cpu",
+        "--sq-thread-cpu,--sq_thread_cpu",
         sq_thread_cpu,
         "sq_thread_cpu field in io_uring_params, to specify the cpu set "
         "kernel poll thread is bound to in SQPOLL mode");
     cli.add_option(
-        "--ro_sq_thread_cpu",
+        "--ro-sq-thread-cpu,--ro_sq_thread_cpu",
         ro_sq_thread_cpu,
         "sq_thread_cpu for the read only db (optional, disables SQPOLL if not "
         "specified)");
@@ -172,14 +172,17 @@ try {
         "configure the storage pool with one or more files/devices. If no "
         "value is passed, the replay will run with an in-memory triedb");
     cli.add_option(
-        "--dump_snapshot",
+        "--dump-snapshot,--dump_snapshot",
         dump_snapshot,
         "directory to dump state to at the end of run");
-    cli.add_flag("--trace_calls", trace_calls, "enable call tracing");
+    cli.add_flag(
+        "--trace-calls,--trace_calls", trace_calls, "enable call tracing");
     auto *const as_eth_blocks_flag = cli.add_flag(
-        "--as_eth_blocks", as_eth_blocks, "ingest monad blocks in evm format");
+        "--as-eth-blocks,--as_eth_blocks",
+        as_eth_blocks,
+        "ingest monad blocks in evm format");
     cli.add_option(
-           "--block_db_timeout",
+           "--block-db-timeout,--block_db_timeout",
            block_db_timeout,
            "timeout in seconds for reading blocks from blockdb (0 = no retry)")
         ->needs(as_eth_blocks_flag);
@@ -216,7 +219,8 @@ try {
             });
 #ifdef ENABLE_EVENT_TRACING
     fs::path trace_log = fs::absolute("trace");
-    cli.add_option("--trace_log", trace_log, "path to output trace file");
+    cli.add_option(
+        "--trace-log,--trace_log", trace_log, "path to output trace file");
 #endif
 
     try {

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -808,12 +808,12 @@ int main(int argc, char *argv[])
            "A comma-separated list of previously created database paths")
         ->required();
     cli.add_option(
-        "--sq_thread_cpu",
+        "--sq-thread-cpu,--sq_thread_cpu",
         sq_thread_cpu,
         "CPU core binding for the io_uring SQPOLL thread. Specifies the CPU "
         "set for the kernel polling thread in SQPOLL mode. Defaults to "
         "disabled SQPOLL mode.");
-    cli.add_option("--log_level", log_level, "level of logging")
+    cli.add_option("--log-level,--log_level", log_level, "level of logging")
         ->transform(CLI::CheckedTransformer(log_level_map, CLI::ignore_case));
     auto *const mode_group =
         cli.add_option_group("mode", "different modes of the cli");
@@ -823,16 +823,16 @@ int main(int argc, char *argv[])
         mode_group->add_option_group("cli", "options for non-interactive mode");
     cli_group->add_option("--version", version)->required();
     auto *const dump_binary_snapshot_option = cli_group->add_option(
-        "--dump_binary_snapshot",
+        "--dump-binary-snapshot,--dump_binary_snapshot",
         dump_binary_snapshot,
         "Dump a binary snapshot to directory");
     cli_group->add_option(
-        "--dump_concurrency_limit",
+        "--dump-concurrency-limit,--dump_concurrency_limit",
         dump_concurrency_limit,
         "Read concurrency limit for snapshot dump");
     cli_group
         ->add_option(
-            "--total_shards",
+            "--total-shards,--total_shards",
             total_shards,
             "Total number of shards to split snapshot creation across nodes "
             "(default: 1)")
@@ -840,7 +840,7 @@ int main(int argc, char *argv[])
         ->needs(dump_binary_snapshot_option);
     cli_group
         ->add_option(
-            "--shard_number",
+            "--shard-number,--shard_number",
             shard_number,
             "Shard number for this node (0 to total_shards-1, default: 0). "
             "Each "
@@ -848,7 +848,7 @@ int main(int argc, char *argv[])
         ->needs(dump_binary_snapshot_option);
     cli_group
         ->add_option(
-            "--load_binary_snapshot",
+            "--load-binary-snapshot,--load_binary_snapshot",
             load_binary_snapshot,
             "Load a binary snapshot to db")
         ->check(CLI::ExistingDirectory)


### PR DESCRIPTION
This style is more popular than --underscore_style, and matches the consensus daemon.

For now, we'll accept either to avoid breaking anything. This is somewhat ugly because they're both printed in the --help text. The underscore style can be removed during the next command-line breaking change.