### PR TITLE
Inline/replace silkpre precompile gas cost functions

### DIFF
--- a/category/execution/ethereum/precompiles.cpp
+++ b/category/execution/ethereum/precompiles.cpp
@@ -74,8 +74,8 @@ std::optional<PrecompiledContract> resolve_precompile(Address const &address)
 
     // Ethereum precompiles
     CASE(0x01, ecrecover_gas_cost<traits>, ecrecover_execute);
-    CASE(0x02, sha256_gas_cost<traits>, sha256_execute);
-    CASE(0x03, ripemd160_gas_cost<traits>, ripemd160_execute);
+    CASE(0x02, sha256_gas_cost, sha256_execute);
+    CASE(0x03, ripemd160_gas_cost, ripemd160_execute);
     CASE(0x04, identity_gas_cost, identity_execute);
 
     if constexpr (traits::evm_rev() >= EVMC_BYZANTIUM) {
@@ -155,10 +155,9 @@ std::optional<evmc::Result> check_call_eth_precompile(evmc_message const &msg)
     byte_string_view const input{msg.input_data, msg.input_size};
     std::optional<uint64_t> const cost = gas_cost_func(input);
 
-    // If cost is std::nullopt, the gas function got an invalid input. This is
-    // currently only possible for EXPMOD with EIP-7823.
+    // If cost is std::nullopt, the gas function got an invalid input.
     if (!cost.has_value()) {
-        return evmc::Result{evmc_status_code::EVMC_FAILURE};
+        return evmc::Result{evmc_status_code::EVMC_PRECOMPILE_FAILURE};
     }
 
     if (MONAD_UNLIKELY(std::cmp_less(msg.gas, cost.value()))) {

--- a/category/execution/ethereum/precompiles.hpp
+++ b/category/execution/ethereum/precompiles.hpp
@@ -25,6 +25,8 @@
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 
+#include <bit>
+#include <cstring>
 #include <optional>
 
 MONAD_NAMESPACE_BEGIN
@@ -51,10 +53,8 @@ using precompiled_gas_cost_fn = std::optional<uint64_t>(byte_string_view);
 template <Traits traits>
 uint64_t ecrecover_gas_cost(byte_string_view);
 
-template <Traits traits>
 uint64_t sha256_gas_cost(byte_string_view);
 
-template <Traits traits>
 uint64_t ripemd160_gas_cost(byte_string_view);
 
 uint64_t identity_gas_cost(byte_string_view);
@@ -68,11 +68,38 @@ uint64_t ecadd_gas_cost(byte_string_view);
 template <Traits traits>
 uint64_t ecmul_gas_cost(byte_string_view);
 
+template <evmc_revision Rev>
+[[gnu::always_inline]] inline uint64_t
+snarkv_gas_cost_ethereum(byte_string_view const input)
+{
+    uint64_t const k{input.size() / 192};
+    if constexpr (Rev >= EVMC_ISTANBUL) {
+        return 34'000 * k + 45'000; // EIP-1108
+    }
+    else {
+        return 80'000 * k + 100'000; // EIP-197
+    }
+}
+
 template <Traits traits>
 uint64_t snarkv_gas_cost(byte_string_view);
 
+[[gnu::always_inline]] inline std::optional<uint64_t>
+blake2bf_gas_cost_ethereum(byte_string_view const input)
+{
+    if (input.size() < 4) {
+        return std::nullopt;
+    }
+    uint32_t rounds{0};
+    std::memcpy(&rounds, input.data(), sizeof(uint32_t));
+    static_assert(
+        std::endian::native == std::endian::little,
+        "blake2bf_gas_cost_ethereum only works on little-endian platforms");
+    return std::byteswap(rounds);
+}
+
 template <Traits traits>
-uint64_t blake2bf_gas_cost(byte_string_view);
+std::optional<uint64_t> blake2bf_gas_cost(byte_string_view);
 
 template <Traits traits>
 uint64_t point_evaluation_gas_cost(byte_string_view);

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -114,31 +114,25 @@ static inline PrecompileResult silkpre_execute(byte_string_view const input)
 }
 
 template <Traits traits>
-uint64_t ecrecover_gas_cost(byte_string_view const input)
+uint64_t ecrecover_gas_cost(byte_string_view const)
 {
-    return silkpre_ecrec_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    // YP eqn 211
+    return 3'000;
 }
 
 EXPLICIT_EVM_TRAITS(ecrecover_gas_cost);
 
-template <Traits traits>
 uint64_t sha256_gas_cost(byte_string_view const input)
 {
-    return silkpre_sha256_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    // YP eqn 223
+    return 60 + 12 * num_words(input.size());
 }
 
-EXPLICIT_TRAITS(sha256_gas_cost);
-
-template <Traits traits>
 uint64_t ripemd160_gas_cost(byte_string_view const input)
 {
-    return silkpre_rip160_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    // YP eqn 226
+    return 600 + 120 * num_words(input.size());
 }
-
-EXPLICIT_TRAITS(ripemd160_gas_cost);
 
 uint64_t identity_gas_cost(byte_string_view const input)
 {
@@ -147,19 +141,27 @@ uint64_t identity_gas_cost(byte_string_view const input)
 }
 
 template <Traits traits>
-uint64_t ecadd_gas_cost(byte_string_view const input)
+uint64_t ecadd_gas_cost(byte_string_view const)
 {
-    return silkpre_bn_add_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    if constexpr (traits::evm_rev() >= EVMC_ISTANBUL) {
+        return 150; // EIP-1108
+    }
+    else {
+        return 500; // EIP-196
+    }
 }
 
 EXPLICIT_EVM_TRAITS(ecadd_gas_cost);
 
 template <Traits traits>
-uint64_t ecmul_gas_cost(byte_string_view const input)
+uint64_t ecmul_gas_cost(byte_string_view const)
 {
-    return silkpre_bn_mul_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    if constexpr (traits::evm_rev() >= EVMC_ISTANBUL) {
+        return 6'000; // EIP-1108
+    }
+    else {
+        return 40'000; // EIP-196
+    }
 }
 
 EXPLICIT_EVM_TRAITS(ecmul_gas_cost);
@@ -167,17 +169,15 @@ EXPLICIT_EVM_TRAITS(ecmul_gas_cost);
 template <Traits traits>
 uint64_t snarkv_gas_cost(byte_string_view const input)
 {
-    return silkpre_snarkv_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    return snarkv_gas_cost_ethereum<traits::evm_rev()>(input);
 }
 
 EXPLICIT_EVM_TRAITS(snarkv_gas_cost);
 
 template <Traits traits>
-uint64_t blake2bf_gas_cost(byte_string_view const input)
+std::optional<uint64_t> blake2bf_gas_cost(byte_string_view const input)
 {
-    return silkpre_blake2_f_gas(
-        input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    return blake2bf_gas_cost_ethereum(input);
 }
 
 EXPLICIT_EVM_TRAITS(blake2bf_gas_cost);

--- a/category/execution/ethereum/precompiles_test.cpp
+++ b/category/execution/ethereum/precompiles_test.cpp
@@ -701,7 +701,7 @@ TYPED_TEST(TraitsTest, modexp_truncated_input)
         // modulus size in this example fails to validate.
         static constexpr auto expected_failure =
             TestFixture::Trait::eip_7823_active()
-                ? evmc_status_code::EVMC_FAILURE
+                ? evmc_status_code::EVMC_PRECOMPILE_FAILURE
                 : evmc_status_code::EVMC_OUT_OF_GAS;
 
         static constexpr auto min_gas = [] {

--- a/category/execution/monad/monad_precompiles_impl.cpp
+++ b/category/execution/monad/monad_precompiles_impl.cpp
@@ -19,48 +19,44 @@
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
-#include <silkpre/precompile.h>
-
 MONAD_NAMESPACE_BEGIN
 
 template <Traits traits>
-uint64_t ecrecover_gas_cost(byte_string_view const input)
+uint64_t ecrecover_gas_cost(byte_string_view const)
 {
     // Monad specification §4.3: Precompiles
     static constexpr auto pricing_factor =
         traits::monad_pricing_version() >= 1 ? 2 : 1;
 
-    return pricing_factor *
-           silkpre_ecrec_gas(
-               input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    return pricing_factor * 3'000;
 }
 
 EXPLICIT_MONAD_TRAITS(ecrecover_gas_cost);
 
 template <Traits traits>
-uint64_t ecadd_gas_cost(byte_string_view const input)
+uint64_t ecadd_gas_cost(byte_string_view const)
 {
     // Monad specification §4.3: Precompiles
     static constexpr auto pricing_factor =
         traits::monad_pricing_version() >= 1 ? 2 : 1;
 
-    return pricing_factor *
-           silkpre_bn_add_gas(
-               input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    static_assert(traits::evm_rev() >= EVMC_ISTANBUL);
+
+    return pricing_factor * 150;
 }
 
 EXPLICIT_MONAD_TRAITS(ecadd_gas_cost);
 
 template <Traits traits>
-uint64_t ecmul_gas_cost(byte_string_view const input)
+uint64_t ecmul_gas_cost(byte_string_view const)
 {
     // Monad specification §4.3: Precompiles
     static constexpr auto pricing_factor =
         traits::monad_pricing_version() >= 1 ? 5 : 1;
 
-    return pricing_factor *
-           silkpre_bn_mul_gas(
-               input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    static_assert(traits::evm_rev() >= EVMC_ISTANBUL);
+
+    return pricing_factor * 6'000;
 }
 
 EXPLICIT_MONAD_TRAITS(ecmul_gas_cost);
@@ -72,23 +68,22 @@ uint64_t snarkv_gas_cost(byte_string_view const input)
     static constexpr auto pricing_factor =
         traits::monad_pricing_version() >= 1 ? 5 : 1;
 
-    return pricing_factor *
-           silkpre_snarkv_gas(
-               input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    return pricing_factor * snarkv_gas_cost_ethereum<traits::evm_rev()>(input);
 }
 
 EXPLICIT_MONAD_TRAITS(snarkv_gas_cost);
 
 template <Traits traits>
-uint64_t blake2bf_gas_cost(byte_string_view const input)
+std::optional<uint64_t> blake2bf_gas_cost(byte_string_view const input)
 {
     // Monad specification §4.3: Precompiles
     static constexpr auto pricing_factor =
         traits::monad_pricing_version() >= 1 ? 2 : 1;
 
-    return pricing_factor *
-           silkpre_blake2_f_gas(
-               input.data(), input.size(), static_cast<int>(traits::evm_rev()));
+    if (auto const ethereum_cost = blake2bf_gas_cost_ethereum(input)) {
+        return pricing_factor * *ethereum_cost;
+    }
+    return std::nullopt;
 }
 
 EXPLICIT_MONAD_TRAITS(blake2bf_gas_cost);


### PR DESCRIPTION
This PR is preparatory work for removing/in-lining the silkpre precompiles library. This has been a goal for some time due to silkpre no longer being actively maintained. The current main motivation for this change, however, is due to efforts to cross-compile monad as a guest program in ZisK/SP1 zkVMs. In a followup PR (together with #2090), the calls to precompiles in a zkVM will be re-routed to ZisK/SP1/RISC0/etc. implementations via the following [interface](https://github.com/eth-act/zkvm-standards/blob/main/standards/c-interface-accelerators/zkvm_accelerators.h).