### PR TITLE
removed set_code_hash

### DIFF
--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -179,8 +179,8 @@ namespace
         static constexpr Address test_addr =
             0x0000000000000000000000000000000000000123_address;
         state.create_contract(test_addr);
-        state.set_code_hash(test_addr, code_hash);
         state.set_code(test_addr, bytecode_view);
+        EXPECT_EQ(state.get_code_hash(test_addr), code_hash);
         state.set_nonce(test_addr, 1);
     }
 }

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -19,6 +19,7 @@
 #include <category/core/blake3.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/keccak.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
@@ -272,15 +273,15 @@ TEST_F(InMemoryStateTest, get_code_hash)
     EXPECT_EQ(s.get_code_hash(c), NULL_HASH);
 }
 
-TEST_F(InMemoryStateTest, set_code_hash)
+TEST_F(InMemoryStateTest, set_code_sets_code_hash)
 {
     BlockState bs{this->tdb, this->vm};
 
     State s{bs, Incarnation{1, 1}};
     s.create_contract(b);
-    s.set_code_hash(b, hash1);
+    s.set_code(b, code1);
 
-    EXPECT_EQ(s.get_code_hash(b), hash1);
+    EXPECT_EQ(s.get_code_hash(b), to_bytes(keccak256(code1)));
 }
 
 TYPED_TEST(InMemoryStateTraitsTest, selfdestruct)

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -339,13 +339,6 @@ void State::subtract_from_balance(
     account_state.touch();
 }
 
-void State::set_code_hash(Address const &address, bytes32_t const &hash)
-{
-    auto &account = current_account(address);
-    MONAD_ASSERT(account.has_value());
-    account.value().code_hash = hash;
-}
-
 evmc_storage_status State::set_storage(
     Address const &address, bytes32_t const &key, bytes32_t const &value)
 {

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -136,8 +136,6 @@ public:
 
     void subtract_from_balance(Address const &, uint256_t const &delta);
 
-    void set_code_hash(Address const &, bytes32_t const &hash);
-
     evmc_storage_status
     set_storage(Address const &, bytes32_t const &key, bytes32_t const &value);
 

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -1436,9 +1436,9 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_code_hash)
 
     State s(bs, Incarnation{0, 0});
 
-    // Modify the code hash of the beneficiary, which implies it
+    // Re-setting beneficiary code marks account as modified and
     // must show up in the prestate trace.
-    s.set_code_hash(ADDR_A, A_CODE_HASH);
+    s.set_code(ADDR_A, A_CODE);
 
     {
         // Run prestate tracer


### PR DESCRIPTION
Calling `set_code_hash` arbitrarily may break invariants of the State class, e.g. that the account's code's hash is the same. Clients should call `set_code` instead to update the state in a consistent way.
Already, it was only being called in testcases, which I modified to use `set_code` instead.

co-authored with codex-cli