### PR TITLE
[test] Enable statesync parallel test execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,24 +229,11 @@ function(monad_add_test2 target)
     PRIVATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test/unit/common/include")
   target_include_directories(${target} PRIVATE "${TOP_CURRENT_BINARY_DIR}/test")
   target_link_libraries(${target} monad_execution GTest::GTest GTest::Main)
-  if("${target}" MATCHES "test_statesync")
-    gtest_discover_tests(
-      ${target} DISCOVERY_MODE PRE_TEST
-      PROPERTIES RUN_SERIAL
-                 TRUE
-                 ENVIRONMENT
-                 ASAN_OPTIONS=abort_on_error=1
-                 ENVIRONMENT
-                 UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1
-                 ENVIRONMENT
-                 TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer)
-  else()
-    gtest_discover_tests(
-      ${target} DISCOVERY_MODE PRE_TEST
-      PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
-                 UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
-                 TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer)
-  endif()
+  gtest_discover_tests(
+    ${target} DISCOVERY_MODE PRE_TEST
+    PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
+               UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
+               TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer)
 endfunction()
 
 function(monad_add_test_folder target)

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -50,6 +50,7 @@ monad_statesync_client_context *monad_statesync_client_context_create(
         sq_thread_cpu == MONAD_SQPOLL_DISABLED
             ? std::nullopt
             : std::make_optional(sq_thread_cpu),
+        32,
         sync,
         statesync_send_request};
 }

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -30,7 +30,7 @@ using namespace monad::mpt;
 
 monad_statesync_client_context::monad_statesync_client_context(
     std::vector<std::filesystem::path> const dbname_paths,
-    std::optional<unsigned> const sq_thread_cpu,
+    std::optional<unsigned> const sq_thread_cpu, unsigned const wr_buffers,
     monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
@@ -40,7 +40,7 @@ monad_statesync_client_context::monad_statesync_client_context(
              .compaction = false,
              .rewind_to_latest_finalized = true,
              .rd_buffers = 8192,
-             .wr_buffers = 32,
+             .wr_buffers = wr_buffers,
              .uring_entries = 128,
              .sq_thread_cpu = sq_thread_cpu,
              .dbname_paths = dbname_paths}}

--- a/category/statesync/statesync_client_context.hpp
+++ b/category/statesync/statesync_client_context.hpp
@@ -64,7 +64,8 @@ struct monad_statesync_client_context
 
     monad_statesync_client_context(
         std::vector<std::filesystem::path> dbname_paths,
-        std::optional<unsigned> sq_thread_cpu, monad_statesync_client *,
+        std::optional<unsigned> sq_thread_cpu, unsigned wr_buffers,
+        monad_statesync_client *,
         void (*statesync_send_request)(
             struct monad_statesync_client *, struct monad_sync_request));
 

--- a/category/statesync/test/test_network_shutdown.cpp
+++ b/category/statesync/test/test_network_shutdown.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/async/util.hpp>
 #include <category/core/assert.h>
 #include <category/core/basic_formatter.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
@@ -37,13 +38,60 @@
 #include <thread>
 #include <unistd.h>
 
+namespace
+{
+    // Returns a socket path unique per process to avoid bind() collisions when
+    // tests run in parallel. Assumes TMPDIR is short enough that the full path
+    // stays within sun_path (108 bytes).
+    std::filesystem::path unique_socket_path(std::string_view name)
+    {
+        return std::filesystem::temp_directory_path() /
+               (std::string(name) + "_" + std::to_string(::getpid()) + ".sock");
+    }
+
+    // RAII wrapper for a temporary DB file with no persistent directory entry
+    // (accessed via /proc/self/fd/<n>, auto-deleted when fd is closed).
+    // The constructor also initializes the on-disk DB format so the file is
+    // ready for subsequent Db opens.
+    struct TempDb
+    {
+        int fd;
+        std::string path;
+
+        TempDb()
+            : fd{MONAD_ASYNC_NAMESPACE::make_temporary_inode()}
+            , path{"/proc/self/fd/" + std::to_string(fd)}
+        {
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 !=
+                ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
+            monad::OnDiskMachine machine;
+            // Initialize the on-disk DB format; the Db object is not needed
+            // after this point.
+            (void)monad::mpt::Db{
+                machine,
+                monad::mpt::OnDiskDbConfig{
+                    .append = false, .dbname_paths = {path}}};
+        }
+
+        TempDb(TempDb const &) = delete;
+        TempDb &operator=(TempDb const &) = delete;
+
+        ~TempDb()
+        {
+            ::close(fd);
+        }
+    };
+}
+
 TEST(StateSyncThread, shutdown_via_jthread_stop_token)
 {
     // Tests production shutdown: request_stop() → stop_callback →
     // signal_shutdown() → eventfd → poll() wakes → thread exits
 
     std::filesystem::path const socket_path =
-        std::filesystem::temp_directory_path() / "test_statesync_prod.sock";
+        unique_socket_path("test_statesync_prod");
     std::filesystem::remove(socket_path);
     BOOST_SCOPE_EXIT(&socket_path)
     {
@@ -53,6 +101,11 @@ TEST(StateSyncThread, shutdown_via_jthread_stop_token)
 
     int const listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     ASSERT_GE(listen_fd, 0) << "Failed to create socket: " << strerror(errno);
+    BOOST_SCOPE_EXIT(&listen_fd)
+    {
+        close(listen_fd);
+    }
+    BOOST_SCOPE_EXIT_END
 
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
@@ -64,24 +117,10 @@ TEST(StateSyncThread, shutdown_via_jthread_stop_token)
     ASSERT_EQ(listen(listen_fd, 1), 0)
         << "Failed to listen on socket: " << strerror(errno);
 
-    std::filesystem::path const dbname =
-        std::filesystem::temp_directory_path() / "test_triedb_shutdown.mdb";
-    std::filesystem::remove(dbname);
-    BOOST_SCOPE_EXIT(&dbname)
-    {
-        std::filesystem::remove(dbname);
-    }
-    BOOST_SCOPE_EXIT_END
-
-    int const fd =
-        ::open(dbname.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
-    ASSERT_GE(fd, 0) << "Failed to create db file: " << strerror(errno);
-    ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)), 0)
-        << "Failed to truncate db file: " << strerror(errno);
-    ::close(fd);
+    TempDb const db_file;
 
     monad::mpt::AsyncIOContext io_ctx{
-        monad::mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}};
+        monad::mpt::ReadOnlyOnDiskDbConfig{.dbname_paths = {db_file.path}}};
     monad::mpt::Db db{io_ctx};
     monad::TrieDb triedb(db);
 
@@ -100,14 +139,13 @@ TEST(StateSyncThread, shutdown_via_jthread_stop_token)
     BOOST_SCOPE_EXIT_END
 
     connect_thread.join();
-    close(listen_fd);
 
     std::unique_ptr<monad::StateSyncServer> sync_server =
         monad::make_statesync_server(monad::StateSyncServerConfig{
             .triedb = &triedb,
             .network = &*net,
             .ro_sq_thread_cpu = std::nullopt,
-            .dbname_paths = {dbname}});
+            .dbname_paths = {db_file.path}});
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
@@ -120,8 +158,7 @@ TEST(StateSyncThread, shutdown_during_reconnect)
     // Tests shutdown works when connect() is stuck in retry loop
 
     std::filesystem::path const socket_path =
-        std::filesystem::temp_directory_path() /
-        "test_statesync_reconnect.sock";
+        unique_socket_path("test_statesync_reconnect");
     std::filesystem::remove(socket_path);
     BOOST_SCOPE_EXIT(&socket_path)
     {
@@ -131,6 +168,11 @@ TEST(StateSyncThread, shutdown_during_reconnect)
 
     int const listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     ASSERT_GE(listen_fd, 0) << "Failed to create socket: " << strerror(errno);
+    BOOST_SCOPE_EXIT(&listen_fd)
+    {
+        close(listen_fd);
+    }
+    BOOST_SCOPE_EXIT_END
 
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
@@ -142,24 +184,10 @@ TEST(StateSyncThread, shutdown_during_reconnect)
     ASSERT_EQ(listen(listen_fd, 1), 0)
         << "Failed to listen on socket: " << strerror(errno);
 
-    std::filesystem::path const dbname =
-        std::filesystem::temp_directory_path() / "test_triedb_reconnect.mdb";
-    std::filesystem::remove(dbname);
-    BOOST_SCOPE_EXIT(&dbname)
-    {
-        std::filesystem::remove(dbname);
-    }
-    BOOST_SCOPE_EXIT_END
-
-    int const fd =
-        ::open(dbname.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
-    ASSERT_GE(fd, 0) << "Failed to create db file: " << strerror(errno);
-    ASSERT_EQ(::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)), 0)
-        << "Failed to truncate db file: " << strerror(errno);
-    ::close(fd);
+    TempDb const db_file;
 
     monad::mpt::AsyncIOContext io_ctx{
-        monad::mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}};
+        monad::mpt::ReadOnlyOnDiskDbConfig{.dbname_paths = {db_file.path}}};
     monad::mpt::Db db{io_ctx};
     monad::TrieDb triedb(db);
 
@@ -178,14 +206,13 @@ TEST(StateSyncThread, shutdown_during_reconnect)
     BOOST_SCOPE_EXIT_END
 
     connect_thread.join();
-    close(listen_fd);
 
     std::unique_ptr<monad::StateSyncServer> sync_server =
         monad::make_statesync_server(monad::StateSyncServerConfig{
             .triedb = &triedb,
             .network = &*net,
             .ro_sq_thread_cpu = std::nullopt,
-            .dbname_paths = {dbname}});
+            .dbname_paths = {db_file.path}});
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -26,6 +26,7 @@
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_client.h>
+#include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
 #include <category/statesync/statesync_version.h>
@@ -166,13 +167,12 @@ namespace
 
         void init()
         {
-            char const *const str = cdbname.c_str();
-            cctx = monad_statesync_client_context_create(
-                &str,
-                1,
-                static_cast<unsigned>(get_nprocs() - 1),
+            cctx = new monad_statesync_client_context{
+                {cdbname},
+                std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),
+                4,
                 &client,
-                &statesync_send_request);
+                &statesync_send_request};
             net = {.client = &client, .cctx = cctx};
             for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
                 monad_statesync_client_handle_new_peer(


### PR DESCRIPTION
Three issues prevented statesync tests from running in parallel:

1. test_network_shutdown.cpp used hardcoded Unix socket paths, causing bind() failures when multiple test processes ran simultaneously. Fixed by using PID-unique paths. Also replaced manual DB file management with a TempDb RAII wrapper using anonymous inodes for automatic cleanup, and added BOOST_SCOPE_EXIT guards for listen_fd so it is always closed even if an ASSERT fires early.

2. test_statesync.cpp used wr_buffers=32 (256 MB of locked hugepages) via monad_statesync_client_context_create, exhausting the hugepage pool under parallel load. Fixed by making wr_buffers a constructor parameter (default 32 for production via the C wrapper) and having the test construct monad_statesync_client_context directly with wr_buffers=4.

3. CMakeLists.txt had RUN_SERIAL TRUE for all targets matching "test_statesync". Removed now that the root causes are fixed.