### PR TITLE
Fix ThreadSanitizer race in PriorityPool shutdown

### DIFF
--- a/category/core/fiber/fiber_thread_pool.cpp
+++ b/category/core/fiber/fiber_thread_pool.cpp
@@ -87,10 +87,12 @@ FiberThreadPool::FiberThreadPool(
                 }
             }};
 
-        bootstrap_fiber.detach();
+        {
+            std::unique_lock<boost::fibers::mutex> lock{mutex_};
+            cv_.wait(lock, [this] { return done_; });
+        }
 
-        std::unique_lock<boost::fibers::mutex> lock{mutex_};
-        cv_.wait(lock, [this] { return done_; });
+        bootstrap_fiber.join();
     });
     threads_.push_back(std::move(thread));
 }


### PR DESCRIPTION
The fix ensures the bootstrap fiber is joined (not detached) before
the thread exits, guaranteeing the fiber and all its work is complete
before TLS cleanup occurs.



🤖 Generated with [Claude Code](https://claude.com/claude-code)