### PR TITLE
Fix incorrect auto_expire_version initialization after DB reset

### DIFF
--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -129,7 +129,7 @@ TEST(DbBinarySnapshot, Basic)
         }
         TrieDb tdb{db};
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
-        test::commit_simple(
+        monad::test::commit_simple(
             tdb,
             deltas,
             code_delta,
@@ -242,7 +242,7 @@ TEST(DbBinarySnapshot, MultipleShards)
         }
         TrieDb tdb{db};
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
-        test::commit_simple(
+        monad::test::commit_simple(
             tdb,
             deltas,
             code_delta,

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1318,6 +1318,12 @@ bool Db::is_read_only() const
     return is_on_disk() && impl_->aux().io->is_read_only();
 }
 
+UpdateAuxImpl const &Db::aux() const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux();
+}
+
 uint64_t Db::get_history_length() const
 {
     return is_on_disk() ? impl_->aux().version_history_length() : 1;

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -42,6 +42,11 @@ struct StateMachine;
 struct TraverseMachine;
 struct AsyncContext;
 
+namespace test
+{
+    struct DbAccessor;
+}
+
 struct AsyncIOContext
 {
     async::storage_pool pool;
@@ -161,6 +166,10 @@ public:
 
     bool is_on_disk() const;
     bool is_read_only() const;
+
+private:
+    friend struct test::DbAccessor;
+    UpdateAuxImpl const &aux() const;
 };
 
 // The following are not threadsafe. Please use async get from the RODb owning

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -19,14 +19,11 @@
 #include <category/async/connected_operation.hpp>
 #include <category/async/detail/scope_polyfill.hpp>
 #include <category/async/erased_connected_operation.hpp>
-#include <category/async/storage_pool.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/hex.hpp>
-#include <category/core/io/buffers.hpp>
-#include <category/core/io/ring.hpp>
 #include <category/core/keccak.h>
 #include <category/core/result.hpp>
 #include <category/core/small_prng.hpp>
@@ -78,6 +75,17 @@
 
 using namespace monad::mpt;
 using namespace monad::test;
+
+namespace monad::mpt::test
+{
+    struct DbAccessor
+    {
+        static UpdateAuxImpl const &aux(Db const &db)
+        {
+            return db.aux();
+        }
+    };
+}
 
 namespace
 {
@@ -830,7 +838,7 @@ TEST(DbTest, history_length_adjustment_never_under_min)
 {
     auto const dbname = create_temp_file(4);
     StateMachineAlwaysEmpty machine{};
-    OnDiskDbConfig config{
+    OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname}};
@@ -851,19 +859,6 @@ TEST(DbTest, history_length_adjustment_never_under_min)
             .next = UpdateList{}});
     }
 
-    // construct a read-only aux
-    monad::async::storage_pool::creation_flags pool_options;
-    pool_options.open_read_only = true;
-    monad::async::storage_pool pool(
-        config.dbname_paths,
-        monad::async::storage_pool::mode::open_existing,
-        pool_options);
-    monad::io::Ring read_ring{monad::io::RingConfig{128}};
-    monad::io::Buffers read_buffers = monad::io::make_buffers_for_read_only(
-        read_ring, 128, monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
-    monad::async::AsyncIO io_ctx(pool, read_buffers);
-    UpdateAux const aux_reader{io_ctx};
-
     auto batch_upsert_once = [&](uint64_t const version) {
         UpdateList ls;
         for (auto &u : updates_alloc) {
@@ -876,13 +871,13 @@ TEST(DbTest, history_length_adjustment_never_under_min)
         batch_upsert_once(block_id);
         ++block_id;
     }
-    auto const disk_usage_before = aux_reader.disk_usage();
-    while (aux_reader.disk_usage() == disk_usage_before) {
+    auto const disk_usage_before = test::DbAccessor::aux(db).disk_usage();
+    while (test::DbAccessor::aux(db).disk_usage() == disk_usage_before) {
         batch_upsert_once(block_id);
         ++block_id;
     }
     // Db stops adjusting down history length at MIN_HISTORY_LENGTH
-    EXPECT_GT(aux_reader.disk_usage(), disk_usage_before);
+    EXPECT_GT(test::DbAccessor::aux(db).disk_usage(), disk_usage_before);
     EXPECT_EQ(db.get_history_length(), MIN_HISTORY_LENGTH);
 
     remove(dbname);
@@ -2231,27 +2226,15 @@ TEST(DbTest, move_trie_version_forward_history_ring_wrap_around)
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
     StateMachineAlwaysEmpty machine{};
-    OnDiskDbConfig config{
+    OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname}};
     Db db{machine, config};
     Node::SharedPtr root;
 
-    uint64_t const root_offsets_ring_capacity = [&] {
-        monad::async::storage_pool::creation_flags pool_options;
-        pool_options.open_read_only = true;
-        monad::async::storage_pool pool_ro(
-            config.dbname_paths,
-            monad::async::storage_pool::mode::open_existing,
-            pool_options);
-        monad::io::Ring ring;
-        monad::io::Buffers robuf = monad::io::make_buffers_for_read_only(
-            ring, 2, monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
-        monad::async::AsyncIO testio(pool_ro, robuf);
-        monad::mpt::UpdateAux const aux_reader{testio};
-        return aux_reader.root_offsets().capacity();
-    }();
+    uint64_t const root_offsets_ring_capacity =
+        test::DbAccessor::aux(db).root_offsets().capacity();
 
     auto const prefix = 0x0012_bytes;
     monad::byte_string const kv = keccak_int_to_string(10);
@@ -2313,20 +2296,8 @@ TEST_F(OnDiskDbWithFileFixture, history_ring_buffer_wrap_around)
         kv_alloc.emplace_back(keccak_int_to_string(i));
     }
 
-    uint64_t const root_offsets_ring_capacity = [&] {
-        monad::async::storage_pool::creation_flags pool_options;
-        pool_options.open_read_only = true;
-        monad::async::storage_pool pool_ro(
-            config.dbname_paths,
-            monad::async::storage_pool::mode::open_existing,
-            pool_options);
-        monad::io::Ring ring;
-        monad::io::Buffers robuf = monad::io::make_buffers_for_read_only(
-            ring, 2, monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
-        monad::async::AsyncIO testio(pool_ro, robuf);
-        monad::mpt::UpdateAux const aux_reader{testio};
-        return aux_reader.root_offsets().capacity();
-    }();
+    uint64_t const root_offsets_ring_capacity =
+        test::DbAccessor::aux(db).root_offsets().capacity();
     std::cout << root_offsets_ring_capacity << std::endl;
 
     auto const version_begin = root_offsets_ring_capacity * 2;
@@ -2882,4 +2853,30 @@ TYPED_TEST(DbTest, scalability)
             i.join();
         }
     }
+}
+
+TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
+{
+    // After upsert at version 0 and move_trie_version_forward
+    // to 1000, auto_expire_version_metadata should be updated to 1000 (not
+    // remain at 0).
+    auto const prefix = 0x00_bytes;
+    auto const key0 = 0x0000000000000000_bytes;
+
+    root = upsert_updates_flat_list(
+        nullptr, db, prefix, 0, make_update(key0, key0));
+
+    // After upsert at version 0, auto_expire_version_metadata should be 0
+    EXPECT_EQ(test::DbAccessor::aux(db).get_auto_expire_version_metadata(), 0);
+
+    // Move trie from version 0 to version 1000
+    constexpr uint64_t start_version = 1000;
+    db.move_trie_version_forward(0, start_version);
+
+    // After move, auto_expire_version_metadata should be updated to 1000
+    EXPECT_EQ(
+        test::DbAccessor::aux(db).get_auto_expire_version_metadata(),
+        start_version)
+        << "auto_expire_version_metadata should be moved forward with "
+           "move_trie_version_forward";
 }

--- a/category/mpt/test/state_machine_test.cpp
+++ b/category/mpt/test/state_machine_test.cpp
@@ -84,7 +84,7 @@ namespace
 
         virtual Compute &get_compute() const override
         {
-            static test::EmptyCompute compute{};
+            static monad::test::EmptyCompute compute{};
             compute_calls.emplace(path);
             return compute;
         }

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -401,7 +401,7 @@ UpdateAuxImpl::calc_auto_expire_version(uint64_t const upsert_version) noexcept
 {
     MONAD_ASSERT(is_on_disk());
     if (db_history_max_version() == INVALID_BLOCK_NUM) {
-        return 0;
+        return static_cast<int64_t>(upsert_version);
     }
     auto const min_valid_version = db_history_min_valid_version();
     auto const max_version_post_upsert =
@@ -1354,6 +1354,9 @@ void UpdateAuxImpl::move_trie_version_forward(
     append_root_offset(offset);
     MONAD_ASSERT(dest == db_history_max_version());
     MONAD_ASSERT(version_is_valid_ondisk(dest));
+    if (get_auto_expire_version_metadata() == static_cast<int64_t>(src)) {
+        set_auto_expire_version_metadata(static_cast<int64_t>(dest));
+    }
 }
 
 void UpdateAuxImpl::update_disk_growth_data()


### PR DESCRIPTION
After reset, auto_expire_version is expected to match the reset/upsert version, but could be computed incorrectly due to:

1. move_trie_version_forward did not update auto_expire_version_metadata to the destination version, leaving it at the old source version.
2. calc_auto_expire_version returned 0 instead of the upsert version when db_history_max_version is INVALID_BLOCK_NUM.

Also add Db::aux() const accessor for unit testing. Simplify existing tests that constructed standalone read-only UpdateAux instances.