### PR TITLE
Refactor Db::commit to use callback-based API with explicit header population                                                                                            

### DIFF
--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -22,8 +22,10 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
 
 #include <evmc/evmc.hpp>
 #include <nlohmann/json.hpp>
@@ -47,19 +49,26 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
             intx::from_string<uint256_t>(item.value()["wei_balance"]);
         deltas.emplace(addr, StateDelta{.account = {std::nullopt, account}});
     }
+
+    CommitBuilder builder(genesis.header.number);
+    builder.add_state_deltas(deltas)
+        .add_code(Code{})
+        .add_receipts(std::vector<Receipt>{})
+        .add_transactions(std::vector<Transaction>{}, std::vector<Address>{})
+        .add_call_frames(std::vector<std::vector<CallFrame>>{})
+        .add_ommers(std::vector<BlockHeader>{});
+    if (genesis.header.withdrawals_root == NULL_ROOT) {
+        builder.add_withdrawals({});
+    }
     db.commit(
-        deltas,
-        Code{},
-        NULL_HASH_BLAKE3,
-        genesis.header,
-        std::vector<Receipt>{},
-        std::vector<std::vector<CallFrame>>{},
-        std::vector<Address>{},
-        std::vector<Transaction>{},
-        std::vector<BlockHeader>{},
-        genesis.header.withdrawals_root == NULL_ROOT
-            ? std::make_optional<std::vector<Withdrawal>>()
-            : std::nullopt);
+        NULL_HASH_BLAKE3, builder, genesis.header, deltas, [&](BlockHeader &h) {
+            h.receipts_root = db.receipts_root();
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.ommers_hash = compute_ommers_hash({});
+        });
+
     db.finalize(0, NULL_HASH_BLAKE3);
 }
 

--- a/category/execution/ethereum/db/commit_builder.hpp
+++ b/category/execution/ethereum/db/commit_builder.hpp
@@ -60,6 +60,9 @@ public:
 
     CommitBuilder &add_block_header(BlockHeader const &);
 
+    // Consumes updates_ but preserves the backing deque storage. New updates
+    // can be added after a build() call (e.g. add_block_header between the
+    // two commit stages), but previously built updates are not retained.
     mpt::UpdateList build(mpt::NibblesView);
 };
 

--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -29,10 +29,13 @@
 #include <category/vm/vm.hpp>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 
 MONAD_NAMESPACE_BEGIN
+
+class CommitBuilder;
 
 struct Db
 {
@@ -61,19 +64,11 @@ struct Db
 
     virtual uint64_t get_block_number() const = 0;
 
+    // two-stage commit
     virtual void commit(
-        StateDeltas const &, Code const &, bytes32_t const &block_id,
-        BlockHeader const &, std::vector<Receipt> const & = {},
-        std::vector<std::vector<CallFrame>> const & = {},
-        std::vector<Address> const & = {},
-        std::vector<Transaction> const & = {},
-        std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt) = 0;
-
-    virtual void update_proposal_state(
-        std::unique_ptr<StateDeltas>, uint64_t, bytes32_t const &)
-    {
-    }
+        bytes32_t const &block_id, CommitBuilder &builder,
+        BlockHeader const &header, StateDeltas const &state_deltas,
+        std::function<void(BlockHeader &)> populate_header_fn) = 0;
 
     virtual std::string print_stats()
     {

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -159,33 +159,23 @@ public:
     }
 
     virtual void commit(
-        StateDeltas const &state_deltas, Code const &code,
-        bytes32_t const &block_id, BlockHeader const &header,
-        std::vector<Receipt> const &receipts = {},
-        std::vector<std::vector<CallFrame>> const &call_frames = {},
-        std::vector<Address> const &senders = {},
-        std::vector<Transaction> const &transactions = {},
-        std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const &withdrawals =
-            std::nullopt) override
+        bytes32_t const &block_id, CommitBuilder &builder,
+        BlockHeader const &header, StateDeltas const &state_deltas,
+        std::function<void(BlockHeader &)> populate_header_fn) override
     {
         db_.commit(
-            state_deltas,
-            code,
             block_id,
+            builder,
             header,
-            receipts,
-            call_frames,
-            senders,
-            transactions,
-            ommers,
-            withdrawals);
+            state_deltas,
+            std::move(populate_header_fn));
     }
 
-    virtual void update_proposal_state(
+    void update_proposal_state(
         std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
-        bytes32_t const &block_id) override
+        bytes32_t const &block_id)
     {
+        MONAD_ASSERT(state_deltas);
         proposals_.commit(std::move(state_deltas), block_number, block_id);
     }
 

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
+
+#include <optional>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace test
+{
+
+    inline void commit_simple(
+        ::monad::Db &db, StateDeltas const &deltas, Code const &code,
+        bytes32_t const &block_id, BlockHeader const &header,
+        std::vector<Receipt> const &receipts = {},
+        std::vector<std::vector<CallFrame>> const &call_frames = {},
+        std::vector<Address> const &senders = {},
+        std::vector<Transaction> const &txns = {},
+        std::vector<BlockHeader> const &ommers = {},
+        std::optional<std::vector<Withdrawal>> const &withdrawals =
+            std::nullopt)
+    {
+        CommitBuilder builder(header.number);
+        builder.add_state_deltas(deltas)
+            .add_code(code)
+            .add_receipts(receipts)
+            .add_transactions(txns, senders)
+            .add_call_frames(call_frames)
+            .add_ommers(ommers);
+        if (withdrawals.has_value()) {
+            builder.add_withdrawals(withdrawals.value());
+        }
+        db.commit(block_id, builder, header, deltas, [&](BlockHeader &h) {
+            // eth pre-byzantium receipts root is invalid
+            if (h.receipts_root == NULL_ROOT) {
+                h.receipts_root = db.receipts_root();
+            }
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+            h.logs_bloom = compute_bloom(receipts);
+            h.ommers_hash = compute_ommers_hash(ommers);
+        });
+    }
+
+} // namespace test
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -327,7 +327,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header0{.number = 10};
     bytes32_t const block_id0{header0.number};
     block_ids.emplace(block_id0);
-    tdb.commit(StateDeltas{}, Code{}, block_id0, header0);
+    commit_simple(tdb, StateDeltas{}, Code{}, block_id0, header0);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -336,7 +336,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header1{.number = 10};
     bytes32_t const block_id1{header1.number};
     block_ids.emplace(block_id1);
-    tdb.commit(StateDeltas{}, Code{}, block_id1, header1);
+    commit_simple(tdb, StateDeltas{}, Code{}, block_id1, header1);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -346,7 +346,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header2{.number = 10};
     bytes32_t const block_id2{header2.number};
     block_ids.emplace(block_id2);
-    tdb.commit(StateDeltas{}, Code{}, block_id2, header2);
+    commit_simple(tdb, StateDeltas{}, Code{}, block_id2, header2);
 
     tdb.finalize(10, block_id0);
     EXPECT_EQ(db.get_latest_finalized_version(), 10);

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -156,45 +156,30 @@ vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
 }
 
 void TrieDb::commit(
-    StateDeltas const &state_deltas, Code const &code,
-    bytes32_t const &block_id, BlockHeader const &header,
-    std::vector<Receipt> const &receipts,
-    std::vector<std::vector<CallFrame>> const &call_frames,
-    std::vector<Address> const &senders,
-    std::vector<Transaction> const &transactions,
-    std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals)
+    bytes32_t const &block_id, CommitBuilder &builder,
+    BlockHeader const &header, StateDeltas const &,
+    std::function<void(BlockHeader &)> populate_header_fn)
 {
-    MONAD_ASSERT(header.number <= std::numeric_limits<int64_t>::max());
+    auto const block_number = header.number;
+    MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());
 
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk() && block_id != proposal_block_id_) {
         auto const dest_prefix = proposal_prefix(block_id);
         if (db_.get_latest_version() != INVALID_BLOCK_NUM) {
-            MONAD_ASSERT(header.number != block_number_);
+            MONAD_ASSERT(block_number != block_number_);
             curr_root_ = db_.copy_trie(
                 curr_root_,
                 prefix_,
-                db_.load_root_for_version(header.number),
+                db_.load_root_for_version(block_number),
                 dest_prefix,
-                header.number,
+                block_number,
                 false);
         }
         proposal_block_id_ = block_id;
         prefix_ = dest_prefix;
     }
-    block_number_ = header.number;
-
-    CommitBuilder builder(block_number_);
-    builder.add_state_deltas(state_deltas)
-        .add_code(code)
-        .add_receipts(receipts)
-        .add_transactions(transactions, senders)
-        .add_call_frames(call_frames)
-        .add_ommers(ommers);
-    if (withdrawals.has_value()) {
-        builder.add_withdrawals(withdrawals.value());
-    }
+    block_number_ = block_number;
 
     curr_root_ = db_.upsert(
         std::move(curr_root_),
@@ -205,30 +190,12 @@ void TrieDb::commit(
         false);
 
     BlockHeader complete_header = header;
-    if (MONAD_LIKELY(header.receipts_root == NULL_ROOT)) {
-        // TODO: TrieDb does not calculate receipts root correctly before the
-        // BYZANTIUM fork. However, for empty receipts our receipts root
-        // calculation is correct.
-        //
-        // On monad, the receipts root input is always null. On replay, we set
-        // our receipts root to any non-null header input so our eth header is
-        // correct in the Db.
-        complete_header.receipts_root = receipts_root();
-    }
-    complete_header.state_root = state_root();
-    complete_header.withdrawals_root = withdrawals_root();
-    complete_header.transactions_root = transactions_root();
-    complete_header.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-    complete_header.logs_bloom = compute_bloom(receipts);
-    complete_header.ommers_hash = compute_ommers_hash(ommers);
+    MONAD_ASSERT(populate_header_fn);
+    populate_header_fn(complete_header);
 
     builder.add_block_header(complete_header);
-    bool const enable_compaction = false;
     curr_root_ = db_.upsert(
-        std::move(curr_root_),
-        builder.build(prefix_),
-        block_number_,
-        enable_compaction);
+        std::move(curr_root_), builder.build(prefix_), block_number_, false);
 }
 
 void TrieDb::set_block_and_prefix(

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -67,13 +67,9 @@ public:
         bytes32_t const &block_id = bytes32_t{}) override;
 
     virtual void commit(
-        StateDeltas const &, Code const &, bytes32_t const &block_id,
-        BlockHeader const &, std::vector<Receipt> const & = {},
-        std::vector<std::vector<CallFrame>> const & = {},
-        std::vector<Address> const & = {},
-        std::vector<Transaction> const & = {},
-        std::vector<BlockHeader> const &ommers = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt) override;
+        bytes32_t const &block_id, CommitBuilder &builder,
+        BlockHeader const &header, StateDeltas const &state_deltas,
+        std::function<void(BlockHeader &)> populate_header_fn) override;
 
     virtual void
     finalize(uint64_t block_number, bytes32_t const &block_id) override;

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -132,13 +132,8 @@ public:
     }
 
     virtual void commit(
-        StateDeltas const &, Code const &, bytes32_t const &,
-        BlockHeader const &, std::vector<Receipt> const & = {},
-        std::vector<std::vector<CallFrame>> const & = {},
-        std::vector<Address> const & = {},
-        std::vector<Transaction> const & = {},
-        std::vector<BlockHeader> const & = {},
-        std::optional<std::vector<Withdrawal>> const & = std::nullopt) override
+        bytes32_t const &, CommitBuilder &, BlockHeader const &,
+        StateDeltas const &, std::function<void(BlockHeader &)>) override
     {
         MONAD_ABORT();
     }

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -241,8 +241,9 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
     auto const &transactions = block.value().transactions;
     BlockHeader const header{.number = 1};
     bytes32_t const block_id{header.number};
-    auto [state, code] = bs.release();
-    tdb.commit(
+    auto [state, code] = std::move(bs).release();
+    commit_simple(
+        tdb,
         *state,
         code,
         block_id,
@@ -526,8 +527,9 @@ TYPED_TEST(TraitsTest, call_frames_refund)
     auto const &transactions = block.value().transactions;
     BlockHeader const header = block.value().header;
     bytes32_t const block_id{header.number};
-    auto [state, code] = bs.release();
-    tdb.commit(
+    auto [state, code] = std::move(bs).release();
+    commit_simple(
+        tdb,
         *state,
         code,
         block_id,

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -236,7 +236,7 @@ void BlockState::merge(State const &state)
     }
 }
 
-BlockState::ReleasedState BlockState::release()
+BlockState::ReleasedState BlockState::release() &&
 {
     return {std::move(state_), std::move(code_)};
 }

--- a/category/execution/ethereum/state2/block_state.hpp
+++ b/category/execution/ethereum/state2/block_state.hpp
@@ -64,7 +64,7 @@ public:
         Code code;
     };
 
-    ReleasedState release();
+    ReleasedState release() &&;
 
     void log_debug();
 };

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -584,8 +584,9 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
         bs.merge(s2);
     }
     {
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{1},
@@ -638,8 +639,9 @@ TYPED_TEST(
         bs.merge(s2);
     }
     {
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{1},
@@ -697,8 +699,9 @@ TYPED_TEST(
         bs.merge(s2);
     }
     {
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             NULL_HASH_BLAKE3,
@@ -1268,8 +1271,9 @@ TEST_F(InMemoryStateTest, commit_storage_and_account_together_regression)
     as.set_storage(a, key1, value1);
 
     bs.merge(as);
-    auto [released_state, released_code] = bs.release();
-    this->tdb.commit(
+    auto [released_state, released_code] = std::move(bs).release();
+    commit_simple(
+        this->tdb,
         *released_state,
         released_code,
         NULL_HASH_BLAKE3,
@@ -1298,8 +1302,9 @@ TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
     EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
     EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
     bs.merge(as);
-    auto [released_state, released_code] = bs.release();
-    this->tdb.commit(
+    auto [released_state, released_code] = std::move(bs).release();
+    commit_simple(
+        this->tdb,
         *released_state,
         released_code,
         NULL_HASH_BLAKE3,
@@ -1322,7 +1327,8 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
 
     // commit to Block 9 Finalized
     this->tdb.set_block_and_prefix(8);
-    this->tdb.commit(
+    commit_simple(
+        this->tdb,
         StateDeltas{
             {a,
              StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
@@ -1356,8 +1362,9 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
             as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{10},
@@ -1382,8 +1389,9 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         cs.destruct_suicides<typename TestFixture::Trait>();
         EXPECT_TRUE(bs.can_merge(cs));
         bs.merge(cs);
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{11},
@@ -1425,7 +1433,8 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
 
     // commit to block 10, round 5
     this->tdb.set_block_and_prefix(9);
-    this->tdb.commit(
+    commit_simple(
+        this->tdb,
         StateDeltas{
             {a,
              StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
@@ -1462,8 +1471,9 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         // Commit block 11 round 8 on top of block 10 round 5
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{118},
@@ -1489,8 +1499,9 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         // Commit block 11 round 6 on top of block 10 round 5
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{116},
@@ -1518,8 +1529,9 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         // Commit block 11 round 7 on top of block 10 round 5
-        auto [released_state, released_code] = bs.release();
-        this->tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            this->tdb,
             *released_state,
             released_code,
             bytes32_t{117},
@@ -1547,7 +1559,8 @@ TEST_F(OnDiskStateTest, proposal_basics)
     this->tdb.reset_root(
         load_header({}, this->db, BlockHeader{.number = 9}), 9);
     Db &db = this->tdb;
-    db.commit(
+    commit_simple(
+        db,
         StateDeltas{
             {a,
              StateDelta{
@@ -1562,8 +1575,9 @@ TEST_F(OnDiskStateTest, proposal_basics)
     db_cache.set_block_and_prefix(10, bytes32_t{10});
     BlockState bs1(db_cache, this->vm);
     EXPECT_EQ(bs1.read_account(a).value().balance, 30'000);
-    auto [released_state1, released_code1] = bs1.release();
-    db_cache.commit(
+    auto [released_state1, released_code1] = std::move(bs1).release();
+    commit_simple(
+        db_cache,
         *released_state1,
         released_code1,
         bytes32_t{11},
@@ -1580,8 +1594,9 @@ TEST_F(OnDiskStateTest, proposal_basics)
     EXPECT_TRUE(bs2.can_merge(as));
     bs2.merge(as);
     EXPECT_EQ(db_cache.read_account(a).value().balance, 30'000);
-    auto [released_state2, released_code2] = bs2.release();
-    db_cache.commit(
+    auto [released_state2, released_code2] = std::move(bs2).release();
+    commit_simple(
+        db_cache,
         *released_state2,
         released_code2,
         bytes32_t{12},
@@ -1625,8 +1640,12 @@ TEST_F(OnDiskStateTest, undecided_proposals)
                  {key1, {bytes32_t{}, value1}},
                  {key2, {bytes32_t{}, value2}}}}}}};
     db_cache.set_block_and_prefix(9);
-    db_cache.commit(
-        *state_deltas, Code{}, bytes32_t{10}, BlockHeader{.number = 10});
+    commit_simple(
+        db_cache,
+        *state_deltas,
+        Code{},
+        bytes32_t{10},
+        BlockHeader{.number = 10});
     db_cache.update_proposal_state(std::move(state_deltas), 10, bytes32_t{10});
     db_cache.finalize(10, bytes32_t{10});
     EXPECT_TRUE(db_cache.read_account(a).has_value());
@@ -1652,8 +1671,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_111.can_merge(as));
         bs_111.merge(as);
     }
-    auto [released_state_111, released_code_111] = bs_111.release();
-    db_cache.commit(
+    auto [released_state_111, released_code_111] = std::move(bs_111).release();
+    commit_simple(
+        db_cache,
         *released_state_111,
         released_code_111,
         bytes32_t{111},
@@ -1684,8 +1704,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_121.can_merge(as));
         bs_121.merge(as);
     }
-    auto [released_state_121, released_code_121] = bs_121.release();
-    db_cache.commit(
+    auto [released_state_121, released_code_121] = std::move(bs_121).release();
+    commit_simple(
+        db_cache,
         *released_state_121,
         released_code_121,
         bytes32_t{121},
@@ -1716,8 +1737,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_112.can_merge(as));
         bs_112.merge(as);
     }
-    auto [released_state_112, released_code_112] = bs_112.release();
-    db_cache.commit(
+    auto [released_state_112, released_code_112] = std::move(bs_112).release();
+    commit_simple(
+        db_cache,
         *released_state_112,
         released_code_112,
         bytes32_t{112},
@@ -1736,8 +1758,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_122.can_merge(as));
         bs_122.merge(as);
     }
-    auto [released_state_122, released_code_122] = bs_122.release();
-    db_cache.commit(
+    auto [released_state_122, released_code_122] = std::move(bs_122).release();
+    commit_simple(
+        db_cache,
         *released_state_122,
         released_code_122,
         bytes32_t{122},
@@ -1759,8 +1782,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_131.can_merge(as));
         bs_131.merge(as);
     }
-    auto [released_state_131, released_code_131] = bs_131.release();
-    db_cache.commit(
+    auto [released_state_131, released_code_131] = std::move(bs_131).release();
+    commit_simple(
+        db_cache,
         *released_state_131,
         released_code_131,
         bytes32_t{131},
@@ -1780,8 +1804,9 @@ TEST_F(OnDiskStateTest, undecided_proposals)
         EXPECT_TRUE(bs_132.can_merge(as));
         bs_132.merge(as);
     }
-    auto [released_state_132, released_code_132] = bs_132.release();
-    db_cache.commit(
+    auto [released_state_132, released_code_132] = std::move(bs_132).release();
+    commit_simple(
+        db_cache,
         *released_state_132,
         released_code_132,
         bytes32_t{132},
@@ -1835,7 +1860,7 @@ namespace
 
         std::mt19937_64 rng_;
         Db &db1_;
-        Db &db2_;
+        DbCache &db2_;
         vm::VM &vm_;
         uint64_t finalized_block_{0};
         uint64_t finalized_proposal_seed_{0};
@@ -1857,7 +1882,7 @@ namespace
 
     public:
         RandomProposalGenerator(
-            uint64_t const seed, Db &db1, Db &db2, vm::VM &vm)
+            uint64_t const seed, Db &db1, DbCache &db2, vm::VM &vm)
             : rng_(seed)
             , db1_(db1)
             , db2_(db2)
@@ -2070,20 +2095,18 @@ namespace
             bs1.merge(st1);
             bs2.merge(st2);
             {
-                auto [state1, code1] = bs1.release();
-                db1_.commit(
+                auto [state1, code1] = std::move(bs1).release();
+                commit_simple(
+                    db1_,
                     *state1,
                     code1,
                     get_dummy_block_id(proposal_seed),
                     BlockHeader{.number = block});
-                db1_.update_proposal_state(
-                    std::move(state1),
-                    block,
-                    get_dummy_block_id(proposal_seed));
             }
             {
-                auto [state2, code2] = bs2.release();
-                db2_.commit(
+                auto [state2, code2] = std::move(bs2).release();
+                commit_simple(
+                    db2_,
                     *state2,
                     code2,
                     get_dummy_block_id(proposal_seed),

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -25,6 +25,8 @@
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 
+#include <test_resource_data.h>
+
 #include <ankerl/unordered_dense.h>
 #include <gtest/gtest.h>
 
@@ -127,8 +129,12 @@ TEST(DbBinarySnapshot, Basic)
         }
         TrieDb tdb{db};
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
-        tdb.commit(
-            deltas, code_delta, bytes32_t{100}, BlockHeader{.number = 100});
+        test::commit_simple(
+            tdb,
+            deltas,
+            code_delta,
+            bytes32_t{100},
+            BlockHeader{.number = 100});
         tdb.finalize(100, bytes32_t{100});
         last_header = tdb.read_eth_header();
         root_hash = tdb.state_root();
@@ -236,8 +242,12 @@ TEST(DbBinarySnapshot, MultipleShards)
         }
         TrieDb tdb{db};
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
-        tdb.commit(
-            deltas, code_delta, bytes32_t{100}, BlockHeader{.number = 100});
+        test::commit_simple(
+            tdb,
+            deltas,
+            code_delta,
+            bytes32_t{100},
+            BlockHeader{.number = 100});
         tdb.finalize(100, bytes32_t{100});
         last_header = tdb.read_eth_header();
         root_hash = tdb.state_root();

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -15,12 +15,14 @@
 
 #include <category/execution/ethereum/core/contract/abi_encode.hpp>
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
+#include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/monad/staking/fuzzer/staking_contract_model.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 
 namespace
 {
     using namespace monad;
+    using namespace monad::test;
 
     Result<u64_be> decode_u64_be_result(Result<byte_string> &&res)
     {
@@ -44,7 +46,8 @@ namespace monad::staking::test
 {
     StakingContractModel::StakingContractModel()
     {
-        trie_db_.commit(
+        commit_simple(
+            trie_db_,
             StateDeltas{
                 {STAKING_CA,
                  StateDelta{

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -109,8 +109,9 @@ protected:
 
             MONAD_ASSERT(bs.can_merge(state));
             bs.merge(state);
-            auto [state_deltas, code] = bs.release();
-            tdb.commit(
+            auto [state_deltas, code] = std::move(bs).release();
+            test::commit_simple(
+                tdb,
                 *state_deltas,
                 code,
                 NULL_HASH_BLAKE3,

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -32,6 +32,7 @@
 #include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
 #include <category/execution/ethereum/core/signature.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/reserve_balance.hpp>
@@ -414,7 +415,7 @@ TEST_F(EthCallFixture, on_proposed_block)
         .gas_limit = 100000u, .to = to, .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    tdb.commit({}, {}, bytes32_t{256}, header);
+    commit_simple(tdb, {}, {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
@@ -492,7 +493,7 @@ TEST_F(EthCallFixture, blockhash_before_fork)
         .data = byte_string{bytecode.data(), bytecode.size()}};
     BlockHeader const header{.number = 256};
 
-    tdb.commit({}, {}, bytes32_t{256}, header);
+    commit_simple(tdb, {}, {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -295,27 +295,13 @@ void monad_statesync_server_context::update_proposed_metadata(
 }
 
 void monad_statesync_server_context::commit(
-    StateDeltas const &state_deltas, Code const &code,
-    bytes32_t const &block_id, BlockHeader const &header,
-    std::vector<Receipt> const &receipts,
-    std::vector<std::vector<CallFrame>> const &call_frames,
-    std::vector<Address> const &senders,
-    std::vector<Transaction> const &transactions,
-    std::vector<BlockHeader> const &ommers,
-    std::optional<std::vector<Withdrawal>> const &withdrawals)
+    bytes32_t const &block_id, CommitBuilder &builder,
+    BlockHeader const &header, StateDeltas const &state_deltas,
+    std::function<void(BlockHeader &)> populate_header_fn)
 {
     on_commit(*this, state_deltas, header.number, block_id);
     rw.commit(
-        state_deltas,
-        code,
-        block_id,
-        header,
-        receipts,
-        call_frames,
-        senders,
-        transactions,
-        ommers,
-        withdrawals);
+        block_id, builder, header, state_deltas, std::move(populate_header_fn));
 }
 
 uint64_t monad_statesync_server_context::get_block_number() const

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -130,15 +130,9 @@ struct monad_statesync_server_context final : public monad::Db
         uint64_t block_number, monad::bytes32_t const &block_id) override;
 
     virtual void commit(
-        monad::StateDeltas const &state_deltas, monad::Code const &code,
-        monad::bytes32_t const &block_id, monad::BlockHeader const &,
-        std::vector<monad::Receipt> const &receipts = {},
-        std::vector<std::vector<monad::CallFrame>> const & = {},
-        std::vector<monad::Address> const & = {},
-        std::vector<monad::Transaction> const &transactions = {},
-        std::vector<monad::BlockHeader> const &ommers = {},
-        std::optional<std::vector<monad::Withdrawal>> const & =
-            std::nullopt) override;
+        monad::bytes32_t const &, monad::CommitBuilder &,
+        monad::BlockHeader const &, monad::StateDeltas const &,
+        std::function<void(monad::BlockHeader &)>) override;
 
     virtual uint64_t get_block_number() const override;
 };

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -19,6 +19,7 @@
 #include <category/core/unaligned.hpp>
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
+#include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/statesync/statesync_client.h>
@@ -309,7 +310,8 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
 
     // write the genesis block
     {
-        sctx->commit(StateDeltas{}, Code{}, NULL_HASH_BLAKE3, hdr);
+        monad::test::commit_simple(
+            *sctx, StateDeltas{}, Code{}, NULL_HASH_BLAKE3, hdr);
         sctx->finalize(0, NULL_HASH_BLAKE3);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));
@@ -351,7 +353,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
         hdr.parent_hash = parent_hash;
         bytes32_t const curr_block_id = bytes32_t{hdr.number};
         sctx->set_block_and_prefix(hdr.number - 1);
-        sctx->commit(deltas, {}, curr_block_id, hdr);
+        monad::test::commit_simple(*sctx, deltas, {}, curr_block_id, hdr);
         sctx->finalize(hdr.number, curr_block_id);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -229,7 +229,8 @@ TEST_F(StateSyncFixture, sync_from_latest)
         load_db(tdb, N);
         // commit some proposal to client db
         tdb.set_block_and_prefix(N);
-        tdb.commit({}, {}, bytes32_t{N + 1}, BlockHeader{.number = N + 1});
+        commit_simple(
+            tdb, {}, {}, bytes32_t{N + 1}, BlockHeader{.number = N + 1});
         init();
     }
     handle_target(
@@ -317,7 +318,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         TrieDb tdb{db};
         load_genesis_state(GENESIS_STATE, tdb);
         // commit some proposal to client db
-        tdb.commit({}, {}, NULL_HASH_BLAKE3, BlockHeader{.number = 1});
+        commit_simple(tdb, {}, {}, NULL_HASH_BLAKE3, BlockHeader{.number = 1});
         load_genesis_state(GENESIS_STATE, stdb);
         init();
     }
@@ -526,12 +527,10 @@ TEST_F(StateSyncFixture, deletion_proposal)
             0x000d836201318ec6899a67540690382780743280_address;
         auto const acct = sctx.read_account(ADDR1);
         ASSERT_TRUE(acct.has_value());
+        StateDeltas deltas{{ADDR1, {.account = {acct, std::nullopt}}}};
         sctx.set_block_and_prefix(0);
-        sctx.commit(
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
-            Code{},
-            bytes32_t{1},
-            BlockHeader{.number = 1});
+        commit_simple(
+            sctx, deltas, Code{}, bytes32_t{1}, BlockHeader{.number = 1});
     }
     // delete ADDR2 on another
     {
@@ -539,12 +538,10 @@ TEST_F(StateSyncFixture, deletion_proposal)
             0x001762430ea9c3a26e5749afdb70da5f78ddbb8c_address;
         auto const acct = sctx.read_account(ADDR2);
         ASSERT_TRUE(acct.has_value());
+        StateDeltas deltas{{ADDR2, {.account = {acct, std::nullopt}}}};
         sctx.set_block_and_prefix(0);
-        sctx.commit(
-            StateDeltas{{ADDR2, {.account = {acct, std::nullopt}}}},
-            Code{},
-            bytes32_t{2},
-            BlockHeader{.number = 1});
+        commit_simple(
+            sctx, deltas, Code{}, bytes32_t{2}, BlockHeader{.number = 1});
     }
     sctx.finalize(1, bytes32_t{2});
 
@@ -629,7 +626,7 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
         TrieDb tdb{db};
         tdb.reset_root(load_header({}, db, BlockHeader{.number = 0}), 0);
         for (uint64_t n = 1; n <= 249; ++n) {
-            tdb.commit({}, {}, bytes32_t{n}, BlockHeader{.number = n});
+            commit_simple(tdb, {}, {}, bytes32_t{n}, BlockHeader{.number = n});
         }
     }
 

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -4,6 +4,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/core/address.hpp>
+#include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/vm/vm.hpp>
 
@@ -96,6 +97,8 @@ inline auto const H_CODE =
 inline auto const H_CODE_HASH = to_bytes(keccak256(H_CODE));
 inline auto const H_ICODE = vm::make_shared_intercode(H_CODE);
 
+using monad::test::commit_simple;
+
 inline bytes32_t commit_sequential(
     monad::Db &db, StateDeltas const &deltas, Code const &code,
     BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
@@ -107,17 +110,10 @@ inline bytes32_t commit_sequential(
 {
     bytes32_t const block_id =
         eth_header.number ? bytes32_t{eth_header.number} : NULL_HASH_BLAKE3;
-    db.commit(
-        deltas,
-        code,
-        block_id,
-        eth_header,
-        receipts,
-        call_frames,
-        senders,
-        txns,
-        ommers,
-        withdrawals);
+
+    commit_simple(db, deltas, code, block_id, eth_header,
+        receipts, call_frames, senders, txns, ommers, withdrawals);
+
     db.finalize(eth_header.number, block_id);
     db.set_block_and_prefix(eth_header.number); // set to finalized
 

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -24,9 +24,11 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
-#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -80,7 +82,7 @@ void log_tps(
 // Process a single historical Ethereum block
 template <Traits traits>
 Result<void> process_ethereum_block(
-    Chain const &chain, Db &db, vm::VM &vm,
+    Chain const &chain, DbCache &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing)
@@ -152,23 +154,36 @@ Result<void> process_ethereum_block(
     // Database commit of state changes (incl. Merkle root calculations)
     block_state.log_debug();
     auto const commit_begin = std::chrono::steady_clock::now();
-    auto [state, code] = block_state.release();
-    db.commit(
-        *state,
-        code,
-        bytes32_t{block.header.number},
-        block.header,
-        receipts,
-        call_frames,
-        senders,
-        block.transactions,
-        block.ommers,
-        block.withdrawals);
-    // Transfer state ownership to DbCache for proposal tracking. This must
-    // come after commit since it takes ownership of the state. Safe to
-    // reorder: DbCache is only read on the next block, not during commit.
-    db.update_proposal_state(
-        std::move(state), block.header.number, bytes32_t{block.header.number});
+    auto [state, code] = std::move(block_state).release();
+
+    CommitBuilder builder(block.header.number);
+    builder.add_state_deltas(*state)
+        .add_code(code)
+        .add_receipts(receipts)
+        .add_transactions(block.transactions, senders)
+        .add_call_frames(call_frames)
+        .add_ommers(block.ommers);
+    if (block.withdrawals.has_value()) {
+        builder.add_withdrawals(block.withdrawals.value());
+    }
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        if constexpr (traits::evm_rev() <= EVMC_BYZANTIUM) {
+            // TrieDb receipts root is not valid pre-Byzantium; use the
+            // block's original receipts root.
+            h.receipts_root = block.header.receipts_root;
+        }
+        else {
+            h.receipts_root = db.receipts_root();
+        }
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(receipts);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
+    db.update_proposal_state(std::move(state), block.header.number, block_id);
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
@@ -231,7 +246,7 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &chain, std::filesystem::path const &ledger_dir, Db &db,
+    Chain const &chain, std::filesystem::path const &ledger_dir, DbCache &db,
     vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,

--- a/cmd/monad/runloop_ethereum.hpp
+++ b/cmd/monad/runloop_ethereum.hpp
@@ -28,7 +28,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct Chain;
-struct Db;
+class DbCache;
 class BlockHashBufferFinalized;
 
 namespace fiber
@@ -37,7 +37,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &, std::filesystem::path const &, Db &, vm::VM &,
+    Chain const &, std::filesystem::path const &, DbCache &, vm::VM &,
     BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
     sig_atomic_t const volatile &, bool enable_tracing);
 

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -28,7 +28,8 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
-#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
@@ -177,7 +178,7 @@ template <Traits traits, class MonadConsensusBlockHeader>
 Result<BlockExecOutput> propose_block(
     bytes32_t const &block_id,
     MonadConsensusBlockHeader const &consensus_header, Block block,
-    BlockHashChain &block_hash_chain, MonadChain const &chain, Db &db,
+    BlockHashChain &block_hash_chain, MonadChain const &chain, DbCache &db,
     vm::VM &vm, fiber::PriorityPool &priority_pool, bool const is_first_block,
     bool const enable_tracing, BlockCache &block_cache)
 {
@@ -305,21 +306,28 @@ Result<BlockExecOutput> propose_block(
     // Database commit of state changes (incl. Merkle root calculations)
     block_state.log_debug();
     auto const commit_begin = std::chrono::steady_clock::now();
-    auto [state, code] = block_state.release();
-    db.commit(
-        *state,
-        code,
-        block_id,
-        block.header,
-        results,
-        call_frames,
-        senders,
-        block.transactions,
-        block.ommers,
-        block.withdrawals);
-    // Transfer state ownership to DbCache for proposal tracking. This must
-    // come after commit since it takes ownership of the state. Safe to
-    // reorder: DbCache is only read on the next block, not during commit.
+    auto [state, code] = std::move(block_state).release();
+
+    CommitBuilder builder(block.header.number);
+    builder.add_state_deltas(*state)
+        .add_code(code)
+        .add_receipts(results)
+        .add_transactions(block.transactions, senders)
+        .add_call_frames(call_frames)
+        .add_ommers(block.ommers);
+    if (block.withdrawals.has_value()) {
+        builder.add_withdrawals(block.withdrawals.value());
+    }
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        h.receipts_root = db.receipts_root();
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = results.empty() ? 0 : results.back().gas_used;
+        h.logs_bloom = compute_bloom(results);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
     db.update_proposal_state(std::move(state), block.header.number, block_id);
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
@@ -465,7 +473,7 @@ MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &chain, std::filesystem::path const &ledger_dir,
-    mpt::Db &raw_db, Db &db, vm::VM &vm,
+    mpt::Db &raw_db, DbCache &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,

--- a/cmd/monad/runloop_monad.hpp
+++ b/cmd/monad/runloop_monad.hpp
@@ -28,7 +28,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct MonadChain;
-struct Db;
+class DbCache;
 class BlockHashBufferFinalized;
 
 namespace mpt
@@ -42,7 +42,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
-    MonadChain const &, std::filesystem::path const &, mpt::Db &, Db &,
+    MonadChain const &, std::filesystem::path const &, mpt::Db &, DbCache &,
     vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
     uint64_t, sig_atomic_t const volatile &, bool enable_tracing);
 

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -23,9 +23,11 @@
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
-#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -110,7 +112,7 @@ void get_block_with_retry(
 template <Traits traits>
     requires is_monad_trait_v<traits>
 Result<void> process_monad_block(
-    MonadChain const &chain, Db &db, vm::VM &vm,
+    MonadChain const &chain, DbCache &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing,
@@ -204,21 +206,28 @@ Result<void> process_monad_block(
     // Database commit of state changes (incl. Merkle root calculations)
     block_state.log_debug();
     auto const commit_begin = std::chrono::steady_clock::now();
-    auto [state, code] = block_state.release();
-    db.commit(
-        *state,
-        code,
-        block_id,
-        block.header,
-        receipts,
-        call_frames,
-        senders,
-        block.transactions,
-        block.ommers,
-        block.withdrawals);
-    // Transfer state ownership to DbCache for proposal tracking. This must
-    // come after commit since it takes ownership of the state. Safe to
-    // reorder: DbCache is only read on the next block, not during commit.
+    auto [state, code] = std::move(block_state).release();
+
+    CommitBuilder builder(block.header.number);
+    builder.add_state_deltas(*state)
+        .add_code(code)
+        .add_receipts(receipts)
+        .add_transactions(block.transactions, senders)
+        .add_call_frames(call_frames)
+        .add_ommers(block.ommers);
+    if (block.withdrawals.has_value()) {
+        builder.add_withdrawals(block.withdrawals.value());
+    }
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        h.receipts_root = db.receipts_root();
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(receipts);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
     db.update_proposal_state(std::move(state), block.header.number, block_id);
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
@@ -282,8 +291,8 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
-    MonadChain const &chain, std::filesystem::path const &ledger_dir, Db &db,
-    vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
+    MonadChain const &chain, std::filesystem::path const &ledger_dir,
+    DbCache &db, vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &finalized_block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
     bool const enable_tracing, std::chrono::seconds const block_db_timeout)

--- a/cmd/monad/runloop_monad_ethblocks.hpp
+++ b/cmd/monad/runloop_monad_ethblocks.hpp
@@ -30,7 +30,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct MonadChain;
-struct Db;
+class DbCache;
 class BlockHashBufferFinalized;
 
 namespace fiber
@@ -39,7 +39,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
-    MonadChain const &, std::filesystem::path const &, Db &, vm::VM &,
+    MonadChain const &, std::filesystem::path const &, DbCache &, vm::VM &,
     BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
     sig_atomic_t const volatile &, bool enable_tracing,
     std::chrono::seconds block_db_timeout);

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -39,6 +39,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/int_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
@@ -384,18 +385,41 @@ Result<BlockExecOutput> execute(
             chain_context));
 
     block_state.log_debug();
-    auto [state, code] = block_state.release();
+    auto [state, code] = std::move(block_state).release();
+
+    CommitBuilder builder(block.header.number);
+    builder.add_state_deltas(*state)
+        .add_code(code)
+        .add_receipts(receipts)
+        .add_transactions(block.transactions, senders)
+        .add_call_frames(
+            std::vector<std::vector<CallFrame>>(block.transactions.size()))
+        .add_ommers(block.ommers);
+    if (block.withdrawals.has_value()) {
+        builder.add_withdrawals(block.withdrawals.value());
+    }
     db.commit(
-        *state,
-        code,
         bytes32_t{block.header.number},
+        builder,
         block.header,
-        receipts,
-        std::vector<std::vector<CallFrame>>{block.transactions.size()},
-        senders,
-        block.transactions,
-        block.ommers,
-        block.withdrawals);
+        *state,
+        [&](BlockHeader &h) {
+            if constexpr (traits::evm_rev() <= EVMC_BYZANTIUM) {
+                // TrieDb receipts root is not valid pre-Byzantium; use the
+                // block's original receipts root.
+                h.receipts_root = block.header.receipts_root;
+            }
+            else {
+                h.receipts_root = db.receipts_root();
+            }
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+            h.logs_bloom = compute_bloom(receipts);
+            h.ommers_hash = compute_ommers_hash(block.ommers);
+        });
+
     db.finalize(block.header.number, bytes32_t{block.header.number});
 
     BlockExecOutput exec_output;
@@ -496,8 +520,9 @@ void process_test(
         State state{bs, Incarnation{0, 0}};
         j_contents.at("pre").get_to(state);
         bs.merge(state);
-        auto [released_state, released_code] = bs.release();
-        tdb.commit(
+        auto [released_state, released_code] = std::move(bs).release();
+        commit_simple(
+            tdb,
             *released_state,
             released_code,
             NULL_HASH_BLAKE3,


### PR DESCRIPTION
   
  Replace Db::commit() with a single virtual commit() that accepts a                                                                                                       
  populate_header_fn callback, invoked between the two internal upserts.
  Callers populate all header fields explicitly in the lambda, removing
  the receipts root hack from TrieDb.

  Separate ownership semantics: BlockState::commit() is replaced with
  release(), which returns a ReleasedState via move. Callers now release
  state, call db.commit() with a const reference, and transfer ownership
  to DbCache via an explicit update_proposal_state() method.

  Extract commit_simple into a shared test header. DbCache becomes a
  clean pass-through for commits with proposal tracking via
  update_proposal_state.

  Resolves https://github.com/category-labs/monad/issues/2094