### PR TITLE
del ASSERT that relied on suboptimality of reserve balance accounting

### DIFF
--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -156,8 +156,8 @@ void run_revert_transaction_test(
     uint8_t const prevent_dip_bitset, uint64_t const initial_balance_mon,
     uint64_t const gas_fee_mon, uint64_t const value_mon, bool const expected)
 {
-    constexpr uint256_t BASE_FEE_PER_GAS = 10;
-    constexpr Address SENDER{1};
+    static constexpr uint256_t BASE_FEE_PER_GAS = 10;
+    static constexpr Address SENDER{1};
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
@@ -347,6 +347,83 @@ TYPED_TEST(MonadTraitsTest, reserve_balance_checks_disabled_before_monad_four)
     }
 }
 
+TYPED_TEST(
+    MonadTraitsTest,
+    sender_gas_fee_above_reserve_stays_failed_after_large_credit)
+{
+    using traits = typename TestFixture::Trait;
+    if constexpr (traits::monad_rev() < MONAD_FOUR) {
+        GTEST_SKIP() << "reserve-balance checks are disabled before MONAD_FOUR";
+    }
+
+    static constexpr Address SENDER{1};
+    static constexpr uint256_t BASE_FEE_PER_GAS = 10;
+    auto const to_wei = [](uint64_t mon) {
+        return uint256_t{mon} * 1000000000000000000ULL;
+    };
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+
+    {
+        State init_state{bs, Incarnation{0, 0}};
+        init_state.add_to_balance(SENDER, to_wei(20));
+        MONAD_ASSERT(bs.can_merge(init_state));
+        bs.merge(init_state);
+    }
+
+    uint256_t const sender_gas_fee = to_wei(11); // reserve is capped at 10 MON
+    uint256_t const gas_limit_u256 = sender_gas_fee / BASE_FEE_PER_GAS;
+    MONAD_ASSERT(
+        (sender_gas_fee % BASE_FEE_PER_GAS) == 0 &&
+        gas_limit_u256 <= std::numeric_limits<uint64_t>::max());
+
+    Transaction const tx{
+        .max_fee_per_gas = BASE_FEE_PER_GAS,
+        .gas_limit = static_cast<uint64_t>(gas_limit_u256),
+        .type = TransactionType::legacy,
+        .max_priority_fee_per_gas = 0,
+    };
+
+    ankerl::unordered_dense::segmented_set<Address> const
+        empty_grandparent_senders_and_authorities;
+    ankerl::unordered_dense::segmented_set<Address>
+        parent_senders_and_authorities;
+    parent_senders_and_authorities.insert(SENDER); // sender cannot dip
+    std::vector<Address> const senders = {SENDER};
+    std::vector<std::vector<std::optional<Address>>> const authorities = {{}};
+    ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
+    senders_and_authorities.insert(SENDER);
+    ChainContext<traits> const context{
+        .grandparent_senders_and_authorities =
+            empty_grandparent_senders_and_authorities,
+        .parent_senders_and_authorities = parent_senders_and_authorities,
+        .senders_and_authorities = senders_and_authorities,
+        .senders = senders,
+        .authorities = authorities,
+    };
+
+    State state{bs, Incarnation{1, 1}};
+    init_reserve_balance_context<traits>(
+        state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+    state.subtract_from_balance(SENDER, sender_gas_fee);
+
+    EXPECT_TRUE(revert_transaction<traits>(
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context));
+    EXPECT_TRUE(revert_transaction_cached<traits>(state));
+
+    uint256_t const sender_balance = state.get_balance(SENDER);
+    state.add_to_balance(
+        SENDER, std::numeric_limits<uint256_t>::max() - sender_balance);
+
+    EXPECT_TRUE(revert_transaction<traits>(
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context));
+    EXPECT_TRUE(revert_transaction_cached<traits>(state));
+}
+
 TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
 {
     if constexpr (TestFixture::Trait::monad_rev() < MONAD_FOUR) {
@@ -480,9 +557,9 @@ TYPED_TEST(MonadTraitsTest, can_sender_dip_into_reserve)
 TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
 {
     using traits = typename TestFixture::Trait;
-    constexpr Address SENDER{1};
-    constexpr Address NEW_CONTRACT{2};
-    constexpr uint64_t BASE_FEE_PER_GAS = 10;
+    static constexpr Address SENDER{1};
+    static constexpr Address NEW_CONTRACT{2};
+    static constexpr uint64_t BASE_FEE_PER_GAS = 10;
     auto const to_wei = [](uint64_t mon) {
         return uint256_t{mon} * 1000000000000000000ULL;
     };
@@ -559,9 +636,9 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
 TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
 {
     using traits = typename TestFixture::Trait;
-    constexpr Address SENDER{1};
-    constexpr Address NEW_CONTRACT{2};
-    constexpr uint64_t BASE_FEE_PER_GAS = 10;
+    static constexpr Address SENDER{1};
+    static constexpr Address NEW_CONTRACT{2};
+    static constexpr uint64_t BASE_FEE_PER_GAS = 10;
     auto const to_wei = [](uint64_t mon) {
         return uint256_t{mon} * 1000000000000000000ULL;
     };

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -119,12 +119,6 @@ bool dipped_into_reserve(
             if (addr == sender) {
                 if (!can_sender_dip_into_reserve(
                         sender, i, effective_is_delegated, ctx)) {
-                    // Safety: this assertion is recoverable because it can be
-                    // triggered via RPC parameter setting.
-                    MONAD_ASSERT_THROW(
-                        violation_threshold.has_value(),
-                        "gas fee greater than reserve for non-dipping "
-                        "transaction");
                     return true;
                 }
                 // Skip if allowed to dip into reserve
@@ -244,9 +238,21 @@ void ReserveBalance::update_violation_status(Address const &address)
                 failed_.erase(address);
                 return;
             }
-            MONAD_ASSERT_THROW(
-                sender_gas_fees_ <= reserve,
-                "gas fee greater than reserve for non-dipping transaction");
+            if (sender_gas_fees_ > reserve) {
+                // This currently only happens in the RPC path.
+                // If we later use a more permissive reserve-balance design that
+                // accounts for credits to non-delegated accounts, this could
+                // also occur during speculative execution with stale pre-tx
+                // data. In that case, a retry is guaranteed, so what we do here
+                // will not matter in such cases.
+                //
+                // For RPC, treat this as a transaction revert: keep the
+                // threshold unset and the sender marked failed for this
+                // transaction. This avoids underflow in the subtraction below.
+                violation_threshold.reset();
+                failed_.insert(address);
+                return;
+            }
             reserve = reserve - sender_gas_fees_;
         }
         violation_threshold = reserve;

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -3694,8 +3694,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
     monad_state_override_destroy(state_override);
 }
 
-// Check that gas < reserve assertion in reserve balance implementation doesn't
-// crash the RPC process
+// Check reserve-balance failure in eth_call returns explicit violation status.
 TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
 {
     for (uint64_t i = 0; i < 256; ++i) {
@@ -3800,10 +3799,8 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
         true);
     f.get();
 
-    EXPECT_EQ(ctx.result->status_code, EVMC_INTERNAL_ERROR);
-    EXPECT_EQ(
-        std::string_view{ctx.result->message},
-        "gas fee greater than reserve for non-dipping transaction");
+    EXPECT_EQ(ctx.result->status_code, EVMC_MONAD_RESERVE_BALANCE_VIOLATION);
+    EXPECT_EQ(ctx.result->message, nullptr);
 
     monad_executor_destroy(executor);
     monad_state_override_destroy(state_override);


### PR DESCRIPTION
The 2 occurrences of `MONAD_ASSERT_THROW` that are being deleted are basically the same: one for the uncached and one for the cached implementation of reserve balance.

There is a history of problems with this assert. In [November2025](https://github.com/category-labs/monad/commit/dfd5207b9ae874861f24e051a43db885ac94a20a), it was changed from `MONAD_ASSERT` to `MONAD_ASSERT_THROW` when it was discovered that this assert can fire when balance overrides are used in the RPC path. At that time, it was believed, including by me, that the assert can only fire in the RPC path but not when running as a live mainnet node where the transactions are coming from consensus which checks reserve balance conditions. 

While doing the Coq proof of this C++ code, I found that although it would not fire in live mainnet context, the reasoning is much more tricky than I thought initially thought. Perhaps the authors/reviewers had the same misunderstanding. Also, the reasoning may actually not hold if we further optimize the reserve balance design to be more permissive to users (e.g. allow multiple emptying transactions, track statically known credits to non-delegated accounts): if we do that, this deleted assert may crash the node under some interleavings of optimistic execution.

The issue is that even though consensus has ensured this assert condition, it estimates that by considering transactions sequentially (debiting fees (and value for emptying txs) one by one). But at this point in code, we may be doing speculative execution so the accound balances and account codes (which determines the delegation status) may be wrong/different from what will happen in the actual sequential execution, so the consensus guarantee of reserve balance being sufficient to pay at least the fee do not apply directly. Fortunately, there is no problem currently because the reserve-balance design is not very aggressive: it allows only 1 emptying transaction and disregards even statically known credits, even to non-delegated accounts:

We do [validate the transactions](https://github.com/category-labs/monad/blob/fa50e08ea0ce55fc2251312841658dda31632697/category/execution/ethereum/validate_transaction.cpp#L257) before reaching this point and only reach here when validation succeeds. The validation success implies that the original balance (speculatively assumed pre-tx balance) is at least as large as the max fee (+tx.value). For non-emptying transactions, this is sufficient because consensus also checks that for non-emptying transactions max_fee is <= 10 MON, and these 2 assumptions imply the asserted condition:
```
Lemma foo (original_bal value gas_fee: N) :
  value + gas_fee <= original_bal (* condition checked by transaction validation in execution. original_bal may be a speculated value *)
  -> gas_fee <= 10 (* condition checked by consensus for non-emptying txs. gas_fee is fixed for a tx and not affected by speculation *)
  -> gas_fee <= original_bal `min` 10 (* this assert *).
Proof. lia. Qed.
```

But for emptying transactions, consensus does *not* check that `gas_fee <= 10`. Fortunately, the assert occurs only inside the non-emptying case, when `can_sender_dip_into_reserve` returns false. But one problem is that because of speculation, the `Account::code` read in `dipped_into_reserve` to computed the delegation status for `can_sender_dip_into_reserve` may  not be what consensus used its calculations. But that turns out to not be a problem. This assert only pertains to the sender and we know the sender's address cannot be an SC (cryptographic hardness).So the sender's code is either empty or has a delegaton marker. But there can be a delegation mismatch: consensus considered the sender's account delegated as it would be in a sequential execution but this account is not delegated in speculative execution, or vice versa.
But if consensus determined that the tx was allowed to empty, then execution would also make the same determination: even if it speculatively reads `Account::code` even before the previous transaction has finished or even started. The reason is as follows:
If consensus determined that the tx was allowed to empty, there must be no delegation/undelegation requests (EIP7702 authorities) for the sender in this block, at least till this transaction. Also, the account must be undelegated at the beginning of the block. Also, any sender's account cannot be a smart contract, so `Account::code` must be empty. Thus `Account::code` must be empty in the pre-block state and remains empty during the execution of all the previous transactions. So even if speculative execution reads an state that is not that from the just previous transaction, it will read the correct delegation status (not delegated): the same as what consensus used in its calculations.
