### PR TITLE
Include remaining account balance in selfdestruct call tracer frame

### DIFF
--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -140,8 +140,11 @@ struct EvmcHost final : public EvmcHostBase
         Address const &address, Address const &beneficiary) noexcept override
     {
         try {
-            call_tracer_.on_self_destruct(address, beneficiary);
-            return state_.selfdestruct<traits>(address, beneficiary);
+            auto const [result, transferred_balance] =
+                state_.selfdestruct<traits>(address, beneficiary);
+            call_tracer_.on_self_destruct(
+                address, beneficiary, transferred_balance);
+            return result;
         }
         catch (...) {
             capture_current_exception();

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -401,11 +401,13 @@ State::access_storage(Address const &address, bytes32_t const &key)
 }
 
 template <Traits traits>
-bool State::selfdestruct(Address const &address, Address const &beneficiary)
+std::pair<bool, uint256_t>
+State::selfdestruct(Address const &address, Address const &beneficiary)
 {
     auto &account_state = current_account_state(address);
     auto &account = account_state.account_;
     MONAD_ASSERT(account.has_value());
+    auto const initial_balance = account.value().balance;
 
     if constexpr (traits::evm_rev() < EVMC_CANCUN) {
         add_to_balance(beneficiary, account.value().balance);
@@ -420,7 +422,7 @@ bool State::selfdestruct(Address const &address, Address const &beneficiary)
         }
     }
 
-    return account_state.destruct();
+    return {account_state.destruct(), initial_balance};
 }
 
 EXPLICIT_TRAITS_MEMBER(State::selfdestruct);

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -153,7 +153,8 @@ public:
     ////////////////////////////////////////
 
     template <Traits traits>
-    bool selfdestruct(Address const &, Address const &beneficiary);
+    std::pair<bool, uint256_t>
+    selfdestruct(Address const &, Address const &beneficiary);
 
     // YP (87)
     template <Traits traits>

--- a/category/execution/ethereum/trace/call_tracer.cpp
+++ b/category/execution/ethereum/trace/call_tracer.cpp
@@ -71,7 +71,10 @@ void NoopCallTracer::on_exit(evmc::Result const &) {}
 
 void NoopCallTracer::on_log(Receipt::Log) {}
 
-void NoopCallTracer::on_self_destruct(Address const &, Address const &) {}
+void NoopCallTracer::on_self_destruct(
+    Address const &, Address const &, uint256_t const &)
+{
+}
 
 void NoopCallTracer::on_finish(uint64_t const) {}
 
@@ -190,7 +193,9 @@ void CallTracer::on_log(Receipt::Log log)
     frame.logs->emplace_back(std::move(log), positions_.top());
 }
 
-void CallTracer::on_self_destruct(Address const &from, Address const &to)
+void CallTracer::on_self_destruct(
+    Address const &from, Address const &to,
+    uint256_t const &transferred_balance)
 {
     MONAD_ASSERT(!last_.empty());
     MONAD_ASSERT(!positions_.empty());
@@ -203,7 +208,7 @@ void CallTracer::on_self_destruct(Address const &from, Address const &to)
         .flags = 0,
         .from = from,
         .to = to,
-        .value = 0,
+        .value = transferred_balance,
         .gas = 0,
         .gas_used = 0,
         .input = {},

--- a/category/execution/ethereum/trace/call_tracer.hpp
+++ b/category/execution/ethereum/trace/call_tracer.hpp
@@ -39,7 +39,9 @@ struct CallTracerBase
     virtual void on_enter(evmc_message const &) = 0;
     virtual void on_exit(evmc::Result const &) = 0;
     virtual void on_log(Receipt::Log) = 0;
-    virtual void on_self_destruct(Address const &from, Address const &to) = 0;
+    virtual void on_self_destruct(
+        Address const &from, Address const &to,
+        uint256_t const &transferred_balance) = 0;
     virtual void on_finish(uint64_t const) = 0;
     virtual void reset() = 0;
     virtual std::span<CallFrame const> get_call_frames() const = 0;
@@ -50,7 +52,8 @@ struct NoopCallTracer final : public CallTracerBase
     virtual void on_enter(evmc_message const &) override;
     virtual void on_exit(evmc::Result const &) override;
     virtual void on_log(Receipt::Log) override;
-    virtual void on_self_destruct(Address const &, Address const &) override;
+    virtual void on_self_destruct(
+        Address const &, Address const &, uint256_t const &) override;
     virtual void on_finish(uint64_t const) override;
     virtual void reset() override;
     virtual std::span<CallFrame const> get_call_frames() const override;
@@ -72,8 +75,9 @@ public:
     virtual void on_enter(evmc_message const &) override;
     virtual void on_exit(evmc::Result const &) override;
     virtual void on_log(Receipt::Log) override;
-    virtual void
-    on_self_destruct(Address const &from, Address const &to) override;
+    virtual void on_self_destruct(
+        Address const &from, Address const &to,
+        uint256_t const &transferred_balance) override;
     virtual void on_finish(uint64_t const) override;
     virtual void reset() override;
     virtual std::span<CallFrame const> get_call_frames() const override;

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -60,6 +60,8 @@ inline constexpr auto ADDR_A =
     0x0000000000000000000000000000000000000100_address;
 inline constexpr auto ADDR_B =
     0x0000000000000000000000000000000000000101_address;
+inline constexpr auto ADDR_C =
+    0x0000000000000000000000000000000000000102_address;
 inline auto const A_CODE =
     evmc::from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
                    "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"


### PR DESCRIPTION
## Context

Other EVM implementation include the balance of the self destructed account (that is transferred to the account passed as argument to the `SELFDESTRUCT` instruction) in the value field of selfdestruct call tracer frames. This PR makes the monad execution client do the same.