### PR TITLE
Fix docker base image cache to be shared across branches

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -88,15 +88,6 @@ jobs:
         - name: Setup Docker Buildx
           uses: docker/setup-buildx-action@v3
 
-        - name: Build `base` stage
-          uses: docker/build-push-action@v5
-          with:
-            context: .
-            file: docker/Dockerfile
-            target: base
-            cache-from: type=gha,scope=base
-            cache-to: type=gha,scope=base,mode=max
-
         - name: Build `code_quality` stage
           uses: docker/build-push-action@v5
           with:

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -1,0 +1,35 @@
+name: Docker Base Image
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'docker/Dockerfile'
+      - 'scripts/ubuntu-build/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-base:
+    runs-on: ubuntu-24.04-32
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and cache `base` stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          ulimit: "memlock=-1:-1"
+          target: base
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,scope=base,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,16 +40,6 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build `base` stage
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/Dockerfile
-          ulimit: "memlock=-1:-1"
-          target: base
-          cache-from: type=gha,scope=base
-          cache-to: type=gha,scope=base,mode=max
-
       - run: cat /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
       - run: cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
       - run: sudo bash -c "echo 2048 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"

--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -92,15 +92,6 @@ jobs:
             - name: Setup Docker Buildx
               uses: docker/setup-buildx-action@v3
 
-            - name: Build `base` stage
-              uses: docker/build-push-action@v5
-              with:
-                context: .
-                file: docker/Dockerfile
-                target: base
-                cache-from: type=gha,scope=base
-                cache-to: type=gha,scope=base,mode=max
-
             - name: Build `build_and_test_vm` stage
               uses: docker/build-push-action@v5
               with:
@@ -145,15 +136,6 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Build `base` stage
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/Dockerfile
-          target: base
-          cache-from: type=gha,scope=base
-          cache-to: type=gha,scope=base,mode=max
 
       - name: Build `vm_fuzz` stage
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Only write to the GHA cache on main pushes so all branches share the same base image instead of each creating a separate copy.