### PR TITLE
Add Claude Code build skill and pre-PR checklist

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,216 @@
+Configure and build the monad C++ project.
+
+## Arguments
+
+The user may pass arguments like:
+- `configure` — only run cmake configure step
+- `build` — only run the build step (configure first if build/ doesn't exist)
+- `clean` — remove the build directory and reconfigure from scratch
+- `<target>` — build a specific cmake target (e.g., `monad`, `monad-cli`, a test name)
+- Compiler selection: `--clang` to use Clang 19+ instead of GCC 15+ (default)
+- CMake options as flags: `--llvm`, `--debug`, `--release`, `--asan`, `--tsan`, `--ubsan`, `--coverage`, `--avx512`
+
+If no arguments are given, run the full cycle: configure (if needed) + build.
+
+## Instructions
+
+You are helping the user configure and build the monad C++ project located at $CWD.
+
+### Build system details
+
+- Generator: Ninja
+- Build directory: `build/` (relative to project root)
+- Default build type: `RelWithDebInfo`
+- Compiler requirements: GCC 15+ or Clang 19+
+- CPU architecture: `-march=haswell` minimum (x86-64-v3)
+- Toolchain files: `category/core/toolchains/` — these set architecture and sanitizer flags
+
+### Available toolchain files
+
+| Toolchain | Use case |
+|-----------|----------|
+| `category/core/toolchains/gcc-avx2.cmake` | **Default** — `-march=haswell` (AVX2). Works with both GCC and Clang. |
+| `category/core/toolchains/gcc-avx512.cmake` | `-march=skylake-avx512`. Works with both GCC and Clang. |
+| `category/core/toolchains/gcc-asan.cmake` | ASAN + UBSAN (includes `-march=haswell`). **GCC only — do not use with Clang** (use `clang-fuzz.cmake` instead). |
+| `category/core/toolchains/gcc-tsan.cmake` | TSAN (includes `-march=haswell`). **GCC only.** |
+| `category/core/toolchains/clang-tsan.cmake` | TSAN (includes `-march=haswell`). **Clang only.** Note: currently hard-codes a `-fsanitize-blacklist` path that may not exist on all machines. |
+| `category/core/toolchains/clang-fuzz.cmake` | ASAN + UBSAN + fuzzing coverage instrumentation. **Clang only.** Note: includes fuzzing flags (`-fsanitize-coverage`, `-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`), so this is more than plain ASAN. There is no plain Clang ASAN toolchain — warn the user about the extra flags if they just asked for `--asan --clang`. |
+
+### CMake options available
+
+**Build type and linking:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `CMAKE_BUILD_TYPE` | `RelWithDebInfo` | Build type (Debug, Release, RelWithDebInfo, MinSizeRel) |
+| `BUILD_SHARED_LIBS` | OFF | Build with shared libraries (also enables `-fPIC`) |
+
+**JIT compiler options** (defined in root `CMakeLists.txt`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `MONAD_COMPILER_LLVM` | OFF | Build LLVM JIT backend (requires LLVM 19.1.7 installed) |
+| `MONAD_COMPILER_COVERAGE` | OFF | Build with coverage instrumentation |
+| `MONAD_COMPILER_TESTING` | OFF | Build compiler tests (requires `third_party/evmone` — see evmone note below) |
+| `MONAD_COMPILER_BENCHMARKS` | OFF | Build compiler benchmarks (requires `third_party/evmone` — see evmone note below) |
+| `MONAD_COMPILER_DUMP_ASM` | OFF | Dump assembly files into `build/asm` |
+| `MONAD_COMPILER_STATS` | OFF | Print JIT compiler statistics |
+| `MONAD_COMPILER_HOT_PATH_STATS` | OFF | Print VM hot-path statistics |
+
+**Core options** (defined in `category/core/CMakeLists.txt`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `MONAD_CORE_FORCE_DEBUG_ASSERT` | OFF | Enable `MONAD_DEBUG_ASSERT` in any build mode (normally Debug-only) |
+
+**VM interpreter options** (defined in `category/vm/interpreter/CMakeLists.txt`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `MONAD_VM_INTERPRETER_DEBUG` | OFF | Trace every instruction executed by the interpreter |
+| `MONAD_VM_INTERPRETER_STATS` | OFF | Print opcode statistics as CSV on exit (not thread-safe, benchmarking only) |
+
+**Event subsystem options** (defined in `category/event/CMakeLists.txt`):
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `MONAD_EVENT_USE_LIBHUGETLBFS` | ON (Linux) | Build with libhugetlbfs support for huge-page-backed event rings |
+| `MONAD_EVENT_BUILD_EXAMPLE` | ON | Build the event API example program |
+
+**Environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `GIT_COMMIT_HASH` | Override the commit hash baked into `monad` and `monad-cli` binaries (defaults to `git rev-parse HEAD`) |
+
+### Step-by-step behavior
+
+1. **Parse the user's arguments** (provided as $ARGUMENTS) and determine which steps to run and which options to set.
+
+2. **Ensure submodules are initialized**:
+   - Check if `third_party/asmjit/CMakeLists.txt` exists (a quick proxy for submodule state)
+   - If not, run `git submodule update --init --recursive` before configuring
+   - This is especially important in fresh clones and git worktrees
+
+3. **Check system dependencies** (only when running the configure step):
+   - Run the following checks and collect all missing items before reporting:
+     ```bash
+     # Tools (check via which)
+     which cmake ninja pkg-config
+     # Compiler (check whichever was selected)
+     which gcc-15 g++-15    # GCC (default)
+     which clang-19 clang++-19  # Clang (if --clang)
+     # Key dev libraries (check via pkg-config — TBB uses find_package, not pkg-config)
+     pkg-config --exists liburing libzstd libcrypto++ gmp
+     # TBB: cmake's find_package(TBB) looks for TBBConfig.cmake; check via dpkg
+     dpkg -s libtbb-dev 2>/dev/null | grep -q "Status: install ok installed"
+     # Additional dev packages (check via dpkg)
+     dpkg -s libgtest-dev libgmock-dev libboost1.83-dev libhugetlbfs-dev libcli11-dev libbenchmark-dev libarchive-dev libbrotli-dev libcap-dev 2>/dev/null | grep -c "Status: install ok installed"
+     ```
+   - If anything is missing, list all missing items and suggest the apt install command. Reference `scripts/ubuntu-build/` for the full Docker install scripts.
+   - Do not proceed to configure until dependencies are resolved.
+
+4. **Configure step** (`cmake -G Ninja -B build ...`):
+   - **Compiler selection**: The system default compiler may be too old. Explicitly set the compiler:
+     - GCC (default): `CC=gcc-15 CXX=g++-15`
+     - Clang (`--clang` flag): `CC=clang-19 CXX=clang++-19`
+   - Ensure the required architecture flags are set (`-march=haswell` minimum) so that C/C++ and assembly sources (e.g., `keccak_impl.S`) compile correctly. The recommended way is to pass `-DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/<toolchain>.cmake`. Alternatively, `CFLAGS`, `CXXFLAGS`, and `ASMFLAGS` environment variables can provide the same flags.
+   - Always pass `-G Ninja`
+   - Always pass `-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE`
+   - Set `CMAKE_BUILD_TYPE` based on flags: `--debug` -> Debug, `--release` -> Release, default -> RelWithDebInfo
+   - Select toolchain based on compiler and sanitizer flags:
+     - **GCC (default)**:
+       - Default (no sanitizer flags): `gcc-avx2.cmake`
+       - `--avx512`: `gcc-avx512.cmake`
+       - `--asan`: `gcc-asan.cmake` (includes ASAN + UBSAN + `-march=haswell`). **Warning:** GCC ASAN breaks the must-tail calling convention used by the VM interpreter. CI excludes the GCC+ASAN combination for VM tests. If the user is working on VM code, recommend `--asan --clang` instead.
+       - `--tsan`: `gcc-tsan.cmake` (includes TSAN + `-march=haswell`)
+       - `--ubsan`: `gcc-asan.cmake` (UBSAN is bundled with ASAN in this toolchain)
+     - **Clang (`--clang`)**:
+       - Default (no sanitizer flags): `gcc-avx2.cmake` (arch-only flags are compiler-agnostic)
+       - `--avx512`: `gcc-avx512.cmake` (arch-only flags are compiler-agnostic)
+       - `--tsan`: `clang-tsan.cmake`
+       - `--asan` / `--ubsan`: `clang-fuzz.cmake`. **Warn the user** that this toolchain also includes fuzzing instrumentation flags (sanitize-coverage, `-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`). There is no plain Clang ASAN toolchain. If they only want ASAN without fuzzing flags, they would need to create a custom toolchain file.
+   - Map `--llvm` to `-DMONAD_COMPILER_LLVM=ON`
+   - Map `--coverage` to `-DMONAD_COMPILER_COVERAGE=ON`
+   - Skip if `build/` already exists and user didn't request `configure` or `clean` explicitly, **unless** the user passed configuration-affecting flags (`--clang`, `--asan`, `--tsan`, `--ubsan`, `--avx512`, `--debug`, `--release`, `--llvm`, `--coverage`). These flags change the toolchain, compiler, or build type — silently reusing a stale `build/` will produce a broken or mismatched build. In that case, reconfigure (wipe `build/CMakeCache.txt` first if the compiler changed, since CMake does not allow switching compilers in-place).
+
+5. **Build step** (`cmake --build build --parallel`):
+   - Default target: `all`
+   - If user specified a specific target, pass `--target <target>`
+   - If build fails, read the error output carefully and diagnose the issue
+
+6. **Clean step**:
+   - Remove the `build/` directory
+   - Then run configure and build (i.e., proceed to steps 3–5)
+
+### evmone (custom fork — not a submodule)
+
+`third_party/evmone/` is gitignored and must be cloned manually from the Category Labs fork. It is required for `MONAD_COMPILER_TESTING=ON`, `MONAD_COMPILER_BENCHMARKS=ON`, `/lint`, and `/fuzz`. Not needed for standard builds.
+
+**To set up** (run from the project root):
+```bash
+git clone git@github.com:category-labs/evmone.git third_party/evmone
+git -C third_party/evmone checkout v0.18.0-category
+```
+**Do not `cd` into the evmone directory** — subsequent cmake commands use relative paths that break if the working directory has changed.
+
+The branch `v0.18.0-category` is the current stable fork used in CI. Check `.github/workflows/test-vm.yml` for the latest ref if in doubt. This requires SSH access to the `category-labs` GitHub organization.
+
+### Example configure commands
+
+Default GCC build:
+```bash
+CC=gcc-15 CXX=g++-15 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+Clang build:
+```bash
+CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+GCC ASAN build (not recommended for VM code — see step 3 warning):
+```bash
+CC=gcc-15 CXX=g++-15 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-asan.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=Debug
+```
+
+Clang ASAN build (includes fuzzing instrumentation — no plain Clang ASAN toolchain exists):
+```bash
+CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/clang-fuzz.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=Debug
+```
+
+Clang TSAN build:
+```bash
+CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/clang-tsan.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+### Error handling
+
+- If cmake configure fails, check for missing dependencies and suggest install commands
+- If configure fails with "GCC version 15 or higher is required", ensure `CC=gcc-15 CXX=g++-15` is set (or use `CC=clang-19 CXX=clang++-19` for Clang)
+- If configure fails with missing `CMakeLists.txt` in `third_party/`, run `git submodule update --init --recursive`
+- If build fails with `#error avx2 or avx512 required`, ensure a toolchain file is being used
+- If configure fails with "third_party/evmone to be present", the custom evmone fork needs to be cloned — see the evmone section above
+- If the evmone clone fails with a permission error, the user needs SSH access to the `category-labs` GitHub organization
+- If build fails, show the relevant error lines and suggest fixes
+
+### Important
+
+- Always run commands from the project root directory: $CWD
+- Show the user what commands you're running before executing them
+- After a successful build, briefly note the key artifacts produced (e.g., `build/cmd/monad`, `build/cmd/monad-cli`)
+- Do NOT modify any source files — this skill is only for building

--- a/.claude/commands/format.md
+++ b/.claude/commands/format.md
@@ -1,0 +1,22 @@
+Run clang-format on all monad C++ source files.
+
+## Instructions
+
+You are formatting source files for the monad C++ project located at $CWD.
+
+### Steps
+
+1. **Run clang-format:**
+   ```bash
+   scripts/apply-clang-format.sh
+   ```
+   This runs `clang-format-19` in-place on all `.hpp`, `.cpp`, `.c`, `.h` files under `category/`, `cmd/`, `test/`.
+
+2. **Check results:**
+   Run `git diff --stat` to show which files were modified. If no files changed, formatting was already clean.
+
+No build is required — this works standalone.
+
+### Important
+
+- Always run commands from the project root directory: $CWD

--- a/.claude/commands/fuzz.md
+++ b/.claude/commands/fuzz.md
@@ -1,0 +1,68 @@
+Run VM fuzzers for the monad C++ project.
+
+## Arguments
+
+The user may pass arguments like:
+- `compiler` — run the compiler fuzzer (default)
+- `typechecker` — run the typechecker fuzzer
+- `staking` — run the staking contract fuzzer
+- `--seed <N>` — set the random seed
+- `--multi` — run multiple fuzzer sessions via tmux
+- `status` — check tmux fuzzer session status
+- `kill` — stop all tmux fuzzer sessions
+
+## Instructions
+
+You are running fuzzers for the monad C++ project located at $CWD.
+
+### Build requirements
+
+The compiler and typechecker fuzzers require `MONAD_COMPILER_TESTING=ON` at configure time and `third_party/evmone` (see `/build` for evmone setup instructions). The staking contract fuzzer is always built with no special options.
+
+If the fuzzer binaries don't exist, offer to reconfigure. The CI fuzzing configuration is:
+```bash
+CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMONAD_COMPILER_TESTING=ON
+```
+Then build the fuzzer target:
+```bash
+cmake --build build --target monad-compiler-fuzzer --parallel
+```
+
+### Fuzzer binaries
+
+| Binary | Target | Description |
+|--------|--------|-------------|
+| `build/test/vm/fuzzer/monad-compiler-fuzzer` | `monad-compiler-fuzzer` | Fuzzes the JIT compiler |
+| `build/test/vm/fuzzer/monad-typechecker-fuzzer` | `monad-typechecker-fuzzer` | Fuzzes the typechecker |
+| `build/category/execution/monad_staking_contract_fuzzer` | `monad_staking_contract_fuzzer` | Fuzzes the staking contract |
+
+### Single-process run
+
+Use the wrapper scripts which set `MONAD_COMPILER_FUZZING=1`:
+```bash
+# Compiler fuzzer (pass --implementation compiler or --implementation interpreter, and --seed N)
+scripts/vm/fuzzer.sh --implementation compiler --seed 143
+# Typechecker fuzzer
+scripts/vm/typechecker-fuzzer.sh --seed 143
+# Staking contract fuzzer (run directly)
+build/category/execution/monad_staking_contract_fuzzer
+```
+
+### Multi-process run via tmux
+
+`scripts/vm/tmux-fuzzer.sh` manages multiple fuzzer sessions (11 compiler + 2 interpreter by default):
+```bash
+scripts/vm/tmux-fuzzer.sh start --base-seed=143   # start all sessions
+scripts/vm/tmux-fuzzer.sh status                   # check which are running
+scripts/vm/tmux-fuzzer.sh kill                     # stop all sessions
+```
+Logs go to `tmux-fuzzer-log/`.
+
+### Important
+
+- Always run commands from the project root directory: $CWD
+- Do NOT modify any source files

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,62 @@
+Run clang-tidy and trait instantiation checks on the monad C++ project.
+
+## Arguments
+
+The user may pass arguments like:
+- `--fix` — apply clang-tidy fixes in-place (requires clean git state)
+- No arguments — check only, report issues without modifying files
+
+## Instructions
+
+You are running lint checks for the monad C++ project located at $CWD.
+
+### Build requirements
+
+Linting requires a specific build configuration to match CI. All of these must be true, otherwise tell the user and offer to reconfigure:
+- Clang 19 compiler
+- Debug build type
+- `MONAD_COMPILER_TESTING=ON` and `MONAD_COMPILER_BENCHMARKS=ON`
+- `UTILS_CLANG_TIDY_AUTO_CONST=ON`
+- `third_party/evmone` must be present (see `/build` for evmone setup instructions)
+
+### Steps
+
+1. **Check build configuration.** Verify `build/compile_commands.json` exists and was generated with the right settings. If the build doesn't exist or doesn't match, configure it:
+   ```bash
+   CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+     -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake \
+     -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+     -DCMAKE_BUILD_TYPE=Debug \
+     -DMONAD_COMPILER_TESTING=ON \
+     -DMONAD_COMPILER_BENCHMARKS=ON \
+     -DUTILS_CLANG_TIDY_AUTO_CONST=ON
+   ```
+
+2. **Build the const-correctness plugin:**
+   ```bash
+   cmake --build build --target ConstCorrectnessChecks
+   ```
+   This produces `build/utils/clang-tidy-auto-const/libConstCorrectnessChecks.so`, which `check-clang-tidy.sh` automatically loads if present. Without this plugin, the custom `misc-auto-const-correctness` check won't run and lint results will differ from CI.
+
+3. **Run clang-tidy:**
+   - **Check only** (no `--fix`): `scripts/check-clang-tidy.sh -p build`
+   - **Fix mode** (`--fix`): `scripts/apply-clang-tidy-fixes.sh build` — this requires a clean git working tree (no uncommitted changes) and will error otherwise.
+
+4. **Run trait instantiation check:**
+   ```bash
+   python3 scripts/check-trait-instantiations.py
+   ```
+   Checks that explicit template instantiation macros (`EXPLICIT_EVM_TRAITS*`, `EXPLICIT_MONAD_TRAITS*`, `EXPLICIT_TRAITS*`) don't overlap across translation units and are only used in `.cpp` files (not headers). No build required for this check. It has no auto-fix — report issues for manual resolution.
+
+The project's `.clang-tidy` config treats all warnings as errors and covers bugprone, clang-analyzer, modernize, performance, and readability checks.
+
+### Error handling
+
+- If `build/` doesn't exist or was configured with the wrong compiler/build type, reconfigure as shown above
+- If `third_party/evmone` is missing, tell the user to set it up (see `/build` for instructions)
+- If `--fix` is used with uncommitted changes, the fix script will error — tell the user to commit or stash first
+
+### Important
+
+- Always run commands from the project root directory: $CWD
+- Do NOT modify source files unless the user explicitly requested `--fix`

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,39 @@
+Run tests for the monad C++ project.
+
+## Arguments
+
+The user may pass arguments like:
+- A test filter string — passed as `-R <filter>` to ctest (e.g., `monad_trie`, `EvmcHost`)
+- No arguments — run all tests
+
+## Instructions
+
+You are running tests for the monad C++ project located at $CWD.
+
+### Prerequisites
+
+A build must exist in `build/`. If it doesn't, tell the user to run `/build` first.
+
+### Steps
+
+1. **Run ctest:**
+   ```bash
+   ctest --test-dir build --output-on-failure --timeout 500 --parallel
+   ```
+   If the user specified a test filter, add `-R <filter>`.
+
+2. **Run the Python test layer:**
+   ```bash
+   pytest-3 --pyargs monad
+   ```
+   This runs additional tests (e.g., disassembly validation). If pytest-3 is not installed or the `monad` Python package isn't available, treat it as a failure and tell the user — this is a required part of the pre-PR test gate.
+
+### Error handling
+
+- If tests fail, show which tests failed and their output
+- If `build/` doesn't exist, tell the user to run `/build` first
+
+### Important
+
+- Always run commands from the project root directory: $CWD
+- Do NOT modify any source files

--- a/.gitignore
+++ b/.gitignore
@@ -163,5 +163,6 @@ tmux-fuzzer-log/
 # optional third-party dependencies
 third_party/evmone/
 
-# Claude Code
-.claude/
+# Claude Code — ignore everything except shared commands
+.claude/*
+!.claude/commands/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,216 @@
+# monad (C++) Development Guide
+
+## Quick Reference
+
+```bash
+# Configure (default GCC 15, RelWithDebInfo, AVX2)
+CC=gcc-15 CXX=g++-15 cmake -G Ninja -B build \
+  -DCMAKE_TOOLCHAIN_FILE=category/core/toolchains/gcc-avx2.cmake \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+# Build
+cmake --build build --parallel
+
+# Test
+ctest --test-dir build --output-on-failure --timeout 500 --parallel
+pytest-3 --pyargs monad
+
+# Format
+scripts/apply-clang-format.sh
+
+# Lint (requires Clang+Debug build with MONAD_COMPILER_TESTING — use /lint skill)
+scripts/check-clang-tidy.sh -p build
+python3 scripts/check-trait-instantiations.py
+```
+
+Use `/build`, `/test`, `/lint`, `/format`, `/fuzz` skills for full options (sanitizers, Clang, specific targets, etc.).
+
+### Toolchain files (`category/core/toolchains/`)
+
+| Toolchain | Compiler | Flags |
+|-----------|----------|-------|
+| `gcc-avx2.cmake` | GCC or Clang | `-march=haswell` (default) |
+| `gcc-avx512.cmake` | GCC or Clang | `-march=skylake-avx512` |
+| `gcc-asan.cmake` | GCC only | ASAN + UBSAN. **Breaks VM interpreter** (must-tail incompatibility) |
+| `gcc-tsan.cmake` | GCC only | TSAN |
+| `clang-tsan.cmake` | Clang only | TSAN |
+| `clang-fuzz.cmake` | Clang only | ASAN + UBSAN + fuzzing instrumentation |
+
+## PR Conventions
+
+- **Single-commit PRs** unless there are very distinct changes (e.g. a lint fix followed by a feature). Squash/rebase before merging.
+- **Rebase on main** — no merge commits. Use `git rebase origin/main` before pushing.
+- Before creating a PR, ensure these checks pass:
+  1. **Formatting** (`/format`): `clang-format-19` on all source files
+  2. **Linting** (`/lint`): clang-tidy with const-correctness plugin, and trait instantiation checks
+  3. **Tests** (`/test`): ctest unit tests and pytest
+
+## Traits and Explicit Instantiation
+
+All execution code is templated on a `Traits` parameter that encodes the chain revision at compile time. This is the central abstraction for supporting both standard Ethereum revisions and Monad-specific revisions without runtime branching.
+
+### Trait types
+
+There are two trait families, defined in `category/vm/evm/traits.hpp`:
+
+- **`EvmTraits<evmc_revision>`** — one per EVM fork (HOMESTEAD through OSAKA, 14 total)
+- **`MonadTraits<monad_revision>`** — one per Monad revision (MONAD_ZERO through MONAD_NEXT, 11 total)
+
+Both satisfy the `Traits` concept, which exposes `consteval` methods for:
+- `evm_rev()` — the underlying EVM revision (MonadTraits maps to an EVM rev, e.g. MONAD_FOUR+ maps to EVMC_PRAGUE)
+- Feature flags like `eip_2929_active()`, `eip_4844_active()`, `mip_3_active()`
+- Constants like `cold_account_cost()`, `max_code_size()`
+
+Because all methods are `consteval`, `if constexpr` on trait queries is zero-cost — dead branches are eliminated at compile time.
+
+### How dispatch works
+
+Runtime revision values are mapped to the correct template instantiation via switch macros in `category/vm/evm/switch_traits.hpp`:
+
+```cpp
+// At a call site that has a runtime evmc_revision:
+SWITCH_EVM_TRAITS(execute_transaction, chain, tx, header, ...);
+
+// At a call site that has a runtime monad_revision:
+SWITCH_MONAD_TRAITS(execute_transaction, chain, tx, header, ...);
+```
+
+Each expands to a switch statement that calls `execute_transaction<EvmTraits<EVMC_OSAKA>>(...)`, `execute_transaction<EvmTraits<EVMC_PRAGUE>>(...)`, etc.
+
+### Explicit instantiation macros
+
+Templates must be explicitly instantiated in `.cpp` files using macros from `category/vm/evm/explicit_traits.hpp`:
+
+| Macro | What it instantiates | Revisions |
+|-------|---------------------|-----------|
+| `EXPLICIT_EVM_TRAITS(f)` | Free function `f` | 14 EVM revisions |
+| `EXPLICIT_MONAD_TRAITS(f)` | Free function `f` | 11 Monad revisions |
+| `EXPLICIT_TRAITS(f)` | Free function `f` | All 25 |
+| `EXPLICIT_EVM_TRAITS_CLASS(c)` | Class template `c` | 14 EVM revisions |
+| `EXPLICIT_MONAD_TRAITS_CLASS(c)` | Class template `c` | 11 Monad revisions |
+| `EXPLICIT_MONAD_TRAITS_STRUCT(c)` | Struct template `c` | 11 Monad revisions |
+| `EXPLICIT_TRAITS_CLASS(c)` | Class template `c` | All 25 |
+| `EXPLICIT_EVM_TRAITS_MEMBER(f)` | Member function `f` | 14 EVM revisions |
+| `EXPLICIT_MONAD_TRAITS_MEMBER(f)` | Member function `f` | 11 Monad revisions |
+| `EXPLICIT_TRAITS_MEMBER(f)` | Member function `f` | All 25 |
+
+**Rules:**
+- Instantiation macros go in `.cpp` files only, never in headers.
+- A function/class must not be instantiated by the same macro in multiple translation units. Using `EXPLICIT_EVM_TRAITS` in one TU and `EXPLICIT_MONAD_TRAITS` in another for the same function IS allowed — that's the ethereum/monad split pattern. The `check-trait-instantiations.py` lint enforces this.
+- Choose the narrowest macro: use `EXPLICIT_EVM_TRAITS` for EVM-only code, `EXPLICIT_MONAD_TRAITS` for Monad-only code, `EXPLICIT_TRAITS` only when the same implementation serves both.
+
+### The ethereum/ vs monad/ convention
+
+The `category/execution/` tree is split into `ethereum/` and `monad/` subdirectories. The key convention:
+
+**Do not branch on `is_monad_trait_v` vs `is_evm_trait_v` inside `ethereum/` code.** Instead, use the trait system to dispatch different behavior via separate instantiations.
+
+The pattern is:
+1. **Declare** the function template in `ethereum/` with a `Traits` parameter
+2. **Provide a default implementation** in `ethereum/*.cpp`, instantiated with `EXPLICIT_EVM_TRAITS`
+3. **Provide the Monad override** in `monad/*.cpp`, instantiated with `EXPLICIT_MONAD_TRAITS`
+
+Example — `revert_transaction`:
+
+```cpp
+// ethereum/reserve_balance.cpp — EVM default: no-op
+template <Traits traits>
+bool revert_transaction(Address const &, Transaction const &,
+    uint256_t const &, uint64_t, State &, ChainContext<traits> const &) {
+    return false;
+}
+EXPLICIT_EVM_TRAITS(revert_transaction);
+
+// monad/reserve_balance.cpp — Monad override: real implementation
+template <Traits traits>
+bool revert_transaction(Address const &sender, Transaction const &tx,
+    uint256_t const &base_fee_per_gas, uint64_t i, State &state,
+    ChainContext<traits> const &ctx) {
+    // ... actual reserve balance revert logic ...
+}
+EXPLICIT_MONAD_TRAITS(revert_transaction);
+```
+
+The linker picks the right instantiation — EVM callers get the no-op, Monad callers get the real implementation. No `if constexpr (is_monad_trait_v<traits>)` needed in the shared code.
+
+**When branching IS acceptable:**
+- Using `if constexpr` on **feature flags** like `traits::eip_2929_active()` or `traits::evm_rev() >= EVMC_ISTANBUL` is fine — these are per-revision decisions, not monad-vs-EVM decisions.
+- Using `requires is_monad_trait_v<traits>` constraints on functions that only make sense for Monad (e.g. `can_sender_dip_into_reserve`) is fine — these aren't branches, they're compile-time constraints that prevent misuse.
+- **Pragmatic exceptions** exist in `ethereum/` where the separate-instantiation pattern would be unwieldy — e.g. one-line initialization guards like `if constexpr (is_monad_trait_v<traits>) { init_reserve_balance_context(...); }` in `execute_transaction.cpp` and `execute_block.cpp`. Prefer the split-instantiation pattern for new code, but a guarded call is acceptable when the alternative would be splitting an entire function just to add one Monad-specific line.
+
+### ChainContext specialization
+
+`ChainContext<traits>` is the main type that differs between EVM and Monad. It's forward-declared in `ethereum/chain/chain.hpp` and specialized via `requires` constraints:
+
+- `ChainContext<T> requires is_evm_trait_v<T>` — empty struct (no extra context needed)
+- `ChainContext<T> requires is_monad_trait_v<T>` — contains sender sets, authorities, etc. (defined in `monad/chain/monad_chain.hpp`)
+
+Functions in `ethereum/` that take `ChainContext<traits> const &` work with both — for EVM traits it's an empty struct, for Monad traits it carries the Monad-specific data.
+
+### Monad revisions
+
+Defined in `category/vm/evm/monad/revision.h`:
+
+| Revision | Underlying EVM | Notable changes |
+|----------|---------------|-----------------|
+| MONAD_ZERO–THREE | EVMC_CANCUN | Base Monad; MONAD_TWO raises max code size to 128KB |
+| MONAD_FOUR–EIGHT | EVMC_PRAGUE | EIP-7951 active; larger initcode; Monad pricing v1 at MONAD_SEVEN |
+| MONAD_NINE+ | EVMC_OSAKA | MIP-3 active |
+| MONAD_NEXT | EVMC_OSAKA | Future/development |
+
+Key differences from EVM traits: EIP-4844 (blob gas) is always disabled, cold account/storage costs are higher (Monad pricing), and code size limits are larger (128KB code, 256KB initcode). See the [Monad changelog](https://docs.monad.xyz/developer-essentials/changelog) for user-facing details of each revision.
+
+## Code Conventions
+
+### Namespaces
+
+All code uses macros from `category/core/config.hpp` — do not write `namespace monad {` directly:
+
+```cpp
+#include <category/core/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+// production code
+MONAD_NAMESPACE_END
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+// file-local helpers
+MONAD_ANONYMOUS_NAMESPACE_END
+```
+
+Test code uses `MONAD_TEST_NAMESPACE_BEGIN/END` (from `monad/test/config.hpp`), which nests under `monad::test`.
+
+### Headers and includes
+
+- Always `#pragma once` (not `#ifndef` guards)
+- Include paths use the full `category/` prefix: `#include <category/core/hex.hpp>`
+- Naming: `snake_case` for functions, `PascalCase` for types (some older code uses `snake_case` types), trailing `_` for private members
+
+## Adding Tests
+
+Tests use Google Test. CMake helper functions are defined in root `CMakeLists.txt`:
+
+| CMake function | Usage |
+|---------------|-------|
+| `monad_add_test(name source.cpp)` | Single test executable (auto-links GTest + `monad_execution`, includes custom main) |
+| `monad_add_test_folder(dir/)` | Auto-discovers `test_*.cpp` and `*_test.cpp` in a directory, creates one executable per file |
+| `monad_add_test_death(name FAIL_REGEX "..." SOURCES ...)` | Death test — passes if output matches regex |
+
+New library/executable targets should call `monad_compile_options(target)` to apply the standard C++23 flags, warnings, and compile definitions. Most targets link against `monad_execution` — the aggregate library that bundles all of `category/`.
+
+Test files live in two places:
+- **Alongside source** in `category/` subdirectories (e.g., `category/core/hex_test.cpp`, `category/execution/ethereum/evm_test.cpp`)
+- **In `test/`** for cross-cutting or suite-level tests (e.g., `test/ethereum_test/`, `test/vm/`)
+
+Test data paths are available via generated header `test/test_resource_data.h`:
+- `test_resource::test_data_dir` — `test/`
+- `test_resource::vm_data_dir` — `test/vm/data/`
+- `test_resource::build_dir` — build output directory
+
+## Known Pitfalls
+
+- **GCC + ASAN breaks the VM interpreter** — GCC's ASAN implementation is incompatible with the must-tail calling convention used by the interpreter. Use Clang for ASAN builds when working on VM code.
+- **`third_party/evmone` is not a submodule** — it's gitignored and must be manually cloned from `category-labs/evmone` (branch `v0.18.0-category`). Only needed for `MONAD_COMPILER_TESTING`, `MONAD_COMPILER_BENCHMARKS`, lint, and fuzz builds.
+- **Submodules in worktrees** — Fresh clones and git worktrees need `git submodule update --init --recursive` before configuring.
+- **Always use toolchain files** — Passing bare `-march=haswell` via `CFLAGS`/`CXXFLAGS` misses assembly sources (e.g., `keccak_impl.S`). Use `-DCMAKE_TOOLCHAIN_FILE=...` instead.


### PR DESCRIPTION
## Summary

- Adds a shared `/build` slash command for Claude Code that handles the full C++ build workflow: configure, build, test, format, lint (with const-correctness plugin), and fuzz
- Adds `CLAUDE.md` with a pre-PR checklist (format, lint, test)
- Updates `.gitignore` to track `.claude/commands/` while keeping the rest of `.claude/` ignored

## Details

The build skill documents:
- Toolchain file selection (gcc-avx2, gcc-avx512, gcc-asan, gcc-tsan, clang-tsan, clang-fuzz)
- All CMake options (MONAD_COMPILER_*, MONAD_CORE_*, MONAD_VM_INTERPRETER_*, MONAD_EVENT_*)
- Compiler selection (GCC 15+ / Clang 19+) and the GCC+ASAN interpreter caveat
- Submodule init for worktrees/fresh clones
- evmone custom fork setup (`v0.18.0-category` from `category-labs/evmone`)
- Lint workflow matching CI (Clang Debug + ConstCorrectnessChecks plugin + trait instantiation checks)
- Fuzz workflow (compiler, typechecker, staking contract fuzzers)

## Test plan
- [x] Verified clean configure, build, and test (3566/3566 passed) using the skill in a fresh worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)