### PR TITLE
[event][rust] open snapshot files via the C API

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -479,8 +479,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1156,16 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,7 +1298,6 @@ dependencies = [
  "criterion",
  "itertools 0.10.5",
  "libc",
- "zstd",
 ]
 
 [[package]]
@@ -1459,12 +1446,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -2329,31 +2310,3 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,4 +36,3 @@ serde            = { version = "1.0",     default-features = false }
 serde_json       = { version = "1.0",     default-features = false }
 strum            = { version = "0.27",    default-features = false, features = ["derive"] }
 tracing          = { version = "0.1",     default-features = false }
-zstd             = { version = "0.13",    default-features = false }

--- a/rust/crates/monad-event-ring/Cargo.toml
+++ b/rust/crates/monad-event-ring/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 libc = { workspace = true }
-zstd = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/rust/crates/monad-event-ring/benches/snapshot_raw.rs
+++ b/rust/crates/monad-event-ring/benches/snapshot_raw.rs
@@ -27,9 +27,12 @@ fn bench_snapshot(c: &mut Criterion) {
 
     let mut g = c.benchmark_group("snapshot_raw");
 
-    let snapshot =
-        SnapshotEventRing::<BytesDecoder>::new_from_zstd_bytes(SNAPSHOT_ZSTD_BYTES, SNAPSHOT_NAME)
-            .unwrap();
+    let snapshot = SnapshotEventRing::<BytesDecoder>::new_from_zstd_bytes(
+        SNAPSHOT_NAME,
+        SNAPSHOT_ZSTD_BYTES,
+        None,
+    )
+    .unwrap();
 
     let items = {
         let mut event_reader = snapshot.create_reader();

--- a/rust/crates/monad-event-ring/build.rs
+++ b/rust/crates/monad-event-ring/build.rs
@@ -42,7 +42,11 @@ fn main() {
         client_dst.display()
     );
     println!("cargo:rustc-link-lib=static=monad_event");
+    println!("cargo:rustc-link-lib=zstd");
+    #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-lib=hugetlbfs");
+    #[cfg(not(target_os = "linux"))]
+    println!("cargo:rustc-link-lib=monad_event_os_compat");
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 

--- a/rust/crates/monad-event-ring/src/ffi.rs
+++ b/rust/crates/monad-event-ring/src/ffi.rs
@@ -18,7 +18,8 @@
 
 use std::{
     ffi::{CStr, CString},
-    path::Path,
+    os::fd::{AsRawFd, FromRawFd},
+    path::{Path, PathBuf},
 };
 
 pub(crate) use self::bindings::{
@@ -173,4 +174,113 @@ pub(crate) fn monad_check_path_supports_map_hugetlb(
     };
 
     get_last_ring_library_error(r).map(|()| supported)
+}
+
+pub(crate) fn monad_event_resolve_ring_file(
+    default_path: Option<impl AsRef<Path>>,
+    input: impl AsRef<Path>,
+) -> Result<PathBuf, String> {
+    let opt_default_path_cstring = match default_path {
+        Some(ref_path) => {
+            let p = ref_path.as_ref().to_str().ok_or(format!(
+                "cannot extract path bytes from `{:?}`",
+                ref_path.as_ref()
+            ))?;
+            let p_cstr = CString::new(p).map_err(|e| e.to_string())?;
+            Some(p_cstr)
+        }
+        None => None,
+    };
+    let input_bytes = input.as_ref().to_str().ok_or(format!(
+        "cannot extract path bytes from `{:?}`",
+        input.as_ref()
+    ))?;
+    let c_input = CString::new(input_bytes).map_err(|e| e.to_string())?;
+
+    let mut pathbuf = vec![0u8; libc::PATH_MAX as usize];
+    let r = unsafe {
+        self::bindings::monad_event_resolve_ring_file(
+            opt_default_path_cstring.map_or(std::ptr::null(), |c| c.as_ptr()),
+            c_input.as_ptr(),
+            pathbuf.as_mut_ptr() as *mut libc::c_char,
+            pathbuf.len(),
+        )
+    };
+    get_last_ring_library_error(r)?;
+    let pathbuf_cstr = match CStr::from_bytes_until_nul(pathbuf.as_slice()) {
+        Ok(cstr) => cstr,
+        Err(err) => return Err(err.to_string()),
+    };
+    let pathbuf_str = pathbuf_cstr
+        .to_str()
+        .map_err(|utf_err| utf_err.to_string())?;
+    Ok(PathBuf::from(pathbuf_str))
+}
+
+pub(crate) fn monad_event_is_snapshot_file(
+    file: &std::fs::File,
+    error_name: impl AsRef<str>,
+) -> Result<bool, String> {
+    let mut is_snapshot = false;
+    let error_name_cstring =
+        CString::new(error_name.as_ref()).map_err(|nul_err| nul_err.to_string())?;
+    let r = unsafe {
+        self::bindings::monad_event_is_snapshot_file(
+            file.as_raw_fd(),
+            error_name_cstring.as_ptr(),
+            &mut is_snapshot,
+        )
+    };
+    get_last_ring_library_error(r)?;
+    Ok(is_snapshot)
+}
+
+pub(crate) fn monad_event_decompress_snapshot_fd(
+    file: &std::fs::File,
+    max_size: Option<usize>,
+    error_name: impl AsRef<str>,
+) -> Result<Option<std::fs::File>, String> {
+    let error_name_cstring =
+        CString::new(error_name.as_ref()).map_err(|nul_err| nul_err.to_string())?;
+    let mut fd_out: libc::c_int = -1;
+    let r = unsafe {
+        self::bindings::monad_event_decompress_snapshot_fd(
+            file.as_raw_fd(),
+            max_size.unwrap_or(0),
+            error_name_cstring.as_ptr(),
+            &mut fd_out,
+        )
+    };
+    get_last_ring_library_error(r)?;
+    if fd_out == -1 {
+        Ok(None)
+    } else {
+        Ok(Some(unsafe { std::fs::File::from_raw_fd(fd_out) }))
+    }
+}
+
+pub(crate) fn monad_event_decompress_snapshot_mem(
+    bytes: &[u8],
+    max_size: Option<usize>,
+    error_name: impl AsRef<str>,
+) -> Result<Option<std::fs::File>, String> {
+    let error_name_cstring =
+        CString::new(error_name.as_ref()).map_err(|nul_err| nul_err.to_string())?;
+    let mut fd: libc::c_int = -1;
+    let r = unsafe {
+        self::bindings::monad_event_decompress_snapshot_mem(
+            bytes.as_ptr() as *const ::std::os::raw::c_void,
+            bytes.len(),
+            max_size.unwrap_or(0),
+            error_name_cstring.as_ptr(),
+            &mut fd,
+        )
+    };
+    get_last_ring_library_error(r)?;
+    if fd == -1 {
+        Ok(None)
+    } else {
+        let file = unsafe { std::fs::File::from_raw_fd(fd) };
+        Ok(Some(file))
+    }
 }

--- a/rust/crates/monad-event-ring/src/ring/snapshot.rs
+++ b/rust/crates/monad-event-ring/src/ring/snapshot.rs
@@ -13,10 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::ffi::CString;
+use std::path::Path;
 
 use super::{raw::RawEventRing, DecodedEventRing, EventRing, RawEventReader};
-use crate::{EventDecoder, EventReader};
+use crate::{ffi, EventDecoder, EventReader};
 
 /// A special kind of event ring mapped to a static file for replaying events.
 ///
@@ -35,44 +35,85 @@ impl<D> SnapshotEventRing<D>
 where
     D: EventDecoder,
 {
-    /// Produces an event ring by [`zstd`] decoding the provided `zstd_bytes` input.
+    /// Produces an event ring by decoding the provided `bytes` input, which is expected to contain
+    /// a snapshot file (a single zstd-compressed frame containing an event ring).
     ///
     /// Internally, this function writes the decoded bytes to an anonymous file which is destroyed
     /// when the [`SnapshotEventRing`] is dropped.
-    pub fn new_from_zstd_bytes(zstd_bytes: &[u8], name: impl AsRef<str>) -> Result<Self, String> {
-        let error_name_cstr = CString::new(name.as_ref()).unwrap();
+    pub fn new_from_zstd_bytes(
+        name: impl AsRef<str>,
+        zstd_bytes: &[u8],
+        max_size: Option<usize>,
+    ) -> Result<Self, String> {
+        let name = name.as_ref();
+        if let Some(decompressed_file) =
+            ffi::monad_event_decompress_snapshot_mem(zstd_bytes, max_size, name)?
+        {
+            Self::new_from_decompressed_file(decompressed_file, name)
+        } else {
+            Err(format!("{name} is not an event ring snapshot"))
+        }
+    }
 
-        let snapshot_fd: libc::c_int =
-            unsafe { libc::memfd_create(error_name_cstr.as_ptr(), libc::MFD_CLOEXEC) };
-        assert_ne!(snapshot_fd, -1);
+    /// Produces an event ring by decoding the file at the provided input path, which is expected to
+    /// be a snapshot file (a single zstd-compressed frame containing an event ring).
+    ///
+    /// Internally, this function writes the decoded bytes to an anonymous file which is destroyed
+    /// when the [`SnapshotEventRing`] is dropped.
+    pub fn new_from_zstd_path(
+        path: impl AsRef<Path>,
+        max_size: Option<usize>,
+    ) -> Result<Self, String> {
+        let file = Self::resolve_path_to_file(&path)?;
+        let error_name = path.as_ref().display().to_string();
+        if let Some(decompressed_file) =
+            ffi::monad_event_decompress_snapshot_fd(&file, max_size, &error_name)?
+        {
+            Self::new_from_decompressed_file(decompressed_file, &error_name)
+        } else {
+            Err(format!("{error_name} is not an event ring snapshot"))
+        }
+    }
 
-        let snapshot_off: libc::off_t = 0;
+    /// Returns true if the given file is likely to be an event ring snapshot file.
+    pub fn is_snapshot_file(path: impl AsRef<Path>) -> Result<bool, String> {
+        let file = Self::resolve_path_to_file(&path)?;
+        ffi::monad_event_is_snapshot_file(&file, path.as_ref().display().to_string())
+    }
 
-        let mut decompressed = Vec::new();
-
-        zstd::stream::copy_decode(zstd_bytes, &mut decompressed)
-            .expect(format!("could not decompress `{}`", name.as_ref()).as_str());
-
-        let n_write = unsafe {
-            libc::write(
-                snapshot_fd,
-                decompressed.as_ptr() as *const libc::c_void,
-                decompressed.len() as libc::size_t,
+    /// Ensure that snapshot event ring paths are translated using the same mechanism as
+    /// [`EventRing::new_from_path`]; this may seem odd at first, as snapshot files should not live
+    /// on a hugetlbfs mount. Treating the path translation exactly the same for both types makes it
+    /// easier to open an either kind of event ring file behind a common interface, without
+    /// encountering subtle bugs.
+    fn resolve_path_to_file(path: impl AsRef<Path>) -> Result<std::fs::File, String> {
+        let resolved_path = ffi::monad_event_resolve_ring_file(None::<&str>, path.as_ref())?;
+        let file = std::fs::File::open(&resolved_path).map_err(|err| {
+            format!(
+                "could not open event ring file `{}`: {}",
+                resolved_path.display(),
+                err
             )
-        };
-        assert_eq!(n_write as usize, decompressed.len());
+        })?;
+        Ok(file)
+    }
 
+    fn new_from_decompressed_file(
+        file: std::fs::File,
+        name: impl AsRef<str>,
+    ) -> Result<Self, String> {
+        use std::os::fd::{AsRawFd, IntoRawFd};
+        let snapshot_off: libc::off_t = 0;
         let raw = RawEventRing::mmap_from_fd(
             libc::PROT_READ,
             0,
-            snapshot_fd,
+            file.as_raw_fd(),
             snapshot_off,
             name.as_ref(),
         )?;
-
         Ok(Self {
             ring: EventRing::new(raw)?,
-            snapshot_fd,
+            snapshot_fd: file.into_raw_fd(),
         })
     }
 }

--- a/rust/crates/monad-exec-events/benches/snapshot_exec.rs
+++ b/rust/crates/monad-exec-events/benches/snapshot_exec.rs
@@ -30,8 +30,9 @@ fn bench_snapshot(c: &mut Criterion) {
     let mut g = c.benchmark_group("snapshot_exec");
 
     let snapshot = SnapshotEventRing::<ExecEventDecoder>::new_from_zstd_bytes(
-        SNAPSHOT_ZSTD_BYTES,
         SNAPSHOT_NAME,
+        SNAPSHOT_ZSTD_BYTES,
+        None,
     )
     .unwrap();
 
@@ -56,8 +57,9 @@ fn bench_snapshot(c: &mut Criterion) {
     g.throughput(criterion::Throughput::Elements(items));
     g.bench_function("iter_read", |b| {
         let snapshot = SnapshotEventRing::<ExecEventDecoder>::new_from_zstd_bytes(
-            SNAPSHOT_ZSTD_BYTES,
             SNAPSHOT_NAME,
+            SNAPSHOT_ZSTD_BYTES,
+            None,
         )
         .unwrap();
 

--- a/rust/crates/monad-exec-events/src/block_builder/commit_state/mod.rs
+++ b/rust/crates/monad-exec-events/src/block_builder/commit_state/mod.rs
@@ -301,7 +301,8 @@ mod test {
         snapshot_zstd_bytes: &'static [u8],
     ) {
         let snapshot =
-            ExecSnapshotEventRing::new_from_zstd_bytes(snapshot_zstd_bytes, snapshot_name).unwrap();
+            ExecSnapshotEventRing::new_from_zstd_bytes(snapshot_name, snapshot_zstd_bytes, None)
+                .unwrap();
 
         let mut event_reader = snapshot.create_reader();
 

--- a/rust/crates/monad-exec-events/src/block_builder/executed/mod.rs
+++ b/rust/crates/monad-exec-events/src/block_builder/executed/mod.rs
@@ -481,7 +481,8 @@ mod test {
 
     fn run_block_builder(snapshot_name: &'static str, snapshot_zstd_bytes: &'static [u8]) {
         let snapshot =
-            ExecSnapshotEventRing::new_from_zstd_bytes(snapshot_zstd_bytes, snapshot_name).unwrap();
+            ExecSnapshotEventRing::new_from_zstd_bytes(snapshot_name, snapshot_zstd_bytes, None)
+                .unwrap();
 
         let mut event_reader = snapshot.create_reader();
 

--- a/rust/crates/monad-exec-events/src/events/mod.rs
+++ b/rust/crates/monad-exec-events/src/events/mod.rs
@@ -513,8 +513,9 @@ mod test {
             include_bytes!("../../test/data/exec-events-emn-30b-15m/snapshot.zst");
 
         let snapshot = SnapshotEventRing::<ExecEventDecoder>::new_from_zstd_bytes(
-            SNAPSHOT_ZSTD_BYTES,
             SNAPSHOT_NAME,
+            SNAPSHOT_ZSTD_BYTES,
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
Event ring files that are zstd-compressed are interpreted as "event ring snapshots": bit-wise copies of an event ring file as it existed at a particular moment in time. They are used during testing and development, and are part of the "Getting Started" guide:

> https://docs.monad.xyz/execution-events/getting-started/snapshot

The basic infrastructure for working with snapshot files exists in the C API, in `event_ring_util.h`. Before this commit, the Rust API had its own reimplementation. This commit removes that, and uses the C API instead.

This commit also adds the FFI wrapper for the
`monad_event_resolve_ring_file` function. This is not directly related to this change, but there is a "chicken-and-egg" problem of how to cut bigger changes that affect each other into multiple PRs, so it is included now for simplicity.