### PR TITLE
[zkVM] Add RISC-V cross-compilation target

### DIFF
--- a/.github/workflows/test-zk.yml
+++ b/.github/workflows/test-zk.yml
@@ -1,0 +1,48 @@
+name: ZK Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >
+    ${{
+      (github.event_name == 'push' && format('push-{0}-zk-tests', github.ref))
+      || (github.event_name == 'pull_request' && format('pr-{0}-zk-tests', github.event.pull_request.number))
+      || (github.event_name == 'workflow_dispatch' && format('workflow-dispatch-{0}-zk-tests', github.run_id))
+      || format('{0}-zk-tests', github.run_id)
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    build:
+      name: Compile for RISC-V
+      runs-on: ubuntu-24.04-32
+      steps:
+      - name: Tell git to do submodules in parallel
+        run: |
+          git config --global submodule.fetchJobs "$(nproc)"
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build `build_zk` stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: build_zk
+          cache-from: |
+            type=gha,scope=zk
+            type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=zk

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### monad ignore
 
 build
+build-zkvm
 perf.data*
 scratch
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,45 +62,7 @@ include(cmake/test.cmake)
 
 set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 
-function(monad_compile_options target)
-  set_property(TARGET ${target} PROPERTY C_STANDARD 23)
-  set_property(TARGET ${target} PROPERTY C_STANDARD_REQUIRED ON)
-  set_property(TARGET ${target} PROPERTY CXX_STANDARD 23)
-  set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
-
-  target_compile_options(${target} PRIVATE -Wall -Wextra -Wconversion -Werror)
-  target_compile_definitions(${target} PUBLIC "_GNU_SOURCE")
-
-  target_compile_options(
-    ${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>)
-
-  target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Og>)
-
-  target_compile_definitions(${target} PUBLIC QUILL_ROOT_LOGGER_ONLY)
-
-  if(MONAD_COMPILER_TESTING)
-    target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_TESTING=1")
-    target_compile_definitions(${target} PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT=1")
-  endif()
-
-  if(MONAD_COMPILER_STATS)
-      target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_STATS=1")
-  endif()
-
-  if(MONAD_COMPILER_HOT_PATH_STATS)
-      target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_HOT_PATH_STATS=1")
-  endif()
-
-  target_compile_options(
-    ${target}
-    PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes=clang::no_sanitize>)
-
-  # this is needed to turn off ranges support in nlohmann_json, because the
-  # ranges standard header triggers a clang bug which is fixed in trunk but not
-  # currently available to us
-  # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=109647
-  target_compile_definitions(${target} PUBLIC "JSON_HAS_RANGES=0")
-endfunction()
+include(cmake/compile_options.cmake)
 
 find_package(Boost REQUIRED COMPONENTS context filesystem json CONFIG)
 find_package(PkgConfig REQUIRED)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ You can also run the full test suite in parallel with:
 CTEST_PARALLEL_LEVEL=$(nproc) ctest
 ```
 
+## Compiling zkVM binary
+
+To compile monad as a guest program for various zkVMs, such as ZisK or SP1, we need to use a riscv64 cross-compiler. The easiest way to do this is to use the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain) which includes newlib. The cmake build extracts only the needed libc objects (setjmp/longjmp) from the unmodified newlib; malloc and syscalls are weakly linked by the zkVM frameworks.
+
+```shell
+cmake -B build-zkvm -S zkvm/guest \
+   -DCMAKE_TOOLCHAIN_FILE=$PWD/category/core/toolchains/riscv64-elf.cmake \
+   -DRISCV_TOOLCHAIN_DIR="path/to/riscv_gcc" \
+   -DCMAKE_BUILD_TYPE=Release -GNinja
+```
+
+We can then build the static library:
+
+```shell
+cmake --build build-zkvm --target monad-zkvm --parallel
+```
+
 ## A tour of execution
 
 To understand how the source code is organized, you should start by reading

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(
   "small_prng.hpp"
   "spinlock.h"
   "srcloc.h"
+  "thread_local.h"
+  "throw.hpp"
   "tl_tid.c"
   "tl_tid.h"
   "detail/start_lifetime_as_polyfill.hpp"

--- a/category/core/runtime/uint128.hpp
+++ b/category/core/runtime/uint128.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
+#include <category/core/throw.hpp>
 
 #include <algorithm>
 #include <bit>
@@ -72,7 +73,7 @@ struct uint128_t
             constexpr size_t max_hex_digits = sizeof(uint128_t) * 2;
             size_t num_digits = 0;
             if (*p == '\0') {
-                throw std::invalid_argument(s);
+                MONAD_THROW(std::invalid_argument, s);
             }
             unsigned __int128 r = 0;
             while (*p != '\0') {
@@ -87,10 +88,10 @@ struct uint128_t
                     d = static_cast<uint8_t>(*p - 'A' + 10);
                 }
                 else {
-                    throw std::invalid_argument(s);
+                    MONAD_THROW(std::invalid_argument, s);
                 }
                 if (++num_digits > max_hex_digits) {
-                    throw std::out_of_range(s);
+                    MONAD_THROW(std::out_of_range, s);
                 }
                 r = (r << 4) | d;
                 ++p;
@@ -112,20 +113,20 @@ struct uint128_t
                  << 64) |
                 std::numeric_limits<uint64_t>::max();
             if (*p == '\0') {
-                throw std::invalid_argument(s);
+                MONAD_THROW(std::invalid_argument, s);
             }
             unsigned __int128 r = 0;
             while (*p != '\0') {
                 if (*p < '0' || *p > '9') {
-                    throw std::invalid_argument(s);
+                    MONAD_THROW(std::invalid_argument, s);
                 }
                 auto const digit = static_cast<uint8_t>(*p - '0');
                 if (r > max_before_mul10) {
-                    throw std::out_of_range(s);
+                    MONAD_THROW(std::out_of_range, s);
                 }
                 r *= 10;
                 if (r > uint128_max - digit) {
-                    throw std::out_of_range(s);
+                    MONAD_THROW(std::out_of_range, s);
                 }
                 r += digit;
                 ++p;

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -22,6 +22,7 @@
 #include <category/core/runtime/uint256/intrinsics.hpp>
 #include <category/core/runtime/uint256/portable.hpp>
 #include <category/core/runtime/uint256/types.hpp>
+#include <category/core/throw.hpp>
 
 #include <algorithm>
 #include <array>
@@ -1174,7 +1175,7 @@ inline constexpr uint8_t from_dec(char const chr)
     if (chr >= '0' && chr <= '9') {
         return static_cast<uint8_t>(chr - '0');
     }
-    throw std::invalid_argument("invalid digit");
+    MONAD_THROW(std::invalid_argument, "invalid digit");
 }
 
 [[gnu::always_inline]]
@@ -1220,30 +1221,30 @@ inline constexpr uint256_t uint256_t::from_string(char const *const str)
     if (ptr[0] == '0' && (ptr[1] == 'x' || ptr[1] == 'X')) {
         ptr += 2;
         if (*ptr == '\0') {
-            throw std::invalid_argument(str);
+            MONAD_THROW(std::invalid_argument, str);
         }
         size_t const max_digits = sizeof(uint256_t) * 2;
         while (auto const chr = *ptr++) {
             num_digits += 1;
             if (num_digits > max_digits) {
-                throw std::out_of_range(str);
+                MONAD_THROW(std::out_of_range, str);
             }
             result = (result << 4) | from_hex(chr);
         }
     }
     else {
         if (*ptr == '\0') {
-            throw std::invalid_argument(str);
+            MONAD_THROW(std::invalid_argument, str);
         }
         while (auto const chr = *ptr++) {
             num_digits += 1;
             if (result > MAX_MULTIPLIABLE_BY_10) {
-                throw std::out_of_range(str);
+                MONAD_THROW(std::out_of_range, str);
             }
             auto const digit = from_dec(chr);
             result = (truncating_mul(result, 10)) + digit;
             if (result < digit) {
-                throw std::out_of_range(str);
+                MONAD_THROW(std::out_of_range, str);
             }
         }
     }

--- a/category/core/thread_local.h
+++ b/category/core/thread_local.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,18 +15,7 @@
 
 #pragma once
 
-#include <category/core/thread_local.h>
-#include <category/vm/runtime/cached_allocator.hpp>
-
-namespace monad::vm::runtime
-{
-    struct EvmStackAllocatorMeta
-    {
-        using base_type = uint256_t;
-        static constexpr size_t size = 1024;
-        static constexpr size_t alignment = 32;
-        static MONAD_THREAD_LOCAL CachedAllocatorList cache_list;
-    };
-
-    using EvmStackAllocator = CachedAllocator<EvmStackAllocatorMeta>;
-}
+// Thread-local storage qualifier. Expands to `thread_local` on the host
+// build; the zkVM mirror leaves it empty since the bare-metal zkVM
+// environment is single-threaded.
+#define MONAD_THREAD_LOCAL thread_local

--- a/category/core/throw.hpp
+++ b/category/core/throw.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,18 +15,7 @@
 
 #pragma once
 
-#include <category/core/thread_local.h>
-#include <category/vm/runtime/cached_allocator.hpp>
-
-namespace monad::vm::runtime
-{
-    struct EvmStackAllocatorMeta
-    {
-        using base_type = uint256_t;
-        static constexpr size_t size = 1024;
-        static constexpr size_t alignment = 32;
-        static MONAD_THREAD_LOCAL CachedAllocatorList cache_list;
-    };
-
-    using EvmStackAllocator = CachedAllocator<EvmStackAllocatorMeta>;
-}
+// Throw a C++ exception. The zkVM mirror replaces this with
+// MONAD_ASSERT(false) since the bare-metal zkVM build is compiled with
+// -fno-exceptions.
+#define MONAD_THROW(exc, msg) throw exc(msg)

--- a/category/core/toolchains/riscv64-elf.cmake
+++ b/category/core/toolchains/riscv64-elf.cmake
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Configurable toolchain directory — pass -DRISCV_TOOLCHAIN_DIR=<path> to cmake.
+set(RISCV_TOOLCHAIN_DIR "/opt/riscv" CACHE PATH "RISC-V toolchain directory")
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES RISCV_TOOLCHAIN_DIR)
+
+if(EXISTS "${RISCV_TOOLCHAIN_DIR}/bin/riscv64-unknown-elf-gcc")
+    set(RISCV_PREFIX "riscv64-unknown-elf-")
+else()
+    message(FATAL_ERROR "No riscv64 gcc found in ${RISCV_TOOLCHAIN_DIR}/bin/")
+endif()
+
+set(CMAKE_C_COMPILER "${RISCV_TOOLCHAIN_DIR}/bin/${RISCV_PREFIX}gcc")
+set(CMAKE_CXX_COMPILER "${RISCV_TOOLCHAIN_DIR}/bin/${RISCV_PREFIX}g++")
+set(CMAKE_AR "${RISCV_TOOLCHAIN_DIR}/bin/${RISCV_PREFIX}ar")
+set(CMAKE_RANLIB "${RISCV_TOOLCHAIN_DIR}/bin/${RISCV_PREFIX}ranlib")
+
+set(CMAKE_C_FLAGS_INIT
+    "-march=rv64ima -mabi=lp64 -mcmodel=medany -nostartfiles -nostdlib -ffunction-sections -fdata-sections")
+set(CMAKE_CXX_FLAGS_INIT
+    "-march=rv64ima -mabi=lp64 -mcmodel=medany -nostartfiles -nostdlib++ -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections")
+set(CMAKE_ASM_FLAGS_INIT "-march=rv64ima -mabi=lp64")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -27,7 +27,7 @@
 #include <category/vm/runtime/math.hpp>
 #include <category/vm/runtime/math/intrinsics.hpp>
 #include <category/vm/runtime/storage.hpp>
-#include <category/vm/runtime/transmute.hpp>
+#include <category/vm/runtime/transmute/intrinsics.hpp>
 #include <category/vm/runtime/types.hpp>
 #include <category/vm/utils/debug.hpp>
 

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -25,6 +25,7 @@
 #include <category/vm/compiler/types.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 #include <category/vm/runtime/math.hpp>
+#include <category/vm/runtime/math/intrinsics.hpp>
 #include <category/vm/runtime/storage.hpp>
 #include <category/vm/runtime/transmute.hpp>
 #include <category/vm/runtime/types.hpp>

--- a/category/vm/interpreter/CMakeLists.txt
+++ b/category/vm/interpreter/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(monad-vm-interpreter PRIVATE
   "intercode.hpp"
   "push.hpp"
   "stack.hpp"
+  "trampoline.hpp"
   "types.hpp"
 )
 

--- a/category/vm/interpreter/execute.cpp
+++ b/category/vm/interpreter/execute.cpp
@@ -19,21 +19,10 @@
 #include <category/vm/interpreter/debug.hpp>
 #include <category/vm/interpreter/instruction_table.hpp>
 #include <category/vm/interpreter/intercode.hpp>
+#include <category/vm/interpreter/trampoline.hpp>
 #include <category/vm/runtime/types.hpp>
-#include <category/vm/utils/traits.hpp>
 
 #include <cstdint>
-
-/**
- * Assembly trampoline into the interpreter's core loop (see entry.S). This
- * function sets up the stack to be compatible with the runtime's exit ABI, then
- * jumps to `core_loop<traits>`. It is therefore important that these two
- * functions always maintain the same signature (so that arguments are in the
- * expected registers when jumping to the core loop).
- */
-extern "C" void monad_vm_interpreter_trampoline(
-    void *, ::monad::vm::runtime::Context *,
-    ::monad::vm::interpreter::Intercode const *, monad::uint256_t *, void *);
 
 namespace monad::vm::interpreter
 {
@@ -44,12 +33,6 @@ namespace monad::vm::interpreter
             void *, runtime::Context *ctx, Intercode const *analysis,
             uint256_t *stack_ptr, void *)
         {
-            static_assert(
-                utils::same_signature(
-                    monad_vm_interpreter_trampoline, core_loop<traits>),
-                "Interpreter core loop and trampoline signatures must be "
-                "identical");
-
             auto *const stack_top = stack_ptr - 1;
             auto const *const stack_bottom = stack_top;
             auto const *const instr_ptr = analysis->code();
@@ -72,12 +55,11 @@ namespace monad::vm::interpreter
     void execute(
         runtime::Context &ctx, Intercode const &analysis, uint8_t *stack_ptr)
     {
-        monad_vm_interpreter_trampoline(
-            static_cast<void *>(&ctx.exit_stack_ptr),
-            &ctx,
-            &analysis,
+        trampoline(
+            ctx,
+            analysis,
             reinterpret_cast<uint256_t *>(stack_ptr),
-            reinterpret_cast<void *>(core_loop<traits>));
+            core_loop<traits>);
     }
 
     EXPLICIT_TRAITS(execute);

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -437,7 +437,7 @@ namespace monad::vm::interpreter
         int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MUL, traits>(
-            monad_vm_runtime_mul,
+            runtime::mul,
             ctx,
             analysis,
             stack_bottom,

--- a/category/vm/interpreter/push.hpp
+++ b/category/vm/interpreter/push.hpp
@@ -26,7 +26,9 @@
 
 #include <evmc/evmc.h>
 
-#include <immintrin.h>
+#ifdef __AVX2__
+    #include <immintrin.h>
+#endif
 
 #include <bit>
 #include <cstdint>

--- a/category/vm/interpreter/trampoline.hpp
+++ b/category/vm/interpreter/trampoline.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Host trampoline: assembly entry-point (entry.S) sets up the exit-resume
+// frame and jumps to the supplied core_loop instantiation. The inline
+// wrapper below gives the call site a single typed entry point so the
+// zkVM mirror can substitute an inline setjmp-based variant.
+
+#pragma once
+
+#include <category/core/runtime/uint256.hpp>
+#include <category/vm/interpreter/intercode.hpp>
+#include <category/vm/runtime/types.hpp>
+#include <category/vm/utils/traits.hpp>
+
+// Implemented in entry.S.
+extern "C" void monad_vm_interpreter_trampoline(
+    void *, ::monad::vm::runtime::Context *,
+    ::monad::vm::interpreter::Intercode const *, monad::uint256_t *, void *);
+
+namespace monad::vm::interpreter
+{
+    using core_loop_fn_t = void (*)(
+        void *, runtime::Context *, Intercode const *, uint256_t *, void *);
+
+    static_assert(
+        utils::same_signature(
+            &monad_vm_interpreter_trampoline,
+            static_cast<core_loop_fn_t>(nullptr)),
+        "Interpreter core loop and trampoline signatures must be "
+        "identical");
+
+    [[gnu::always_inline]]
+    inline void trampoline(
+        runtime::Context &ctx, Intercode const &analysis,
+        uint256_t *const stack_ptr, core_loop_fn_t core_loop_fn)
+    {
+        monad_vm_interpreter_trampoline(
+            static_cast<void *>(&ctx.exit_stack_ptr),
+            &ctx,
+            &analysis,
+            stack_ptr,
+            reinterpret_cast<void *>(core_loop_fn));
+    }
+}

--- a/category/vm/runtime/CMakeLists.txt
+++ b/category/vm/runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(monad-vm-runtime PRIVATE
     "log.cpp"
     "math.S"
     "math.hpp"
+    "math/intrinsics.hpp"
     "memory.hpp"
     "runtime.hpp"
     "selfdestruct.hpp"

--- a/category/vm/runtime/CMakeLists.txt
+++ b/category/vm/runtime/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(monad-vm-runtime PRIVATE
     "storage_costs.hpp"
     "transmute.S"
     "transmute.hpp"
+    "transmute/intrinsics.hpp"
     "types.hpp"
 )
 

--- a/category/vm/runtime/CMakeLists.txt
+++ b/category/vm/runtime/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(monad-vm-runtime PRIVATE
     "environment.hpp"
     "environment.cpp"
     "exit.S"
+    "exit.hpp"
     "exit.cpp"
     "keccak.hpp"
     "log.hpp"

--- a/category/vm/runtime/allocator.cpp
+++ b/category/vm/runtime/allocator.cpp
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/thread_local.h>
 #include <category/vm/runtime/allocator.hpp>
 #include <category/vm/runtime/cached_allocator.hpp>
 
 namespace monad::vm::runtime
 {
-    thread_local CachedAllocatorList EvmStackAllocatorMeta::cache_list;
+    MONAD_THREAD_LOCAL CachedAllocatorList EvmStackAllocatorMeta::cache_list;
 }

--- a/category/vm/runtime/exit.cpp
+++ b/category/vm/runtime/exit.cpp
@@ -13,15 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/vm/runtime/exit.hpp>
 #include <category/vm/runtime/types.hpp>
-
-extern "C" void monad_vm_runtime_exit [[noreturn]] (void *);
 
 extern "C" void monad_vm_runtime_context_out_of_gas_exit
     [[noreturn]] (monad::vm::runtime::Context *const ctx)
 {
     ctx->result.status = monad::vm::runtime::StatusCode::OutOfGas;
-    monad_vm_runtime_exit(ctx->exit_stack_ptr);
+    monad::vm::runtime::exit(ctx->exit_stack_ptr);
 }
 
 namespace monad::vm::runtime
@@ -30,12 +29,12 @@ namespace monad::vm::runtime
     {
         is_stack_unwinding_active = true;
         result.status = StatusCode::Error;
-        monad_vm_runtime_exit(exit_stack_ptr);
+        ::monad::vm::runtime::exit(exit_stack_ptr);
     }
 
     void Context::exit [[noreturn]] (StatusCode const code) noexcept
     {
         result.status = code;
-        monad_vm_runtime_exit(exit_stack_ptr);
+        ::monad::vm::runtime::exit(exit_stack_ptr);
     }
 }

--- a/category/vm/runtime/exit.hpp
+++ b/category/vm/runtime/exit.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Host unwind primitive. On the host build the actual implementation is
+// the hand-rolled assembly in exit.S; the inline `exit` wrapper here
+// gives call sites a single typed entry point so the zkVM mirror can
+// supply an inline setjmp/longjmp variant without any extern call.
+
+#pragma once
+
+namespace monad::vm::runtime
+{
+    using exit_stack_ptr_t = void *;
+}
+
+extern "C" void monad_vm_runtime_exit
+    [[noreturn]] (monad::vm::runtime::exit_stack_ptr_t);
+
+namespace monad::vm::runtime
+{
+    [[gnu::always_inline, noreturn]]
+    inline void exit(exit_stack_ptr_t p)
+    {
+        monad_vm_runtime_exit(p);
+    }
+}

--- a/category/vm/runtime/math.hpp
+++ b/category/vm/runtime/math.hpp
@@ -18,28 +18,13 @@
 #include <category/core/assert.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/traits.hpp>
+#include <category/vm/runtime/math/intrinsics.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <evmc/evmc.hpp>
 
-// It is assumed that if the `result` pointer overlaps with `left` and/or
-// `right`, then `result` pointer is equal to `left` and/or `right`.
-extern "C" void monad_vm_runtime_mul(
-    monad::uint256_t *result, monad::uint256_t const *left,
-    monad::uint256_t const *right) noexcept;
-
-// It is assumed that if the `result` pointer overlaps with `left` and/or
-// `right`, then `result` pointer is equal to `left` and/or `right`.
-extern "C" void monad_vm_runtime_mul_192(
-    monad::uint256_t *result, monad::uint256_t const *left,
-    monad::uint256_t const *right) noexcept;
-
 namespace monad::vm::runtime
 {
-    constexpr void (*mul)(
-        uint256_t *, uint256_t const *,
-        uint256_t const *) noexcept = monad_vm_runtime_mul;
-
     constexpr void udiv(
         uint256_t *const result_ptr, uint256_t const *const a_ptr,
         uint256_t const *const b_ptr) noexcept

--- a/category/vm/runtime/math/intrinsics.hpp
+++ b/category/vm/runtime/math/intrinsics.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Platform-specific `mul` for the runtime math interface. The host build
+// links the hand-rolled x86 assembly via the extern declarations below.
+
+#pragma once
+
+#include <category/core/runtime/uint256.hpp>
+
+// It is assumed that if the `result` pointer overlaps with `left` and/or
+// `right`, then `result` pointer is equal to `left` and/or `right`.
+extern "C" void monad_vm_runtime_mul(
+    monad::uint256_t *result, monad::uint256_t const *left,
+    monad::uint256_t const *right) noexcept;
+
+// It is assumed that if the `result` pointer overlaps with `left` and/or
+// `right`, then `result` pointer is equal to `left` and/or `right`.
+extern "C" void monad_vm_runtime_mul_192(
+    monad::uint256_t *result, monad::uint256_t const *left,
+    monad::uint256_t const *right) noexcept;
+
+namespace monad::vm::runtime
+{
+    constexpr void (*mul)(
+        uint256_t *, uint256_t const *,
+        uint256_t const *) noexcept = monad_vm_runtime_mul;
+}

--- a/category/vm/runtime/transmute.hpp
+++ b/category/vm/runtime/transmute.hpp
@@ -20,39 +20,16 @@
 #include <category/core/bytes.hpp>
 #include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
+#include <category/vm/runtime/transmute/intrinsics.hpp>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
-
-#include <immintrin.h>
-
-// Load `load_size` bytes from `src_buffer` and clear the remaining upper bytes
-// of the result. It is required that `load_size <= 32`. If `load_size <= 0`
-// then zero is returned.
-extern "C" __m256i
-monad_vm_runtime_load_bounded_le(uint8_t const *src_buffer, int64_t load_size);
-
-// Note: monad_vm_runtime_load_bounded_le_raw uses non-standard
-// calling convention. See transmute.S. Use the
-// monad_vm_runtime_load_bounded_le function for a version
-// using standard calling convention.
-extern "C" __m256i monad_vm_runtime_load_bounded_le_raw();
 
 namespace monad::vm::runtime
 {
     static_assert(sizeof(evmc_address) == 20);
     static_assert(sizeof(bytes32_t) == 32);
     static_assert(sizeof(uint256_t) == 32);
-
-    [[gnu::always_inline]]
-    inline uint256_t
-    uint256_load_bounded_le(uint8_t const *const bytes, int64_t const max_len)
-    {
-        if (MONAD_LIKELY(max_len >= 32)) {
-            return load_le_unsafe<uint256_t>(bytes);
-        }
-        return uint256_t{monad_vm_runtime_load_bounded_le(bytes, max_len)};
-    }
 
     [[gnu::always_inline]]
     inline uint256_t

--- a/category/vm/runtime/transmute/intrinsics.hpp
+++ b/category/vm/runtime/transmute/intrinsics.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Host (AVX2) implementation of the runtime transmute primitive
+// uint256_load_bounded_le, backed by hand-rolled x86 assembly in
+// transmute.S.
+
+#pragma once
+
+#include <category/core/int.hpp>
+#include <category/core/likely.h>
+#include <category/core/runtime/uint256.hpp>
+
+#include <immintrin.h>
+
+// Load `load_size` bytes from `src_buffer` and clear the remaining upper bytes
+// of the result. It is required that `load_size <= 32`. If `load_size <= 0`
+// then zero is returned.
+extern "C" __m256i
+monad_vm_runtime_load_bounded_le(uint8_t const *src_buffer, int64_t load_size);
+
+// Note: monad_vm_runtime_load_bounded_le_raw uses non-standard
+// calling convention. See transmute.S. Use the
+// monad_vm_runtime_load_bounded_le function for a version
+// using standard calling convention.
+extern "C" __m256i monad_vm_runtime_load_bounded_le_raw();
+
+namespace monad::vm::runtime
+{
+    [[gnu::always_inline]]
+    inline uint256_t
+    uint256_load_bounded_le(uint8_t const *const bytes, int64_t const max_len)
+    {
+        if (MONAD_LIKELY(max_len >= 32)) {
+            return load_le_unsafe<uint256_t>(bytes);
+        }
+        return uint256_t{monad_vm_runtime_load_bounded_le(bytes, max_len)};
+    }
+}

--- a/category/vm/runtime/types.hpp
+++ b/category/vm/runtime/types.hpp
@@ -22,6 +22,7 @@
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/bin.hpp>
+#include <category/vm/runtime/exit.hpp>
 #include <category/vm/runtime/transmute.hpp>
 
 #include <evmc/evmc.hpp>
@@ -244,7 +245,7 @@ namespace monad::vm::runtime
 
         Memory memory;
 
-        void *exit_stack_ptr = nullptr;
+        exit_stack_ptr_t exit_stack_ptr = nullptr;
         bool is_stack_unwinding_active = false;
 
         [[gnu::always_inline]]

--- a/cmake/compile_options.cmake
+++ b/cmake/compile_options.cmake
@@ -1,0 +1,55 @@
+# Copyright (C) 2025 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function(monad_compile_options target)
+  set_property(TARGET ${target} PROPERTY C_STANDARD 23)
+  set_property(TARGET ${target} PROPERTY C_STANDARD_REQUIRED ON)
+  set_property(TARGET ${target} PROPERTY CXX_STANDARD 23)
+  set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
+
+  target_compile_options(${target} PRIVATE -Wall -Wextra -Wconversion -Werror)
+  target_compile_definitions(${target} PUBLIC "_GNU_SOURCE")
+
+  target_compile_options(
+    ${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>)
+
+  target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Og>)
+
+  target_compile_definitions(${target} PUBLIC QUILL_ROOT_LOGGER_ONLY)
+
+  if(MONAD_COMPILER_TESTING)
+    target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_TESTING=1")
+    target_compile_definitions(${target} PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT=1")
+  endif()
+
+  if(MONAD_COMPILER_STATS)
+      target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_STATS=1")
+  endif()
+
+  if(MONAD_COMPILER_HOT_PATH_STATS)
+      target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_HOT_PATH_STATS=1")
+  endif()
+
+  target_compile_options(
+    ${target}
+    PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes=clang::no_sanitize>)
+
+  # this is needed to turn off ranges support in nlohmann_json, because the
+  # ranges standard header triggers a clang bug which is fixed in trunk but not
+  # currently available to us
+  # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=109647
+  target_compile_definitions(${target} PUBLIC "JSON_HAS_RANGES=0")
+
+endfunction()

--- a/cmake/zkvm.cmake
+++ b/cmake/zkvm.cmake
@@ -1,0 +1,62 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Helpers used by zkvm/CMakeLists.txt. Expects MONAD_ROOT to be set by the
+# caller before invoking the functions below that use it.
+
+# Apply the zkVM-specific compile options (warning suppressions, mirror
+# include path, preprocessor definitions) to a target that has already had
+# monad_compile_options applied.
+function(monad_zkvm_compile_options target)
+    # GCC 15+ checks uninstantiated template bodies for errors
+    # (-Wtemplate-body). This fires on constexpr-guarded AVX2 code paths
+    # that are never instantiated on non-x86 targets.
+    target_compile_options(
+        ${target} PRIVATE
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-template-body>)
+
+    target_include_directories(${target} BEFORE PUBLIC "${ZKVM_INCLUDE_DIR}")
+    target_include_directories(${target} PUBLIC "${MONAD_ROOT}")
+
+    # NDEBUG: bare-metal zkVM has no libc, so __assert_func is missing.
+    # _GLIBCXX_HAVE_ALIGNED_ALLOC: tells libstdc++ that our libc shim
+    # (zkvm/core/libc.cpp) provides aligned_alloc; without it,
+    # <cstdlib> does not expose std::aligned_alloc under newlib.
+    target_compile_definitions(${target} PUBLIC
+        NDEBUG _GLIBCXX_HAVE_ALIGNED_ALLOC
+        "MONAD_ZKVM_${_ZKVM_BACKEND_UPPER}")
+endfunction()
+
+# Remove entries from a target's SOURCES whose path ends with one of the
+# given patterns. Used to strip host-only files (e.g. x86 assembly) from
+# targets that are otherwise shared with the host build.
+function(monad_zkvm_drop_sources target)
+    get_target_property(_srcs ${target} SOURCES)
+    set(_kept "")
+    foreach(s ${_srcs})
+        set(_drop OFF)
+        foreach(pat ${ARGN})
+            if(s MATCHES "(^|/)${pat}$")
+                set(_drop ON)
+                break()
+            endif()
+        endforeach()
+        if(NOT _drop)
+            list(APPEND _kept "${s}")
+        endif()
+    endforeach()
+    set_property(TARGET ${target} PROPERTY SOURCES ${_kept})
+endfunction()
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,38 @@ RUN cd src/rust && cargo check --all-targets --all-features
 RUN cd src/rust && cargo doc --all-features --no-deps
 RUN cd src/rust && cargo test --release --doc --all-features
 
+FROM base AS base_riscv_gnu_toolchain
+
+COPY scripts/ubuntu-build/ /opt
+RUN apt-get update && \
+    /opt/install-riscv-deps.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    rm -rf /opt
+
+RUN git clone --depth 1 --branch 2026.06.06 https://github.com/riscv-collab/riscv-gnu-toolchain /riscv-gnu-toolchain
+WORKDIR /riscv-gnu-toolchain
+
+RUN ./configure --prefix=/root/riscv \
+    --with-arch=rv64ima \
+    --with-abi=lp64
+    
+RUN make -j$(nproc)
+
+ENV PATH="/root/riscv/bin:${PATH}"
+
+WORKDIR /
+
+FROM base_riscv_gnu_toolchain AS build_zk
+
+COPY . src
+
+RUN cd src && cmake -B build-zkvm -S zkvm/guest \
+    -DCMAKE_TOOLCHAIN_FILE=/src/category/core/toolchains/riscv64-elf.cmake \
+    -DRISCV_TOOLCHAIN_DIR=/root/riscv \
+    -DCMAKE_BUILD_TYPE=Release
+RUN cd src && cmake --build build-zkvm --target monad-zkvm --parallel
+
 FROM base AS vm_fuzz
 
 RUN apt-get update && apt-get install -y tmux

--- a/scripts/apply-clang-format.sh
+++ b/scripts/apply-clang-format.sh
@@ -8,5 +8,8 @@ root_dir="$(realpath "$script_dir/..")"
 # Only format unignored files.
 cd "${root_dir}"
 rg --files -0 -g '*.hpp' -g '*.cpp' -g '*.c' -g '*.h' \
-  category cmd test \
+  "${root_dir}/category" \
+  "${root_dir}/cmd" \
+  "${root_dir}/test" \
+  "${root_dir}/zkvm" \
   | xargs -0 -r clang-format-19 -i

--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -56,7 +56,8 @@ mapfile -d '' -t inputs < <(\
     category/core  \
     category/mpt   \
     category/rpc   \
-    category/vm)
+    category/vm    \
+    zkvm)
 
 "${RUN_CLANG_TIDY}"                               \
   "${inputs[@]}"                                  \

--- a/scripts/ubuntu-build/install-riscv-deps.sh
+++ b/scripts/ubuntu-build/install-riscv-deps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+packages=(
+  autoconf
+  automake
+  autotools-dev
+  bc
+  bison
+  build-essential
+  cmake
+  curl
+  flex
+  gawk
+  git
+  gperf
+  libexpat-dev
+  libglib2.0-dev
+  libgmp-dev
+  libmpc-dev
+  libmpfr-dev
+  libncurses-dev
+  libslirp-dev
+  libtool
+  ninja-build
+  patchutils
+  python3
+  python3-pip
+  python3-tomli
+  texinfo
+  zlib1g-dev
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"

--- a/scripts/ubuntu-build/install-zisk-deps.sh
+++ b/scripts/ubuntu-build/install-zisk-deps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+packages=(
+  build-essential
+  clang
+  curl
+  jq
+  libclang-dev
+  libgmp-dev
+  libgrpc++-dev
+  libomp-dev
+  libopenmpi-dev
+  libpqxx-dev
+  libsecp256k1-dev
+  libsodium-dev
+  nasm
+  nlohmann-json3-dev
+  openmpi-bin
+  openmpi-common
+  protobuf-compiler
+  qemu-system
+  uuid-dev
+  xz-utils
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"

--- a/zkvm/category/core/runtime/non_temporal_memory.hpp
+++ b/zkvm/category/core/runtime/non_temporal_memory.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,5 +15,19 @@
 
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace monad::vm::runtime
+{
+    inline void non_temporal_bzero(void *dest, size_t n)
+    {
+        std::memset(dest, 0, n);
+    }
+
+    inline void non_temporal_memcpy(void *dest, void const *src, size_t n)
+    {
+        std::memcpy(dest, src, n);
+    }
+}

--- a/zkvm/category/core/runtime/uint256/intrinsics.hpp
+++ b/zkvm/category/core/runtime/uint256/intrinsics.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/runtime/uint256/portable.hpp>
+#include <category/core/runtime/uint256/types.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+// zkVM (RISC-V) replacement for the AVX2/BMI2 x86 intrinsics. RISC-V has no
+// specialised instructions (mulx, shld, shrd, div, addc/subb) corresponding
+// to the x86 backend, so we re-export the portable implementations as the
+// intrinsics implementations.
+
+namespace monad::uint256::intrinsics
+{
+    using portable::addc;
+    using portable::div;
+    using portable::mulx;
+    using portable::shld;
+    using portable::shrd;
+    using portable::subb;
+    using portable::truncating_mul;
+
+    [[gnu::always_inline]] constexpr inline uint64_t
+    force(uint64_t const expr) noexcept
+    {
+        return expr;
+    }
+}

--- a/zkvm/category/core/thread_local.h
+++ b/zkvm/category/core/thread_local.h
@@ -15,5 +15,6 @@
 
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+// zkVM mirror: bare-metal zkVM is single-threaded, so MONAD_THREAD_LOCAL
+// expands to nothing.
+#define MONAD_THREAD_LOCAL

--- a/zkvm/category/core/throw.hpp
+++ b/zkvm/category/core/throw.hpp
@@ -15,5 +15,9 @@
 
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+// zkVM mirror: exceptions are disabled (-fno-exceptions) on the bare-metal
+// zkVM build, so MONAD_THROW falls back to zkvm_halt(1), which must always
+// be marked as noreturn to preserve throw control flow behavior.
+#include <zkvm/core/zkvm_halt.h>
+
+#define MONAD_THROW(exc, msg) zkvm_halt(1)

--- a/zkvm/category/vm/interpreter/debug.hpp
+++ b/zkvm/category/vm/interpreter/debug.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,5 +15,24 @@
 
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/traits.hpp>
+#include <category/vm/interpreter/intercode.hpp>
+#include <category/vm/runtime/types.hpp>
+
+#include <evmc/evmc.h>
+
+namespace monad::vm::interpreter
+{
+    constexpr auto debug_enabled = false;
+
+    // No-op trace under the bare-metal zkVM environment, where there is
+    // no stderr to write to.
+    [[gnu::always_inline]]
+    inline void trace(
+        [[maybe_unused]] Intercode const &analysis,
+        [[maybe_unused]] int64_t const gas_remaining,
+        [[maybe_unused]] uint8_t const *const instr_ptr)
+    {
+    }
+}

--- a/zkvm/category/vm/interpreter/trampoline.hpp
+++ b/zkvm/category/vm/interpreter/trampoline.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// zkVM mirror: the trampoline is implemented inline with setjmp/longjmp instead
+// of via the host's hand-rolled assembly (entry.S). GCC forbids inlining
+// functions that use setjmp so for now we cannot guarantee that the jmp_buf
+// lives on the caller's stack frame.
+//
+// longjmp from monad::vm::runtime::exit lands back here and we return.
+
+#pragma once
+
+#include <category/core/runtime/uint256.hpp>
+#include <category/vm/interpreter/intercode.hpp>
+#include <category/vm/runtime/types.hpp>
+
+#include <csetjmp>
+
+namespace monad::vm::interpreter
+{
+    using core_loop_fn_t = void (*)(
+        void *, runtime::Context *, Intercode const *, uint256_t *, void *);
+
+    // No [[gnu::always_inline]] here — GCC forbids inlining functions
+    // that call setjmp. The optimizer may still inline opportunistically.
+    inline void trampoline(
+        runtime::Context &ctx, Intercode const &analysis,
+        uint256_t *const stack_ptr, core_loop_fn_t core_loop_fn)
+    {
+        std::jmp_buf jb;
+        if (setjmp(jb) == 0) {
+            ctx.exit_stack_ptr = &jb;
+            core_loop_fn(nullptr, &ctx, &analysis, stack_ptr, nullptr);
+        }
+    }
+}

--- a/zkvm/category/vm/runtime/exit.hpp
+++ b/zkvm/category/vm/runtime/exit.hpp
@@ -13,7 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// zkVM mirror: the unwind path is implemented inline with setjmp/longjmp
+// rather than via the host's hand-rolled asm trampoline (see exit.S).
+
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <csetjmp>
+
+namespace monad::vm::runtime
+{
+    using exit_stack_ptr_t = std::jmp_buf *;
+
+    [[gnu::always_inline, noreturn]]
+    inline void exit(exit_stack_ptr_t p)
+    {
+        std::longjmp(*p, 1);
+    }
+}

--- a/zkvm/category/vm/runtime/math/intrinsics.hpp
+++ b/zkvm/category/vm/runtime/math/intrinsics.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,7 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// zkVM fallback for the runtime math `mul`: uses the in-tree uint256
+// operator overload rather than the hand-rolled x86 assembly.
+
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <category/core/runtime/uint256.hpp>
+
+namespace monad::vm::runtime
+{
+    inline void
+    mul(uint256_t *result_ptr, uint256_t const *a_ptr,
+        uint256_t const *b_ptr) noexcept
+    {
+        *result_ptr = *a_ptr * *b_ptr;
+    }
+}

--- a/zkvm/category/vm/runtime/transmute/intrinsics.hpp
+++ b/zkvm/category/vm/runtime/transmute/intrinsics.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,7 +13,30 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// zkVM fallback for uint256_load_bounded_le: memcpy-based, no AVX
+// intrinsics and no asm dependency.
+
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <category/core/runtime/uint256.hpp>
+
+#include <algorithm>
+#include <cstring>
+
+namespace monad::vm::runtime
+{
+    [[gnu::always_inline]]
+    inline uint256_t
+    uint256_load_bounded_le(uint8_t const *const bytes, int64_t const max_len)
+    {
+        uint256_t v{0};
+        if (max_len <= 0) {
+            return v;
+        }
+        std::memcpy(
+            as_bytes(v),
+            bytes,
+            std::min(max_len, static_cast<int64_t>(uint256_t::num_bytes)));
+        return v;
+    }
+}

--- a/zkvm/core/libc.cpp
+++ b/zkvm/core/libc.cpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Minimal C library functions for bare-metal zkVM.
+// The zkVM environment uses a bump allocator — free is a no-op.
+
+#include <zkvm/core/libc.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+extern "C"
+{
+
+void *malloc(std::size_t size)
+{
+    if (size == 0) {
+        return nullptr;
+    }
+    return sys_alloc_aligned(size, 16);
+}
+
+void free(void *ptr)
+{
+    // Bump allocator — no deallocation.
+    (void)ptr;
+}
+
+void *calloc(std::size_t num, std::size_t size)
+{
+    std::size_t total;
+    if (__builtin_mul_overflow(num, size, &total)) {
+        return nullptr;
+    }
+    void *ptr = malloc(total);
+    if (ptr) {
+        std::memset(ptr, 0, total);
+    }
+    return ptr;
+}
+
+void *aligned_alloc(std::size_t alignment, std::size_t size)
+{
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+        return nullptr;
+    }
+    if (size % alignment != 0) {
+        return nullptr;
+    }
+    return sys_alloc_aligned(size, alignment);
+}
+
+} // extern "C"

--- a/zkvm/core/libc.hpp
+++ b/zkvm/core/libc.hpp
@@ -15,5 +15,8 @@
 
 #pragma once
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#include <cstddef>
+
+// sys_alloc_aligned(bytes, align) is supplied by the backend's Rust
+// entrypoint crate (ziskos for ZisK, sp1-zkvm for SP1) at link time.
+extern "C" void *sys_alloc_aligned(std::size_t bytes, std::size_t align);

--- a/zkvm/core/libstdcxx.cpp
+++ b/zkvm/core/libstdcxx.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Minimal C++ runtime stubs for bare-metal zkVM.
+
+#include <zkvm/core/libc.hpp>
+#include <zkvm/core/zkvm_halt.h>
+
+#include <cstddef>
+
+// operator new / delete
+[[gnu::always_inline]] static inline void *alloc_or_exit(std::size_t size)
+{
+    if (size == 0) {
+        size = 1;
+    }
+    void *ptr = sys_alloc_aligned(size, 16);
+    if (!ptr) {
+        zkvm_halt(1);
+    }
+    return ptr;
+}
+
+void *operator new(std::size_t size)
+{
+    return alloc_or_exit(size);
+}
+
+void *operator new[](std::size_t size)
+{
+    return alloc_or_exit(size);
+}
+
+void operator delete(void *) noexcept {}
+
+void operator delete[](void *) noexcept {}
+
+void operator delete(void *, std::size_t) noexcept {}
+
+void operator delete[](void *, std::size_t) noexcept {}
+
+namespace std
+{
+    [[noreturn]] void terminate() noexcept
+    {
+        zkvm_halt(1);
+    }
+}
+
+// Static-storage-duration destructors get registered through __cxa_atexit
+// at construction time. The bare-metal zkVM exits via syscall_halt and
+// never runs these callbacks, so the registration itself is a no-op.
+// __dso_handle is referenced by __cxa_atexit calls the compiler emits.
+extern "C"
+{
+void *__dso_handle = nullptr;
+
+int __cxa_atexit(void (*)(void *), void *, void *)
+{
+    return 0;
+}
+}

--- a/zkvm/core/zkvm_halt.h
+++ b/zkvm/core/zkvm_halt.h
@@ -13,7 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#pragma once
+#ifndef ZKVM_HALT_H
+#define ZKVM_HALT_H
 
-// Throw a C++ exception
-#define MONAD_THROW(exc, msg) throw exc(msg)
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+[[noreturn]] void zkvm_halt(int status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ZKVM_HALT_H

--- a/zkvm/guest/CMakeLists.txt
+++ b/zkvm/guest/CMakeLists.txt
@@ -1,0 +1,159 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Standalone CMake project that builds the Monad VM components for zkVM
+# targets. Produces libmonad-zkvm.a without requiring the full monad
+# dependency tree (no TBB, Boost, asmjit, quill, etc.).
+#
+# Usage:
+#   cmake -B build-zkvm -S zkvm/guest \
+#       -DCMAKE_TOOLCHAIN_FILE=$PWD/category/core/toolchains/riscv64-elf.cmake \
+#       -DRISCV_TOOLCHAIN_DIR=/path/to/riscv
+#   cmake --build build-zkvm --target monad-zkvm
+
+cmake_minimum_required(VERSION 3.20)
+project(monad-zkvm LANGUAGES C CXX ASM)
+
+# Testing features are incompatible with bare-metal zkVM builds.
+if(MONAD_COMPILER_TESTING)
+    message(FATAL_ERROR "MONAD_COMPILER_TESTING is not supported in zkVM builds")
+endif()
+
+# Backend selection — determines which allocator (and future vendor-specific
+# syscall) implementations are linked.
+set(MONAD_ZKVM_BACKEND "zisk" CACHE STRING "zkVM backend (zisk or sp1)")
+set_property(CACHE MONAD_ZKVM_BACKEND PROPERTY STRINGS zisk sp1)
+
+string(TOUPPER "${MONAD_ZKVM_BACKEND}" _ZKVM_BACKEND_UPPER)
+
+# Point to the monad repository root
+set(MONAD_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(CATEGORY_MAIN_DIR "${MONAD_ROOT}")
+set(THIRD_PARTY_DIR "${MONAD_ROOT}/third_party")
+
+# Reuse the shared compile options
+include("${MONAD_ROOT}/cmake/compile_options.cmake")
+
+# Shadow certain headers with zkVM-specific implementations via a mirror
+# tree at zkvm/category/... — the BEFORE keyword ensures these are searched
+# before the upstream `category/...` headers.
+set(ZKVM_INCLUDE_DIR "${MONAD_ROOT}/zkvm")
+
+# zkVM-specific CMake helpers (compile options, source / link-library
+# manipulation, mirror-source substitution).
+include("${MONAD_ROOT}/cmake/zkvm.cmake")
+
+# -------------------------------------------------------------------
+# Third-party dependencies (minimal for bare-metal)
+# -------------------------------------------------------------------
+
+# unordered_dense (header-only hash map used by category/core/bytes.hpp)
+add_subdirectory("${THIRD_PARTY_DIR}/unordered_dense" unordered_dense)
+
+# evmc — only need the header-only interface.
+set(EVMC_INCLUDE_DIR "${THIRD_PARTY_DIR}/evmc/include")
+
+add_library(evmc INTERFACE)
+add_library(evmc::evmc ALIAS evmc)
+target_compile_features(evmc INTERFACE c_std_99)
+target_include_directories(evmc INTERFACE ${EVMC_INCLUDE_DIR})
+
+# ethash — only keccak, no ethash or global_context (needs std::mutex)
+set(ETHASH_BUILD_ETHASH OFF CACHE BOOL "" FORCE)
+set(ETHASH_TESTING OFF CACHE BOOL "" FORCE)
+set(ETHASH_INSTALL_CMAKE_CONFIG OFF CACHE BOOL "" FORCE)
+add_subdirectory("${THIRD_PARTY_DIR}/ethash" ethash)
+
+# -------------------------------------------------------------------
+# VM component libraries
+# -------------------------------------------------------------------
+
+# Stub for monad-vm-utils — the interpreter unconditionally links it, but
+# the utils library itself is not buildable in the zkVM environment (TBB,
+# Boost, etc.). Header-only utils used by the interpreter (debug.hpp,
+# traits.hpp, scope_exit.hpp) are reached via the MONAD_ROOT include path
+# added below.
+add_library(monad-vm-utils INTERFACE)
+add_library(monad-vm::monad-vm-utils ALIAS monad-vm-utils)
+
+add_subdirectory("${MONAD_ROOT}/category/vm/evm" evm)
+add_subdirectory("${MONAD_ROOT}/category/vm/runtime" runtime)
+add_subdirectory("${MONAD_ROOT}/category/vm/interpreter" interpreter)
+
+# Strip x86-only assembly from the otherwise shared targets.
+monad_zkvm_drop_sources(monad-vm-runtime
+    "context\\.S" "exit\\.S" "math\\.S" "transmute\\.S")
+monad_zkvm_drop_sources(monad-vm-interpreter "entry\\.S")
+
+foreach(tgt monad-vm-evm monad-vm-runtime monad-vm-interpreter)
+    monad_zkvm_compile_options(${tgt})
+    target_link_libraries(${tgt} PUBLIC unordered_dense)
+endforeach()
+
+# -------------------------------------------------------------------
+# Extract setjmp/longjmp from the compiler's newlib libc.a.
+# libc.a exists at configure time (it ships with the compiler), so we
+# can extract the objects here for inclusion in the final archive.
+# -------------------------------------------------------------------
+
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -print-file-name=libc.a
+    OUTPUT_VARIABLE _libc_a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(_newlib_dir "${CMAKE_CURRENT_BINARY_DIR}/_libc_objs")
+file(MAKE_DIRECTORY "${_newlib_dir}")
+
+if(EXISTS "${_libc_a}")
+    foreach(_obj libc_a-setjmp.o)
+        execute_process(
+            COMMAND ${CMAKE_AR} x "${_libc_a}" "${_obj}"
+            WORKING_DIRECTORY "${_newlib_dir}"
+            RESULT_VARIABLE _ar_result
+            ERROR_VARIABLE _ar_error
+        )
+        if(NOT _ar_result EQUAL 0)
+            message(FATAL_ERROR
+                "Failed to extract ${_obj} from ${_libc_a} "
+                "(${CMAKE_AR} exited with ${_ar_result}): ${_ar_error}")
+        endif()
+    endforeach()
+    file(GLOB _libc_objs "${_newlib_dir}/*.o")
+    if(NOT _libc_objs)
+        message(FATAL_ERROR "Failed to extract setjmp/longjmp objects from ${_libc_a}")
+    endif()
+else()
+    message(FATAL_ERROR "libc.a not found via compiler query; setjmp/longjmp will be missing")
+endif()
+
+# -------------------------------------------------------------------
+# Assemble all objects into a single static library
+# -------------------------------------------------------------------
+
+add_library(monad-zkvm-core OBJECT
+    "${ZKVM_INCLUDE_DIR}/core/libc.cpp"
+    "${ZKVM_INCLUDE_DIR}/core/libstdcxx.cpp"
+)
+monad_compile_options(monad-zkvm-core)
+monad_zkvm_compile_options(monad-zkvm-core)
+
+add_library(monad-zkvm STATIC
+    $<TARGET_OBJECTS:monad-zkvm-core>
+    $<TARGET_OBJECTS:monad-vm-evm>
+    $<TARGET_OBJECTS:monad-vm-runtime>
+    $<TARGET_OBJECTS:monad-vm-interpreter>
+    ${_libc_objs}
+)


### PR DESCRIPTION
Add a standalone CMake project (`zkvm/`) that builds `libmonad-zkvm.a` for bare-metal RISC-V targets (planned ZisK and SP1 zkVM backends). This allows the Monad EVM interpreter to run inside zkVMs.

Key changes:
- RISC-V toolchain file (rv64ima, lp64, medany, -nostdlib++)
- zkVM-abstracted allocator (zkvm_aligned_alloc) and exit (zkvm_exit) interfaces with planned ZisK/SP1 backends
- Splitting out any platform-specific code from `{X}.hpp` into `{X}/intrinsics.hpp`
- Shadowing of `category/` headers with zkvm specific ones under `zkvm/category/`
- Shared `cmake/compile_options.cmake` extracted from root CMakeLists.txt and a new `cmake/zkvm.cmake` specific options for the zkVM targets
- `zkvm-core` bare-metal shims for libc (malloc/calloc/free), libstdc++ (operator new/delete, std::terminate), and assert handlers
- minimal CI build of `zkvm/` code targeting RISC-V

Co-authored with Claude