### PR TITLE
[vm/utils] `evm-as` quality-of-life improvements

### DIFF
--- a/category/vm/utils/evm-as/builder.hpp
+++ b/category/vm/utils/evm-as/builder.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/hex.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/core/assert.h>
 #include <category/vm/core/cases.hpp>
@@ -146,6 +147,12 @@ namespace monad::vm::utils::evm_as
             return insert(std::move(pushop));
         }
 
+        EvmBuilder &push(FixedBytes auto const &data) noexcept
+            requires(sizeof(data) <= 32)
+        {
+            return push(runtime::from_bytes(sizeof(data), data.bytes));
+        }
+
         EvmBuilder &push(evmc::address const &address) noexcept
         {
             auto const pushop = PushAddressI{address};
@@ -200,6 +207,11 @@ namespace monad::vm::utils::evm_as
         {
             auto commentop = CommentI{comment};
             return insert(std::move(commentop));
+        }
+
+        EvmBuilder &invalid() noexcept
+        {
+            return insert(InvalidI{"INVALID"});
         }
 
         // Macro expansions

--- a/category/vm/utils/evm-as/validator.hpp
+++ b/category/vm/utils/evm-as/validator.hpp
@@ -52,10 +52,12 @@ namespace monad::vm::utils::evm_as::internal
     struct EvmDebugValidator
     {
 
-        explicit EvmDebugValidator(std::vector<ValidationError> &errors)
+        EvmDebugValidator(
+            std::vector<ValidationError> &errors, bool allow_invalid)
             : errors(errors)
             , vstack_size(0)
             , pos(0)
+            , allow_invalid(allow_invalid)
         {
         }
 
@@ -151,6 +153,10 @@ namespace monad::vm::utils::evm_as::internal
 
         bool operator()(InvalidI const &invalid)
         {
+            if (allow_invalid) {
+                return true;
+            }
+
             if (invalid.has_name()) {
                 error(
                     pos, std::format("Invalid instruction '{}'", invalid.name));
@@ -202,25 +208,36 @@ namespace monad::vm::utils::evm_as::internal
         size_t vstack_size = 0;
         size_t pos = 0;
         bool result = true;
+        bool allow_invalid = false;
     };
 
 }
 
 namespace monad::vm::utils::evm_as
 {
-    template <Traits traits>
-    bool
-    validate(EvmBuilder<traits> const &eb, std::vector<ValidationError> &errors)
+
+    struct validation_config
     {
-        internal::EvmDebugValidator<traits, true> v(errors);
+        bool const allow_invalid = false;
+    };
+
+    template <Traits traits>
+    bool validate(
+        EvmBuilder<traits> const &eb, std::vector<ValidationError> &errors,
+        validation_config const &config = {})
+    {
+        internal::EvmDebugValidator<traits, true> v(
+            errors, config.allow_invalid);
         return v.validate(eb);
     }
 
     template <Traits traits>
-    bool validate(EvmBuilder<traits> const &eb)
+    bool
+    validate(EvmBuilder<traits> const &eb, validation_config const &config = {})
     {
         std::vector<ValidationError> errors;
-        internal::EvmDebugValidator<traits, false> v(errors);
+        internal::EvmDebugValidator<traits, false> v(
+            errors, config.allow_invalid);
         return v.validate(eb);
     }
 }

--- a/test/vm/unit/evm-as_tests.cpp
+++ b/test/vm/unit/evm-as_tests.cpp
@@ -1861,3 +1861,146 @@ TEST(EvmAs, CallMacroExpansions)
         EXPECT_EQ(evm_as::mcompile(eb1), expected);
     }
 }
+
+template <size_t N>
+    requires(N > 0 && N <= 32)
+struct fixed_bytes
+{
+    explicit fixed_bytes(runtime::uint256_t const &value)
+    {
+        uint8_t buf[32] = {};
+        value.store_be(buf);
+        std::memcpy(bytes, buf + (32 - N), N);
+    }
+
+    uint8_t bytes[N];
+};
+
+TEST(EvmAs, FixedBytesPush)
+{
+    auto eb = evm_as::latest();
+
+    eb.push(fixed_bytes<1>(255))
+        .push(fixed_bytes<2>(0xABCD))
+        .push(fixed_bytes<11>(0x0123456789ABCDEFFEDCBA_u256))
+        .push(fixed_bytes<27>(
+            0x0123456789ABCDEFFEDCBA9876543210FEDCBA9876543210123456_u256))
+        .push(fixed_bytes<32>(
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u256));
+
+    EXPECT_TRUE(evm_as::validate(eb));
+
+    std::vector<uint8_t> bytecode{};
+    evm_as::compile(eb, bytecode);
+
+    std::vector<uint8_t> expected{
+        compiler::EvmOpCode::PUSH1,
+        0xFF,
+        compiler::EvmOpCode::PUSH2,
+        0xAB,
+        0xCD,
+        compiler::EvmOpCode::PUSH11,
+        0x01,
+        0x23,
+        0x45,
+        0x67,
+        0x89,
+        0xAB,
+        0xCD,
+        0xEF,
+        0xFE,
+        0xDC,
+        0xBA,
+        compiler::EvmOpCode::PUSH27,
+        0x01,
+        0x23,
+        0x45,
+        0x67,
+        0x89,
+        0xAB,
+        0xCD,
+        0xEF,
+        0xFE,
+        0xDC,
+        0xBA,
+        0x98,
+        0x76,
+        0x54,
+        0x32,
+        0x10,
+        0xFE,
+        0xDC,
+        0xBA,
+        0x98,
+        0x76,
+        0x54,
+        0x32,
+        0x10,
+        0x12,
+        0x34,
+        0x56,
+        compiler::EvmOpCode::PUSH32,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF,
+        0xFF};
+
+    EXPECT_EQ(bytecode.size(), expected.size());
+    EXPECT_EQ(bytecode, expected);
+
+    std::string const expected_mnemonic =
+        "PUSH1 0xFF\n"
+        "PUSH2 0xABCD\n"
+        "PUSH11 0x123456789ABCDEFFEDCBA\n"
+        "PUSH27 0x123456789ABCDEFFEDCBA9876543210FEDCBA9876543210123456\n"
+        "PUSH32 "
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\n";
+    EXPECT_EQ(evm_as::mcompile(eb), expected_mnemonic);
+}
+
+TEST(EvmAs, Invalid)
+{
+    auto eb = evm_as::latest();
+    eb.invalid();
+
+    EXPECT_FALSE(evm_as::validate(eb));
+    EXPECT_TRUE(evm_as::validate(eb, {.allow_invalid = true}));
+
+    std::vector<uint8_t> bytecode{};
+    evm_as::compile(eb, bytecode);
+
+    std::vector<uint8_t> expected{0xFE};
+
+    EXPECT_EQ(bytecode, expected);
+
+    std::string const expected_mnemonic = "INVALID\n";
+    EXPECT_EQ(evm_as::mcompile(eb), expected_mnemonic);
+}


### PR DESCRIPTION
This patch adds functionality for pushing arbitrary fixed byte vectors (max 32 bytes). It adds a method for constructing the `invalid` instruction. Consequently, the validator has been tweaked to configure whether to allow/disallow occurrences of the `invalid` instruction.