### PR TITLE
[event] fix size check in monad_event_ring_init_file

### DIFF
--- a/category/core/event/event_ring.c
+++ b/category/core/event/event_ring.c
@@ -176,7 +176,7 @@ int monad_event_ring_init_file(
         return FORMAT_ERRC(
             errno, "unable to fstat event ring file `%s`", error_name);
     }
-    if (ring_offset + (off_t)sizeof header > ring_stat.st_size) {
+    if (ring_offset + (off_t)ring_bytes > ring_stat.st_size) {
         return FORMAT_ERRC(
             ENOSPC,
             "event ring file `%s` cannot hold total event ring size %lu",

--- a/category/core/event/event_ring_util.h
+++ b/category/core/event/event_ring_util.h
@@ -62,8 +62,8 @@ struct monad_event_flock_info
 
 /// "All in one" convenience event ring file init for simple cases: given an
 /// event ring fd and the required options, calculate the required size of the
-/// event ring, call fallocate(2) to ensure the storage is available, then call
-/// monad_event_ring_init_file
+/// event ring, call posix_fallocate(2) to ensure the storage is available, then
+/// call monad_event_ring_init_file
 int monad_event_ring_init_simple(
     struct monad_event_ring_simple_config const *, int ring_fd,
     off_t ring_offset, char const *error_name);


### PR DESCRIPTION
Also adds a drive-by change: fix a comment that says we use fallocate(2) to ensure the file is large enough (it was changed to posix_fallocate(2) recently)