### PR TITLE
Fix LLVM build following EVM memory changes

### DIFF
--- a/category/vm/llvm/llvm.cpp
+++ b/category/vm/llvm/llvm.cpp
@@ -75,9 +75,8 @@ namespace monad::vm::llvm
         }
     }
 
-    VM::VM(std::size_t max_stack_cache, std::size_t max_memory_cache)
+    VM::VM(std::size_t max_stack_cache)
         : stack_allocator_{max_stack_cache}
-        , memory_allocator_{max_memory_cache}
         , cached_llvm_code_(
               EVMC_MAX_REVISION + 1,
               std::unordered_map<evmc::bytes32, std::shared_ptr<LLVMState>>())
@@ -111,8 +110,8 @@ namespace monad::vm::llvm
         evmc_host_interface const *host, evmc_host_context *context,
         evmc_message const *msg, uint8_t const *code, size_t code_size)
     {
-        auto ctx = runtime::Context::from(
-            memory_allocator_, host, context, msg, {code, code_size});
+        auto ctx =
+            runtime::Context::from(host, context, msg, {code, code_size});
 
         auto const stack_ptr = stack_allocator_.allocate();
         uint256_t *evm_stack = reinterpret_cast<uint256_t *>(stack_ptr.get());

--- a/category/vm/llvm/llvm.hpp
+++ b/category/vm/llvm/llvm.hpp
@@ -31,7 +31,6 @@ namespace monad::vm::llvm
     class VM
     {
         runtime::EvmStackAllocator stack_allocator_;
-        runtime::EvmMemoryAllocator memory_allocator_;
         std::vector<
             std::unordered_map<evmc::bytes32, std::shared_ptr<LLVMState>>>
             cached_llvm_code_;
@@ -39,9 +38,7 @@ namespace monad::vm::llvm
     public:
         explicit VM(
             std::size_t max_stack_cache_byte_size =
-                runtime::EvmStackAllocator::DEFAULT_MAX_CACHE_BYTE_SIZE,
-            std::size_t max_memory_cache_byte_size =
-                runtime::EvmMemoryAllocator::DEFAULT_MAX_CACHE_BYTE_SIZE);
+                runtime::EvmStackAllocator::DEFAULT_MAX_CACHE_BYTE_SIZE);
 
         evmc::Result execute_llvm(
             evmc_revision rev, evmc::bytes32 const &code_hash,


### PR DESCRIPTION
Fix LLVM compiler build following the changes in https://github.com/category-labs/monad/pull/2009