### PR TITLE
more permissive reserve balance checks

### DIFF
--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -259,6 +259,7 @@ evmc::Result execute_create_message(
         .memory_capacity = msg.memory_capacity,
     };
 
+    state.note_initcode_execution(contract_address);
     auto result = state.vm().execute_bytecode<traits>(
         *host, &m_call, {msg.input_data, msg.input_size});
 

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -254,6 +254,11 @@ bool State::is_current_incarnation(Address const &address)
     return false;
 }
 
+bool State::has_executed_initcode(Address const &address) const
+{
+    return rb_.has_executed_initcode(address);
+}
+
 bytes32_t State::get_storage(Address const &address, bytes32_t const &key)
 {
     auto const it = current_.find(address);
@@ -609,6 +614,11 @@ void State::create_account_no_rollback(Address const &address)
             incarnation_.get_block(),
             Incarnation::LAST_TX,
         }};
+}
+
+void State::note_initcode_execution(Address const &address)
+{
+    rb_.on_initcode_execution(address);
 }
 
 immer::vector<Receipt::Log> const &State::logs()

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -138,6 +138,8 @@ public:
 
     bool is_current_incarnation(Address const &);
 
+    bool has_executed_initcode(Address const &) const;
+
     bytes32_t get_storage(Address const &, bytes32_t const &key);
 
     bytes32_t get_transient_storage(Address const &, bytes32_t const &key);
@@ -207,6 +209,8 @@ public:
      * to take place before any of the actual transactions in a block.
      */
     void create_account_no_rollback(Address const &);
+
+    void note_initcode_execution(Address const &);
 
     ////////////////////////////////////////
 

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -685,12 +685,90 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
     // create the account in current incarnation, then selfdestruct it before
     // any runtime code is set.
     state.create_contract(NEW_CONTRACT);
+    state.note_initcode_execution(NEW_CONTRACT);
     auto const [inserted, initial_balance] =
         state.selfdestruct<traits>(NEW_CONTRACT, BENEFICIARY);
     EXPECT_TRUE(inserted);
     EXPECT_EQ(initial_balance, to_wei(3));
     EXPECT_EQ(state.get_balance(NEW_CONTRACT), 0);
     EXPECT_EQ(state.get_balance(BENEFICIARY), to_wei(3));
+
+    bool const should_revert = revert_transaction<traits>(
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context);
+    bool const should_revert_cached = revert_transaction_cached<traits>(state);
+
+    if constexpr (traits::monad_rev() < MONAD_FOUR) {
+        EXPECT_FALSE(should_revert);
+        EXPECT_FALSE(should_revert_cached);
+    }
+    else if constexpr (traits::monad_rev() >= MONAD_NINE) {
+        EXPECT_FALSE(should_revert);
+        EXPECT_FALSE(should_revert_cached);
+    }
+    else {
+        EXPECT_TRUE(should_revert);
+        EXPECT_TRUE(should_revert_cached);
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, reserve_checks_executed_initcode)
+{
+    using traits = typename TestFixture::Trait;
+    constexpr Address SENDER{1};
+    constexpr Address NEW_CONTRACT{2};
+    constexpr uint64_t BASE_FEE_PER_GAS = 10;
+    auto const to_wei = [](uint64_t mon) {
+        return uint256_t{mon} * 1000000000000000000ULL;
+    };
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+
+    {
+        State init_state{bs, Incarnation{0, 0}};
+        init_state.add_to_balance(SENDER, to_wei(20));
+        init_state.add_to_balance(NEW_CONTRACT, to_wei(11));
+        MONAD_ASSERT(bs.can_merge(init_state));
+        bs.merge(init_state);
+    }
+
+    Transaction const tx{
+        .max_fee_per_gas = BASE_FEE_PER_GAS,
+        .gas_limit = 1,
+        .type = TransactionType::legacy,
+        .max_priority_fee_per_gas = 0,
+    };
+    uint256_t const gas_cost =
+        uint256_t{BASE_FEE_PER_GAS} * uint256_t{tx.gas_limit};
+
+    ankerl::unordered_dense::segmented_set<Address> const
+        empty_grandparent_senders_and_authorities;
+    ankerl::unordered_dense::segmented_set<Address> const
+        empty_parent_senders_and_authorities;
+    std::vector<Address> const senders = {SENDER};
+    std::vector<std::vector<std::optional<Address>>> const authorities = {{}};
+    ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
+    senders_and_authorities.insert(SENDER);
+    ChainContext<traits> const context{
+        .grandparent_senders_and_authorities =
+            empty_grandparent_senders_and_authorities,
+        .parent_senders_and_authorities = empty_parent_senders_and_authorities,
+        .senders_and_authorities = senders_and_authorities,
+        .senders = senders,
+        .authorities = authorities};
+
+    State state{bs, Incarnation{1, 1}};
+    init_reserve_balance_context<traits>(
+        state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+    state.subtract_from_balance(SENDER, gas_cost);
+
+    state.create_contract(NEW_CONTRACT);
+    state.set_nonce(NEW_CONTRACT, 1);
+    state.note_initcode_execution(NEW_CONTRACT);
+    state.subtract_from_balance(NEW_CONTRACT, to_wei(11));
 
     bool const should_revert = revert_transaction<traits>(
         SENDER, tx, BASE_FEE_PER_GAS, 0, state, context);

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -61,7 +61,7 @@ bool dipped_into_reserve(
     MONAD_ASSERT(i < ctx.authorities.size());
     MONAD_ASSERT(ctx.senders.size() == ctx.authorities.size());
 
-    static constexpr bool allow_init_selfdestruct_exemption =
+    static constexpr bool allow_initcode_exemption =
         traits::monad_rev() >= MONAD_NINE;
 
     uint256_t const gas_fees =
@@ -94,8 +94,7 @@ bool dipped_into_reserve(
             }
         }
         else if (
-            allow_init_selfdestruct_exemption && state.is_destructed(addr) &&
-            state.is_current_incarnation(addr)) {
+            allow_initcode_exemption && state.has_executed_initcode(addr)) {
             continue;
         }
 
@@ -222,14 +221,11 @@ void ReserveBalance::update_violation_status(Address const &address)
     }
 
     auto &violation_threshold = violation_thresholds_[address];
-    if (allow_init_selfdestruct_exemption_ && state_->is_destructed(address) &&
-        state_->is_current_incarnation(address)) {
-        // Contracts that selfdestruct during init never get a code hash.
+    if (has_executed_initcode(address)) {
         violation_threshold = uint256_t{0};
         failed_.erase(address);
         return;
     }
-
     if (!violation_threshold.has_value()) {
         if (!subject_account(address)) {
             violation_threshold = uint256_t{0};
@@ -310,6 +306,21 @@ void ReserveBalance::on_set_code(
     update_violation_status(address);
 }
 
+void ReserveBalance::on_initcode_execution(Address const &address)
+{
+    if (!allow_initcode_exemption_) {
+        return;
+    }
+    initcode_exec_accounts_.insert(address);
+    update_violation_status(address);
+}
+
+bool ReserveBalance::has_executed_initcode(Address const &address) const
+{
+    return allow_initcode_exemption_ &&
+           initcode_exec_accounts_.contains(address);
+}
+
 template <Traits traits>
 void ReserveBalance::init_from_tx(
     Address const &sender, Transaction const &tx,
@@ -328,12 +339,14 @@ void ReserveBalance::init_from_tx(
     if constexpr (tracking_disabled) {
         tracking_enabled_ = false;
         use_recent_code_hash_ = false;
-        allow_init_selfdestruct_exemption_ = false;
+        allow_initcode_exemption_ = false;
         sender_ = {};
         sender_gas_fees_ = 0;
         sender_can_dip_ = false;
         get_max_reserve_ = {};
         failed_.clear();
+        initcode_exec_accounts_.clear();
+        violation_thresholds_.clear();
         return;
     }
 
@@ -341,7 +354,7 @@ void ReserveBalance::init_from_tx(
     MONAD_ASSERT(i < ctx.authorities.size());
     MONAD_ASSERT(ctx.senders.size() == ctx.authorities.size());
     use_recent_code_hash_ = traits::monad_rev() >= MONAD_EIGHT;
-    allow_init_selfdestruct_exemption_ = traits::monad_rev() >= MONAD_NINE;
+    allow_initcode_exemption_ = traits::monad_rev() >= MONAD_NINE;
     bytes32_t const sender_code_hash =
         use_recent_code_hash_
             ? state_->get_code_hash(sender)
@@ -357,6 +370,7 @@ void ReserveBalance::init_from_tx(
         return get_max_reserve<traits>(addr);
     };
     failed_.clear();
+    initcode_exec_accounts_.clear();
     violation_thresholds_.clear();
 }
 

--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -41,17 +41,19 @@ struct Transaction;
 class ReserveBalance
 {
     using FailedSet = ankerl::unordered_dense::segmented_set<Address>;
+    using InitcodeExecSet = ankerl::unordered_dense::segmented_set<Address>;
     using ViolationThresholdMap = ankerl::unordered_dense::segmented_map<
         Address, std::optional<uint256_t>>;
 
     State *state_;
     bool tracking_enabled_{false};
     bool use_recent_code_hash_{false};
-    bool allow_init_selfdestruct_exemption_{false};
+    bool allow_initcode_exemption_{false};
     Address sender_{};
     uint256_t sender_gas_fees_{0};
     bool sender_can_dip_{false};
     FailedSet failed_{};
+    InitcodeExecSet initcode_exec_accounts_{};
     ViolationThresholdMap violation_thresholds_{};
     std::function<uint256_t(Address const &)> get_max_reserve_{};
 
@@ -74,6 +76,10 @@ public:
     void on_pop_reject(FailedSet const &accounts);
 
     void on_set_code(Address const &address, byte_string_view const code);
+
+    void on_initcode_execution(Address const &address);
+
+    bool has_executed_initcode(Address const &address) const;
 
     template <Traits traits>
     void init_from_tx(

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -18,6 +18,7 @@
 #include <category/execution/ethereum/core/address.hpp>
 #include <category/execution/ethereum/core/contract/abi_encode.hpp>
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
+#include <category/execution/ethereum/create_contract_address.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
@@ -224,6 +225,178 @@ void add_call_code(
         g[18], g[17], g[16], g[15], g[14], g[13],  g[12],  g[11], g[10], g[9],
         g[8],  g[7],  g[6],  g[5],  g[4],  g[3],   g[2],   g[1],  g[0],  CALL,
     });
+}
+
+void add_deploy_stop_code(std::vector<uint8_t> &code)
+{
+    code.append_range(std::initializer_list<uint8_t>{
+        PUSH0,
+        PUSH0,
+        MSTORE8,
+        PUSH1,
+        1,
+        PUSH0,
+        RETURN,
+    });
+}
+
+void add_selfdestruct_code(Address beneficiary, std::vector<uint8_t> &code)
+{
+    auto const *b = intx::as_bytes(beneficiary);
+    code.append_range(std::initializer_list<uint8_t>{
+        PUSH20, b[0],  b[1],  b[2],  b[3],  b[4],         b[5],  b[6],
+        b[7],   b[8],  b[9],  b[10], b[11], b[12],        b[13], b[14],
+        b[15],  b[16], b[17], b[18], b[19], SELFDESTRUCT,
+    });
+}
+
+void add_create_code(
+    std::vector<uint8_t> &code, std::vector<uint8_t> const &initcode)
+{
+    MONAD_ASSERT(initcode.size() < 256);
+    code.append_range(std::initializer_list<uint8_t>{
+        PUSH1,
+        static_cast<uint8_t>(initcode.size()),
+        PUSH1,
+        0,
+        PUSH0,
+        CODECOPY,
+        PUSH1,
+        static_cast<uint8_t>(initcode.size()),
+        PUSH0,
+        PUSH0,
+        CREATE,
+        ISZERO,
+    });
+    size_t const initcode_offset_index = 3;
+    add_revert_if_true(code);
+    add_revert_check(code);
+    add_revert_if_true(code);
+    code.push_back(STOP);
+    MONAD_ASSERT(code.size() < 256);
+    code[initcode_offset_index] = static_cast<uint8_t>(code.size());
+    code.append_range(initcode);
+}
+
+enum class InitcodeFinalization
+{
+    DeployCode,
+    DeployEmptyCode,
+    Selfdestruct,
+};
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void run_initcode_dipped_into_reserve_test(
+    InitcodeFinalization const finalization)
+{
+    static constexpr Address TX_SENDER{0xaaaaaaaa};
+    static constexpr Address FACTORY{0xbbbbbbbb};
+    static constexpr Address BENEFICIARY{0xcccccccc};
+    static constexpr uint64_t GAS_LIMIT = 1'000'000;
+    static constexpr uint256_t INITIAL_BALANCE =
+        uint256_t{11} * 1000000000000000000ULL;
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+    NoopCallTracer call_tracer;
+    evmc_tx_context const tx_context{};
+    BlockHashBufferFinalized block_hash_buffer{};
+
+    std::vector<uint8_t> initcode;
+    add_spend_code(11, initcode);
+    add_revert_check(initcode);
+    add_revert_if_true(initcode);
+    switch (finalization) {
+    case InitcodeFinalization::DeployCode:
+        add_deploy_stop_code(initcode);
+        break;
+    case InitcodeFinalization::DeployEmptyCode:
+        initcode.append_range(std::initializer_list<uint8_t>{
+            PUSH0,
+            PUSH0,
+            RETURN,
+        });
+        break;
+    case InitcodeFinalization::Selfdestruct:
+        add_selfdestruct_code(BENEFICIARY, initcode);
+        break;
+    }
+
+    std::vector<uint8_t> factory_code;
+    add_create_code(factory_code, initcode);
+
+    Address const new_contract = create_contract_address(FACTORY, 0);
+
+    {
+        State state{bs, Incarnation{0, 0}};
+        state.add_to_balance(TX_SENDER, INITIAL_BALANCE);
+        state.add_to_balance(new_contract, INITIAL_BALANCE);
+        state.create_contract(FACTORY);
+        state.set_code(FACTORY, byte_string_view{factory_code});
+        MONAD_ASSERT(bs.can_merge(state));
+        bs.merge(state);
+    }
+
+    Transaction const tx{
+        .max_fee_per_gas = 0,
+        .gas_limit = GAS_LIMIT,
+        .type = TransactionType::legacy,
+        .max_priority_fee_per_gas = 0,
+    };
+
+    std::vector<Address> const senders = {TX_SENDER};
+    std::vector<std::vector<std::optional<Address>>> const authorities = {{}};
+    ankerl::unordered_dense::segmented_set<Address> const
+        empty_grandparent_senders_and_authorities;
+    ankerl::unordered_dense::segmented_set<Address> const
+        empty_parent_senders_and_authorities;
+    ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
+    senders_and_authorities.insert(TX_SENDER);
+    ChainContext<traits> const chain_context{
+        .grandparent_senders_and_authorities =
+            empty_grandparent_senders_and_authorities,
+        .parent_senders_and_authorities = empty_parent_senders_and_authorities,
+        .senders_and_authorities = senders_and_authorities,
+        .senders = senders,
+        .authorities = authorities};
+
+    State state{bs, Incarnation{1, 1}};
+
+    EvmcHost<traits> host{
+        call_tracer,
+        tx_context,
+        block_hash_buffer,
+        state,
+        tx,
+        0,
+        0,
+        chain_context};
+
+    monad::vm::test::TestMessage test_msg;
+    evmc_message msg{*test_msg};
+    msg.gas = static_cast<int64_t>(GAS_LIMIT);
+    msg.recipient = FACTORY;
+    msg.sender = TX_SENDER;
+
+    init_reserve_balance_context<traits>(
+        state,
+        msg.sender,
+        tx,
+        host.base_fee_per_gas_,
+        host.i_,
+        host.chain_ctx_);
+
+    auto const factory_code_hash =
+        to_bytes(keccak256(byte_string_view{factory_code}));
+    auto const factory_intercode =
+        make_shared_intercode(std::span<uint8_t const>{factory_code});
+    auto const result = vm.execute<traits>(
+        host, &msg, factory_code_hash, make_shared<Varcode>(factory_intercode));
+    EXPECT_EQ(EVMC_SUCCESS, result.status_code);
 }
 
 template <Traits traits>
@@ -545,6 +718,37 @@ TYPED_TEST(MonadTraitsTest, reverttransaction_revert)
     }();
 
     run_dipped_into_reserve_test<typename TestFixture::Trait>(15, 11, outcome);
+}
+
+TYPED_TEST(MonadTraitsTest, dipped_into_reserve_executed_initcode_deploy)
+{
+    if constexpr (TestFixture::Trait::monad_rev() < MONAD_NINE) {
+        return;
+    }
+
+    run_initcode_dipped_into_reserve_test<typename TestFixture::Trait>(
+        InitcodeFinalization::DeployCode);
+}
+
+TYPED_TEST(
+    MonadTraitsTest, dipped_into_reserve_executed_initcode_deploy_empty_code)
+{
+    if constexpr (TestFixture::Trait::monad_rev() < MONAD_NINE) {
+        return;
+    }
+
+    run_initcode_dipped_into_reserve_test<typename TestFixture::Trait>(
+        InitcodeFinalization::DeployEmptyCode);
+}
+
+TYPED_TEST(MonadTraitsTest, dipped_into_reserve_executed_initcode_selfdestruct)
+{
+    if constexpr (TestFixture::Trait::monad_rev() < MONAD_NINE) {
+        return;
+    }
+
+    run_initcode_dipped_into_reserve_test<typename TestFixture::Trait>(
+        InitcodeFinalization::Selfdestruct);
 }
 
 template <Traits traits>


### PR DESCRIPTION
For MONAD_NINE+, any account whose initcode was executed by CREATE/CREATE2 is exempt from reserve-balance checks for the rest of that transaction.
This is a generalization of #2037, which avoided adding more state, but as Piotr pointed out,  lead to some behaviors that are safe but ugly to document for users (and may be confusing to them): e.g. what if the cached reserve balance check was done in initcode before `SELFDESTRUCT`, after a `CALL` to debit too much. The behavior of the code was also less permissive than the Coq [model](https://category-labs.github.io/category-research/reserve-balance-coq-proofs/monad.proofs.reservebal.html#finalBalSufficient).
The drawback of this PR vs #2037 is that now there is more state to track (more memory usage) but this impact may be negligible.

This PR adds a set of accounts (in `ReserveBalance::initcode_exec_accounts_`) whose initcode was executed by CREATE/CREATE2 during the transaction. Any account in this set is exempted from reserve balance checks because nobody can have its private key as the account address is created by hashing nonce/code etc. 
Co-authored with codex-cli

