### PR TITLE
Implement block overrides for `eth_simulatev1`

### DIFF
--- a/category/rpc/CMakeLists.txt
+++ b/category/rpc/CMakeLists.txt
@@ -23,7 +23,8 @@ add_library(
   monad_rpc
   OBJECT
   # rpc
-  "monad_executor.cpp" "monad_executor.h")
+  "monad_executor.cpp" "monad_executor.h"
+  "overrides.cpp" "overrides.h" "overrides.hpp")
 
 target_include_directories(monad_rpc PUBLIC ${CATEGORY_MAIN_DIR})
 

--- a/category/rpc/monad_executor.h
+++ b/category/rpc/monad_executor.h
@@ -17,6 +17,7 @@
 
 #include <category/execution/ethereum/chain/chain_config.h>
 #include <category/execution/ethereum/trace/tracer_config.h>
+#include <category/rpc/overrides.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -28,37 +29,7 @@ extern "C"
 
 static uint64_t const MONAD_ETH_CALL_LOW_GAS_LIMIT = 8'100'000;
 
-struct monad_state_override;
 struct monad_executor;
-
-struct monad_state_override *monad_state_override_create();
-
-void monad_state_override_destroy(struct monad_state_override *);
-
-void add_override_address(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len);
-
-void set_override_balance(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
-    uint8_t const *balance, size_t balance_len);
-
-void set_override_nonce(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
-    uint64_t nonce);
-
-void set_override_code(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
-    uint8_t const *code, size_t code_len);
-
-void set_override_state_diff(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
-    uint8_t const *key, size_t key_len, uint8_t const *value,
-    size_t valuen_len);
-
-void set_override_state(
-    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
-    uint8_t const *key, size_t key_len, uint8_t const *value,
-    size_t valuen_len);
 
 typedef struct monad_executor_result
 {

--- a/category/rpc/overrides.cpp
+++ b/category/rpc/overrides.cpp
@@ -1,0 +1,245 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+#include <category/rpc/overrides.h>
+#include <category/rpc/overrides.hpp>
+
+#include <intx/intx.hpp>
+
+#include <cstdint>
+#include <cstring>
+
+using namespace monad;
+
+monad_state_override *monad_state_override_create()
+{
+    monad_state_override *const m = new monad_state_override();
+
+    return m;
+}
+
+void monad_state_override_destroy(monad_state_override *const m)
+{
+    MONAD_ASSERT(m);
+    delete m;
+}
+
+void add_override_address(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+
+    MONAD_ASSERT(m->override_sets.find(address) == m->override_sets.end());
+    m->override_sets.emplace(
+        address, monad_state_override::monad_state_override_object{});
+}
+
+void set_override_balance(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len, uint8_t const *const balance,
+    size_t const balance_len)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    MONAD_ASSERT(m->override_sets.find(address) != m->override_sets.end());
+
+    MONAD_ASSERT(balance);
+    MONAD_ASSERT(balance_len == sizeof(uint256_t));
+    m->override_sets[address].balance =
+        intx::be::unsafe::load<uint256_t>(balance);
+}
+
+void set_override_nonce(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len, uint64_t const nonce)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    MONAD_ASSERT(m->override_sets.find(address) != m->override_sets.end());
+
+    m->override_sets[address].nonce = nonce;
+}
+
+void set_override_code(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len, uint8_t const *const code, size_t const code_len)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    MONAD_ASSERT(m->override_sets.find(address) != m->override_sets.end());
+
+    MONAD_ASSERT(code);
+    m->override_sets[address].code = {code, code + code_len};
+}
+
+void set_override_state_diff(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len, uint8_t const *const key, size_t const key_len,
+    uint8_t const *const value, size_t const value_len)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    MONAD_ASSERT(m->override_sets.find(address) != m->override_sets.end());
+
+    MONAD_ASSERT(key);
+    MONAD_ASSERT(key_len == sizeof(bytes32_t));
+    bytes32_t k;
+    std::memcpy(k.bytes, key, sizeof(bytes32_t));
+
+    MONAD_ASSERT(value);
+    MONAD_ASSERT(value_len == sizeof(bytes32_t));
+    bytes32_t v;
+    std::memcpy(v.bytes, value, sizeof(bytes32_t));
+
+    auto &state_object = m->override_sets[address].state_diff;
+    MONAD_ASSERT(state_object.find(k) == state_object.end());
+    state_object.emplace(k, v);
+}
+
+void set_override_state(
+    monad_state_override *const m, uint8_t const *const addr,
+    size_t const addr_len, uint8_t const *const key, size_t const key_len,
+    uint8_t const *const value, size_t const value_len)
+{
+    MONAD_ASSERT(m);
+
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    MONAD_ASSERT(m->override_sets.find(address) != m->override_sets.end());
+
+    MONAD_ASSERT(key);
+    MONAD_ASSERT(key_len == sizeof(bytes32_t));
+    bytes32_t k;
+    std::memcpy(k.bytes, key, sizeof(bytes32_t));
+
+    MONAD_ASSERT(value);
+    MONAD_ASSERT(value_len == sizeof(bytes32_t));
+    bytes32_t v;
+    std::memcpy(v.bytes, value, sizeof(bytes32_t));
+
+    auto &state_object = m->override_sets[address].state;
+    MONAD_ASSERT(state_object.find(k) == state_object.end());
+    state_object.emplace(k, v);
+}
+
+monad_block_override *monad_block_override_create()
+{
+    return new monad_block_override();
+}
+
+void monad_block_override_destroy(monad_block_override *const m)
+{
+    MONAD_ASSERT(m);
+    delete m;
+}
+
+void set_block_override_number(
+    monad_block_override *const m, uint64_t const number)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(!m->number.has_value());
+    m->number = number;
+}
+
+void set_block_override_time(monad_block_override *const m, uint64_t const time)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(!m->time.has_value());
+    m->time = time;
+}
+
+void set_block_override_gas_limit(
+    monad_block_override *const m, uint64_t const gas_limit)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(!m->gas_limit.has_value());
+    m->gas_limit = gas_limit;
+}
+
+void set_block_override_fee_recipient(
+    monad_block_override *const m, uint8_t const *const addr,
+    size_t const addr_len)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(addr);
+    MONAD_ASSERT(addr_len == sizeof(Address));
+    MONAD_ASSERT(!m->fee_recipient.has_value());
+    Address address;
+    std::memcpy(address.bytes, addr, sizeof(Address));
+    m->fee_recipient = address;
+}
+
+void set_block_override_prev_randao(
+    monad_block_override *const m, uint8_t const *const randao,
+    size_t const randao_len)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(randao);
+    MONAD_ASSERT(randao_len == sizeof(bytes32_t));
+    MONAD_ASSERT(!m->prev_randao.has_value());
+    bytes32_t val;
+    std::memcpy(val.bytes, randao, sizeof(bytes32_t));
+    m->prev_randao = val;
+}
+
+void set_block_override_base_fee_per_gas(
+    monad_block_override *const m, uint8_t const *const fee,
+    size_t const fee_len)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(fee);
+    MONAD_ASSERT(fee_len == sizeof(uint256_t));
+    MONAD_ASSERT(!m->base_fee_per_gas.has_value());
+    m->base_fee_per_gas = intx::be::unsafe::load<uint256_t>(fee);
+}
+
+void set_block_override_blob_base_fee(
+    monad_block_override *const m, uint8_t const *const fee,
+    size_t const fee_len)
+{
+    MONAD_ASSERT(m);
+    MONAD_ASSERT(fee);
+    MONAD_ASSERT(fee_len == sizeof(uint256_t));
+    MONAD_ASSERT(!m->blob_base_fee.has_value());
+    m->blob_base_fee = intx::be::unsafe::load<uint256_t>(fee);
+}

--- a/category/rpc/overrides.h
+++ b/category/rpc/overrides.h
@@ -1,0 +1,82 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+struct monad_state_override;
+
+struct monad_state_override *monad_state_override_create();
+
+void monad_state_override_destroy(struct monad_state_override *);
+
+void add_override_address(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len);
+
+void set_override_balance(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
+    uint8_t const *balance, size_t balance_len);
+
+void set_override_nonce(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
+    uint64_t nonce);
+
+void set_override_code(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
+    uint8_t const *code, size_t code_len);
+
+void set_override_state_diff(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
+    uint8_t const *key, size_t key_len, uint8_t const *value, size_t value_len);
+
+void set_override_state(
+    struct monad_state_override *, uint8_t const *addr, size_t addr_len,
+    uint8_t const *key, size_t key_len, uint8_t const *value, size_t value_len);
+
+struct monad_block_override;
+
+struct monad_block_override *monad_block_override_create();
+
+void monad_block_override_destroy(struct monad_block_override *);
+
+void set_block_override_number(struct monad_block_override *, uint64_t number);
+
+void set_block_override_time(struct monad_block_override *, uint64_t time);
+
+void set_block_override_gas_limit(
+    struct monad_block_override *, uint64_t gas_limit);
+
+void set_block_override_fee_recipient(
+    struct monad_block_override *, uint8_t const *addr, size_t addr_len);
+
+void set_block_override_prev_randao(
+    struct monad_block_override *, uint8_t const *randao, size_t randao_len);
+
+void set_block_override_base_fee_per_gas(
+    struct monad_block_override *, uint8_t const *fee, size_t fee_len);
+
+void set_block_override_blob_base_fee(
+    struct monad_block_override *, uint8_t const *fee, size_t fee_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/category/rpc/overrides.hpp
+++ b/category/rpc/overrides.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <cstdint>
+#include <optional>
+
+struct monad_state_override
+{
+    struct monad_state_override_object
+    {
+        std::optional<monad::uint256_t> balance{std::nullopt};
+        std::optional<uint64_t> nonce{std::nullopt};
+        std::optional<monad::byte_string> code{std::nullopt};
+        ankerl::unordered_dense::segmented_map<
+            monad::bytes32_t, monad::bytes32_t>
+            state{};
+        ankerl::unordered_dense::segmented_map<
+            monad::bytes32_t, monad::bytes32_t>
+            state_diff{};
+    };
+
+    ankerl::unordered_dense::segmented_map<
+        monad::Address, monad_state_override_object>
+        override_sets;
+};
+
+struct monad_block_override
+{
+    std::optional<uint64_t> number{std::nullopt};
+    std::optional<uint64_t> time{std::nullopt};
+    std::optional<uint64_t> gas_limit{std::nullopt};
+    std::optional<monad::Address> fee_recipient{std::nullopt};
+    std::optional<monad::bytes32_t> prev_randao{std::nullopt};
+    std::optional<monad::uint256_t> base_fee_per_gas{std::nullopt};
+    std::optional<monad::uint256_t> blob_base_fee{std::nullopt};
+};


### PR DESCRIPTION
This is preparatory work that isn't live yet; these overrides are required for `eth_simulatev1` support. Rather than overriding the state of particular accounts, they apply to block-level metadata. Additionally extract the state and block override code into a new header / TU pair to facilitate unit tests.

Geth spec for these overrides: https://geth.ethereum.org/docs/interacting-with-geth/rpc/objects#block-overrides. Note that this PR doesn't implement overriding withdrawals (as we don't have them in Monad, and it would be a lot of extra complexity), but does allow overriding blob base fees as that's very little extra code.

Developed with Claude Opus 4.6; this is mechanical code with a clear API and existing examples of similar work in the repo already.