### PR TITLE
[monad] Reserve balance precompile scaffolding

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -233,6 +233,11 @@ add_library(
   "monad/validate_monad_transaction.hpp"
   "monad/validate_system_transaction.cpp"
   "monad/validate_system_transaction.hpp"
+  # monad/reserve_balance
+  "monad/reserve_balance/reserve_balance_contract.cpp"
+  "monad/reserve_balance/reserve_balance_contract.hpp"
+  "monad/reserve_balance/reserve_balance_error.cpp"
+  "monad/reserve_balance/reserve_balance_error.hpp"
   # monad/staking
   "monad/staking/config.hpp"
   "monad/staking/execute_block_prelude.cpp"

--- a/category/execution/monad/reserve_balance/reserve_balance_contract.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/core/contract/abi_decode.hpp>
+#include <category/execution/ethereum/core/contract/abi_encode.hpp>
+#include <category/execution/ethereum/core/contract/abi_signatures.hpp>
+#include <category/execution/ethereum/core/contract/events.hpp>
+#include <category/execution/ethereum/core/contract/storage_variable.hpp>
+#include <category/execution/monad/reserve_balance/reserve_balance_contract.hpp>
+#include <category/execution/monad/reserve_balance/reserve_balance_error.hpp>
+#include <category/vm/evm/explicit_traits.hpp>
+
+#include <boost/outcome/success_failure.hpp>
+#include <boost/outcome/try.hpp>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+//
+// Gas Costs
+//
+
+constexpr uint64_t FALLBACK_COST = 40'000;
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+//
+// Contract implementation
+//
+
+MONAD_NAMESPACE_BEGIN
+
+ReserveBalanceContract::ReserveBalanceContract(
+    State &state, CallTracerBase &tracer)
+    : state_{state}
+    , call_tracer_{tracer}
+{
+    state_.add_to_balance(RESERVE_BALANCE_CA, 0);
+}
+
+template <Traits traits>
+std::pair<ReserveBalanceContract::PrecompileFunc, uint64_t>
+ReserveBalanceContract::precompile_dispatch(byte_string_view &input)
+{
+    if (MONAD_UNLIKELY(input.size() < 4)) {
+        return {&ReserveBalanceContract::precompile_fallback, FALLBACK_COST};
+    }
+
+    auto const signature =
+        intx::be::unsafe::load<uint32_t>(input.substr(0, 4).data());
+    input.remove_prefix(4);
+
+    switch (signature) {
+    default:
+        return {&ReserveBalanceContract::precompile_fallback, FALLBACK_COST};
+    }
+}
+
+EXPLICIT_MONAD_TRAITS(ReserveBalanceContract::precompile_dispatch);
+
+Result<byte_string> ReserveBalanceContract::precompile_fallback(
+    byte_string_view, evmc_address const &, evmc_uint256be const &)
+{
+    return ReserveBalanceError::MethodNotSupported;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/byte_string.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/core/result.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/vm/evm/traits.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+static constexpr Address RESERVE_BALANCE_CA = Address{0x1001};
+
+class ReserveBalanceContract
+{
+    State &state_;
+    // TODO(dhil): Remove annotation once used in event emission.
+    [[maybe_unused]] CallTracerBase &call_tracer_;
+
+public:
+    ReserveBalanceContract(State &state, CallTracerBase &tracer);
+
+    using PrecompileFunc = Result<byte_string> (ReserveBalanceContract::*)(
+        byte_string_view, evmc_address const &, evmc_bytes32 const &);
+
+    //
+    // Precompile methods
+    //
+    template <Traits traits>
+    static std::pair<PrecompileFunc, uint64_t>
+    precompile_dispatch(byte_string_view &);
+
+    Result<byte_string> precompile_fallback(
+        byte_string_view, evmc_address const &, evmc_uint256be const &);
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/core/contract/abi_encode.hpp>
+#include <category/execution/ethereum/core/contract/abi_signatures.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/evmc_host.hpp>
+#include <category/execution/ethereum/state2/block_state.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/ethereum/tx_context.hpp>
+#include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/reserve_balance/reserve_balance_contract.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/utils/evm-as.hpp>
+#include <category/vm/vm.hpp>
+
+#include <ankerl/unordered_dense.h>
+#include <evmc/evmc.h>
+#include <intx/intx.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace monad;
+
+struct ReserveBalance : public ::testing::Test
+{
+    static constexpr auto account_a = Address{0xdeadbeef};
+    static constexpr auto account_b = Address{0xcafebabe};
+    static constexpr auto account_c = Address{0xabbaabba};
+
+    OnDiskMachine machine;
+    vm::VM vm;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+    NoopCallTracer call_tracer;
+    ReserveBalanceContract contract{state, call_tracer};
+};
+
+struct ReserveBalanceEvm : public ReserveBalance
+{
+    BlockHashBufferFinalized const block_hash_buffer;
+    Transaction const empty_tx{};
+
+    ankerl::unordered_dense::segmented_set<Address> const
+        grandparent_senders_and_authorities{};
+    ankerl::unordered_dense::segmented_set<Address> const
+        parent_senders_and_authorities{};
+    ankerl::unordered_dense::segmented_set<Address> const
+        senders_and_authorities{};
+    // The {}s are needed here to pass the 0 < senders.size() assertion checks
+    // in `dipped_into_reserve`.
+    std::vector<Address> const senders{{}};
+    std::vector<std::vector<std::optional<Address>>> const authorities{{}};
+    ChainContext<MonadTraits<MONAD_NEXT>> const chain_ctx{
+        grandparent_senders_and_authorities,
+        parent_senders_and_authorities,
+        senders_and_authorities,
+        senders,
+        authorities};
+
+    EvmcHost<MonadTraits<MONAD_NEXT>> h{
+        call_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        state,
+        empty_tx,
+        0,
+        0,
+        chain_ctx};
+};
+
+TEST_F(ReserveBalanceEvm, precompile_fallback)
+{
+    auto input = std::array<uint8_t, 4>{};
+
+    auto const m = evmc_message{
+        .gas = 40'000,
+        .recipient = RESERVE_BALANCE_CA,
+        .sender = account_a,
+        .input_data = input.data(),
+        .input_size = input.size(),
+        .code_address = RESERVE_BALANCE_CA,
+    };
+
+    auto const result = h.call(m);
+    EXPECT_EQ(result.status_code, EVMC_REVERT);
+    EXPECT_EQ(result.gas_left, 0);
+    EXPECT_EQ(result.gas_refund, 0);
+    EXPECT_EQ(result.output_size, 20);
+
+    auto const message = std::string_view{
+        reinterpret_cast<char const *>(result.output_data), 20};
+    EXPECT_EQ(message, "method not supported");
+}

--- a/category/execution/monad/reserve_balance/reserve_balance_error.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/monad/reserve_balance/reserve_balance_error.hpp>
+
+// TODO unstable paths between versions
+#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
+    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
+    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
+    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
+#else
+    #include <boost/outcome/experimental/status-code/config.hpp>
+    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
+#endif
+
+#include <initializer_list>
+
+BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_BEGIN
+
+std::initializer_list<
+    quick_status_code_from_enum<monad::ReserveBalanceError>::mapping> const &
+quick_status_code_from_enum<monad::ReserveBalanceError>::value_mappings()
+{
+    using monad::ReserveBalanceError;
+
+    static std::initializer_list<mapping> const v = {
+        {ReserveBalanceError::Success, "success", {errc::success}},
+        {ReserveBalanceError::MethodNotSupported, "method not supported", {}},
+    };
+
+    return v;
+}
+
+BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_END

--- a/category/execution/monad/reserve_balance/reserve_balance_error.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+
+// TODO unstable paths between versions
+#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
+    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
+    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
+#else
+    #include <boost/outcome/experimental/status-code/config.hpp>
+    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
+#endif
+
+#include <initializer_list>
+
+MONAD_NAMESPACE_BEGIN
+
+enum class ReserveBalanceError
+{
+    Success = 0,
+    MethodNotSupported,
+};
+
+MONAD_NAMESPACE_END
+
+BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_BEGIN
+
+template <>
+struct quick_status_code_from_enum<monad::ReserveBalanceError>
+    : quick_status_code_from_enum_defaults<monad::ReserveBalanceError>
+{
+    static constexpr auto const domain_name = "Reserve Error";
+    static constexpr auto const domain_uuid =
+        "44b2d608-e6eb-40b1-8c89-a0a3184a3cfb";
+
+    static std::initializer_list<mapping> const &value_mappings();
+};
+
+BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE_END


### PR DESCRIPTION
This patch adds the basic scaffolding for the reserve balance precompile contract at address `0x1001`. The contract currently only implements a fallback function, but with the basic infrastructure in place this allows us to work in parallel on implementing its methods.