### PR TITLE
[monad] add block-level event recording for replay

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(
   "ethereum/event/exec_iter_help.h"
   "ethereum/event/record_block_events.cpp"
   "ethereum/event/record_block_events.hpp"
+  "ethereum/event/record_consensus_events.cpp"
+  "ethereum/event/record_consensus_events.hpp"
   "ethereum/event/record_txn_events.cpp"
   "ethereum/event/record_txn_events.hpp"
   # ethereum/execution

--- a/category/execution/ethereum/event/record_consensus_events.cpp
+++ b/category/execution/ethereum/event/record_consensus_events.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_consensus_events.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+void record_mock_consensus_events(
+    bytes32_t const &block_id, uint64_t block_number)
+{
+    if (auto *exec_recorder = g_exec_event_recorder.get()) {
+        ReservedExecEvent const block_qc =
+            exec_recorder->reserve_block_event<monad_exec_block_qc>(
+                MONAD_EXEC_BLOCK_QC);
+        *block_qc.payload = monad_exec_block_qc{
+            .block_tag = {.id = block_id, .block_number = block_number},
+            .round = block_number + 1,
+            .epoch = 0};
+        exec_recorder->commit(block_qc);
+
+        ReservedExecEvent const block_finalized =
+            exec_recorder->reserve_block_event<monad_exec_block_finalized>(
+                MONAD_EXEC_BLOCK_FINALIZED);
+        *block_finalized.payload = monad_exec_block_finalized{
+            .id = block_id, .block_number = block_number};
+        exec_recorder->commit(block_finalized);
+
+        ReservedExecEvent const block_verified =
+            exec_recorder->reserve_block_event<monad_exec_block_verified>(
+                MONAD_EXEC_BLOCK_VERIFIED);
+        *block_verified.payload =
+            monad_exec_block_verified{.block_number = block_number};
+        exec_recorder->commit(block_verified);
+    }
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/event/record_consensus_events.hpp
+++ b/category/execution/ethereum/event/record_consensus_events.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+/// Other EVM implementations do not emit consensus events like the Monad chain,
+/// but emitting dummy versions reduces the difference for event consumers that
+/// wait to see a particular commitment state (e.g., finalized) before acting.
+void record_mock_consensus_events(
+    bytes32_t const &block_id, uint64_t block_number);
+
+MONAD_NAMESPACE_END

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -29,6 +29,10 @@
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_block_events.hpp>
+#include <category/execution/ethereum/event/record_consensus_events.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -90,6 +94,18 @@ Result<void> process_ethereum_block(
     [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
     auto const block_begin = std::chrono::steady_clock::now();
 
+    record_block_start(
+        block_id,
+        chain.get_chain_id(),
+        block.header,
+        block.header.parent_hash,
+        block.header.number,
+        0,
+        block.header.timestamp * 1'000'000'000UL,
+        block.transactions.size(),
+        std::nullopt,
+        std::nullopt);
+
     // Block input validation
     BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
@@ -136,6 +152,7 @@ Result<void> process_ethereum_block(
     BlockState block_state(db, vm);
 
     ChainContext<traits> const chain_ctx{};
+    record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
     BOOST_OUTCOME_TRY(
         auto const receipts,
         execute_block<traits>(
@@ -150,6 +167,7 @@ Result<void> process_ethereum_block(
             call_tracers,
             state_tracers,
             chain_ctx));
+    record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 
     // Database commit of state changes (incl. Merkle root calculations)
     block_state.log_debug();
@@ -194,16 +212,20 @@ Result<void> process_ethereum_block(
             commit_time);
     }
     // Post-commit validation of header, with Merkle root fields filled in
-    auto const output_header = db.read_eth_header();
-    BOOST_OUTCOME_TRY(validate_output_header(block.header, output_header));
+    BlockExecOutput exec_output;
+    exec_output.eth_header = db.read_eth_header();
+    BOOST_OUTCOME_TRY(
+        validate_output_header(block.header, exec_output.eth_header));
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
     db.finalize(block.header.number, block_id);
     db.update_verified_block(block.header.number);
-    auto const eth_block_hash =
-        to_bytes(keccak256(rlp::encode_block_header(output_header)));
-    block_hash_buffer.set(block.header.number, eth_block_hash);
+    exec_output.eth_block_hash =
+        to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
+    block_hash_buffer.set(
+        exec_output.eth_header.number, exec_output.eth_block_hash);
+    (void)record_block_result(exec_output);
 
     // Emit the block metrics log line
     [[maybe_unused]] auto const block_time =
@@ -230,10 +252,11 @@ Result<void> process_ethereum_block(
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
-        output_header.gas_used,
-        output_header.gas_used /
+        exec_output.eth_header.gas_used,
+        exec_output.eth_header.gas_used /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        output_header.gas_used / (uint64_t)std::max(1L, block_time.count()),
+        exec_output.eth_header.gas_used /
+            (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -260,9 +283,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
     uint64_t batch_gas = 0;
     auto batch_begin = std::chrono::steady_clock::now();
     uint64_t ntxs = 0;
-
     BlockDb block_db(ledger_dir);
     bytes32_t parent_block_id{};
+
     while (block_num <= end_block_num && stop == 0) {
         Block block;
         MONAD_ASSERT_PRINTF(
@@ -289,6 +312,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 
+        record_mock_consensus_events(block_id, block_num);
         ntxs += block.transactions.size();
         batch_num_txs += block.transactions.size();
         total_gas += block.header.gas_used;

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -28,6 +28,10 @@
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_block_events.hpp>
+#include <category/execution/ethereum/event/record_consensus_events.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -126,6 +130,23 @@ Result<void> process_monad_block(
     [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
     auto const block_begin = std::chrono::steady_clock::now();
 
+    // This is exactly the same as the recording call in runloop_ethereum.cpp;
+    // even though these are historical Monad block inputs, we don't have the
+    // additional information from the consensus header here (the consensus
+    // timestamp, the `monad_c_native_block_input` protocol extensions, etc.),
+    // so there are a few std::nullopt values, and the timestamp is approximate
+    record_block_start(
+        block_id,
+        chain.get_chain_id(),
+        block.header,
+        block.header.parent_hash,
+        block.header.number,
+        0,
+        block.header.timestamp * 1'000'000'000UL,
+        block.transactions.size(),
+        std::nullopt,
+        std::nullopt);
+
     // Block input validation
     BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
@@ -188,6 +209,7 @@ Result<void> process_monad_block(
 
     BlockMetrics block_metrics;
     BlockState block_state(db, vm);
+    record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
     BOOST_OUTCOME_TRY(
         auto const receipts,
         execute_block<traits>(
@@ -202,6 +224,7 @@ Result<void> process_monad_block(
             call_tracers,
             state_tracers,
             chain_context));
+    record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 
     // Database commit of state changes (incl. Merkle root calculations)
     block_state.log_debug();
@@ -239,16 +262,20 @@ Result<void> process_monad_block(
             commit_time);
     }
     // Post-commit validation of header, with Merkle root fields filled in
-    auto const output_header = db.read_eth_header();
-    BOOST_OUTCOME_TRY(validate_output_header(block.header, output_header));
+    BlockExecOutput exec_output;
+    exec_output.eth_header = db.read_eth_header();
+    BOOST_OUTCOME_TRY(
+        validate_output_header(block.header, exec_output.eth_header));
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
     db.finalize(block.header.number, block_id);
     db.update_verified_block(block.header.number);
-    auto const eth_block_hash =
-        to_bytes(keccak256(rlp::encode_block_header(output_header)));
-    block_hash_buffer.set(block.header.number, eth_block_hash);
+    exec_output.eth_block_hash =
+        to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
+    block_hash_buffer.set(
+        exec_output.eth_header.number, exec_output.eth_block_hash);
+    (void)record_block_result(exec_output);
 
     // Emit the block metrics log line
     [[maybe_unused]] auto const block_time =
@@ -275,10 +302,11 @@ Result<void> process_monad_block(
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
-        output_header.gas_used,
-        output_header.gas_used /
+        exec_output.eth_header.gas_used,
+        exec_output.eth_header.gas_used /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        output_header.gas_used / (uint64_t)std::max(1L, block_time.count()),
+        exec_output.eth_header.gas_used /
+            (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -403,6 +431,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 
+        record_mock_consensus_events(block_id, block_num);
         ntxs += block.transactions.size();
         batch_num_txs += block.transactions.size();
         total_gas += block.header.gas_used;


### PR DESCRIPTION
This emits block-level execution events for both Ethereum replay and Monad replay. Because transaction-level events are emitted by code that is shared between live execution and replay, the vast majority of execution events are already published in replay mode.

However, those event streams are unusable because the block-level events (BLOCK_START, BLOCK_END, etc.) are missing. The dummy consensus events are useful because most event-consuming code assumes that proposal execution is happening live, and will typically wait for a proposal to reach the finalized state before
"committing" to an action. If the BLOCK_FINALIZED event is never written, these readers will break. To avoid all readers needing to explicitly support live mode and replay mode, this commit makes replay mode perform a crude
imitation of live mode consensus behavior.