### PR TITLE
cached/incremental reserve balance checks: design2 

### DIFF
--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -53,6 +53,24 @@ using db_t = TrieDb;
 
 #define PUSH3(x) 0x62, (((x) >> 16) & 0xFF), (((x) >> 8) & 0xFF), ((x) & 0xFF)
 
+namespace
+{
+    template <Traits traits>
+    void init_rb_for_test(
+        State &state, EvmcHost<traits> &host, Address const &sender)
+    {
+        if constexpr (is_monad_trait_v<traits>) {
+            init_reserve_balance_context<traits>(
+                state,
+                sender,
+                host.tx_,
+                host.base_fee_per_gas_,
+                host.i_,
+                host.chain_ctx_);
+        }
+    }
+}
+
 TYPED_TEST(TraitsTest, create_with_insufficient)
 {
     InMemoryMachine machine;
@@ -102,6 +120,7 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
     auto const result = create<typename TestFixture::Trait>(&h, s, m);
 
     EXPECT_EQ(result.status_code, EVMC_INSUFFICIENT_BALANCE);
@@ -163,6 +182,7 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
 
     auto const result = create<typename TestFixture::Trait>(&h, s, m);
 
@@ -242,6 +262,7 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
     auto const result = create<typename TestFixture::Trait>(&h, s, m);
     EXPECT_EQ(result.status_code, EVMC_INVALID_INSTRUCTION);
 }
@@ -301,6 +322,7 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
     uint256_t const v{70'000'000};
     intx::be::store(m.value.bytes, v);
 
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
     auto const result = create<typename TestFixture::Trait>(&h, s, m);
 
     EXPECT_FALSE(s.account_exists(new_addr));
@@ -347,6 +369,7 @@ TYPED_TEST(TraitsTest, static_precompile_execution)
                  .account = {std::nullopt, Account{.balance = 15'000}}}}},
         Code{},
         BlockHeader{});
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);
@@ -414,6 +437,7 @@ TYPED_TEST(TraitsTest, out_of_gas_static_precompile_execution)
                  .account = {std::nullopt, Account{.balance = 15'000}}}}},
         Code{},
         BlockHeader{});
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
 
     static constexpr char data[] = "hello world";
     static constexpr auto data_size = sizeof(data);
@@ -512,6 +536,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
 
     // Initcode fits inside size limit
     if constexpr (
@@ -632,6 +657,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
 
     // Initcode fits inside size limit
     if constexpr (
@@ -888,6 +914,7 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
 
     if constexpr (TestFixture::Trait::evm_rev() >= EVMC_PRAGUE) {
         auto const result = h.call(m);
@@ -1017,6 +1044,7 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
 
     if constexpr (TestFixture::Trait::evm_rev() >= EVMC_PRAGUE) {
         auto const result = h.call(m);
@@ -1132,6 +1160,7 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
             base_fee,
             0,
             chain_ctx};
+        init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
 
         auto const result = h.call(m);
 
@@ -1212,6 +1241,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
         base_fee,
         0,
         chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
     auto const result = h.call(m);
     auto const gas_used = gas_limit - result.gas_left;
 

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -33,7 +33,6 @@
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/execution/ethereum/tx_context.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
-#include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/switch_traits.hpp>
 #include <category/vm/evm/traits.hpp>
@@ -220,6 +219,16 @@ template <Traits traits>
 evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
     State &state, EvmcHost<traits> &host)
 {
+    if constexpr (::monad::is_monad_trait_v<traits>) {
+        init_reserve_balance_context<traits>(
+            state,
+            sender_,
+            tx_,
+            header_.base_fee_per_gas,
+            host.i_,
+            host.chain_ctx_);
+    }
+
     irrevocable_change<traits>(
         state,
         tx_,

--- a/category/execution/ethereum/reserve_balance.cpp
+++ b/category/execution/ethereum/reserve_balance.cpp
@@ -29,4 +29,12 @@ bool revert_transaction(
 
 EXPLICIT_EVM_TRAITS(revert_transaction);
 
+template <Traits traits>
+bool revert_transaction_cached(State &)
+{
+    return false;
+}
+
+EXPLICIT_EVM_TRAITS(revert_transaction_cached);
+
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/reserve_balance.hpp
+++ b/category/execution/ethereum/reserve_balance.hpp
@@ -24,6 +24,7 @@
 #include <evmc/evmc.h>
 
 #include <cstdint>
+#include <optional>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -35,5 +36,15 @@ bool revert_transaction(
     Address const &sender, Transaction const &,
     uint256_t const &base_fee_per_gas, uint64_t i, State &,
     ChainContext<traits> const &);
+
+template <Traits traits>
+bool revert_transaction_cached(State &);
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void init_reserve_balance_context(
+    State &state, Address const &sender, Transaction const &tx,
+    std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
+    ChainContext<traits> const &ctx);
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -27,6 +27,7 @@
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/reserve_balance.h>
 #include <category/execution/monad/reserve_balance.hpp>
+#include <category/execution/monad/staking/util/constants.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -71,6 +72,13 @@ bool dipped_into_reserve(
                 ? cur_account.recent().get_code_hash()
                 : orig_code_hash;
         bool effective_is_delegated = false;
+
+        // the balance of the staking contract address can decrease but that
+        // should not cause this tx to revert as that address cannot send
+        // transactions
+        if (addr == staking::STAKING_CA) {
+            continue;
+        }
 
         // Skip if not EOA
         if (effective_code_hash != NULL_HASH) {
@@ -126,9 +134,227 @@ bool dipped_into_reserve(
     return false;
 }
 
+bool is_delegated(State &state, bytes32_t const &code_hash)
+{
+    if (MONAD_UNLIKELY(code_hash == NULL_HASH)) {
+        return false;
+    }
+
+    auto const vcode = state.read_code(code_hash);
+    MONAD_ASSERT(vcode);
+    auto const &icode = vcode->intercode();
+    return vm::evm::is_delegated({icode->code(), icode->size()});
+}
+
+bool is_smart_contract_code(byte_string_view const code)
+{
+    return !code.empty() && !vm::evm::is_delegated({code.data(), code.size()});
+}
+
+bool dipped_into_reserve_cached(ReserveBalance const &rb)
+{
+    MONAD_ASSERT(rb.tracking_enabled());
+    return rb.has_violation();
+}
+
 MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
+
+ReserveBalance::ReserveBalance(State *state)
+    : state_{state}
+{
+}
+
+bool ReserveBalance::tracking_enabled() const
+{
+    return tracking_enabled_;
+}
+
+bool ReserveBalance::has_violation() const
+{
+    return !failed_.empty();
+}
+
+bool ReserveBalance::failed_contains(Address const &address) const
+{
+    return failed_.contains(address);
+}
+
+bool ReserveBalance::subject_account(Address const &address)
+{
+    // the balance of the staking contract address can decrease but that
+    // should not cause this tx to revert as that address cannot send
+    // transactions
+    if (address == staking::STAKING_CA) {
+        return false;
+    }
+
+    OriginalAccountState &orig_state = state_->original_account_state(address);
+    bytes32_t const effective_code_hash = use_recent_code_hash_
+                                              ? state_->get_code_hash(address)
+                                              : orig_state.get_code_hash();
+    if (effective_code_hash == NULL_HASH) {
+        return true;
+    }
+    return is_delegated(*state_, effective_code_hash);
+}
+
+uint256_t ReserveBalance::pretx_reserve(Address const &address)
+{
+    MONAD_ASSERT(get_max_reserve_);
+    uint256_t const max_reserve = get_max_reserve_(address);
+    return std::min(max_reserve, state_->get_original_balance(address));
+}
+
+void ReserveBalance::update_violation_status(Address const &address)
+{
+    if (!tracking_enabled_) {
+        return;
+    }
+
+    auto &violation_threshold = violation_thresholds_[address];
+    if (!violation_threshold.has_value()) {
+        if (!subject_account(address)) {
+            violation_threshold = uint256_t{0};
+            failed_.erase(address);
+            return;
+        }
+
+        uint256_t reserve = pretx_reserve(address);
+        if (address == sender_) {
+            if (sender_can_dip_) {
+                violation_threshold = uint256_t{0};
+                failed_.erase(address);
+                return;
+            }
+            MONAD_ASSERT_THROW(
+                sender_gas_fees_ <= reserve,
+                "gas fee greater than reserve for non-dipping transaction");
+            reserve = reserve - sender_gas_fees_;
+        }
+        violation_threshold = reserve;
+    }
+
+    if (*violation_threshold == 0) {
+        failed_.erase(address);
+        return;
+    }
+
+    if (state_->get_balance(address) < *violation_threshold) {
+        failed_.insert(address);
+    }
+    else {
+        failed_.erase(address);
+    }
+}
+
+void ReserveBalance::on_credit(Address const &address)
+{
+    if (!tracking_enabled_) {
+        return;
+    }
+    if (failed_.contains(address)) {
+        update_violation_status(address);
+    }
+}
+
+void ReserveBalance::on_debit(Address const &address)
+{
+    update_violation_status(address);
+}
+
+void ReserveBalance::on_pop_reject(FailedSet const &accounts)
+{
+    if (!tracking_enabled_) {
+        return;
+    }
+    for (auto const &dirty_address : accounts) {
+        violation_thresholds_[dirty_address].reset();
+        update_violation_status(dirty_address);
+    }
+}
+
+void ReserveBalance::on_set_code(
+    Address const &address, byte_string_view const code)
+{
+    if (!tracking_enabled_) {
+        return;
+    }
+    if (!use_recent_code_hash_) {
+        return;
+    }
+    auto &violation_threshold = violation_thresholds_[address];
+    if (is_smart_contract_code(code)) {
+        violation_threshold = uint256_t{0};
+        failed_.erase(address);
+        return;
+    }
+    violation_threshold.reset();
+    update_violation_status(address);
+}
+
+template <Traits traits>
+void ReserveBalance::init_from_tx(
+    Address const &sender, Transaction const &tx,
+    std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
+    ChainContext<traits> const &ctx)
+{
+    constexpr bool tracking_disabled = []() {
+        if constexpr (!is_monad_trait_v<traits>) {
+            return true;
+        }
+        else {
+            return traits::monad_rev() < MONAD_FOUR;
+        }
+    }();
+
+    if constexpr (tracking_disabled) {
+        tracking_enabled_ = false;
+        use_recent_code_hash_ = false;
+        sender_ = {};
+        sender_gas_fees_ = 0;
+        sender_can_dip_ = false;
+        get_max_reserve_ = {};
+        failed_.clear();
+        return;
+    }
+
+    MONAD_ASSERT(i < ctx.senders.size());
+    MONAD_ASSERT(i < ctx.authorities.size());
+    MONAD_ASSERT(ctx.senders.size() == ctx.authorities.size());
+    use_recent_code_hash_ = traits::monad_rev() >= MONAD_EIGHT;
+    bytes32_t const sender_code_hash =
+        use_recent_code_hash_
+            ? state_->get_code_hash(sender)
+            : state_->original_account_state(sender).get_code_hash();
+    bool const sender_can_dip = can_sender_dip_into_reserve<traits>(
+        sender, i, is_delegated(*state_, sender_code_hash), ctx);
+    tracking_enabled_ = true;
+    sender_ = sender;
+    sender_gas_fees_ = uint256_t{tx.gas_limit} *
+                       gas_price<traits>(tx, base_fee_per_gas.value_or(0));
+    sender_can_dip_ = sender_can_dip;
+    get_max_reserve_ = [](Address const &addr) {
+        return get_max_reserve<traits>(addr);
+    };
+    failed_.clear();
+    violation_thresholds_.clear();
+}
+
+EXPLICIT_MONAD_TRAITS_MEMBER(ReserveBalance::init_from_tx);
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void init_reserve_balance_context(
+    State &state, Address const &sender, Transaction const &tx,
+    std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
+    ChainContext<traits> const &ctx)
+{
+    state.rb_.init_from_tx<traits>(sender, tx, base_fee_per_gas, i, ctx);
+}
+
+EXPLICIT_MONAD_TRAITS(init_reserve_balance_context);
 
 template <Traits traits>
 bool revert_transaction(
@@ -146,6 +372,19 @@ bool revert_transaction(
 }
 
 EXPLICIT_MONAD_TRAITS(revert_transaction);
+
+template <Traits traits>
+bool revert_transaction_cached(State &state)
+{
+    if constexpr (traits::monad_rev() >= MONAD_FOUR) {
+        return dipped_into_reserve_cached(state.rb_);
+    }
+    else if constexpr (traits::monad_rev() >= MONAD_ZERO) {
+        return false;
+    }
+}
+
+EXPLICIT_MONAD_TRAITS(revert_transaction_cached);
 
 template <Traits traits>
     requires is_monad_trait_v<traits>

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -40,7 +40,7 @@
 
 using namespace monad;
 
-struct ReserveBalance : public ::testing::Test
+struct ReserveBalanceTest : public ::testing::Test
 {
     static constexpr auto account_a = Address{0xdeadbeef};
     static constexpr auto account_b = Address{0xcafebabe};
@@ -56,7 +56,7 @@ struct ReserveBalance : public ::testing::Test
     ReserveBalanceContract contract{state, call_tracer};
 };
 
-struct ReserveBalanceEvm : public ReserveBalance
+struct ReserveBalanceEvm : public ReserveBalanceTest
 {
     BlockHashBufferFinalized const block_hash_buffer;
     Transaction const empty_tx{};
@@ -101,6 +101,14 @@ TEST_F(ReserveBalanceEvm, precompile_fallback)
         .input_size = input.size(),
         .code_address = RESERVE_BALANCE_CA,
     };
+
+    init_reserve_balance_context<MonadTraits<MONAD_NEXT>>(
+        state,
+        Address{m.sender},
+        empty_tx,
+        h.base_fee_per_gas_,
+        h.i_,
+        h.chain_ctx_);
 
     auto const result = h.call(m);
     EXPECT_EQ(result.status_code, EVMC_REVERT);

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -2492,6 +2492,8 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
         BlockState block_state{tdb, vm};
         State state{
             block_state, Incarnation{header.number - 1, Incarnation::LAST_TX}};
+        init_reserve_balance_context<monad::MonadTraits<MONAD_NEXT>>(
+            state, sender, tx, header.base_fee_per_gas, 0, chain_context);
         state.subtract_from_balance(sender, gas_fee);
         state.subtract_from_balance(sender, value);
         EXPECT_TRUE(block_state.can_merge(state));


### PR DESCRIPTION
Now that reserve balance checks can be done several times during a transaction using a precompile (previously the CHECKRESERVEBALANCE opcode), it is important to do it in an incremental/cached way, as suggested by Piotr. Before this PR, the check was done by [iterating over all changed accounts](https://github.com/category-labs/monad/blob/f5c1bec66612a9acc8f76a7c44681a231dd24f28/category/execution/monad/reserve_balance.cpp#L66). In this PR, the check is done by just checking whether the cached set of "accounts in reserve balance violation" is empty. This set is maintained in `ReserveBalance::failed_`. It is a private field of the `ReserveBalance` class, but the class provides hooks (methods) that are called on changes to parts of `State` relevant to reserve balance: balance and code of accounts, so that `ReserveBalance::failed_` can be updated. Additionally, `ReserveBalance::on_pop_reject()` is called on `State::pop_reject`.


## Balance changes
The method `ReserveBalance::update_violation_status` is the main workhorse which updates the violation status of the given account. It is roughly equivalent to the [loop body of the previous implementation](https://github.com/category-labs/monad/blob/f5c1bec66612a9acc8f76a7c44681a231dd24f28/category/execution/monad/reserve_balance.cpp#L67-L125): it computes the violation threshold if not already cached and then checks if the balance lower.

### `State::subtract_from_balance`
Here, we just add a call to `ReserveBalance::update_violation_status`.

### `State::add_to_balance`
We know that adding to an account's balance can only cause the account to go from being in violation to being not in violation, but not the other direction. Thus, we only call `ReserveBalance::update_violation_status` if the account was in violation.

## `State::set_code`
If the new code is a delegation marker, we recompute the violation threshold. Otherwise, [just like the previous implementation](https://github.com/category-labs/monad/blob/f5c1bec66612a9acc8f76a7c44681a231dd24f28/category/execution/monad/reserve_balance.cpp#L76), such accounts are exempt and thus we remove the account from the violation set.


## `State::pop_reject`

This happens when the changes to the current call frame are discarded, e.g. due to `REVERT`. `State` already maintains the set of addresses that were updated in this call frame. We recompute the violation status of all of them


## Correctness
We are assuming that the above methods are the *only* places where the balances of an account or whether the account is delegated or isSC changes until the point reserve balance checks can still happen.
These assumptions seem to be valid now but will need to be maintained in the future.
I will start doing Coq proofs of the functions added here once this is merged.

co-authored with codex-cli.