### PR TITLE
[mpt] Promote MONAD_DEBUG_ASSERT → MONAD_ASSERT for production invari…

### DIFF
--- a/category/core/io/buffers.hpp
+++ b/category/core/io/buffers.hpp
@@ -113,18 +113,16 @@ public:
 
     [[gnu::always_inline]] unsigned char *get_read_buffer(size_t const i) const
     {
-        MONAD_DEBUG_ASSERT(i < read_count_);
+        MONAD_ASSERT(i < read_count_);
         unsigned char *const ret = read_buf_.get_data() + (i << read_bits_);
-        MONAD_DEBUG_ASSERT(((void)ret[0], true));
         return ret;
     }
 
     [[gnu::always_inline]] unsigned char *get_write_buffer(size_t const i) const
     {
-        MONAD_DEBUG_ASSERT(i < write_count_);
+        MONAD_ASSERT(i < write_count_);
         unsigned char *const ret =
             write_buf_.value().get_data() + (i << write_bits_);
-        MONAD_DEBUG_ASSERT(((void)ret[0], true));
         return ret;
     }
 };

--- a/category/core/mem/align.h
+++ b/category/core/mem/align.h
@@ -38,14 +38,14 @@
 [[gnu::always_inline]] static inline size_t
 monad_round_size_to_align(size_t const size, size_t const align)
 {
-    MONAD_DEBUG_ASSERT(std::has_single_bit(align));
+    MONAD_ASSERT(std::has_single_bit(align));
     return (size + align - 1) & ~(align - 1);
 }
 #else
 [[gnu::always_inline]] static inline size_t
 monad_round_size_to_align(size_t const size, size_t const align)
 {
-    MONAD_DEBUG_ASSERT(stdc_has_single_bit(align));
+    MONAD_ASSERT(stdc_has_single_bit(align));
     return (size + align - 1) & ~(align - 1);
 }
 #endif

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -114,7 +114,6 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
 
     auto encoded_account = res.value().node->value();
     auto const acct = decode_account_db_ignore_address(encoded_account);
-    MONAD_DEBUG_ASSERT(!acct.has_error());
     return acct.value();
 }
 
@@ -435,7 +434,6 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             auto encoded_account = node.value();
 
             auto acct = decode_account_db(encoded_account);
-            MONAD_DEBUG_ASSERT(!acct.has_error());
 
             auto const key = fmt::format("{}", NibblesView{path});
 
@@ -461,7 +459,6 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             auto encoded_storage = node.value();
 
             auto const storage = decode_storage_db(encoded_storage);
-            MONAD_DEBUG_ASSERT(!storage.has_error());
 
             auto const acct_key = fmt::format(
                 "{}", NibblesView{path}.substr(0, KECCAK256_SIZE * 2));

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -86,7 +86,6 @@ public:
         }
         auto encoded_account = acc_leaf_res.value().node->value();
         auto const acct = decode_account_db_ignore_address(encoded_account);
-        MONAD_DEBUG_ASSERT(!acct.has_error());
         return acct.value();
     }
 

--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -247,7 +247,7 @@ ReservedExecEvent<T> ExecutionEventRecorder::reserve_block_event(
     uint8_t *payload_buf;
     monad_event_descriptor *const event = monad_event_recorder_reserve(
         &exec_recorder_, payload_size, &seqno, &payload_buf);
-    MONAD_DEBUG_ASSERT(event != nullptr);
+    MONAD_ASSERT(event != nullptr);
     if constexpr (sizeof...(trailing_bufs) > 0) {
         // Copy the variable-length trailing buffers; GCC issues a false
         // positive warning about this memcpy that must be disabled

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -107,7 +107,7 @@ static inline PrecompileResult silkpre_execute(byte_string_view const input)
 {
     auto const [output, output_size] = Func(input.data(), input.size());
     if (output == nullptr) {
-        MONAD_DEBUG_ASSERT(output_size == 0);
+        MONAD_ASSERT(output_size == 0);
         return {EVMC_PRECOMPILE_FAILURE, nullptr, 0};
     }
     return {EVMC_SUCCESS, output, output_size};

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -450,7 +450,7 @@ public:
             auto chunkid = item->index(aux.db_metadata());
             count++;
             auto &chunk = pool->chunk(pool->seq, chunkid);
-            MONAD_DEBUG_ASSERT(chunk.zone_id().second == chunkid);
+            MONAD_ASSERT(chunk.zone_id().second == chunkid);
             if constexpr (!std::is_void_v<T>) {
                 if (list != nullptr) {
                     la_int64_t const metadata =

--- a/category/mpt/compute.cpp
+++ b/category/mpt/compute.cpp
@@ -37,7 +37,7 @@ unsigned encode_two_pieces(
 {
     constexpr size_t max_compact_encode_size = KECCAK256_SIZE + 1;
 
-    MONAD_DEBUG_ASSERT(path.data_size() <= KECCAK256_SIZE);
+    MONAD_ASSERT(path.data_size() <= KECCAK256_SIZE);
 
     unsigned char path_arr[max_compact_encode_size];
     auto const first = compact_encode(path_arr, path, has_value);
@@ -55,7 +55,7 @@ unsigned encode_two_pieces(
         memcpy(result.data(), second.data(), second.size());
         return result.subspan(second.size());
     }();
-    MONAD_DEBUG_ASSERT(
+    MONAD_ASSERT(
         (unsigned long)(result.data() - concat_rlp.data()) == concat_len);
 
     byte_string rlp(rlp::list_length(concat_len), 0);
@@ -77,13 +77,12 @@ std::span<unsigned char> encode_16_children(
     unsigned i = 0;
     for (auto &child : children) {
         if (child.is_valid()) {
-            MONAD_DEBUG_ASSERT(child.branch < 16);
+            MONAD_ASSERT(child.branch < 16);
             while (child.branch != i) {
                 result[0] = RLP_EMPTY_STRING;
                 result = result.subspan(1);
                 ++i;
             }
-            MONAD_DEBUG_ASSERT(i == child.branch);
             result = (child.len < KECCAK256_SIZE)
                          ? [&] {
                                memcpy(result.data(), child.data, child.len);
@@ -103,12 +102,10 @@ std::span<unsigned char> encode_16_children(
 std::span<unsigned char>
 encode_16_children(Node const &node, std::span<unsigned char> result)
 {
-
     for (unsigned i = 0, bit = 1; i < 16; ++i, bit <<= 1) {
         if (node.mask & bit) {
             auto const child_index = node.to_child_index(i);
-            MONAD_DEBUG_ASSERT(
-                node.child_data_len(child_index) <= KECCAK256_SIZE);
+            MONAD_ASSERT(node.child_data_len(child_index) <= KECCAK256_SIZE);
             result =
                 (node.child_data_len(child_index) < KECCAK256_SIZE)
                     ? [&] {

--- a/category/mpt/compute.hpp
+++ b/category/mpt/compute.hpp
@@ -40,7 +40,7 @@ namespace detail
 
         void keccak_inplace_to_root_hash()
         {
-            MONAD_DEBUG_ASSERT(len <= KECCAK256_SIZE);
+            MONAD_ASSERT(len <= KECCAK256_SIZE);
             if (len < KECCAK256_SIZE) {
                 keccak256(buffer, len, buffer);
                 len = KECCAK256_SIZE;
@@ -125,7 +125,7 @@ struct MerkleComputeBase : Compute
         NibblesView /*path*/,
         std::optional<byte_string_view> const value) override
     {
-        MONAD_DEBUG_ASSERT(mask);
+        MONAD_ASSERT(mask);
         if (!value.has_value()) {
             // no intermediate data for non-leaf node
             return 0;
@@ -136,9 +136,7 @@ struct MerkleComputeBase : Compute
                 children, [](ChildData const &item) constexpr {
                     return item.is_valid();
                 });
-            MONAD_DEBUG_ASSERT(it != children.end());
-            MONAD_DEBUG_ASSERT(it->branch < 16);
-            MONAD_DEBUG_ASSERT(it->ptr);
+            MONAD_ASSERT(it != children.end());
             compute_hash_with_extra_nibble_to_state_(*it);
             // root data of a subtrie is always a hash
             state.keccak_inplace_to_root_hash();
@@ -151,11 +149,11 @@ struct MerkleComputeBase : Compute
         result = encode_empty_string(result);
         auto const concat_len =
             static_cast<size_t>(result.data() - branch_str_rlp);
-        MONAD_DEBUG_ASSERT(concat_len <= max_branch_rlp_size);
+        MONAD_ASSERT(concat_len <= max_branch_rlp_size);
 
         // encode list
         auto const rlp_len = rlp::list_length(concat_len);
-        MONAD_DEBUG_ASSERT(rlp_len <= max_branch_rlp_size);
+        MONAD_ASSERT(rlp_len <= max_branch_rlp_size);
         unsigned char branch_rlp[max_branch_rlp_size];
         rlp::encode_list(
             branch_rlp, byte_string_view{branch_str_rlp, concat_len});
@@ -191,7 +189,7 @@ struct MerkleComputeBase : Compute
                 LeafValueProcessor::process(node), // processed leaf data
                 true);
         }
-        MONAD_DEBUG_ASSERT(node.number_of_children() > 1);
+        MONAD_ASSERT(node.number_of_children() > 1);
         if (node.has_path()) {
             unsigned char reference[KECCAK256_SIZE];
             unsigned len = compute_branch_reference_(reference, node);
@@ -207,7 +205,7 @@ private:
     unsigned compute_hash_with_extra_nibble_to_state_(ChildData &single_child)
     {
         Node *const node = single_child.ptr.get();
-        MONAD_DEBUG_ASSERT(node);
+        MONAD_ASSERT(node);
 
         return state.len = encode_two_pieces(
                 state.buffer,
@@ -238,7 +236,7 @@ private:
             static_cast<size_t>(result.data() - branch_str_rlp);
         MONAD_ASSERT(concat_len <= max_branch_rlp_size);
         auto const branch_rlp_len = rlp::list_length(concat_len);
-        MONAD_DEBUG_ASSERT(branch_rlp_len <= max_branch_rlp_size);
+        MONAD_ASSERT(branch_rlp_len <= max_branch_rlp_size);
 
         unsigned char branch_rlp[max_branch_rlp_size];
         rlp::encode_list(
@@ -396,9 +394,7 @@ struct RootVarLenMerkleCompute : public VarLenMerkleCompute<LeafValueProcessor>
                 children, [](ChildData const &item) constexpr {
                     return item.is_valid();
                 });
-            MONAD_DEBUG_ASSERT(it != children.end());
-            MONAD_DEBUG_ASSERT(it->branch < 16);
-            MONAD_DEBUG_ASSERT(it->ptr);
+            MONAD_ASSERT(it != children.end());
             compute_hash_with_extra_nibble_to_state_(*it);
         }
         else {
@@ -419,7 +415,7 @@ private:
     unsigned compute_hash_with_extra_nibble_to_state_(ChildData &single_child)
     {
         Node *const node = single_child.ptr.get();
-        MONAD_DEBUG_ASSERT(node);
+        MONAD_ASSERT(node != nullptr);
 
         return state.len = encode_two_pieces(
                    state.buffer,

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -177,7 +177,7 @@ Node::SharedPtr copy_trie_impl(
                 ++node_prefix_index;
                 continue;
             }
-            MONAD_DEBUG_ASSERT(
+            MONAD_ASSERT(
                 prefix_index < std::numeric_limits<unsigned char>::max());
             auto const node_path = node->path_nibble_view();
             // copy children of src_node to under `dest` prefix, move the in
@@ -225,8 +225,7 @@ Node::SharedPtr copy_trie_impl(
             ++prefix_index;
             continue;
         }
-        MONAD_DEBUG_ASSERT(
-            prefix_index < std::numeric_limits<unsigned char>::max());
+        MONAD_ASSERT(prefix_index < std::numeric_limits<unsigned char>::max());
         auto dest_node = make_node(
             src_node,
             dest_prefix.substr(static_cast<unsigned char>(prefix_index) + 1u),

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1073,8 +1073,8 @@ Result<NodeCursor> RODb::find(
     if (result != find_result::success) {
         return find_result_to_db_error(result);
     }
-    MONAD_DEBUG_ASSERT(cursor.is_valid());
-    MONAD_DEBUG_ASSERT(cursor.node->has_value());
+    MONAD_ASSERT(cursor.is_valid());
+    MONAD_ASSERT(cursor.node->has_value());
     return cursor;
 }
 
@@ -1104,7 +1104,7 @@ Db::Db(StateMachine &machine)
 Db::Db(StateMachine &machine, OnDiskDbConfig const &config)
     : impl_{std::make_unique<RWOnDisk>(config, machine)}
 {
-    MONAD_DEBUG_ASSERT(impl_->aux().is_on_disk());
+    MONAD_ASSERT(impl_->aux().is_on_disk());
 }
 
 Db::Db(AsyncIOContext &io_ctx)
@@ -1123,8 +1123,8 @@ Result<NodeCursor> Db::find(
     if (result != find_result::success) {
         return find_result_to_db_error(result);
     }
-    MONAD_DEBUG_ASSERT(it.node != nullptr);
-    MONAD_DEBUG_ASSERT(it.node->has_value());
+    MONAD_ASSERT(it.node != nullptr);
+    MONAD_ASSERT(it.node->has_value());
     return it;
 }
 
@@ -1365,7 +1365,7 @@ namespace detail
             rd_offset = offset_;
             auto const new_offset =
                 round_down_align<DISK_PAGE_BITS>(offset_.offset);
-            MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
+            MONAD_ASSERT(new_offset <= chunk_offset_t::max_offset);
             rd_offset.offset = new_offset & chunk_offset_t::max_offset;
             buffer_off = uint16_t(offset_.offset - rd_offset.offset);
         }

--- a/category/mpt/deserialize_node_from_receiver_result.hpp
+++ b/category/mpt/deserialize_node_from_receiver_result.hpp
@@ -81,7 +81,7 @@ namespace detail
             auto const &buffer = buffer_.assume_value().front();
             MONAD_ASSERT(buffer.size() > buffer_off);
             // Did the Receiver forget to set lifetime_managed_internally?
-            MONAD_DEBUG_ASSERT(io_state->lifetime_is_managed_internally());
+            MONAD_ASSERT(io_state->lifetime_is_managed_internally());
             node = deserialize_node_from_buffer(
                 (unsigned char *)buffer.data() + buffer_off,
                 buffer.size() - buffer_off);

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -189,7 +189,7 @@ namespace detail
             uint32_t index(db_metadata const *parent) const noexcept
             {
                 auto const ret = uint32_t(this - parent->chunk_info);
-                MONAD_DEBUG_ASSERT(ret < parent->chunk_info_count);
+                MONAD_ASSERT(ret < parent->chunk_info_count);
                 return ret;
             }
 
@@ -204,8 +204,7 @@ namespace detail
                 if (prev_chunk_id == INVALID_CHUNK_ID) {
                     return nullptr;
                 }
-                MONAD_DEBUG_ASSERT(prev_chunk_id < parent->chunk_info_count);
-                return &parent->chunk_info[prev_chunk_id];
+                return parent->at(prev_chunk_id);
             }
 
             chunk_info_t const *next(db_metadata const *parent) const noexcept
@@ -213,8 +212,7 @@ namespace detail
                 if (next_chunk_id == INVALID_CHUNK_ID) {
                     return nullptr;
                 }
-                MONAD_DEBUG_ASSERT(next_chunk_id < parent->chunk_info_count);
-                return &parent->chunk_info[next_chunk_id];
+                return parent->at(next_chunk_id);
             }
         };
 #ifdef __clang__
@@ -268,7 +266,7 @@ namespace detail
 
         chunk_info_t const *at(uint32_t idx) const noexcept
         {
-            MONAD_DEBUG_ASSERT(idx < chunk_info_count);
+            MONAD_ASSERT(idx < chunk_info_count);
             return &chunk_info[idx];
         }
 
@@ -280,19 +278,12 @@ namespace detail
                 ->load(load_ord);
         }
 
-        chunk_info_t const &operator[](uint32_t idx) const noexcept
-        {
-            MONAD_DEBUG_ASSERT(idx < chunk_info_count);
-            return chunk_info[idx];
-        }
-
         chunk_info_t const *free_list_begin() const noexcept
         {
             if (free_list.begin == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(free_list.begin < chunk_info_count);
-            return &chunk_info[free_list.begin];
+            return at(free_list.begin);
         }
 
         chunk_info_t const *free_list_end() const noexcept
@@ -300,8 +291,7 @@ namespace detail
             if (free_list.end == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(free_list.end < chunk_info_count);
-            return &chunk_info[free_list.end];
+            return at(free_list.end);
         }
 
         chunk_info_t const *fast_list_begin() const noexcept
@@ -309,8 +299,7 @@ namespace detail
             if (fast_list.begin == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(fast_list.begin < chunk_info_count);
-            return &chunk_info[fast_list.begin];
+            return at(fast_list.begin);
         }
 
         chunk_info_t const *fast_list_end() const noexcept
@@ -318,8 +307,7 @@ namespace detail
             if (fast_list.end == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(fast_list.end < chunk_info_count);
-            return &chunk_info[fast_list.end];
+            return at(fast_list.end);
         }
 
         chunk_info_t const *slow_list_begin() const noexcept
@@ -327,8 +315,7 @@ namespace detail
             if (slow_list.begin == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(slow_list.begin < chunk_info_count);
-            return &chunk_info[slow_list.begin];
+            return at(slow_list.begin);
         }
 
         chunk_info_t const *slow_list_end() const noexcept
@@ -336,14 +323,13 @@ namespace detail
             if (slow_list.end == UINT32_MAX) {
                 return nullptr;
             }
-            MONAD_DEBUG_ASSERT(slow_list.end < chunk_info_count);
-            return &chunk_info[slow_list.end];
+            return at(slow_list.end);
         }
 
     private:
         chunk_info_t *at_(uint32_t idx) noexcept
         {
-            MONAD_DEBUG_ASSERT(idx < chunk_info_count);
+            MONAD_ASSERT(idx < chunk_info_count);
             return &chunk_info[idx];
         }
 
@@ -357,12 +343,12 @@ namespace detail
             info.insertion_count0_ = info.insertion_count1_ = 0;
             info.next_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
             if (list.end == UINT32_MAX) {
-                MONAD_DEBUG_ASSERT(list.begin == UINT32_MAX);
+                MONAD_ASSERT(list.begin == UINT32_MAX);
                 info.prev_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
                 list.begin = list.end = i->index(this);
             }
             else {
-                MONAD_DEBUG_ASSERT((list.end & ~0xfffffU) == 0);
+                MONAD_ASSERT((list.end & ~0xfffffU) == 0);
                 info.prev_chunk_id = list.end & 0xfffffU;
                 auto *tail = at_(list.end);
                 uint32_t const insertion_count =
@@ -401,8 +387,8 @@ namespace detail
             if (i->prev_chunk_id == chunk_info_t::INVALID_CHUNK_ID &&
                 i->next_chunk_id == chunk_info_t::INVALID_CHUNK_ID) {
                 id_pair &list = get_list();
-                MONAD_DEBUG_ASSERT(list.begin == i->index(this));
-                MONAD_DEBUG_ASSERT(list.end == i->index(this));
+                MONAD_ASSERT(list.begin == i->index(this));
+                MONAD_ASSERT(list.end == i->index(this));
                 list.begin = list.end = UINT32_MAX;
 #ifndef NDEBUG
                 i->in_fast_list = i->in_slow_list = false;
@@ -411,7 +397,7 @@ namespace detail
             }
             if (i->prev_chunk_id == chunk_info_t::INVALID_CHUNK_ID) {
                 id_pair &list = get_list();
-                MONAD_DEBUG_ASSERT(list.begin == i->index(this));
+                MONAD_ASSERT(list.begin == i->index(this));
                 auto *next = at_(i->next_chunk_id);
                 next->prev_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
                 list.begin = next->index(this);
@@ -423,7 +409,7 @@ namespace detail
             }
             if (i->next_chunk_id == chunk_info_t::INVALID_CHUNK_ID) {
                 id_pair &list = get_list();
-                MONAD_DEBUG_ASSERT(list.end == i->index(this));
+                MONAD_ASSERT(list.end == i->index(this));
                 auto *prev = at_(i->prev_chunk_id);
                 prev->next_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
                 list.end = prev->index(this);

--- a/category/mpt/detail/unsigned_20.hpp
+++ b/category/mpt/detail/unsigned_20.hpp
@@ -38,7 +38,7 @@ namespace detail
         constexpr unsigned_20(uint32_t v)
             : v_(v & 0xfffff)
         {
-            MONAD_DEBUG_ASSERT(v == uint32_t(-1) || (v >> 20) == 0);
+            MONAD_ASSERT(v == uint32_t(-1) || (v >> 20) == 0);
         }
 
         constexpr explicit operator uint32_t() const noexcept

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -35,7 +35,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <limits>
 #include <memory>
 #include <utility>
 
@@ -76,7 +75,6 @@ namespace
             rd_offset = offset;
             auto const new_offset =
                 round_down_align<DISK_PAGE_BITS>(offset.offset);
-            MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
             rd_offset.offset = new_offset & chunk_offset_t::max_offset;
             buffer_off = uint16_t(offset.offset - rd_offset.offset);
         }
@@ -137,7 +135,6 @@ namespace
             rd_offset = offset;
             auto const new_offset =
                 round_down_align<DISK_PAGE_BITS>(offset.offset);
-            MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
             rd_offset.offset = new_offset & chunk_offset_t::max_offset;
             buffer_off = uint16_t(offset.offset - rd_offset.offset);
         }
@@ -240,8 +237,6 @@ void find_notify_fiber_future(
     MONAD_ASSERT(prefix_index < key.nibble_size());
     if (unsigned char const branch = key.get(prefix_index);
         node->mask & (1u << branch)) {
-        MONAD_DEBUG_ASSERT(
-            prefix_index < std::numeric_limits<unsigned char>::max());
         auto const next_key =
             key.substr(static_cast<unsigned char>(prefix_index) + 1u);
         auto const child_index = node->to_child_index(branch);
@@ -321,8 +316,6 @@ void find_owning_notify_fiber_future(
     MONAD_ASSERT(prefix_index < key.nibble_size());
     if (unsigned char const branch = key.get(prefix_index);
         node->mask & (1u << branch)) {
-        MONAD_DEBUG_ASSERT(
-            prefix_index < std::numeric_limits<unsigned char>::max());
         auto const next_key =
             key.substr(static_cast<unsigned char>(prefix_index) + 1u);
         auto const child_index = node->to_child_index(branch);

--- a/category/mpt/find_request_sender.hpp
+++ b/category/mpt/find_request_sender.hpp
@@ -26,7 +26,6 @@
 #include "deserialize_node_from_receiver_result.hpp"
 
 #include <cstdint>
-#include <limits>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
@@ -169,9 +168,8 @@ struct find_request_sender<T>::find_receiver
         bytes_to_read =
             static_cast<unsigned>(num_pages_to_load_node << DISK_PAGE_BITS);
         rd_offset = offset;
-        auto const new_offset = round_down_align<DISK_PAGE_BITS>(offset.offset);
-        MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
-        rd_offset.offset = new_offset & chunk_offset_t::max_offset;
+        rd_offset.offset = round_down_align<DISK_PAGE_BITS>(offset.offset) &
+                           chunk_offset_t::max_offset;
         buffer_off = uint16_t(offset.offset - rd_offset.offset);
     }
 
@@ -246,8 +244,6 @@ inline MONAD_ASYNC_NAMESPACE::result<void> find_request_sender<T>::operator()(
         MONAD_ASSERT(prefix_index < key_.nibble_size());
         if (unsigned char const branch = key_.get(prefix_index);
             node->mask & (1u << branch)) {
-            MONAD_DEBUG_ASSERT(
-                prefix_index < std::numeric_limits<unsigned char>::max());
             key_ = key_.substr(static_cast<unsigned char>(prefix_index) + 1u);
             auto const child_index = node->to_child_index(branch);
             NodeCache::ConstAccessor acc;

--- a/category/mpt/merkle/compact_encode.hpp
+++ b/category/mpt/merkle/compact_encode.hpp
@@ -27,7 +27,7 @@ MONAD_MPT_NAMESPACE_BEGIN
 inline constexpr unsigned
 compact_encode_len(unsigned const si, unsigned const ei)
 {
-    MONAD_DEBUG_ASSERT(ei >= si);
+    MONAD_ASSERT(ei >= si);
     return (ei - si) / 2 + 1;
 }
 
@@ -38,7 +38,7 @@ compact_encode_len(unsigned const si, unsigned const ei)
 {
     unsigned i = 0;
 
-    MONAD_DEBUG_ASSERT(nibbles.nibble_size() || terminating);
+    MONAD_ASSERT(nibbles.nibble_size() || terminating);
 
     // Populate first byte with the encoded nibbles type and potentially
     // also the first nibble if number of nibbles is odd

--- a/category/mpt/nibbles_view.hpp
+++ b/category/mpt/nibbles_view.hpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <span>
 #include <type_traits>
 
 MONAD_MPT_NAMESPACE_BEGIN
@@ -57,7 +58,7 @@ public:
         , begin_nibble_(false)
         , end_nibble_(static_cast<size_type>(end_nibble))
     {
-        MONAD_DEBUG_ASSERT(end_nibble <= std::numeric_limits<size_type>::max());
+        MONAD_ASSERT(end_nibble <= std::numeric_limits<size_type>::max());
 #ifdef __clang_analyzer__ // false positive
         memset(data_.get(), 0, (end_nibble + 1) / 2);
 #endif
@@ -127,13 +128,13 @@ public:
     [[nodiscard]] unsigned char get(unsigned const i) const
     {
         MONAD_ASSERT(i < nibble_size());
-        return get_nibble(data_.get(), begin_nibble_ + i);
+        return ::get_nibble(data_.get(), begin_nibble_ + i);
     }
 
     constexpr void set(unsigned const i, unsigned char const value)
     {
-        MONAD_DEBUG_ASSERT(value <= 0xF);
-        MONAD_DEBUG_ASSERT(
+        MONAD_ASSERT(value <= 0xF);
+        MONAD_ASSERT(
             i < static_cast<unsigned>(
                     end_nibble_ - static_cast<size_type>(begin_nibble_)));
         ::set_nibble(data_.get(), begin_nibble_ + i, value);
@@ -176,7 +177,7 @@ public:
                                : static_cast<size_type>(
                                      end_nibble - begin_nibble + begin_nibble_))
     {
-        MONAD_DEBUG_ASSERT(
+        MONAD_ASSERT(
             begin_nibble <= end_nibble &&
             end_nibble <= std::numeric_limits<size_type>::max());
     }
@@ -186,8 +187,7 @@ public:
     constexpr NibblesView(byte_string_view const &s) noexcept
         : NibblesView(false, static_cast<uint8_t>(2 * s.size()), s.data())
     {
-        MONAD_DEBUG_ASSERT(
-            (s.size() * 2) <= std::numeric_limits<size_type>::max());
+        MONAD_ASSERT((s.size() * 2) <= std::numeric_limits<size_type>::max());
     }
 
     // constructor from byte_string
@@ -228,6 +228,11 @@ public:
                    : ((end_nibble_ + 1) / 2);
     }
 
+    std::span<unsigned char const> data_span() const noexcept
+    {
+        return {data_, data_size()};
+    }
+
     constexpr size_type nibble_size() const
     {
         return end_nibble_ - static_cast<size_type>(begin_nibble_);
@@ -236,7 +241,7 @@ public:
     constexpr NibblesView
     substr(unsigned const pos, unsigned const count = npos) const
     {
-        MONAD_DEBUG_ASSERT(count == npos || count <= (nibble_size() - pos));
+        MONAD_ASSERT(count == npos || count <= (nibble_size() - pos));
         auto const begin_nibble = static_cast<unsigned>(begin_nibble_) + pos;
         return NibblesView{
             begin_nibble,
@@ -263,7 +268,6 @@ public:
         }
 
         if (nibble_size()) {
-            MONAD_DEBUG_ASSERT(data_ && other.data_);
             for (auto i = 0u; i < nibble_size(); ++i) {
                 if (get(i) != other.get(i)) {
                     return false;

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -58,23 +58,17 @@ Node::Node(
           value.transform(&byte_string_view::size).value_or(0)))
     , version(version)
 {
-    MONAD_DEBUG_ASSERT(
-        value.transform(&byte_string_view::size).value_or(0) <=
-        std::numeric_limits<decltype(value_len)>::max());
-    MONAD_DEBUG_ASSERT(path.begin_nibble_ <= path.end_nibble_);
+    MONAD_ASSERT(!value || value->size() == value_len);
     bitpacked.path_nibble_index_start = path.begin_nibble_;
     bitpacked.has_value = value.has_value();
 
     MONAD_ASSERT(data_size <= Node::max_data_len);
     bitpacked.data_len = static_cast<uint8_t>(data_size & Node::max_data_len);
 
-    if (path.data_size()) {
-        MONAD_DEBUG_ASSERT(path.data_);
-        std::copy_n(path.data_, path.data_size(), path_data());
-    }
+    std::ranges::copy(path.data_span(), path_data());
 
     if (value_len) {
-        std::copy_n(value.value().data(), value.value().size(), value_data());
+        std::ranges::copy(*value, value_data());
     }
 }
 
@@ -91,7 +85,6 @@ unsigned Node::to_child_index(unsigned const branch) const noexcept
 {
     // convert the enabled i'th bit in a 16-bit mask into its corresponding
     // index location - index
-    MONAD_DEBUG_ASSERT(mask & (1u << branch));
     return bitmask_index(mask, branch);
 }
 
@@ -102,7 +95,7 @@ unsigned Node::number_of_children() const noexcept
 
 chunk_offset_t const Node::fnext(unsigned const index) const noexcept
 {
-    MONAD_DEBUG_ASSERT(index < number_of_children());
+    MONAD_ASSERT(index < number_of_children());
     return unaligned_load<chunk_offset_t>(
         fnext_data + index * sizeof(chunk_offset_t));
 }
@@ -224,7 +217,7 @@ unsigned char const *Node::child_off_data() const noexcept
 
 uint16_t Node::child_data_offset(unsigned const index) const noexcept
 {
-    MONAD_DEBUG_ASSERT(index <= number_of_children());
+    MONAD_ASSERT(index <= number_of_children());
     if (index == 0) {
         return 0;
     }
@@ -254,8 +247,7 @@ unsigned char const *Node::path_data() const noexcept
 
 unsigned Node::path_nibbles_len() const noexcept
 {
-    MONAD_DEBUG_ASSERT(
-        bitpacked.path_nibble_index_start <= path_nibble_index_end);
+    MONAD_ASSERT(bitpacked.path_nibble_index_start <= path_nibble_index_end);
     return path_nibble_index_end - bitpacked.path_nibble_index_start;
 }
 
@@ -297,7 +289,7 @@ bool Node::has_value() const noexcept
 
 byte_string_view Node::value() const noexcept
 {
-    MONAD_DEBUG_ASSERT(has_value());
+    MONAD_ASSERT(has_value());
     return {value_data(), value_len};
 }
 
@@ -336,7 +328,7 @@ unsigned char const *Node::child_data() const noexcept
 
 byte_string_view Node::child_data_view(unsigned const index) const noexcept
 {
-    MONAD_DEBUG_ASSERT(index < number_of_children());
+    MONAD_ASSERT(index < number_of_children());
     return byte_string_view{
         child_data() + child_data_offset(index),
         static_cast<size_t>(child_data_len(index))};
@@ -344,13 +336,13 @@ byte_string_view Node::child_data_view(unsigned const index) const noexcept
 
 unsigned char *Node::child_data(unsigned const index) noexcept
 {
-    MONAD_DEBUG_ASSERT(index < number_of_children());
+    MONAD_ASSERT(index < number_of_children());
     return child_data() + child_data_offset(index);
 }
 
 unsigned char const *Node::child_data(unsigned const index) const noexcept
 {
-    MONAD_DEBUG_ASSERT(index < number_of_children());
+    MONAD_ASSERT(index < number_of_children());
     return child_data() + child_data_offset(index);
 }
 
@@ -385,11 +377,12 @@ unsigned char const *Node::next_data_aligned() const noexcept
 
 uint32_t Node::get_disk_size() const noexcept
 {
-    MONAD_DEBUG_ASSERT(next_data() >= (unsigned char *)this);
+    auto const *const nd = next_data();
+    MONAD_ASSERT(nd >= (unsigned char *)this);
     auto const node_disk_size =
-        static_cast<uint32_t>(next_data() - (unsigned char *)this);
+        static_cast<uint32_t>(nd - (unsigned char *)this);
     uint32_t const total_disk_size = node_disk_size + Node::disk_size_bytes;
-    MONAD_DEBUG_ASSERT(total_disk_size <= Node::max_disk_size);
+    MONAD_ASSERT(total_disk_size <= Node::max_disk_size);
     return total_disk_size;
 }
 
@@ -429,9 +422,8 @@ unsigned Node::get_mem_size() const noexcept
 {
     auto const *const end =
         next_data_aligned() + sizeof(Node::SharedPtr) * number_of_children();
-    MONAD_DEBUG_ASSERT(end >= (unsigned char *)this);
     auto const mem_size = static_cast<unsigned>(end - (unsigned char *)this);
-    MONAD_DEBUG_ASSERT(mem_size <= Node::max_size);
+    MONAD_ASSERT(mem_size <= Node::max_size);
     return mem_size;
 }
 
@@ -449,10 +441,10 @@ void ChildData::erase()
 void ChildData::finalize(
     Node::SharedPtr node, Compute &compute, bool const cache)
 {
-    MONAD_DEBUG_ASSERT(is_valid());
+    MONAD_ASSERT(is_valid());
     ptr = std::move(node);
     auto const length = compute.compute(data, *ptr);
-    MONAD_DEBUG_ASSERT(length <= std::numeric_limits<uint8_t>::max());
+    MONAD_ASSERT(length <= std::numeric_limits<uint8_t>::max());
     len = static_cast<uint8_t>(length);
     cache_node = cache;
     subtrie_min_version = calc_min_version(*ptr);
@@ -466,16 +458,16 @@ void ChildData::copy_old_child(Node *const old, unsigned const i)
     }
     auto const old_data = old->child_data_view(index);
     memcpy(&data, old_data.data(), old_data.size());
-    MONAD_DEBUG_ASSERT(old_data.size() <= std::numeric_limits<uint8_t>::max());
+    MONAD_ASSERT(old_data.size() <= std::numeric_limits<uint8_t>::max());
     len = static_cast<uint8_t>(old_data.size());
-    MONAD_DEBUG_ASSERT(i < 16);
+    MONAD_ASSERT(i < 16);
     branch = static_cast<uint8_t>(i);
     offset = old->fnext(index);
     min_offsets = old->min_offsets(index);
     subtrie_min_version = old->subtrie_min_version(index);
     cache_node = ptr != nullptr;
 
-    MONAD_DEBUG_ASSERT(is_valid());
+    MONAD_ASSERT(is_valid());
 }
 
 Node::SharedPtr make_node(
@@ -525,18 +517,13 @@ Node::SharedPtr make_node(
     NibblesView const path, std::optional<byte_string_view> const value,
     size_t const data_size, int64_t const version)
 {
-    for (size_t i = 0; i < 16; ++i) {
-        MONAD_DEBUG_ASSERT(
-            !std::ranges::contains(children, i, &ChildData::branch) ||
-            (mask & (1u << i)));
-    }
-
     auto const number_of_children = static_cast<size_t>(std::popcount(mask));
     std::vector<uint16_t> child_data_offsets;
     child_data_offsets.reserve(children.size());
     uint16_t total_child_data_size = 0;
     for (auto const &child : children) {
         if (child.is_valid()) {
+            MONAD_ASSERT(mask & (1u << child.branch));
             total_child_data_size += child.len;
             child_data_offsets.push_back(total_child_data_size);
         }
@@ -600,7 +587,7 @@ Node::SharedPtr create_node_with_children(
     auto const data_size =
         comp.compute_node_data_len(children, mask, path, value);
     auto node = make_node(mask, children, path, value, data_size, version);
-    MONAD_DEBUG_ASSERT(node);
+    MONAD_ASSERT(node);
     if (data_size) {
         comp.set_node_data(node->data_data(), data_size);
     }

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -214,7 +214,7 @@ public:
     template <class... Args>
     static UniquePtr make(size_t bytes, Args &&...args)
     {
-        MONAD_DEBUG_ASSERT(bytes <= Node::max_size);
+        MONAD_ASSERT(bytes <= Node::max_size);
         return allocators::allocate_aliasing_unique<
             &allocators::aliasing_allocator_pair<Node>>(
             bytes,

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -38,7 +38,7 @@ Node::SharedPtr read_node_blocking(
         return {};
     }
     auto &pool = aux.io->storage_pool();
-    MONAD_DEBUG_ASSERT(
+    MONAD_ASSERT(
         node_offset.spare <=
         round_up_align<DISK_PAGE_BITS>(Node::max_disk_size));
     // spare bits are number of pages needed to load node

--- a/category/mpt/request.hpp
+++ b/category/mpt/request.hpp
@@ -20,6 +20,7 @@
 #include <category/mpt/update.hpp>
 #include <category/mpt/util.hpp>
 
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <optional>
@@ -30,33 +31,35 @@ struct Requests
 {
     uint16_t mask{0};
     uint8_t prefix_len{0};
-    UpdateList sublists[16];
+    std::array<UpdateList, 16> sublists{};
     std::optional<Update> opt_leaf{std::nullopt};
 
     Requests() = default;
 
     UpdateList const &operator[](size_t i) const & noexcept
     {
-        MONAD_DEBUG_ASSERT(i < 16);
         return sublists[i];
     }
 
     UpdateList &&operator[](size_t i) && noexcept
     {
-        MONAD_DEBUG_ASSERT(i < 16);
         return std::move(sublists[i]);
+    }
+
+    UpdateList const &at(size_t i) const &
+    {
+        return sublists.at(i);
+    }
+
+    UpdateList &&at(size_t i) &&
+    {
+        return std::move(sublists.at(i));
     }
 
     constexpr unsigned char get_first_branch() const noexcept
     {
-        MONAD_DEBUG_ASSERT(mask);
+        MONAD_ASSERT(mask);
         return static_cast<unsigned char>(std::countr_zero(mask));
-    }
-
-    constexpr UpdateList &&first_and_only_list() && noexcept
-    {
-        MONAD_DEBUG_ASSERT(std::popcount(mask) == 1);
-        return std::move(sublists[get_first_branch()]);
     }
 
     constexpr NibblesView get_first_path() const noexcept
@@ -68,7 +71,7 @@ struct Requests
     {
         mask = 0;
         opt_leaf = std::nullopt;
-        MONAD_DEBUG_ASSERT(prefix_index <= std::numeric_limits<uint8_t>::max());
+        MONAD_ASSERT(prefix_index <= std::numeric_limits<uint8_t>::max());
         prefix_len = static_cast<uint8_t>(prefix_index);
     }
 

--- a/category/mpt/test/fuzz/in_memory_comparator.hpp
+++ b/category/mpt/test/fuzz/in_memory_comparator.hpp
@@ -24,8 +24,8 @@ namespace monad::test
     [[nodiscard]] inline int
     path_compare(byte_string_view s1, byte_string_view s2)
     {
-        MONAD_DEBUG_ASSERT(!s1.empty());
-        MONAD_DEBUG_ASSERT(!s2.empty());
+        MONAD_ASSERT(!s1.empty());
+        MONAD_ASSERT(!s2.empty());
 
         auto const s1_size = static_cast<uint8_t>(s1[0]);
         auto const s2_size = static_cast<uint8_t>(s2[0]);
@@ -36,8 +36,8 @@ namespace monad::test
         }
 
         bool const odd = s1_size % 2;
-        MONAD_DEBUG_ASSERT(s1.size() == (1u + s1_size / 2u + odd));
-        MONAD_DEBUG_ASSERT(s2.size() == (1u + s1_size / 2u + odd));
+        MONAD_ASSERT(s1.size() == (1u + s1_size / 2u + odd));
+        MONAD_ASSERT(s2.size() == (1u + s1_size / 2u + odd));
         rc = std::memcmp(s1.data(), s2.data(), s1.size() - odd);
         if (rc != 0 || !odd) {
             return rc;
@@ -63,8 +63,8 @@ namespace monad::test
         [[nodiscard]] inline bool
         operator()(byte_string_view element, byte_string_view value) const
         {
-            MONAD_DEBUG_ASSERT(element.size() > 20);
-            MONAD_DEBUG_ASSERT(value.size() > 20);
+            MONAD_ASSERT(element.size() > 20);
+            MONAD_ASSERT(value.size() > 20);
 
             auto const rc = std::memcmp(element.data(), value.data(), 20);
             if (rc != 0) {

--- a/category/mpt/test/fuzz/test_fixtures_fuzz.hpp
+++ b/category/mpt/test/fuzz/test_fixtures_fuzz.hpp
@@ -209,10 +209,10 @@ namespace monad::test
                 }
 
                 auto const it = inputs.find(groups[i]);
-                MONAD_DEBUG_ASSERT(it != inputs.end());
+                MONAD_ASSERT(it != inputs.end());
 
                 auto const next = std::next(it);
-                MONAD_DEBUG_ASSERT(next != inputs.end());
+                MONAD_ASSERT(next != inputs.end());
 
                 if (mods.at(i).has_value()) {
                     // insert kv of {key[i], random generated value in mods}
@@ -244,7 +244,7 @@ namespace monad::test
             std::array<size_t, 100> const &groups,
             std::map<size_t, std::optional<monad::byte_string>> const &mods)
         {
-            MONAD_DEBUG_ASSERT(this->root.get() == nullptr);
+            MONAD_ASSERT(this->root.get() == nullptr);
             Process(one_hundred_updates, groups, mods);
 
             if (!mods.empty()) {
@@ -272,7 +272,7 @@ namespace monad::test
             std::vector<size_t> const &groups,
             std::map<size_t, std::optional<monad::byte_string>> const &mods)
         {
-            MONAD_DEBUG_ASSERT(this->root.get() == nullptr);
+            MONAD_ASSERT(this->root.get() == nullptr);
             std::vector<std::pair<monad::byte_string, monad::byte_string>>
                 transformed;
             for (auto const &p : kv) {

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -72,7 +72,7 @@ namespace monad::test
 
         virtual void up(size_t n) override
         {
-            MONAD_DEBUG_ASSERT(n <= depth);
+            MONAD_ASSERT(n <= depth);
             depth -= n;
         }
 
@@ -131,7 +131,7 @@ namespace monad::test
 
         virtual void up(size_t n) override
         {
-            MONAD_DEBUG_ASSERT(n <= depth);
+            MONAD_ASSERT(n <= depth);
             depth -= n;
         }
 
@@ -197,7 +197,7 @@ namespace monad::test
 
         virtual void up(size_t n) override
         {
-            MONAD_DEBUG_ASSERT(n <= depth);
+            MONAD_ASSERT(n <= depth);
             depth -= n;
         }
 

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -151,7 +151,6 @@ namespace detail
                 rd_offset = offset;
                 auto const new_offset =
                     round_down_align<DISK_PAGE_BITS>(offset.offset);
-                MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
                 rd_offset.offset = new_offset & chunk_offset_t::max_offset;
                 buffer_off = uint16_t(offset.offset - rd_offset.offset);
             }
@@ -337,7 +336,6 @@ namespace detail
                         if (this_child_read < LEFT_SIDE) {
                             priority += LEFT_SIDE - this_child_read;
                         }
-                        MONAD_DEBUG_ASSERT(priority > 0);
                         if (priority >= sender.reads_to_initiate.size()) {
                             sender.reads_to_initiate.resize(priority + 1);
                         }

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -210,7 +210,6 @@ struct load_all_impl_
             rd_offset = offset;
             auto const new_offset =
                 round_down_align<DISK_PAGE_BITS>(offset.offset);
-            MONAD_DEBUG_ASSERT(new_offset <= chunk_offset_t::max_offset);
             rd_offset.offset = new_offset & chunk_offset_t::max_offset;
             buffer_off = uint16_t(offset.offset - rd_offset.offset);
         }
@@ -280,7 +279,7 @@ size_t load_all(UpdateAuxImpl &aux, StateMachine &sm, NodeCursor const &root)
 void upward_update(UpdateAuxImpl &aux, StateMachine &sm, UpdateTNode *tnode)
 {
     while (!tnode->npending && tnode->parent()) {
-        MONAD_DEBUG_ASSERT(tnode->children.size()); // not a leaf
+        MONAD_ASSERT(tnode->children.size()); // not a leaf
         auto *parent = tnode->parent();
         auto &entry = parent->children[tnode->child_index()];
         // put created node and compute to entry in parent
@@ -474,7 +473,7 @@ Node::SharedPtr create_node_from_children_if_any(
     else if (number_of_children == 1 && !leaf_data.has_value()) {
         auto const j = bitmask_index(
             orig_mask, static_cast<unsigned>(std::countr_zero(mask)));
-        MONAD_DEBUG_ASSERT(children[j].ptr);
+        MONAD_ASSERT(children[j].ptr);
         auto node = std::move(children[j].ptr);
         /* Note: there's a potential superfluous extension hash recomputation
         when node coaleases upon erases, because we compute node hash when path
@@ -488,7 +487,7 @@ Node::SharedPtr create_node_from_children_if_any(
                               : std::nullopt,
             version); // node is deallocated
     }
-    MONAD_DEBUG_ASSERT(
+    MONAD_ASSERT(
         number_of_children > 1 ||
         (number_of_children == 1 && leaf_data.has_value()));
     // write children to disk, free any if exceeds the cache level limit
@@ -497,17 +496,16 @@ Node::SharedPtr create_node_from_children_if_any(
             if (child.is_valid() && child.offset == INVALID_OFFSET) {
                 // write updated node or node to be compacted to disk
                 // won't duplicate write of unchanged old child
-                MONAD_DEBUG_ASSERT(child.branch < 16);
-                MONAD_DEBUG_ASSERT(child.ptr);
+                MONAD_ASSERT(child.branch < 16);
+                MONAD_ASSERT(child.ptr);
                 child.offset =
                     async_write_node_set_spare(aux, *child.ptr, true);
                 auto const child_virtual_offset =
                     aux.physical_to_virtual(child.offset);
-                MONAD_DEBUG_ASSERT(
-                    child_virtual_offset != INVALID_VIRTUAL_OFFSET);
+                MONAD_ASSERT(child_virtual_offset != INVALID_VIRTUAL_OFFSET);
                 child.min_offsets =
                     calc_min_offsets(*child.ptr, child_virtual_offset);
-                MONAD_DEBUG_ASSERT(
+                MONAD_ASSERT(
                     !(sm.compact() &&
                       child.min_offsets.any_below(aux.compact_offsets)));
             }
@@ -531,15 +529,14 @@ void create_node_compute_data_possibly_async(
             tnode->orig_mask,
             static_cast<unsigned>(std::countr_zero(tnode->mask)))];
         if (!child.ptr) {
-            MONAD_DEBUG_ASSERT(aux.is_on_disk());
+            MONAD_ASSERT(aux.is_on_disk());
             MONAD_ASSERT(child.offset != INVALID_OFFSET);
             { // some sanity checks
                 auto const virtual_child_offset =
                     aux.physical_to_virtual(child.offset);
-                MONAD_DEBUG_ASSERT(
-                    virtual_child_offset != INVALID_VIRTUAL_OFFSET);
+                MONAD_ASSERT(virtual_child_offset != INVALID_VIRTUAL_OFFSET);
                 // child offset is older than current node writer's start offset
-                MONAD_DEBUG_ASSERT(
+                MONAD_ASSERT(
                     virtual_child_offset <
                     aux.physical_to_virtual((virtual_child_offset.in_fast_list()
                                                  ? aux.node_writer_fast
@@ -551,9 +548,9 @@ void create_node_compute_data_possibly_async(
                 [aux = &aux, sm = sm.clone(), tnode = std::move(tnode)](
                     Node::SharedPtr read_node) mutable {
                     auto *parent = tnode->parent();
-                    MONAD_DEBUG_ASSERT(parent);
+                    MONAD_ASSERT(parent);
                     auto &entry = parent->children[tnode->child_index()];
-                    MONAD_DEBUG_ASSERT(entry.branch < 16);
+                    MONAD_ASSERT(entry.branch < 16);
                     auto &child = tnode->children[bitmask_index(
                         tnode->orig_mask,
                         static_cast<unsigned>(std::countr_zero(tnode->mask)))];
@@ -566,7 +563,7 @@ void create_node_compute_data_possibly_async(
                 },
                 child.offset};
             async_read(aux, std::move(recv));
-            MONAD_DEBUG_ASSERT(parent.npending);
+            MONAD_ASSERT(parent.npending);
             return;
         }
     }
@@ -579,7 +576,7 @@ void create_node_compute_data_possibly_async(
         tnode->path,
         tnode->opt_leaf_data,
         tnode->version);
-    MONAD_DEBUG_ASSERT(entry.branch < 16);
+    MONAD_ASSERT(entry.branch < 16);
     if (node) {
         parent.version = std::max(parent.version, node->version);
         entry.finalize(std::move(node), sm.get_compute(), sm.cache());
@@ -655,12 +652,11 @@ void create_new_trie_(
     }
     if (updates.size() == 1) {
         Update &update = updates.front();
-        MONAD_DEBUG_ASSERT(update.value.has_value());
+        MONAD_ASSERT(update.value.has_value());
         auto const path = update.key.substr(prefix_index);
         for (auto i = 0u; i < path.nibble_size(); ++i) {
             sm.down(path.get(i));
         }
-        MONAD_DEBUG_ASSERT(update.value.has_value());
         MONAD_ASSERT(
             !sm.is_variable_length() || update.next.empty(),
             "Invalid update detected: variable-length tables do not "
@@ -702,8 +698,9 @@ void create_new_trie_(
         if (num_branches > 1 || requests.opt_leaf) {
             break;
         }
-        sm.down(requests.get_first_branch());
-        updates = std::move(requests).first_and_only_list();
+        auto const branch = requests.get_first_branch();
+        sm.down(branch);
+        updates = std::move(requests)[branch];
         ++prefix_index;
     }
     create_new_trie_from_requests_(
@@ -838,7 +835,7 @@ void upsert_(
         if (auto old_nibble = old->path_nibble_view().get(old_prefix_index);
             number_of_sublists == 1 &&
             requests.get_first_branch() == old_nibble) {
-            MONAD_DEBUG_ASSERT(requests.opt_leaf == std::nullopt);
+            MONAD_ASSERT(requests.opt_leaf == std::nullopt);
             updates = std::move(requests)[old_nibble];
             sm.down(old_nibble);
             ++prefix_index;
@@ -895,8 +892,7 @@ void dispatch_updates_impl_(
         version,
         opt_leaf_data,
         opt_leaf_data.has_value() ? old_ptr : Node::SharedPtr{});
-    MONAD_DEBUG_ASSERT(
-        tnode->children.size() == size_t(std::popcount(orig_mask)));
+    MONAD_ASSERT(tnode->children.size() == size_t(std::popcount(orig_mask)));
     auto &children = tnode->children;
 
     for (auto const [index, branch] : NodeChildrenRange(orig_mask)) {
@@ -973,9 +969,9 @@ void mismatch_handler_(
 {
     MONAD_ASSERT(old_ptr);
     Node &old = *old_ptr;
-    MONAD_DEBUG_ASSERT(old.has_path());
+    MONAD_ASSERT(old.has_path());
     // Note: no leaf can be created at an existing non-leaf node
-    MONAD_DEBUG_ASSERT(!requests.opt_leaf.has_value());
+    MONAD_ASSERT(!requests.opt_leaf.has_value());
     unsigned char const old_nibble =
         old.path_nibble_view().get(old_prefix_index);
     uint16_t const orig_mask =
@@ -983,7 +979,7 @@ void mismatch_handler_(
     auto tnode = make_tnode(orig_mask, &parent, entry.branch, path);
     auto const number_of_children =
         static_cast<unsigned>(std::popcount(orig_mask));
-    MONAD_DEBUG_ASSERT(
+    MONAD_ASSERT(
         tnode->children.size() == number_of_children && number_of_children > 0);
     auto &children = tnode->children;
 
@@ -1030,7 +1026,7 @@ void mismatch_handler_(
                 make_node(old, path_suffix, old.opt_value(), old.version),
                 sm.get_compute(),
                 sm.cache());
-            MONAD_DEBUG_ASSERT(child.offset == INVALID_OFFSET);
+            MONAD_ASSERT(child.offset == INVALID_OFFSET);
             // Note that it is possible that we recreate this node later after
             // done expiring all subtries under it
             sm.up(path_suffix.nibble_size() + 1);
@@ -1092,7 +1088,7 @@ void expire_(
                             *aux, *sm, static_cast<UpdateTNode *>(parent));
                         return;
                     }
-                    MONAD_DEBUG_ASSERT(parent->type == tnode_type::expire);
+                    MONAD_ASSERT(parent->type == tnode_type::expire);
                     auto *next_parent = parent->parent();
                     MONAD_ASSERT(next_parent);
                     try_fillin_parent_after_expiration(
@@ -1170,10 +1166,10 @@ void fillin_parent_after_expiration(
             async_write_node_set_spare(aux, *new_node, true);
         auto const new_node_virtual_offset =
             aux.physical_to_virtual(new_offset);
-        MONAD_DEBUG_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
+        MONAD_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
         auto const min_offsets =
             calc_min_offsets(*new_node, new_node_virtual_offset);
-        MONAD_DEBUG_ASSERT(
+        MONAD_ASSERT(
             min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET ||
             min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
         auto const min_version = calc_min_version(*new_node);
@@ -1182,7 +1178,7 @@ void fillin_parent_after_expiration(
             auto &child = static_cast<UpdateTNode *>(parent)->children[index];
             MONAD_ASSERT(!child.ptr); // been transferred to tnode
             child.offset = new_offset;
-            MONAD_DEBUG_ASSERT(cache_node);
+            MONAD_ASSERT(cache_node);
             child.ptr = std::move(new_node);
             child.min_offsets = min_offsets;
             child.subtrie_min_version = min_version;
@@ -1335,7 +1331,7 @@ void try_fillin_parent_with_rewritten_node(
     auto const new_offset =
         async_write_node_set_spare(aux, *tnode->node, tnode->rewrite_to_fast);
     auto const new_node_virtual_offset = aux.physical_to_virtual(new_offset);
-    MONAD_DEBUG_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
+    MONAD_ASSERT(new_node_virtual_offset != INVALID_VIRTUAL_OFFSET);
     compact_virtual_chunk_offset_t const truncated_new_virtual_offset{
         new_node_virtual_offset};
     // update min offsets in subtrie
@@ -1347,12 +1343,12 @@ void try_fillin_parent_with_rewritten_node(
         min_offsets.slow =
             std::min(min_offsets.slow, truncated_new_virtual_offset);
     }
-    MONAD_DEBUG_ASSERT(!min_offsets.any_below(aux.compact_offsets));
+    MONAD_ASSERT(!min_offsets.any_below(aux.compact_offsets));
     TNodeBase *parent = tnode->parent();
     auto const index = tnode->index;
     if (parent->type == tnode_type::update) {
         auto *const p = static_cast<UpdateTNode *>(parent);
-        MONAD_DEBUG_ASSERT(tnode->cache_node);
+        MONAD_ASSERT(tnode->cache_node);
         auto &child = p->children[index];
         child.ptr = std::move(tnode->node);
         child.offset = new_offset;
@@ -1400,7 +1396,7 @@ node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
     // O_DIRECT i/o aligned
     auto const remaining_buffer_bytes = sender->remaining_buffer_bytes();
     auto *tozero = sender->advance_buffer_append(remaining_buffer_bytes);
-    MONAD_DEBUG_ASSERT(tozero != nullptr);
+    MONAD_ASSERT(tozero != nullptr);
     memset(tozero, 0, remaining_buffer_bytes);
 
     /* If there aren't enough write buffers, this may poll uring until a free
@@ -1500,7 +1496,7 @@ node_writer_unique_ptr_type replace_node_writer(
         return {};
     }
     if (ci_ != nullptr) {
-        MONAD_DEBUG_ASSERT(ci_ == aux.db_metadata()->free_list_end());
+        MONAD_ASSERT(ci_ == aux.db_metadata()->free_list_end());
         aux.remove(idx);
         aux.append(
             in_fast_list ? UpdateAuxImpl::chunk_list::fast
@@ -1529,7 +1525,7 @@ retry:
         ret.offset_written_to =
             sender->offset().add_to_offset(sender->written_buffer_bytes());
         auto *where_to_serialize = sender->advance_buffer_append(size);
-        MONAD_DEBUG_ASSERT(where_to_serialize != nullptr);
+        MONAD_ASSERT(where_to_serialize != nullptr);
         serialize_node_to_buffer(
             (unsigned char *)where_to_serialize, size, node, size);
     }
@@ -1558,7 +1554,7 @@ retry:
             auto *where_to_serialize =
                 (unsigned char *)node_writer->sender().advance_buffer_append(
                     bytes_to_append);
-            MONAD_DEBUG_ASSERT(where_to_serialize != nullptr);
+            MONAD_ASSERT(where_to_serialize != nullptr);
             serialize_node_to_buffer(
                 where_to_serialize,
                 bytes_to_append,
@@ -1570,7 +1566,7 @@ retry:
             if (!new_node_writer) {
                 goto retry;
             }
-            MONAD_DEBUG_ASSERT(
+            MONAD_ASSERT(
                 new_node_writer->sender().offset().id ==
                 node_writer->sender().offset().id);
         }
@@ -1618,7 +1614,7 @@ retry:
                     goto retry;
                 }
                 // initiate current node writer
-                MONAD_DEBUG_ASSERT(
+                MONAD_ASSERT(
                     node_writer->sender().written_buffer_bytes() ==
                     node_writer->sender().buffer().size());
                 node_writer->initiate();
@@ -1664,7 +1660,7 @@ void flush_buffered_writes(UpdateAuxImpl &aux)
         auto paddedup = round_up_align<DISK_PAGE_BITS>(written);
         auto const tozerobytes = paddedup - written;
         auto *tozero = sender->advance_buffer_append(tozerobytes);
-        MONAD_DEBUG_ASSERT(tozero != nullptr);
+        MONAD_ASSERT(tozero != nullptr);
         memset(tozero, 0, tozerobytes);
         // replace fast node writer
         auto new_node_writer = replace_node_writer(aux, node_writer);

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -107,7 +107,7 @@ struct read_short_update_sender
     explicit constexpr read_short_update_sender(Receiver const &receiver)
         : read_single_buffer_sender(receiver.rd_offset, receiver.bytes_to_read)
     {
-        MONAD_DEBUG_ASSERT(
+        MONAD_ASSERT(
             receiver.bytes_to_read <=
             MONAD_ASYNC_NAMESPACE::AsyncIO::READ_BUFFER_SIZE);
     }
@@ -128,7 +128,7 @@ public:
                   DISK_PAGE_SIZE, receiver.bytes_to_read),
               receiver.bytes_to_read)
     {
-        MONAD_DEBUG_ASSERT(
+        MONAD_ASSERT(
             receiver.bytes_to_read >
             MONAD_ASYNC_NAMESPACE::AsyncIO::READ_BUFFER_SIZE);
         MONAD_ASSERT(buffer_.data() != nullptr);

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -151,7 +151,7 @@ void UpdateAuxImpl::append(chunk_list const list, uint32_t const idx) noexcept
     if (list == chunk_list::free) {
         auto &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
         auto capacity = chunk.capacity();
-        MONAD_DEBUG_ASSERT(chunk.size() == 0);
+        MONAD_ASSERT(chunk.size() == 0);
         db_metadata_[0].main->free_capacity_add_(capacity);
         db_metadata_[1].main->free_capacity_add_(capacity);
     }
@@ -181,7 +181,7 @@ void UpdateAuxImpl::remove(uint32_t const idx) noexcept
     if (is_free_list) {
         auto &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
         auto capacity = chunk.capacity();
-        MONAD_DEBUG_ASSERT(chunk.size() == 0);
+        MONAD_ASSERT(chunk.size() == 0);
         db_metadata_[0].main->free_capacity_sub_(capacity);
         db_metadata_[1].main->free_capacity_sub_(capacity);
     }
@@ -427,10 +427,10 @@ void UpdateAuxImpl::rewind_to_match_offsets()
     if (last_root_offset != INVALID_OFFSET) {
         auto const virtual_last_root_offset =
             physical_to_virtual(last_root_offset);
-        MONAD_DEBUG_ASSERT(virtual_last_root_offset != INVALID_VIRTUAL_OFFSET);
+        MONAD_ASSERT(virtual_last_root_offset != INVALID_VIRTUAL_OFFSET);
         if (db_metadata()->at(last_root_offset.id)->in_fast_list) {
             auto const virtual_fast_offset = physical_to_virtual(fast_offset);
-            MONAD_DEBUG_ASSERT(virtual_fast_offset != INVALID_VIRTUAL_OFFSET);
+            MONAD_ASSERT(virtual_fast_offset != INVALID_VIRTUAL_OFFSET);
             MONAD_ASSERT_PRINTF(
                 virtual_fast_offset > virtual_last_root_offset,
                 "Detected corruption. Last root offset (id=%d, count=%d, "
@@ -445,7 +445,7 @@ void UpdateAuxImpl::rewind_to_match_offsets()
         }
         else if (db_metadata()->at(last_root_offset.id)->in_slow_list) {
             auto const virtual_slow_offset = physical_to_virtual(slow_offset);
-            MONAD_DEBUG_ASSERT(virtual_slow_offset != INVALID_VIRTUAL_OFFSET);
+            MONAD_ASSERT(virtual_slow_offset != INVALID_VIRTUAL_OFFSET);
             MONAD_ASSERT_PRINTF(
                 virtual_slow_offset > virtual_last_root_offset,
                 "Detected corruption. Last root offset (id=%d, count=%d, "
@@ -828,7 +828,7 @@ void UpdateAuxImpl::set_io(
                 "existing data, stopping now to prevent data loss.");
         }
         memset(db_metadata_[0].main, 0, map_size);
-        MONAD_DEBUG_ASSERT((chunk_count & ~0xfffffU) == 0);
+        MONAD_ASSERT((chunk_count & ~0xfffffU) == 0);
         db_metadata_[0].main->chunk_info_count = chunk_count & 0xfffffU;
         MONAD_ASSERT(io->storage_pool().chunks(storage_pool::cnv) > 1);
         auto &storage = db_metadata_[0].main->root_offsets.storage_;
@@ -898,8 +898,8 @@ void UpdateAuxImpl::set_io(
         chunks.reserve(chunk_count);
         for (uint32_t n = 0; n < chunk_count; n++) {
             auto chunk = io->storage_pool().chunk(storage_pool::seq, n);
-            MONAD_DEBUG_ASSERT(chunk.zone_id().first == storage_pool::seq);
-            MONAD_DEBUG_ASSERT(chunk.zone_id().second == n);
+            MONAD_ASSERT(chunk.zone_id().first == storage_pool::seq);
+            MONAD_ASSERT(chunk.zone_id().second == n);
             MONAD_ASSERT(chunk.size() == 0); // chunks must actually be free
             chunks.push_back(n);
         }

--- a/category/mpt/upward_tnode.hpp
+++ b/category/mpt/upward_tnode.hpp
@@ -243,7 +243,7 @@ struct CompactTNode : public TNodeBase
     static unique_ptr_type
     make(Parent *const parent, unsigned const index, Node::SharedPtr node)
     {
-        MONAD_DEBUG_ASSERT(parent);
+        MONAD_ASSERT(parent);
         return allocators::allocate_unique<allocator_type, &CompactTNode::pool>(
             parent, index, std::move(node));
     }
@@ -320,7 +320,7 @@ struct ExpireTNode : public UpdateExpireBase
         Parent *const parent, unsigned const branch, unsigned index,
         Node::SharedPtr node)
     {
-        MONAD_DEBUG_ASSERT(parent);
+        MONAD_ASSERT(parent);
         return allocators::allocate_unique<allocator_type, &ExpireTNode::pool>(
             parent, branch, index, std::move(node));
     }

--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -177,7 +177,7 @@ public:
         virtual_chunk_offset_t const offset)
         : v_{static_cast<uint32_t>(offset.raw() >> bits_to_truncate)}
     {
-        MONAD_DEBUG_ASSERT(offset != INVALID_VIRTUAL_OFFSET);
+        MONAD_ASSERT(offset != INVALID_VIRTUAL_OFFSET);
     }
 
     void set_value(uint32_t v) noexcept
@@ -264,7 +264,8 @@ static_assert(alignof(compact_offset_pair) == 4);
 inline constexpr unsigned
 bitmask_index(uint16_t const mask, unsigned const i) noexcept
 {
-    MONAD_DEBUG_ASSERT(i < 16);
+    MONAD_ASSERT(i < 16);
+    MONAD_ASSERT(mask & (1u << i));
     uint16_t const filter = UINT16_MAX >> (16 - i);
     return static_cast<unsigned>(
         std::popcount(static_cast<uint16_t>(mask & filter)));

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -713,7 +713,8 @@ void process_test(
 
     bool const has_post_state = j_contents.contains("postState");
     bool const has_post_state_hash = j_contents.contains("postStateHash");
-    MONAD_DEBUG_ASSERT(has_post_state || has_post_state_hash);
+    ASSERT_TRUE(has_post_state || has_post_state_hash)
+        << "Test fixture missing postState/postStateHash: " << name;
 
     if (has_post_state_hash) {
         EXPECT_EQ(


### PR DESCRIPTION
…ants

Audit all ~186 uses of MONAD_DEBUG_ASSERT across the codebase. Since MONAD_DEBUG_ASSERT compiles to a no-op in NDEBUG/release builds, important invariant checks were silently skipped in production.

Remove (7 asserts — redundant or always-true):
- core/io/buffers.hpp: two always-true asserts using comma operator trick
- execution/ethereum/db/trie_db.cpp: three !has_error() checks before value() calls that already throw on error
- execution/ethereum/db/trie_rodb.hpp: same !has_error() pattern
- mpt/trie.cpp: exact duplicate assert (line 763 duplicates line 758)
- mpt/trie.cpp: new_offset <= chunk_offset_t::max_offset always-true (chunk_offset_t::offset is a 28-bit bitfield; round_down_align can only decrease the value)

Promote to MONAD_ASSERT (production-worthy, non-hot-path):
- execution/ethereum/precompiles_impl.cpp: silkpre library contract violation
- execution/ethereum/event/exec_event_recorder.hpp: null event → memory corruption
- core/mem/align.h: alignment precondition (programming error if violated)
- core/io/buffers.hpp: buffer index bounds — only called from BufferPool constructor at initialization, not from hot I/O path
- mpt/ write/update path: ~140 asserts across 18 files covering node construction, trie modification, compaction, Merkle hash computation, chunk metadata, update batching — all O(modified nodes) per block

Keep as MONAD_DEBUG_ASSERT (hot path):
- core/runtime/uint256.hpp: EVM arithmetic inner loops (millions/block)

Additional refinements:
- db_metadata.hpp: use at() accessor to avoid repeating assert+access patterns; operator[] uses MONAD_DEBUG_ASSERT (like std::vector::operator[])
- util.hpp/bitmask_index: move mask-bit precondition into function
- node.cpp/make_node: replace O(16×N) loop with O(N) scan
- node.cpp constructor: remove redundant NibblesView internal field checks (guaranteed by NibblesView constructors); use data_span() + ranges::copy
- node.cpp constructor: assert value_len cast losslessness using already- computed field: MONAD_ASSERT(!value || value->size() == value_len)
- node.cpp get_disk_size: promote next_data() >= this to MONAD_ASSERT; compute pointer once to avoid redundant call
- nibbles_view.hpp: add data_span() returning span<unsigned char const>
- compute.hpp: keep iterator/pointer validity as MONAD_DEBUG_ASSERT; promote actual buffer overflow checks to MONAD_ASSERT
- blockchain_test.cpp: use ASSERT_TRUE for fixture validation (external JSON data) instead of MONAD_ASSERT so failures report via test framework