### PR TITLE
[cmake] compatibility with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,10 @@ target_compile_options(
 
 # silkpre
 set(OPTIONAL_BUILD_TESTS OFF)
+set(OLD_CMAKE_POLICY_VERSION_MINIMUM "${CMAKE_POLICY_VERSION_MINIMUM}")
+set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
 add_subdirectory(third_party/silkpre)
+set(CMAKE_POLICY_VERSION_MINIMUM "${OLD_CMAKE_POLICY_VERSION_MINIMUM}")
 # undo the injection of ccache silkpre/ff does
 set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK)


### PR DESCRIPTION
Third-party library silkpre uses third-party library libff, which sets `cmake_minimum_required(VERSION 3.3)`. This is a problem starting in the CMake 4.x series, which removed compatibility with CMake versions older than 3.5. Setting a minimum version of 3.3 implicitly enables policies that predate the 3.5 defaults, and the CMake generation step has a hard failure.

In practice it does not cause a problem to force the old libff build system to use the policy defaults from 3.5. Although a better long-term solution would be to upgrade the dependencies involved, we intend to remove silkpre entirely soon.