### PR TITLE
Explicitly set binary hardening flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ function(monad_compile_options target)
   target_compile_options(${target} PRIVATE -Wall -Wextra -Wconversion -Werror)
   target_compile_definitions(${target} PUBLIC "_GNU_SOURCE")
 
+  target_compile_options(${target} PRIVATE -fstack-protector-strong -fPIC)
+  target_compile_options(${target} PRIVATE $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1>)
+  target_link_options(${target} PRIVATE -Wl,-z,relro,-z,now,-z,noexecstack,-z,separate-code)
+
   target_compile_options(
     ${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers>)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ ARG GIT_COMMIT_HASH
 
 ENV GIT_COMMIT_HASH=$GIT_COMMIT_HASH
 
-RUN cd src && CC=${CC:?} CXX=${CXX:?} CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:?} CFLAGS="-march=haswell" CXXFLAGS="-march=haswell" ASMFLAGS="-march=haswell" ./scripts/configure.sh
+RUN cd src && CC=${CC:?} CXX=${CXX:?} CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:?} CFLAGS="-march=haswell -fstack-protector-strong -fPIC" CXXFLAGS="-march=haswell -fstack-protector-strong -fPIC" ASMFLAGS="-march=haswell" LDFLAGS="-Wl,-z,relro,-z,now,-z,noexecstack,-z,separate-code" ./scripts/configure.sh
 
 RUN cd src && ./scripts/build.sh
 


### PR DESCRIPTION
Most of these flags are already derived as defaults when compiling on Ubuntu 25.10, but to ensure consistency between builds made with different compilers it's recommended to explicitly define them.

`_FORTIFY_SOURCE` is set to 1 to make sure it isn't adding any overhead, but can be increased if needed.