### PR TITLE
Introduce monad::bytes32_t and uint256_be_t, replacing evmc_bytes32 dependency

### DIFF
--- a/category/core/bytes.hpp
+++ b/category/core/bytes.hpp
@@ -19,6 +19,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
+#include <category/core/hex.hpp>
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 
@@ -26,23 +27,79 @@
 
 #include <ankerl/unordered_dense.h>
 
+#include <algorithm>
 #include <bit>
 #include <cstddef>
 #include <functional>
 
 MONAD_NAMESPACE_BEGIN
 
-using bytes32_t = ::evmc::bytes32;
+struct bytes32_t : evmc_bytes32
+{
+    constexpr bytes32_t() noexcept
+        : evmc_bytes32{}
+    {
+    }
+
+    constexpr bytes32_t(bytes32_t const &) noexcept = default;
+    constexpr bytes32_t &operator=(bytes32_t const &) noexcept = default;
+
+    explicit(false) constexpr bytes32_t(evmc_bytes32 const &other) noexcept
+        : evmc_bytes32{other}
+    {
+    }
+
+    explicit constexpr bytes32_t(uint64_t v) noexcept
+        : evmc_bytes32{}
+    {
+        for (int i = 0; i < 8; ++i) {
+            bytes[31 - i] = static_cast<uint8_t>(v >> (i * 8));
+        }
+    }
+
+    template <std::same_as<uint8_t>... Bytes>
+        requires(sizeof...(Bytes) >= 1 && sizeof...(Bytes) <= 32)
+    explicit(false) constexpr bytes32_t(Bytes... bs) noexcept
+        : evmc_bytes32{{bs...}}
+    {
+    }
+
+    explicit constexpr operator bool() const noexcept
+    {
+        return std::any_of(bytes, bytes + 32, [](uint8_t b) { return b != 0; });
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    explicit(false) constexpr operator byte_string_view() const noexcept
+    {
+        return {bytes, sizeof(bytes)};
+    }
+
+    friend constexpr bool
+    operator==(bytes32_t const &a, bytes32_t const &b) noexcept
+    {
+        return std::equal(a.bytes, a.bytes + 32, b.bytes);
+    }
+
+    friend constexpr auto
+    operator<=>(bytes32_t const &a, bytes32_t const &b) noexcept
+    {
+        return std::lexicographical_compare_three_way(
+            a.bytes, a.bytes + 32, b.bytes, b.bytes + 32);
+    }
+};
 
 static_assert(sizeof(bytes32_t) == 32);
 static_assert(alignof(bytes32_t) == 1);
 
-constexpr bytes32_t to_bytes(uint256_t const n) noexcept
+using uint256_be_t = bytes32_t;
+
+constexpr bytes32_t to_bytes(uint256_t const &n) noexcept
 {
     return std::bit_cast<bytes32_t>(n);
 }
 
-constexpr bytes32_t to_bytes(hash256 const n) noexcept
+constexpr bytes32_t to_bytes(hash256 const &n) noexcept
 {
     return std::bit_cast<bytes32_t>(n);
 }
@@ -59,21 +116,46 @@ constexpr bytes32_t to_bytes(byte_string_view const data) noexcept
     return byte;
 }
 
-using namespace evmc::literals;
-inline constexpr bytes32_t NULL_HASH{
-    0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32};
+namespace literals
+{
+    consteval bytes32_t operator""_bytes32(char const *const s) noexcept
+    {
+        return from_hex<bytes32_t>(s).value();
+    }
+}
 
-inline constexpr bytes32_t NULL_LIST_HASH{
-    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347_bytes32};
+using literals::operator""_bytes32;
+using evmc::literals::operator""_address;
+
+constexpr bytes32_t bytes32_from_hex(char const *const s)
+{
+    return from_hex<bytes32_t>(s).value();
+}
+
+constexpr bytes32_t NULL_HASH{bytes32_from_hex(
+    "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")};
+
+constexpr bytes32_t NULL_LIST_HASH{bytes32_from_hex(
+    "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")};
 
 // Root hash of an empty trie
-inline constexpr bytes32_t NULL_ROOT{
-    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32};
+constexpr bytes32_t NULL_ROOT{bytes32_from_hex(
+    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")};
 
-inline constexpr bytes32_t NULL_HASH_BLAKE3{
-    0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262_bytes32};
+constexpr bytes32_t NULL_HASH_BLAKE3{bytes32_from_hex(
+    "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262")};
 
 MONAD_NAMESPACE_END
+
+template <>
+struct std::hash<monad::bytes32_t>
+{
+    size_t operator()(monad::bytes32_t const &x) const noexcept
+    {
+        return ankerl::unordered_dense::detail::wyhash::hash(
+            x.bytes, sizeof(x.bytes));
+    }
+};
 
 template <>
 struct ankerl::unordered_dense::hash<monad::bytes32_t>
@@ -82,7 +164,7 @@ struct ankerl::unordered_dense::hash<monad::bytes32_t>
 
     uint64_t operator()(monad::bytes32_t const &x) const noexcept
     {
-        return detail::wyhash::hash(x.bytes, sizeof(x.bytes));
+        return std::hash<monad::bytes32_t>{}(x);
     }
 };
 

--- a/category/core/bytes_test.cpp
+++ b/category/core/bytes_test.cpp
@@ -1,0 +1,269 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <gtest/gtest.h>
+
+#include <evmc/evmc.h>
+
+#include <cstdint>
+#include <unordered_set>
+
+using namespace monad;
+using namespace monad::literals;
+
+// ---------------------------------------------------------------------------
+// Default constructor
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, default_constructor_is_zero)
+{
+    constexpr bytes32_t zero;
+    for (auto const b : zero.bytes) {
+        EXPECT_EQ(b, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// uint64_t constructor — big-endian in the last 8 bytes
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, uint64_constructor_big_endian)
+{
+    constexpr bytes32_t val{uint64_t{0x0102030405060708}};
+
+    // Leading 24 bytes must be zero.
+    for (int i = 0; i < 24; ++i) {
+        EXPECT_EQ(val.bytes[i], 0) << "byte " << i;
+    }
+
+    EXPECT_EQ(val.bytes[24], 0x01);
+    EXPECT_EQ(val.bytes[25], 0x02);
+    EXPECT_EQ(val.bytes[26], 0x03);
+    EXPECT_EQ(val.bytes[27], 0x04);
+    EXPECT_EQ(val.bytes[28], 0x05);
+    EXPECT_EQ(val.bytes[29], 0x06);
+    EXPECT_EQ(val.bytes[30], 0x07);
+    EXPECT_EQ(val.bytes[31], 0x08);
+}
+
+TEST(Bytes32, uint64_constructor_zero)
+{
+    constexpr bytes32_t val{uint64_t{0}};
+    constexpr bytes32_t zero;
+    EXPECT_EQ(val, zero);
+}
+
+TEST(Bytes32, uint64_constructor_one)
+{
+    constexpr bytes32_t val{uint64_t{1}};
+    EXPECT_EQ(val.bytes[31], 1);
+    for (int i = 0; i < 31; ++i) {
+        EXPECT_EQ(val.bytes[i], 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variadic byte constructor
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, variadic_byte_constructor)
+{
+    constexpr bytes32_t val{uint8_t{0xAA}, uint8_t{0xBB}, uint8_t{0xCC}};
+
+    EXPECT_EQ(val.bytes[0], 0xAA);
+    EXPECT_EQ(val.bytes[1], 0xBB);
+    EXPECT_EQ(val.bytes[2], 0xCC);
+    for (int i = 3; i < 32; ++i) {
+        EXPECT_EQ(val.bytes[i], 0) << "byte " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// operator bool
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, operator_bool_zero_is_false)
+{
+    constexpr bytes32_t zero;
+    EXPECT_FALSE(static_cast<bool>(zero));
+}
+
+TEST(Bytes32, operator_bool_nonzero_is_true)
+{
+    constexpr bytes32_t val{uint64_t{1}};
+    EXPECT_TRUE(static_cast<bool>(val));
+}
+
+// ---------------------------------------------------------------------------
+// Equality and ordering
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, equality)
+{
+    constexpr auto a = bytes32_from_hex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    constexpr auto b = bytes32_from_hex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    constexpr bytes32_t c{uint64_t{2}};
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, c);
+}
+
+TEST(Bytes32, ordering)
+{
+    constexpr bytes32_t a{uint64_t{1}};
+    constexpr bytes32_t b{uint64_t{2}};
+    EXPECT_LT(a, b);
+    EXPECT_GT(b, a);
+    EXPECT_LE(a, a);
+    EXPECT_GE(b, b);
+}
+
+TEST(Bytes32, ordering_lexicographic)
+{
+    // A value with a higher first byte should compare greater,
+    // regardless of trailing bytes.
+    constexpr bytes32_t high{uint8_t{0xFF}};
+    constexpr bytes32_t low{uint64_t{UINT64_MAX}};
+    EXPECT_GT(high, low);
+}
+
+// ---------------------------------------------------------------------------
+// _bytes32 literal
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, literal_parses_correctly)
+{
+    constexpr auto val =
+        0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+    constexpr bytes32_t expected{uint64_t{1}};
+    EXPECT_EQ(val, expected);
+}
+
+TEST(Bytes32, literal_full_width)
+{
+    constexpr auto val =
+        0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef_bytes32;
+    for (int i = 0; i < 32; i += 4) {
+        EXPECT_EQ(val.bytes[i + 0], 0xDE);
+        EXPECT_EQ(val.bytes[i + 1], 0xAD);
+        EXPECT_EQ(val.bytes[i + 2], 0xBE);
+        EXPECT_EQ(val.bytes[i + 3], 0xEF);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// bytes32_from_hex
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, from_hex_without_prefix)
+{
+    auto const val = bytes32_from_hex(
+        "0000000000000000000000000000000000000000000000000000000000000042");
+    EXPECT_EQ(val.bytes[31], 0x42);
+}
+
+TEST(Bytes32, from_hex_with_prefix)
+{
+    auto const val = bytes32_from_hex(
+        "0x0000000000000000000000000000000000000000000000000000000000000042");
+    EXPECT_EQ(val.bytes[31], 0x42);
+}
+
+// ---------------------------------------------------------------------------
+// Well-known constants
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, null_hash_is_nonzero)
+{
+    EXPECT_TRUE(static_cast<bool>(NULL_HASH));
+}
+
+TEST(Bytes32, null_root_is_nonzero)
+{
+    EXPECT_TRUE(static_cast<bool>(NULL_ROOT));
+}
+
+// ---------------------------------------------------------------------------
+// Hashing — std::hash, ankerl, boost
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, std_hash_equal_values_same_hash)
+{
+    bytes32_t const a{uint64_t{42}};
+    bytes32_t const b{uint64_t{42}};
+    EXPECT_EQ(std::hash<bytes32_t>{}(a), std::hash<bytes32_t>{}(b));
+}
+
+TEST(Bytes32, std_hash_different_values_differ)
+{
+    bytes32_t const a{uint64_t{1}};
+    bytes32_t const b{uint64_t{2}};
+    // Not guaranteed by spec, but overwhelmingly likely for a good hash.
+    EXPECT_NE(std::hash<bytes32_t>{}(a), std::hash<bytes32_t>{}(b));
+}
+
+TEST(Bytes32, ankerl_hash_consistent_with_std)
+{
+    bytes32_t const val{uint64_t{123}};
+    auto const std_h = std::hash<bytes32_t>{}(val);
+    auto const ankerl_h = ankerl::unordered_dense::hash<bytes32_t>{}(val);
+    EXPECT_EQ(std_h, ankerl_h);
+}
+
+TEST(Bytes32, boost_hash_consistent_with_std)
+{
+    bytes32_t const val{uint64_t{456}};
+    auto const std_h = std::hash<bytes32_t>{}(val);
+    auto const boost_h = boost::hash_value(val);
+    EXPECT_EQ(std_h, boost_h);
+}
+
+TEST(Bytes32, usable_in_unordered_set)
+{
+    std::unordered_set<bytes32_t> set;
+    set.insert(bytes32_t{uint64_t{1}});
+    set.insert(bytes32_t{uint64_t{2}});
+    set.insert(bytes32_t{uint64_t{1}});
+    EXPECT_EQ(set.size(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// evmc_bytes32 implicit conversion
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, implicit_from_evmc_bytes32)
+{
+    evmc_bytes32 raw{};
+    raw.bytes[31] = 0x07;
+    bytes32_t const wrapped = raw;
+    EXPECT_EQ(wrapped.bytes[31], 0x07);
+}
+
+// ---------------------------------------------------------------------------
+// byte_string_view conversion
+// ---------------------------------------------------------------------------
+
+TEST(Bytes32, converts_to_byte_string_view)
+{
+    bytes32_t const val{uint64_t{0xFF}};
+    byte_string_view const view = val;
+    EXPECT_EQ(view.size(), 32);
+    EXPECT_EQ(view[31], 0xFF);
+}

--- a/category/execution/ethereum/block_hash_history.cpp
+++ b/category/execution/ethereum/block_hash_history.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
+using literals::operator""_bytes32;
 
 byte_string const BLOCK_HISTORY_CODE =
     from_hex(

--- a/category/execution/ethereum/core/test/test_account_rlp.cpp
+++ b/category/execution/ethereum/core/test/test_account_rlp.cpp
@@ -29,7 +29,7 @@ using namespace monad::rlp;
 TEST(Rlp_Account, Encode)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using monad::literals::operator""_bytes32;
 
     static constexpr uint256_t b{24'000'000};
     static constexpr bytes32_t storage_root{

--- a/category/execution/ethereum/core/test/test_int_rlp.cpp
+++ b/category/execution/ethereum/core/test/test_int_rlp.cpp
@@ -230,7 +230,7 @@ TEST(Rlp_Number, DecodeEncodeBigNumers)
             0xbea34dd04b09ad3b6014251ee24578074087ee60fda8c391cf466dfe5d687d7b_u256);
     }
 
-    using namespace evmc::literals;
+    using monad::literals::operator""_bytes32;
     // bytes32
     {
         auto const encoding = encode_bytes32(

--- a/category/execution/ethereum/core/test/test_receipt_rlp.cpp
+++ b/category/execution/ethereum/core/test/test_receipt_rlp.cpp
@@ -125,7 +125,8 @@ TEST(Rlp_Receipt, DecodeEncodeBloom)
 
 TEST(Rlp_Receipt, DecodeEncodeEip155Receipt)
 {
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr uint64_t gas{2'850'010};
     static constexpr auto addr{
@@ -210,7 +211,8 @@ TEST(Rlp_Receipt, DecodeEncodeEip155Receipt)
 
 TEST(Rlp_Receipt, DecodeEncodeReceiptLogSize)
 {
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr uint64_t gas{2'850'010};
     static constexpr auto addr{
@@ -275,7 +277,8 @@ TEST(Rlp_Receipt, DecodeEncodeReceiptLogSize)
 
 TEST(Rlp_Receipt, EncodeEip1559Receipt)
 {
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr uint64_t gas{2'850'010};
     static constexpr auto addr{
@@ -361,7 +364,8 @@ TEST(Rlp_Receipt, EncodeEip1559Receipt)
 
 TEST(Rlp_Receipt, EncodeEip2930Receipt)
 {
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr uint64_t gas{2'850'010};
     static constexpr auto addr{

--- a/category/execution/ethereum/core/test/test_transaction_rlp.cpp
+++ b/category/execution/ethereum/core/test/test_transaction_rlp.cpp
@@ -118,7 +118,8 @@ TEST(Rlp_Transaction, EncodeAccessListMultipleEntry)
 TEST(Rlp_Transaction, DecodeEncodeLegacy)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -169,7 +170,8 @@ TEST(Rlp_Transaction, DecodeEncodeLegacy)
 TEST(Rlp_Transaction, DecodeEncodeLegacyNoTo)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -205,7 +207,8 @@ TEST(Rlp_Transaction, DecodeEncodeLegacyNoTo)
 TEST(Rlp_Transaction, EncodeEip155)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -259,7 +262,8 @@ TEST(Rlp_Transaction, EncodeEip155)
 TEST(Rlp_Transaction, EncodeEip2930)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -347,7 +351,8 @@ TEST(Rlp_Transaction, EncodeEip2930)
 TEST(Rlp_Transaction, EncodeEip1559TrueParity)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -425,7 +430,8 @@ TEST(Rlp_Transaction, EncodeEip1559TrueParity)
 TEST(Rlp_Transaction, EncodeEip1559FalseParity)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto price{20'000'000'000};
     static constexpr auto value{0xde0b6b3a7640000_u256};
@@ -503,7 +509,8 @@ TEST(Rlp_Transaction, EncodeEip1559FalseParity)
 TEST(Rlp_Transaction, IntTypeMismatchRegression)
 {
     using intx::operator""_u256;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     static constexpr auto to_addr{
         0x3535353535353535353535353535353535353535_address};

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -470,7 +470,8 @@ TYPED_TEST(DBTest, storage_deletion)
 TYPED_TEST(DBTest, commit_receipts_transactions)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     TrieDb tdb{this->db};
     // empty receipts
@@ -650,7 +651,8 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
 TEST_F(OnDiskTrieDbWithFileFixture, get_transactions)
 {
     using namespace intx;
-    using namespace evmc::literals;
+    using evmc::literals::operator""_address;
+    using monad::literals::operator""_bytes32;
 
     TrieDb tdb{this->db};
 

--- a/category/execution/ethereum/event/record_block_events.cpp
+++ b/category/execution/ethereum/event/record_block_events.cpp
@@ -68,7 +68,7 @@ void record_block_start(
              .nonce = std::bit_cast<monad_c_b64>(eth_block_header.nonce),
              .base_fee_per_gas = eth_block_header.base_fee_per_gas.value_or(0),
              .withdrawals_root =
-                 eth_block_header.withdrawals_root.value_or(evmc_bytes32{}),
+                 eth_block_header.withdrawals_root.value_or(bytes32_t{}),
              .txn_count = txn_count},
         .monad_block_input = opt_monad_input.value_or({})};
     memcpy(

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -222,7 +222,8 @@ struct EvmcHost final : public EvmcHostBase
                 abi_encode_event_signature("Transfer(address,address,uint256)");
             static_assert(
                 signature ==
-                0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef_bytes32);
+                bytes32_from_hex("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a"
+                                 "11628f55a4df523b3ef"));
 
             auto event = EventBuilder(native_token_address, signature)
                              .add_topic(abi_encode_address(from))

--- a/category/execution/ethereum/evmc_host_test.cpp
+++ b/category/execution/ethereum/evmc_host_test.cpp
@@ -129,7 +129,7 @@ TYPED_TEST(TraitsTest, emit_log)
         0x1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c_bytes32};
     static constexpr auto topic1{
         0x0000000000000000000000000000000000000000000000000000000000000007_bytes32};
-    static constexpr bytes32_t topics[] = {topic0, topic1};
+    static constexpr evmc::bytes32 topics[] = {topic0, topic1};
     static byte_string const data = {0x00, 0x01, 0x02, 0x03, 0x04};
 
     InMemoryMachine machine;
@@ -154,12 +154,7 @@ TYPED_TEST(TraitsTest, emit_log)
         0,
         chain_ctx};
 
-    host.emit_log(
-        from,
-        data.data(),
-        data.size(),
-        topics,
-        sizeof(topics) / sizeof(bytes32_t));
+    host.emit_log(from, data.data(), data.size(), topics, std::size(topics));
 
     auto const logs = state.logs();
     EXPECT_EQ(logs.size(), 1);

--- a/category/execution/ethereum/test/test_call_frame_rlp.cpp
+++ b/category/execution/ethereum/test/test_call_frame_rlp.cpp
@@ -89,7 +89,7 @@ TEST(Rlp_CallFrame, encode_decode_call_frames)
                 .log =
                     Receipt::Log{
                         .data = {byte_string{0xef, 0xfe}},
-                        .topics = {evmc_bytes32{0x01, 0x02}},
+                        .topics = {bytes32_t{uint8_t{0x01}, uint8_t{0x02}}},
                         .address = a,
                     },
                 .position = 0,
@@ -100,8 +100,8 @@ TEST(Rlp_CallFrame, encode_decode_call_frames)
                         .data = {byte_string{0xab, 0xcd}},
                         .topics =
                             {
-                                evmc_bytes32{0x03},
-                                evmc_bytes32{0x04, 0x05},
+                                bytes32_t{uint8_t{0x03}},
+                                bytes32_t{uint8_t{0x04}, uint8_t{0x05}},
                             },
                         .address = b,
                     },

--- a/category/execution/monad/reserve_balance/reserve_balance_contract.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract.cpp
@@ -64,11 +64,11 @@ ReserveBalanceContract::ReserveBalanceContract(
     state_.add_to_balance(RESERVE_BALANCE_CA, 0);
 }
 
-Result<void> function_not_payable(evmc_uint256be const &value)
+Result<void> function_not_payable(uint256_be_t const &value)
 {
     bool const all_zero = std::all_of(
         value.bytes,
-        value.bytes + sizeof(evmc_uint256be),
+        value.bytes + sizeof(uint256_be_t),
         [](uint8_t const byte) { return byte == 0; });
 
     if (MONAD_UNLIKELY(!all_zero)) {
@@ -103,8 +103,7 @@ EXPLICIT_MONAD_TRAITS(ReserveBalanceContract::precompile_dispatch);
 
 template <Traits traits>
 Result<byte_string> ReserveBalanceContract::precompile_dipped_into_reserve(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -120,7 +119,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(
     ReserveBalanceContract::precompile_dipped_into_reserve);
 
 Result<byte_string> ReserveBalanceContract::precompile_fallback(
-    byte_string_view, evmc_address const &, evmc_uint256be const &)
+    byte_string_view, evmc_address const &, uint256_be_t const &)
 {
     return ReserveBalanceError::MethodNotSupported;
 }

--- a/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract.hpp
@@ -39,7 +39,7 @@ public:
     ReserveBalanceContract(State &state, CallTracerBase &tracer);
 
     using PrecompileFunc = Result<byte_string> (ReserveBalanceContract::*)(
-        byte_string_view, evmc_address const &, evmc_bytes32 const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 
     //
     // Precompile methods
@@ -50,10 +50,10 @@ public:
 
     template <Traits traits>
     Result<byte_string> precompile_dipped_into_reserve(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 
     Result<byte_string> precompile_fallback(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -692,8 +692,8 @@ TYPED_TEST(
                     }
                     msg.flags = flags;
 
-                    for (evmc_uint256be const value :
-                         std::initializer_list<evmc_uint256be>{
+                    for (uint256_be_t const value :
+                         std::initializer_list<uint256_be_t>{
                              0x00_bytes32, 0x01_bytes32}) {
                         msg.value = value;
 
@@ -716,8 +716,8 @@ TYPED_TEST(
         evmc_message msg = make_msg();
         msg.gas = 99;
 
-        for (evmc_uint256be const value : std::initializer_list<evmc_uint256be>{
-                 0x00_bytes32, 0x01_bytes32}) {
+        for (uint256_be_t const value :
+             std::initializer_list<uint256_be_t>{0x00_bytes32, 0x01_bytes32}) {
             msg.value = value;
 
             for (auto const &calldata_variant : calldata_variants) {
@@ -749,8 +749,7 @@ TYPED_TEST(
             msg.input_data = data;
             msg.input_size = size;
 
-            for (evmc_uint256be const value :
-                 std::initializer_list<evmc_uint256be>{
+            for (uint256_be_t const value : std::initializer_list<uint256_be_t>{
                      0x00_bytes32, 0x01_bytes32}) {
                 msg.value = value;
 
@@ -772,8 +771,8 @@ TYPED_TEST(
             {wrong_too_long.data(), wrong_too_long.size()},
         };
 
-        for (evmc_uint256be const value : std::initializer_list<evmc_uint256be>{
-                 0x00_bytes32, 0x01_bytes32}) {
+        for (uint256_be_t const value :
+             std::initializer_list<uint256_be_t>{0x00_bytes32, 0x01_bytes32}) {
             msg.value = value;
 
             for (auto const &[data, size] : wrong_calldata) {

--- a/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
@@ -1123,7 +1123,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     std::tuple<
-        Address, byte_string, byte_string, byte_string, Address, evmc_uint256be>
+        Address, byte_string, byte_string, byte_string, Address, uint256_be_t>
     StakingContractMachine<traits>::gen_precompile_add_validator_input(
         uint256_t const &min_stake, uint256_t const &max_stake)
     {
@@ -1133,7 +1133,7 @@ namespace monad::staking::test
 
         Address const sender = gen_new_or_old_address();
         uint256_t const stake = gen_stake(min_stake, max_stake);
-        auto const value = intx::be::store<evmc_uint256be>(stake);
+        auto const value = intx::be::store<uint256_be_t>(stake);
         Address const auth_address = gen_new_or_old_address();
         auto const commission = gen_bound_biased_uint256(0, MAX_COMMISSION);
         auto const secret = intx::be::store<bytes32_t>(gen_uint256());
@@ -1148,7 +1148,7 @@ namespace monad::staking::test
     u64_be StakingContractMachine<traits>::model_precompile_add_validator(
         Address const &signer, byte_string const &msg, byte_string const &secp,
         byte_string const &bls, Address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         auto result = model_.precompile_add_validator<traits>(
             msg, secp, bls, sender, value);
@@ -1207,8 +1207,8 @@ namespace monad::staking::test
                 consume_bytes(reader, 48).data());
         auto const auth_address = unaligned_load<Address>(
             consume_bytes(reader, sizeof(Address)).data());
-        auto const signed_stake = unaligned_load<evmc_uint256be>(
-            consume_bytes(reader, sizeof(evmc_uint256be)).data());
+        auto const signed_stake = unaligned_load<uint256_be_t>(
+            consume_bytes(reader, sizeof(uint256_be_t)).data());
         auto const commission = unaligned_load<u256_be>(
             consume_bytes(reader, sizeof(u256_be)).data());
 
@@ -1257,11 +1257,11 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::tuple<u64_be, Address, evmc_uint256be>
+    std::tuple<u64_be, Address, uint256_be_t>
     StakingContractMachine<traits>::gen_precompile_delegate_input()
     {
         auto const &sender = gen_new_or_old_address();
-        using R = std::tuple<u64_be, Address, evmc_uint256be>;
+        using R = std::tuple<u64_be, Address, uint256_be_t>;
         return discrete_choice<R>(
             engine_,
             [&, this](auto &) -> R {
@@ -1271,17 +1271,17 @@ namespace monad::staking::test
                 MONAD_ASSERT(val_stake <= MAX_DELEGABLE_STAKE);
                 auto const del_stake =
                     gen_stake(MIN_DELEGATE_STAKE, MAX_STAKE - val_stake);
-                auto const value = intx::be::store<evmc_uint256be>(del_stake);
+                auto const value = intx::be::store<uint256_be_t>(del_stake);
                 return {val_id, sender, value};
             },
             Choice(0.01, [&, this](auto &) -> R {
-                return {gen_potential_val_id(), sender, evmc_uint256be{}};
+                return {gen_potential_val_id(), sender, uint256_be_t{}};
             }));
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_delegate(
-        u64_be val_id, Address const &sender, evmc_uint256be const &value)
+        u64_be val_id, Address const &sender, uint256_be_t const &value)
     {
         auto result = model_.precompile_delegate<traits>(val_id, sender, value);
         MONAD_ASSERT(result.has_value());
@@ -1384,7 +1384,7 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::optional<std::tuple<u64_be, u256_be, u8_be, Address, evmc_uint256be>>
+    std::optional<std::tuple<u64_be, u256_be, u8_be, Address, uint256_be_t>>
     StakingContractMachine<traits>::gen_precompile_undelegate_input(
         uint256_t const &min_undelegate)
     {
@@ -1438,13 +1438,13 @@ namespace monad::staking::test
 
         auto const undelegate_stake = gen_stake(min_undelegate, del_stake);
 
-        return {{val_id, undelegate_stake, w, sender, evmc_uint256be{}}};
+        return {{val_id, undelegate_stake, w, sender, uint256_be_t{}}};
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_undelegate(
         u64_be val_id, u256_be stake, u8_be wid, Address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         MONAD_ASSERT(model_.val_execution(val_id).exists());
 
@@ -1571,7 +1571,7 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::optional<std::tuple<u64_be, Address, evmc_uint256be>>
+    std::optional<std::tuple<u64_be, Address, uint256_be_t>>
     StakingContractMachine<traits>::gen_precompile_compound_input()
     {
         u64_be val_id = 0;
@@ -1590,7 +1590,7 @@ namespace monad::staking::test
                 model_.val_execution(val_id).stake().load().native();
             if (val_stake + rewards <= MAX_STAKE &&
                 (rewards == 0 || rewards >= MIN_DELEGATE_STAKE)) {
-                return {{val_id, sender, evmc_uint256be{}}};
+                return {{val_id, sender, uint256_be_t{}}};
             }
         }
         // Try a few times to find a suitable delegator
@@ -1600,13 +1600,13 @@ namespace monad::staking::test
                 model_.delegator(val_id, sender).rewards().load().native() +
                 model_.unaccumulated_rewards(val_id, sender);
             if (rewards == 0) {
-                return {{val_id, sender, evmc_uint256be{}}};
+                return {{val_id, sender, uint256_be_t{}}};
             }
             if (rewards >= MIN_DELEGATE_STAKE) {
                 auto const val_stake =
                     model_.val_execution(val_id).stake().load().native();
                 if (val_stake + rewards <= MAX_STAKE) {
-                    return {{val_id, sender, evmc_uint256be{}}};
+                    return {{val_id, sender, uint256_be_t{}}};
                 }
             }
         }
@@ -1615,7 +1615,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_compound(
-        u64_be val_id, Address const &sender, evmc_uint256be const &value)
+        u64_be val_id, Address const &sender, uint256_be_t const &value)
     {
         uint256_t const rewards =
             model_.delegator(val_id, sender).rewards().load().native() +
@@ -1725,7 +1725,7 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::optional<std::tuple<u64_be, u8_be, Address, evmc_uint256be>>
+    std::optional<std::tuple<u64_be, u8_be, Address, uint256_be_t>>
     StakingContractMachine<traits>::gen_precompile_withdraw_input()
     {
         if (all_withdrawal_requests_.empty()) {
@@ -1748,13 +1748,13 @@ namespace monad::staking::test
         if (epoch < wepoch) {
             skip_epochs(wepoch - epoch);
         }
-        return {{val_id, wid, sender, evmc_uint256be{}}};
+        return {{val_id, wid, sender, uint256_be_t{}}};
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_withdraw(
         u64_be val_id, u8_be wid, Address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         auto result =
             model_.precompile_withdraw<traits>(val_id, wid, sender, value);
@@ -1822,7 +1822,7 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::tuple<u64_be, Address, evmc_uint256be>
+    std::tuple<u64_be, Address, uint256_be_t>
     StakingContractMachine<traits>::gen_precompile_claim_rewards_input()
     {
         u64_be val_id = 0;
@@ -1833,15 +1833,15 @@ namespace monad::staking::test
             sender = gen_new_or_old_address();
         });
         if (sender != Address{}) {
-            return {val_id, sender, evmc_uint256be{}};
+            return {val_id, sender, uint256_be_t{}};
         }
         std::tie(val_id, sender) = gen_delegator();
-        return {val_id, sender, evmc_uint256be{}};
+        return {val_id, sender, uint256_be_t{}};
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_claim_rewards(
-        u64_be val_id, Address const &sender, evmc_uint256be const &value)
+        u64_be val_id, Address const &sender, uint256_be_t const &value)
     {
         auto const res =
             model_.precompile_claim_rewards<traits>(val_id, sender, value);
@@ -1883,18 +1883,18 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::tuple<u64_be, u256_be, Address, evmc_uint256be>
+    std::tuple<u64_be, u256_be, Address, uint256_be_t>
     StakingContractMachine<traits>::gen_precompile_change_commission_input()
     {
         auto const [val_id, sender] = gen_validator_auth_address();
         auto const commission = gen_bound_biased_uint256(0, MAX_COMMISSION);
-        return {val_id, commission, sender, evmc_uint256be{}};
+        return {val_id, commission, sender, uint256_be_t{}};
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_change_commission(
         u64_be val_id, u256_be const &commission, Address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         auto const res = model_.precompile_change_commission<traits>(
             val_id, commission, sender, value);
@@ -1913,14 +1913,14 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::optional<std::tuple<u64_be, Address, evmc_uint256be>>
+    std::optional<std::tuple<u64_be, Address, uint256_be_t>>
     StakingContractMachine<traits>::gen_precompile_external_reward_input()
     {
         if (auto const val_id = gen_active_consensus_val_id()) {
             auto const sender = gen_new_or_old_address();
             auto const reward = gen_bound_biased_uint256(
                 MIN_EXTERNAL_REWARD, MAX_EXTERNAL_REWARD);
-            auto const value = intx::be::store<evmc_uint256be>(reward);
+            auto const value = intx::be::store<uint256_be_t>(reward);
             return {{*val_id, sender, value}};
         }
         return std::nullopt;
@@ -1928,7 +1928,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_external_reward(
-        u64_be val_id, Address const &sender, evmc_uint256be const &value)
+        u64_be val_id, Address const &sender, uint256_be_t const &value)
     {
         auto const res =
             model_.precompile_external_reward<traits>(val_id, sender, value);
@@ -1985,29 +1985,29 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    std::tuple<u64_be, Address, Address, evmc_uint256be>
+    std::tuple<u64_be, Address, Address, uint256_be_t>
     StakingContractMachine<traits>::gen_precompile_get_delegator_input()
     {
-        using R = std::tuple<u64_be, Address, Address, evmc_uint256be>;
+        using R = std::tuple<u64_be, Address, Address, uint256_be_t>;
         return discrete_choice<R>(
             engine_,
             [&, this](auto &) -> R {
                 auto const [val_id, addr] = gen_delegator();
                 auto const sender = gen_new_or_old_address();
-                return {val_id, addr, sender, evmc_uint256be{}};
+                return {val_id, addr, sender, uint256_be_t{}};
             },
             Choice(0.05, [&, this](auto &) -> R {
                 auto const val_id = gen() % (model_.last_val_id() + 3);
                 auto const addr = gen_new_or_old_address();
                 auto const sender = gen_new_or_old_address();
-                return {val_id, addr, sender, evmc_uint256be{}};
+                return {val_id, addr, sender, uint256_be_t{}};
             }));
     }
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_get_delegator(
         u64_be val_id, Address const &addr, Address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         auto const res = model_.precompile_get_delegator<traits>(
             val_id, addr, sender, value);

--- a/category/execution/monad/staking/fuzzer/staking_contract_machine.hpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_machine.hpp
@@ -194,80 +194,79 @@ namespace monad::staking::test
 
         std::tuple<
             Address, byte_string, byte_string, byte_string, Address,
-            evmc_uint256be>
+            uint256_be_t>
         gen_precompile_add_validator_input(
             uint256_t const &min_stake, uint256_t const &max_stake);
 
         u64_be model_precompile_add_validator(
             Address const &, byte_string const &, byte_string const &,
-            byte_string const &, Address const &, evmc_uint256be const &);
+            byte_string const &, Address const &, uint256_be_t const &);
 
         void precompile_add_validator();
 
-        std::tuple<u64_be, Address, evmc_uint256be>
+        std::tuple<u64_be, Address, uint256_be_t>
         gen_precompile_delegate_input();
 
         void model_precompile_delegate(
-            u64_be, Address const &, evmc_uint256be const &);
+            u64_be, Address const &, uint256_be_t const &);
 
         void precompile_delegate();
 
-        std::optional<
-            std::tuple<u64_be, u256_be, u8_be, Address, evmc_uint256be>>
+        std::optional<std::tuple<u64_be, u256_be, u8_be, Address, uint256_be_t>>
         gen_precompile_undelegate_input(uint256_t const &min_undelegate);
 
         void model_precompile_undelegate(
-            u64_be, u256_be, u8_be, Address const &, evmc_uint256be const &);
+            u64_be, u256_be, u8_be, Address const &, uint256_be_t const &);
 
         void precompile_undelegate();
 
-        std::optional<std::tuple<u64_be, Address, evmc_uint256be>>
+        std::optional<std::tuple<u64_be, Address, uint256_be_t>>
         gen_precompile_compound_input();
 
         void model_precompile_compound(
-            u64_be, Address const &, evmc_uint256be const &);
+            u64_be, Address const &, uint256_be_t const &);
 
         [[nodiscard]]
         bool precompile_compound();
 
-        std::optional<std::tuple<u64_be, u8_be, Address, evmc_uint256be>>
+        std::optional<std::tuple<u64_be, u8_be, Address, uint256_be_t>>
         gen_precompile_withdraw_input();
 
         void model_precompile_withdraw(
-            u64_be, u8_be, Address const &, evmc_uint256be const &);
+            u64_be, u8_be, Address const &, uint256_be_t const &);
 
         [[nodiscard]]
         bool precompile_withdraw();
 
-        std::tuple<u64_be, Address, evmc_uint256be>
+        std::tuple<u64_be, Address, uint256_be_t>
         gen_precompile_claim_rewards_input();
 
         void model_precompile_claim_rewards(
-            u64_be, Address const &, evmc_uint256be const &);
+            u64_be, Address const &, uint256_be_t const &);
 
         void precompile_claim_rewards();
 
-        std::tuple<u64_be, u256_be, Address, evmc_uint256be>
+        std::tuple<u64_be, u256_be, Address, uint256_be_t>
         gen_precompile_change_commission_input();
 
         void model_precompile_change_commission(
-            u64_be, u256_be const &, Address const &, evmc_uint256be const &);
+            u64_be, u256_be const &, Address const &, uint256_be_t const &);
 
         void precompile_change_commission();
 
-        std::optional<std::tuple<u64_be, Address, evmc_uint256be>>
+        std::optional<std::tuple<u64_be, Address, uint256_be_t>>
         gen_precompile_external_reward_input();
 
         void model_precompile_external_reward(
-            u64_be, Address const &, evmc_uint256be const &);
+            u64_be, Address const &, uint256_be_t const &);
 
         bool precompile_external_reward();
 
-        std::tuple<u64_be, Address, Address, evmc_uint256be>
+        std::tuple<u64_be, Address, Address, uint256_be_t>
         gen_precompile_get_delegator_input();
 
         void model_precompile_get_delegator(
-            u64_be, Address const &, Address const &, evmc_uint256be const &);
+            u64_be, Address const &, Address const &, uint256_be_t const &);
 
         void precompile_get_delegator();
     };

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -312,7 +312,7 @@ namespace monad::staking::test
     StakingContractModel::syscall_on_epoch_change(u64_be next_epoch)
     {
         auto const input = abi_encode_uint(next_epoch);
-        pre_call(evmc_uint256be{});
+        pre_call(uint256_be_t{});
         auto res = contract_.syscall_on_epoch_change(input, 0);
         post_call(res);
         if (res.has_value()) {
@@ -334,7 +334,7 @@ namespace monad::staking::test
 
     Result<void> StakingContractModel::syscall_snapshot()
     {
-        pre_call(evmc_uint256be{});
+        pre_call(uint256_be_t{});
         auto res = contract_.syscall_snapshot({}, 0);
         post_call(res);
         return res;
@@ -345,7 +345,7 @@ namespace monad::staking::test
         Address const &addr, u256_be const &reward)
     {
         auto const input = abi_encode_address(addr);
-        pre_call(evmc_uint256be{});
+        pre_call(uint256_be_t{});
         auto res = contract_.syscall_reward<traits>(input, reward.native());
         post_call(res);
         if (res.has_value()) {
@@ -366,7 +366,7 @@ namespace monad::staking::test
     Result<u64_be> StakingContractModel::precompile_add_validator(
         byte_string_view message, byte_string_view secp_signature,
         byte_string_view bls_signature, evmc_address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(
@@ -404,7 +404,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     Result<void> StakingContractModel::precompile_delegate(
-        u64_be val_id, evmc_address const &sender, evmc_uint256be const &value)
+        u64_be val_id, evmc_address const &sender, uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(abi_encode_selector("delegate(uint64)"));
@@ -436,7 +436,7 @@ namespace monad::staking::test
     template <Traits traits>
     Result<void> StakingContractModel::precompile_undelegate(
         u64_be val_id, u256_be const &stake, u8_be withdrawal_id,
-        evmc_address const &sender, evmc_uint256be const &value)
+        evmc_address const &sender, uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(
@@ -481,7 +481,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     Result<void> StakingContractModel::precompile_compound(
-        u64_be val_id, evmc_address const &sender, evmc_uint256be const &value)
+        u64_be val_id, evmc_address const &sender, uint256_be_t const &value)
     {
         auto const stake =
             unaccumulated_rewards(val_id, sender) +
@@ -512,7 +512,7 @@ namespace monad::staking::test
     template <Traits traits>
     Result<void> StakingContractModel::precompile_withdraw(
         u64_be val_id, u8_be withdrawal_id, evmc_address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         auto const reward = withdrawal_reward(val_id, sender, withdrawal_id);
 
@@ -535,7 +535,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     Result<void> StakingContractModel::precompile_claim_rewards(
-        u64_be val_id, evmc_address const &sender, evmc_uint256be const &value)
+        u64_be val_id, evmc_address const &sender, uint256_be_t const &value)
     {
         auto const stake =
             unaccumulated_rewards(val_id, sender) +
@@ -558,7 +558,7 @@ namespace monad::staking::test
     template <Traits traits>
     Result<void> StakingContractModel::precompile_change_commission(
         u64_be val_id, u256_be const &new_commission,
-        evmc_address const &sender, evmc_uint256be const &value)
+        evmc_address const &sender, uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(
@@ -575,7 +575,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     Result<void> StakingContractModel::precompile_external_reward(
-        u64_be val_id, evmc_address const &sender, evmc_uint256be const &value)
+        u64_be val_id, evmc_address const &sender, uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(abi_encode_selector("externalReward(uint64)"));
@@ -596,7 +596,7 @@ namespace monad::staking::test
     template <Traits traits>
     Result<void> StakingContractModel::precompile_get_delegator(
         u64_be val_id, Address const &addr, evmc_address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         AbiEncoder encoder;
         encoder.add_uint<u32_be>(
@@ -674,7 +674,7 @@ namespace monad::staking::test
         MONAD_ASSERT(computed_total_stake == active_consensus_stake_[v]);
     }
 
-    void StakingContractModel::pre_call(evmc_uint256be const &value)
+    void StakingContractModel::pre_call(uint256_be_t const &value)
     {
         state_.push();
         state_.add_to_balance(
@@ -695,7 +695,7 @@ namespace monad::staking::test
     template <Traits traits>
     Result<byte_string> StakingContractModel::dispatch(
         byte_string const &input, evmc_address const &sender,
-        evmc_uint256be const &value)
+        uint256_be_t const &value)
     {
         pre_call(value);
         byte_string_view msg_input(input);

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.hpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.hpp
@@ -163,49 +163,49 @@ namespace monad::staking::test
         Result<u64_be> precompile_add_validator(
             byte_string_view message, byte_string_view secp_signature,
             byte_string_view bls_signature, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_delegate(
             u64_be val_id, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_undelegate(
             u64_be val_id, u256_be const &stake, u8_be withdrawal_id,
-            evmc_address const &sender, evmc_uint256be const &value);
+            evmc_address const &sender, uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_compound(
             u64_be val_id, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_withdraw(
             u64_be val_id, u8_be withdrawal_id, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_claim_rewards(
             u64_be val_id, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_change_commission(
             u64_be val_id, u256_be const &new_commission,
-            evmc_address const &sender, evmc_uint256be const &value);
+            evmc_address const &sender, uint256_be_t const &value);
 
         template <Traits traits>
         Result<void> precompile_external_reward(
             u64_be val_id, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
         // Result type is not accurate. Just interested in the side
         // effects of this function on the state:
         template <Traits traits>
         Result<void> precompile_get_delegator(
             u64_be val_id, Address const &addr, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
 
     private:
         uint256_t get_delegator_stake(uint64_t, Address const &, uint64_t);
@@ -217,7 +217,7 @@ namespace monad::staking::test
 
         void distribute_reward(u64_be, u256_be const &);
 
-        void pre_call(evmc_uint256be const &value);
+        void pre_call(uint256_be_t const &value);
 
         template <typename T>
         void post_call(Result<T> const &);
@@ -225,6 +225,6 @@ namespace monad::staking::test
         template <Traits traits>
         Result<byte_string> dispatch(
             byte_string const &input, evmc_address const &sender,
-            evmc_uint256be const &value);
+            uint256_be_t const &value);
     };
 }

--- a/category/execution/monad/staking/read_valset.hpp
+++ b/category/execution/monad/staking/read_valset.hpp
@@ -20,7 +20,7 @@
 #include <optional>
 #include <vector>
 
-#include <evmc/evmc.h>
+#include <category/core/bytes.hpp>
 #include <stdint.h>
 
 MONAD_NAMESPACE_BEGIN
@@ -38,7 +38,7 @@ struct Validator
 {
     uint8_t secp_pubkey[33];
     uint8_t bls_pubkey[48];
-    evmc_uint256be stake;
+    uint256_be_t stake;
 };
 
 std::optional<std::vector<Validator>>

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -45,6 +45,7 @@
 #include <memory>
 
 MONAD_STAKING_ANONYMOUS_NAMESPACE_BEGIN
+using monad::literals::operator""_bytes32;
 
 ////////////////////////
 // Function Selectors //
@@ -345,11 +346,11 @@ Result<uint256_t> calculate_rewards(
     return checked_mul_div(delta, stake, UNIT_BIAS);
 }
 
-Result<void> function_not_payable(evmc_uint256be const &value)
+Result<void> function_not_payable(uint256_be_t const &value)
 {
     bool const all_zero = std::all_of(
         value.bytes,
-        value.bytes + sizeof(evmc_uint256be),
+        value.bytes + sizeof(uint256_be_t),
         [](uint8_t const byte) { return byte == 0; });
 
     if (MONAD_UNLIKELY(!all_zero)) {
@@ -905,8 +906,7 @@ StakingContract::get_validators_for_delegator(
 }
 
 Result<byte_string> StakingContract::precompile_get_validator(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -940,8 +940,7 @@ Result<byte_string> StakingContract::precompile_get_validator(
 }
 
 Result<byte_string> StakingContract::precompile_get_delegator(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -996,7 +995,7 @@ Result<byte_string> StakingContract::get_valset(
 
 Result<byte_string> StakingContract::precompile_get_consensus_valset(
     byte_string_view const input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     return get_valset(input, vars.valset_consensus);
@@ -1004,7 +1003,7 @@ Result<byte_string> StakingContract::precompile_get_consensus_valset(
 
 Result<byte_string> StakingContract::precompile_get_snapshot_valset(
     byte_string_view const input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     return get_valset(input, vars.valset_snapshot);
@@ -1012,7 +1011,7 @@ Result<byte_string> StakingContract::precompile_get_snapshot_valset(
 
 Result<byte_string> StakingContract::precompile_get_execution_valset(
     byte_string_view const input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     auto const valset = vars.valset_execution;
@@ -1021,8 +1020,7 @@ Result<byte_string> StakingContract::precompile_get_execution_valset(
 
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_get_delegations(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1046,8 +1044,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::precompile_get_delegations);
 
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_get_delegators(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1073,8 +1070,7 @@ Result<byte_string> StakingContract::precompile_get_delegators(
 EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::precompile_get_delegators);
 
 Result<byte_string> StakingContract::precompile_get_epoch(
-    byte_string_view const, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view const, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1085,7 +1081,7 @@ Result<byte_string> StakingContract::precompile_get_epoch(
 }
 
 Result<byte_string> StakingContract::precompile_get_proposer_val_id(
-    byte_string_view, evmc_address const &, evmc_uint256be const &msg_value)
+    byte_string_view, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1095,8 +1091,7 @@ Result<byte_string> StakingContract::precompile_get_proposer_val_id(
 }
 
 Result<byte_string> StakingContract::precompile_get_withdrawal_request(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1118,15 +1113,14 @@ Result<byte_string> StakingContract::precompile_get_withdrawal_request(
 }
 
 Result<byte_string> StakingContract::precompile_fallback(
-    byte_string_view const, evmc_address const &, evmc_uint256be const &)
+    byte_string_view const, evmc_address const &, uint256_be_t const &)
 {
     return StakingError::MethodNotSupported;
 }
 
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_add_validator(
-    byte_string_view input, evmc_address const &,
-    evmc_uint256be const &msg_value)
+    byte_string_view input, evmc_address const &, uint256_be_t const &msg_value)
 {
     constexpr size_t MESSAGE_SIZE = 33 /* compressed secp pubkey */ +
                                     48 /* compressed bls pubkey */ +
@@ -1161,15 +1155,15 @@ Result<byte_string> StakingContract::precompile_add_validator(
         unaligned_load<byte_string_fixed<48>>(consume_bytes(reader, 48).data());
     auto const auth_address =
         unaligned_load<Address>(consume_bytes(reader, sizeof(Address)).data());
-    auto const signed_stake = unaligned_load<evmc_uint256be>(
-        consume_bytes(reader, sizeof(evmc_uint256be)).data());
+    auto const signed_stake = unaligned_load<uint256_be_t>(
+        consume_bytes(reader, sizeof(uint256_be_t)).data());
     auto const commission =
         unaligned_load<u256_be>(consume_bytes(reader, sizeof(u256_be)).data());
 
     if (MONAD_UNLIKELY(
             0 !=
             memcmp(
-                signed_stake.bytes, msg_value.bytes, sizeof(evmc_uint256be)))) {
+                signed_stake.bytes, msg_value.bytes, sizeof(uint256_be_t)))) {
         return StakingError::InvalidInput;
     }
 
@@ -1335,7 +1329,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::delegate);
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_delegate(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(auto const val_id, abi_decode_fixed<u64_be>(input));
     if (MONAD_UNLIKELY(!input.empty())) {
@@ -1354,7 +1348,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::precompile_delegate);
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_undelegate(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1448,7 +1442,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::precompile_undelegate);
 template <Traits traits>
 Result<byte_string> StakingContract::precompile_compound(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1479,7 +1473,7 @@ EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::precompile_compound);
 
 Result<byte_string> StakingContract::precompile_withdraw(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1528,7 +1522,7 @@ Result<byte_string> StakingContract::precompile_withdraw(
 
 Result<byte_string> StakingContract::precompile_claim_rewards(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1551,7 +1545,7 @@ Result<byte_string> StakingContract::precompile_claim_rewards(
 
 Result<byte_string> StakingContract::precompile_change_commission(
     byte_string_view input, evmc_address const &msg_sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
 
@@ -1587,7 +1581,7 @@ Result<byte_string> StakingContract::precompile_change_commission(
 
 Result<byte_string> StakingContract::precompile_external_reward(
     byte_string_view input, evmc_address const &sender,
-    evmc_uint256be const &msg_value)
+    uint256_be_t const &msg_value)
 {
     auto const external_reward = intx::be::load<uint256_t>(msg_value);
     BOOST_OUTCOME_TRY(auto const val_id, abi_decode_fixed<u64_be>(input));

--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -44,6 +44,7 @@ class State;
 MONAD_NAMESPACE_END
 
 MONAD_STAKING_NAMESPACE_BEGIN
+using monad::literals::operator""_bytes32;
 
 class StakingContract
 {
@@ -553,7 +554,7 @@ private:
 
 public:
     using PrecompileFunc = Result<byte_string> (StakingContract::*)(
-        byte_string_view, evmc_address const &, evmc_bytes32 const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 
     /////////////////
     // Precompiles //
@@ -564,50 +565,50 @@ public:
     precompile_dispatch(byte_string_view &);
 
     Result<byte_string> precompile_get_validator(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_delegator(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_withdrawal_request(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_consensus_valset(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_snapshot_valset(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_execution_valset(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_get_delegations(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_get_delegators(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_epoch(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_get_proposer_val_id(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 
     Result<byte_string> precompile_fallback(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_add_validator(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_delegate(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_undelegate(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     template <Traits traits>
     Result<byte_string> precompile_compound(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_withdraw(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_claim_rewards(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_change_commission(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
     Result<byte_string> precompile_external_reward(
-        byte_string_view, evmc_address const &, evmc_uint256be const &);
+        byte_string_view, evmc_address const &, uint256_be_t const &);
 
     ////////////////////
     //  System Calls  //

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -217,7 +217,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
     {
         auto const [input, sign_address] =
             craft_add_validator_input(auth_address, stake, commission, secret);
-        auto const msg_value = intx::be::store<evmc_uint256be>(stake);
+        auto const msg_value = intx::be::store<uint256_be_t>(stake);
         state.push();
         auto res = contract.precompile_add_validator<Trait>(
             input, auth_address, msg_value);
@@ -233,7 +233,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
         u64_be const val_id, Address const &del_address, uint256_t const &stake)
     {
         auto const input = abi_encode_uint<u64_be>(val_id);
-        auto const msg_value = intx::be::store<evmc_uint256be>(stake);
+        auto const msg_value = intx::be::store<uint256_be_t>(stake);
         state.push();
         auto res =
             contract.precompile_delegate<Trait>(input, del_address, msg_value);
@@ -302,7 +302,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
         u64_be const val_id, Address const &sender, uint256_t const &reward)
     {
         auto const input = abi_encode_uint<u64_be>(val_id);
-        auto const msg_value = intx::be::store<evmc_uint256be>(reward);
+        auto const msg_value = intx::be::store<uint256_be_t>(reward);
         state.push();
         auto res =
             contract.precompile_external_reward(input, sender, msg_value);
@@ -347,7 +347,7 @@ DEFINE_MONAD_TRAITS_FIXTURE(StakeAllRevisions);
 TEST_F(StakeLatest, invoke_fallback)
 {
     auto const sender = 0xdeadbeef_address;
-    auto const value = intx::be::store<evmc_uint256be>(MIN_VALIDATE_STAKE);
+    auto const value = intx::be::store<uint256_be_t>(MIN_VALIDATE_STAKE);
 
     byte_string_fixed<8> const signature_bytes = {0xff, 0xff, 0xff, 0xff};
     auto signature = to_byte_string_view(signature_bytes);
@@ -583,7 +583,7 @@ TEST_F(StakeLatest, validator_changes_commission)
 TEST_F(StakeLatest, add_validator_revert_invalid_input_size)
 {
     auto const sender = 0xdeadbeef_address;
-    auto const value = intx::be::store<evmc_uint256be>(MIN_VALIDATE_STAKE);
+    auto const value = intx::be::store<uint256_be_t>(MIN_VALIDATE_STAKE);
 
     byte_string_view too_short{};
     auto res =
@@ -601,7 +601,7 @@ TEST_F(StakeLatest, add_validator_revert_bad_signature)
 {
     auto const [message, good_secp_sig, good_bls_sig, _] =
         craft_add_validator_input_raw(0xababab_address, MIN_VALIDATE_STAKE);
-    auto const value = intx::be::store<evmc_uint256be>(MIN_VALIDATE_STAKE);
+    auto const value = intx::be::store<uint256_be_t>(MIN_VALIDATE_STAKE);
 
     // bad secp signature
     {
@@ -636,7 +636,7 @@ TEST_F(StakeLatest, add_validator_revert_bad_signature)
 
 TEST_F(StakeLatest, add_validator_revert_msg_value_not_signed)
 {
-    auto const value = intx::be::store<evmc_uint256be>(MIN_VALIDATE_STAKE);
+    auto const value = intx::be::store<uint256_be_t>(MIN_VALIDATE_STAKE);
     auto const [input, address] =
         craft_add_validator_input(0xababab_address, 2 * MIN_VALIDATE_STAKE);
     auto const res =
@@ -646,7 +646,7 @@ TEST_F(StakeLatest, add_validator_revert_msg_value_not_signed)
 
 TEST_F(StakeLatest, add_validator_revert_already_exists)
 {
-    auto const value = intx::be::store<evmc_uint256be>(MIN_VALIDATE_STAKE);
+    auto const value = intx::be::store<uint256_be_t>(MIN_VALIDATE_STAKE);
     auto const [input, address] =
         craft_add_validator_input(0xababab_address, MIN_VALIDATE_STAKE);
     EXPECT_FALSE(contract.precompile_add_validator<Trait>(input, address, value)
@@ -659,7 +659,7 @@ TEST_F(StakeLatest, add_validator_revert_already_exists)
 
 TEST_F(StakeLatest, add_validator_revert_minimum_stake_not_met)
 {
-    auto const value = intx::be::store<evmc_uint256be>(uint256_t{1});
+    auto const value = intx::be::store<uint256_be_t>(uint256_t{1});
     auto const [input, address] =
         craft_add_validator_input(0xababab_address, uint256_t{1});
     auto const res =
@@ -678,7 +678,7 @@ TEST_F(StakeLatest, nonpayable_functions_revert)
         StakingError::ValueNonZero);
 
     // precompiles
-    evmc_uint256be value = intx::be::store<evmc_uint256be>(5 * MON);
+    uint256_be_t value = intx::be::store<uint256_be_t>(5 * MON);
     EXPECT_EQ(
         contract.precompile_undelegate<Trait>({}, {}, value).assume_error(),
         StakingError::ValueNonZero);

--- a/cmd/monad/wal_reader.hpp
+++ b/cmd/monad/wal_reader.hpp
@@ -18,7 +18,7 @@
 #include <category/core/config.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
 
-#include <evmc/evmc.h>
+#include <category/core/bytes.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -40,7 +40,7 @@ static_assert(alignof(WalAction) == 1);
 struct WalEntry
 {
     WalAction action;
-    struct evmc_bytes32 id;
+    monad::bytes32_t id;
 };
 
 static_assert(sizeof(WalEntry) == 33);

--- a/cmd/vm/mce/src/instrumentable_compiler.hpp
+++ b/cmd/vm/mce/src/instrumentable_compiler.hpp
@@ -37,14 +37,10 @@
 #include <memory>
 #include <optional>
 
-using namespace monad;
-using namespace monad::vm;
-using namespace monad::vm::compiler;
-
 struct LLVMBinary
 {
 #ifdef MONAD_COMPILER_LLVM
-    std::shared_ptr<llvm::LLVMState> llvm_code;
+    std::shared_ptr<monad::vm::llvm::LLVMState> llvm_code;
 #else
     bool llvm_backend_unavailable{true};
 #endif
@@ -52,7 +48,7 @@ struct LLVMBinary
 
 struct CompilerBinary
 {
-    std::shared_ptr<native::Nativecode> ncode;
+    std::shared_ptr<monad::vm::compiler::native::Nativecode> ncode;
 };
 
 using Binary = std::variant<CompilerBinary, LLVMBinary>;
@@ -116,8 +112,9 @@ public:
     {
         if (use_llvm) {
 #ifdef MONAD_COMPILER_LLVM
-            std::shared_ptr<llvm::LLVMState> p =
-                llvm::compile_basicblocks_llvm<traits>(ir, "mce_llvm");
+            std::shared_ptr<monad::vm::llvm::LLVMState> p =
+                monad::vm::llvm::compile_basicblocks_llvm<traits>(
+                    ir, "mce_llvm");
             return LLVMBinary{p};
 #else
             LOG_ERROR("Unable to compile with LLVM.  LLVM not configured in "

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -637,34 +637,37 @@ void process_test(
             if (check_exec_events) {
                 EXPECT_FALSE(exec_events.block_reject_code) << name;
                 EXPECT_EQ(
-                    exec_events.block_end->exec_output.state_root,
+                    bytes32_t(exec_events.block_end->exec_output.state_root),
                     tdb.state_root())
                     << name;
                 EXPECT_EQ(
-                    exec_events.block_start->eth_block_input.transactions_root,
+                    bytes32_t(exec_events.block_start->eth_block_input
+                                  .transactions_root),
                     tdb.transactions_root())
                     << name;
                 if (tdb.withdrawals_root()) {
                     EXPECT_EQ(
-                        exec_events.block_start->eth_block_input
-                            .withdrawals_root,
+                        bytes32_t(exec_events.block_start->eth_block_input
+                                      .withdrawals_root),
                         *tdb.withdrawals_root())
                         << name;
                 }
                 else {
                     EXPECT_EQ(
-                        exec_events.block_start->eth_block_input
-                            .withdrawals_root,
+                        bytes32_t(exec_events.block_start->eth_block_input
+                                      .withdrawals_root),
                         bytes32_t{})
                         << name;
                 }
                 EXPECT_EQ(
-                    exec_events.block_start->eth_block_input.ommers_hash,
+                    bytes32_t(
+                        exec_events.block_start->eth_block_input.ommers_hash),
                     tdb_ommers_hash)
                     << name;
                 if constexpr (traits::evm_rev() >= EVMC_BYZANTIUM) {
                     EXPECT_EQ(
-                        exec_events.block_end->exec_output.receipts_root,
+                        bytes32_t(
+                            exec_events.block_end->exec_output.receipts_root),
                         tdb.receipts_root())
                         << name;
                 }
@@ -718,7 +721,8 @@ void process_test(
                 if (check_exec_events) {
                     ASSERT_LT(i, size(exec_events.txn_inputs));
                     EXPECT_EQ(
-                        exec_events.txn_inputs[i]->txn_hash, to_bytes(hash))
+                        bytes32_t(exec_events.txn_inputs[i]->txn_hash),
+                        to_bytes(hash))
                         << name;
                 }
             }

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -279,7 +279,8 @@ static void clean_storage(State &state)
         for (auto it = acc.storage.begin(); it != acc.storage.end();) {
             auto const &[k, v] = *it;
 
-            if (v.current == bytes32_t{} && v.original == bytes32_t{} &&
+            if (bytes32_t(v.current) == bytes32_t{} &&
+                bytes32_t(v.original) == bytes32_t{} &&
                 v.access_status == EVMC_ACCESS_COLD) {
                 it = acc.storage.erase(it);
             }
@@ -290,7 +291,7 @@ static void clean_storage(State &state)
         for (auto it = acc.transient_storage.begin();
              it != acc.transient_storage.end();) {
             auto const &[k, v] = *it;
-            if (v == bytes32_t{}) {
+            if (bytes32_t(v) == bytes32_t{}) {
                 it = acc.transient_storage.erase(it);
             }
             else {


### PR DESCRIPTION
Replace the `using bytes32_t = evmc::bytes32` alias with a standalone struct inheriting from `evmc_bytes32`. This gives us control over construction, comparison, and hashing while maintaining ABI compatibility with the EVMC C layer.

`bytes32_t` features:
- Zero-initializing default constructor
- Implicit converting constructor from `evmc_bytes32`
- Explicit `uint64_t` constructor (big-endian storage)
- Variadic byte constructor accepting 1–32 `uint8_t` arguments (no narrowing)
- Implicit conversion to `byte_string_view`
- Explicit conversion to `bool` (non-zero check via `std::any_of`)
- `operator==` and `operator<=>` (lexicographic)
- `std::hash` and `ankerl::unordered_dense::hash` specializations (wyhash)

Other changes:
- Add `uint256_be_t` as a type alias for `bytes32_t`, replacing `evmc_uint256be` in internal code to convey big-endian uint256 semantics
- Add `monad::literals::operator""_bytes32` and `bytes32_from_hex()`, replacing the blanket `using namespace evmc::literals` import
- Migrate all internal `evmc_bytes32`/`evmc_uint256be` usage to `bytes32_t`/`uint256_be_t` across staking, reserve balance, WAL reader, event recording, and test/fuzzer code
- Remove `using namespace monad` from `instrumentable_compiler.hpp` header to fix ambiguous `operator""_bytes32` resolution with evmone headers
- Add explicit `bytes32_t()` casts in `blockchain_test.cpp` and `fuzzer.cpp` where `evmc::bytes32` (from `monad_c_bytes32` ctypes) is compared with `bytes32_t`

Conversion to `evmc::bytes32` at the EVMC boundary works implicitly through the base class path (`bytes32_t` → `evmc_bytes32` → `evmc::bytes32` constructor). Remaining `evmc::bytes32` uses are at the EVMC interface boundary (host overrides, C API callbacks, arrays passed to EVMC functions) and must stay as evmc types.