### PR TITLE
[monad] Reserve balance contract: `static constexpr` => `inline constexpr`

### DIFF
--- a/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
@@ -27,7 +27,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-static constexpr Address RESERVE_BALANCE_CA = Address{0x1001};
+inline constexpr Address RESERVE_BALANCE_CA = Address{0x1001};
 
 class ReserveBalanceContract
 {


### PR DESCRIPTION
The `RESERVE_BALANCE_CA` constant erroneously had internal linkage. This patch fixes the problem by replacing the `static` qualifier by `inline` to give the constant external linkage.