### PR TITLE
[mpt] Optimize node array access by hoisting base pointers via std::s…

### DIFF
--- a/category/async/CMakeLists.txt
+++ b/category/async/CMakeLists.txt
@@ -31,7 +31,6 @@ add_library(
   "connected_operation.hpp"
   "detail/connected_operation_storage.hpp"
   "detail/scope_polyfill.hpp"
-  "detail/start_lifetime_as_polyfill.hpp"
   "erased_connected_operation.hpp"
   "io.cpp"
   "io.hpp"

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -17,9 +17,9 @@
 
 #include <category/async/config.hpp>
 #include <category/async/detail/scope_polyfill.hpp>
-#include <category/async/detail/start_lifetime_as_polyfill.hpp>
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/hash.hpp>
 
 #include <algorithm>

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -17,7 +17,7 @@
 
 #include <category/async/util.hpp>
 
-#include <category/async/detail/start_lifetime_as_polyfill.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 
 #include <atomic>
 #include <filesystem>

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(
   "srcloc.h"
   "tl_tid.c"
   "tl_tid.h"
+  "detail/start_lifetime_as_polyfill.hpp"
   "lru/lru_cache.hpp"
   "lru/static_lru_cache.hpp"
   "mem/batch_mem_pool.hpp"

--- a/category/core/detail/start_lifetime_as_polyfill.hpp
+++ b/category/core/detail/start_lifetime_as_polyfill.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "../config.hpp"
+#include <category/core/config.hpp>
 
 #ifndef MONAD_USE_STD_START_LIFETIME_AS
     #if __cpp_lib_start_lifetime_as >= 202207L

--- a/category/core/runtime/unaligned.hpp
+++ b/category/core/runtime/unaligned.hpp
@@ -15,17 +15,15 @@
 
 #pragma once
 
-#include <category/core/config.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 
 #include <algorithm>
 #include <array>
 #include <bit>
-#include <cstdint>
+#include <compare>
+#include <cstring>
+#include <span>
 #include <type_traits>
-
-static_assert(
-    std::is_same_v<std::uint8_t, unsigned char>,
-    "unaligned_load/store assume uint8_t is unsigned char");
 
 MONAD_NAMESPACE_BEGIN
 
@@ -44,6 +42,76 @@ unaligned_store(unsigned char *const buf, T const &value)
 {
     auto data = std::bit_cast<std::array<unsigned char, sizeof(T)>>(value);
     std::copy_n(data.data(), sizeof(T), buf);
+}
+
+// Element type for std::span over a packed unaligned array of T.
+//
+// Stores T as raw bytes; read via std::bit_cast, write via memcpy, so the
+// compiler emits unaligned load/store instructions and no alignment fault can
+// occur.  Works for any trivially-copyable T including non-POD class types.
+//
+// Implicit conversion to/from T means it behaves transparently at most call
+// sites. Use as_unaligned_span() to construct a std::span<unaligned_t<T>>.
+//
+// Note: std::min(T, unaligned_t<T>) fails template deduction (mixed-type case
+// only; std::min(unaligned_t<T>, unaligned_t<T>) deduces fine); use
+// std::min<T>(...) or a range-for loop with a T loop variable.
+//
+// [[gnu::may_alias]] — an unaligned_t<T>* may alias arbitrary storage,
+//                      mirroring the permission that unsigned char* already
+//                      has in the other direction.  Prevents the compiler from
+//                      assuming the typed pointer is disjoint from the
+//                      surrounding heterogeneous Node layout.
+template <typename T>
+struct [[gnu::may_alias]] unaligned_t
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+
+    unsigned char bytes[sizeof(T)];
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator T() const noexcept
+    {
+        return std::bit_cast<T>(bytes);
+    }
+
+    // implicit write
+    unaligned_t &operator=(T const &v) noexcept
+    {
+        std::memcpy(bytes, &v, sizeof(v));
+        return *this;
+    }
+
+    // comparisons (for std::min(unaligned_t, unaligned_t) and range algos)
+    bool operator==(unaligned_t const &o) const noexcept
+    {
+        return static_cast<T>(*this) == static_cast<T>(o);
+    }
+
+    auto operator<=>(unaligned_t const &o) const noexcept
+    {
+        return static_cast<T>(*this) <=> static_cast<T>(o);
+    }
+};
+
+static_assert(sizeof(unaligned_t<int64_t>) == sizeof(int64_t));
+static_assert(alignof(unaligned_t<int64_t>) == 1);
+
+// Returns std::span<unaligned_t<T>> over [ptr, ptr + n*sizeof(T)).
+// Safe because [[gnu::may_alias]] permits unaligned_t<T>* to alias the buffer.
+template <typename T>
+[[nodiscard]] std::span<unaligned_t<T>>
+as_unaligned_span(unsigned char *ptr, unsigned n) noexcept
+{
+    return {monad::start_lifetime_as_array<unaligned_t<T>>(ptr, n), n};
+}
+
+// Const overload.
+template <typename T>
+[[nodiscard]] std::span<unaligned_t<T> const>
+as_unaligned_span(unsigned char const *ptr, unsigned n) noexcept
+{
+    return {monad::start_lifetime_as_array<unaligned_t<T>>(ptr, n), n};
 }
 
 MONAD_NAMESPACE_END

--- a/category/mpt/bench/CMakeLists.txt
+++ b/category/mpt/bench/CMakeLists.txt
@@ -13,6 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# benchmark calc_min_version
+add_executable(calc_min_version_bench "calc_min_version_bench.cpp")
+monad_compile_options(calc_min_version_bench)
+target_link_libraries(calc_min_version_bench PUBLIC monad_trie monad_async monad_core)
+
 # benchmark async reads
 add_executable(async_read_bench "async_read_bench.cpp")
 monad_compile_options(async_read_bench)

--- a/category/mpt/bench/calc_min_version_bench.cpp
+++ b/category/mpt/bench/calc_min_version_bench.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Microbenchmark for calc_min_version().
+//
+// Compares the original implementation (calling subtrie_min_version(i) per
+// iteration, which re-derives the version array base pointer via three chained
+// arithmetic steps — popcount + multiply — on each call) against the optimized
+// one (child_min_version_data() called once before the loop as a span).
+//
+// Creates nodes with 1, 4, 8, and 16 children and measures ns/call.
+
+#include <category/mpt/nibbles_view.hpp>
+#include <category/mpt/node.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <span>
+#include <vector>
+
+using namespace monad::mpt;
+
+// Original: calls subtrie_min_version(i) each iteration, recomputing base.
+static int64_t calc_min_version_original(Node const &node)
+{
+    int64_t min_version = node.version;
+    for (unsigned i = 0; i < node.number_of_children(); ++i) {
+        min_version = std::min(min_version, node.subtrie_min_version(i));
+    }
+    return min_version;
+}
+
+// Build a node whose mask has exactly `nchildren` bits set (low bits).
+static Node::SharedPtr make_bench_node(unsigned nchildren, int64_t version)
+{
+    uint16_t const mask = static_cast<uint16_t>((1u << nchildren) - 1u);
+
+    std::vector<ChildData> children(nchildren);
+    for (unsigned i = 0; i < nchildren; ++i) {
+        children[i].branch = static_cast<uint8_t>(i);
+        children[i].subtrie_min_version = version - static_cast<int64_t>(i);
+    }
+
+    return make_node(
+        mask,
+        std::span<ChildData>{children},
+        NibblesView{},
+        std::nullopt,
+        /*data_size=*/0,
+        version);
+}
+
+template <typename Fn>
+static int64_t
+run_bench(char const *label, unsigned nchildren, uint64_t iterations, Fn &&fn)
+{
+    auto const node = make_bench_node(nchildren, 1000);
+
+    // Warm up CPU caches and branch predictor.
+    int64_t volatile sink = 0;
+    for (uint64_t i = 0; i < 1000; ++i) {
+        sink = fn(*node);
+    }
+
+    auto const t0 = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < iterations; ++i) {
+        sink = fn(*node);
+    }
+    auto const t1 = std::chrono::steady_clock::now();
+    (void)sink;
+
+    auto const ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    auto const per_call = ns / static_cast<int64_t>(iterations);
+    std::cout << label << "  children=" << nchildren
+              << "  per_call=" << per_call << "ns\n";
+    return per_call;
+}
+
+int main()
+{
+    constexpr uint64_t ITERS = 50'000'000;
+
+    std::cout << "--- original (subtrie_min_version(i) per iteration) ---\n";
+    for (unsigned const n : {1u, 4u, 8u, 16u}) {
+        run_bench("original", n, ITERS, calc_min_version_original);
+    }
+
+    std::cout << "\n--- optimized (hoisted base pointer) ---\n";
+    for (unsigned const n : {1u, 4u, 8u, 16u}) {
+        run_bench("optimized", n, ITERS, calc_min_version);
+    }
+}

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -17,11 +17,11 @@
 
 #include <category/async/config.hpp>
 #include <category/async/detail/scope_polyfill.hpp>
-#include <category/async/detail/start_lifetime_as_polyfill.hpp>
 #include <category/async/io.hpp>
 #include <category/async/storage_pool.hpp>
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -22,7 +22,7 @@
 #include <category/mpt/util.hpp>
 
 #include <category/async/config.hpp>
-#include <category/async/detail/start_lifetime_as_polyfill.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 
 #include "unsigned_20.hpp"
 

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -101,62 +101,64 @@ void Node::set_fnext(unsigned const index, chunk_offset_t const off) noexcept
         sizeof(chunk_offset_t));
 }
 
-unsigned char *Node::child_min_offset_fast_data() noexcept
+std::span<unaligned_t<compact_virtual_chunk_offset_t>>
+Node::child_min_offset_fast_data() noexcept
 {
-    return fnext_data + number_of_children() * sizeof(file_offset_t);
+    unsigned const n = number_of_children();
+    return as_unaligned_span<compact_virtual_chunk_offset_t>(
+        fnext_data + n * sizeof(chunk_offset_t), n);
 }
 
-unsigned char const *Node::child_min_offset_fast_data() const noexcept
+std::span<unaligned_t<compact_virtual_chunk_offset_t> const>
+Node::child_min_offset_fast_data() const noexcept
 {
-    return fnext_data + number_of_children() * sizeof(file_offset_t);
+    unsigned const n = number_of_children();
+    return as_unaligned_span<compact_virtual_chunk_offset_t>(
+        fnext_data + n * sizeof(chunk_offset_t), n);
 }
 
 compact_virtual_chunk_offset_t
 Node::min_offset_fast(unsigned const index) const noexcept
 {
-    return unaligned_load<compact_virtual_chunk_offset_t>(
-        child_min_offset_fast_data() +
-        index * sizeof(compact_virtual_chunk_offset_t));
+    return child_min_offset_fast_data()[index];
 }
 
 void Node::set_min_offset_fast(
     unsigned const index, compact_virtual_chunk_offset_t const offset) noexcept
 {
-    std::memcpy(
-        child_min_offset_fast_data() +
-            index * sizeof(compact_virtual_chunk_offset_t),
-        &offset,
-        sizeof(compact_virtual_chunk_offset_t));
+    child_min_offset_fast_data()[index] = offset;
 }
 
-unsigned char *Node::child_min_offset_slow_data() noexcept
+std::span<unaligned_t<compact_virtual_chunk_offset_t>>
+Node::child_min_offset_slow_data() noexcept
 {
-    return child_min_offset_fast_data() +
-           number_of_children() * sizeof(compact_virtual_chunk_offset_t);
+    unsigned const n = number_of_children();
+    auto const fast = child_min_offset_fast_data();
+    return as_unaligned_span<compact_virtual_chunk_offset_t>(
+        reinterpret_cast<unsigned char *>(fast.data()) + fast.size_bytes(), n);
 }
 
-unsigned char const *Node::child_min_offset_slow_data() const noexcept
+std::span<unaligned_t<compact_virtual_chunk_offset_t> const>
+Node::child_min_offset_slow_data() const noexcept
 {
-    return child_min_offset_fast_data() +
-           number_of_children() * sizeof(compact_virtual_chunk_offset_t);
+    unsigned const n = number_of_children();
+    auto const fast = child_min_offset_fast_data();
+    return as_unaligned_span<compact_virtual_chunk_offset_t>(
+        reinterpret_cast<unsigned char const *>(fast.data()) +
+            fast.size_bytes(),
+        n);
 }
 
 compact_virtual_chunk_offset_t
 Node::min_offset_slow(unsigned const index) const noexcept
 {
-    return unaligned_load<compact_virtual_chunk_offset_t>(
-        child_min_offset_slow_data() +
-        index * sizeof(compact_virtual_chunk_offset_t));
+    return child_min_offset_slow_data()[index];
 }
 
 void Node::set_min_offset_slow(
     unsigned const index, compact_virtual_chunk_offset_t const offset) noexcept
 {
-    std::memcpy(
-        child_min_offset_slow_data() +
-            index * sizeof(compact_virtual_chunk_offset_t),
-        &offset,
-        sizeof(compact_virtual_chunk_offset_t));
+    child_min_offset_slow_data()[index] = offset;
 }
 
 compact_offset_pair Node::min_offsets(unsigned const index) const noexcept
@@ -171,41 +173,48 @@ void Node::set_min_offsets(
     set_min_offset_slow(index, offsets.slow);
 }
 
-unsigned char *Node::child_min_version_data() noexcept
+std::span<unaligned_t<int64_t>> Node::child_min_version_data() noexcept
 {
-    return child_min_offset_slow_data() +
-           number_of_children() * sizeof(compact_virtual_chunk_offset_t);
+    unsigned const n = number_of_children();
+    auto const slow = child_min_offset_slow_data();
+    return as_unaligned_span<int64_t>(
+        reinterpret_cast<unsigned char *>(slow.data()) + slow.size_bytes(), n);
 }
 
-unsigned char const *Node::child_min_version_data() const noexcept
+std::span<unaligned_t<int64_t> const>
+Node::child_min_version_data() const noexcept
 {
-    return child_min_offset_slow_data() +
-           number_of_children() * sizeof(compact_virtual_chunk_offset_t);
+    unsigned const n = number_of_children();
+    auto const slow = child_min_offset_slow_data();
+    return as_unaligned_span<int64_t>(
+        reinterpret_cast<unsigned char const *>(slow.data()) +
+            slow.size_bytes(),
+        n);
 }
 
 int64_t Node::subtrie_min_version(unsigned const index) const noexcept
 {
-    return unaligned_load<int64_t>(
-        child_min_version_data() + index * sizeof(int64_t));
+    return child_min_version_data()[index];
 }
 
 void Node::set_subtrie_min_version(
     unsigned const index, int64_t const min_version) noexcept
 {
-    std::memcpy(
-        child_min_version_data() + index * sizeof(int64_t),
-        &min_version,
-        sizeof(int64_t));
+    child_min_version_data()[index] = min_version;
 }
 
 unsigned char *Node::child_off_data() noexcept
 {
-    return child_min_version_data() + number_of_children() * sizeof(int64_t);
+    auto const versions = child_min_version_data();
+    return reinterpret_cast<unsigned char *>(versions.data()) +
+           versions.size_bytes();
 }
 
 unsigned char const *Node::child_off_data() const noexcept
 {
-    return child_min_version_data() + number_of_children() * sizeof(int64_t);
+    auto const versions = child_min_version_data();
+    return reinterpret_cast<unsigned char const *>(versions.data()) +
+           versions.size_bytes();
 }
 
 uint16_t Node::child_data_offset(unsigned const index) const noexcept
@@ -615,8 +624,8 @@ void serialize_node_to_buffer(
 int64_t calc_min_version(Node const &node)
 {
     int64_t min_version = node.version;
-    for (unsigned i = 0; i < node.number_of_children(); ++i) {
-        min_version = std::min(min_version, node.subtrie_min_version(i));
+    for (int64_t const v : node.child_min_version_data()) {
+        min_version = std::min(min_version, v);
     }
     return min_version;
 }

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -241,15 +241,19 @@ public:
     void set_fnext(unsigned index, chunk_offset_t) noexcept;
 
     //! fastlist min_offset array
-    unsigned char *child_min_offset_fast_data() noexcept;
-    unsigned char const *child_min_offset_fast_data() const noexcept;
+    std::span<unaligned_t<compact_virtual_chunk_offset_t>>
+    child_min_offset_fast_data() noexcept;
+    std::span<unaligned_t<compact_virtual_chunk_offset_t> const>
+    child_min_offset_fast_data() const noexcept;
     compact_virtual_chunk_offset_t
     min_offset_fast(unsigned index) const noexcept;
     void set_min_offset_fast(
         unsigned index, compact_virtual_chunk_offset_t) noexcept;
     //! slowlist min_offset array
-    unsigned char *child_min_offset_slow_data() noexcept;
-    unsigned char const *child_min_offset_slow_data() const noexcept;
+    std::span<unaligned_t<compact_virtual_chunk_offset_t>>
+    child_min_offset_slow_data() noexcept;
+    std::span<unaligned_t<compact_virtual_chunk_offset_t> const>
+    child_min_offset_slow_data() const noexcept;
     compact_virtual_chunk_offset_t
     min_offset_slow(unsigned index) const noexcept;
     void set_min_offset_slow(
@@ -259,8 +263,9 @@ public:
     void set_min_offsets(unsigned index, compact_offset_pair) noexcept;
 
     //! subtrie min version array
-    unsigned char *child_min_version_data() noexcept;
-    unsigned char const *child_min_version_data() const noexcept;
+    std::span<unaligned_t<int64_t>> child_min_version_data() noexcept;
+    std::span<unaligned_t<int64_t> const>
+    child_min_version_data() const noexcept;
     int64_t subtrie_min_version(unsigned index) const noexcept;
     void set_subtrie_min_version(unsigned index, int64_t version) noexcept;
 

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -483,15 +483,20 @@ std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
     for (unsigned i = 0; i < node->number_of_children(); ++i) {
         new (node->child_ptr(i)) Node::SharedPtr();
     }
+    auto const orig_fast = orig->child_min_offset_fast_data();
+    auto const orig_slow = orig->child_min_offset_slow_data();
+    auto const orig_ver = orig->child_min_version_data();
+    auto const node_fast = node->child_min_offset_fast_data();
+    auto const node_slow = node->child_min_offset_slow_data();
+    auto const node_ver = node->child_min_version_data();
     for (unsigned j = 0; j < number_of_children; ++j) {
-        auto const &orig_j = orig_indexes[j];
+        auto const orig_j = orig_indexes[j];
         node->set_fnext(j, orig->fnext(orig_j));
-        node->set_min_offset_fast(j, orig->min_offset_fast(orig_j));
-        node->set_min_offset_slow(j, orig->min_offset_slow(orig_j));
-        MONAD_ASSERT(
-            orig->subtrie_min_version(orig_j) >=
-            aux.curr_upsert_auto_expire_version);
-        node->set_subtrie_min_version(j, orig->subtrie_min_version(orig_j));
+        node_fast[j] = orig_fast[orig_j];
+        node_slow[j] = orig_slow[orig_j];
+        auto const ver = orig_ver[orig_j];
+        MONAD_ASSERT(ver >= aux.curr_upsert_auto_expire_version);
+        node_ver[j] = ver;
         if (tnode->cache_mask & (1u << orig_j)) {
             node->set_next(j, orig->move_next(orig_j));
         }
@@ -1252,9 +1257,12 @@ void compact_(
         virtual_node_offset,
         compact_node.get_disk_size());
 
-    for (unsigned j = 0; j < compact_node.number_of_children(); ++j) {
+    unsigned const n = compact_node.number_of_children();
+    auto const fast = compact_node.child_min_offset_fast_data();
+    auto const slow = compact_node.child_min_offset_slow_data();
+    for (unsigned j = 0; j < n; ++j) {
         auto child_ptr = compact_node.move_next(j);
-        auto const child_min_offsets = compact_node.min_offsets(j);
+        compact_offset_pair const child_min_offsets{fast[j], slow[j]};
         if (sm.compact() && child_min_offsets.any_below(aux.compact_offsets)) {
             compact_(
                 aux,

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -758,9 +758,12 @@ inline compact_offset_pair calc_min_offsets(
         auto &r = node_virtual_offset.in_fast_list() ? ret.fast : ret.slow;
         r = compact_virtual_chunk_offset_t{node_virtual_offset};
     }
-    for (unsigned i = 0; i < node.number_of_children(); ++i) {
-        ret.fast = std::min(ret.fast, node.min_offset_fast(i));
-        ret.slow = std::min(ret.slow, node.min_offset_slow(i));
+    unsigned const n = node.number_of_children();
+    auto const fast = node.child_min_offset_fast_data();
+    auto const slow = node.child_min_offset_slow_data();
+    for (unsigned i = 0; i < n; ++i) {
+        ret.fast = std::min<compact_virtual_chunk_offset_t>(ret.fast, fast[i]);
+        ret.slow = std::min<compact_virtual_chunk_offset_t>(ret.slow, slow[i]);
     }
     return ret;
 }

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -15,11 +15,11 @@
 
 #include <category/async/config.hpp>
 #include <category/async/detail/scope_polyfill.hpp>
-#include <category/async/detail/start_lifetime_as_polyfill.hpp>
 #include <category/async/storage_pool.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/util/stopwatch.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/detail/collected_stats.hpp>


### PR DESCRIPTION
…pan<unaligned_t<T>>

Add unaligned_t<T> to category/core/unaligned.hpp: a 1-byte-aligned element type for std::span over packed unaligned arrays. Stores T as unsigned char bytes[sizeof(T)]; reads via std::bit_cast, writes via memcpy. Works for any trivially-copyable T including non-POD class types. Provides as_unaligned_span() factory functions returning std::span.

Change child_min_offset_fast_data(), child_min_offset_slow_data(), and child_min_version_data() on Node to return std::span<unaligned_t<T>> instead of unsigned char*. This simplifies the leaf accessors (min_offset_fast, set_subtrie_min_version, etc.) to single-expression span subscripts and allows callers to hoist the base pointer once before a loop.

Hoist base spans in four sites that previously recomputed the array base address on every iteration via per-element accessor calls:
- calc_min_version: ~3 popcount/iter -> 0
- calc_min_offsets (trie.hpp): ~3 popcount/iter -> 0
- create_node_with_expired_branches copy loop: ~15 popcount/iter -> 0
- compact_ child loop: ~3 popcount/iter -> 0

Microbenchmark (calc_min_version_bench) shows 8-9x speedup on the originally optimized function (35ns -> 4ns for a 16-child node).