### PR TITLE
[mpt] Introduce compact_offset_pair to reduce fast/slow offset boiler…

### DIFF
--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -50,9 +50,8 @@ Node::SharedPtr create_node_add_new_branch(
             if (aux.is_on_disk()) {
                 child.offset =
                     async_write_node_set_spare(aux, *child.ptr, true);
-                std::tie(child.min_offset_fast, child.min_offset_slow) =
-                    calc_min_offsets(
-                        *child.ptr, aux.physical_to_virtual(child.offset));
+                child.min_offsets = calc_min_offsets(
+                    *child.ptr, aux.physical_to_virtual(child.offset));
             }
             ++j;
         }
@@ -62,8 +61,7 @@ Node::SharedPtr create_node_add_new_branch(
             child.ptr = node->move_next(old_j);
             child.subtrie_min_version = node->subtrie_min_version(old_j);
             if (aux.is_on_disk()) {
-                child.min_offset_fast = node->min_offset_fast(old_j);
-                child.min_offset_slow = node->min_offset_slow(old_j);
+                child.min_offsets = node->min_offsets(old_j);
                 child.offset = node->fnext(old_j);
                 MONAD_ASSERT(child.offset != INVALID_OFFSET);
             }
@@ -98,8 +96,7 @@ Node::SharedPtr create_node_with_two_children(
         child.branch = branch0;
         if (aux.is_on_disk()) {
             child.offset = async_write_node_set_spare(aux, *child.ptr, true);
-            std::tie(child.min_offset_fast, child.min_offset_slow) =
-                calc_min_offsets(*child.ptr);
+            child.min_offsets = calc_min_offsets(*child.ptr);
         }
     }
     {
@@ -109,8 +106,7 @@ Node::SharedPtr create_node_with_two_children(
         child.branch = branch1;
         if (aux.is_on_disk()) {
             child.offset = async_write_node_set_spare(aux, *child.ptr, true);
-            std::tie(child.min_offset_fast, child.min_offset_slow) =
-                calc_min_offsets(*child.ptr);
+            child.min_offsets = calc_min_offsets(*child.ptr);
         }
     }
     return make_node(
@@ -142,9 +138,8 @@ Node::SharedPtr copy_trie_impl(
         child.subtrie_min_version = calc_min_version(*child.ptr);
         if (aux.is_on_disk()) {
             child.offset = async_write_node_set_spare(aux, *child.ptr, true);
-            std::tie(child.min_offset_fast, child.min_offset_slow) =
-                calc_min_offsets(
-                    *child.ptr, aux.physical_to_virtual(child.offset));
+            child.min_offsets = calc_min_offsets(
+                *child.ptr, aux.physical_to_virtual(child.offset));
         }
         return make_node(
             static_cast<uint16_t>(1u << child.branch),
@@ -273,10 +268,7 @@ Node::SharedPtr copy_trie_impl(
             auto const &[p, i] = parents_and_indexes.top();
             auto &node = *p->next(i);
             p->set_fnext(i, async_write_node_set_spare(aux, node, true));
-            auto const [min_offset_fast, min_offset_slow] =
-                calc_min_offsets(node);
-            p->set_min_offset_fast(i, min_offset_fast);
-            p->set_min_offset_slow(i, min_offset_slow);
+            p->set_min_offsets(i, calc_min_offsets(node));
             p->set_subtrie_min_version(i, calc_min_version(node));
             parents_and_indexes.pop();
         }

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -173,6 +173,18 @@ void Node::set_min_offset_slow(
         sizeof(compact_virtual_chunk_offset_t));
 }
 
+compact_offset_pair Node::min_offsets(unsigned const index) const noexcept
+{
+    return {min_offset_fast(index), min_offset_slow(index)};
+}
+
+void Node::set_min_offsets(
+    unsigned const index, compact_offset_pair const offsets) noexcept
+{
+    set_min_offset_fast(index, offsets.fast);
+    set_min_offset_slow(index, offsets.slow);
+}
+
 unsigned char *Node::child_min_version_data() noexcept
 {
     return child_min_offset_slow_data() +
@@ -459,8 +471,7 @@ void ChildData::copy_old_child(Node *const old, unsigned const i)
     MONAD_DEBUG_ASSERT(i < 16);
     branch = static_cast<uint8_t>(i);
     offset = old->fnext(index);
-    min_offset_fast = old->min_offset_fast(index);
-    min_offset_slow = old->min_offset_slow(index);
+    min_offsets = old->min_offsets(index);
     subtrie_min_version = old->subtrie_min_version(index);
     cache_node = ptr != nullptr;
 
@@ -557,8 +568,7 @@ Node::SharedPtr make_node(
     for (unsigned index = 0; auto &child : children) {
         if (child.is_valid()) {
             node->set_fnext(index, child.offset);
-            node->set_min_offset_fast(index, child.min_offset_fast);
-            node->set_min_offset_slow(index, child.min_offset_slow);
+            node->set_min_offsets(index, child.min_offsets);
             node->set_subtrie_min_version(index, child.subtrie_min_version);
             node->set_next(index, std::move(child.ptr));
             node->set_child_data(index, {child.data, child.len});

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -254,6 +254,9 @@ public:
     min_offset_slow(unsigned index) const noexcept;
     void set_min_offset_slow(
         unsigned index, compact_virtual_chunk_offset_t) noexcept;
+    //! combined fast/slow min_offset pair
+    compact_offset_pair min_offsets(unsigned index) const noexcept;
+    void set_min_offsets(unsigned index, compact_offset_pair) noexcept;
 
     //! subtrie min version array
     unsigned char *child_min_version_data() noexcept;
@@ -334,10 +337,7 @@ struct ChildData
     chunk_offset_t offset{INVALID_OFFSET}; // physical offsets
     unsigned char data[32] = {0};
     int64_t subtrie_min_version{std::numeric_limits<int64_t>::max()};
-    compact_virtual_chunk_offset_t min_offset_fast{
-        INVALID_COMPACT_VIRTUAL_OFFSET};
-    compact_virtual_chunk_offset_t min_offset_slow{
-        INVALID_COMPACT_VIRTUAL_OFFSET};
+    compact_offset_pair min_offsets{};
 
     uint8_t branch{INVALID_BRANCH};
     uint8_t len{0};

--- a/category/mpt/test/min_truncated_offsets_test.cpp
+++ b/category/mpt/test/min_truncated_offsets_test.cpp
@@ -98,10 +98,9 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
     };
     ensure_total_bytes_written(0, eightMB, 0, eightMB);
 
-    auto [trie_min_offset_fast, trie_min_offset_slow] =
-        calc_min_offsets(*this->root);
-    EXPECT_EQ(trie_min_offset_fast, 0);
-    EXPECT_EQ(trie_min_offset_slow, 0);
+    auto const trie_min_offsets = calc_min_offsets(*this->root);
+    EXPECT_EQ(trie_min_offsets.fast, 0);
+    EXPECT_EQ(trie_min_offsets.slow, 0);
 
     struct TraverseCalculateAndVerifyMinTruncatedOffsets
         : public TraverseMachine
@@ -114,10 +113,7 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
             Node const *node{nullptr};
             // record the calculated min truncated inorder offsets of trie
             // rooted at node in traversal
-            compact_virtual_chunk_offset_t test_min_offset_fast{
-                INVALID_COMPACT_VIRTUAL_OFFSET};
-            compact_virtual_chunk_offset_t test_min_offset_slow{
-                INVALID_COMPACT_VIRTUAL_OFFSET};
+            compact_offset_pair test_min_offsets{};
         };
 
         std::stack<traverse_record_t> root_to_node_records;
@@ -144,18 +140,16 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                 parent->fnext(parent->to_child_index(branch_in_parent));
             auto const virtual_node_offset =
                 aux.physical_to_virtual(node_offset);
+            compact_offset_pair node_offsets;
             if (virtual_node_offset.in_fast_list()) {
-                root_to_node_records.push(
-                    {&node,
-                     compact_virtual_chunk_offset_t{virtual_node_offset},
-                     INVALID_COMPACT_VIRTUAL_OFFSET});
+                node_offsets.fast =
+                    compact_virtual_chunk_offset_t{virtual_node_offset};
             }
             else {
-                root_to_node_records.push(
-                    {&node,
-                     INVALID_COMPACT_VIRTUAL_OFFSET,
-                     compact_virtual_chunk_offset_t{virtual_node_offset}});
+                node_offsets.slow =
+                    compact_virtual_chunk_offset_t{virtual_node_offset};
             }
+            root_to_node_records.push({&node, node_offsets});
             return true;
         }
 
@@ -168,36 +162,27 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
             root_to_node_records.pop();
             if (root_to_node_records.empty()) { // node is root
                 // verify that offset equals calculated one in traversal
-                auto [node_branch_min_fast_off, node_branch_min_slow_off] =
-                    calc_min_offsets(
-                        *const_cast<Node *>(&node),
-                        aux.physical_to_virtual(aux.get_latest_root_offset()));
-                EXPECT_EQ(
-                    node_record.test_min_offset_fast, node_branch_min_fast_off);
-                EXPECT_EQ(
-                    node_record.test_min_offset_slow, node_branch_min_slow_off);
+                auto const expected_min_offsets = calc_min_offsets(
+                    *const_cast<Node *>(&node),
+                    aux.physical_to_virtual(aux.get_latest_root_offset()));
+                EXPECT_EQ(node_record.test_min_offsets, expected_min_offsets);
             }
             else {
                 auto &parent_record = root_to_node_records.top();
                 Node *const parent = const_cast<Node *>(parent_record.node);
-                auto const node_branch_min_fast_off = parent->min_offset_fast(
-                    parent->to_child_index(branch_in_parent));
-                auto const node_branch_min_slow_off = parent->min_offset_slow(
+                auto const stored_min_offsets = parent->min_offsets(
                     parent->to_child_index(branch_in_parent));
                 // verify that min offset stored in parent equals the calculated
                 // one during traversal
-                EXPECT_EQ(
-                    node_branch_min_fast_off, node_record.test_min_offset_fast);
-                EXPECT_EQ(
-                    node_branch_min_slow_off, node_record.test_min_offset_slow);
+                EXPECT_EQ(stored_min_offsets, node_record.test_min_offsets);
 
                 // update parent record.
-                parent_record.test_min_offset_fast = std::min(
-                    parent_record.test_min_offset_fast,
-                    node_record.test_min_offset_fast);
-                parent_record.test_min_offset_slow = std::min(
-                    parent_record.test_min_offset_slow,
-                    node_record.test_min_offset_slow);
+                parent_record.test_min_offsets.fast = std::min(
+                    parent_record.test_min_offsets.fast,
+                    node_record.test_min_offsets.fast);
+                parent_record.test_min_offsets.slow = std::min(
+                    parent_record.test_min_offsets.slow,
+                    node_record.test_min_offsets.slow);
             }
         }
 

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -505,14 +505,11 @@ Node::SharedPtr create_node_from_children_if_any(
                     aux.physical_to_virtual(child.offset);
                 MONAD_DEBUG_ASSERT(
                     child_virtual_offset != INVALID_VIRTUAL_OFFSET);
-                std::tie(child.min_offset_fast, child.min_offset_slow) =
+                child.min_offsets =
                     calc_min_offsets(*child.ptr, child_virtual_offset);
-                if (sm.compact()) {
-                    MONAD_DEBUG_ASSERT(
-                        child.min_offset_fast >= aux.compact_offset_fast);
-                    MONAD_DEBUG_ASSERT(
-                        child.min_offset_slow >= aux.compact_offset_slow);
-                }
+                MONAD_DEBUG_ASSERT(
+                    !(sm.compact() &&
+                      child.min_offsets.any_below(aux.compact_offsets)));
             }
             // apply cache based on state machine state, always cache node that
             // is a single child
@@ -945,10 +942,7 @@ void dispatch_updates_impl_(
                 }
                 else if (
                     sm.compact() &&
-                    (child.min_offset_fast < aux.compact_offset_fast ||
-                     child.min_offset_slow < aux.compact_offset_slow)) {
-                    bool const copy_node_for_fast =
-                        child.min_offset_fast < aux.compact_offset_fast;
+                    child.min_offsets.any_below(aux.compact_offsets)) {
                     auto compact_tnode = CompactTNode::make(
                         tnode.get(), index, std::move(child.ptr));
                     compact_(
@@ -956,7 +950,7 @@ void dispatch_updates_impl_(
                         sm,
                         std::move(compact_tnode),
                         child.offset,
-                        copy_node_for_fast);
+                        child.min_offsets.fast_below(aux.compact_offsets));
                 }
                 else {
                     --tnode->npending;
@@ -1048,15 +1042,12 @@ void mismatch_handler_(
                         tnode.get(), branch, index, std::move(child.ptr));
                     expire_(aux, sm, std::move(expire_tnode), INVALID_OFFSET);
                 }
-                else if (auto const [min_offset_fast, min_offset_slow] =
+                else if (auto const child_min_offsets =
                              calc_min_offsets(*child.ptr);
                          // same as old, TODO: can optimize by passing in the
                          // min offsets stored in old's parent
                          sm.compact() &&
-                         (min_offset_fast < aux.compact_offset_fast ||
-                          min_offset_slow < aux.compact_offset_slow)) {
-                    bool const copy_node_for_fast =
-                        min_offset_fast < aux.compact_offset_fast;
+                         child_min_offsets.any_below(aux.compact_offsets)) {
                     auto compact_tnode = CompactTNode::make(
                         tnode.get(), index, std::move(child.ptr));
                     compact_(
@@ -1064,7 +1055,7 @@ void mismatch_handler_(
                         sm,
                         std::move(compact_tnode),
                         INVALID_OFFSET,
-                        copy_node_for_fast);
+                        child_min_offsets.fast_below(aux.compact_offsets));
                 }
                 else {
                     --tnode->npending;
@@ -1144,9 +1135,8 @@ void expire_(
                 tnode.get(), branch, index, node.move_next(index));
             expire_(aux, sm, std::move(child_tnode), node.fnext(index));
         }
-        else if (
-            node.min_offset_fast(index) < aux.compact_offset_fast ||
-            node.min_offset_slow(index) < aux.compact_offset_slow) {
+        else if (auto const child_min_offsets = node.min_offsets(index);
+                 child_min_offsets.any_below(aux.compact_offsets)) {
             auto child_tnode =
                 CompactTNode::make(tnode.get(), index, node.move_next(index));
             compact_(
@@ -1154,7 +1144,7 @@ void expire_(
                 sm,
                 std::move(child_tnode),
                 node.fnext(index),
-                node.min_offset_fast(index) < aux.compact_offset_fast);
+                child_min_offsets.fast_below(aux.compact_offsets));
         }
         else {
             --tnode->npending;
@@ -1181,11 +1171,11 @@ void fillin_parent_after_expiration(
         auto const new_node_virtual_offset =
             aux.physical_to_virtual(new_offset);
         MONAD_DEBUG_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
-        auto const &[min_offset_fast, min_offset_slow] =
+        auto const min_offsets =
             calc_min_offsets(*new_node, new_node_virtual_offset);
         MONAD_DEBUG_ASSERT(
-            min_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET ||
-            min_offset_slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+            min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET ||
+            min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
         auto const min_version = calc_min_version(*new_node);
         MONAD_ASSERT(min_version >= aux.curr_upsert_auto_expire_version);
         if (parent->type == tnode_type::update) {
@@ -1194,8 +1184,7 @@ void fillin_parent_after_expiration(
             child.offset = new_offset;
             MONAD_DEBUG_ASSERT(cache_node);
             child.ptr = std::move(new_node);
-            child.min_offset_fast = min_offset_fast;
-            child.min_offset_slow = min_offset_slow;
+            child.min_offsets = min_offsets;
             child.subtrie_min_version = min_version;
         }
         else {
@@ -1206,8 +1195,7 @@ void fillin_parent_after_expiration(
             }
             expire_parent->node->set_next(index, std::move(new_node));
             expire_parent->node->set_subtrie_min_version(index, min_version);
-            expire_parent->node->set_min_offset_fast(index, min_offset_fast);
-            expire_parent->node->set_min_offset_slow(index, min_offset_slow);
+            expire_parent->node->set_min_offsets(index, min_offsets);
             expire_parent->node->set_fnext(index, new_offset);
         }
     }
@@ -1297,10 +1285,10 @@ void compact_(
         }
         compact_virtual_chunk_offset_t const compacted_virtual_offset{
             virtual_node_offset};
-        return (virtual_node_offset.in_fast_list() &&
-                compacted_virtual_offset >= aux.compact_offset_fast) ||
-               (!virtual_node_offset.in_fast_list() &&
-                compacted_virtual_offset >= aux.compact_offset_slow);
+        auto const threshold = virtual_node_offset.in_fast_list()
+                                   ? aux.compact_offsets.fast
+                                   : aux.compact_offsets.slow;
+        return compacted_virtual_offset >= threshold;
     }();
 
     Node &node = *tnode->node;
@@ -1312,8 +1300,8 @@ void compact_(
         node.get_disk_size());
 
     for (unsigned j = 0; j < node.number_of_children(); ++j) {
-        if (node.min_offset_fast(j) < aux.compact_offset_fast ||
-            node.min_offset_slow(j) < aux.compact_offset_slow) {
+        if (auto const child_min_offsets = node.min_offsets(j);
+            child_min_offsets.any_below(aux.compact_offsets)) {
             auto child_tnode =
                 CompactTNode::make(tnode.get(), j, node.move_next(j));
             compact_(
@@ -1321,7 +1309,7 @@ void compact_(
                 sm,
                 std::move(child_tnode),
                 node.fnext(j),
-                node.min_offset_fast(j) < aux.compact_offset_fast);
+                child_min_offsets.fast_below(aux.compact_offsets));
         }
         else {
             --tnode->npending;
@@ -1339,10 +1327,9 @@ void try_fillin_parent_with_rewritten_node(
         tnode.release();
         return;
     }
-    auto [min_offset_fast, min_offset_slow] =
-        calc_min_offsets(*tnode->node, INVALID_VIRTUAL_OFFSET);
+    auto min_offsets = calc_min_offsets(*tnode->node, INVALID_VIRTUAL_OFFSET);
     // If subtrie contains nodes from fast list, write itself to fast list too
-    if (min_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET) {
+    if (min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET) {
         tnode->rewrite_to_fast = true; // override that
     }
     auto const new_offset =
@@ -1353,15 +1340,14 @@ void try_fillin_parent_with_rewritten_node(
         new_node_virtual_offset};
     // update min offsets in subtrie
     if (tnode->rewrite_to_fast) {
-        min_offset_fast =
-            std::min(min_offset_fast, truncated_new_virtual_offset);
+        min_offsets.fast =
+            std::min(min_offsets.fast, truncated_new_virtual_offset);
     }
     else {
-        min_offset_slow =
-            std::min(min_offset_slow, truncated_new_virtual_offset);
+        min_offsets.slow =
+            std::min(min_offsets.slow, truncated_new_virtual_offset);
     }
-    MONAD_DEBUG_ASSERT(min_offset_fast >= aux.compact_offset_fast);
-    MONAD_DEBUG_ASSERT(min_offset_slow >= aux.compact_offset_slow);
+    MONAD_DEBUG_ASSERT(!min_offsets.any_below(aux.compact_offsets));
     TNodeBase *parent = tnode->parent();
     auto const index = tnode->index;
     if (parent->type == tnode_type::update) {
@@ -1370,15 +1356,13 @@ void try_fillin_parent_with_rewritten_node(
         auto &child = p->children[index];
         child.ptr = std::move(tnode->node);
         child.offset = new_offset;
-        child.min_offset_fast = min_offset_fast;
-        child.min_offset_slow = min_offset_slow;
+        child.min_offsets = min_offsets;
     }
     else if (parent->type == tnode_type::compact) {
         auto *const p = static_cast<CompactTNode *>(parent);
         MONAD_ASSERT(p->node);
         p->node->set_fnext(index, new_offset);
-        p->node->set_min_offset_fast(index, min_offset_fast);
-        p->node->set_min_offset_slow(index, min_offset_slow);
+        p->node->set_min_offsets(index, min_offsets);
         if (tnode->cache_node) {
             p->node->set_next(index, std::move(tnode->node));
         }
@@ -1388,8 +1372,7 @@ void try_fillin_parent_with_rewritten_node(
         auto *const p = static_cast<ExpireTNode *>(parent);
         MONAD_ASSERT(p->node);
         p->node->set_fnext(index, new_offset);
-        p->node->set_min_offset_fast(index, min_offset_fast);
-        p->node->set_min_offset_slow(index, min_offset_slow);
+        p->node->set_min_offsets(index, min_offsets);
         // Delay tnode->node deallocation to parent ExpireTNode
         p->node->set_next(index, std::move(tnode->node));
         if (tnode->cache_node) {

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -243,10 +243,8 @@ public:
     static constexpr unsigned cnv_chunks_for_db_metadata = 1;
 
     int64_t curr_upsert_auto_expire_version{0};
-    compact_virtual_chunk_offset_t compact_offset_fast{
-        MIN_COMPACT_VIRTUAL_OFFSET};
-    compact_virtual_chunk_offset_t compact_offset_slow{
-        MIN_COMPACT_VIRTUAL_OFFSET};
+    compact_offset_pair compact_offsets{
+        MIN_COMPACT_VIRTUAL_OFFSET, MIN_COMPACT_VIRTUAL_OFFSET};
 
     // On disk stuff
     MONAD_ASYNC_NAMESPACE::AsyncIO *io{nullptr};
@@ -751,22 +749,20 @@ inline constexpr unsigned num_pages(file_offset_t const offset, unsigned bytes)
     return (bytes + DISK_PAGE_SIZE - 1) >> DISK_PAGE_BITS;
 }
 
-inline std::pair<compact_virtual_chunk_offset_t, compact_virtual_chunk_offset_t>
-calc_min_offsets(
+inline compact_offset_pair calc_min_offsets(
     Node &node,
     virtual_chunk_offset_t node_virtual_offset = INVALID_VIRTUAL_OFFSET)
 {
-    auto fast_ret = INVALID_COMPACT_VIRTUAL_OFFSET;
-    auto slow_ret = INVALID_COMPACT_VIRTUAL_OFFSET;
+    compact_offset_pair ret;
     if (node_virtual_offset != INVALID_VIRTUAL_OFFSET) {
-        auto &ret = node_virtual_offset.in_fast_list() ? fast_ret : slow_ret;
-        ret = compact_virtual_chunk_offset_t{node_virtual_offset};
+        auto &r = node_virtual_offset.in_fast_list() ? ret.fast : ret.slow;
+        r = compact_virtual_chunk_offset_t{node_virtual_offset};
     }
     for (unsigned i = 0; i < node.number_of_children(); ++i) {
-        fast_ret = std::min(fast_ret, node.min_offset_fast(i));
-        slow_ret = std::min(slow_ret, node.min_offset_slow(i));
+        ret.fast = std::min(ret.fast, node.min_offset_fast(i));
+        ret.slow = std::min(ret.slow, node.min_offset_slow(i));
     }
-    return {fast_ret, slow_ret};
+    return ret;
 }
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -68,18 +68,15 @@ namespace
         return result_floor + static_cast<uint32_t>(r <= fractional);
     }
 
-    std::pair<compact_virtual_chunk_offset_t, compact_virtual_chunk_offset_t>
+    compact_offset_pair
     deserialize_compaction_offsets(byte_string_view const bytes)
     {
         MONAD_ASSERT(bytes.size() == 2 * sizeof(uint32_t));
-        compact_virtual_chunk_offset_t fast_offset{
-            INVALID_COMPACT_VIRTUAL_OFFSET};
-        compact_virtual_chunk_offset_t slow_offset{
-            INVALID_COMPACT_VIRTUAL_OFFSET};
-        fast_offset.set_value(unaligned_load<uint32_t>(bytes.data()));
-        slow_offset.set_value(
+        compact_offset_pair offsets;
+        offsets.fast.set_value(unaligned_load<uint32_t>(bytes.data()));
+        offsets.slow.set_value(
             unaligned_load<uint32_t>(bytes.data() + sizeof(uint32_t)));
-        return {fast_offset, slow_offset};
+        return offsets;
     }
 }
 
@@ -1121,8 +1118,7 @@ Node::SharedPtr UpdateAuxImpl::do_update(
 
     if (prev_root) {
         // previous compaction offset
-        std::tie(compact_offset_fast, compact_offset_slow) =
-            deserialize_compaction_offsets(prev_root->value());
+        compact_offsets = deserialize_compaction_offsets(prev_root->value());
     }
     if (compaction) {
         if (enable_dynamic_history_length_) {
@@ -1138,9 +1134,7 @@ Node::SharedPtr UpdateAuxImpl::do_update(
 
     curr_upsert_auto_expire_version = calc_auto_expire_version(version);
     UpdateList root_updates;
-    byte_string const compact_offsets_bytes =
-        serialize((uint32_t)compact_offset_fast) +
-        serialize((uint32_t)compact_offset_slow);
+    byte_string const compact_offsets_bytes = compact_offsets.serialize();
     auto root_update = make_update(
         {}, compact_offsets_bytes, false, std::move(updates), version);
     root_updates.push_front(root_update);
@@ -1181,8 +1175,8 @@ Node::SharedPtr UpdateAuxImpl::do_update(
         curr_fast_writer_offset.offset,
         curr_slow_writer_offset.count,
         curr_slow_writer_offset.offset,
-        (uint32_t)compact_offset_fast,
-        (uint32_t)compact_offset_slow);
+        (uint32_t)compact_offsets.fast,
+        (uint32_t)compact_offsets.slow);
     return root;
 }
 
@@ -1196,19 +1190,19 @@ void UpdateAuxImpl::release_unreferenced_chunks()
         *this,
         get_root_offset_at_version(min_valid_version),
         min_valid_version);
-    auto const [min_offset_fast, min_offset_slow] =
+    auto const min_offsets =
         deserialize_compaction_offsets(min_valid_root->value());
     MONAD_ASSERT(
-        min_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
-        min_offset_slow != INVALID_COMPACT_VIRTUAL_OFFSET);
-    chunks_to_remove_before_count_fast_ = min_offset_fast.get_count();
-    chunks_to_remove_before_count_slow_ = min_offset_slow.get_count();
+        min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
+        min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+    chunks_to_remove_before_count_fast_ = min_offsets.fast.get_count();
+    chunks_to_remove_before_count_slow_ = min_offsets.slow.get_count();
     LOG_INFO_CFORMAT(
         "Min valid version %lu compaction offset fast=%u, slow=%u. Remove "
         "chunks before count fast=%u, slow=%u",
         min_valid_version,
-        (uint32_t)min_offset_fast,
-        (uint32_t)min_offset_slow,
+        (uint32_t)min_offsets.fast,
+        (uint32_t)min_offsets.slow,
         chunks_to_remove_before_count_fast_,
         chunks_to_remove_before_count_slow_);
     MONAD_ASSERT(
@@ -1239,21 +1233,21 @@ double UpdateAuxImpl::calculate_disk_usage_if_erased_up_to_and_including(
         *this,
         get_root_offset_at_version(min_version_post_erase),
         min_version_post_erase);
-    auto const [min_offset_fast, min_offset_slow] =
+    auto const min_offsets =
         deserialize_compaction_offsets(min_valid_root_post_erase->value());
     MONAD_ASSERT(
-        min_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
-        min_offset_slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+        min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
+        min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
     auto const fast_list_max_count =
         db_metadata()->fast_list_end()->insertion_count();
     auto const slow_list_max_count =
         db_metadata()->slow_list_end()->insertion_count();
-    MONAD_ASSERT(fast_list_max_count >= min_offset_fast.get_count());
-    MONAD_ASSERT(slow_list_max_count >= min_offset_slow.get_count());
+    MONAD_ASSERT(fast_list_max_count >= min_offsets.fast.get_count());
+    MONAD_ASSERT(slow_list_max_count >= min_offsets.slow.get_count());
     auto const num_fast_chunks =
-        fast_list_max_count - min_offset_fast.get_count() + 1;
+        fast_list_max_count - min_offsets.fast.get_count() + 1;
     auto const num_slow_chunks =
-        slow_list_max_count - min_offset_slow.get_count() + 1;
+        slow_list_max_count - min_offsets.slow.get_count() + 1;
     return (num_fast_chunks + num_slow_chunks) / (double)io->chunk_count();
 }
 
@@ -1413,13 +1407,13 @@ void UpdateAuxImpl::advance_compact_offsets()
          num_chunks(chunk_list::fast) <
              fast_chunk_count_limit_start_compaction) ||
         max_version == INVALID_BLOCK_NUM ||
-        compact_offset_fast >= last_block_end_offset_fast_) {
+        compact_offsets.fast >= last_block_end_offset_fast_) {
         return;
     }
 
     MONAD_ASSERT(
-        compact_offset_fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
-        compact_offset_slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+        compact_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
+        compact_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
     /* The fast list compaction offset range is determined both by the
     average disk growth over historical blocks, and the fast list offset
     range of the latest version, so that fast-list usage adapts appropriately to
@@ -1449,7 +1443,7 @@ void UpdateAuxImpl::advance_compact_offsets()
     // worth of growth, to prevent over-compaction when the history window
     // shrinks.
     uint32_t const latest_block_fast_uncompacted_range =
-        curr_fast_writer_offset - compact_offset_fast;
+        curr_fast_writer_offset - compact_offsets.fast;
     if (latest_block_fast_uncompacted_range >
         static_cast<uint64_t>(avg_disk_growth_fast) *
             min_versions_of_growth_before_compact_fast_list) {
@@ -1463,7 +1457,7 @@ void UpdateAuxImpl::advance_compact_offsets()
         to_advance =
             std::min(to_advance, max_compact_offset_range); // Cap at 32MB
         compact_offset_range_fast_.set_value(to_advance);
-        compact_offset_fast += compact_offset_range_fast_;
+        compact_offsets.fast += compact_offset_range_fast_;
     }
     constexpr double usage_limit_start_compact_slow = 0.6;
     constexpr double slow_usage_limit_start_compact_slow = 0.2;
@@ -1492,7 +1486,7 @@ void UpdateAuxImpl::advance_compact_offsets()
             // No valid data, use minimum progress
             compact_offset_range_slow_.set_value(1);
         }
-        compact_offset_slow += compact_offset_range_slow_;
+        compact_offsets.slow += compact_offset_range_slow_;
     }
     else {
         compact_offset_range_slow_ = MIN_COMPACT_VIRTUAL_OFFSET;
@@ -1687,7 +1681,7 @@ void UpdateAuxImpl::print_update_stats(uint64_t const version)
                 ? (100.0 * stats.nodes_copied_fast_to_fast_for_fast /
                    nodes_copied_for_slow)
                 : 0);
-        if (compact_offset_slow) {
+        if (compact_offsets.slow) {
             auto const nodes_copied_for_slow =
                 stats.compacted_nodes_in_slow +
                 stats.nodes_copied_fast_to_fast_for_slow +
@@ -1784,8 +1778,8 @@ void UpdateAuxImpl::collect_compaction_read_stats(
 #if MONAD_MPT_COLLECT_STATS
     auto const node_offset = physical_to_virtual(physical_node_offset);
     if (compact_virtual_chunk_offset_t(node_offset) <
-        (node_offset.in_fast_list() ? compact_offset_fast
-                                    : compact_offset_slow)) {
+        (node_offset.in_fast_list() ? compact_offsets.fast
+                                    : compact_offsets.slow)) {
         // node orig offset in fast list but compact to slow list
         ++stats.nreads_before_compact_offset[!node_offset.in_fast_list()];
         stats.bytes_read_before_compact_offset[!node_offset.in_fast_list()] +=
@@ -1845,7 +1839,7 @@ void UpdateAuxImpl::collect_compacted_nodes_stats(
             MONAD_ASSERT(!node_offset.in_fast_list());
             MONAD_ASSERT(
                 compact_virtual_chunk_offset_t{node_offset} <
-                compact_offset_slow);
+                compact_offsets.slow);
             ++stats.compacted_nodes_in_slow;
             stats.compacted_bytes_in_slow += node_disk_size;
         }
@@ -1854,7 +1848,7 @@ void UpdateAuxImpl::collect_compacted_nodes_stats(
     if (!copy_node_for_fast && !rewrite_to_fast) {
         MONAD_ASSERT(!node_offset.in_fast_list());
         MONAD_ASSERT(
-            compact_virtual_chunk_offset_t{node_offset} < compact_offset_slow);
+            compact_virtual_chunk_offset_t{node_offset} < compact_offsets.slow);
         stats.compacted_bytes_in_slow += node_disk_size;
     }
     (void)copy_node_for_fast;

--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -233,6 +233,33 @@ static constexpr compact_virtual_chunk_offset_t INVALID_COMPACT_VIRTUAL_OFFSET =
 static constexpr compact_virtual_chunk_offset_t MIN_COMPACT_VIRTUAL_OFFSET =
     compact_virtual_chunk_offset_t::min_value();
 
+//! A pair of compact virtual chunk offsets for fast and slow lists.
+struct compact_offset_pair
+{
+    compact_virtual_chunk_offset_t fast{INVALID_COMPACT_VIRTUAL_OFFSET};
+    compact_virtual_chunk_offset_t slow{INVALID_COMPACT_VIRTUAL_OFFSET};
+
+    // Returns true if either component is below the corresponding threshold
+    constexpr bool any_below(compact_offset_pair threshold) const noexcept
+    {
+        return fast < threshold.fast || slow < threshold.slow;
+    }
+
+    // Returns true if the fast component is below the threshold
+    constexpr bool fast_below(compact_offset_pair threshold) const noexcept
+    {
+        return fast < threshold.fast;
+    }
+
+    byte_string serialize() const;
+
+    constexpr bool
+    operator==(compact_offset_pair const &) const noexcept = default;
+};
+
+static_assert(sizeof(compact_offset_pair) == 8);
+static_assert(alignof(compact_offset_pair) == 4);
+
 inline constexpr unsigned
 bitmask_index(uint16_t const mask, unsigned const i) noexcept
 {
@@ -293,6 +320,12 @@ inline byte_string serialize(V n)
     static_assert(std::endian::native == std::endian::little);
     auto arr = std::bit_cast<std::array<unsigned char, sizeof(V)>>(n);
     return byte_string{arr.data(), arr.size()};
+}
+
+inline byte_string compact_offset_pair::serialize() const
+{
+    return ::monad::mpt::serialize((uint32_t)fast) +
+           ::monad::mpt::serialize((uint32_t)slow);
 }
 
 MONAD_MPT_NAMESPACE_END


### PR DESCRIPTION
…plate

Paired fast/slow compact offsets are used throughout trie compaction and expiration code. Introduce a compact_offset_pair struct with any_below() and fast_below() helpers to replace repeated two-line comparisons, paired assertions, and paired assignments with single expressions.