### PR TITLE
Expose event descriptor info in events SDK

### DIFF
--- a/rust/crates/monad-event-ring/src/descriptor/mod.rs
+++ b/rust/crates/monad-event-ring/src/descriptor/mod.rs
@@ -45,6 +45,11 @@ where
         }
     }
 
+    /// Produces the [`EventDescriptorInfo`] associated with this descriptor.
+    pub fn info(&self) -> EventDescriptorInfo<D> {
+        EventDescriptorInfo::new(self.raw.info())
+    }
+
     /// Attempts to read the payload associated with this event descriptor as the associated
     /// [`T::Event`](EventDecoder::Event) type.
     pub fn try_read(&self) -> EventPayloadResult<D::Event> {
@@ -134,6 +139,9 @@ where
     /// See [`EventDecoder`] for more details.
     pub event_type: u16,
 
+    /// The time at which the event was recorded.
+    pub record_epoch_nanos: u64,
+
     /// The flow information associated with this event descriptor,
     ///
     /// See [`EventDecoder::FlowInfo`] for more details.
@@ -148,6 +156,7 @@ where
         Self {
             seqno: raw.seqno,
             event_type: raw.event_type,
+            record_epoch_nanos: raw.record_epoch_nanos,
             flow_info: D::transmute_flow_info(raw.content_ext),
         }
     }

--- a/rust/crates/monad-event-ring/src/descriptor/raw.rs
+++ b/rust/crates/monad-event-ring/src/descriptor/raw.rs
@@ -35,6 +35,15 @@ impl<'ring> RawEventDescriptor<'ring> {
         }
     }
 
+    pub(super) fn info(&self) -> RawEventDescriptorInfo {
+        RawEventDescriptorInfo {
+            seqno: self.inner.seqno,
+            event_type: self.inner.event_type,
+            record_epoch_nanos: self.inner.record_epoch_nanos,
+            content_ext: self.inner.content_ext,
+        }
+    }
+
     pub(super) fn try_filter_map<T>(
         &self,
         f: impl FnOnce(RawEventDescriptorInfo, &[u8]) -> T,
@@ -43,14 +52,8 @@ impl<'ring> RawEventDescriptor<'ring> {
             return EventPayloadResult::Expired;
         };
 
-        let value = f(
-            RawEventDescriptorInfo {
-                seqno: self.inner.seqno,
-                event_type: self.inner.event_type,
-                content_ext: self.inner.content_ext,
-            },
-            bytes,
-        );
+        let info = self.info();
+        let value = f(info, bytes);
 
         if monad_event_ring_payload_check(&self.ring.inner, &self.inner) {
             EventPayloadResult::Ready(value)
@@ -64,6 +67,8 @@ pub(super) struct RawEventDescriptorInfo {
     pub seqno: u64,
 
     pub event_type: u16,
+
+    pub record_epoch_nanos: u64,
 
     pub content_ext: [u64; 4],
 }

--- a/rust/crates/monad-exec-events/src/events/mod.rs
+++ b/rust/crates/monad-exec-events/src/events/mod.rs
@@ -279,9 +279,15 @@ impl<'ring> ExecEventRef<'ring> {
 
 /// Flow info for execution events.
 pub struct ExecEventRingFlowInfo {
-    block_seqno: u64,
-    txn_idx: Option<usize>,
-    account_idx: u64,
+    /// The sequence number of the first event related to this block. This is guaranteed to be
+    /// a BlockStart event.
+    pub block_seqno: u64,
+
+    /// The index of the transaction this event corresponds to, within the event's associated block.
+    pub txn_idx: Option<usize>,
+
+    /// The index of the account in the account access list referred to by this event.
+    pub account_idx: u64,
 }
 
 impl EventDecoder for ExecEventDecoder {


### PR DESCRIPTION
This change makes the fields of the event descriptor info struct public in the events rust SDK.