### PR TITLE
[event] Zero-initialize padding bits in execution events

### DIFF
--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -267,6 +267,30 @@ ReservedExecEvent<T> ExecutionEventRecorder::reserve_block_event(
     event->content_ext[MONAD_FLOW_TXN_ID] = 0;
     event->content_ext[MONAD_FLOW_ACCOUNT_INDEX] = 0;
 
+    // TODO(ken): remove the memset(3) below if the C++ standard evolves
+    //
+    // Both the C23 and C++20 standards specify that an initialization of the
+    // form `S s = {}` will zero-initialize the entire bit representation of
+    // the aggregate `S`, including padding bits. As of C23 and C++26, neither
+    // specifies what happens to the padding bits if any designated
+    // initializers are present. Designated initializers in aggregates is
+    // how the memory of `payload_buf` is usually initialized and the execution
+    // events ABI requires all padding bits to be zeroed.
+    //
+    // 1. As an extension, clang-20 and later always explicitly zero-initialize
+    //    padding bits, but only in C23 and not C++, see:
+    //    https://clang.llvm.org/docs/LanguageExtensions.html#union-and-aggregate-initialization-in-c
+    //    https://github.com/llvm/llvm-project/commit/7a086e1b2dc05f54afae3591614feede727601fa
+    //
+    // 2. In gcc, zero-init of padding bits can be guaranteed in both languages,
+    //    in all contexts, via -fzero-init-padding-bits=all; this is both
+    //    too heavy-handed and doesn't work in clang++
+    //
+    // If at some point, the clang C extension behavior becomes standard, then
+    // the below memset(3) can be removed. Because the current function is
+    // inlineable, the dead stores created by this memset are eliminated, and
+    // it has minimal performance impact.
+    memset(payload_buf, 0, sizeof(T));
     return {event, reinterpret_cast<T *>(payload_buf), seqno};
 }
 

--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -52,27 +52,29 @@ void init_txn_header_start(
     Transaction const &txn, Address const &sender,
     monad_exec_txn_header_start *const event)
 {
-    event->txn_hash = to_bytes(keccak256(rlp::encode_transaction(txn)));
-    event->sender = sender;
-    auto &header = event->txn_header;
-    header.nonce = txn.nonce;
-    header.gas_limit = txn.gas_limit;
-    header.max_fee_per_gas = txn.max_fee_per_gas;
-    header.max_priority_fee_per_gas = txn.max_priority_fee_per_gas;
-    header.value = txn.value;
-    header.to = txn.to ? *txn.to : Address{};
-    header.is_contract_creation = !txn.to;
-    header.txn_type = std::bit_cast<monad_c_transaction_type>(txn.type);
-    header.r = txn.sc.r;
-    header.s = txn.sc.s;
-    header.y_parity = txn.sc.y_parity == 1;
-    header.chain_id = txn.sc.chain_id.value_or(0);
-    header.data_length = static_cast<uint32_t>(txn.data.size());
-    header.blob_versioned_hash_length =
-        static_cast<uint32_t>(txn.blob_versioned_hashes.size());
-    header.access_list_count = static_cast<uint32_t>(txn.access_list.size());
-    header.auth_list_count =
-        static_cast<uint32_t>(txn.authorization_list.size());
+    *event = monad_exec_txn_header_start{
+        .txn_hash = to_bytes(keccak256(rlp::encode_transaction(txn))),
+        .sender = sender,
+        .txn_header = {
+            .txn_type = std::bit_cast<monad_c_transaction_type>(txn.type),
+            .chain_id = txn.sc.chain_id.value_or(0),
+            .nonce = txn.nonce,
+            .gas_limit = txn.gas_limit,
+            .max_fee_per_gas = txn.max_fee_per_gas,
+            .max_priority_fee_per_gas = txn.max_priority_fee_per_gas,
+            .value = txn.value,
+            .to = txn.to ? *txn.to : Address{},
+            .is_contract_creation = !txn.to,
+            .r = txn.sc.r,
+            .s = txn.sc.s,
+            .y_parity = txn.sc.y_parity == 1,
+            .max_fee_per_blob_gas = txn.max_fee_per_blob_gas,
+            .data_length = static_cast<uint32_t>(txn.data.size()),
+            .blob_versioned_hash_length =
+                static_cast<uint32_t>(txn.blob_versioned_hashes.size()),
+            .access_list_count = static_cast<uint32_t>(txn.access_list.size()),
+            .auth_list_count =
+                static_cast<uint32_t>(txn.authorization_list.size())}};
 }
 
 // Tracks information about an accessed account, including (1) the prestate and


### PR DESCRIPTION
Zero-initialization of padding is important for two different reasons:

1. Event payloads from different captures of the same events will memcmp(3) as equal; this will be used in a later PR, for replay-based testing of the event system

2. The future "event schema upgrade plan" permits new structure members to be inserted into currently-unused tail padding (including in the middle of a structure) without requiring a version change to the event. Without this commit, this aspect of the upgrade plan would not work: it relies on a field that is missing in older data to be initialized by a zero bit pattern

The "meat" of this change is a single memset(3) placed in the event reservation step that zero-initializes the memory region that will hold the payload type `T`.

This also changes the initialization of the `TXN_HEADER_START` payload to aggregate initialization with designated initializers, which makes it visually consistent with other event payloads.

With the current compiler settings, the visual appearance of aggregate initialization does not generate different code, although in some compiler modes (e.g., clang with -std=c23) or with some extra options (e.g., gcc's -fzero-init-padding-bits=always in C or C++) this initialization style would guarantee zero-initialization of the padding everywhere, and we would not need the memset(3).

If a future language standard adds support for clang's C23 extension, the memset(3) can be removed. A comment is left that explains the issue. The benefit of removing it is that it technically will generate a lot of dead stores, although it should be (and currently is) removed by the DSE optimization passes in practice.