### PR TITLE
Remove rust toolchain config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,8 +68,8 @@ ENV TRIEDB_TARGET="triedb_driver"
 
 RUN cd src/rust && cargo update --workspace --locked
 RUN cd src/rust && cargo +nightly-2025-12-09 fmt --all --check
-RUN cd src/rust && CC=${CC:?} CXX=${CXX:?} CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" cargo build --release --all-targets --all-features
-RUN cd src/rust && CC=${CC:?} CXX=${CXX:?} CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" cargo test  --release --all-targets --all-features
+RUN cd src/rust && CC=${CC:?} CXX=${CXX:?} CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" RUSTFLAGS="-C linker=${CC:?}" cargo build --release --all-targets --all-features
+RUN cd src/rust && CC=${CC:?} CXX=${CXX:?} CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" RUSTFLAGS="-C linker=${CC:?}" cargo test  --release --all-targets --all-features
 
 FROM base AS code_quality
 

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "gcc-15"
-


### PR DESCRIPTION
Previously, the linker was hard coded as `gcc-15` in the toolchain file. This removes that requirement and updates the docker build to use whatever `CC` was passed in as the linker executable.