### PR TITLE
Remove unnecessary fiber yield calls from DB worker thread

### DIFF
--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -488,10 +488,6 @@ struct OnDiskWithWorkerThreadImpl
                     did_nothing = false;
                 }
                 async_io.io.poll_nonblocking(1);
-                boost::this_fiber::yield();
-                if (boost::fibers::has_ready_fibers()) {
-                    did_nothing = false;
-                }
                 if (did_nothing && async_io.io.io_in_flight() > 0) {
                     did_nothing = false;
                 }
@@ -649,10 +645,6 @@ struct OnDiskWithWorkerThreadImpl
                     did_nothing = false;
                 }
                 async_io.io.poll_nonblocking(1);
-                boost::this_fiber::yield();
-                if (boost::fibers::has_ready_fibers()) {
-                    did_nothing = false;
-                }
                 if (did_nothing && async_io.io.io_in_flight() > 0) {
                     did_nothing = false;
                 }


### PR DESCRIPTION
The DB worker thread runs as a regular thread, not in fiber context. Fiber operations occur on client threads via promise/future mechanism. The yield() and has_ready_fibers() calls serve no purpose since no fibers are scheduled on the DB worker thread.