### PR TITLE
[event][rust] add the eventwatch example program

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -320,6 +320,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -434,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +518,9 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -630,6 +647,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1081,6 +1104,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1242,12 @@ checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1315,6 +1378,7 @@ dependencies = [
  "criterion",
  "hex",
  "itertools 0.10.5",
+ "lazy_static",
  "monad-event-ring",
  "ratatui",
  "serde",
@@ -2214,6 +2278,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,10 +2354,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,12 +24,13 @@ alloy-primitives = { version = "1.5",     default-features = false }
 alloy-rpc-types  = { version = "1.7",     default-features = false, features = ["eth"] }
 bindgen          = { version = "0.71.1",  default-features = false }
 cc               = { version = "1.2.27",  default-features = false }
-chrono           = { version = "0.4.34",  default-features = false, features = ["std"] }
+chrono           = { version = "0.4.34",  default-features = false, features = ["std", "clock"] }
 clap             = { version = "4.2",     default-features = false }
 cmake            = { version = "0.1",     default-features = false }
 criterion        = { version = "0.8",     default-features = false, features = ["html_reports"] }
 hex              = { version = "0.4",     default-features = false, features = ["std"] }
 itertools        = { version = "0.10",    default-features = false, features = ["use_std"] }
+lazy_static      = { version = "1.5.0",   default-features = false }
 libc             = { version = "0.2.153", default-features = false }
 ratatui          = { version = "0.30.0",  default-features = false, features = ["crossterm"] }
 serde            = { version = "1.0",     default-features = false }

--- a/rust/crates/monad-exec-events/Cargo.toml
+++ b/rust/crates/monad-exec-events/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true }
 hex = { workspace = true }
+lazy_static = { workspace = true }
 ratatui = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }

--- a/rust/crates/monad-exec-events/examples/eventwatch.rs
+++ b/rust/crates/monad-exec-events/examples/eventwatch.rs
@@ -1,0 +1,247 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{ffi::CStr, path::PathBuf, time::Duration};
+
+use chrono::{DateTime, Local};
+use clap::Parser;
+use lazy_static::lazy_static;
+use monad_event_ring::{
+    DecodedEventRing, EventDescriptor, EventDescriptorInfo, EventNextResult, EventPayloadResult,
+    EventRingPath,
+};
+use monad_exec_events::{
+    ffi::{g_monad_exec_event_metadata, DEFAULT_FILE_NAME, MONAD_EXEC_EVENT_COUNT},
+    ExecEventDecoder, ExecEventDescriptorExt, ExecEventReaderExt, ExecEventRing, ExecEventType,
+    ExecSnapshotEventRing,
+};
+
+lazy_static! {
+    static ref EXEC_EVENT_NAMES: [&'static str; MONAD_EXEC_EVENT_COUNT] =
+        std::array::from_fn(|event_type| unsafe {
+            CStr::from_ptr(g_monad_exec_event_metadata[event_type].c_name)
+                .to_str()
+                .unwrap()
+        });
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "eventwatch", about, long_about = None)]
+pub struct Cli {
+    #[arg(long)]
+    event_ring_path: Option<PathBuf>,
+
+    #[arg(short, long)]
+    dump_payload: bool,
+}
+
+/// Print a summary line of this event
+/// <HH:MM:SS.nanos-TZ> <event-c-name> [<event-type> <event-type-hex>]
+///     SEQ: <sequence-no>
+fn print_event(event: &EventDescriptor<ExecEventDecoder>, dump_payload: bool) -> bool {
+    let EventDescriptorInfo {
+        seqno,
+        event_type,
+        record_epoch_nanos,
+        flow_info,
+    } = event.info();
+
+    let event_time_tz = DateTime::from_timestamp_nanos(record_epoch_nanos as i64)
+        .with_timezone(&Local)
+        .format("%H:%M:%S.%9f");
+
+    let event_name = EXEC_EVENT_NAMES[event_type as usize];
+
+    // Format the fields present for all events
+    print!("{event_time_tz} {event_name} [{event_type} {event_type:#x}] SEQ: {seqno}");
+
+    // Some events have an associated block number and transaction number;
+    // print those now
+    if flow_info.block_seqno != 0 {
+        let block_number = event.get_block_number().unwrap();
+        print!(" BLK: {block_number}");
+    }
+    if let Some(i) = flow_info.txn_idx {
+        print!(" TXN: {i}");
+    }
+    println!();
+
+    let exec_event = match event.try_read() {
+        EventPayloadResult::Expired => {
+            // The payload buffer is a circular buffer, similar to how the
+            // event descriptor FIFO queue is. Much like how the EventReader
+            // can gap if you don't consume events fast enough, trying to read
+            // a payload from a live event ring could return that it has expired
+            eprintln!("ERROR: payload expired!");
+            return false;
+        }
+        EventPayloadResult::Ready(exec_event) => exec_event,
+    };
+
+    if dump_payload {
+        // One advantage of the Rust SDK over the C SDK is the #[derive(Debug)]
+        // attribute on ExecEvent decoded representation; this is helpful for
+        // debugging
+        println!("Payload: {exec_event:x?}");
+    }
+    true
+}
+
+// This example program works with two different kinds of events rings:
+//
+//   1. "Live" event rings -- these are a source of real-time data. In the
+//      case of an event ring containing execution events, the Category Labs
+//      execution daemon is writing EVM event notifications into them in
+//      real time
+//
+//   2. "Snapshot" event rings -- these are compressed snapshots taken
+//      of an event ring file as it existed at a particular moment in
+//      time; they implicitly "rewind" to the first event in the queue
+//      and to replay a fixed set of historical execution events. Snapshots
+//      are useful for testing and development workflows, because you do not
+//      need to be running an active monad node to use them
+//
+// Using either kind of ring is largely the same, but there are some
+// important differences. Because a snapshot is an "offline" image of
+// historical events, it (1) can never gap and (2) as soon as it replays
+// all of it events, there can't be any more.
+//
+// A live event ring is more complex, since it needs to be polled
+// moment-to-moment, and there are some classic inter-process communication
+// complexities (you need some kind of a "timeout" mechanism to detect when
+// the execution process appears to be dead or hung).
+enum OpenEventRing {
+    Live(ExecEventRing),
+    Snapshot(ExecSnapshotEventRing),
+}
+
+impl OpenEventRing {
+    fn new(event_ring_path: EventRingPath) -> Result<Self, String> {
+        if event_ring_path.is_snapshot_file()? {
+            let snapshot = ExecSnapshotEventRing::new_from_zstd_path(event_ring_path, None)?;
+            Ok(OpenEventRing::Snapshot(snapshot))
+        } else {
+            let live = ExecEventRing::new(event_ring_path)?;
+            Ok(OpenEventRing::Live(live))
+        }
+    }
+}
+
+fn main() {
+    let Cli {
+        event_ring_path,
+        dump_payload,
+    } = Cli::parse();
+
+    // The event ring shared memory data structure typically lives inside
+    // of a regular file; any process that wants shared access to it, first
+    // locates it via the filesystem, then maps a shared view of it into the
+    // process' virtual memory map using the mmap(2) system call.
+    //
+    // Most real-time programs take a path to the event ring file as a CLI
+    // input parameter, but also allow it to be absent, in which case the
+    // default file name is used.
+    //
+    // Event ring files can be located anywhere, but there is a performance
+    // benefit to placing them on a hugetlbfs in-memory filesystem; the function
+    // EventRingPath::resolve will turn "pure" file names (i.e., those with no
+    // '/' character in the path) into a full path located in a special
+    // directory on a hugetlbfs filesystem, e.g., `my-ring` will be translated
+    // into `<hugetlbfs-root>/my-ring`. Any path that already contains a path
+    // separator character, e.g., `./my-ring`, will be not be modified.
+    //
+    // An "EventRingPath" is just a regular filesystem path that has gone
+    // through the automatic path expansion rules for "pure" filenames, so
+    // that the application writers do not need to understand all the logic
+    // for how the hugetlbfs path location works. The functions that open
+    // event rings take an "EventRingPath" instead of a PathBuf to ensure
+    // that these expansions rules have been followed. To see all the details,
+    // check the SDK documentation section:
+    //
+    //   Execution Events > Advanced Topics > Location of event ring files
+    let event_ring_path =
+        EventRingPath::resolve(event_ring_path.unwrap_or(PathBuf::from(DEFAULT_FILE_NAME)))
+            .unwrap();
+
+    // Try to open the event ring file, and exit if we can't
+    let event_ring = OpenEventRing::new(event_ring_path).unwrap();
+
+    let mut event_reader = match event_ring {
+        OpenEventRing::Live(ref live) => {
+            let mut event_reader = live.create_reader();
+
+            // The EventReader for a live event ring has its initial iteration
+            // point set to the most recently produced event. If our listening
+            // process starts after the execution daemon has already been
+            // running, then the "last written event" will usually be in the
+            // middle of a block.
+            //
+            // This is rarely what we want, because most blockchain data
+            // processing is inherently block-oriented. This function will
+            // rewind the reader's iteration point so that it will always start
+            // on a block boundary
+            event_reader.consensus_prev(Some(ExecEventType::BlockStart));
+            event_reader
+        }
+        OpenEventRing::Snapshot(ref snapshot) => snapshot.create_reader(),
+    };
+
+    // This is used to detect when the execution daemon has died
+    let mut last_event_timestamp_ns: u64 = Local::now().timestamp_nanos_opt().unwrap_or(0) as u64;
+
+    // The event processing loop of the application
+    loop {
+        match event_reader.next_descriptor() {
+            EventNextResult::Gap => {
+                // Event rings use circular buffers to hold their data, and
+                // live event rings can gap if the consumer does not keep up
+                eprintln!("ERROR: event sequence number gap occurred!");
+                event_reader.reset();
+                continue;
+            }
+            EventNextResult::NotReady => {
+                match event_ring {
+                    OpenEventRing::Snapshot(_) => {
+                        // A snapshot is always "ready" until it runs out of events;
+                        // the first time it's not ready, it's finished, so exit
+                        return;
+                    }
+                    OpenEventRing::Live(_) => {
+                        let now = Local::now();
+                        let last_event_time =
+                            DateTime::from_timestamp_nanos(last_event_timestamp_ns as i64);
+                        if now.signed_duration_since(last_event_time).num_seconds() > 5 {
+                            // If a live execution daemon does not write a new event for
+                            // five seconds, it's almost certainly dead; this is good enough
+                            // for our example, but in a production-grade real-time data
+                            // processing program, you will probably want to use a more
+                            // sophisticated death detection mechanism
+                            std::process::exit(0);
+                        }
+                        std::thread::sleep(Duration::from_micros(100));
+                    }
+                }
+                continue;
+            }
+            EventNextResult::Ready(event) => {
+                // We got an event; remember the timestamp and print it to stdout
+                last_event_timestamp_ns = event.info().record_epoch_nanos;
+                if !print_event(&event, dump_payload) {
+                    event_reader.reset(); // Payload expired
+                }
+            }
+        };
+    }
+}

--- a/rust/crates/monad-exec-events/src/ffi.rs
+++ b/rust/crates/monad-exec-events/src/ffi.rs
@@ -24,8 +24,8 @@ pub use self::bindings::{
     monad_exec_block_verified, monad_exec_evm_error, monad_exec_storage_access,
     monad_exec_txn_access_list_entry, monad_exec_txn_auth_list_entry, monad_exec_txn_call_frame,
     monad_exec_txn_evm_output, monad_exec_txn_header_start, monad_exec_txn_log,
-    monad_exec_txn_reject, MONAD_TXN_EIP1559, MONAD_TXN_EIP2930, MONAD_TXN_EIP4844,
-    MONAD_TXN_EIP7702, MONAD_TXN_LEGACY,
+    monad_exec_txn_reject, MONAD_EXEC_EVENT_COUNT, MONAD_TXN_EIP1559, MONAD_TXN_EIP2930,
+    MONAD_TXN_EIP4844, MONAD_TXN_EIP7702, MONAD_TXN_LEGACY,
 };
 pub(crate) use self::bindings::{
     g_monad_exec_event_schema_hash, monad_exec_event_type, MONAD_EXEC_ACCOUNT_ACCESS,
@@ -140,3 +140,20 @@ pub(crate) fn monad_exec_iter_block_id_prev(
 
     success.then_some(c_event_descriptor)
 }
+
+/// The default filename that the execution daemon uses when it creates the
+/// execution events file.
+///
+/// This is just the filename, not the full path: the full path is determined
+/// by the pathname resolution process followed by
+/// [`EventRingPath::resolve`](::monad_event_ring::EventRingPath::resolve). If
+/// a user just wants "the default path" to the live execution events file,
+/// they should resolve this filename.
+pub const DEFAULT_FILE_NAME: &str = unsafe {
+    std::str::from_utf8_unchecked(
+        std::ffi::CStr::from_bytes_with_nul_unchecked(
+            self::bindings::MONAD_EVENT_DEFAULT_EXEC_FILE_NAME,
+        )
+        .to_bytes(),
+    )
+};


### PR DESCRIPTION
In Rust, there are two core example programs, corresponding to the two levels of abstraction offered by the library:

- eventwatch - dumps each event to stdout as soon as it is encountered

- blockdump - reassembles event sequences into block-oriented updates

`blockdump` is easier to use, and you do not have to directly interact with the events. Instead the "block builder" utility scans the events, and you are given fully-reconstructed block types from the Rust alloy libraries.

`eventwatch` is the low-level utility, and is similar to the utility of the same name in the C language SDK. This is the example that best describes how to use the event ring API.

This commit also has a few other changes that make some internals of the SDK public. These were needed to implement eventwatch with the same features as the C example.