### PR TITLE
Add iter helpers to execution events SDK

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
  "bindgen",
+ "cc",
  "chrono",
  "clap",
  "criterion",

--- a/rust/crates/monad-event-ring/src/descriptor/mod.rs
+++ b/rust/crates/monad-event-ring/src/descriptor/mod.rs
@@ -17,7 +17,10 @@ use std::marker::PhantomData;
 
 pub(crate) use self::raw::RawEventDescriptor;
 use self::raw::RawEventDescriptorInfo;
-use crate::{EventDecoder, EventPayloadResult};
+use crate::{
+    ffi::{monad_event_descriptor, monad_event_ring},
+    EventDecoder, EventPayloadResult,
+};
 
 mod raw;
 
@@ -107,6 +110,14 @@ where
 
             f(info, bytes)
         })
+    }
+
+    /// Exposes the underlying c-types.
+    pub fn with_raw<R>(
+        &self,
+        f: impl FnOnce(&monad_event_ring, &monad_event_descriptor) -> R,
+    ) -> R {
+        f(&self.raw.ring.inner, &self.raw.inner)
     }
 }
 

--- a/rust/crates/monad-event-ring/src/descriptor/raw.rs
+++ b/rust/crates/monad-event-ring/src/descriptor/raw.rs
@@ -20,8 +20,8 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) struct RawEventDescriptor<'ring> {
-    inner: monad_event_descriptor,
-    ring: &'ring RawEventRing,
+    pub(super) inner: monad_event_descriptor,
+    pub(super) ring: &'ring RawEventRing,
 }
 
 impl<'ring> RawEventDescriptor<'ring> {
@@ -35,7 +35,7 @@ impl<'ring> RawEventDescriptor<'ring> {
         }
     }
 
-    pub(crate) fn try_filter_map<T>(
+    pub(super) fn try_filter_map<T>(
         &self,
         f: impl FnOnce(RawEventDescriptorInfo, &[u8]) -> T,
     ) -> EventPayloadResult<T> {
@@ -60,7 +60,7 @@ impl<'ring> RawEventDescriptor<'ring> {
     }
 }
 
-pub(crate) struct RawEventDescriptorInfo {
+pub(super) struct RawEventDescriptorInfo {
     pub seqno: u64,
 
     pub event_type: u16,

--- a/rust/crates/monad-event-ring/src/ffi.rs
+++ b/rust/crates/monad-event-ring/src/ffi.rs
@@ -22,16 +22,16 @@ use std::{
 };
 
 pub(crate) use self::bindings::{
-    g_monad_event_content_type_names, monad_event_descriptor, monad_event_iter_result,
-    monad_event_iterator, monad_event_ring, MONAD_EVENT_CONTENT_TYPE_COUNT,
+    g_monad_event_content_type_names, monad_event_iter_result, MONAD_EVENT_CONTENT_TYPE_COUNT,
     MONAD_EVENT_CONTENT_TYPE_NONE, MONAD_EVENT_GAP, MONAD_EVENT_NOT_READY, MONAD_EVENT_SUCCESS,
 };
 pub use self::bindings::{
-    monad_event_content_type, monad_event_record_error, MONAD_EVENT_CONTENT_TYPE_EXEC,
+    monad_event_content_type, monad_event_descriptor, monad_event_iterator,
+    monad_event_record_error, monad_event_ring, MONAD_EVENT_CONTENT_TYPE_EXEC,
     MONAD_EVENT_CONTENT_TYPE_TEST,
 };
 
-#[allow(dead_code, non_camel_case_types, non_upper_case_globals)]
+#[allow(dead_code, missing_docs, non_camel_case_types, non_upper_case_globals)]
 mod bindings {
     use libc::{off_t, pid_t};
 

--- a/rust/crates/monad-event-ring/src/lib.rs
+++ b/rust/crates/monad-event-ring/src/lib.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 

--- a/rust/crates/monad-exec-events/Cargo.toml
+++ b/rust/crates/monad-exec-events/Cargo.toml
@@ -13,10 +13,12 @@ alloy-primitives = { workspace = true, optional = true }
 alloy-rpc-types = { workspace = true, optional = true }
 itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 
 [build-dependencies]
 bindgen = { workspace = true }
+cc = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/rust/crates/monad-exec-events/build.rs
+++ b/rust/crates/monad-exec-events/build.rs
@@ -23,10 +23,13 @@ const INCLUDES: &[(&str, &[&str])] = &[
             "category/execution/ethereum/core/base_ctypes.h",
             "category/execution/ethereum/core/eth_ctypes.h",
             "category/execution/ethereum/event/exec_event_ctypes.h",
+            "category/execution/ethereum/event/exec_iter_help.h",
             "category/execution/monad/core/monad_ctypes.h",
         ],
     ),
 ];
+
+const STATIC_FNS_PATH: &str = "monad_exec_events__wrap_static_fns";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -38,6 +41,8 @@ fn main() {
         .header("wrapper.h")
         .clang_args(["-x", "c", "-std=c23"])
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .wrap_static_fns(true)
+        .wrap_static_fns_path(out_dir.join(STATIC_FNS_PATH))
         .derive_copy(true)
         .derive_debug(true)
         .derive_hash(true)
@@ -69,4 +74,16 @@ fn main() {
         .replace(r#"#[doc = " "#, r#"#[doc = ""#);
 
     std::fs::write(out_dir.join("bindings.rs"), &bindings_str).expect("Couldn't write bindings!");
+
+    cc::Build::new()
+        .std("c2x")
+        .file(out_dir.join(format!("{STATIC_FNS_PATH}.c")))
+        .includes(
+            std::iter::once(PathBuf::from(env!("CARGO_MANIFEST_DIR"))).chain(
+                INCLUDES
+                    .iter()
+                    .map(|(include_path, _)| PathBuf::from(include_path)),
+            ),
+        )
+        .compile(STATIC_FNS_PATH);
 }

--- a/rust/crates/monad-exec-events/src/events/mod.rs
+++ b/rust/crates/monad-exec-events/src/events/mod.rs
@@ -23,10 +23,10 @@ use crate::ffi::{
     self, g_monad_exec_event_schema_hash, monad_exec_account_access,
     monad_exec_account_access_list_header, monad_exec_block_end, monad_exec_block_finalized,
     monad_exec_block_qc, monad_exec_block_reject, monad_exec_block_start,
-    monad_exec_block_verified, monad_exec_evm_error, monad_exec_storage_access,
-    monad_exec_txn_access_list_entry, monad_exec_txn_auth_list_entry, monad_exec_txn_call_frame,
-    monad_exec_txn_evm_output, monad_exec_txn_header_start, monad_exec_txn_log,
-    monad_exec_txn_reject,
+    monad_exec_block_verified, monad_exec_event_type, monad_exec_evm_error,
+    monad_exec_storage_access, monad_exec_txn_access_list_entry, monad_exec_txn_auth_list_entry,
+    monad_exec_txn_call_frame, monad_exec_txn_evm_output, monad_exec_txn_header_start,
+    monad_exec_txn_log, monad_exec_txn_reject,
 };
 
 mod bytes;
@@ -42,7 +42,8 @@ pub struct ExecEventDecoder;
 ///
 /// See [`ExecEventRef`] for the zero-copy ref version.
 #[allow(missing_docs)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, strum::EnumDiscriminants)]
+#[strum_discriminants(name(ExecEventType), allow(missing_docs))]
 pub enum ExecEvent {
     RecordError(monad_event_record_error),
     BlockStart(monad_exec_block_start),
@@ -159,6 +160,37 @@ pub enum ExecEventRef<'ring> {
     AccountAccess(&'ring monad_exec_account_access),
     StorageAccess(&'ring monad_exec_storage_access),
     EvmError(&'ring monad_exec_evm_error),
+}
+
+impl ExecEventType {
+    pub(crate) fn as_c_event_type(self) -> monad_exec_event_type {
+        match self {
+            ExecEventType::RecordError => ffi::MONAD_EXEC_RECORD_ERROR,
+            ExecEventType::BlockStart => ffi::MONAD_EXEC_BLOCK_START,
+            ExecEventType::BlockReject => ffi::MONAD_EXEC_BLOCK_REJECT,
+            ExecEventType::BlockPerfEvmEnter => ffi::MONAD_EXEC_BLOCK_PERF_EVM_ENTER,
+            ExecEventType::BlockPerfEvmExit => ffi::MONAD_EXEC_BLOCK_PERF_EVM_EXIT,
+            ExecEventType::BlockEnd => ffi::MONAD_EXEC_BLOCK_END,
+            ExecEventType::BlockQC => ffi::MONAD_EXEC_BLOCK_QC,
+            ExecEventType::BlockFinalized => ffi::MONAD_EXEC_BLOCK_FINALIZED,
+            ExecEventType::BlockVerified => ffi::MONAD_EXEC_BLOCK_VERIFIED,
+            ExecEventType::TxnHeaderStart => ffi::MONAD_EXEC_TXN_HEADER_START,
+            ExecEventType::TxnAccessListEntry => ffi::MONAD_EXEC_TXN_ACCESS_LIST_ENTRY,
+            ExecEventType::TxnAuthListEntry => ffi::MONAD_EXEC_TXN_AUTH_LIST_ENTRY,
+            ExecEventType::TxnHeaderEnd => ffi::MONAD_EXEC_TXN_HEADER_END,
+            ExecEventType::TxnReject => ffi::MONAD_EXEC_TXN_REJECT,
+            ExecEventType::TxnPerfEvmEnter => ffi::MONAD_EXEC_TXN_PERF_EVM_ENTER,
+            ExecEventType::TxnPerfEvmExit => ffi::MONAD_EXEC_TXN_PERF_EVM_EXIT,
+            ExecEventType::TxnEvmOutput => ffi::MONAD_EXEC_TXN_EVM_OUTPUT,
+            ExecEventType::TxnLog => ffi::MONAD_EXEC_TXN_LOG,
+            ExecEventType::TxnCallFrame => ffi::MONAD_EXEC_TXN_CALL_FRAME,
+            ExecEventType::TxnEnd => ffi::MONAD_EXEC_TXN_END,
+            ExecEventType::AccountAccessListHeader => ffi::MONAD_EXEC_ACCOUNT_ACCESS_LIST_HEADER,
+            ExecEventType::AccountAccess => ffi::MONAD_EXEC_ACCOUNT_ACCESS,
+            ExecEventType::StorageAccess => ffi::MONAD_EXEC_STORAGE_ACCESS,
+            ExecEventType::EvmError => ffi::MONAD_EXEC_EVM_ERROR,
+        }
+    }
 }
 
 impl<'ring> ExecEventRef<'ring> {

--- a/rust/crates/monad-exec-events/src/ffi.rs
+++ b/rust/crates/monad-exec-events/src/ffi.rs
@@ -15,8 +15,20 @@
 
 //! This module contains low-level bindings to the monad execution client event types.
 
+pub use self::bindings::{
+    g_monad_exec_event_metadata, monad_c_access_list_entry, monad_c_address,
+    monad_c_auth_list_entry, monad_c_bytes32, monad_c_eth_txn_header, monad_c_eth_txn_receipt,
+    monad_c_uint256_ne, monad_exec_account_access, monad_exec_account_access_context,
+    monad_exec_account_access_list_header, monad_exec_block_end, monad_exec_block_finalized,
+    monad_exec_block_qc, monad_exec_block_reject, monad_exec_block_start, monad_exec_block_tag,
+    monad_exec_block_verified, monad_exec_evm_error, monad_exec_storage_access,
+    monad_exec_txn_access_list_entry, monad_exec_txn_auth_list_entry, monad_exec_txn_call_frame,
+    monad_exec_txn_evm_output, monad_exec_txn_header_start, monad_exec_txn_log,
+    monad_exec_txn_reject, MONAD_TXN_EIP1559, MONAD_TXN_EIP2930, MONAD_TXN_EIP4844,
+    MONAD_TXN_EIP7702, MONAD_TXN_LEGACY,
+};
 pub(crate) use self::bindings::{
-    g_monad_exec_event_schema_hash, MONAD_EXEC_ACCOUNT_ACCESS,
+    g_monad_exec_event_schema_hash, monad_exec_event_type, MONAD_EXEC_ACCOUNT_ACCESS,
     MONAD_EXEC_ACCOUNT_ACCESS_LIST_HEADER, MONAD_EXEC_BLOCK_END, MONAD_EXEC_BLOCK_FINALIZED,
     MONAD_EXEC_BLOCK_PERF_EVM_ENTER, MONAD_EXEC_BLOCK_PERF_EVM_EXIT, MONAD_EXEC_BLOCK_QC,
     MONAD_EXEC_BLOCK_REJECT, MONAD_EXEC_BLOCK_START, MONAD_EXEC_BLOCK_VERIFIED,
@@ -27,17 +39,6 @@ pub(crate) use self::bindings::{
     MONAD_EXEC_TXN_PERF_EVM_EXIT, MONAD_EXEC_TXN_REJECT, MONAD_FLOW_ACCOUNT_INDEX,
     MONAD_FLOW_BLOCK_SEQNO, MONAD_FLOW_TXN_ID,
 };
-pub use self::bindings::{
-    monad_c_access_list_entry, monad_c_address, monad_c_auth_list_entry, monad_c_bytes32,
-    monad_c_eth_txn_header, monad_c_eth_txn_receipt, monad_c_uint256_ne, monad_exec_account_access,
-    monad_exec_account_access_context, monad_exec_account_access_list_header, monad_exec_block_end,
-    monad_exec_block_finalized, monad_exec_block_qc, monad_exec_block_reject,
-    monad_exec_block_start, monad_exec_block_tag, monad_exec_block_verified, monad_exec_evm_error,
-    monad_exec_storage_access, monad_exec_txn_access_list_entry, monad_exec_txn_auth_list_entry,
-    monad_exec_txn_call_frame, monad_exec_txn_evm_output, monad_exec_txn_header_start,
-    monad_exec_txn_log, monad_exec_txn_reject, MONAD_TXN_EIP1559, MONAD_TXN_EIP2930,
-    MONAD_TXN_EIP4844, MONAD_TXN_EIP7702, MONAD_TXN_LEGACY,
-};
 
 #[allow(
     dead_code,
@@ -47,5 +48,95 @@ pub use self::bindings::{
     rustdoc::broken_intra_doc_links
 )]
 mod bindings {
+    use ::monad_event_ring::ffi::{monad_event_descriptor, monad_event_iterator, monad_event_ring};
+
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+use ::monad_event_ring::ffi::{monad_event_descriptor, monad_event_iterator, monad_event_ring};
+
+pub(crate) fn monad_exec_ring_get_block_number(
+    c_event_ring: &monad_event_ring,
+    c_event_descriptor: &monad_event_descriptor,
+) -> Option<u64> {
+    let mut block_number = 0;
+
+    let success = unsafe {
+        self::bindings::monad_exec_ring_get_block_number(
+            c_event_ring,
+            c_event_descriptor,
+            &mut block_number,
+        )
+    };
+
+    success.then_some(block_number)
+}
+
+pub(crate) fn monad_exec_ring_block_id_matches(
+    c_event_ring: &monad_event_ring,
+    c_event_descriptor: &monad_event_descriptor,
+    block_id: &monad_c_bytes32,
+) -> bool {
+    unsafe {
+        self::bindings::monad_exec_ring_block_id_matches(c_event_ring, c_event_descriptor, block_id)
+    }
+}
+
+pub(crate) fn monad_exec_iter_consensus_prev(
+    c_event_iterator: &mut monad_event_iterator,
+    c_exec_event_filter: monad_exec_event_type,
+) -> Option<monad_event_descriptor> {
+    let mut c_event_descriptor: monad_event_descriptor = unsafe { std::mem::zeroed() };
+
+    let success = unsafe {
+        self::bindings::monad_exec_iter_consensus_prev(
+            c_event_iterator,
+            c_exec_event_filter,
+            &mut c_event_descriptor,
+        )
+    };
+
+    success.then_some(c_event_descriptor)
+}
+
+pub(crate) fn monad_exec_iter_block_number_prev(
+    c_event_iterator: &mut monad_event_iterator,
+    c_event_ring: &monad_event_ring,
+    block_number: u64,
+    c_exec_event_filter: monad_exec_event_type,
+) -> Option<monad_event_descriptor> {
+    let mut c_event_descriptor: monad_event_descriptor = unsafe { std::mem::zeroed() };
+
+    let success = unsafe {
+        self::bindings::monad_exec_iter_block_number_prev(
+            c_event_iterator,
+            c_event_ring,
+            block_number,
+            c_exec_event_filter,
+            &mut c_event_descriptor,
+        )
+    };
+
+    success.then_some(c_event_descriptor)
+}
+
+pub(crate) fn monad_exec_iter_block_id_prev(
+    c_event_iterator: &mut monad_event_iterator,
+    c_event_ring: &monad_event_ring,
+    block_id: &monad_c_bytes32,
+    c_exec_event_filter: monad_exec_event_type,
+) -> Option<monad_event_descriptor> {
+    let mut c_event_descriptor: monad_event_descriptor = unsafe { std::mem::zeroed() };
+
+    let success = unsafe {
+        self::bindings::monad_exec_iter_block_id_prev(
+            c_event_iterator,
+            c_event_ring,
+            block_id,
+            c_exec_event_filter,
+            &mut c_event_descriptor,
+        )
+    };
+
+    success.then_some(c_event_descriptor)
 }

--- a/rust/crates/monad-exec-events/src/lib.rs
+++ b/rust/crates/monad-exec-events/src/lib.rs
@@ -84,12 +84,13 @@
 
 use monad_event_ring::{EventRing, SnapshotEventRing};
 
-pub use self::{block::*, block_builder::*, events::*};
+pub use self::{block::*, block_builder::*, events::*, reader::*};
 
 mod block;
 mod block_builder;
 mod events;
 pub mod ffi;
+mod reader;
 
 /// A type alias for an event ring that produces monad execution events.
 pub type ExecEventRing = EventRing<ExecEventDecoder>;

--- a/rust/crates/monad-exec-events/src/reader.rs
+++ b/rust/crates/monad-exec-events/src/reader.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use monad_event_ring::{EventDescriptor, EventReader};
+
+use crate::{
+    ffi::{
+        monad_c_bytes32, monad_exec_iter_block_id_prev, monad_exec_iter_block_number_prev,
+        monad_exec_iter_consensus_prev, monad_exec_ring_block_id_matches,
+        monad_exec_ring_get_block_number, MONAD_EXEC_NONE,
+    },
+    ExecEventDecoder, ExecEventType,
+};
+
+/// Provides utilities for [`ExecEventDecoder`] [`EventDescriptor`]s.
+pub trait ExecEventDescriptorExt {
+    /// Produces the block number associated with the current [`EventDescriptor`].
+    fn get_block_number(&self) -> Option<u64>;
+
+    /// Checks whether the current [`EventDescriptor`] is associated with the provided `block_id`.
+    fn block_id_matches(&self, block_id: &monad_c_bytes32) -> bool;
+}
+
+impl<'ring> ExecEventDescriptorExt for EventDescriptor<'ring, ExecEventDecoder> {
+    fn get_block_number(&self) -> Option<u64> {
+        self.with_raw(monad_exec_ring_get_block_number)
+    }
+
+    fn block_id_matches(&self, block_id: &monad_c_bytes32) -> bool {
+        self.with_raw(|c_event_ring, c_event_descriptor| {
+            monad_exec_ring_block_id_matches(c_event_ring, c_event_descriptor, block_id)
+        })
+    }
+}
+
+/// Provides utilities for [`ExecEventDecoder`] [`EventReader`]s.
+pub trait ExecEventReaderExt<'ring> {
+    /// Rewinds the [`EventReader`] to the last consensus event specified by the `filter` argument,
+    /// producing an [`EventDescriptor`] to it.
+    ///
+    /// If this method succeeds, the next call to [`EventReader::next_descriptor`] produces the same
+    /// event descriptor. Otherwise, the reader remains unchanged.
+    fn consensus_prev(
+        &mut self,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>>;
+
+    /// Rewinds the [`EventReader`] to the last event in the provided `block_number` specified by
+    /// the `filter` argument.
+    ///
+    /// If this method succeeds, the next call to [`EventReader::next_descriptor`] produces the same
+    /// event descriptor. Otherwise, the reader remains unchanged.
+    fn block_number_prev(
+        &mut self,
+        block_number: u64,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>>;
+
+    /// Rewinds the [`EventReader`] to the last event in the provided `block_id` specified by the
+    /// `filter` argument.
+    ///
+    /// If this method succeeds, the next call to [`EventReader::next_descriptor`] produces the same
+    /// event descriptor. Otherwise, the reader remains unchanged.
+    fn block_id_prev(
+        &mut self,
+        block_id: &monad_c_bytes32,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>>;
+}
+
+impl<'ring> ExecEventReaderExt<'ring> for EventReader<'ring, ExecEventDecoder> {
+    fn consensus_prev(
+        &mut self,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>> {
+        self.with_raw(|_, c_event_iterator| {
+            monad_exec_iter_consensus_prev(
+                c_event_iterator,
+                filter.map_or(MONAD_EXEC_NONE, ExecEventType::as_c_event_type),
+            )
+        })
+    }
+
+    fn block_number_prev(
+        &mut self,
+        block_number: u64,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>> {
+        self.with_raw(|c_event_ring, c_event_iterator| {
+            monad_exec_iter_block_number_prev(
+                c_event_iterator,
+                c_event_ring,
+                block_number,
+                filter.map_or(MONAD_EXEC_NONE, ExecEventType::as_c_event_type),
+            )
+        })
+    }
+
+    fn block_id_prev(
+        &mut self,
+        block_id: &monad_c_bytes32,
+        filter: Option<ExecEventType>,
+    ) -> Option<EventDescriptor<'ring, ExecEventDecoder>> {
+        self.with_raw(|c_event_ring, c_event_iterator| {
+            monad_exec_iter_block_id_prev(
+                c_event_iterator,
+                c_event_ring,
+                block_id,
+                filter.map_or(MONAD_EXEC_NONE, ExecEventType::as_c_event_type),
+            )
+        })
+    }
+}

--- a/rust/crates/monad-exec-events/wrapper.h
+++ b/rust/crates/monad-exec-events/wrapper.h
@@ -16,3 +16,4 @@
 #include <category/execution/ethereum/core/base_ctypes.h>
 #include <category/execution/ethereum/core/eth_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_iter_help.h>


### PR DESCRIPTION
The iter helpers are a set of functions that enable more advanced navigation of execution events. This change adds support for them in Rust through a set of traits.