### PR TITLE
Fix compilation of microbenchmark code

### DIFF
--- a/test/vm/micro_benchmarks/main.cpp
+++ b/test/vm/micro_benchmarks/main.cpp
@@ -128,7 +128,7 @@ struct BenchmarkResult
     std::string impl;
     std::string title;
     std::string base_seq;
-    std::vector<SeqResult> results;
+    std::vector<SeqResult> results{};
 
     void add(SeqResult res)
     {


### PR DESCRIPTION
This doesn't compile with Clang 19 in Debug mode because the results field isn't supplied as a designated initializer later in the file.