### PR TITLE
Activate Osaka in MONAD_NEXT

### DIFF
--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -155,6 +155,9 @@ namespace monad
     {
         static consteval evmc_revision evm_rev() noexcept
         {
+            if constexpr (Rev >= MONAD_NEXT) {
+                return EVMC_OSAKA;
+            }
             if constexpr (Rev >= MONAD_FOUR) {
                 return EVMC_PRAGUE;
             }


### PR DESCRIPTION
Currently, Osaka features are not activated for any Monad revisions. This PR activates Osaka for the experimental / staging `MONAD_NEXT` revision.

Flagged by @pdobacz