### PR TITLE
Fix compact_virtual_chunk_offset_t sentinel collision and remove overly restrictive assert

### DIFF
--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -367,8 +367,11 @@ namespace detail
                 auto *tail = at_(list.end);
                 uint32_t const insertion_count =
                     uint32_t(tail->insertion_count()) + 1;
+                // Strict less-than because MAX_COUNT is reserved for
+                // INVALID_VIRTUAL_OFFSET so that no valid virtual offset
+                // compacts to INVALID_COMPACT_VIRTUAL_OFFSET.
                 MONAD_ASSERT(
-                    insertion_count <= virtual_chunk_offset_t::MAX_COUNT,
+                    insertion_count < virtual_chunk_offset_t::MAX_COUNT,
                     "Chunk count overflow detected. The 20-bit address "
                     "space for chunk count has been exhausted. Please "
                     "perform a database reset. TODO: expand the address "

--- a/category/mpt/test/virtual_offset_test.cpp
+++ b/category/mpt/test/virtual_offset_test.cpp
@@ -50,3 +50,44 @@ TEST(VirtualOffsetTest, use_virtual_offset_as_map_key)
     ASSERT_TRUE(map.find(virtual_chunk_offset_t(2, 0, 0)) != map.end());
     EXPECT_EQ(map[virtual_chunk_offset_t(2, 0, 0)], 2);
 }
+
+TEST(VirtualOffsetTest, compact_conversion)
+{
+    // compact_virtual_chunk_offset_t truncates the low 16 bits of raw(),
+    // preserving count in the top 20 bits and the high 12 bits of offset.
+    virtual_chunk_offset_t const v1(5, 0x1234567, 0, 0);
+    compact_virtual_chunk_offset_t const c1(v1);
+    EXPECT_EQ(c1.get_count(), 5U);
+
+    // Two offsets differing only in the low 16 bits of raw() should
+    // compact to the same value.
+    virtual_chunk_offset_t const v2(5, 0x1230000, 0, 0);
+    virtual_chunk_offset_t const v3(5, 0x123FFFF, 0, 0);
+    compact_virtual_chunk_offset_t const c2(v2);
+    compact_virtual_chunk_offset_t const c3(v3);
+    EXPECT_EQ(c2, c3);
+
+    virtual_chunk_offset_t const v4(6, 0x1234567, 0, 0);
+    compact_virtual_chunk_offset_t const c4(v4);
+    EXPECT_NE(c1, c4);
+    EXPECT_EQ(c4.get_count(), 6U);
+
+    EXPECT_GT(c4, c1);
+
+    // spare and is_in_fast_list do not affect compact conversion.
+    virtual_chunk_offset_t const v5(5, 0x1234567, 1, 100);
+    compact_virtual_chunk_offset_t const c5(v5);
+    EXPECT_EQ(c1, c5);
+
+    // max virtual offset's compact representation collides with
+    // INVALID_COMPACT_VIRTUAL_OFFSET. This is why the insertion count assertion
+    // in db_metadata::append_() uses strict less-than to prevent
+    // insertion_count from reaching MAX_COUNT.
+    virtual_chunk_offset_t const v6(
+        virtual_chunk_offset_t::MAX_COUNT,
+        virtual_chunk_offset_t::MAX_OFFSET,
+        0,
+        0);
+    EXPECT_EQ(
+        compact_virtual_chunk_offset_t(v6), INVALID_COMPACT_VIRTUAL_OFFSET);
+}

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -759,25 +759,12 @@ calc_min_offsets(
     auto fast_ret = INVALID_COMPACT_VIRTUAL_OFFSET;
     auto slow_ret = INVALID_COMPACT_VIRTUAL_OFFSET;
     if (node_virtual_offset != INVALID_VIRTUAL_OFFSET) {
-        auto const truncated_offset =
-            compact_virtual_chunk_offset_t{node_virtual_offset};
-        if (node_virtual_offset.in_fast_list()) {
-            fast_ret = truncated_offset;
-        }
-        else {
-            slow_ret = truncated_offset;
-        }
+        auto &ret = node_virtual_offset.in_fast_list() ? fast_ret : slow_ret;
+        ret = compact_virtual_chunk_offset_t{node_virtual_offset};
     }
     for (unsigned i = 0; i < node.number_of_children(); ++i) {
         fast_ret = std::min(fast_ret, node.min_offset_fast(i));
         slow_ret = std::min(slow_ret, node.min_offset_slow(i));
-    }
-    // if ret is valid
-    if (fast_ret != INVALID_COMPACT_VIRTUAL_OFFSET) {
-        MONAD_ASSERT(fast_ret < (1u << 31));
-    }
-    if (slow_ret != INVALID_COMPACT_VIRTUAL_OFFSET) {
-        MONAD_ASSERT(slow_ret < (1u << 31));
     }
     return {fast_ret, slow_ret};
 }

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -158,6 +158,18 @@ void UpdateAuxImpl::append(chunk_list const list, uint32_t const idx) noexcept
         db_metadata_[0].main->free_capacity_add_(capacity);
         db_metadata_[1].main->free_capacity_add_(capacity);
     }
+    else {
+        auto const insertion_count = static_cast<uint32_t>(
+            db_metadata_[0].main->at(idx)->insertion_count());
+        if (insertion_count >= virtual_chunk_offset_t::MAX_COUNT * 9 / 10) {
+            LOG_WARNING_CFORMAT(
+                "Virtual offset space is running out "
+                "(insertion count: %u / %u). "
+                "Please perform a database reset.",
+                insertion_count,
+                (uint32_t)virtual_chunk_offset_t::MAX_COUNT);
+        }
+    }
 }
 
 void UpdateAuxImpl::remove(uint32_t const idx) noexcept


### PR DESCRIPTION
- Reserve `MAX_COUNT` for `INVALID_VIRTUAL_OFFSET` by changing the                                                                           
    `db_metadata::append_()` insertion count guard from `<=` to `<`.                                                                           
    A virtual offset at `MAX_COUNT`/`MAX_OFFSET` compacts to
    `INVALID_COMPACT_VIRTUAL_OFFSET`, so valid data must never reach
    `MAX_COUNT`.
 - Remove the overly restrictive `< (1u << 31)` asserts in
    `calc_min_offsets()` that were firing under stressnet load.
 - Simplify `calc_min_offsets()` readability.
 - Add test for `virtual_chunk_offset_t` to `compact_virtual_chunk_offset_t`
    conversion, including a case documenting the sentinel collision.

🤖 Generated with Claude Opus 4.6