### PR TITLE
Remove intx usage from 6 files

### DIFF
--- a/category/core/unaligned.hpp
+++ b/category/core/unaligned.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <category/core/config.hpp>
+
 #include <algorithm>
 #include <array>
 #include <bit>

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -19,6 +19,7 @@
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/unaligned.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet_alloc.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
@@ -32,6 +33,7 @@
 
 #include <evmc/evmc.h>
 
+#include <bit>
 #include <boost/outcome/config.hpp>
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
@@ -103,10 +105,15 @@ EthereumMainnet::static_validate_header(BlockHeader const &header) const
 
 GenesisState EthereumMainnet::get_genesis_state() const
 {
+    // byteswap for nonce storage requires little-endian
+    static_assert(
+        std::endian::native == std::endian::little,
+        "get_genesis_state requires little-endian for byteswap");
+
     BlockHeader header;
     header.difficulty = 17179869184;
     header.gas_limit = 5000;
-    intx::be::unsafe::store<uint64_t>(header.nonce.data(), 66);
+    unaligned_store(header.nonce.data(), std::byteswap(uint64_t{66}));
     header.extra_data = evmc::from_hex("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33a"
                                        "db3db69cbdb7a38e1e50b1b82fa")
                             .value();

--- a/category/execution/ethereum/dao.hpp
+++ b/category/execution/ethereum/dao.hpp
@@ -20,8 +20,6 @@
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 
-#include <intx/intx.hpp>
-
 MONAD_NAMESPACE_BEGIN
 
 namespace dao

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -52,7 +52,6 @@
 #include <boost/fiber/future/promise.hpp>
 #include <boost/outcome/try.hpp>
 #include <evmc/evmc.h>
-#include <intx/intx.hpp>
 
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
Replace intx big-endian operations with std::byteswap and unaligned_load/store for primitive types. Remove unused intx includes where no intx APIs are used.