### PR TITLE
Remove State::set_balance and make selfdestruct access balances using get_balance/add/subtract only

### DIFF
--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -152,8 +152,6 @@ public:
 
     void subtract_from_balance(Address const &, uint256_t const &delta);
 
-    void set_balance(Address const &, uint256_t const &balance);
-
     evmc_storage_status
     set_storage(Address const &, bytes32_t const &key, bytes32_t const &value);
 


### PR DESCRIPTION
While updating PR 1966 (relaxed merge of balance), it occurred to me that State::set_balance shouldn't exist.
- Balance changes should always be expressed as deltas (add_to_balance/subtract_from_balance), not as absolute values. In contrast, set_balance allows direct overwrites.
- The only caller is selfdestruct, which uses set_balance(address, 0) to zero out the selfdestructing contract and can be replaced with get_balance and subtract.
- Removing set_balance and using get_balance and add/subtract instead reduces the surface area for improperly annotating balance validation requirements.

This PR:
- Replaces set_balance in selfdestruct with get_balance and subtract_from_balance.
- Removes set_balance
