### PR TITLE
More premissive licence check allowing "Copyright (C) 2025-26 ..."

### DIFF
--- a/.github/workflows/license.sh
+++ b/.github/workflows/license.sh
@@ -1,43 +1,72 @@
-C_LICENSE_HEADER="\
-// Copyright (C) 2025 Category Labs, Inc.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>."
+#!/bin/bash
 
-PYTHON_LICENSE_HEADER="\
-# Copyright (C) 2025 Category Labs, Inc.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>."
+C_LICENSE_LINES=(
+    "^// Copyright \(C\) 2025(-26)? Category Labs, Inc\.$"
+    "//"
+    "// This program is free software: you can redistribute it and/or modify"
+    "// it under the terms of the GNU General Public License as published by"
+    "// the Free Software Foundation, either version 3 of the License, or"
+    "// (at your option) any later version."
+    "//"
+    "// This program is distributed in the hope that it will be useful,"
+    "// but WITHOUT ANY WARRANTY; without even the implied warranty of"
+    "// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"
+    "// GNU General Public License for more details."
+    "//"
+    "// You should have received a copy of the GNU General Public License"
+    "// along with this program.  If not, see <http://www.gnu.org/licenses/>."
+)
 
-# Check for two newlines after the license header
-C_LICENSE_HEADER_LEN=$(("${#C_LICENSE_HEADER}" + 2))
-PYTHON_LICENSE_HEADER_LEN=$(("${#PYTHON_LICENSE_HEADER}" + 2))
+PYTHON_LICENSE_LINES=(
+    "^# Copyright \(C\) 2025(-26)? Category Labs, Inc\.$"
+    "#"
+    "# This program is free software: you can redistribute it and/or modify"
+    "# it under the terms of the GNU General Public License as published by"
+    "# the Free Software Foundation, either version 3 of the License, or"
+    "# (at your option) any later version."
+    "#"
+    "# This program is distributed in the hope that it will be useful,"
+    "# but WITHOUT ANY WARRANTY; without even the implied warranty of"
+    "# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"
+    "# GNU General Public License for more details."
+    "#"
+    "# You should have received a copy of the GNU General Public License"
+    "# along with this program.  If not, see <http://www.gnu.org/licenses/>."
+)
+
+# Function to check if a file has valid license header
+check_license() {
+    local file="$1"
+    shift
+    local patterns=("$@")
+    local num_lines=${#patterns[@]}
+
+    # Read the first num_lines (+1 for potential blank line) into an array
+    mapfile -n $((num_lines + 1)) -t lines < "$file"
+
+    # Check first line (copyright) with regex
+    if ! [[ "${lines[0]}" =~ ${patterns[0]} ]]; then
+        return 1
+    fi
+
+    # Check remaining lines with exact string comparison
+    for ((i=1; i<num_lines; i++)); do
+        if [[ "${lines[$i]}" != "${patterns[$i]}" ]]; then
+            return 1
+        fi
+    done
+
+    # If file has content beyond the header, check for blank line
+    if [[ "${lines[$num_lines]}" != "" ]]; then
+            return 1
+    fi
+
+    return 0
+}
 
 exit_code=0
 
-for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp'); do
-    contents=$(head -c $C_LICENSE_HEADER_LEN "$file")
+for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp' '*.S'); do
     directory=$(dirname "$file")
 
     if [ "$directory" == "utils/clang-tidy-auto-const" ]; then
@@ -48,7 +77,7 @@ for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp'); do
         continue
     fi
 
-    if [ "$contents" == "$C_LICENSE_HEADER" ]; then
+    if check_license "$file" "${C_LICENSE_LINES[@]}"; then
         continue
     fi
 
@@ -58,9 +87,7 @@ for file in $(git ls-files -- '*.rs' '*.h' '*.hpp' '*.c' '*.cpp'); do
 done
 
 for file in $(git ls-files -- '*.py' '*CMakeLists.txt'); do
-    contents=$(head -c $PYTHON_LICENSE_HEADER_LEN "$file")
-
-    if [ "$contents" == "$PYTHON_LICENSE_HEADER" ]; then
+    if check_license "$file" "${PYTHON_LICENSE_LINES[@]}"; then
         continue
     fi
 

--- a/category/core/keccak_impl.S
+++ b/category/core/keccak_impl.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/category/vm/interpreter/entry.S
+++ b/category/vm/interpreter/entry.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This function acts as a trampoline to make the interpreter's core loop
 // compatible with the existing runtime exit mechanism. It sets up the stack and
 // preserved registers so that `monad_vm_runtime_exit` can clean them up in the

--- a/category/vm/llvm/entry.S
+++ b/category/vm/llvm/entry.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This function acts as a trampoline to make the llvm backend's exit
 // compatible with the existing runtime exit mechanism. It sets up the stack and
 // preserved registers so that `monad_runtime_exit` can clean them up in the

--- a/category/vm/runtime/context.S
+++ b/category/vm/runtime/context.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 .intel_syntax noprefix
 
 // offsetof(Context, gas_remaining):

--- a/category/vm/runtime/exit.S
+++ b/category/vm/runtime/exit.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 .text
 .globl monad_vm_runtime_exit
 .type monad_vm_runtime_exit, @function

--- a/category/vm/runtime/math.S
+++ b/category/vm/runtime/math.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 .text
 .intel_syntax noprefix
 .globl monad_vm_runtime_mul

--- a/category/vm/runtime/transmute.S
+++ b/category/vm/runtime/transmute.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 .intel_syntax noprefix
 
 .text

--- a/test/vm/unit/runtime/fixture.S
+++ b/test/vm/unit/runtime/fixture.S
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // fixture.S
 .text
 .globl tests_trampoline


### PR DESCRIPTION
This version of the licence check was produced by Claude version `claude-sonnet-4-5-20250929`

The PR also adds missing licence headers in `.S` files.