### PR TITLE
Implement nonblocking async_write_node with delayed write queue

### DIFF
--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -481,6 +481,19 @@ public:
             (std::byte *)mem, detail::write_buffer_deleter(this));
     }
 
+    //! Non-blocking variant of get_write_buffer(). Returns null
+    //! write_buffer_ptr if pool is empty instead of blocking.
+    write_buffer_ptr try_get_write_buffer()
+    {
+        unsigned char *mem = wr_pool_.alloc();
+        if (mem == nullptr) {
+            return write_buffer_ptr(
+                nullptr, detail::write_buffer_deleter(this));
+        }
+        return write_buffer_ptr(
+            (std::byte *)mem, detail::write_buffer_deleter(this));
+    }
+
 private:
     unsigned char *poll_uring_while_no_io_buffers_(bool is_write);
 
@@ -511,6 +524,36 @@ private:
         else {
             MONAD_ASSERT(rwbuf_.get_read_size() >= READ_BUFFER_SIZE);
         }
+        return ret;
+    }
+
+    //! Non-blocking variant of make_connected_impl_. Returns nullptr if no
+    //! write buffer is immediately available. Write-only.
+    template <bool is_write, class F>
+    auto try_make_connected_impl_(F &&connect)
+    {
+        static_assert(is_write);
+        using connected_type = decltype(connect());
+        static_assert(sizeof(connected_type) <= MAX_CONNECTED_OPERATION_SIZE);
+        using traits =
+            std::allocator_traits<connected_operation_storage_allocator_type_>;
+        using ret_type = std::unique_ptr<
+            connected_type,
+            io_connected_operation_unique_ptr_deleter>;
+        auto buf = try_get_write_buffer();
+        if (!buf) {
+            return ret_type(nullptr);
+        }
+        unsigned char *mem = (unsigned char *)traits::allocate(
+            connected_operation_storage_pool_, 1);
+        MONAD_ASSERT_PRINTF(
+            mem != nullptr, "failed due to %s", strerror(errno));
+        auto ret = ret_type(new (mem) connected_type(connect()));
+        MONAD_ASSERT(ret->sender().buffer().data() == nullptr);
+        MONAD_ASSERT(rwbuf_.get_write_size() >= WRITE_BUFFER_SIZE);
+        auto buffer = std::move(ret->sender()).buffer();
+        buffer.set_write_buffer(std::move(buf));
+        ret->sender().reset(ret->sender().offset(), std::move(buffer));
         return ret;
     }
 
@@ -564,6 +607,26 @@ public:
                        std::move(sender_args),
                        std::move(receiver_args));
                });
+    }
+
+    //! Non-blocking variant of make_connected for write operations.
+    //! Returns nullptr if no write buffer is immediately available.
+    template <sender Sender, receiver Receiver>
+        requires(
+            Sender::my_operation_type == operation_type::write &&
+            requires(
+                Receiver r, erased_connected_operation *o,
+                typename Sender::result_type x) {
+                r.set_value(o, std::move(x));
+            })
+    auto try_make_connected(Sender &&sender, Receiver &&receiver)
+    {
+        return try_make_connected_impl_<true>([&] {
+            return connect<Sender, Receiver>(
+                *this,
+                std::forward<Sender>(sender),
+                std::forward<Receiver>(receiver));
+        });
     }
 
     template <class Base, sender Sender, receiver Receiver>

--- a/category/async/io_senders.hpp
+++ b/category/async/io_senders.hpp
@@ -392,9 +392,11 @@ public:
 
     constexpr std::byte *advance_buffer_append(size_t bytes) noexcept
     {
-        if (bytes > remaining_buffer_bytes()) {
-            return nullptr;
-        }
+        MONAD_ASSERT_PRINTF(
+            bytes <= remaining_buffer_bytes(),
+            "advance_buffer_append: requested %zu bytes but only %zu remaining",
+            bytes,
+            remaining_buffer_bytes());
         auto *ret = append_;
         append_ += bytes;
         return ret;

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -48,8 +48,7 @@ Node::SharedPtr create_node_add_new_branch(
             child.ptr = std::move(new_child);
             child.subtrie_min_version = calc_min_version(*child.ptr);
             if (aux.is_on_disk()) {
-                child.offset =
-                    async_write_node_set_spare(aux, *child.ptr, true);
+                child.offset = async_write_node_set_spare(aux, child.ptr, true);
                 child.min_offsets = calc_min_offsets(
                     *child.ptr, aux.physical_to_virtual(child.offset));
             }
@@ -95,7 +94,7 @@ Node::SharedPtr create_node_with_two_children(
         child.subtrie_min_version = calc_min_version(*child.ptr);
         child.branch = branch0;
         if (aux.is_on_disk()) {
-            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            child.offset = async_write_node_set_spare(aux, child.ptr, true);
             child.min_offsets = calc_min_offsets(*child.ptr);
         }
     }
@@ -105,7 +104,7 @@ Node::SharedPtr create_node_with_two_children(
         child.subtrie_min_version = calc_min_version(*child.ptr);
         child.branch = branch1;
         if (aux.is_on_disk()) {
-            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            child.offset = async_write_node_set_spare(aux, child.ptr, true);
             child.min_offsets = calc_min_offsets(*child.ptr);
         }
     }
@@ -137,7 +136,7 @@ Node::SharedPtr copy_trie_impl(
             .ptr = std::move(new_node), .branch = dest_prefix.get(0)};
         child.subtrie_min_version = calc_min_version(*child.ptr);
         if (aux.is_on_disk()) {
-            child.offset = async_write_node_set_spare(aux, *child.ptr, true);
+            child.offset = async_write_node_set_spare(aux, child.ptr, true);
             child.min_offsets = calc_min_offsets(
                 *child.ptr, aux.physical_to_virtual(child.offset));
         }
@@ -266,10 +265,10 @@ Node::SharedPtr copy_trie_impl(
         // serialize nodes of insert path up until root (excludes root)
         while (!parents_and_indexes.empty()) {
             auto const &[p, i] = parents_and_indexes.top();
-            auto &node = *p->next(i);
-            p->set_fnext(i, async_write_node_set_spare(aux, node, true));
-            p->set_min_offsets(i, calc_min_offsets(node));
-            p->set_subtrie_min_version(i, calc_min_version(node));
+            auto node_ptr = p->next(i);
+            p->set_fnext(i, async_write_node_set_spare(aux, node_ptr, true));
+            p->set_min_offsets(i, calc_min_offsets(*node_ptr));
+            p->set_subtrie_min_version(i, calc_min_version(*node_ptr));
             parents_and_indexes.pop();
         }
     }
@@ -290,7 +289,7 @@ Node::SharedPtr copy_trie_to_dest(
         dest_prefix,
         dest_version);
     if (aux.is_on_disk() && write_root) {
-        write_new_root_node(aux, *dest_root, dest_version);
+        write_new_root_node(aux, dest_root, dest_version);
         MONAD_ASSERT(aux.db_history_max_version() >= dest_version);
     }
     if (aux.is_on_disk()) {

--- a/category/mpt/deserialize_node_from_receiver_result.hpp
+++ b/category/mpt/deserialize_node_from_receiver_result.hpp
@@ -66,6 +66,7 @@ namespace detail
                               result_type>) {
             auto &buffer = std::move(buffer_).assume_value().get();
             MONAD_ASSERT(buffer.size() > buffer_off);
+
             node = deserialize_node_from_buffer(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -66,6 +66,7 @@ Node::SharedPtr read_node_blocking(
             rd_offset,
             strerror(errno));
     }
+
     return aux.version_is_valid_ondisk(version)
                ? deserialize_node_from_buffer(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)

--- a/category/mpt/test/append_test.cpp
+++ b/category/mpt/test/append_test.cpp
@@ -80,9 +80,11 @@ TYPED_TEST(AppendTest, works)
     EXPECT_EQ(this->state()->aux.get_start_of_wip_fast_offset(), last_fast_off);
     EXPECT_EQ(this->state()->aux.get_start_of_wip_slow_offset(), last_slow_off);
     EXPECT_EQ(
-        this->state()->aux.node_writer_fast->sender().offset(), last_fast_off);
+        this->state()->aux.writer_fast.node_writer->sender().offset(),
+        last_fast_off);
     EXPECT_EQ(
-        this->state()->aux.node_writer_slow->sender().offset(), last_slow_off);
+        this->state()->aux.writer_slow.node_writer->sender().offset(),
+        last_slow_off);
 
     // Has the root hash returned to what it should be?
     EXPECT_EQ(this->state()->root_hash(), root_hash_before);

--- a/category/mpt/test/min_truncated_offsets_test.cpp
+++ b/category/mpt/test/min_truncated_offsets_test.cpp
@@ -87,10 +87,10 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                  count_slow++, ci = ci->next(aux.db_metadata())) {
             }
             if (count_fast >= fast_chunks &&
-                aux.node_writer_fast->sender().offset().offset >=
+                aux.writer_fast.node_writer->sender().offset().offset >=
                     chunk_inner_offset_fast &&
                 count_slow >= slow_chunks &&
-                aux.node_writer_slow->sender().offset().offset >=
+                aux.writer_slow.node_writer->sender().offset().offset >=
                     chunk_inner_offset_slow) {
                 break;
             }

--- a/category/mpt/test/node_writer_test.cpp
+++ b/category/mpt/test/node_writer_test.cpp
@@ -106,19 +106,85 @@ struct NodeWriterTestBase : public ::testing::Test
             auto const remaining_bytes = sender.remaining_buffer_bytes();
             if (bytes <= remaining_bytes) {
                 sender.advance_buffer_append(bytes);
-                return;
+                bytes = 0;
+                break;
             }
             if (remaining_bytes > 0) {
                 sender.advance_buffer_append(remaining_bytes);
                 bytes -= remaining_bytes;
             }
 
-            auto new_node_writer = replace_node_writer(aux, node_writer);
-            MONAD_ASSERT(new_node_writer);
+            // Determine if this is fast or slow writer from chunk metadata
+            bool is_fast = aux.db_metadata()
+                               ->at(node_writer->sender().offset().id)
+                               ->in_fast_list;
+
+            // Compute aligned target offset for new buffer
+            auto current_offset = node_writer->sender().offset();
+            auto written = node_writer->sender().written_buffer_bytes();
+            file_offset_t next_pos = current_offset.offset + written;
+            next_pos = round_up_align<DISK_PAGE_BITS>(next_pos);
+
+            auto chunk_capacity = aux.io->chunk_capacity(current_offset.id);
+            chunk_offset_t target_offset{0, 0};
+
+            // Check if we need next chunk
+            if (next_pos >= chunk_capacity) {
+                // Need next chunk - allocate it (test helper behavior)
+                auto const *ci_ = aux.db_metadata()->free_list_end();
+                MONAD_ASSERT(ci_ != nullptr);
+                auto idx = ci_->index(aux.db_metadata());
+
+                aux.remove(idx);
+                aux.append(
+                    is_fast ? UpdateAuxImpl::chunk_list::fast
+                            : UpdateAuxImpl::chunk_list::slow,
+                    idx);
+
+                target_offset = chunk_offset_t{idx, 0};
+            }
+            else {
+                target_offset = chunk_offset_t{
+                    static_cast<uint32_t>(current_offset.id),
+                    static_cast<uint32_t>(next_pos) &
+                        chunk_offset_t::max_offset};
+            }
+
+            // Initiate old buffer I/O, then allocate new one. If all write
+            // buffers are in flight, poll until one completes and frees up.
+            node_writer->receiver().reset(
+                node_writer->sender().written_buffer_bytes());
             node_writer->initiate();
-            // shall be recycled by the i/o receiver
             node_writer.release();
+            node_writer_unique_ptr_type new_node_writer;
+            while (
+                !(new_node_writer =
+                      replace_node_writer(aux, target_offset, is_fast))) {
+                aux.io->poll_blocking(1);
+            }
             node_writer = std::move(new_node_writer);
+        }
+
+        // Update write_position to match the physical node_writer position
+        bool is_fast = aux.db_metadata()
+                           ->at(node_writer->sender().offset().id)
+                           ->in_fast_list;
+        auto &write_pos = aux.writer(is_fast).write_position;
+        auto const &sender = node_writer->sender();
+        write_pos.current_chunk_id = sender.offset().id;
+        write_pos.current_offset =
+            sender.offset().offset + sender.written_buffer_bytes();
+    }
+
+    // Block until all delayed writes for the given writer are drained.
+    // With non-blocking buffer allocation, process_delayed_writes may
+    // return with items still queued. This helper polls io_uring until
+    // completions re-trigger draining and the queue is empty.
+    void drain_delayed_writes(bool is_fast)
+    {
+        auto &ws = aux.writer(is_fast);
+        while (!ws.delayed_writes.empty()) {
+            aux.io->poll_blocking(1);
         }
     }
 
@@ -140,9 +206,9 @@ using NodeWriterTest = NodeWriterTestBase<>;
 TEST_F(NodeWriterTest, write_nodes_each_within_buffer)
 {
     auto const node_writer_chunk_id_before =
-        get_writer_chunk_id(aux.node_writer_fast);
+        get_writer_chunk_id(aux.writer_fast.node_writer);
     auto const node_writer_chunk_count_before =
-        get_writer_chunk_count(aux.node_writer_fast);
+        get_writer_chunk_count(aux.writer_fast.node_writer);
     ASSERT_EQ(node_writer_chunk_count_before, 0);
 
     unsigned const node_disk_size = 1024;
@@ -150,27 +216,32 @@ TEST_F(NodeWriterTest, write_nodes_each_within_buffer)
         AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
     auto node = make_node_of_size(node_disk_size);
     for (unsigned i = 0; i < num_nodes; ++i) {
-        auto const node_offset = async_write_node_set_spare(aux, *node, true);
+        auto const node_offset = async_write_node_set_spare(aux, node, true);
         EXPECT_EQ(node_offset.offset, node_disk_size * i);
 
-        EXPECT_EQ(node_offset.id, get_writer_chunk_id(aux.node_writer_fast));
         EXPECT_EQ(
-            get_writer_chunk_id(aux.node_writer_fast),
+            node_offset.id, get_writer_chunk_id(aux.writer_fast.node_writer));
+        EXPECT_EQ(
+            get_writer_chunk_id(aux.writer_fast.node_writer),
             node_writer_chunk_id_before);
         EXPECT_EQ(
-            aux.node_writer_fast->sender().written_buffer_bytes(),
+            aux.writer_fast.node_writer->sender().written_buffer_bytes(),
             node_offset.offset + node_disk_size);
     }
     // first buffer is full
-    EXPECT_EQ(aux.node_writer_fast->sender().remaining_buffer_bytes(), 0);
+    EXPECT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
     // continue write more node, node writer will switch to next buffer
-    auto const node_offset = async_write_node_set_spare(aux, *node, true);
+    auto const node_offset = async_write_node_set_spare(aux, node, true);
+    drain_delayed_writes(true);
     EXPECT_EQ(node_offset.offset, AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
     EXPECT_EQ(
-        get_writer_chunk_id(aux.node_writer_fast), node_writer_chunk_id_before);
+        get_writer_chunk_id(aux.writer_fast.node_writer),
+        node_writer_chunk_id_before);
     EXPECT_EQ(node_offset.id, node_writer_chunk_id_before);
     EXPECT_EQ(
-        aux.node_writer_fast->sender().written_buffer_bytes(), node_disk_size);
+        aux.writer_fast.node_writer->sender().written_buffer_bytes(),
+        node_disk_size);
 }
 
 TEST_F(NodeWriterTest, write_node_across_buffers_ends_at_buffer_boundary)
@@ -180,33 +251,36 @@ TEST_F(NodeWriterTest, write_node_across_buffers_ends_at_buffer_boundary)
         2 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024;
     MONAD_ASSERT(chunk_remaining_bytes < chunk_size);
     node_writer_append_dummy_bytes(
-        aux.node_writer_fast, 3 * chunk_size - chunk_remaining_bytes);
+        aux.writer_fast.node_writer, 3 * chunk_size - chunk_remaining_bytes);
 
     auto const node_writer_chunk_count_before =
-        get_writer_chunk_count(aux.node_writer_fast);
+        get_writer_chunk_count(aux.writer_fast.node_writer);
     EXPECT_EQ(node_writer_chunk_count_before, 2);
 
     // node spans buffer 3 buffers
     auto node = make_node_of_size(chunk_remaining_bytes);
-    auto const node_offset = async_write_node_set_spare(aux, *node, true);
+    auto const node_offset = async_write_node_set_spare(aux, node, true);
+    drain_delayed_writes(true);
     EXPECT_EQ(
-        get_writer_chunk_count(aux.node_writer_fast),
+        get_writer_chunk_count(aux.writer_fast.node_writer),
         node_writer_chunk_count_before);
-    EXPECT_EQ(node_offset.id, get_writer_chunk_id(aux.node_writer_fast));
-    EXPECT_EQ(aux.node_writer_fast->sender().remaining_buffer_bytes(), 0);
+    EXPECT_EQ(node_offset.id, get_writer_chunk_id(aux.writer_fast.node_writer));
+    EXPECT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
 
     // write another node, node writer will switch to next buffer at next chunk
-    auto const new_node_offset = async_write_node_set_spare(aux, *node, true);
+    auto const new_node_offset = async_write_node_set_spare(aux, node, true);
+    drain_delayed_writes(true);
     EXPECT_EQ(new_node_offset.offset, 0);
     auto const node_writer_chunk_count_after =
-        get_writer_chunk_count(aux.node_writer_fast);
+        get_writer_chunk_count(aux.writer_fast.node_writer);
     EXPECT_EQ(
         aux.db_metadata()->at(new_node_offset.id)->insertion_count(),
         node_writer_chunk_count_after);
     EXPECT_EQ(
         node_writer_chunk_count_before + 1, node_writer_chunk_count_after);
     EXPECT_EQ(
-        aux.node_writer_fast->sender().written_buffer_bytes(),
+        aux.writer_fast.node_writer->sender().written_buffer_bytes(),
         chunk_remaining_bytes % AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
 }
 
@@ -215,19 +289,548 @@ TEST_F(NodeWriterTest, write_node_at_new_chunk)
     // prepare less than 3 chunks
     auto const chunk_remaining_bytes = 1024;
     node_writer_append_dummy_bytes(
-        aux.node_writer_fast, 3 * chunk_size - chunk_remaining_bytes);
+        aux.writer_fast.node_writer, 3 * chunk_size - chunk_remaining_bytes);
 
     auto const node_writer_chunk_count_before_write_node =
-        get_writer_chunk_count(aux.node_writer_fast);
+        get_writer_chunk_count(aux.writer_fast.node_writer);
     EXPECT_EQ(node_writer_chunk_count_before_write_node, 2);
 
     // make a node that is too big to fit in current chunk
     auto node = make_node_of_size(chunk_remaining_bytes + 1024);
-    auto const node_offset = async_write_node_set_spare(aux, *node, true);
+    auto const node_offset = async_write_node_set_spare(aux, node, true);
+    drain_delayed_writes(true);
     auto const node_offset_chunk_count =
         aux.db_metadata()->at(node_offset.id)->insertion_count();
     EXPECT_EQ(
         node_offset_chunk_count, node_writer_chunk_count_before_write_node + 1);
     EXPECT_EQ(
-        node_offset_chunk_count, get_writer_chunk_count(aux.node_writer_fast));
+        node_offset_chunk_count,
+        get_writer_chunk_count(aux.writer_fast.node_writer));
+}
+
+// Tests for the delayed write queue
+TEST_F(NodeWriterTest, delayed_write_node_larger_than_remaining_buffer)
+{
+    // Fill the buffer so only a small amount remains
+    unsigned const node_disk_size = 1024;
+    auto small_node = make_node_of_size(node_disk_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+
+    // Fill buffer to exactly full minus one node
+    for (unsigned i = 0; i < num_nodes - 1; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    auto const remaining =
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes();
+    ASSERT_EQ(remaining, node_disk_size);
+
+    // Write a node larger than remaining buffer - triggers delayed write path
+    unsigned const large_node_size = node_disk_size * 2;
+    auto large_node = make_node_of_size(large_node_size);
+    auto const offset = async_write_node_set_spare(aux, large_node, true);
+
+    // Offset should be allocated correctly
+    EXPECT_NE(offset.offset, 0u);
+
+    // write_position should have advanced past the large node
+    EXPECT_GE(
+        aux.writer_fast.write_position.current_offset,
+        offset.offset + large_node_size);
+
+    // I/O should complete and delayed writes should drain
+    aux.io->flush();
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, multiple_delayed_writes_maintain_order)
+{
+    unsigned const node_disk_size = 1024;
+    auto small_node = make_node_of_size(node_disk_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+
+    // Fill buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Write multiple nodes that must be queued - they can't fit in the
+    // full buffer. The first write triggers the delayed path, subsequent
+    // writes append to the non-empty queue.
+    unsigned const large_node_size = node_disk_size * 2;
+    auto large_node = make_node_of_size(large_node_size);
+    auto const offset0 = async_write_node_set_spare(aux, large_node, true);
+    auto const offset1 = async_write_node_set_spare(aux, large_node, true);
+    auto const offset2 = async_write_node_set_spare(aux, large_node, true);
+
+    // Offsets must be monotonically increasing (ordered allocation)
+    EXPECT_GT(offset1.raw(), offset0.raw());
+    EXPECT_GT(offset2.raw(), offset1.raw());
+
+    // Flush all I/O - delayed writes should be fully drained
+    aux.io->flush();
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, delayed_write_across_chunk_boundary)
+{
+    // Fill up to near end of a chunk so the next large write must go
+    // to a new chunk via allocate_write_offset
+    auto const near_end = chunk_size - 1024;
+    node_writer_append_dummy_bytes(aux.writer_fast.node_writer, near_end);
+
+    auto const chunk_id_before =
+        aux.writer_fast.write_position.current_chunk_id;
+
+    // Write a node larger than remaining chunk space - forces new chunk
+    // allocation via the delayed write path
+    unsigned const large_node_size = 2048;
+    auto large_node = make_node_of_size(large_node_size);
+    auto const offset = async_write_node_set_spare(aux, large_node, true);
+
+    // Should be allocated at start of a new chunk
+    EXPECT_EQ(offset.offset, 0u);
+    EXPECT_NE(offset.id, chunk_id_before);
+
+    // The new chunk must be in the fast list
+    EXPECT_TRUE(aux.db_metadata()->at(offset.id)->in_fast_list);
+
+    // Flush and verify queue drained
+    aux.io->flush();
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, write_position_tracks_through_delayed_writes)
+{
+    unsigned const node_disk_size = 1024;
+    auto node = make_node_of_size(node_disk_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+
+    // Record initial write_position
+    auto const initial_chunk = aux.writer_fast.write_position.current_chunk_id;
+    auto const initial_offset = aux.writer_fast.write_position.current_offset;
+    EXPECT_EQ(initial_offset, 0u);
+
+    // Write nodes that fit in buffer (fast path) - write_position advances
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, node, true);
+    }
+    EXPECT_EQ(aux.writer_fast.write_position.current_chunk_id, initial_chunk);
+    EXPECT_EQ(
+        aux.writer_fast.write_position.current_offset,
+        (file_offset_t)num_nodes * node_disk_size);
+
+    // Now write a node that triggers delayed path
+    unsigned const large_node_size = node_disk_size * 2;
+    auto large_node = make_node_of_size(large_node_size);
+    auto const pos_before_delayed =
+        aux.writer_fast.write_position.current_offset;
+    async_write_node_set_spare(aux, large_node, true);
+
+    // write_position must have advanced even though write is delayed
+    EXPECT_EQ(
+        aux.writer_fast.write_position.current_offset,
+        pos_before_delayed + large_node_size);
+}
+
+TEST_F(NodeWriterTest, flush_after_delayed_writes_produces_valid_state)
+{
+    unsigned const node_disk_size = 1024;
+    auto node = make_node_of_size(node_disk_size);
+
+    // Write enough to trigger a delayed write
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Queue delayed writes
+    unsigned const large_node_size = node_disk_size * 2;
+    auto large_node = make_node_of_size(large_node_size);
+    async_write_node_set_spare(aux, large_node, true);
+    async_write_node_set_spare(aux, large_node, true);
+
+    // Use write_new_root_node which calls flush_buffered_writes internally
+    auto root_node = make_node_of_size(node_disk_size);
+    auto const root_offset = write_new_root_node(aux, root_node, 1);
+
+    // Root offset should be valid
+    EXPECT_TRUE(aux.db_metadata()->at(root_offset.id)->in_fast_list);
+
+    // All delayed writes must have been drained by flush
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+    EXPECT_TRUE(aux.writer_slow.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, delayed_written_nodes_can_be_read_back)
+{
+    unsigned const node_disk_size = 1024;
+    auto small_node = make_node_of_size(node_disk_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / node_disk_size;
+
+    // Fill buffer completely so subsequent writes go through delayed path
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Write nodes of different sizes through the delayed path, track offsets
+    unsigned const sizes[] = {1024, 2048, 4096, 1536};
+    std::vector<std::pair<chunk_offset_t, Node::SharedPtr>> written_nodes;
+    for (auto sz : sizes) {
+        auto node = make_node_of_size(sz);
+        auto offset = async_write_node_set_spare(aux, node, true);
+        written_nodes.emplace_back(offset, node);
+    }
+
+    // Flush everything to disk and register a version
+    auto root = make_node_of_size(node_disk_size);
+    auto const root_offset = write_new_root_node(aux, root, 1);
+    ASSERT_TRUE(aux.writer_fast.delayed_writes.empty());
+
+    // Read back each delayed-written node and verify data integrity
+    for (auto const &[offset, original_node] : written_nodes) {
+        auto read_back = read_node_blocking(aux, offset, 1);
+        ASSERT_NE(read_back, nullptr)
+            << "Failed to read node at chunk=" << offset.id
+            << " offset=" << offset.offset;
+        EXPECT_EQ(read_back->get_disk_size(), original_node->get_disk_size());
+        EXPECT_EQ(read_back->value(), original_node->value());
+    }
+
+    // Also verify the root node
+    auto root_read_back = read_node_blocking(aux, root_offset, 1);
+    ASSERT_NE(root_read_back, nullptr);
+    EXPECT_EQ(root_read_back->get_disk_size(), root->get_disk_size());
+    EXPECT_EQ(root_read_back->value(), root->value());
+}
+
+TEST_F(NodeWriterTest, delayed_write_node_spanning_multiple_buffers)
+{
+    // Create a node larger than WRITE_BUFFER_SIZE (8MB) so that when
+    // process_delayed_writes serializes it, the node must span multiple
+    // I/O buffers, exercising the inner loop's buffer-replacement path.
+    unsigned const large_node_size =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024 * 1024; // 9MB
+    auto large_node = make_node_of_size(large_node_size);
+
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill buffer completely to force delayed path
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Write the large node — must be queued as delayed
+    auto const offset = async_write_node_set_spare(aux, large_node, true);
+
+    // Flush to disk and register version
+    auto root = make_node_of_size(small_size);
+    (void)write_new_root_node(aux, root, 1);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+
+    // Read back the large node and verify integrity
+    auto read_back = read_node_blocking(aux, offset, 1);
+    ASSERT_NE(read_back, nullptr);
+    EXPECT_EQ(read_back->get_disk_size(), large_node->get_disk_size());
+    EXPECT_EQ(read_back->value(), large_node->value());
+}
+
+// --- Non-blocking buffer exhaustion tests ---
+//
+// With 4 write buffers total (fast holds 1, slow holds 1, 2 free), writing
+// a node larger than 3 * WRITE_BUFFER_SIZE inside process_delayed_writes
+// deterministically exhausts all available buffers: the initial full buffer
+// plus the 2 free ones are consumed (submitted to io_uring), leaving
+// node_writer null with offset_in_data pointing mid-node.
+// No polling occurs inside process_delayed_writes, so this is race-free.
+
+TEST_F(NodeWriterTest, async_write_node_queues_when_node_writer_null)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill fast buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Write a node spanning >3 buffers. process_delayed_writes will consume
+    // all 3 available write buffers (current full + 2 free) and fail to
+    // allocate a 4th (held by slow writer), leaving node_writer null.
+    unsigned const huge_node_size =
+        3 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024 * 1024;
+    auto huge_node = make_node_of_size(huge_node_size);
+    async_write_node_set_spare(aux, huge_node, true);
+
+    // node_writer should be null (all buffers in flight or held by slow)
+    ASSERT_EQ(aux.writer_fast.node_writer, nullptr);
+
+    // Now write another small node — must be queued because node_writer is null
+    auto const queued_offset =
+        async_write_node_set_spare(aux, small_node, true);
+
+    // The small node should be in the delayed writes queue
+    // (it was appended because !node_writer)
+    bool found = false;
+    for (auto const &dw : aux.writer_fast.delayed_writes) {
+        if (dw.allocated_offset.id == queued_offset.id &&
+            dw.allocated_offset.offset == queued_offset.offset) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "Small node not found in delayed_writes queue";
+
+    // write_position should have advanced for both the huge and small nodes
+    EXPECT_GE(
+        aux.writer_fast.write_position.current_offset,
+        queued_offset.offset + small_size);
+
+    // Drain and verify everything completes
+    drain_delayed_writes(true);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, buffer_exhaustion_increments_alloc_failure_counter)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill fast buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+
+    auto const failures_before = aux.writer_fast.buffer_alloc_failures;
+
+    // Write a huge node that exhausts all available write buffers
+    unsigned const huge_node_size =
+        3 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024 * 1024;
+    auto huge_node = make_node_of_size(huge_node_size);
+    async_write_node_set_spare(aux, huge_node, true);
+
+    // buffer_alloc_failures must have been incremented
+    EXPECT_GT(aux.writer_fast.buffer_alloc_failures, failures_before);
+
+    // delayed_writes must be non-empty (partially written node remains)
+    EXPECT_FALSE(aux.writer_fast.delayed_writes.empty());
+
+    // Drain via I/O completions and verify everything finishes
+    drain_delayed_writes(true);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, process_delayed_writes_resumes_partial_node)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill fast buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+
+    // Write a huge node (>3 buffers). process_delayed_writes writes 3 buffers
+    // worth (~24MB), then fails to allocate a 4th. The node remains in the
+    // queue with offset_in_data pointing to the resume position.
+    unsigned const huge_node_size =
+        3 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024 * 1024;
+    auto huge_node = make_node_of_size(huge_node_size);
+    auto const offset = async_write_node_set_spare(aux, huge_node, true);
+
+    // Verify partial progress: front of queue should have offset_in_data > 0
+    ASSERT_FALSE(aux.writer_fast.delayed_writes.empty());
+    auto const &front = aux.writer_fast.delayed_writes.front();
+    EXPECT_GT(front.offset_in_data, 0u);
+    EXPECT_LT(front.offset_in_data, huge_node_size);
+
+    // Resume position must be disk-page aligned (we only pause at buffer
+    // boundaries, which are always disk-page aligned)
+    EXPECT_EQ(front.offset_in_data % DISK_PAGE_SIZE, 0u);
+
+    // Drain — I/O completions free buffers, process_delayed_writes resumes
+    // from offset_in_data and finishes the node
+    drain_delayed_writes(true);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+
+    // Verify the node can be read back correctly
+    auto root = make_node_of_size(small_size);
+    (void)write_new_root_node(aux, root, 1);
+
+    auto read_back = read_node_blocking(aux, offset, 1);
+    ASSERT_NE(read_back, nullptr);
+    EXPECT_EQ(read_back->get_disk_size(), huge_node->get_disk_size());
+    EXPECT_EQ(read_back->value(), huge_node->value());
+}
+
+TEST_F(NodeWriterTest, io_completion_triggers_delayed_write_drain)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill fast buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+
+    // Queue several distinct delayed writes that each fill a buffer
+    unsigned const big_size = AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + small_size;
+    auto big_node = make_node_of_size(big_size);
+
+    async_write_node_set_spare(aux, big_node, true);
+    async_write_node_set_spare(aux, big_node, true);
+    async_write_node_set_spare(aux, big_node, true);
+
+    // Some writes should be pending (buffers exhausted)
+    auto const initial_queue_size = aux.writer_fast.delayed_writes.size();
+
+    // Poll one I/O at a time — each completion should trigger
+    // process_delayed_writes via write_operation_io_receiver::set_value,
+    // draining more items from the queue
+    size_t prev_size = initial_queue_size;
+    unsigned polls = 0;
+    while (!aux.writer_fast.delayed_writes.empty()) {
+        aux.io->poll_blocking(1);
+        ++polls;
+        // Queue should be monotonically non-increasing
+        EXPECT_LE(aux.writer_fast.delayed_writes.size(), prev_size);
+        prev_size = aux.writer_fast.delayed_writes.size();
+    }
+
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+    // Verify that at least one poll was needed (drain wasn't instant)
+    EXPECT_GT(polls, 0u);
+}
+
+TEST_F(NodeWriterTest, ensure_writer_at_offset_creates_from_null)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill fast buffer completely
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+
+    // Exhaust all write buffers to get node_writer to null
+    unsigned const huge_node_size =
+        3 * AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE + 1024 * 1024;
+    auto huge_node = make_node_of_size(huge_node_size);
+    async_write_node_set_spare(aux, huge_node, true);
+    ASSERT_EQ(aux.writer_fast.node_writer, nullptr);
+
+    // Free one buffer by completing one I/O
+    aux.io->poll_blocking(1);
+
+    // After I/O completion, the callback should have re-created node_writer
+    // via process_delayed_writes -> ensure_writer_at_offset (null path)
+    // The delayed queue should have made progress
+    EXPECT_LT(aux.writer_fast.delayed_writes.size(), static_cast<size_t>(2))
+        << "Queue should have made progress after I/O completion";
+
+    // Drain remaining
+    drain_delayed_writes(true);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+}
+
+TEST_F(NodeWriterTest, interleaved_fast_and_slow_delayed_writes)
+{
+    unsigned const small_size = 1024;
+    auto small_node = make_node_of_size(small_size);
+    unsigned const num_nodes =
+        AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE / small_size;
+
+    // Fill both fast and slow buffers completely so that subsequent
+    // writes trigger the delayed write path for both writers.
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, true);
+    }
+    ASSERT_EQ(
+        aux.writer_fast.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    for (unsigned i = 0; i < num_nodes; ++i) {
+        async_write_node_set_spare(aux, small_node, false);
+    }
+    ASSERT_EQ(
+        aux.writer_slow.node_writer->sender().remaining_buffer_bytes(), 0);
+
+    // Write nodes larger than remaining buffer through both the fast and
+    // slow delayed write paths. Each write triggers process_delayed_writes
+    // which submits the full buffer and allocates a replacement.
+    unsigned const big_size = small_size * 4;
+    auto big_node = make_node_of_size(big_size);
+
+    std::vector<std::pair<chunk_offset_t, bool>> written_nodes;
+
+    // Interleave fast and slow writes
+    for (int i = 0; i < 4; ++i) {
+        auto fast_off = async_write_node_set_spare(aux, big_node, true);
+        written_nodes.emplace_back(fast_off, true);
+        auto slow_off = async_write_node_set_spare(aux, big_node, false);
+        written_nodes.emplace_back(slow_off, false);
+    }
+
+    // Verify offsets are in the correct lists (is_fast flag propagation)
+    for (auto const &[off, is_fast] : written_nodes) {
+        if (is_fast) {
+            EXPECT_TRUE(aux.db_metadata()->at(off.id)->in_fast_list)
+                << "Fast node at chunk " << off.id << " not in fast list";
+        }
+        else {
+            EXPECT_TRUE(aux.db_metadata()->at(off.id)->in_slow_list)
+                << "Slow node at chunk " << off.id << " not in slow list";
+        }
+    }
+
+    // write_position should have advanced for both writers
+    EXPECT_GT(aux.writer_fast.write_position.current_offset, 0u);
+    EXPECT_GT(aux.writer_slow.write_position.current_offset, 0u);
+
+    // Flush everything via write_new_root_node and verify both queues drain
+    auto root = make_node_of_size(small_size);
+    auto const root_offset = write_new_root_node(aux, root, 1);
+    EXPECT_TRUE(aux.writer_fast.delayed_writes.empty());
+    EXPECT_TRUE(aux.writer_slow.delayed_writes.empty());
+
+    // Read back all nodes and verify data integrity
+    for (auto const &[off, is_fast] : written_nodes) {
+        auto read_back = read_node_blocking(aux, off, 1);
+        ASSERT_NE(read_back, nullptr)
+            << "Failed to read node at chunk=" << off.id
+            << " offset=" << off.offset << " is_fast=" << is_fast;
+        EXPECT_EQ(read_back->get_disk_size(), big_node->get_disk_size());
+        EXPECT_EQ(read_back->value(), big_node->value());
+    }
+
+    // Verify root node
+    auto root_read = read_node_blocking(aux, root_offset, 1);
+    ASSERT_NE(root_read, nullptr);
+    EXPECT_EQ(root_read->get_disk_size(), root->get_disk_size());
 }

--- a/category/mpt/test/rewind_test.cpp
+++ b/category/mpt/test/rewind_test.cpp
@@ -143,7 +143,8 @@ TEST_F(
               << "]. " << std::endl;
 
     // advance fast writer head to the next chunk
-    auto const fast_writer_offset = aux.node_writer_fast->sender().offset();
+    auto const fast_writer_offset =
+        aux.writer_fast.node_writer->sender().offset();
     auto const *ci = aux.db_metadata()->free_list_end();
     ASSERT_TRUE(ci != nullptr);
     auto const idx = ci->index(aux.db_metadata());
@@ -151,7 +152,7 @@ TEST_F(
     aux.append(monad::mpt::UpdateAuxImpl::chunk_list::fast, idx);
     monad::async::chunk_offset_t const new_fast_writer_offset{idx, 0};
     aux.advance_db_offsets_to(
-        new_fast_writer_offset, aux.node_writer_slow->sender().offset());
+        new_fast_writer_offset, aux.writer_slow.node_writer->sender().offset());
     std::cout << "Advanced start of fast list offset on disk from ["
               << fast_writer_offset.id << ", " << fast_writer_offset.offset
               << "] to the beginning of a new chunk, id: " << idx << std::endl;

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -145,15 +145,16 @@ TEST(update_aux_test, root_offsets_fast_slow)
 
         // Root offset at 0, fast list offset at 50. This is correct
         auto const start_offset =
-            aux_writer.node_writer_fast->sender().offset();
+            aux_writer.writer_fast.node_writer->sender().offset();
         (void)pool
             .chunk(monad::async::storage_pool::chunk_type::seq, start_offset.id)
             .write_fd(50);
         auto const end_offset =
-            aux_writer.node_writer_fast->sender().offset().add_to_offset(50);
+            aux_writer.writer_fast.node_writer->sender().offset().add_to_offset(
+                50);
         aux_writer.append_root_offset(start_offset);
         aux_writer.advance_db_offsets_to(
-            end_offset, aux_writer.node_writer_slow->sender().offset());
+            end_offset, aux_writer.writer_slow.node_writer->sender().offset());
     }
     {
         // verify set_io() succeeds
@@ -164,12 +165,13 @@ TEST(update_aux_test, root_offsets_fast_slow)
         // Write version 1. However, append the new root offset without
         // advancing fast list
         auto const start_offset =
-            aux_writer.node_writer_fast->sender().offset();
+            aux_writer.writer_fast.node_writer->sender().offset();
         (void)pool
             .chunk(monad::async::storage_pool::chunk_type::seq, start_offset.id)
             .write_fd(100);
         auto const end_offset =
-            aux_writer.node_writer_fast->sender().offset().add_to_offset(100);
+            aux_writer.writer_fast.node_writer->sender().offset().add_to_offset(
+                100);
         aux_writer.append_root_offset(end_offset);
     }
 

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -107,12 +107,12 @@ struct async_write_node_result
 {
     chunk_offset_t offset_written_to;
     unsigned bytes_appended;
-    erased_connected_operation *io_state;
 };
 
 // invoke at the end of each block upsert
 void flush_buffered_writes(UpdateAuxImpl &);
-chunk_offset_t write_new_root_node(UpdateAuxImpl &, Node &, uint64_t);
+chunk_offset_t
+write_new_root_node(UpdateAuxImpl &, Node::SharedPtr const &, uint64_t);
 
 Node::SharedPtr upsert(
     UpdateAuxImpl &aux, uint64_t const version, StateMachine &sm,
@@ -166,7 +166,7 @@ Node::SharedPtr upsert(
     auto root = entry.ptr;
     if (aux.is_on_disk() && root) {
         if (write_root) {
-            write_new_root_node(aux, *root, version);
+            write_new_root_node(aux, root, version);
         }
         else {
             flush_buffered_writes(aux);
@@ -499,8 +499,7 @@ Node::SharedPtr create_node_from_children_if_any(
                 // won't duplicate write of unchanged old child
                 MONAD_DEBUG_ASSERT(child.branch < 16);
                 MONAD_DEBUG_ASSERT(child.ptr);
-                child.offset =
-                    async_write_node_set_spare(aux, *child.ptr, true);
+                child.offset = async_write_node_set_spare(aux, child.ptr, true);
                 auto const child_virtual_offset =
                     aux.physical_to_virtual(child.offset);
                 MONAD_DEBUG_ASSERT(
@@ -538,14 +537,12 @@ void create_node_compute_data_possibly_async(
                     aux.physical_to_virtual(child.offset);
                 MONAD_DEBUG_ASSERT(
                     virtual_child_offset != INVALID_VIRTUAL_OFFSET);
-                // child offset is older than current node writer's start offset
+                // child offset is older than current write position
                 MONAD_DEBUG_ASSERT(
                     virtual_child_offset <
-                    aux.physical_to_virtual((virtual_child_offset.in_fast_list()
-                                                 ? aux.node_writer_fast
-                                                 : aux.node_writer_slow)
-                                                ->sender()
-                                                .offset()));
+                    aux.physical_to_virtual(
+                        aux.writer(virtual_child_offset.in_fast_list())
+                            .write_position.to_chunk_offset()));
             }
             node_receiver_t recv{
                 [aux = &aux, sm = sm.clone(), tnode = std::move(tnode)](
@@ -1166,8 +1163,7 @@ void fillin_parent_after_expiration(
         }
     }
     else {
-        auto const new_offset =
-            async_write_node_set_spare(aux, *new_node, true);
+        auto const new_offset = async_write_node_set_spare(aux, new_node, true);
         auto const new_node_virtual_offset =
             aux.physical_to_virtual(new_offset);
         MONAD_DEBUG_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
@@ -1333,7 +1329,7 @@ void try_fillin_parent_with_rewritten_node(
         tnode->rewrite_to_fast = true; // override that
     }
     auto const new_offset =
-        async_write_node_set_spare(aux, *tnode->node, tnode->rewrite_to_fast);
+        async_write_node_set_spare(aux, tnode->node, tnode->rewrite_to_fast);
     auto const new_node_virtual_offset = aux.physical_to_virtual(new_offset);
     MONAD_DEBUG_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
     compact_virtual_chunk_offset_t const truncated_new_virtual_offset{
@@ -1386,251 +1382,349 @@ void try_fillin_parent_with_rewritten_node(
 // Async write
 /////////////////////////////////////////////////////
 
-node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
-    UpdateAuxImpl &aux, node_writer_unique_ptr_type &node_writer)
+node_writer_unique_ptr_type create_node_writer_at_offset(
+    UpdateAuxImpl &aux, chunk_offset_t target_offset, bool is_fast);
+
+// Pad node_writer's buffer to DISK_PAGE_SIZE (512-byte) alignment with zeros.
+// Required before initiating any O_DIRECT write with a partially-filled buffer.
+// Returns the number of padding bytes appended.
+size_t
+pad_writer_to_disk_page_alignment(node_writer_unique_ptr_type &node_writer)
 {
     auto *sender = &node_writer->sender();
-    bool const in_fast_list =
-        aux.db_metadata()->at(sender->offset().id)->in_fast_list;
-    auto const *ci_ = aux.db_metadata()->free_list_end();
-    MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-    auto idx = ci_->index(aux.db_metadata());
-    chunk_offset_t const offset_of_new_writer{idx, 0};
-    // Pad buffer of existing node write that is about to get initiated so it's
-    // O_DIRECT i/o aligned
-    auto const remaining_buffer_bytes = sender->remaining_buffer_bytes();
-    auto *tozero = sender->advance_buffer_append(remaining_buffer_bytes);
-    MONAD_DEBUG_ASSERT(tozero != nullptr);
-    memset(tozero, 0, remaining_buffer_bytes);
-
-    /* If there aren't enough write buffers, this may poll uring until a free
-    write buffer appears. However, that polling may write a node, causing
-    this function to be reentered, and another free chunk allocated and now
-    writes are being directed there instead. Obviously then replacing that new
-    partially filled chunk with this new chunk is something which trips the
-    asserts.
-
-    Replacing the runloop exposed this bug much more clearly than before, but we
-    had been seeing occasional issues somewhere around here for some time now,
-    it just wasn't obvious the cause. Anyway detect when reentrancy occurs, and
-    if so undo this operation and tell the caller to retry.
-    */
-    static thread_local struct reentrancy_detection_t
-    {
-        int count{0}, max_count{0};
-    } reentrancy_detection;
-
-    int const my_reentrancy_count = reentrancy_detection.count++;
-    MONAD_ASSERT(my_reentrancy_count >= 0);
-    if (my_reentrancy_count == 0) {
-        // We are at the base
-        reentrancy_detection.max_count = 0;
+    auto const written = sender->written_buffer_bytes();
+    auto const padded = round_up_align<DISK_PAGE_BITS>(written);
+    auto const pad_bytes = padded - written;
+    if (pad_bytes > 0) {
+        auto *tozero = sender->advance_buffer_append(pad_bytes);
+        memset(tozero, 0, pad_bytes);
     }
-    else if (my_reentrancy_count > reentrancy_detection.max_count) {
-        // We are reentering
-        LOG_INFO_CFORMAT(
-            "replace_node_writer_to_start_at_new_chunk reenter "
-            "my_reentrancy_count = "
-            "%d max_count = %d",
-            my_reentrancy_count,
-            reentrancy_detection.max_count);
-        reentrancy_detection.max_count = my_reentrancy_count;
+    return pad_bytes;
+}
+
+// Ensure ws.node_writer is positioned at target_offset, submitting the
+// current buffer and repositioning as needed. Non-blocking: returns false
+// if no write buffer is immediately available.
+bool ensure_writer_at_offset(
+    UpdateAuxImpl &aux, UpdateAuxImpl::WriterState &ws,
+    chunk_offset_t target_offset, bool is_fast)
+{
+    if (ws.node_writer) {
+        auto current_offset = ws.node_writer->sender().offset();
+        auto current_pos = current_offset.offset +
+                           ws.node_writer->sender().written_buffer_bytes();
+
+        if (current_offset.id != target_offset.id) {
+            // Different chunk - offset must be 0 (allocate_write_offset
+            // always allocates new chunks at offset 0)
+            MONAD_ASSERT_PRINTF(
+                target_offset.offset == 0,
+                "ensure_writer_at_offset: new chunk allocation must start at "
+                "offset 0! chunk=%u offset=%u",
+                target_offset.id,
+                target_offset.offset);
+
+            // Pad and flush current buffer before repositioning to new chunk
+            if (ws.node_writer->sender().written_buffer_bytes() > 0) {
+                pad_writer_to_disk_page_alignment(ws.node_writer);
+                ws.node_writer->receiver().reset(
+                    ws.node_writer->sender().written_buffer_bytes());
+                ws.node_writer->initiate();
+                ws.node_writer.release();
+            }
+            ws.node_writer =
+                create_node_writer_at_offset(aux, target_offset, is_fast);
+            return ws.node_writer != nullptr;
+        }
+
+        // Same chunk - buffer position MUST match allocated offset
+        // (if not, write_position is out of sync with buffer)
+        MONAD_ASSERT_PRINTF(
+            current_pos == target_offset.offset,
+            "ensure_writer_at_offset: buffer position mismatch! "
+            "chunk=%u current_pos=%lu allocated_offset=%u",
+            current_offset.id,
+            (unsigned long)current_pos,
+            target_offset.offset);
+        return true;
     }
-    auto ret = aux.io->make_connected(
-        write_single_buffer_sender{
-            offset_of_new_writer, AsyncIO::WRITE_BUFFER_SIZE},
-        write_operation_io_receiver{AsyncIO::WRITE_BUFFER_SIZE});
-    reentrancy_detection.count--;
-    MONAD_ASSERT(reentrancy_detection.count >= 0);
-    // The deepest-most reentrancy must succeed, and all less deep reentrancies
-    // must retry
-    if (my_reentrancy_count != reentrancy_detection.max_count) {
-        // We reentered, please retry
-        LOG_INFO_CFORMAT(
-            "replace_node_writer_to_start_at_new_chunk retry "
-            "my_reentrancy_count = "
-            "%d max_count = %d",
-            my_reentrancy_count,
-            reentrancy_detection.max_count);
-        return {};
+
+    // No buffer - create one at the target offset (non-blocking)
+    ws.node_writer = create_node_writer_at_offset(aux, target_offset, is_fast);
+    return ws.node_writer != nullptr;
+}
+
+// Non-blocking drain of delayed writes into available I/O buffers. Processes
+// queued writes until buffer exhaustion: if no write buffer is immediately
+// available, returns and lets I/O completion callbacks re-trigger draining.
+// When a buffer completes, write_operation_io_receiver::set_value calls this
+// again, creating a self-sustaining drain loop.
+void process_delayed_writes(UpdateAuxImpl &aux, bool is_fast)
+{
+    auto &ws = aux.writer(is_fast);
+
+    // Guard against recursive calls from I/O completion callbacks.
+    if (ws.processing_delayed_writes) {
+        return;
     }
-    aux.remove(idx);
-    aux.append(
-        in_fast_list ? UpdateAuxImpl::chunk_list::fast
-                     : UpdateAuxImpl::chunk_list::slow,
-        idx);
-    return ret;
+
+    ws.processing_delayed_writes = true;
+    auto guard = monad::make_scope_exit(
+        [&ws]() noexcept { ws.processing_delayed_writes = false; });
+
+    while (!ws.delayed_writes.empty()) {
+        auto &delayed = ws.delayed_writes.front();
+
+        // For a partially-written node (resuming after buffer exhaustion),
+        // the resume position is past the allocated start by offset_in_data.
+        // By construction this is already disk-page-aligned since we only
+        // pause at buffer boundaries.
+        auto target_offset = delayed.allocated_offset;
+        if (delayed.offset_in_data > 0) {
+            target_offset = chunk_offset_t{
+                static_cast<uint32_t>(target_offset.id),
+                static_cast<uint32_t>(
+                    target_offset.offset + delayed.offset_in_data)};
+            MONAD_ASSERT((target_offset.offset & (DISK_PAGE_SIZE - 1)) == 0);
+        }
+
+        if (!ensure_writer_at_offset(aux, ws, target_offset, is_fast)) {
+            // All write buffers genuinely in flight. When one completes,
+            // its I/O completion callback will re-invoke
+            // process_delayed_writes to continue draining the queue.
+            MONAD_ASSERT(aux.io->writes_in_flight() > 0);
+            ++ws.buffer_alloc_failures;
+            return;
+        }
+
+        auto *sender = &ws.node_writer->sender();
+        auto const data_size = static_cast<size_t>(delayed.disk_size);
+        unsigned &offset_in_data = delayed.offset_in_data;
+
+        // Serialize delayed node into buffers, replacing when full
+        while (offset_in_data < data_size) {
+            auto remaining_buffer = sender->remaining_buffer_bytes();
+
+            if (remaining_buffer == 0) {
+                // Need new buffer - compute aligned position after current
+                // buffer
+                auto current_offset = sender->offset();
+                auto written = sender->written_buffer_bytes();
+                file_offset_t next_pos = current_offset.offset + written;
+                next_pos = round_up_align<DISK_PAGE_BITS>(next_pos);
+
+                chunk_offset_t next_offset{
+                    static_cast<uint32_t>(current_offset.id),
+                    static_cast<uint32_t>(next_pos)};
+
+                // Nodes always fit within a single chunk (ensured by
+                // allocate_write_offset), so we should never cross a chunk
+                // boundary while writing a single node.
+                MONAD_ASSERT_PRINTF(
+                    next_pos < aux.io->chunk_capacity(current_offset.id),
+                    "process_delayed_writes: node write crossed chunk "
+                    "boundary! chunk=%u next_pos=%lu capacity=%lu",
+                    current_offset.id,
+                    (unsigned long)next_pos,
+                    (unsigned long)aux.io->chunk_capacity(current_offset.id));
+
+                // Initiate current buffer
+                ws.node_writer->receiver().reset(
+                    ws.node_writer->sender().written_buffer_bytes());
+                ws.node_writer->initiate();
+                ws.node_writer.release();
+
+                // Create new buffer at computed position (non-blocking)
+                ws.node_writer = replace_node_writer(aux, next_offset, is_fast);
+                if (!ws.node_writer) {
+                    // All buffers in flight. I/O completion callbacks will
+                    // re-invoke process_delayed_writes to continue draining.
+                    MONAD_ASSERT(aux.io->writes_in_flight() > 0);
+                    ++ws.buffer_alloc_failures;
+                    return;
+                }
+                sender = &ws.node_writer->sender();
+                remaining_buffer = sender->remaining_buffer_bytes();
+            }
+
+            // Write what we can to current buffer
+            auto bytes_to_write =
+                std::min((size_t)remaining_buffer, data_size - offset_in_data);
+            auto *where =
+                (unsigned char *)sender->advance_buffer_append(bytes_to_write);
+            serialize_node_to_buffer(
+                where,
+                static_cast<unsigned>(bytes_to_write),
+                *delayed.node,
+                delayed.disk_size,
+                offset_in_data);
+            offset_in_data += static_cast<unsigned>(bytes_to_write);
+            MONAD_DEBUG_ASSERT(offset_in_data <= delayed.disk_size);
+        }
+
+        // Node fully written, remove from queue
+        ws.delayed_writes.pop_front();
+    }
 }
 
 node_writer_unique_ptr_type replace_node_writer(
-    UpdateAuxImpl &aux, node_writer_unique_ptr_type const &node_writer)
+    UpdateAuxImpl &aux, chunk_offset_t target_offset, bool is_fast)
 {
-    // Can't use add_to_offset(), because it asserts if we go past the
-    // capacity
-    auto offset_of_next_writer = node_writer->sender().offset();
-    bool const in_fast_list =
-        aux.db_metadata()->at(offset_of_next_writer.id)->in_fast_list;
-    file_offset_t offset = offset_of_next_writer.offset;
-    offset += node_writer->sender().written_buffer_bytes();
-    offset_of_next_writer.offset = offset & chunk_offset_t::max_offset;
-    auto const chunk_capacity =
-        aux.io->chunk_capacity(offset_of_next_writer.id);
-    MONAD_ASSERT(offset <= chunk_capacity);
-    detail::db_metadata::chunk_info_t const *ci_ = nullptr;
-    uint32_t idx;
-    if (offset == chunk_capacity) {
-        // If after the current write buffer we're hitting chunk capacity, we
-        // replace writer to the start of next chunk.
-        ci_ = aux.db_metadata()->free_list_end();
-        MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-        idx = ci_->index(aux.db_metadata());
-        offset_of_next_writer.id = idx & 0xfffffU;
-        offset_of_next_writer.offset = 0;
-    }
-    // See above about handling potential reentrancy correctly
-    auto *const node_writer_ptr = node_writer.get();
+    // Position new buffer at target_offset (provided by caller).
+    // Target must be disk-page-aligned.
+
+    auto const chunk_capacity = aux.io->chunk_capacity(target_offset.id);
+
+    // Verify offset is 512-byte aligned for O_DIRECT I/O
+    MONAD_ASSERT_PRINTF(
+        (target_offset.offset & (DISK_PAGE_SIZE - 1)) == 0,
+        "replace_node_writer: target offset %u is not 512-aligned! chunk=%u",
+        target_offset.offset,
+        target_offset.id);
+
     size_t const bytes_to_write = std::min(
         AsyncIO::WRITE_BUFFER_SIZE,
-        (size_t)(chunk_capacity - offset_of_next_writer.offset));
-    auto ret = aux.io->make_connected(
-        write_single_buffer_sender{offset_of_next_writer, bytes_to_write},
-        write_operation_io_receiver{bytes_to_write});
-    if (node_writer.get() != node_writer_ptr) {
-        // We reentered, please retry
-        return {};
-    }
-    if (ci_ != nullptr) {
-        MONAD_DEBUG_ASSERT(ci_ == aux.db_metadata()->free_list_end());
+        (size_t)(chunk_capacity - target_offset.offset));
+
+    return aux.io->try_make_connected(
+        write_single_buffer_sender{target_offset, bytes_to_write},
+        write_operation_io_receiver{bytes_to_write, &aux, is_fast});
+}
+
+// Create a node_writer positioned at a specific offset.
+// Returns nullptr if no write buffer is available.
+node_writer_unique_ptr_type create_node_writer_at_offset(
+    UpdateAuxImpl &aux, chunk_offset_t target_offset, bool is_fast)
+{
+    // Note: We don't assert chunk.size() >= target_offset.offset because
+    // delayed writes may allocate ahead of the physical write position
+
+    auto const chunk_capacity = aux.io->chunk_capacity(target_offset.id);
+    size_t const bytes_to_write = std::min(
+        AsyncIO::WRITE_BUFFER_SIZE,
+        (size_t)(chunk_capacity - target_offset.offset));
+
+    auto ret = aux.io->try_make_connected(
+        write_single_buffer_sender{target_offset, bytes_to_write},
+        write_operation_io_receiver{bytes_to_write, &aux, is_fast});
+
+    // Metadata (chunk list ownership) is managed solely by
+    // allocate_write_offset(). This function only creates the I/O buffer; don't
+    // update metadata here.
+
+    return ret;
+}
+
+// Allocate offset for node write. Non-blocking (no I/O or polling).
+// Aborts if free chunk list is exhausted when a new chunk is needed.
+chunk_offset_t
+allocate_write_offset(UpdateAuxImpl &aux, size_t node_size, bool is_fast)
+{
+    auto &write_pos = aux.writer(is_fast).write_position;
+    auto const chunk_capacity =
+        aux.io->chunk_capacity(write_pos.current_chunk_id);
+    auto const chunk_remaining = chunk_capacity - write_pos.current_offset;
+
+    chunk_offset_t allocated_offset{0, 0};
+
+    if (node_size > chunk_remaining) {
+        // Need new chunk - remove from free list and mark as allocated
+        auto const *ci_ = aux.db_metadata()->free_list_end();
+        MONAD_ASSERT(ci_ != nullptr);
+        auto idx = ci_->index(aux.db_metadata());
+
+        // Reserve this chunk by removing from free list and adding to
+        // appropriate list
         aux.remove(idx);
         aux.append(
-            in_fast_list ? UpdateAuxImpl::chunk_list::fast
-                         : UpdateAuxImpl::chunk_list::slow,
+            is_fast ? UpdateAuxImpl::chunk_list::fast
+                    : UpdateAuxImpl::chunk_list::slow,
             idx);
-    }
-    return ret;
-}
 
-// return physical offset the node is written at
-async_write_node_result async_write_node(
-    UpdateAuxImpl &aux, node_writer_unique_ptr_type &node_writer,
-    Node const &node)
-{
-retry:
-    aux.io->poll_nonblocking_if_not_within_completions(1);
-    auto *sender = &node_writer->sender();
-    auto const size = node.get_disk_size();
-    auto const remaining_bytes = sender->remaining_buffer_bytes();
-    async_write_node_result ret{
-        .offset_written_to = INVALID_OFFSET,
-        .bytes_appended = size,
-        .io_state = node_writer.get()};
-    [[likely]] if (size <= remaining_bytes) { // Node can fit into current
-                                              // buffer
-        ret.offset_written_to =
-            sender->offset().add_to_offset(sender->written_buffer_bytes());
-        auto *where_to_serialize = sender->advance_buffer_append(size);
-        MONAD_DEBUG_ASSERT(where_to_serialize != nullptr);
-        serialize_node_to_buffer(
-            (unsigned char *)where_to_serialize, size, node, size);
+        // Allocate at start of new chunk
+        MONAD_DEBUG_ASSERT(node_size <= aux.io->chunk_capacity(idx));
+        allocated_offset = chunk_offset_t{idx, 0};
+        write_pos.current_chunk_id = idx;
+        write_pos.current_offset = node_size;
     }
     else {
-        auto const chunk_remaining_bytes =
-            aux.io->chunk_capacity(sender->offset().id) -
-            sender->offset().offset - sender->written_buffer_bytes();
-        node_writer_unique_ptr_type new_node_writer{};
-        unsigned offset_in_on_disk_node = 0;
-        if (size > chunk_remaining_bytes) {
-            // Node won't fit in the rest of current chunk, start at a new chunk
-            new_node_writer =
-                replace_node_writer_to_start_at_new_chunk(aux, node_writer);
-            if (!new_node_writer) {
-                goto retry;
-            }
-            ret.offset_written_to = new_node_writer->sender().offset();
-        }
-        else {
-            // serialize node to current writer's remaining bytes because node
-            // serialization will not cross chunk boundary
-            ret.offset_written_to =
-                sender->offset().add_to_offset(sender->written_buffer_bytes());
-            auto bytes_to_append = std::min(
-                (unsigned)remaining_bytes, size - offset_in_on_disk_node);
-            auto *where_to_serialize =
-                (unsigned char *)node_writer->sender().advance_buffer_append(
-                    bytes_to_append);
-            MONAD_DEBUG_ASSERT(where_to_serialize != nullptr);
-            serialize_node_to_buffer(
-                where_to_serialize,
-                bytes_to_append,
-                node,
-                size,
-                offset_in_on_disk_node);
-            offset_in_on_disk_node += bytes_to_append;
-            new_node_writer = replace_node_writer(aux, node_writer);
-            if (!new_node_writer) {
-                goto retry;
-            }
-            MONAD_DEBUG_ASSERT(
-                new_node_writer->sender().offset().id ==
-                node_writer->sender().offset().id);
-        }
-        // initiate current node writer
-        if (node_writer->sender().written_buffer_bytes() !=
-            node_writer->sender().buffer().size()) {
-            LOG_INFO_CFORMAT(
-                "async_write_node %zu != %zu",
-                node_writer->sender().written_buffer_bytes(),
-                node_writer->sender().buffer().size());
-        }
-        MONAD_ASSERT(
-            node_writer->sender().written_buffer_bytes() ==
-            node_writer->sender().buffer().size());
-        node_writer->initiate();
-        // shall be recycled by the i/o receiver
-        node_writer.release();
-        node_writer = std::move(new_node_writer);
-        // serialize the rest of the node to buffer
-        while (offset_in_on_disk_node < size) {
-            auto *where_to_serialize =
-                (unsigned char *)node_writer->sender().buffer().data();
-            auto bytes_to_append = std::min(
-                (unsigned)node_writer->sender().remaining_buffer_bytes(),
-                size - offset_in_on_disk_node);
-            serialize_node_to_buffer(
-                where_to_serialize,
-                bytes_to_append,
-                node,
-                size,
-                offset_in_on_disk_node);
-            offset_in_on_disk_node += bytes_to_append;
-            MONAD_ASSERT(offset_in_on_disk_node <= size);
-            MONAD_ASSERT(
-                node_writer->sender().advance_buffer_append(bytes_to_append) !=
-                nullptr);
-            if (offset_in_on_disk_node < size &&
-                node_writer->sender().remaining_buffer_bytes() == 0) {
-                // replace node writer
-                new_node_writer = replace_node_writer(aux, node_writer);
-                if (new_node_writer) {
-                    // initiate current node writer
-                    MONAD_DEBUG_ASSERT(
-                        node_writer->sender().written_buffer_bytes() ==
-                        node_writer->sender().buffer().size());
-                    node_writer->initiate();
-                    // shall be recycled by the i/o receiver
-                    node_writer.release();
-                    node_writer = std::move(new_node_writer);
-                }
-            }
-        }
+        // Allocate in current chunk
+        allocated_offset = write_pos.to_chunk_offset();
+        write_pos.current_offset += node_size;
+
+        // Sanity check: if we've exceeded chunk capacity, something is wrong
+        MONAD_ASSERT(write_pos.current_offset <= chunk_capacity);
     }
-    return ret;
+
+    return allocated_offset;
 }
 
-// Return node's physical offset the node is written at, triedb should not
-// depend on any metadata to walk the data structure.
-chunk_offset_t
-async_write_node_set_spare(UpdateAuxImpl &aux, Node &node, bool write_to_fast)
+// Return the allocated physical offset for this node. Three paths:
+// 1. Ordering enqueue: if the delayed queue is non-empty or no write buffer
+//    exists, enqueue to preserve write ordering.
+// 2. Fast path: node fits in the current buffer and is written immediately.
+// 3. Capacity enqueue: node does not fit in the remaining buffer; enqueue and
+//    attempt to drain the delayed queue.
+async_write_node_result async_write_node(
+    UpdateAuxImpl &aux, node_writer_unique_ptr_type &node_writer,
+    Node::SharedPtr const &node, bool is_fast)
+{
+    auto const size = node->get_disk_size();
+
+    aux.io->poll_nonblocking_if_not_within_completions(1);
+
+    auto &delayed_writes = aux.writer(is_fast).delayed_writes;
+
+    // If delay queue not empty or no buffer, queue to maintain order
+    if (!delayed_writes.empty() || !node_writer) {
+        chunk_offset_t allocated_offset =
+            allocate_write_offset(aux, size, is_fast);
+
+        delayed_writes.push_back(DelayedNodeWrite{
+            .node = node,
+            .disk_size = size,
+            .allocated_offset = allocated_offset});
+
+        process_delayed_writes(aux, is_fast);
+
+        return async_write_node_result{
+            .offset_written_to = allocated_offset, .bytes_appended = size};
+    }
+
+    // Fast path: node fits in current buffer
+    auto *sender = &node_writer->sender();
+    auto const remaining_bytes = sender->remaining_buffer_bytes();
+
+    [[likely]] if (size <= remaining_bytes) {
+        // Can write immediately without buffer allocation
+        chunk_offset_t allocated_offset =
+            allocate_write_offset(aux, size, is_fast);
+        auto *where_to_serialize = sender->advance_buffer_append(size);
+        serialize_node_to_buffer(
+            (unsigned char *)where_to_serialize, size, *node, size);
+
+        return async_write_node_result{
+            .offset_written_to = allocated_offset, .bytes_appended = size};
+    }
+
+    // Slow path: node doesn't fit, queue it and return allocated offset
+    chunk_offset_t allocated_offset = allocate_write_offset(aux, size, is_fast);
+
+    delayed_writes.push_back(DelayedNodeWrite{
+        .node = node, .disk_size = size, .allocated_offset = allocated_offset});
+
+    // Attempt to drain delayed writes. Returns immediately if no buffers
+    // are available; I/O completion callbacks will retry.
+    process_delayed_writes(aux, is_fast);
+
+    return async_write_node_result{
+        .offset_written_to = allocated_offset, .bytes_appended = size};
+}
+
+// Return node's allocated physical offset. The actual write may be deferred.
+// Triedb should not depend on any metadata to walk the data structure.
+chunk_offset_t async_write_node_set_spare(
+    UpdateAuxImpl &aux, Node::SharedPtr const &node, bool write_to_fast)
 {
     write_to_fast &= aux.can_write_to_fast();
     if (aux.alternate_slow_fast_writer()) {
@@ -1638,61 +1732,78 @@ async_write_node_set_spare(UpdateAuxImpl &aux, Node &node, bool write_to_fast)
         aux.set_can_write_to_fast(!aux.can_write_to_fast());
     }
 
-    auto off = async_write_node(
-                   aux,
-                   write_to_fast ? aux.node_writer_fast : aux.node_writer_slow,
-                   node)
-                   .offset_written_to;
+    auto off =
+        async_write_node(
+            aux, aux.writer(write_to_fast).node_writer, node, write_to_fast)
+            .offset_written_to;
     MONAD_ASSERT(
         (write_to_fast && aux.db_metadata()->at(off.id)->in_fast_list) ||
         (!write_to_fast && aux.db_metadata()->at(off.id)->in_slow_list));
-    unsigned const pages = num_pages(off.offset, node.get_disk_size());
+    unsigned const pages = num_pages(off.offset, node->get_disk_size());
     off.set_spare(static_cast<uint16_t>(node_disk_pages_spare_15{pages}));
     return off;
 }
 
 void flush_buffered_writes(UpdateAuxImpl &aux)
 {
-    // Round up with all bits zero
-    auto replace = [&](node_writer_unique_ptr_type &node_writer) {
-        auto *sender = &node_writer->sender();
-        auto written = sender->written_buffer_bytes();
-        auto paddedup = round_up_align<DISK_PAGE_BITS>(written);
-        auto const tozerobytes = paddedup - written;
-        auto *tozero = sender->advance_buffer_append(tozerobytes);
-        MONAD_DEBUG_ASSERT(tozero != nullptr);
-        memset(tozero, 0, tozerobytes);
-        // replace fast node writer
-        auto new_node_writer = replace_node_writer(aux, node_writer);
-        while (!new_node_writer) {
-            new_node_writer = replace_node_writer(aux, node_writer);
+    // Submit current buffers. If node_writer is null, the buffer was already
+    // submitted (all buffers in flight). If non-null, pad and submit it;
+    // replacement allocation is non-blocking — if no buffer is available,
+    // node_writer is left null (next write will allocate or enqueue).
+    auto flush = [&](node_writer_unique_ptr_type &node_writer, bool is_fast) {
+        if (!node_writer) {
+            return;
         }
+
+        // Nothing written (e.g. slow writer with no slow nodes) - skip flush
+        if (node_writer->sender().written_buffer_bytes() == 0) {
+            return;
+        }
+
+        // Pad to O_DIRECT alignment and advance write_position for the padding
+        auto const pad_bytes = pad_writer_to_disk_page_alignment(node_writer);
+        if (pad_bytes > 0) {
+            allocate_write_offset(aux, pad_bytes, is_fast);
+        }
+
+        // Get current write_position for new buffer
+        auto const next_offset =
+            aux.writer(is_fast).write_position.to_chunk_offset();
+
+        // Non-blocking replacement: null node_writer is fine
+        auto new_node_writer = replace_node_writer(aux, next_offset, is_fast);
         auto to_initiate = std::move(node_writer);
         node_writer = std::move(new_node_writer);
         to_initiate->receiver().reset(
             to_initiate->sender().written_buffer_bytes());
         to_initiate->initiate();
-        // shall be recycled by the i/o receiver
+        // Ownership transferred to I/O subsystem. On completion, the
+        // receiver frees the buffer and triggers process_delayed_writes.
         to_initiate.release();
     };
-    replace(aux.node_writer_fast);
-    if (aux.node_writer_slow->sender().written_buffer_bytes()) {
-        // replace slow node writer
-        replace(aux.node_writer_slow);
-    }
+
+    flush(aux.writer_fast.node_writer, true);
+    flush(aux.writer_slow.node_writer, false);
     aux.io->flush();
+    // Completion callbacks during io->flush() may have drained delayed writes
+    // into a new buffer that was not yet submitted. Flush and wait once more.
+    flush(aux.writer_fast.node_writer, true);
+    flush(aux.writer_slow.node_writer, false);
+    aux.io->flush();
+    MONAD_ASSERT(aux.writer_fast.delayed_writes.empty());
+    MONAD_ASSERT(aux.writer_slow.delayed_writes.empty());
 }
 
 // return root physical offset
-chunk_offset_t
-write_new_root_node(UpdateAuxImpl &aux, Node &root, uint64_t const version)
+chunk_offset_t write_new_root_node(
+    UpdateAuxImpl &aux, Node::SharedPtr const &root, uint64_t const version)
 {
     auto const offset_written_to = async_write_node_set_spare(aux, root, true);
     flush_buffered_writes(aux);
     // advance fast and slow ring's latest offset in db metadata
-    aux.advance_db_offsets_to(
-        aux.node_writer_fast->sender().offset(),
-        aux.node_writer_slow->sender().offset());
+    auto const fast_offset = aux.writer_fast.write_position.to_chunk_offset();
+    auto const slow_offset = aux.writer_slow.write_position.to_chunk_offset();
+    aux.advance_db_offsets_to(fast_offset, slow_offset);
     // update root offset
     auto const max_version_in_db = aux.db_history_max_version();
     if (MONAD_UNLIKELY(max_version_in_db == INVALID_BLOCK_NUM)) {

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -23,11 +23,13 @@
 #include <category/mpt/detail/collected_stats.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/node.hpp>
+
 #include <category/mpt/node_cursor.hpp>
 #include <category/mpt/state_machine.hpp>
 #include <category/mpt/update.hpp>
 #include <category/mpt/upward_tnode.hpp>
 #include <category/mpt/util.hpp>
+#include <deque>
 
 #include <category/async/io.hpp>
 #include <category/async/io_senders.hpp>
@@ -58,16 +60,29 @@
 MONAD_MPT_NAMESPACE_BEGIN
 
 class Node;
+class UpdateAuxImpl;
+
+// Non-blocking drain of delayed writes into available I/O buffers.
+// Called from I/O completion callbacks and at explicit flush points.
+void process_delayed_writes(UpdateAuxImpl &, bool is_fast);
 
 struct write_operation_io_receiver
 {
     size_t should_be_written;
-
-    // Node *parent{nullptr};
+    UpdateAuxImpl *aux{nullptr};
+    bool is_fast{false};
 
     explicit constexpr write_operation_io_receiver(
         size_t const should_be_written_)
         : should_be_written(should_be_written_)
+    {
+    }
+
+    explicit constexpr write_operation_io_receiver(
+        size_t const should_be_written_, UpdateAuxImpl *aux_, bool is_fast_)
+        : should_be_written(should_be_written_)
+        , aux(aux_)
+        , is_fast(is_fast_)
     {
     }
 
@@ -80,11 +95,12 @@ struct write_operation_io_receiver
         res.assume_value()
             .get()
             .reset(); // release i/o buffer before initiating other work
-        // TODO: when adding upsert_sender
-        // if (parent->current_process_updates_sender_ != nullptr) {
-        //     parent->current_process_updates_sender_
-        //         ->notify_write_operation_completed_(rawstate);
-        // }
+
+        // On I/O completion, trigger the delayed write drain loop.
+        // Queued writes are progressively flushed as buffers become available.
+        if (aux != nullptr) {
+            process_delayed_writes(*aux, is_fast);
+        }
     }
 
     void reset(size_t const should_be_written_)
@@ -164,14 +180,22 @@ public:
     }
 };
 
-chunk_offset_t
-async_write_node_set_spare(UpdateAuxImpl &, Node &, bool is_fast);
+chunk_offset_t async_write_node_set_spare(
+    UpdateAuxImpl &, Node::SharedPtr const &node, bool is_fast);
 
-chunk_offset_t
-write_new_root_node(UpdateAuxImpl &, Node &root, uint64_t version);
+chunk_offset_t write_new_root_node(
+    UpdateAuxImpl &, Node::SharedPtr const &root, uint64_t version);
 
-node_writer_unique_ptr_type
-replace_node_writer(UpdateAuxImpl &, node_writer_unique_ptr_type const &);
+struct DelayedNodeWrite
+{
+    Node::SharedPtr node;
+    unsigned disk_size; // Cached result of node->get_disk_size()
+    chunk_offset_t allocated_offset; // Pre-allocated before the physical write
+    unsigned offset_in_data{0}; // How many bytes already written
+};
+
+node_writer_unique_ptr_type replace_node_writer(
+    UpdateAuxImpl &, chunk_offset_t target_offset, bool is_fast);
 
 // \class Auxiliaries for triedb update
 class UpdateAuxImpl
@@ -248,8 +272,35 @@ public:
 
     // On disk stuff
     MONAD_ASYNC_NAMESPACE::AsyncIO *io{nullptr};
-    node_writer_unique_ptr_type node_writer_fast{};
-    node_writer_unique_ptr_type node_writer_slow{};
+
+    // Tracks current chunk and offset for logical writes (buffer-independent)
+    struct write_position_t
+    {
+        uint32_t current_chunk_id{0};
+        file_offset_t current_offset{0}; // Within current chunk
+
+        MONAD_ASYNC_NAMESPACE::chunk_offset_t to_chunk_offset() const noexcept
+        {
+            return MONAD_ASYNC_NAMESPACE::chunk_offset_t{
+                current_chunk_id, current_offset};
+        }
+    };
+
+    // Per-writer state for fast and slow storage rings
+    struct WriterState
+    {
+        node_writer_unique_ptr_type node_writer{};
+        write_position_t write_position;
+        std::deque<DelayedNodeWrite> delayed_writes;
+        bool processing_delayed_writes{false}; // Re-entrancy guard
+        uint64_t buffer_alloc_failures{
+            0}; // Diagnostic: buffer pool exhaustion count
+    } writer_fast, writer_slow;
+
+    WriterState &writer(bool is_fast) noexcept
+    {
+        return is_fast ? writer_fast : writer_slow;
+    }
 
     detail::TrieUpdateCollectedStats stats;
 
@@ -582,7 +633,7 @@ public:
 };
 
 static_assert(
-    sizeof(UpdateAuxImpl) == 144 + sizeof(detail::TrieUpdateCollectedStats));
+    sizeof(UpdateAuxImpl) == 368 + sizeof(detail::TrieUpdateCollectedStats));
 static_assert(alignof(UpdateAuxImpl) == 8);
 
 class UpdateAux final : public UpdateAuxImpl

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -1033,8 +1033,10 @@ void UpdateAuxImpl::set_io(
 
 void UpdateAuxImpl::unset_io()
 {
-    node_writer_fast.reset();
-    node_writer_slow.reset();
+    MONAD_ASSERT(writer_fast.delayed_writes.empty());
+    MONAD_ASSERT(writer_slow.delayed_writes.empty());
+    writer_fast.node_writer.reset();
+    writer_slow.node_writer.reset();
     if (db_metadata_[0].root_offsets.data() != nullptr) {
         (void)::munmap(
             db_metadata_[0].root_offsets.data(),
@@ -1060,8 +1062,8 @@ void UpdateAuxImpl::unset_io()
 
 void UpdateAuxImpl::reset_node_writers()
 {
-    auto init_node_writer = [&](chunk_offset_t const node_writer_offset)
-        -> node_writer_unique_ptr_type {
+    auto init_node_writer = [&](chunk_offset_t const node_writer_offset,
+                                bool is_fast) -> node_writer_unique_ptr_type {
         auto &chunk =
             io->storage_pool().chunk(storage_pool::seq, node_writer_offset.id);
         MONAD_ASSERT(chunk.size() >= node_writer_offset.offset);
@@ -1071,18 +1073,28 @@ void UpdateAuxImpl::reset_node_writers()
         return io ? io->make_connected(
                         write_single_buffer_sender{
                             node_writer_offset, bytes_to_write},
-                        write_operation_io_receiver{bytes_to_write})
+                        write_operation_io_receiver{
+                            bytes_to_write, this, is_fast})
                   : node_writer_unique_ptr_type{};
     };
-    node_writer_fast =
-        init_node_writer(db_metadata()->db_offsets.start_of_wip_offset_fast);
-    node_writer_slow =
-        init_node_writer(db_metadata()->db_offsets.start_of_wip_offset_slow);
+    auto const &fast_offset =
+        db_metadata()->db_offsets.start_of_wip_offset_fast;
+    auto const &slow_offset =
+        db_metadata()->db_offsets.start_of_wip_offset_slow;
+
+    writer_fast.node_writer = init_node_writer(fast_offset, true);
+    writer_slow.node_writer = init_node_writer(slow_offset, false);
+
+    // Initialize write positions to track logical offsets independently
+    writer_fast.write_position.current_chunk_id = fast_offset.id;
+    writer_fast.write_position.current_offset = fast_offset.offset;
+    writer_slow.write_position.current_chunk_id = slow_offset.id;
+    writer_slow.write_position.current_offset = slow_offset.offset;
 
     last_block_end_offset_fast_ = compact_virtual_chunk_offset_t{
-        physical_to_virtual(node_writer_fast->sender().offset())};
+        physical_to_virtual(writer_fast.node_writer->sender().offset())};
     last_block_end_offset_slow_ = compact_virtual_chunk_offset_t{
-        physical_to_virtual(node_writer_slow->sender().offset())};
+        physical_to_virtual(writer_slow.node_writer->sender().offset())};
 }
 
 /* upsert() supports both on disk and in memory db updates. User should
@@ -1115,6 +1127,8 @@ Node::SharedPtr UpdateAuxImpl::do_update(
     }
     MONAD_ASSERT(is_on_disk());
     set_can_write_to_fast(can_write_to_fast);
+    auto const fast_failures_before = writer_fast.buffer_alloc_failures;
+    auto const slow_failures_before = writer_slow.buffer_alloc_failures;
 
     if (prev_root) {
         // previous compaction offset
@@ -1156,14 +1170,14 @@ Node::SharedPtr UpdateAuxImpl::do_update(
         print_update_stats(version);
     }
     [[maybe_unused]] auto const curr_fast_writer_offset =
-        physical_to_virtual(node_writer_fast->sender().offset());
+        physical_to_virtual(writer_fast.write_position.to_chunk_offset());
     [[maybe_unused]] auto const curr_slow_writer_offset =
-        physical_to_virtual(node_writer_slow->sender().offset());
+        physical_to_virtual(writer_slow.write_position.to_chunk_offset());
     LOG_INFO_CFORMAT(
         "Finish upserting version %lu. Min valid version %lu. Time elapsed: "
         "%ld us. Disk usage: %.4f. Chunks: %u fast, %u slow, %u free. Writer "
         "offsets: fast={%u,%u}, slow={%u,%u}. Compaction head offset fast=%u, "
-        "slow=%u",
+        "slow=%u. Buffer alloc failures: fast=%lu, slow=%lu",
         version,
         db_history_min_valid_version(),
         upsert_duration.count(),
@@ -1176,7 +1190,23 @@ Node::SharedPtr UpdateAuxImpl::do_update(
         curr_slow_writer_offset.count,
         curr_slow_writer_offset.offset,
         (uint32_t)compact_offsets.fast,
-        (uint32_t)compact_offsets.slow);
+        (uint32_t)compact_offsets.slow,
+        (unsigned long)writer_fast.buffer_alloc_failures,
+        (unsigned long)writer_slow.buffer_alloc_failures);
+    auto const fast_this_block =
+        writer_fast.buffer_alloc_failures - fast_failures_before;
+    auto const slow_this_block =
+        writer_slow.buffer_alloc_failures - slow_failures_before;
+    if (fast_this_block > 0 || slow_this_block > 0) {
+        LOG_WARNING_CFORMAT(
+            "Version %lu: write buffer stalls this block: fast=%lu, slow=%lu; "
+            "total since start: fast=%lu, slow=%lu",
+            version,
+            (unsigned long)fast_this_block,
+            (unsigned long)slow_this_block,
+            (unsigned long)writer_fast.buffer_alloc_failures,
+            (unsigned long)writer_slow.buffer_alloc_failures);
+    }
     return root;
 }
 
@@ -1351,9 +1381,9 @@ void UpdateAuxImpl::move_trie_version_forward(
 void UpdateAuxImpl::update_disk_growth_data()
 {
     compact_virtual_chunk_offset_t const curr_fast_writer_offset{
-        physical_to_virtual(node_writer_fast->sender().offset())};
+        physical_to_virtual(writer_fast.write_position.to_chunk_offset())};
     compact_virtual_chunk_offset_t const curr_slow_writer_offset{
-        physical_to_virtual(node_writer_slow->sender().offset())};
+        physical_to_virtual(writer_slow.write_position.to_chunk_offset())};
     last_block_disk_growth_fast_ = // unused for speed control for now
         curr_fast_writer_offset - last_block_end_offset_fast_;
     last_block_disk_growth_slow_ =
@@ -1423,7 +1453,7 @@ void UpdateAuxImpl::advance_compact_offsets()
     uint64_t const min_version = db_history_min_valid_version();
     MONAD_ASSERT(min_version != INVALID_BLOCK_NUM);
     compact_virtual_chunk_offset_t const curr_fast_writer_offset{
-        physical_to_virtual(node_writer_fast->sender().offset())};
+        physical_to_virtual(writer_fast.node_writer->sender().offset())};
     // Estimate average fast-list disk growth per version. If the oldest root
     // is on the fast list, compute from the full history range. Otherwise fall
     // back to the last block's growth (e.g. roots from statesync may be on the


### PR DESCRIPTION
Replace blocking buffer-wait loop in async_write_node with a non-blocking delayed write queue. When the current write buffer is full, nodes are queued as DelayedNodeWrite (holding Node::SharedPtr) and serialized on demand when buffers become available. A separate write_position tracks logical offsets independently of physical buffer state, enabling offset allocation without blocking.