### PR TITLE
[test] Use anonymous inodes for temp DB files in snapshot and valset …

### DIFF
--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -32,25 +32,52 @@
 
 namespace
 {
-    std::filesystem::path tmp_dbname()
+    struct TempDb
     {
-        std::filesystem::path dbname(
-            MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
-            "monad_db_snapshot_test_XXXXXX");
-        int const fd = ::mkstemp((char *)dbname.native().data());
-        MONAD_ASSERT(fd != -1);
-        MONAD_ASSERT(
-            -1 !=
-            ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
-        ::close(fd);
-        char const *const path = dbname.c_str();
-        monad::OnDiskMachine machine;
-        monad::mpt::Db const db{
-            machine,
-            monad::mpt::OnDiskDbConfig{
-                .append = false, .dbname_paths = {path}}};
-        return dbname;
-    }
+        int fd;
+        std::string path;
+
+        TempDb()
+            : fd{MONAD_ASYNC_NAMESPACE::make_temporary_inode()}
+            , path{"/proc/self/fd/" + std::to_string(fd)}
+        {
+            MONAD_ASSERT(
+                -1 !=
+                ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
+        }
+
+        TempDb(TempDb const &) = delete;
+        TempDb &operator=(TempDb const &) = delete;
+
+        ~TempDb()
+        {
+            ::close(fd);
+        }
+    };
+
+    struct TempDir
+    {
+        std::filesystem::path path;
+
+        TempDir()
+        {
+            std::filesystem::path tmpl =
+                MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+                "monad_snapshot_test_XXXXXX";
+            char *const result = ::mkdtemp((char *)tmpl.native().data());
+            MONAD_ASSERT(result != nullptr);
+            path = result;
+        }
+
+        TempDir(TempDir const &) = delete;
+        TempDir &operator=(TempDir const &) = delete;
+
+        ~TempDir()
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(path, ec);
+        }
+    };
 }
 
 TEST(DbBinarySnapshot, Basic)
@@ -58,14 +85,16 @@ TEST(DbBinarySnapshot, Basic)
     using namespace monad;
     using namespace monad::mpt;
 
-    auto const src_db = tmp_dbname();
+    TempDb const src_db;
+    TempDb const dest_db;
+    TempDir const snapshot_dir;
 
     bytes32_t root_hash;
     Code code_delta;
     BlockHeader last_header;
     {
         OnDiskMachine machine;
-        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db}}};
+        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db.path}}};
         Node::SharedPtr root{};
         for (uint64_t i = 0; i < 100; ++i) {
             root = load_header(std::move(root), db, BlockHeader{.number = i});
@@ -105,13 +134,11 @@ TEST(DbBinarySnapshot, Basic)
         root_hash = tdb.state_root();
     }
 
-    auto const dest_db = tmp_dbname();
     {
-        auto const root = std::filesystem::temp_directory_path() / "snapshot";
         auto *const context =
             monad_db_snapshot_filesystem_write_user_context_create(
-                root.c_str(), 100);
-        char const *dbname_paths[] = {src_db.c_str()};
+                snapshot_dir.path.c_str(), 100);
+        char const *dbname_paths[] = {src_db.path.c_str()};
         EXPECT_TRUE(monad_db_dump_snapshot(
             dbname_paths,
             1,
@@ -125,16 +152,23 @@ TEST(DbBinarySnapshot, Basic)
 
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
 
-        char const *dbname_paths_new[] = {dest_db.c_str()};
+        {
+            OnDiskMachine machine;
+            mpt::Db dest_init{
+                machine, OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+        }
+        char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(
-            dbname_paths_new, 1, static_cast<unsigned>(-1), root.c_str(), 100);
-
-        std::filesystem::remove_all(root);
+            dbname_paths_new,
+            1,
+            static_cast<unsigned>(-1),
+            snapshot_dir.path.c_str(),
+            100);
     }
 
     {
         AsyncIOContext io_context{
-            ReadOnlyOnDiskDbConfig{.dbname_paths = {dest_db}}};
+            ReadOnlyOnDiskDbConfig{.dbname_paths = {dest_db.path}}};
         mpt::Db db{io_context};
         TrieDb tdb{db};
         for (uint64_t i = 0; i < 100; ++i) {
@@ -152,9 +186,6 @@ TEST(DbBinarySnapshot, Basic)
                 byte_string_view(icode->code(), icode->size()));
         }
     }
-
-    std::filesystem::remove(src_db);
-    std::filesystem::remove(dest_db);
 }
 
 TEST(DbBinarySnapshot, MultipleShards)
@@ -162,14 +193,17 @@ TEST(DbBinarySnapshot, MultipleShards)
     using namespace monad;
     using namespace monad::mpt;
 
-    auto const src_db = tmp_dbname();
+    TempDb const src_db;
+    TempDb const dest_db;
+    TempDir const base_root;
+    TempDir const combined_root;
 
     bytes32_t root_hash;
     Code code_delta;
     BlockHeader last_header;
     {
         OnDiskMachine machine;
-        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db}}};
+        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db.path}}};
         Node::SharedPtr root{};
         for (uint64_t i = 0; i < 100; ++i) {
             root = load_header(std::move(root), db, BlockHeader{.number = i});
@@ -209,27 +243,19 @@ TEST(DbBinarySnapshot, MultipleShards)
         root_hash = tdb.state_root();
     }
 
-    auto const dest_db = tmp_dbname();
     {
         constexpr uint64_t NUM_SHARDS = 4;
-        std::filesystem::path const base_root =
-            std::filesystem::temp_directory_path() / "snapshot_sharded";
-
-        if (std::filesystem::exists(base_root)) {
-            std::filesystem::remove_all(base_root);
-        }
-        std::filesystem::create_directories(base_root);
 
         std::vector<std::filesystem::path> shard_roots;
         for (uint64_t shard = 0; shard < NUM_SHARDS; ++shard) {
             auto const shard_root =
-                base_root / ("shard_" + std::to_string(shard));
+                base_root.path / ("shard_" + std::to_string(shard));
             shard_roots.push_back(shard_root);
 
             auto *const context =
                 monad_db_snapshot_filesystem_write_user_context_create(
                     shard_root.c_str(), 100);
-            char const *dbname_paths[] = {src_db.c_str()};
+            char const *dbname_paths[] = {src_db.path.c_str()};
             EXPECT_TRUE(monad_db_dump_snapshot(
                 dbname_paths,
                 1,
@@ -244,14 +270,7 @@ TEST(DbBinarySnapshot, MultipleShards)
             monad_db_snapshot_filesystem_write_user_context_destroy(context);
         }
 
-        auto const combined_root =
-            std::filesystem::temp_directory_path() / "snapshot_combined";
-
-        if (std::filesystem::exists(combined_root)) {
-            std::filesystem::remove_all(combined_root);
-        }
-
-        auto const combined_version_dir = combined_root / "100";
+        auto const combined_version_dir = combined_root.path / "100";
         std::filesystem::create_directories(combined_version_dir);
 
         uint64_t total_shards_copied = 0;
@@ -280,20 +299,22 @@ TEST(DbBinarySnapshot, MultipleShards)
         }
 
         EXPECT_EQ(total_shards_copied, 256u);
-        char const *dbname_paths_new[] = {dest_db.c_str()};
+        {
+            OnDiskMachine machine;
+            mpt::Db dest_init{
+                machine, OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+        }
+        char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(
             dbname_paths_new,
             1,
             static_cast<unsigned>(-1),
-            combined_root.c_str(),
+            combined_root.path.c_str(),
             100);
-
-        std::filesystem::remove_all(base_root);
-        std::filesystem::remove_all(combined_root);
     }
     {
         AsyncIOContext io_context{
-            ReadOnlyOnDiskDbConfig{.dbname_paths = {dest_db}}};
+            ReadOnlyOnDiskDbConfig{.dbname_paths = {dest_db.path}}};
         mpt::Db db{io_context};
         TrieDb tdb{db};
         for (uint64_t i = 0; i < 100; ++i) {
@@ -311,7 +332,4 @@ TEST(DbBinarySnapshot, MultipleShards)
                 byte_string_view(icode->code(), icode->size()));
         }
     }
-
-    std::filesystem::remove(src_db);
-    std::filesystem::remove(dest_db);
 }

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/async/util.hpp>
 #include <category/execution/ethereum/core/contract/big_endian.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
@@ -23,6 +24,8 @@
 #include <category/mpt/ondisk_db_config.hpp>
 
 #include <test_resource_data.h>
+
+#include <optional>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -39,82 +42,87 @@ namespace
     constexpr uint256_t SNAPSHOT_STAKE = 100_u256;
     constexpr uint256_t CONSENSUS_STAKE = 300_u256;
 
-    std::filesystem::path tmp_dbname()
+    struct TempDb
     {
-        std::filesystem::path dbname(
-            MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
-            "staking_read_valset_test_XXXXXX");
-        int const fd = ::mkstemp((char *)dbname.native().data());
-        MONAD_ASSERT(fd != -1);
-        MONAD_ASSERT(
-            -1 !=
-            ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
-        ::close(fd);
-        char const *const path = dbname.c_str();
-        OnDiskMachine machine;
-        mpt::Db const db{
-            machine,
-            mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
-        return dbname;
-    }
+        int fd;
+        std::string path;
+
+        TempDb()
+            : fd{MONAD_ASYNC_NAMESPACE::make_temporary_inode()}
+            , path{"/proc/self/fd/" + std::to_string(fd)}
+        {
+            MONAD_ASSERT(
+                -1 !=
+                ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
+        }
+
+        TempDb(TempDb const &) = delete;
+        TempDb &operator=(TempDb const &) = delete;
+
+        ~TempDb()
+        {
+            ::close(fd);
+        }
+    };
 }
 
 class ReadValsetBase : public ::testing::Test
 {
 protected:
-    std::filesystem::path dbname;
-    mpt::AsyncIOContext io_ctx;
-    mpt::Db ro;
-
-    ReadValsetBase()
-        : dbname{tmp_dbname()}
-        , io_ctx{mpt::ReadOnlyOnDiskDbConfig{.dbname_paths = {dbname}}}
-        , ro{io_ctx}
-
-    {
-    }
+    // db_file must be declared first: io_ctx holds an open fd to the same
+    // inode and must be destroyed before db_file closes it.
+    TempDb db_file;
+    std::optional<mpt::AsyncIOContext> io_ctx;
+    std::optional<mpt::Db> ro;
 
     void SetUp() override
     {
-        OnDiskMachine machine;
-        vm::VM vm;
-        mpt::Db db{machine, mpt::OnDiskDbConfig{.dbname_paths = {dbname}}};
-        TrieDb tdb{db};
-        BlockState bs{tdb, vm};
-        State state{bs, Incarnation{0, 0}};
-        NoopCallTracer call_tracer{};
-        StakingContract contract{state, call_tracer};
+        {
+            OnDiskMachine machine;
+            vm::VM vm;
+            mpt::Db db{
+                machine, mpt::OnDiskDbConfig{.dbname_paths = {db_file.path}}};
+            TrieDb tdb{db};
+            BlockState bs{tdb, vm};
+            State state{bs, Incarnation{0, 0}};
+            NoopCallTracer call_tracer{};
+            StakingContract contract{state, call_tracer};
 
-        state.add_to_balance(STAKING_CA, 0);
+            state.add_to_balance(STAKING_CA, 0);
 
-        // push the consensus and snapshot valsets. they have different lengths
-        // so they can easily be identified.
-        for (uint64_t id = 1; id <= SNAPSHOT_VALSET_LENGTH; ++id) {
-            contract.vars.valset_snapshot.push(id);
-            contract.vars.snapshot_view(id).stake().store(SNAPSHOT_STAKE);
+            // push the consensus and snapshot valsets. they have different
+            // lengths so they can easily be identified.
+            for (uint64_t id = 1; id <= SNAPSHOT_VALSET_LENGTH; ++id) {
+                contract.vars.valset_snapshot.push(id);
+                contract.vars.snapshot_view(id).stake().store(SNAPSHOT_STAKE);
+            }
+            for (uint64_t id = 1; id <= CONSENSUS_VALSET_LENGTH; ++id) {
+                contract.vars.valset_consensus.push(
+                    id + SNAPSHOT_VALSET_LENGTH);
+                contract.vars.consensus_view(id + SNAPSHOT_VALSET_LENGTH)
+                    .stake()
+                    .store(CONSENSUS_STAKE);
+            }
+
+            contract.vars.epoch.store(TEST_EPOCH);
+            contract.vars.in_epoch_delay_period.store(in_epoch_delay_period());
+
+            MONAD_ASSERT(bs.can_merge(state));
+            bs.merge(state);
+            bs.commit(
+                NULL_HASH_BLAKE3,
+                BlockHeader{.number = TEST_BLOCK_NUM},
+                {},
+                {},
+                {},
+                {},
+                {},
+                {});
+            tdb.finalize(TEST_BLOCK_NUM, NULL_HASH_BLAKE3);
         }
-        for (uint64_t id = 1; id <= CONSENSUS_VALSET_LENGTH; ++id) {
-            contract.vars.valset_consensus.push(id + SNAPSHOT_VALSET_LENGTH);
-            contract.vars.consensus_view(id + SNAPSHOT_VALSET_LENGTH)
-                .stake()
-                .store(CONSENSUS_STAKE);
-        }
-
-        contract.vars.epoch.store(TEST_EPOCH);
-        contract.vars.in_epoch_delay_period.store(in_epoch_delay_period());
-
-        MONAD_ASSERT(bs.can_merge(state));
-        bs.merge(state);
-        bs.commit(
-            NULL_HASH_BLAKE3,
-            BlockHeader{.number = TEST_BLOCK_NUM},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {});
-        tdb.finalize(TEST_BLOCK_NUM, NULL_HASH_BLAKE3);
+        io_ctx.emplace(
+            mpt::ReadOnlyOnDiskDbConfig{.dbname_paths = {db_file.path}});
+        ro.emplace(*io_ctx);
     }
 
     virtual bool in_epoch_delay_period() const = 0;
@@ -130,7 +138,7 @@ class ReadValsetBeforeBoundary : public ReadValsetBase
 
 TEST_F(ReadValsetBeforeBoundary, get_this_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH);
     ASSERT_TRUE(set.has_value());
     EXPECT_EQ(set.value().size(), CONSENSUS_VALSET_LENGTH);
     for (auto const &validator : set.value()) {
@@ -140,19 +148,19 @@ TEST_F(ReadValsetBeforeBoundary, get_this_epoch_valset)
 
 TEST_F(ReadValsetBeforeBoundary, get_next_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
     EXPECT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetBeforeBoundary, asking_for_expired_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
     ASSERT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetBeforeBoundary, asking_for_future_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
     ASSERT_FALSE(set.has_value());
 }
 
@@ -166,7 +174,7 @@ class ReadValsetAfterBoundary : public ReadValsetBase
 
 TEST_F(ReadValsetAfterBoundary, get_this_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH);
 
     // expect the snapshot view when requesting current epoch valset
     ASSERT_TRUE(set.has_value());
@@ -178,7 +186,7 @@ TEST_F(ReadValsetAfterBoundary, get_this_epoch_valset)
 
 TEST_F(ReadValsetAfterBoundary, get_next_epoch_valset)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH + 1);
 
     // expect the consensus view when requesting current epoch valset
     ASSERT_TRUE(set.has_value());
@@ -190,12 +198,12 @@ TEST_F(ReadValsetAfterBoundary, get_next_epoch_valset)
 
 TEST_F(ReadValsetAfterBoundary, asking_for_expired_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH - 1);
     EXPECT_FALSE(set.has_value());
 }
 
 TEST_F(ReadValsetAfterBoundary, asking_for_future_epoch)
 {
-    auto const set = read_valset(ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
+    auto const set = read_valset(*ro, TEST_BLOCK_NUM, TEST_EPOCH + 3);
     EXPECT_FALSE(set.has_value());
 }


### PR DESCRIPTION
…tests

Replace named temp files (mkstemp + manual cleanup) with anonymous inodes via make_temporary_inode(), referenced through /proc/self/fd/<N>. Files are automatically reclaimed by the OS when the fd closes, even on crash or abort.

Also replace hardcoded /tmp/snapshot paths with mkdtemp-based TempDir RAII to avoid conflicts between concurrent test runs.