### PR TITLE
Fix LLVM build and blockchain tests after MIP3

### DIFF
--- a/category/vm/llvm/execute.cpp
+++ b/category/vm/llvm/execute.cpp
@@ -81,7 +81,7 @@ namespace monad::vm::llvm
         LLVMState &llvm = *ptr;
 
         llvm.insert_symbol(
-            "ffi_context_expand_memory", (void *)context_expand_memory);
+            "ffi_context_expand_memory", (void *)context_expand_memory<traits>);
 
         llvm.insert_symbol(
             "ffi_llvm_runtime_debug", (void *)llvm_runtime_debug);
@@ -112,19 +112,20 @@ namespace monad::vm::llvm
         llvm.insert_symbol("ffi_TLOAD", (void *)tload);
         llvm.insert_symbol("ffi_EXP", (void *)exp<traits>);
 
-        llvm.insert_symbol("ffi_KECCAK256", (void *)sha3);
+        llvm.insert_symbol("ffi_KECCAK256", (void *)sha3<traits>);
 
         llvm.insert_symbol("ffi_TSTORE", (void *)tstore);
-        llvm.insert_symbol("ffi_CALLDATACOPY", (void *)calldatacopy);
-        llvm.insert_symbol("ffi_CODECOPY", (void *)codecopy);
-        llvm.insert_symbol("ffi_MCOPY", (void *)mcopy);
-        llvm.insert_symbol("ffi_RETURNDATACOPY", (void *)returndatacopy);
+        llvm.insert_symbol("ffi_CALLDATACOPY", (void *)calldatacopy<traits>);
+        llvm.insert_symbol("ffi_CODECOPY", (void *)codecopy<traits>);
+        llvm.insert_symbol("ffi_MCOPY", (void *)mcopy<traits>);
+        llvm.insert_symbol(
+            "ffi_RETURNDATACOPY", (void *)returndatacopy<traits>);
         llvm.insert_symbol("ffi_EXTCODECOPY", (void *)extcodecopy<traits>);
-        llvm.insert_symbol("ffi_LOG0", (void *)log0);
-        llvm.insert_symbol("ffi_LOG1", (void *)log1);
-        llvm.insert_symbol("ffi_LOG2", (void *)log2);
-        llvm.insert_symbol("ffi_LOG3", (void *)log3);
-        llvm.insert_symbol("ffi_LOG4", (void *)log4);
+        llvm.insert_symbol("ffi_LOG0", (void *)log0<traits>);
+        llvm.insert_symbol("ffi_LOG1", (void *)log1<traits>);
+        llvm.insert_symbol("ffi_LOG2", (void *)log2<traits>);
+        llvm.insert_symbol("ffi_LOG3", (void *)log3<traits>);
+        llvm.insert_symbol("ffi_LOG4", (void *)log4<traits>);
 
         llvm.insert_symbol("rt_EXIT", (void *)&rt_exit);
         llvm.insert_symbol("ffi_SelfDestruct", (void *)selfdestruct<traits>);

--- a/category/vm/llvm/llvm.hpp
+++ b/category/vm/llvm/llvm.hpp
@@ -42,8 +42,7 @@ namespace monad::vm::llvm
 
         evmc::Result execute_llvm(
             evmc_revision rev, evmc::bytes32 const &code_hash,
-            evmc_host_interface const *host, evmc_host_context *context,
-            evmc_message const *msg, uint8_t const *code, size_t code_size);
+            runtime::Context &ctx, uint8_t const *code, size_t code_size);
 
         std::shared_ptr<LLVMState> cache_llvm(
             evmc_revision rev, evmc::bytes32 const &code_hash,

--- a/test/vm/vm/test_vm.cpp
+++ b/test/vm/vm/test_vm.cpp
@@ -299,8 +299,7 @@ evmc::Result BlockchainTestVM::execute_llvm(
 {
     auto code_hash = host->get_code_hash(context, &msg->code_address);
 
-    return llvm_vm_.execute_llvm(
-        rev, code_hash, host, context, msg, code, code_size);
+    return llvm_vm_.execute_llvm(rev, code_hash, *rt_ctx_, code, code_size);
 }
 #endif
 


### PR DESCRIPTION
Update LLVM emitter and runtime to work with MIP3 memory changes:
- Add explicit template instantiations for LLVM runtime functions
- Fix memory expansion traits usage in LLVM emitter
- Update blockchain test assertions for new memory behavior
- Correct template instantiation calls in llvm.cpp