### PR TITLE
Remove redundant wait_until_done() from AsyncIO, keep only flush()

### DIFF
--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -255,7 +255,7 @@ AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
 AsyncIO::~AsyncIO()
 {
     try {
-        wait_until_done();
+        flush();
     }
     catch (...) {
         std::terminate();

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -298,16 +298,11 @@ public:
         return poll_nonblocking(count);
     }
 
-    void wait_until_done()
+    void flush()
     {
         while (io_in_flight() > 0) {
             poll_blocking(size_t(-1));
         }
-    }
-
-    void flush()
-    {
-        wait_until_done();
     }
 
     void reset_records()

--- a/category/async/test/benchmark_io_test.cpp
+++ b/category/async/test/benchmark_io_test.cpp
@@ -529,7 +529,7 @@ set it to the desired size beforehand).
                 while (std::chrono::steady_clock::now() - begin <
                        std::chrono::seconds(duration_secs));
                 shared_state.done = true;
-                io.wait_until_done();
+                io.flush();
             }
             print_statistics();
         }

--- a/category/async/test/io.cpp
+++ b/category/async/test/io.cpp
@@ -122,7 +122,7 @@ namespace
             state->initiate(); // will reap completions if no buffers free
             (void)state.release();
         }
-        testio.wait_until_done();
+        testio.flush();
     }
 
     TEST(AsyncIO, buffer_exhaustion_pauses_until_io_completes_read)
@@ -144,7 +144,7 @@ namespace
             state->initiate(); // will reap completions if no buffers free
             (void)state.release();
         }
-        testio.wait_until_done();
+        testio.flush();
     }
 
     struct sqe_exhaustion_does_not_reorder_writes_receiver
@@ -238,7 +238,7 @@ namespace
         s1->sender().advance_buffer_append(monad::async::DISK_PAGE_SIZE);
         s1->initiate();
         (void)s1.release();
-        testio.wait_until_done();
+        testio.flush();
         std::cout << "   " << seq.size() << " offsets written." << std::endl;
 
         uint32_t offset2 = 0;
@@ -304,7 +304,7 @@ namespace
             (void)state.release();
         }
 
-        testio.wait_until_done();
+        testio.flush();
 
         EXPECT_LE(testio.max_reads_in_flight(), 2u);
 

--- a/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
@@ -52,8 +52,8 @@ namespace
             monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testrwbuf);
         std::vector<monad::async::read_single_buffer_sender::buffer_type> bufs;
-        auto const empty_testio = monad::make_scope_exit(
-            [&]() noexcept { testio.wait_until_done(); });
+        auto const empty_testio =
+            monad::make_scope_exit([&]() noexcept { testio.flush(); });
 
         struct empty_receiver
         {

--- a/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
@@ -51,8 +51,8 @@ namespace
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testrwbuf);
         std::vector<monad::async::erased_connected_operation_ptr> states;
-        auto const empty_testio = monad::make_scope_exit(
-            [&]() noexcept { testio.wait_until_done(); });
+        auto const empty_testio =
+            monad::make_scope_exit([&]() noexcept { testio.flush(); });
 
         struct empty_receiver
         {

--- a/category/async/test/sender_receiver.cpp
+++ b/category/async/test/sender_receiver.cpp
@@ -130,7 +130,7 @@ public:
     void stop()
     {
         test_is_done_ = true;
-        fixture_shared_state_->testio->wait_until_done();
+        fixture_shared_state_->testio->flush();
     }
 
     virtual bool reinitiate(

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -1127,7 +1127,7 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
                 result_holder}));
         state->initiate();
     }
-    ctx->aux.io->wait_until_done();
+    ctx->aux.io->flush();
     for (auto &r : results) {
         EXPECT_TRUE(r.traverse_success);
         EXPECT_EQ(r.num_leaves_traversed, nkeys);
@@ -1146,7 +1146,7 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
                 block_id),
             expect_failure}));
     state->initiate();
-    ctx->aux.io->wait_until_done();
+    ctx->aux.io->flush();
     EXPECT_FALSE(expect_failure.traverse_success);
     EXPECT_EQ(expect_failure.num_leaves_traversed, 0);
 }

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -797,7 +797,7 @@ int main(int argc, char *argv[])
                     "   Did %f random reads per second.\n",
                     1000000.0 * double(ops) / double(diff.count()));
                 signal_done = true;
-                aux.io->wait_until_done();
+                aux.io->flush();
             }
 
             {
@@ -870,7 +870,7 @@ int main(int argc, char *argv[])
                 fflush(stdout);
                 signal_done = true;
                 for (auto &fiber : fibers) {
-                    io.wait_until_done();
+                    io.flush();
                     fiber.join();
                 }
                 poll_fiber.join();
@@ -941,7 +941,7 @@ int main(int argc, char *argv[])
                             aux->io->poll_nonblocking(1);
                         }
                         else {
-                            aux->io->wait_until_done();
+                            aux->io->flush();
                             return;
                         }
                         if (req.try_dequeue(request)) {

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -477,7 +477,7 @@ TYPED_TEST(PlainTrieTest, large_values)
         find_notify_fiber_future(this->aux, inflights, p, this->root, key1);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
-            this->aux.io->wait_until_done();
+            this->aux.io->flush();
         }
         auto [leaf_it, res] = fut.get();
         auto &leaf = leaf_it.node;
@@ -495,7 +495,7 @@ TYPED_TEST(PlainTrieTest, large_values)
         find_notify_fiber_future(this->aux, inflights, p, this->root, key2);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
-            this->aux.io->wait_until_done();
+            this->aux.io->flush();
         }
         auto [leaf_it, res] = fut.get();
         auto &leaf = leaf_it.node;

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -419,7 +419,7 @@ inline bool preorder_traverse_ondisk(
         TraverseReceiver{version_expired_before_traverse_complete}));
     state->initiate();
 
-    aux.io->wait_until_done();
+    aux.io->flush();
 
     // return traversal succeeds or not
     return !version_expired_before_traverse_complete;

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -279,7 +279,7 @@ size_t load_all(UpdateAuxImpl &aux, StateMachine &sm, NodeCursor const &root)
 {
     load_all_impl_ impl(aux);
     impl.process(root, sm);
-    aux.io->wait_until_done();
+    aux.io->flush();
     return impl.nodes_loaded;
 }
 


### PR DESCRIPTION
Simplify AsyncIO interface by removing wait_until_done() function which was identical to flush(). The flush() function simply called wait_until_done(), so we inline the implementation and remove the redundant method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)