### PR TITLE
[core/rlp]: decode: Error for oversized bytes32

### DIFF
--- a/category/execution/ethereum/core/rlp/bytes_rlp.hpp
+++ b/category/execution/ethereum/core/rlp/bytes_rlp.hpp
@@ -17,9 +17,11 @@
 
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/likely.h>
 #include <category/core/result.hpp>
 #include <category/core/rlp/config.hpp>
 #include <category/execution/ethereum/rlp/decode.hpp>
+#include <category/execution/ethereum/rlp/decode_error.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
 
 MONAD_RLP_NAMESPACE_BEGIN
@@ -43,6 +45,9 @@ inline Result<bytes32_t> decode_bytes32(byte_string_view &enc)
 inline Result<bytes32_t> decode_bytes32_compact(byte_string_view &enc)
 {
     BOOST_OUTCOME_TRY(auto const byte_array, decode_string(enc));
+    if (MONAD_UNLIKELY(byte_array.size() > sizeof(bytes32_t))) {
+        return DecodeError::InputTooLong;
+    }
     return to_bytes(byte_array);
 }
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -25,6 +25,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
@@ -1354,4 +1355,19 @@ TEST_F(StateSyncFixture, validation_old_target_greater_than_target)
     client.rqs.push_back(rq);
     monad_statesync_server_run_once(server);
     EXPECT_FALSE(client.success);
+}
+
+TEST(ProtocolValidation, storage_deletion_rejects_oversized_key)
+{
+    StatesyncProtocolV1 proto;
+
+    Address a{0xdeadbeef};
+    byte_string oversized_key(33, 0xff);
+
+    byte_string buf{};
+    buf += to_byte_string_view(a.bytes);
+    buf += rlp::encode_string2(oversized_key);
+
+    EXPECT_FALSE(proto.handle_upsert(
+        nullptr, SYNC_TYPE_UPSERT_STORAGE_DELETE, buf.data(), buf.size()));
 }


### PR DESCRIPTION
Added a unit test in statesync that passes with this fix.