### PR TITLE
Ignore claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ tmux-fuzzer-log/
 
 # optional third-party dependencies
 third_party/evmone/
+
+# Claude Code
+.claude/


### PR DESCRIPTION
When Claude is used for any task on the repo (review, exploration, etc.) it spits some local settings out into `.claude/`, which we want to ignore rather than commit.