### PR TITLE
[event][rust] fix build issue in the Getting Started guide

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
  "proc-macro2",
  "quote",
  "regex",
@@ -558,6 +559,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1254,6 +1256,16 @@ name = "libc"
 version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ alloy-consensus  = { version = "1.7",     default-features = false }
 alloy-eips       = { version = "1.7",     default-features = false }
 alloy-primitives = { version = "1.5",     default-features = false }
 alloy-rpc-types  = { version = "1.7",     default-features = false, features = ["eth"] }
-bindgen          = { version = "0.71.1",  default-features = false }
+bindgen          = { version = "0.71.1",  default-features = false, features = ["logging", "runtime"] }
 cc               = { version = "1.2.27",  default-features = false }
 chrono           = { version = "0.4.34",  default-features = false, features = ["std", "clock"] }
 clap             = { version = "4.2",     default-features = false }

--- a/rust/crates/monad-event-ring/src/ring/mod.rs
+++ b/rust/crates/monad-event-ring/src/ring/mod.rs
@@ -64,7 +64,10 @@ where
 
         let raw = RawEventRing::mmap_from_fd(
             libc::PROT_READ,
+            #[cfg(target_os = "linux")]
             libc::MAP_POPULATE,
+            #[cfg(not(target_os = "linux"))]
+            0,
             file.as_raw_fd(),
             0,
             &path.as_ref().as_error_name(),


### PR DESCRIPTION
Because running a full Monad node is somewhat difficult, the tutorial lets users "try before you buy" and play around with the SDK using historical event data. This works via the use of event ring snapshot files, which are identical to normal event ring files except they are compressed, and the loading API treats them differently.

To lower barriers to entry, this "try out" step can be done on almost any machine, including macOS which some developers find easier. macOS has been an officially supported platform for the SDK since v1.0, although only for the portion of the SDK used in the tutorial.

This commit fixes the macOS build, where `bindgen` needs to use the `runtime` feature flag to correctly find libclang. It also removes the use of the MAP_POPULATE `mmap(2)` flag on non-Linux platforms. This is just an optimization, and no other systems have it (FreeBSD has the similar MAP_PREFAULT_READ, but macOS has no such thing).