### PR TITLE
Skip reserve checks for init-selfdestruct contracts

### DIFF
--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -134,6 +134,10 @@ public:
 
     bytes32_t get_code_hash(Address const &);
 
+    bool is_destructed(Address const &);
+
+    bool is_current_incarnation(Address const &);
+
     bytes32_t get_storage(Address const &, bytes32_t const &key);
 
     bytes32_t get_transient_storage(Address const &, bytes32_t const &key);

--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -47,6 +47,7 @@ class ReserveBalance
     State *state_;
     bool tracking_enabled_{false};
     bool use_recent_code_hash_{false};
+    bool allow_init_selfdestruct_exemption_{false};
     Address sender_{};
     uint256_t sender_gas_fees_{0};
     bool sender_can_dip_{false};


### PR DESCRIPTION
# Problem
This PR solves https://github.com/category-labs/category-external/issues/133

> If I create a contract under an address that has been previously sent a balance, then self destruct that contract, the entire transaction reverts.
TX 1: send address 0xFOO... 1 gwei
TX 2 create contract at 0xFOO... and self destruct it in the constructor. Reverts.

>You can repro this by doing:
>Simulate the create/destruct with debug_traceCall.

>curl -X POST $ETH_RPC_URL -H "Content-Type: application/json" --data '{"method":"debug_traceCall","params":[{"from":".....YOUR_ADDDRESS_HERE.....", "data":"0x60256000600073608c4c81f4c5b60a56d05d3ab7fc2034ffd841683c602560006000f060005560016025f3","gas":"0x2dc6c0"}, "latest",{}],"id":1,"jsonrpc":"2.0"}' | jq .
send any amount of funds to the second create call's "to" address. 1gwei works. You must do this from a different address than the simulated "from" so that you don't change the nonces.
Simulate the call again, and it will revert.

# Diagnosis
In the above example, no contract was actually ever deployed at `0xfoo`, because `SELFDESTRUCT` was called during construction: `code_hash` was always `NULL_HASH`.
Note that as long as a contract does get deployed in a transaction, even if SELFDESTRUCT happens in the same transaction where the contract was deployed, the current implementation already does the right (permissive) thing because actual [account nullification](https://github.com/category-labs/monad/blob/d22abd656c70a598d67fa1756db471921ddb06ba/category/execution/ethereum/state3/state.cpp#L446) is deferred until the end of the transaction ([destruct_suicides](https://github.com/category-labs/monad/blob/d22abd656c70a598d67fa1756db471921ddb06ba/category/execution/ethereum/execute_transaction.cpp#L375) in [execute_final](https://github.com/category-labs/monad/blob/d22abd656c70a598d67fa1756db471921ddb06ba/category/execution/ethereum/execute_transaction.cpp#L448)), which happens after reserve balance checks.

So, to solve the problem we mainly need to tweak the implementation to make more permissive the case where `SELFDESTRUCT` happens during construction. This PR does a very minor tweak: it doesn't add any new state/tracking/marking and just uses the existing info.

# Design/Justification 

## Correctness criteria
First, we can recall the main correctness criteria for this isSC (is smart contract) exemption (from reverts): we need to ensure that nobody has a private key for accounts exempted this way. (Coq proofs needed the assumption that no transactions were sent by accounts exempted under this isSC exemption). We should aim to choose a maximally permissive check satisfying this criteria. Over time, we have been making this more and more permissive, and this PR is another one in that direction. The correctness criteria is satisfied by the [current design](https://github.com/category-labs/monad/pull/1916) because SC addresses are derived from hashes of code/nonces and thus having a corresponding private key is cryptographically hard.

## Design
In reserve balance checks, ac.[is_destructed()](https://github.com/category-labs/monad/blob/d22abd656c70a598d67fa1756db471921ddb06ba/category/execution/ethereum/state3/account_substate.hpp#L50-L53) returns true iff SELFDESTRUCT was done on the account ac during the transaction. If ac.[is_destructed()](https://github.com/category-labs/monad/blob/d22abd656c70a598d67fa1756db471921ddb06ba/category/execution/ethereum/state3/account_substate.hpp#L50-L53) is true, before exempting ac, we need to ensure that ac can never be an EOA. It suffices to check that `ac.incarnation` is equal to the current block/tx index (suggestion made by codex-cli originally).

## Justification
We need to prove that `ac.is_destructed() == true /\ ac.incarnation == current_block_tx` implies nobody has a private key for the address of `ac`.
Because `ac.is_destructed() = true`, when that `SELFDESTRUCT` happened, the code was running as `ac`. 
We consider the two cases: whether `ac.code` indicated delegation (started with the delegation marker) at the beginning of the execution of that specific call frame.

### Case 1. `ac.code` indicated delegation
Whether an account's code indicates delegation is a property that does not change after a transaction starts executing, because in this codebase the delegation marker is only written during the pre-execution EIP7702 auth processing stage (there is no precompile/opcode that can set it during contract execution). 
So, at the end of auth processing, `ac.code` was already indicating delegation. At that time, the account must already have existed and had an incarnation. 
That incarnation can only be LAST_TX (if the account was created during auth processing), or something strictly less than the current block/tx (the account was created before this transaction). 
Since then, the incarnation must have remained the same.
During normal transaction execution (as opposed to eth_call overrides), the only place we upgrade an account's incarnation is when CREATE(2) targets an address that has empty code (and 0 nonce, any balance), but in this case, the account's code has a delegation marker.

So this case is impossible, because it contradicts the assumption `ac.incarnation == current_block_tx`.
(If this PR didn't also check `ac.incarnation == current_block_tx`, it would have been possible that the self-destructed account was a delegated EOA. EVM semantics seems to allow SELFDESTRUCT to be called when the code is being run on behalf of a delegated EOA and in that case, [the EOA's balance gets transferred but the code/nonce fields remain the same](https://chatgpt.com/share/6973013f-5314-8003-bcc3-6c0924c793f1))

### Case 2. `ac.code` did not indicate delegation
There are 3 possibilities:
1. the call frame was running init code for `ac`.
2. the call frame was running already-deployed code at `ac`.
3. the call frame was running already-deployed code at some other address (e.g. `DELEGATECALL`).

In each case, the code executes in `ac`'s context, so `ac` must be a smart contract account, thus its address is derived from hashing nonce/initcode (and other items); thus, nobody can have a private key for it.
