### PR TITLE
Fix static_validate_ommers on ommers from a different rev

### DIFF
--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -58,6 +58,7 @@ enum class BlockError
     WrongMerkleRoot
 };
 
+struct Chain;
 struct Block;
 struct BlockHeader;
 
@@ -69,9 +70,10 @@ template <Traits traits>
 Result<void> static_validate_header(BlockHeader const &);
 
 template <Traits traits>
-Result<void> static_validate_block(Block const &);
+Result<void> static_validate_block(Chain const &chain, Block const &);
 
-Result<void> static_validate_block(evmc_revision, Block const &);
+Result<void>
+static_validate_block(evmc_revision, Chain const &chain, Block const &);
 
 Result<void>
 validate_output_header(BlockHeader const &input, BlockHeader const &output);

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -90,7 +90,7 @@ Result<void> process_ethereum_block(
 
     // Block input validation
     BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
     // Sender and authority recovery
     auto const sender_recovery_begin = std::chrono::steady_clock::now();

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -188,7 +188,7 @@ Result<BlockExecOutput> propose_block(
     // Block input validation
     BOOST_OUTCOME_TRY(static_validate_consensus_header(consensus_header));
     BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
     // Sender and EIP-7702 authorities recovery
     auto const sender_recovery_begin = std::chrono::steady_clock::now();

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -126,7 +126,7 @@ Result<void> process_monad_block(
 
     // Block input validation
     BOOST_OUTCOME_TRY(chain.static_validate_header(block.header));
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
     // Sender and authority recovery
     auto const sender_recovery_begin = std::chrono::steady_clock::now();

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -320,11 +320,11 @@ Result<BlockExecOutput> execute(
 {
     using namespace monad::test;
 
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(block));
+    TraitsMainnet<traits> const chain{};
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
 
     BlockState block_state(db, vm);
     BlockMetrics metrics;
-    TraitsMainnet<traits> const chain{};
     auto const recovered_senders = recover_senders(block.transactions, *pool_);
     auto const recovered_authorities =
         recover_authorities(block.transactions, *pool_);


### PR DESCRIPTION
Currently, `static_validate_ommers` validates each ommer header using the block's own `evmc_revision`. However, ommers can reference ancestor blocks that belong to a different revision. This means ommer headers are validated against the wrong revision's rules. 

This PR fixes this by resolving `traits` from the correct revision from the ommer's number and timestamp.