### PR TITLE
[zkVM] Partial trie DB

### DIFF
--- a/category/core/rlp/decode_error.cpp
+++ b/category/core/rlp/decode_error.cpp
@@ -44,6 +44,8 @@ quick_status_code_from_enum<monad::rlp::DecodeError>::value_mappings()
         {DecodeError::ArrayLengthUnexpected, "array length unexpected", {}},
         {DecodeError::InvalidTxnType, "invalid txn type", {}},
         {DecodeError::LeadingZero, "leading zero", {}},
+        {DecodeError::PathTooShort, "path too short", {}},
+        {DecodeError::PathTooLong, "path too long", {}},
     };
 
     return v;

--- a/category/core/rlp/decode_error.hpp
+++ b/category/core/rlp/decode_error.hpp
@@ -40,6 +40,8 @@ enum class DecodeError
     ArrayLengthUnexpected,
     InvalidTxnType,
     LeadingZero,
+    PathTooShort,
+    PathTooLong,
 };
 
 MONAD_RLP_NAMESPACE_END

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(
   "ethereum/db/db_snapshot_filesystem.h"
   "ethereum/db/file_db.cpp"
   "ethereum/db/file_db.hpp"
+  "ethereum/db/partial_trie_db.hpp"
+  "ethereum/db/partial_trie_db.cpp"
   "ethereum/db/trie_db.cpp"
   "ethereum/db/trie_db.hpp"
   "ethereum/db/trie_rodb.hpp"
@@ -176,6 +178,8 @@ add_library(
   "ethereum/rlp/config.hpp"
   "ethereum/rlp/decode.hpp"
   "ethereum/rlp/encode2.hpp"
+  "ethereum/rlp/execution_witness.cpp"
+  "ethereum/rlp/execution_witness.hpp"
   # ethereum/state2
   "ethereum/state2/block_state.cpp"
   "ethereum/state2/block_state.hpp"

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -1,0 +1,454 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/cases.hpp>
+#include <category/core/config.hpp>
+#include <category/core/keccak.hpp>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/db/partial_trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/rlp/decode.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/vm/code.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <span>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace
+{
+
+    // Forward declaration for mutual recursion.
+    template <typename T>
+    Result<ChildRef<T>> decode_child_ref(
+        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
+        NodeIndex const &nodes);
+
+    template <typename T>
+    byte_string encode_child_ref(ChildRef<T> const &child);
+
+    // ensures enc.empty() if successful
+    template <typename T>
+    Result<PartialNode<T>> decode_partial_node(
+        byte_string_view &enc, mpt::NibblesView curr_path,
+        NodeIndex const &nodes)
+    {
+        if (MONAD_UNLIKELY(enc.empty())) {
+            return rlp::DecodeError::InputTooShort;
+        }
+
+        {
+            // Make a copy of enc in case we need to backtrack in the branch
+            // case below
+            byte_string_view short_node_enc{enc};
+            BOOST_OUTCOME_TRY(
+                auto key_enc, rlp::parse_metadata(short_node_enc));
+            BOOST_OUTCOME_TRY(
+                auto val_enc, rlp::parse_metadata(short_node_enc));
+
+            if (short_node_enc.empty()) {
+                enc = short_node_enc;
+                // Extension/Leaf node
+                if (MONAD_UNLIKELY(key_enc.first != rlp::RlpType::String)) {
+                    return rlp::DecodeError::TypeUnexpected;
+                }
+
+                BOOST_OUTCOME_TRY(
+                    auto decoded_pair, mpt::compact_decode(key_enc.second));
+                auto const &[decoded_path, is_leaf] = decoded_pair;
+                mpt::Nibbles full_path =
+                    mpt::concat(curr_path, mpt::NibblesView{decoded_path});
+
+                if (MONAD_UNLIKELY(full_path.nibble_size() > 64)) {
+                    return rlp::DecodeError::PathTooLong;
+                }
+
+                if (is_leaf) {
+                    if (MONAD_UNLIKELY(val_enc.first != rlp::RlpType::String)) {
+                        return rlp::DecodeError::TypeUnexpected;
+                    }
+                    BOOST_OUTCOME_TRY(
+                        auto value, T::decode(val_enc.second, nodes));
+                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
+                    return PartialNode<T>{
+                        LeafData<T>{std::move(decoded_path), std::move(value)}};
+                }
+                else {
+                    BOOST_OUTCOME_TRY(
+                        auto child,
+                        decode_child_ref<T>(
+                            val_enc.first,
+                            val_enc.second,
+                            mpt::NibblesView{full_path},
+                            nodes));
+                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
+                    return PartialNode<T>{ExtensionData<T>{
+                        std::move(decoded_path), std::move(child)}};
+                }
+            }
+        }
+
+        // Branch node: re-parse from the beginning since we consumed k and v
+        // above
+        BranchData<T> branch{};
+
+        if (MONAD_UNLIKELY(curr_path.nibble_size() + 1 > 64)) {
+            return rlp::DecodeError::PathTooLong;
+        }
+
+        for (unsigned i = 0; i < 16; ++i) {
+            BOOST_OUTCOME_TRY(auto child_enc, rlp::parse_metadata(enc));
+            mpt::Nibbles child_path =
+                mpt::concat(curr_path, static_cast<unsigned char>(i));
+            BOOST_OUTCOME_TRY(
+                auto child,
+                decode_child_ref<T>(
+                    child_enc.first,
+                    child_enc.second,
+                    mpt::NibblesView{child_path},
+                    nodes));
+            branch.children[i] = std::move(child);
+        }
+        BOOST_OUTCOME_TRY(auto v_enc, rlp::decode_string(enc));
+        if (!v_enc.empty()) {
+            BOOST_OUTCOME_TRY(auto value, T::decode(v_enc, nodes));
+            MONAD_DEBUG_ASSERT(v_enc.empty());
+            branch.value = std::move(value);
+        }
+        if (MONAD_UNLIKELY(!enc.empty())) {
+            return rlp::DecodeError::InputTooLong;
+        }
+        return PartialNode<T>{std::move(branch)};
+    }
+
+    // ensures enc.empty() if successful
+    template <typename T>
+    Result<ChildRef<T>> decode_child_ref(
+        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
+        NodeIndex const &nodes)
+    {
+        if (ty == rlp::RlpType::List) {
+            // Embedded node (inline RLP list). Ethereum requires the *full* RLP
+            // encoding of an inline node to be < 32 bytes; since `enc` is the
+            // list payload (header already stripped), its size must be <= 30.
+            if (MONAD_UNLIKELY(enc.size() > 30)) {
+                return rlp::DecodeError::InputTooLong;
+            }
+            // Manual expansion of BOOST_OUTCOME_TRY to avoid a named
+            // PartialNode<T> local that triggers a GCC false-positive
+            // -Wmaybe-uninitialized on the unique_ptr inside AccountLeafValue.
+            auto node_result_ = decode_partial_node<T>(enc, path, nodes);
+            if (MONAD_UNLIKELY(node_result_.has_failure())) {
+                return std::move(node_result_).as_failure();
+            }
+            MONAD_DEBUG_ASSERT(enc.empty());
+            return std::make_unique<PartialNode<T>>(
+                std::move(node_result_).assume_value());
+        }
+        else {
+            // String: either empty (null slot) or 32-byte hash reference
+            if (enc.empty()) {
+                return nullptr;
+            }
+            if (MONAD_UNLIKELY(enc.size() < 32)) {
+                return rlp::DecodeError::InputTooShort;
+            }
+            if (MONAD_UNLIKELY(enc.size() > 32)) {
+                return rlp::DecodeError::InputTooLong;
+            }
+            bytes32_t hash{};
+            std::memcpy(hash.bytes, enc.data(), 32);
+            enc = enc.substr(32);
+            MONAD_DEBUG_ASSERT(enc.empty());
+            // NULL_ROOT is the canonical empty-trie hash; represent it as a
+            // null pointer so encode/decode are symmetric with
+            // AccountLeafValue.
+            if (hash == NULL_ROOT) {
+                return nullptr;
+            }
+            auto it = nodes.find(hash);
+            if (it == nodes.end()) {
+                return std::make_unique<PartialNode<T>>(HashStub{hash});
+            }
+            // The NodeIndex stores the raw RLP item (list). Strip the list
+            // header before passing the payload to decode_partial_node.
+            byte_string_view node_enc{it->second};
+            BOOST_OUTCOME_TRY(auto payload, rlp::parse_list_metadata(node_enc));
+            if (MONAD_UNLIKELY(!node_enc.empty())) {
+                return rlp::DecodeError::InputTooLong;
+            }
+            BOOST_OUTCOME_TRY(
+                auto v, decode_partial_node<T>(payload, path, nodes));
+            MONAD_DEBUG_ASSERT(payload.empty());
+            return std::make_unique<PartialNode<T>>(std::move(v));
+        }
+    }
+
+    template <typename T>
+    byte_string encode_partial_node(PartialNode<T> const &node)
+    {
+        return std::visit(
+            Cases{
+                [](LeafData<T> const &leaf) {
+                    MONAD_ASSERT(leaf.path.nibble_size() <= 64);
+                    unsigned char compact_buf[33];
+                    auto compact_sv = mpt::compact_encode(
+                        compact_buf,
+                        mpt::NibblesView{leaf.path},
+                        /*terminating=*/true);
+                    return rlp::encode_list2(
+                        rlp::encode_string2(compact_sv),
+                        rlp::encode_string2(T::encode(leaf.value)));
+                },
+                [](ExtensionData<T> const &ext) {
+                    MONAD_ASSERT(ext.path.nibble_size() <= 64);
+                    unsigned char compact_buf[33];
+                    auto compact_sv = mpt::compact_encode(
+                        compact_buf,
+                        mpt::NibblesView{ext.path},
+                        /*terminating=*/false);
+                    return rlp::encode_list2(
+                        rlp::encode_string2(compact_sv),
+                        encode_child_ref(ext.child));
+                },
+                [](BranchData<T> const &branch) {
+                    byte_string body;
+                    for (unsigned i = 0; i < 16; ++i) {
+                        body += encode_child_ref(branch.children[i]);
+                    }
+                    body += branch.value ? T::encode(*branch.value)
+                                         : rlp::EMPTY_STRING;
+                    return rlp::encode_list2(body);
+                },
+                [](HashStub const &) -> byte_string {
+                    // HashStub is handled by callers; never arrives here.
+                    MONAD_ASSERT(false);
+                    return {};
+                },
+            },
+            node.v);
+    }
+
+    template <typename T>
+    byte_string encode_child_ref(ChildRef<T> const &child)
+    {
+        if (!child) {
+            return rlp::EMPTY_STRING;
+        }
+        if (auto const *stub = std::get_if<HashStub>(&child->v)) {
+            return rlp::encode_string2(byte_string_view{stub->hash.bytes, 32});
+        }
+        byte_string rlp_bytes = encode_partial_node(*child);
+        if (rlp_bytes.size() < 32) {
+            return rlp_bytes; // embedded inline
+        }
+        unsigned char hash[32];
+        keccak256(rlp_bytes.data(), rlp_bytes.size(), hash);
+        return rlp::encode_string2(byte_string_view{hash, 32});
+    }
+
+} // anonymous namespace
+
+// ensures enc.empty() if successful
+Result<AccountLeafValue>
+AccountLeafValue::decode(byte_string_view &enc, NodeIndex const &nodes)
+{
+    bytes32_t storage_root{};
+    BOOST_OUTCOME_TRY(Account acct, rlp::decode_account(storage_root, enc));
+    if (MONAD_UNLIKELY(!enc.empty())) {
+        return rlp::DecodeError::InputTooLong;
+    }
+    StorageTrie strie;
+    if (storage_root != NULL_ROOT) {
+        mpt::Nibbles empty_path{};
+        byte_string_view storage_root_enc{
+            storage_root.bytes, sizeof(storage_root.bytes)};
+        BOOST_OUTCOME_TRY(
+            strie,
+            decode_child_ref<StorageLeafValue>(
+                rlp::RlpType::String,
+                storage_root_enc,
+                mpt::NibblesView{empty_path},
+                nodes));
+        MONAD_DEBUG_ASSERT(storage_root_enc.empty());
+    }
+
+    return AccountLeafValue{.account = acct, .storage = std::move(strie)};
+}
+
+byte_string AccountLeafValue::encode(AccountLeafValue const &v)
+{
+    bytes32_t storage_root;
+    if (!v.storage) {
+        storage_root = NULL_ROOT;
+    }
+    else {
+        auto const &storage_node = *v.storage;
+        if (auto const *stub = std::get_if<HashStub>(&storage_node.v)) {
+            storage_root = stub->hash;
+        }
+        else {
+            byte_string rlp_bytes = encode_partial_node(storage_node);
+            storage_root = to_bytes(keccak256(
+                byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
+        }
+    }
+
+    return rlp::encode_account(v.account, storage_root);
+}
+
+// ensures enc.empty() if successful
+Result<StorageLeafValue>
+StorageLeafValue::decode(byte_string_view &enc, NodeIndex const & /*nodes*/)
+{
+    BOOST_OUTCOME_TRY(auto const raw, rlp::decode_bytes32_compact(enc));
+    if (MONAD_UNLIKELY(!enc.empty())) {
+        return rlp::DecodeError::InputTooLong;
+    }
+    return StorageLeafValue{raw};
+}
+
+byte_string StorageLeafValue::encode(StorageLeafValue const &v)
+{
+    return rlp::encode_bytes32_compact(v.value);
+}
+
+Result<PartialTrieDb> PartialTrieDb::from_reth_witness(
+    bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
+    byte_string_view encoded_codes)
+{
+    NodeIndex node_index;
+    {
+        while (!encoded_nodes.empty()) {
+            BOOST_OUTCOME_TRY(
+                auto payload, rlp::parse_string_metadata(encoded_nodes));
+            bytes32_t key = to_bytes(keccak256(payload));
+            node_index.emplace(
+                key, byte_string{payload.data(), payload.size()});
+        }
+    }
+
+    CodeIndex code_index;
+    {
+        while (!encoded_codes.empty()) {
+            BOOST_OUTCOME_TRY(
+                auto bytes, rlp::parse_string_metadata(encoded_codes));
+            bytes32_t key = to_bytes(keccak256(bytes));
+            code_index.emplace(
+                key,
+                vm::make_shared_intercode(
+                    std::span<uint8_t const>{bytes.data(), bytes.size()}));
+        }
+    }
+
+    AccountTrie root_node;
+    {
+        mpt::Nibbles empty_path{};
+        byte_string_view pre_state_root_enc{
+            pre_state_root.bytes, sizeof(pre_state_root.bytes)};
+        BOOST_OUTCOME_TRY(
+            root_node,
+            decode_child_ref<AccountLeafValue>(
+                rlp::RlpType::String,
+                pre_state_root_enc,
+                mpt::NibblesView{empty_path},
+                node_index));
+        MONAD_DEBUG_ASSERT(pre_state_root_enc.empty());
+    }
+
+    return PartialTrieDb{std::move(root_node), std::move(code_index)};
+}
+
+std::optional<Account> PartialTrieDb::read_account(Address const &)
+{
+    return std::nullopt;
+}
+
+bytes32_t
+PartialTrieDb::read_storage(Address const &, Incarnation, bytes32_t const &)
+{
+    return {};
+}
+
+vm::SharedIntercode PartialTrieDb::read_code(bytes32_t const &code_hash)
+{
+    auto it = codes_.find(code_hash);
+    if (it == codes_.end()) {
+        return vm::make_shared_intercode({});
+    }
+    return it->second;
+}
+
+BlockHeader PartialTrieDb::read_eth_header()
+{
+    return last_committed_header_;
+}
+
+bytes32_t PartialTrieDb::state_root()
+{
+    if (!root_) {
+        return NULL_ROOT;
+    }
+    if (auto const *stub = std::get_if<HashStub>(&root_->v)) {
+        return stub->hash;
+    }
+    byte_string rlp_bytes = encode_partial_node(*root_);
+    return to_bytes(
+        keccak256(byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
+}
+
+bytes32_t PartialTrieDb::receipts_root()
+{
+    return receipts_root_;
+}
+
+bytes32_t PartialTrieDb::transactions_root()
+{
+    return transactions_root_;
+}
+
+std::optional<bytes32_t> PartialTrieDb::withdrawals_root()
+{
+    return withdrawals_root_;
+}
+
+uint64_t PartialTrieDb::get_block_number() const
+{
+    return block_number_;
+}
+
+void PartialTrieDb::set_block_and_prefix(
+    uint64_t block_number, bytes32_t const &)
+{
+    block_number_ = block_number;
+}
+
+void PartialTrieDb::commit(
+    bytes32_t const &, CommitBuilder &, BlockHeader const &,
+    StateDeltas const &, std::function<void(BlockHeader &)>)
+{
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -1,0 +1,204 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/core/result.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/vm/vm.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <variant>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+/// An unresolved subtree whose contents are absent from the witness.
+struct HashStub
+{
+    bytes32_t hash;
+};
+
+using NodeIndex = ankerl::unordered_dense::map<bytes32_t, byte_string>;
+
+template <typename T>
+concept LeafValue =
+    requires(byte_string_view &enc, NodeIndex const &nodes, T const &v) {
+        { T::decode(enc, nodes) } -> std::same_as<Result<T>>;
+        { T::encode(v) } -> std::same_as<byte_string>;
+    };
+
+template <LeafValue V>
+struct PartialNode;
+
+/// Owning pointer to a child node. A null pointer represents an empty branch
+/// slot (analogous to an absent nibble in a standard Ethereum branch node).
+template <LeafValue V>
+using ChildRef = std::unique_ptr<PartialNode<V>>;
+
+template <LeafValue V>
+struct BranchData
+{
+    std::array<ChildRef<V>, 16> children;
+    std::optional<V> value;
+};
+
+template <LeafValue V>
+struct ExtensionData
+{
+    mpt::Nibbles path;
+    ChildRef<V> child;
+};
+
+template <LeafValue V>
+struct LeafData
+{
+    mpt::Nibbles path;
+    V value;
+};
+
+/// Four-way variant: branch, extension, leaf, or opaque hash stub.
+template <LeafValue V>
+struct PartialNode
+{
+    using Variant =
+        std::variant<BranchData<V>, ExtensionData<V>, LeafData<V>, HashStub>;
+
+    Variant v;
+
+    PartialNode() = default;
+
+    template <class T>
+        requires std::constructible_from<Variant, T>
+    explicit PartialNode(T &&x)
+        : v(std::forward<T>(x))
+    {
+    }
+};
+
+struct StorageLeafValue
+{
+    bytes32_t value;
+
+    static Result<StorageLeafValue>
+    decode(byte_string_view &enc, NodeIndex const & /*nodes*/);
+
+    static byte_string encode(StorageLeafValue const &v);
+};
+
+using StorageTrie = ChildRef<StorageLeafValue>;
+
+struct AccountLeafValue
+{
+    Account account;
+    StorageTrie
+        storage{}; ///< per-account storage MPT, embedded directly in the leaf
+
+    static Result<AccountLeafValue>
+    decode(byte_string_view &enc, NodeIndex const &nodes);
+
+    static byte_string encode(AccountLeafValue const &v);
+};
+
+using AccountTrie = ChildRef<AccountLeafValue>;
+
+using CodeIndex = ankerl::unordered_dense::map<bytes32_t, vm::SharedIntercode>;
+
+// ---------------------------------------------------------------------------
+// PartialTrieDb
+// ---------------------------------------------------------------------------
+
+/// A sparse Ethereum account + storage MPT that implements the Db interface.
+///
+/// Built from a Reth witness bundle; serves as a drop-in replacement for
+/// TrieDb during zkVM STF proving. The trie IS the pre-state — there are no
+/// separate account or storage vectors.
+class PartialTrieDb final : public Db
+{
+    AccountTrie root_;
+    CodeIndex codes_;
+    uint64_t block_number_{0};
+    BlockHeader last_committed_header_{};
+    bytes32_t receipts_root_{};
+    bytes32_t transactions_root_{};
+    std::optional<bytes32_t> withdrawals_root_{};
+
+    PartialTrieDb(AccountTrie root, CodeIndex codes)
+        : root_{std::move(root)}
+        , codes_{std::move(codes)}
+    {
+    }
+
+public:
+    PartialTrieDb() = delete;
+
+    static Result<PartialTrieDb> from_reth_witness(
+        bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
+        byte_string_view encoded_codes);
+
+    std::optional<Account> read_account(Address const &) override;
+
+    bytes32_t
+    read_storage(Address const &, Incarnation, bytes32_t const &key) override;
+
+    vm::SharedIntercode read_code(bytes32_t const &code_hash) override;
+
+    BlockHeader read_eth_header() override;
+
+    bytes32_t state_root() override;
+    bytes32_t receipts_root() override;
+    bytes32_t transactions_root() override;
+    std::optional<bytes32_t> withdrawals_root() override;
+
+    uint64_t get_block_number() const override;
+
+    void set_block_and_prefix(
+        uint64_t block_number,
+        bytes32_t const &block_id = bytes32_t{}) override;
+
+    void commit(
+        bytes32_t const &block_id, CommitBuilder &, BlockHeader const &,
+        StateDeltas const &, std::function<void(BlockHeader &)>) override;
+
+    // No-op overrides for operations that are irrelevant in the witness
+    // context.
+    void finalize(uint64_t, bytes32_t const &) override {}
+
+    void update_verified_block(uint64_t) override {}
+
+    void update_voted_metadata(uint64_t, bytes32_t const &) override {}
+
+    void update_proposed_metadata(uint64_t, bytes32_t const &) override {}
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -1,0 +1,405 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/rlp/decode_error.hpp>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/db/partial_trie_db.hpp>
+#include <category/execution/ethereum/rlp/decode.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/rlp/execution_witness.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <variant>
+
+using namespace monad;
+
+namespace
+{
+    constexpr auto PRE_ROOT =
+        0x0101010101010101010101010101010101010101010101010101010101010101_bytes32;
+    constexpr auto POST_ROOT =
+        0x0202020202020202020202020202020202020202020202020202020202020202_bytes32;
+
+    byte_string make_minimal_witness(
+        bytes32_t const &pre, bytes32_t const &post,
+        byte_string nodes_payload = {}, byte_string codes_payload = {})
+    {
+        return rlp::encode_list2(
+            rlp::encode_string2({}), // [0] block_rlp (empty)
+            rlp::encode_string2(
+                byte_string_view{pre.bytes, 32}), // [1] pre_state_root
+            rlp::encode_string2(
+                byte_string_view{post.bytes, 32}), // [2] post_state_root
+            rlp::encode_list2(nodes_payload), // [3] node preimages
+            rlp::encode_list2(codes_payload), // [4] contract bytecodes
+            byte_string{
+                static_cast<unsigned char>(0xc0)}, // [5] preimages (skipped)
+            byte_string{static_cast<unsigned char>(0xc0)}
+            // [6] ancestor headers
+        );
+    }
+
+    void storage_leaf_roundtrip(
+        bytes32_t const &val, NodeIndex &nodes, std::string_view label = {})
+    {
+        byte_string const enc = StorageLeafValue::encode(StorageLeafValue{val});
+
+        byte_string_view view{enc};
+        auto const decoded = StorageLeafValue::decode(view, nodes);
+        ASSERT_FALSE(decoded.has_error()) << label;
+        EXPECT_EQ(decoded.value().value, val) << label;
+        ASSERT_TRUE(view.empty()) << label;
+    }
+
+    byte_string
+    make_branch_with_child(unsigned slot, byte_string const &child_rlp)
+    {
+        byte_string body;
+        for (unsigned i = 0; i < 16; ++i) {
+            body += (i == slot) ? child_rlp : rlp::EMPTY_STRING;
+        }
+        body += rlp::EMPTY_STRING; // value slot
+        return rlp::encode_list2(body);
+    }
+
+    Result<PartialTrieDb> try_decode_node(byte_string const &node_rlp)
+    {
+        bytes32_t const root = to_bytes(
+            keccak256(byte_string_view{node_rlp.data(), node_rlp.size()}));
+        byte_string const encoded_nodes = rlp::encode_string2(
+            byte_string_view{node_rlp.data(), node_rlp.size()});
+        return PartialTrieDb::from_reth_witness(
+            root,
+            byte_string_view{encoded_nodes.data(), encoded_nodes.size()},
+            {});
+    }
+} // namespace
+
+TEST(ParseExecutionWitness, ValidMinimalWitness)
+{
+    auto const w = make_minimal_witness(PRE_ROOT, POST_ROOT);
+    auto const result = parse_execution_witness(w);
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(result.value().pre_state_root, PRE_ROOT);
+    EXPECT_EQ(result.value().post_state_root, POST_ROOT);
+    EXPECT_TRUE(result.value().encoded_nodes.empty());
+    EXPECT_TRUE(result.value().encoded_codes.empty());
+    EXPECT_TRUE(result.value().encoded_headers.empty());
+}
+
+TEST(ParseExecutionWitness, EmptyInput)
+{
+    auto const result = parse_execution_witness({});
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(ParseExecutionWitness, OuterTypeNotList)
+{
+    // A single empty-string byte (0x80) is not a list.
+    byte_string const bad{static_cast<unsigned char>(0x80)};
+    auto const result = parse_execution_witness(bad);
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(ParseExecutionWitness, Truncated)
+{
+    auto w = make_minimal_witness(PRE_ROOT, POST_ROOT);
+    w.resize(w.size() - 5);
+    auto const result = parse_execution_witness(w);
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(ParseExecutionWitness, PreRootWrongLength)
+{
+    // Replace the 32-byte pre_state_root item with a 16-byte one so that
+    // decode_byte_string_fixed<32> returns ArrayLengthUnexpected.
+    byte_string const w = rlp::encode_list2(
+        rlp::encode_string2({}),
+        rlp::encode_string2(
+            byte_string_view{PRE_ROOT.bytes, 16}), // 16 bytes, not 32
+        rlp::encode_string2(byte_string_view{POST_ROOT.bytes, 32}),
+        byte_string{static_cast<unsigned char>(0xc0)},
+        byte_string{static_cast<unsigned char>(0xc0)},
+        byte_string{static_cast<unsigned char>(0xc0)},
+        byte_string{static_cast<unsigned char>(0xc0)});
+    auto const result = parse_execution_witness(w);
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(StorageLeafValue, DecodeZeroValue)
+{
+    // rlp(uint256(0)) = 0x80 (empty string), representing the zero storage
+    // value.
+    NodeIndex nodes{};
+    byte_string const zero_rlp{static_cast<unsigned char>(0x80)};
+    byte_string_view enc{zero_rlp.data(), zero_rlp.size()};
+    auto const result = StorageLeafValue::decode(enc, nodes);
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(result.value().value, bytes32_t{});
+}
+
+TEST(StorageLeafValue, DecodeEncodeRoundtrip)
+{
+    // Seed with a fixed value so the test is deterministic.
+    std::mt19937_64 rng{0xc0ffee'dead'beef'13ULL};
+    std::uniform_int_distribution<unsigned int> byte_dist{0, 255};
+
+    NodeIndex nodes{};
+
+    for (int i = 0; i < 10000; ++i) {
+        bytes32_t val{};
+        std::generate(std::begin(val.bytes), std::end(val.bytes), [&] {
+            return static_cast<uint8_t>(byte_dist(rng));
+        });
+        storage_leaf_roundtrip(val, nodes, "iteration " + std::to_string(i));
+    }
+}
+
+TEST(StorageLeafValue, DecodeEncodeRoundtrip_ExtremeValues)
+{
+    NodeIndex nodes{};
+
+    bytes32_t all_zeros{};
+    storage_leaf_roundtrip(all_zeros, nodes, "all zeros");
+
+    bytes32_t all_ffs{};
+    std::fill(
+        std::begin(all_ffs.bytes), std::end(all_ffs.bytes), uint8_t{0xff});
+    storage_leaf_roundtrip(all_ffs, nodes, "all 0xFF");
+}
+
+TEST(StorageLeafValue, DecodeTooLong)
+{
+    // rlp(33 bytes) is a string with a 33-byte payload — one byte over
+    // bytes32_t capacity.
+    byte_string const overlong =
+        rlp::encode_string2(byte_string(33, static_cast<unsigned char>(0xff)));
+    NodeIndex nodes{};
+    byte_string_view enc{overlong.data(), overlong.size()};
+    auto const result = StorageLeafValue::decode(enc, nodes);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
+}
+
+TEST(AccountLeafValue, DecodeEncodeRoundtrip_EmptyStorage)
+{
+    constexpr auto code_hash =
+        0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890_bytes32;
+    Account const acct{.balance = 99999, .code_hash = code_hash, .nonce = 7};
+    byte_string const encoded_acct = rlp::encode_account(acct, NULL_ROOT);
+
+    NodeIndex nodes{};
+    byte_string_view enc{encoded_acct};
+    auto const decoded = AccountLeafValue::decode(enc, nodes);
+    ASSERT_FALSE(decoded.has_error());
+
+    auto const &decoded_acct = decoded.value();
+    EXPECT_EQ(decoded_acct.account.nonce, acct.nonce);
+    EXPECT_EQ(decoded_acct.account.balance, acct.balance);
+    EXPECT_EQ(decoded_acct.account.code_hash, code_hash);
+
+    // NULL_ROOT storage is represented as nullptr (empty trie), not HashStub.
+    EXPECT_EQ(decoded_acct.storage, nullptr);
+
+    EXPECT_EQ(AccountLeafValue::encode(decoded_acct), encoded_acct);
+}
+
+TEST(PartialTrieDb, StateRoot_HashStubWhenRootAbsentFromNodeIndex)
+{
+    // When pre_state_root is not present in the node index the root remains a
+    // HashStub, and state_root() must return the original hash unchanged.
+    constexpr auto sentinel =
+        0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef_bytes32;
+
+    auto result = PartialTrieDb::from_reth_witness(sentinel, {}, {});
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(result.value().state_root(), sentinel);
+}
+
+TEST(PartialTrieDb, StateRoot_SingleLeafRoundtrip)
+{
+    // Build a single-account leaf node manually, then verify that
+    // state_root() re-encodes and re-hashes it to the same value.
+
+    // Dummy leaf path: two nibbles [0xA, 0xB] (even length, so compact prefix =
+    // 0x20).
+    mpt::Nibbles path{2};
+    path.set(0, 0xA);
+    path.set(1, 0xB);
+
+    unsigned char compact_buf[33];
+    auto const compact_sv = mpt::compact_encode(
+        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
+    // compact_sv == { 0x20, 0xAB }
+
+    AccountLeafValue const val{.account = {.nonce = 1}};
+    byte_string const encoded_val = AccountLeafValue::encode(val);
+
+    byte_string const leaf_rlp = rlp::encode_list2(
+        rlp::encode_string2(compact_sv),
+        rlp::encode_string2(
+            byte_string_view{encoded_val.data(), encoded_val.size()}));
+
+    auto result = try_decode_node(leaf_rlp);
+    ASSERT_FALSE(result.has_error());
+
+    bytes32_t const expected_root =
+        to_bytes(keccak256(byte_string_view{leaf_rlp.data(), leaf_rlp.size()}));
+    EXPECT_EQ(result.value().state_root(), expected_root);
+}
+
+TEST(PartialTrieDb, ShortHashReference)
+{
+    // A branch child that is a 20-byte string (too short for a hash
+    // reference, too long for an empty slot) must fail with InputTooShort.
+    byte_string const short_hash(20, static_cast<unsigned char>(0xAA));
+    byte_string const child_rlp = rlp::encode_string2(
+        byte_string_view{short_hash.data(), short_hash.size()});
+
+    byte_string const branch = make_branch_with_child(0, child_rlp);
+    auto result = try_decode_node(branch);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
+}
+
+TEST(PartialTrieDb, ShortHashReference_OneByte)
+{
+    // A single non-zero byte (self-encodes for [0x01..0x7f]) is a 1-byte
+    // string — too short for a hash reference.
+    byte_string const child_rlp{static_cast<unsigned char>(0x42)};
+
+    byte_string const branch = make_branch_with_child(0, child_rlp);
+    auto result = try_decode_node(branch);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
+}
+
+TEST(PartialTrieDb, LongHashReference)
+{
+    // A branch child that is a 33-byte string (one byte over the expected
+    // 32) must fail with InputTooLong.
+    byte_string const long_hash(33, static_cast<unsigned char>(0xBB));
+    byte_string const child_rlp = rlp::encode_string2(
+        byte_string_view{long_hash.data(), long_hash.size()});
+
+    byte_string const branch = make_branch_with_child(0, child_rlp);
+    auto result = try_decode_node(branch);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
+}
+
+TEST(PartialTrieDb, OversizedInlineNode)
+{
+    // An inline (embedded) node must have full RLP encoding < 32 bytes.
+    // Build a list whose payload is 31 bytes to trigger InputTooLong.
+    byte_string const payload(31, static_cast<unsigned char>(0x00));
+    byte_string const child_rlp = rlp::encode_list2(payload);
+
+    byte_string const branch = make_branch_with_child(0, child_rlp);
+    auto result = try_decode_node(branch);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
+}
+
+TEST(PartialTrieDb, EmptyInlineNode)
+{
+    // An empty list (0xc0) has zero-length payload.
+    // Decoding should fail with InputTooShort.
+    byte_string const child_rlp{static_cast<unsigned char>(0xc0)};
+
+    byte_string const branch = make_branch_with_child(0, child_rlp);
+    auto result = try_decode_node(branch);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
+}
+
+TEST(PartialTrieDb, NodeIndexEntryTrailingData)
+{
+    // When a hash resolves to a node in the index, the raw entry must be
+    // exactly one RLP list with no trailing bytes.  Append a spurious byte
+    // so that the "!node_enc.empty()" check fires InputTooLong.
+    mpt::Nibbles leaf_path{2};
+    leaf_path.set(0, 0xA);
+    leaf_path.set(1, 0xB);
+
+    unsigned char compact_buf[33];
+    auto const compact_sv = mpt::compact_encode(
+        compact_buf, mpt::NibblesView{leaf_path}, /*terminating=*/true);
+
+    AccountLeafValue const val{.account = {.nonce = 1}};
+    byte_string const encoded_val = AccountLeafValue::encode(val);
+
+    byte_string node_rlp = rlp::encode_list2(
+        rlp::encode_string2(compact_sv),
+        rlp::encode_string2(
+            byte_string_view{encoded_val.data(), encoded_val.size()}));
+    node_rlp.push_back(static_cast<unsigned char>(0xFF));
+
+    auto result = try_decode_node(node_rlp);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
+}
+
+TEST(PartialTrieDb, PathTooLong)
+{
+    // A leaf whose compact-encoded path decodes to 65 nibbles exceeds the
+    // 64-nibble MPT key limit and must fail with PathTooLong.
+    mpt::Nibbles path{65};
+    for (unsigned i = 0; i < 65; ++i) {
+        path.set(i, static_cast<unsigned char>(i % 16));
+    }
+
+    unsigned char compact_buf[34];
+    auto const compact_sv = mpt::compact_encode(
+        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
+
+    AccountLeafValue const val{.account = {.nonce = 1}};
+    byte_string const encoded_val = AccountLeafValue::encode(val);
+
+    byte_string const leaf_rlp = rlp::encode_list2(
+        rlp::encode_string2(compact_sv),
+        rlp::encode_string2(
+            byte_string_view{encoded_val.data(), encoded_val.size()}));
+
+    auto result = try_decode_node(leaf_rlp);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
+}
+
+TEST(PartialTrieDb, PathTooLongOver255CompactPath)
+{
+    byte_string compact_key(129, 0x00);
+    compact_key[0] = 0x20; // leaf node, even path length
+    AccountLeafValue const val{.account = {.nonce = 1}};
+    byte_string const encoded_val = AccountLeafValue::encode(val);
+    byte_string const leaf_rlp = rlp::encode_list2(
+        rlp::encode_string2(
+            byte_string_view{compact_key.data(), compact_key.size()}),
+        rlp::encode_string2(
+            byte_string_view{encoded_val.data(), encoded_val.size()}));
+    auto result = try_decode_node(leaf_rlp);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
+}

--- a/category/execution/ethereum/rlp/execution_witness.cpp
+++ b/category/execution/ethereum/rlp/execution_witness.cpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/rlp/decode.hpp>
+#include <category/execution/ethereum/rlp/execution_witness.hpp>
+
+#include <boost/outcome/try.hpp>
+
+#include <cstring>
+
+MONAD_NAMESPACE_BEGIN
+
+Result<ExecutionWitness> parse_execution_witness(byte_string_view witness_bytes)
+{
+    byte_string_view view{witness_bytes.data(), witness_bytes.size()};
+
+    // Strip the outer RLP list envelope.
+    BOOST_OUTCOME_TRY(auto outer, rlp::parse_list_metadata(view));
+
+    // No bytes may follow the outer list.
+    if (MONAD_UNLIKELY(!view.empty())) {
+        return rlp::DecodeError::InputTooLong;
+    }
+
+    ExecutionWitness w{};
+
+    BOOST_OUTCOME_TRY(w.block_rlp, rlp::parse_string_metadata(outer));
+
+    BOOST_OUTCOME_TRY(
+        auto const pre_root, rlp::decode_byte_string_fixed<32>(outer));
+    std::memcpy(w.pre_state_root.bytes, pre_root.data(), 32);
+
+    BOOST_OUTCOME_TRY(
+        auto const post_root, rlp::decode_byte_string_fixed<32>(outer));
+    std::memcpy(w.post_state_root.bytes, post_root.data(), 32);
+
+    BOOST_OUTCOME_TRY(w.encoded_nodes, rlp::parse_list_metadata(outer));
+
+    BOOST_OUTCOME_TRY(w.encoded_codes, rlp::parse_list_metadata(outer));
+
+    // preimages — advance past it, do not store.
+    BOOST_OUTCOME_TRY(auto const preimages, rlp::parse_list_metadata(outer));
+    (void)preimages;
+
+    BOOST_OUTCOME_TRY(w.encoded_headers, rlp::parse_list_metadata(outer));
+
+    if (MONAD_UNLIKELY(!outer.empty())) {
+        return rlp::DecodeError::InputTooLong;
+    }
+
+    return w;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/rlp/execution_witness.hpp
+++ b/category/execution/ethereum/rlp/execution_witness.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/result.hpp>
+
+#include <cstdint>
+#include <span>
+
+MONAD_NAMESPACE_BEGIN
+
+/// A shallowly-parsed Reth witness bundle.
+///
+/// Only the two fixed-size root hashes (fields [1] and [2]) are eagerly
+/// decoded. All other fields are represented as byte_string_view spans
+/// pointing into the original witness bytes; the caller must keep that
+/// buffer alive for as long as this struct is used.
+///
+/// Wire format (7-field RLP list):
+///   [0] block_rlp        RLP-encoded block
+///   [1] pre_state_root   bytes32
+///   [2] post_state_root  bytes32
+///   [3] [node...]        RLP list of MPT node preimages
+///   [4] [code...]        RLP list of contract bytecodes
+///   [5] [key...]         RLP list of address/slot preimages (not stored)
+///   [6] [header...]      RLP list of ancestor block headers
+struct ExecutionWitness
+{
+    byte_string_view block_rlp;
+    bytes32_t pre_state_root;
+    bytes32_t post_state_root;
+    byte_string_view encoded_nodes;
+    byte_string_view encoded_codes;
+    byte_string_view encoded_headers;
+};
+
+Result<ExecutionWitness>
+parse_execution_witness(byte_string_view witness_bytes);
+
+MONAD_NAMESPACE_END

--- a/category/mpt/merkle/compact_encode.hpp
+++ b/category/mpt/merkle/compact_encode.hpp
@@ -17,10 +17,14 @@
 
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
+#include <category/core/result.hpp>
+#include <category/core/rlp/decode_error.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/nibbles_view.hpp>
 
 #include <cassert>
+#include <limits>
+#include <utility>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
@@ -56,6 +60,58 @@ compact_encode_len(unsigned const si, unsigned const ei)
 
     return byte_string_view{
         res, nibbles.nibble_size() ? (nibbles.nibble_size() / 2 + 1) : 1u};
+}
+
+// Decode a compact-encoded path.
+// Returns {nibbles, is_leaf} on success, or an rlp::DecodeError if enc is
+// empty or otherwise invalid.
+[[nodiscard]] inline Result<std::pair<Nibbles, bool>>
+compact_decode(byte_string_view const enc)
+{
+    if (MONAD_UNLIKELY(enc.empty())) {
+        return rlp::DecodeError::InputTooShort;
+    }
+
+    // High two bits of the prefix byte must be zero (valid range 0x00–0x3F).
+    if (MONAD_UNLIKELY(enc[0] & 0xC0)) {
+        return rlp::DecodeError::TypeUnexpected;
+    }
+
+    bool const terminating = enc[0] & 0x20;
+    bool const odd = enc[0] & 0x10;
+
+    // For even-length paths the low nibble of the prefix is padding and must
+    // be zero.
+    if (MONAD_UNLIKELY(!odd && (enc[0] & 0x0F))) {
+        return rlp::DecodeError::TypeUnexpected;
+    }
+
+    size_t const nibble_count = (enc.size() - 1) * 2 + static_cast<size_t>(odd);
+
+    // A non-terminating (extension) node with an empty path is structurally
+    // invalid — compact_encode asserts against it, so reject here to keep
+    // decode/encode symmetric.
+    if (MONAD_UNLIKELY(nibble_count == 0 && !terminating)) {
+        return rlp::DecodeError::PathTooShort;
+    }
+
+    // Nibbles uses uint8_t for length; reject inputs that would overflow it.
+    if (MONAD_UNLIKELY(nibble_count > std::numeric_limits<uint8_t>::max())) {
+        return rlp::DecodeError::PathTooLong;
+    }
+
+    Nibbles result{nibble_count};
+
+    size_t nibble_i = 0;
+    if (odd) {
+        result.set(static_cast<unsigned>(nibble_i++), enc[0] & 0x0F);
+    }
+    for (size_t i = 1; i < enc.size(); ++i) {
+        result.set(static_cast<unsigned>(nibble_i++), enc[i] >> 4);
+        result.set(static_cast<unsigned>(nibble_i++), enc[i] & 0x0F);
+    }
+
+    return std::pair{std::move(result), terminating};
 }
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_trie_test(
   LINK_LIBRARIES
   PkgConfig::zstd
   PkgConfig::archive)
+add_trie_test(TARGET compact_encode_test SOURCES "compact_encode_test.cpp")
 add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")
 add_trie_test(TARGET update_aux_test SOURCES "update_aux_test.cpp")

--- a/category/mpt/test/compact_encode_test.cpp
+++ b/category/mpt/test/compact_encode_test.cpp
@@ -1,0 +1,198 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/rlp/decode_error.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace monad::mpt;
+using monad::rlp::DecodeError;
+
+namespace
+{
+    // Build a Nibbles from an initializer list of nibble values [0, 15].
+    Nibbles make_nibbles(std::initializer_list<unsigned char> values)
+    {
+        Nibbles n{values.size()};
+        unsigned i = 0;
+        for (auto const v : values) {
+            n.set(i++, v);
+        }
+        return n;
+    }
+
+    void check_roundtrip(NibblesView const path, bool const is_leaf)
+    {
+        // Buffer size: one prefix byte + one byte per two nibbles (rounded up).
+        std::vector<unsigned char> buf(path.nibble_size() / 2 + 1);
+        auto const encoded = compact_encode(buf.data(), path, is_leaf);
+
+        auto const decoded = compact_decode(encoded);
+        ASSERT_TRUE(decoded.has_value());
+
+        auto const &[nibbles, decoded_is_leaf] = decoded.value();
+        EXPECT_EQ(decoded_is_leaf, is_leaf);
+        EXPECT_EQ(NibblesView{nibbles}, path);
+    }
+} // namespace
+
+TEST(CompactDecode, EmptyInput)
+{
+    auto const result = compact_decode({});
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), DecodeError::InputTooShort);
+}
+
+TEST(CompactDecode, InvalidHighBits)
+{
+    // Prefix bytes with bits 7–6 set are not valid compact encodings.
+    unsigned char const b40[1] = {0x40};
+    unsigned char const b80[1] = {0x80};
+    unsigned char const bff[1] = {0xFF};
+    auto const r40 = compact_decode({b40, 1});
+    auto const r80 = compact_decode({b80, 1});
+    auto const rff = compact_decode({bff, 1});
+    ASSERT_TRUE(r40.has_error());
+    ASSERT_TRUE(r80.has_error());
+    ASSERT_TRUE(rff.has_error());
+    EXPECT_EQ(r40.error(), DecodeError::TypeUnexpected);
+    EXPECT_EQ(r80.error(), DecodeError::TypeUnexpected);
+    EXPECT_EQ(rff.error(), DecodeError::TypeUnexpected);
+}
+
+TEST(CompactDecode, InvalidEvenPaddingNibble)
+{
+    // Even-length prefix (bit 4 clear) requires the low nibble to be 0x0.
+    // 0x01 claims even extension but has a non-zero padding nibble.
+    unsigned char const b01[1] = {0x01};
+    unsigned char const b25[1] = {0x25};
+    auto const r01 = compact_decode({b01, 1});
+    // 0x25 claims even leaf but has a non-zero padding nibble.
+    auto const r25 = compact_decode({b25, 1});
+    ASSERT_TRUE(r01.has_error());
+    ASSERT_TRUE(r25.has_error());
+    EXPECT_EQ(r01.error(), DecodeError::TypeUnexpected);
+    EXPECT_EQ(r25.error(), DecodeError::TypeUnexpected);
+}
+
+TEST(CompactDecode, NonTerminatingEmptyPath)
+{
+    // Prefix 0x00 with no following bytes → even extension, 0 nibbles.
+    // This is structurally invalid (compact_encode asserts non-empty for
+    // extensions), so compact_decode must reject it.
+    unsigned char const b00[1] = {0x00};
+    auto const result = compact_decode({b00, 1});
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), DecodeError::PathTooShort);
+}
+
+TEST(CompactDecode, PathOver255Nibbles)
+{
+    // Nibbles uses uint8_t for length; 129 bytes after a 0x20 leaf prefix
+    // would decode to 256 nibbles, which compact_decode must reject.
+    std::vector<unsigned char> buf(129, 0x00);
+    buf[0] = 0x20; // even leaf
+    auto const result =
+        compact_decode({buf.data(), static_cast<unsigned>(buf.size())});
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), DecodeError::PathTooLong);
+}
+
+TEST(CompactRoundtrip, EvenLeaf)
+{
+    // Even-length path, terminating (prefix byte 0x20).
+    auto const path = make_nibbles({0xA, 0xB, 0xC, 0xD});
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/true);
+}
+
+TEST(CompactRoundtrip, OddLeaf)
+{
+    // Odd-length path, terminating (prefix byte 0x3X, first nibble inline).
+    auto const path = make_nibbles({0x1, 0x2, 0x3});
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/true);
+}
+
+TEST(CompactRoundtrip, EvenExtension)
+{
+    // Even-length path, non-terminating (prefix byte 0x00).
+    auto const path = make_nibbles({0xE, 0xF, 0x0, 0x1});
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/false);
+}
+
+TEST(CompactRoundtrip, OddExtension)
+{
+    // Odd-length path, non-terminating (prefix byte 0x1X).
+    auto const path = make_nibbles({0x7, 0x8, 0x9});
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/false);
+}
+
+TEST(CompactRoundtrip, EmptyPath)
+{
+    // An empty extension path is structurally invalid (compact_encode asserts
+    // it), so only the leaf case is tested here.
+    Nibbles const empty{0};
+    check_roundtrip(NibblesView{empty}, /*is_leaf=*/true);
+}
+
+TEST(CompactRoundtrip, SingleNibble)
+{
+    auto const path = make_nibbles({0xF});
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/true);
+    check_roundtrip(NibblesView{path}, /*is_leaf=*/false);
+}
+
+TEST(CompactRoundtrip, LongPath)
+{
+    // compact_encode/compact_decode have no length limit; test well beyond the
+    // Ethereum-specific 64-nibble (33-byte) case.
+    for (unsigned const len : {64u, 128u, 255u}) {
+        Nibbles path{len};
+        for (unsigned i = 0; i < len; ++i) {
+            path.set(i, static_cast<unsigned char>(i & 0xF));
+        }
+        check_roundtrip(NibblesView{path}, /*is_leaf=*/true);
+        check_roundtrip(NibblesView{path}, /*is_leaf=*/false);
+    }
+}
+
+TEST(CompactRoundtrip, Random)
+{
+    std::mt19937_64 rng{0xc0ffee'dead'beef'13ULL};
+    std::uniform_int_distribution<unsigned int> nibble_dist{0, 15};
+    std::uniform_int_distribution<unsigned int> len_dist{0, 255};
+
+    for (int i = 0; i < 500; ++i) {
+        unsigned const len = len_dist(rng);
+        bool const is_leaf =
+            (len == 0) || (rng() & 1); // empty path must be leaf
+
+        Nibbles path{len};
+        for (unsigned j = 0; j < len; ++j) {
+            path.set(j, static_cast<unsigned char>(nibble_dist(rng)));
+        }
+
+        SCOPED_TRACE(
+            "iteration " + std::to_string(i) + ", len=" + std::to_string(len) +
+            ", is_leaf=" + std::to_string(is_leaf));
+        check_roundtrip(NibblesView{path}, is_leaf);
+    }
+}


### PR DESCRIPTION
~~Depends on https://github.com/category-labs/monad/pull/2222~~
~~Depends on #2240~~

This adds a new simple implementation of a "partial" MPT, i.e. some child nodes only contain a keccak hash of the node instead of the actual subtree. This Db back-end will be used by the zkVM guest program compiled to RISCV.
This PR introduces the core data-structure as well as the decoder from reth's RLP encoded execution witness. The witness is encoded as an RLP list and has the following form:

| Index | Field | Type | Description |
|-------|-------|------|-------------|
| 0 | `block_rlp` | `string` | RLP-encoded block |
| 1 | `pre_state_root` | `bytes32` | State root before execution (for debugging only, will likely be removed) |
| 2 | `post_state_root` | `bytes32` | State root after execution |
| 3 | `[node...]` | `list<string>` | Flat, unordered trie node preimages; `keccak256(node_i) == key` |
| 4 | `[code...]` | `list<string>` | Contract bytecodes; `keccak256(code_i) == code_hash` |
| 5 | `[key...]` | `list<string>` | 20-byte addresses or 32-byte slots (un-hashed preimages) |
| 6 | `[header...]` | `list<string>` | RLP-encoded ancestor headers |

All the overridden virtual methods (besides `state_root`) currently return dummy values and will be properly implemented in followup PR(s)