### PR TITLE
Make BlockMetrics a struct

### DIFF
--- a/category/execution/ethereum/dispatch_transaction.hpp
+++ b/category/execution/ethereum/dispatch_transaction.hpp
@@ -33,10 +33,10 @@
 MONAD_NAMESPACE_BEGIN
 
 class BlockHashBuffer;
-class BlockMetrics;
 class BlockState;
 class State;
 struct BlockHeader;
+struct BlockMetrics;
 struct CallTracerBase;
 struct Chain;
 struct Transaction;

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -285,9 +285,9 @@ Result<std::vector<Receipt>> execute_block_transactions(
 
     auto const last = static_cast<std::ptrdiff_t>(transactions.size());
     promises[last].get_future().get();
-    block_metrics.set_tx_exec_time(
+    block_metrics.tx_exec_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::steady_clock::now() - tx_exec_begin));
+            std::chrono::steady_clock::now() - tx_exec_begin);
 
     // All transactions have released their merge-order synchronization
     // primitive (promises[i + 1]) but some stragglers could still be running

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -428,7 +428,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             return receipt;
         }
     }
-    block_metrics_.inc_retries();
+    ++block_metrics_.num_retries;
     {
         TRACE_TXN_EVENT(StartRetry);
 

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -31,8 +31,8 @@
 MONAD_NAMESPACE_BEGIN
 
 class BlockHashBuffer;
-class BlockMetrics;
 struct BlockHeader;
+struct BlockMetrics;
 class BlockState;
 struct CallTracerBase;
 struct Chain;

--- a/category/execution/ethereum/metrics/block_metrics.hpp
+++ b/category/execution/ethereum/metrics/block_metrics.hpp
@@ -21,31 +21,10 @@
 
 MONAD_NAMESPACE_BEGIN
 
-class BlockMetrics
+struct BlockMetrics
 {
-    uint32_t n_retries_{0};
-    std::chrono::microseconds tx_exec_time_{1};
-
-public:
-    void inc_retries()
-    {
-        ++n_retries_;
-    }
-
-    uint32_t num_retries() const
-    {
-        return n_retries_;
-    }
-
-    void set_tx_exec_time(std::chrono::microseconds const exec_time)
-    {
-        tx_exec_time_ = exec_time;
-    }
-
-    std::chrono::microseconds tx_exec_time() const
-    {
-        return tx_exec_time_;
-    }
+    uint32_t num_retries{0};
+    std::chrono::microseconds tx_exec_time{1};
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -119,7 +119,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
             return receipt;
         }
     }
-    block_metrics_.inc_retries();
+    ++block_metrics_.num_retries;
     {
         TRACE_TXN_EVENT(StartRetry);
 

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -194,20 +194,20 @@ Result<void> process_ethereum_block(
             block_start.time_since_epoch())
             .count(),
         block.transactions.size(),
-        block_metrics.num_retries(),
-        100.0 * (double)block_metrics.num_retries() /
+        block_metrics.num_retries,
+        100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
         sender_recovery_time,
-        block_metrics.tx_exec_time(),
+        block_metrics.tx_exec_time,
         commit_time,
         block_time,
         block.transactions.size() * 1'000'000 /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
         output_header.gas_used,
         output_header.gas_used /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         output_header.gas_used / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -361,20 +361,20 @@ Result<BlockExecOutput> propose_block(
             block_start.time_since_epoch())
             .count(),
         block.transactions.size(),
-        block_metrics.num_retries(),
-        100.0 * (double)block_metrics.num_retries() /
+        block_metrics.num_retries,
+        100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
         sender_recovery_time,
-        block_metrics.tx_exec_time(),
+        block_metrics.tx_exec_time,
         commit_time,
         block_time,
         block.transactions.size() * 1'000'000 /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
         exec_output.eth_header.gas_used,
         exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         exec_output.eth_header.gas_used /
             (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -269,20 +269,20 @@ Result<void> process_monad_block(
             block_start.time_since_epoch())
             .count(),
         block.transactions.size(),
-        block_metrics.num_retries(),
-        100.0 * (double)block_metrics.num_retries() /
+        block_metrics.num_retries,
+        100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
         sender_recovery_time,
-        block_metrics.tx_exec_time(),
+        block_metrics.tx_exec_time,
         commit_time,
         block_time,
         block.transactions.size() * 1'000'000 /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
         output_header.gas_used,
         output_header.gas_used /
-            (uint64_t)std::max(1L, block_metrics.tx_exec_time().count()),
+            (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         output_header.gas_used / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),


### PR DESCRIPTION
Make BlockMetrics a struct to avoid the need for defining getter and modifier member functions.