### PR TITLE
[fiber] Add awakened_from_remote() to bypass remote_ready_queue for cross-thread fiber scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,11 @@ endforeach()
 add_subdirectory("third_party/fiber" SYSTEM)
 # Boost.Fiber triggers warnings under C++23 strict flags.
 target_compile_options(boost_fiber PRIVATE -Wno-deprecated-declarations -Wno-conversion)
+# Enables the thread-safety machinery required for algorithms that
+# implement algorithm::awakened_from_remote(): a spinlock on the
+# worker-queue, so ctx->detach() from a remote thread doesn't race
+# with the owning thread's attach of another fiber.
+target_compile_definitions(boost_fiber PUBLIC BOOST_FIBERS_AWAKENED_FROM_REMOTE)
 
 # immer
 option(immer_BUILD_TESTS OFF)

--- a/category/core/fiber/priority_algorithm.cpp
+++ b/category/core/fiber/priority_algorithm.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/fiber/priority_algorithm.hpp>
 
+#include <category/core/assert.h>
 #include <category/core/fiber/config.hpp>
 #include <category/core/fiber/priority_properties.hpp>
 #include <category/core/fiber/priority_queue.hpp>
@@ -48,6 +49,14 @@ void PriorityAlgorithm::awakened(
         rqueue_.push(ctx);
         recent_ = true;
     }
+}
+
+bool PriorityAlgorithm::awakened_from_remote(context *ctx) noexcept
+{
+    MONAD_ASSERT(!ctx->is_context(boost::fibers::type::pinned_context));
+    ctx->detach();
+    rqueue_.push(ctx);
+    return true;
 }
 
 context *PriorityAlgorithm::pick_next() noexcept

--- a/category/core/fiber/priority_algorithm.hpp
+++ b/category/core/fiber/priority_algorithm.hpp
@@ -23,8 +23,6 @@
 #include <boost/fiber/context.hpp>
 #include <boost/fiber/scheduler.hpp>
 
-#include <chrono>
-
 MONAD_FIBER_NAMESPACE_BEGIN
 
 using boost::fibers::context;
@@ -53,14 +51,13 @@ public:
 
     void awakened(context *, PriorityProperties &) noexcept override;
 
+    bool awakened_from_remote(context *ctx) noexcept override;
+
     context *pick_next() noexcept override;
 
     bool has_ready_fibers() const noexcept override;
 
-    void suspend_until(
-        std::chrono::steady_clock::time_point const &) noexcept override
-    {
-    }
+    void suspend() noexcept override {}
 
     void notify() noexcept override {}
 };


### PR DESCRIPTION
Depends on category-labs/fiber#3