### PR TITLE
Pool: support multiple DBs

### DIFF
--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -150,7 +150,6 @@ namespace detail
 AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
     : owning_tid_(get_tl_tid())
     , storage_pool_{std::addressof(pool)}
-    , cnv_chunk_{pool.chunk(storage_pool::cnv, 0)}
     , uring_(rwbuf.ring())
     , wr_uring_(rwbuf.wr_ring())
     , rwbuf_(rwbuf)
@@ -177,9 +176,7 @@ AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
 
     auto const count = pool.chunks(storage_pool::seq);
     std::vector<int> fds;
-    fds.reserve(count * 2 + 2);
-    fds.push_back(cnv_chunk_.io_uring_read_fd);
-    fds.push_back(cnv_chunk_.io_uring_write_fd);
+    fds.reserve(count * 2);
     for (size_t n = 0; n < count; n++) {
         seq_chunks_.emplace_back(
             pool.chunk(storage_pool::seq, static_cast<uint32_t>(n)));
@@ -246,7 +243,6 @@ AsyncIO::AsyncIO(class storage_pool &pool, monad::io::Buffers &rwbuf)
         MONAD_ASSERT(it != fd_to_iouring_map.end());
         p.io_uring_write_fd = it->second;
     };
-    replace_fds_with_iouring_fds(cnv_chunk_);
     for (auto &chnk : seq_chunks_) {
         replace_fds_with_iouring_fds(chnk);
     }

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -77,7 +77,6 @@ private:
 
     pid_t const owning_tid_;
     class storage_pool *storage_pool_{nullptr};
-    chunk_ref_ cnv_chunk_;
     std::vector<chunk_ref_> seq_chunks_;
 
     monad::io::Ring &uring_, *wr_uring_{nullptr};
@@ -646,7 +645,7 @@ private:
 using erased_connected_operation_ptr =
     AsyncIO::erased_connected_operation_unique_ptr_type;
 
-static_assert(sizeof(AsyncIO) == 272);
+static_assert(sizeof(AsyncIO) == 256);
 static_assert(alignof(AsyncIO) == 8);
 
 namespace detail

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -404,9 +405,18 @@ storage_pool::device_t storage_pool::make_device_(
             bytesread != -1, "pread failed due to %s", std::strerror(errno));
         auto *const metadata_footer = start_lifetime_as<device_t::metadata_t>(
             buffer + bytesread - sizeof(device_t::metadata_t));
-        if (memcmp(metadata_footer->magic, "MND0", 4) != 0 ||
+        if (memcmp(metadata_footer->magic, "MND1", 4) != 0 ||
             op == mode::truncate) {
-            // Uninitialised
+            if (op == mode::create_if_needed &&
+                memcmp(metadata_footer->magic, "MND", 3) == 0) {
+                MONAD_ABORT_PRINTF(
+                    "Storage pool source %s has incompatible format "
+                    "(found %.4s, expected MND1). Use monad-mpt --create "
+                    "to reinitialize.",
+                    path.string().c_str(),
+                    metadata_footer->magic);
+            }
+            // Uninitialised — chunk_owner array is zero-filled by truncate.
             if (op == mode::open_existing) {
                 MONAD_ABORT_PRINTF(
                     "Storage pool source %s has not been initialised "
@@ -450,8 +460,9 @@ storage_pool::device_t storage_pool::make_device_(
                 chunk_capacity <= std::numeric_limits<uint32_t>::max());
             for (off_t offset2 = static_cast<off_t>(
                      offset - round_up_align<DISK_PAGE_BITS>(
-                                  (monad::async::file_offset_t(stat.st_size) /
-                                   chunk_capacity * sizeof(uint32_t))));
+                                  monad::async::file_offset_t(stat.st_size) /
+                                  chunk_capacity *
+                                  device_t::metadata_t::PER_CHUNK_META_BYTES));
                  offset2 < static_cast<off_t>(offset);
                  offset2 += DISK_PAGE_SIZE) {
                 MONAD_ASSERT_PRINTF(
@@ -459,10 +470,14 @@ storage_pool::device_t storage_pool::make_device_(
                     "failed due to %s",
                     std::strerror(errno));
             }
-            memcpy(metadata_footer->magic, "MND0", 4);
+            memcpy(metadata_footer->magic, "MND1", 4);
             metadata_footer->chunk_capacity =
                 static_cast<uint32_t>(chunk_capacity);
             metadata_footer->num_cnv_chunks = flags.num_cnv_chunks;
+            metadata_footer->num_dbs = 0;
+            memset(metadata_footer->dbs, 0, sizeof(metadata_footer->dbs));
+            memset(
+                metadata_footer->spare3_, 0, sizeof(metadata_footer->spare3_));
             MONAD_ASSERT_PRINTF(
                 ::pwrite(
                     readwritefd,
@@ -504,7 +519,7 @@ storage_pool::device_t storage_pool::make_device_(
     auto *const metadata = start_lifetime_as<device_t::metadata_t>(
         reinterpret_cast<std::byte *>(addr) + stat.st_size - offset -
         sizeof(device_t::metadata_t));
-    MONAD_ASSERT(0 == memcmp(metadata->magic, "MND0", 4));
+    MONAD_ASSERT(0 == memcmp(metadata->magic, "MND1", 4));
     if (auto const **const dev = std::get_if<1>(&dev_no_or_dev)) {
         unique_hash = (*dev)->unique_hash_;
     }
@@ -650,6 +665,18 @@ void storage_pool::fill_chunks_(creation_flags const &flags)
                     zone_id(seq)));
             }
         }
+    }
+    // Build device-local → global seq ID lookup
+    local_to_global_seq_.resize(devices_.size());
+    for (size_t di = 0; di < devices_.size(); ++di) {
+        auto const dev_total = devices_[di].metadata_->chunks(
+            static_cast<file_offset_t>(devices_[di].size_of_file_));
+        local_to_global_seq_[di].resize(dev_total, ALLOC_FAILED);
+    }
+    for (uint32_t g = 0; g < chunks_[seq].size(); ++g) {
+        auto const &c = chunks_[seq][g];
+        auto const di = static_cast<size_t>(&c.device() - devices_.data());
+        local_to_global_seq_[di][c.chunkid_within_device_] = g;
     }
 }
 
@@ -880,6 +907,204 @@ storage_pool::chunk_t storage_pool::activate_chunk(
 storage_pool storage_pool::clone_as_read_only() const
 {
     return storage_pool(this, clone_as_read_only_tag_{});
+}
+
+storage_pool::db_slot const *
+storage_pool::find_db_slot(uint8_t const db_id) const noexcept
+{
+    auto const *m = devices_[0].metadata_;
+    for (uint16_t i = 0; i < m->num_dbs; ++i) {
+        if (m->dbs[i].db_id == db_id) {
+            return &m->dbs[i];
+        }
+    }
+    return nullptr;
+}
+
+void storage_pool::register_db_slot(db_slot const &slot)
+{
+    MONAD_ASSERT(!is_read_only_);
+    MONAD_ASSERT_PRINTF(slot.db_id != 0, "db_id 0 is reserved (unused slot)");
+
+    auto const total_cnv = chunks(cnv);
+    MONAD_ASSERT_PRINTF(
+        slot.metadata_cnv < total_cnv,
+        "metadata_cnv %u out of range (pool has %zu CNV chunks)",
+        slot.metadata_cnv,
+        total_cnv);
+    MONAD_ASSERT_PRINTF(
+        slot.root_offset_cnv_end() <= total_cnv,
+        "root_offset range [%u, %u) out of range (pool has %zu CNV chunks)",
+        slot.root_offset_cnv_start,
+        slot.root_offset_cnv_end(),
+        total_cnv);
+    MONAD_ASSERT_PRINTF(
+        !slot.cnv_range_contains(slot.metadata_cnv),
+        "metadata_cnv %u overlaps root_offset range [%u, %u)",
+        slot.metadata_cnv,
+        slot.root_offset_cnv_start,
+        slot.root_offset_cnv_end());
+    MONAD_ASSERT_PRINTF(
+        slot.root_offset_cnv_count > 0 &&
+            (slot.root_offset_cnv_count & (slot.root_offset_cnv_count - 1)) ==
+                0,
+        "root_offset_cnv_count %u must be a non-zero power of 2",
+        slot.root_offset_cnv_count);
+
+    for (auto &device : devices_) {
+        auto *m = device.metadata_;
+        MONAD_ASSERT_PRINTF(
+            m->num_dbs < device_t::metadata_t::MAX_DBS,
+            "DB catalog full (%u/%zu)",
+            m->num_dbs,
+            device_t::metadata_t::MAX_DBS);
+        for (uint16_t i = 0; i < m->num_dbs; ++i) {
+            MONAD_ASSERT_PRINTF(
+                m->dbs[i].db_id != slot.db_id,
+                "Duplicate db_id %u in pool catalog",
+                slot.db_id);
+            MONAD_ASSERT_PRINTF(
+                !slot.cnv_conflicts_with(m->dbs[i]),
+                "db_id %u CNV range overlaps with existing db_id %u",
+                slot.db_id,
+                m->dbs[i].db_id);
+        }
+        m->dbs[m->num_dbs++] = slot;
+    }
+}
+
+// Linear scan over chunk_states (~14KB for 7000 chunks, fits in L1).
+// Only called on chunk rollover (once per ~256MB of writes).
+uint32_t storage_pool::allocate_seq_chunk(uint8_t const db_id) noexcept
+{
+    MONAD_ASSERT(db_id != 0);
+    auto const desired =
+        std::bit_cast<uint16_t>(chunk_state{db_id, CHUNK_RESERVED});
+    for (size_t di = 0; di < devices_.size(); ++di) {
+        auto *m = devices_[di].metadata_;
+        auto const sz = static_cast<file_offset_t>(devices_[di].size_of_file_);
+        auto states = m->chunk_states(sz);
+        auto const cnv = m->num_cnv_chunks;
+        for (uint32_t i = cnv; i < states.size(); ++i) {
+            auto expected = std::bit_cast<uint16_t>(chunk_state{0, CHUNK_FREE});
+            if (states[i].compare_exchange_strong(
+                    expected, desired, std::memory_order_acq_rel)) {
+                return local_to_global_seq_[di][i];
+            }
+        }
+    }
+    return ALLOC_FAILED;
+}
+
+std::atomic<uint16_t> &
+storage_pool::chunk_state_at_(uint32_t const global_seq_id) noexcept
+{
+    auto &c = chunks_[seq][global_seq_id];
+    auto *m = c.device().metadata_;
+    auto const sz = static_cast<file_offset_t>(c.device().size_of_file_);
+    return m->chunk_states(sz)[c.chunkid_within_device_];
+}
+
+void storage_pool::commit_seq_chunk(uint32_t const global_seq_id) noexcept
+{
+    auto &slot = chunk_state_at_(global_seq_id);
+    auto const cur =
+        std::bit_cast<chunk_state>(slot.load(std::memory_order_relaxed));
+    MONAD_ASSERT(cur.status == CHUNK_RESERVED);
+    slot.store(
+        std::bit_cast<uint16_t>(chunk_state{cur.db_id, CHUNK_OWNED}),
+        std::memory_order_release);
+}
+
+void storage_pool::begin_free_seq_chunk(uint32_t const global_seq_id) noexcept
+{
+    auto &slot = chunk_state_at_(global_seq_id);
+    auto const cur =
+        std::bit_cast<chunk_state>(slot.load(std::memory_order_relaxed));
+    MONAD_ASSERT(cur.status == CHUNK_OWNED);
+    slot.store(
+        std::bit_cast<uint16_t>(chunk_state{cur.db_id, CHUNK_RESERVED}),
+        std::memory_order_release);
+}
+
+void storage_pool::free_seq_chunk(uint32_t const global_seq_id) noexcept
+{
+    auto &c = chunks_[seq][global_seq_id];
+    auto *m = c.device().metadata_;
+    auto const sz = static_cast<file_offset_t>(c.device().size_of_file_);
+    MONAD_ASSERT(
+        m->chunk_bytes_used(sz)[c.chunkid_within_device_].load(
+            std::memory_order_relaxed) == 0,
+        "chunk must be destroyed before returning to pool");
+    auto &slot = chunk_state_at_(global_seq_id);
+    MONAD_ASSERT(
+        std::bit_cast<chunk_state>(slot.load(std::memory_order_relaxed))
+            .status == CHUNK_RESERVED);
+    slot.store(
+        std::bit_cast<uint16_t>(chunk_state{0, CHUNK_FREE}),
+        std::memory_order_release);
+}
+
+size_t storage_pool::free_seq_chunk_count() const noexcept
+{
+    size_t count = 0;
+    for (auto const &device : devices_) {
+        auto const *m = device.metadata_;
+        auto const sz = static_cast<file_offset_t>(device.size_of_file_);
+        auto states = m->chunk_states(sz);
+        auto const cnv = m->num_cnv_chunks;
+        for (uint32_t i = cnv; i < states.size(); ++i) {
+            if (std::bit_cast<chunk_state>(
+                    states[i].load(std::memory_order_relaxed))
+                    .status == CHUNK_FREE) {
+                ++count;
+            }
+        }
+    }
+    return count;
+}
+
+// Each DB should have at most one RESERVED chunk at any time.
+uint32_t storage_pool::find_reserved_chunk(uint8_t const db_id) const noexcept
+{
+    for (size_t di = 0; di < devices_.size(); ++di) {
+        auto const *m = devices_[di].metadata_;
+        auto const sz = static_cast<file_offset_t>(devices_[di].size_of_file_);
+        auto states = m->chunk_states(sz);
+        auto const cnv = m->num_cnv_chunks;
+        for (uint32_t i = cnv; i < states.size(); ++i) {
+            auto const s = std::bit_cast<chunk_state>(
+                states[i].load(std::memory_order_relaxed));
+            if (s.status == CHUNK_RESERVED && s.db_id == db_id) {
+                return local_to_global_seq_[di][i];
+            }
+        }
+    }
+    return ALLOC_FAILED;
+}
+
+void storage_pool::reclaim_all_chunks_for_db(uint8_t const db_id) noexcept
+{
+    for (size_t di = 0; di < devices_.size(); ++di) {
+        auto *m = devices_[di].metadata_;
+        auto const sz = static_cast<file_offset_t>(devices_[di].size_of_file_);
+        auto states = m->chunk_states(sz);
+        auto const cnv = m->num_cnv_chunks;
+        for (uint32_t i = cnv; i < states.size(); ++i) {
+            if (std::bit_cast<chunk_state>(
+                    states[i].load(std::memory_order_relaxed))
+                    .db_id != db_id) {
+                continue;
+            }
+            auto const global = local_to_global_seq_[di][i];
+            // Bypass the normal state machine — DB metadata is invalid
+            // so there's no list to update. Just destroy and free.
+            chunks_[seq][global].destroy_contents();
+            states[i].store(
+                std::bit_cast<uint16_t>(chunk_state{0, CHUNK_FREE}),
+                std::memory_order_release);
+        }
+    }
 }
 
 MONAD_ASYNC_NAMESPACE_END

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -20,7 +20,9 @@
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <mutex>
 #include <span>
 #include <variant>
@@ -75,6 +77,58 @@ public:
         seq = 1
     };
 
+    static constexpr uint32_t ALLOC_FAILED =
+        std::numeric_limits<uint32_t>::max();
+
+    static constexpr uint8_t CHUNK_FREE = 0;
+    static constexpr uint8_t CHUNK_RESERVED = 1;
+    static constexpr uint8_t CHUNK_OWNED = 2;
+
+    struct chunk_state
+    {
+        uint8_t db_id;
+        uint8_t status;
+    };
+
+    static_assert(sizeof(chunk_state) == sizeof(uint16_t));
+
+    //! \brief A DB slot in the pool catalog, mapping a db_id to its CNV
+    //! chunk assignment.
+    struct db_slot
+    {
+        uint8_t db_id; // 0 = unused slot
+        uint8_t db_id_pad_{};
+        uint16_t metadata_cnv;
+        uint16_t root_offset_cnv_start; // first root offset CNV ID
+        uint16_t root_offset_cnv_count;
+
+        uint32_t root_offset_cnv_end() const noexcept
+        {
+            return uint32_t(root_offset_cnv_start) + root_offset_cnv_count;
+        }
+
+        bool cnv_range_contains(uint16_t id) const noexcept
+        {
+            return id >= root_offset_cnv_start && id < root_offset_cnv_end();
+        }
+
+        bool cnv_overlaps(db_slot const &other) const noexcept
+        {
+            return root_offset_cnv_start < other.root_offset_cnv_end() &&
+                   root_offset_cnv_end() > other.root_offset_cnv_start;
+        }
+
+        bool cnv_conflicts_with(db_slot const &other) const noexcept
+        {
+            return cnv_overlaps(other) ||
+                   cnv_range_contains(other.metadata_cnv) ||
+                   other.cnv_range_contains(metadata_cnv) ||
+                   metadata_cnv == other.metadata_cnv;
+        }
+    };
+
+    static_assert(sizeof(db_slot) == 8);
+
     /*! \brief A source of backing storage for the storage pool.
      */
     class device_t
@@ -93,32 +147,39 @@ public:
 
         struct metadata_t
         {
-            // Preceding this is an array of uint32_t of chunk bytes used
+            // Preceding this on disk (growing downward from metadata_t):
+            //   chunk_bytes_used[N]:  uint32_t per seq chunk
+            //   chunk_states[N]:      chunk_state (2 bytes) per seq chunk
 
-            uint32_t spare_[12]; // set aside for flags later
+            static constexpr size_t MAX_DBS = 4;
+
+            uint16_t num_dbs; // populated db_slot count
+            uint16_t spare_pad_; // reserved
+            storage_pool::db_slot dbs[MAX_DBS]; // 4 * 8 = 32 bytes
+            uint32_t spare3_[3];
             uint32_t num_cnv_chunks; // number of cnv chunks per device
             uint32_t config_hash; // hash of this configuration
             uint32_t chunk_capacity;
-            uint8_t magic[4]; // "MND0" for v1 of this metadata
+            uint8_t magic[4]; // "MND1"
+
+            static constexpr size_t PER_CHUNK_META_BYTES =
+                sizeof(uint32_t) + sizeof(storage_pool::chunk_state);
 
             size_t chunks(file_offset_t end_of_this_offset) const noexcept
             {
                 end_of_this_offset -= sizeof(metadata_t);
-                auto const ret =
-                    end_of_this_offset / (chunk_capacity + sizeof(uint32_t));
-                // We need the front CPU_PAGE_SIZE of this metadata to not
-                // include any chunk
+                auto const ret = end_of_this_offset /
+                                 (chunk_capacity + PER_CHUNK_META_BYTES);
                 auto const endofchunks =
                     round_down_align<CPU_PAGE_BITS>(ret * chunk_capacity);
                 auto const startofmetadata = round_down_align<CPU_PAGE_BITS>(
-                    end_of_this_offset - ret * sizeof(uint32_t));
+                    end_of_this_offset - ret * PER_CHUNK_META_BYTES);
                 if (startofmetadata == endofchunks) {
                     return ret - 1;
                 }
                 return ret;
             }
 
-            // Only used for seq chunks
             std::span<std::atomic<uint32_t>>
             chunk_bytes_used(file_offset_t end_of_this_offset) const noexcept
             {
@@ -134,11 +195,27 @@ public:
                     count};
             }
 
-            // Bytes used by the pool metadata on this device
+            std::span<std::atomic<uint16_t>>
+            chunk_states(file_offset_t end_of_this_offset) const noexcept
+            {
+                static_assert(
+                    sizeof(uint16_t) == sizeof(std::atomic<uint16_t>));
+                static_assert(
+                    sizeof(storage_pool::chunk_state) == sizeof(uint16_t));
+                auto const count = chunks(end_of_this_offset);
+                return {
+                    start_lifetime_as_array<std::atomic<uint16_t>>(
+                        const_cast<std::byte *>(
+                            reinterpret_cast<std::byte const *>(this)) -
+                            count * sizeof(uint32_t) - count * sizeof(uint16_t),
+                        count),
+                    count};
+            }
+
             size_t total_size(file_offset_t end_of_this_offset) const noexcept
             {
                 auto const count = chunks(end_of_this_offset);
-                return sizeof(metadata_t) + count * sizeof(uint32_t);
+                return sizeof(metadata_t) + count * PER_CHUNK_META_BYTES;
             }
         } *const metadata_;
 
@@ -347,6 +424,11 @@ private:
     mutable std::mutex lock_;
 
     std::vector<chunk_t> chunks_[2];
+    // Per-device mapping: device-local chunk ID → global seq ID.
+    // Only needed for interleaved multi-device pools where device-local
+    // IDs don't map to global IDs with simple arithmetic.
+    // Built once in fill_chunks_().
+    std::vector<std::vector<uint32_t>> local_to_global_seq_;
 
     device_t make_device_(
         mode op, device_t::type_t_ type, std::filesystem::path const &path,
@@ -414,10 +496,43 @@ public:
     //! \brief Get an existing chunk, if it is activated
     chunk_t &chunk(chunk_type which, uint32_t id);
 
+    //! \brief Look up a DB slot by db_id. Returns nullptr if not found.
+    db_slot const *find_db_slot(uint8_t db_id) const noexcept;
+
+    //! \brief Register a DB slot in pool metadata. Asserts on duplicate db_id
+    //! or full catalog. Only valid on writable pools.
+    void register_db_slot(db_slot const &slot);
+
+    // FREE → RESERVED(db_id). Returns global chunk index or ALLOC_FAILED.
+    uint32_t allocate_seq_chunk(uint8_t db_id) noexcept;
+
+    // RESERVED(db_id) → OWNED(db_id). Call after appending to DB list.
+    void commit_seq_chunk(uint32_t chunk_id) noexcept;
+
+    // OWNED → RESERVED. Call before removing from DB list.
+    void begin_free_seq_chunk(uint32_t chunk_id) noexcept;
+
+    // RESERVED → FREE. Chunk must be destroyed first.
+    void free_seq_chunk(uint32_t chunk_id) noexcept;
+
+    // Number of FREE seq chunks (relaxed reads, diagnostic only).
+    size_t free_seq_chunk_count() const noexcept;
+
+    // Find the RESERVED chunk for db_id (at most one per DB).
+    // Returns global seq chunk ID, or ALLOC_FAILED if none.
+    uint32_t find_reserved_chunk(uint8_t db_id) const noexcept;
+
+    // Reclaim all chunks (RESERVED or OWNED) belonging to db_id.
+    // Destroys contents and returns each to FREE. Use only when
+    // DB metadata is invalid and a fresh init is about to run.
+    void reclaim_all_chunks_for_db(uint8_t db_id) noexcept;
+
     //! \brief Clones an existing storage pool as read-only
     storage_pool clone_as_read_only() const;
 
 private:
+    std::atomic<uint16_t> &chunk_state_at_(uint32_t global_seq_id) noexcept;
+
     //! \brief Activate a chunk (i.e. open file descriptors to it, if necessary)
     chunk_t activate_chunk(
         chunk_type which, device_t &device, uint32_t id_within_device,

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -36,6 +36,7 @@
 #include <CLI/CLI.hpp>
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cctype>
 #include <cerrno>
@@ -394,6 +395,15 @@ struct impl_t
     MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
     uint8_t chunk_capacity = flags.chunk_capacity;
     uint32_t root_offsets_chunk_count = 16;
+    uint32_t num_dbs = 1;
+
+    struct per_db_config
+    {
+        uint32_t root_offsets_chunk_count{16};
+        std::optional<uint32_t> max_seq_chunks;
+    };
+
+    std::array<per_db_config, 4> db_configs;
     bool allow_dirty = false;
     bool no_prompt = false;
     bool create_database = false;
@@ -402,6 +412,7 @@ struct impl_t
     std::optional<uint64_t> rewind_database_to;
     std::optional<uint64_t> reset_history_length;
     bool create_chunk_increasing = false;
+    std::optional<uint32_t> set_max_seq_chunks;
     bool debug_printing = false;
     std::filesystem::path archive_database;
     std::filesystem::path restore_database;
@@ -730,7 +741,7 @@ public:
                     MONAD_ASYNC_NAMESPACE::AsyncIO::
                         MONAD_IO_BUFFERS_WRITE_SIZE);
             auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{*pool, rwbuf};
-            MONAD_MPT_NAMESPACE::UpdateAux aux(io);
+            MONAD_MPT_NAMESPACE::UpdateAux aux(io, 1);
             for (;;) {
                 auto const *item = aux.db_metadata()->fast_list_begin();
                 if (item == nullptr) {
@@ -751,15 +762,14 @@ public:
                 aux.remove(chunkid);
                 chunks.push_back(chunkid);
             }
+            // Drain remaining free chunks from pool
             for (;;) {
-                auto const *item = aux.db_metadata()->free_list_begin();
-                if (item == nullptr) {
+                auto const id = pool->allocate_seq_chunk(1);
+                if (id == MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED) {
                     break;
                 }
-                auto const chunkid = item->index(aux.db_metadata());
-                MONAD_ASSERT(chunkid != UINT32_MAX);
-                aux.remove(chunkid);
-                chunks.push_back(chunkid);
+                pool->commit_seq_chunk(id);
+                chunks.push_back(id);
             }
         }
 
@@ -834,6 +844,9 @@ public:
                               "version.";
                         throw std::runtime_error(ss.str());
                     }
+                    // TODO(phase0): archive restore still hardcodes CNV chunk 0
+                    // for metadata. Thread db_id through here when
+                    // archive/export support for non-legacy DBs is added.
                     auto &cnv_chunk =
                         pool->chunk(monad::async::storage_pool::cnv, 0);
                     auto [wfd, offset] = cnv_chunk.write_fd(0);
@@ -975,7 +988,7 @@ public:
             2,
             MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
         auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{*pool, rwbuf};
-        MONAD_MPT_NAMESPACE::UpdateAux aux(io);
+        MONAD_MPT_NAMESPACE::UpdateAux aux(io, 1);
         size_t slow_chunks_inserted = 0;
         size_t fast_chunks_inserted = 0;
         auto override_insertion_count =
@@ -1069,7 +1082,10 @@ public:
 
         for (unsigned int const &chunk : chunks) {
             if (chunk != UINT32_MAX) {
-                aux.append(monad::mpt::UpdateAuxImpl::chunk_list::free, chunk);
+                pool->begin_free_seq_chunk(chunk);
+                pool->chunk(MONAD_ASYNC_NAMESPACE::storage_pool::seq, chunk)
+                    .destroy_contents();
+                pool->free_seq_chunk(chunk);
             }
         }
 
@@ -1466,6 +1482,45 @@ opened.
                     }
                     return "";
                 });
+            cli.add_option(
+                   "--num-dbs",
+                   impl.num_dbs,
+                   "Number of DBs to register in the pool catalog at creation "
+                   "(default 1, max 4).")
+                ->check([](std::string const &s) -> std::string {
+                    auto const v = std::stoul(s);
+                    if (v < 1 || v > 4) {
+                        return "Must be between 1 and 4";
+                    }
+                    return "";
+                });
+            for (unsigned i = 0; i < 4; ++i) {
+                auto const n = std::to_string(i + 1);
+                cli.add_option(
+                       "--root-offsets-chunk-count-db" + n,
+                       impl.db_configs[i].root_offsets_chunk_count,
+                       "Root offset chunk count for DB" + n +
+                           " (default 16, power of 2).")
+                    ->check([](std::string const &s) {
+                        auto const v = std::stoll(s);
+                        if (v <= 0) {
+                            return "Value must be positive";
+                        }
+                        if ((v & (v - 1)) != 0) {
+                            return "Value must be a power of 2";
+                        }
+                        return "";
+                    });
+                cli.add_option(
+                    "--max-seq-chunks-db" + n,
+                    impl.db_configs[i].max_seq_chunks,
+                    "Max seq chunks DB" + n + " may own (0 = unlimited).");
+            }
+            cli.add_option(
+                "--set-max-seq-chunks",
+                impl.set_max_seq_chunks,
+                "Set the max seq chunk limit for DB1 on an existing pool "
+                "(0 = unlimited). Takes effect immediately.");
             cli.add_flag(
                 "--chunk-increasing",
                 impl.create_chunk_increasing,
@@ -1499,9 +1554,15 @@ opened.
             impl.flags.open_read_only = true;
             impl.flags.open_read_only_allow_dirty =
                 impl.allow_dirty || !impl.archive_database.empty();
-            impl.flags.num_cnv_chunks =
-                impl.root_offsets_chunk_count +
-                monad::mpt::UpdateAuxImpl::cnv_chunks_for_db_metadata;
+            // Compute total CNV chunks needed for all DBs
+            {
+                uint32_t total_cnv = 0;
+                for (uint32_t i = 0; i < impl.num_dbs; ++i) {
+                    total_cnv +=
+                        1 + impl.db_configs[i].root_offsets_chunk_count;
+                }
+                impl.flags.num_cnv_chunks = total_cnv;
+            }
             if (!impl.restore_database.empty()) {
                 if (!impl.archive_database.empty()) {
                     impl.cli_ask_question(
@@ -1542,7 +1603,15 @@ opened.
                 ss << ". Are you sure?\n";
                 impl.cli_ask_question(ss.str().c_str());
             }
-            else if (impl.rewind_database_to || impl.reset_history_length) {
+            else if (
+                impl.rewind_database_to || impl.reset_history_length ||
+                impl.set_max_seq_chunks.has_value() ||
+                std::any_of(
+                    impl.db_configs.begin(),
+                    impl.db_configs.begin() + impl.num_dbs,
+                    [](auto const &c) {
+                        return c.max_seq_chunks.has_value();
+                    })) {
                 impl.flags.open_read_only = false;
                 impl.flags.open_read_only_allow_dirty = false;
             }
@@ -1553,6 +1622,62 @@ opened.
                 mode = MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
             }
             impl.pool.emplace(std::span{impl.storage_paths}, mode, impl.flags);
+            // Register any missing DB slots (writable only)
+            if (!impl.pool->is_read_only()) {
+                uint16_t cnv_cursor = 0;
+                for (uint32_t i = 0; i < impl.num_dbs; ++i) {
+                    auto const db_id = static_cast<uint8_t>(i + 1);
+                    auto const *existing = impl.pool->find_db_slot(db_id);
+                    if (existing != nullptr) {
+                        // Advance cursor past this DB's existing allocation
+                        auto const end = existing->root_offset_cnv_start +
+                                         existing->root_offset_cnv_count;
+                        if (end > cnv_cursor) {
+                            cnv_cursor = static_cast<uint16_t>(end);
+                        }
+                    }
+                    else {
+                        auto const ro_count = static_cast<uint16_t>(
+                            impl.num_dbs == 1
+                                ? impl.root_offsets_chunk_count
+                                : impl.db_configs[i].root_offsets_chunk_count);
+                        impl.pool->register_db_slot(
+                            MONAD_ASYNC_NAMESPACE::storage_pool::db_slot{
+                                .db_id = db_id,
+                                .metadata_cnv = cnv_cursor,
+                                .root_offset_cnv_start =
+                                    static_cast<uint16_t>(cnv_cursor + 1),
+                                .root_offset_cnv_count = ro_count});
+                        cnv_cursor =
+                            static_cast<uint16_t>(cnv_cursor + 1 + ro_count);
+                    }
+                }
+            }
+            // Apply per-DB chunk limits
+            if (!impl.pool->is_read_only()) {
+                for (uint32_t i = 0; i < impl.num_dbs; ++i) {
+                    if (!impl.db_configs[i].max_seq_chunks.has_value()) {
+                        continue;
+                    }
+                    auto const limit = *impl.db_configs[i].max_seq_chunks;
+                    auto const db_id = static_cast<uint8_t>(i + 1);
+                    monad::io::Ring r{monad::io::RingConfig{1}};
+                    monad::io::Ring w{monad::io::RingConfig{4}};
+                    auto buf =
+                        monad::io::make_buffers_for_segregated_read_write(
+                            r,
+                            w,
+                            2,
+                            4,
+                            MONAD_ASYNC_NAMESPACE::AsyncIO::
+                                MONAD_IO_BUFFERS_READ_SIZE,
+                            MONAD_ASYNC_NAMESPACE::AsyncIO::
+                                MONAD_IO_BUFFERS_WRITE_SIZE);
+                    auto aio = MONAD_ASYNC_NAMESPACE::AsyncIO{*impl.pool, buf};
+                    MONAD_MPT_NAMESPACE::UpdateAux aux{aio, db_id};
+                    aux.set_max_seq_chunks(limit);
+                }
+            }
         }
 
         if (!impl.restore_database.empty()) {
@@ -1582,7 +1707,11 @@ opened.
                       MONAD_ASYNC_NAMESPACE::AsyncIO::
                           MONAD_IO_BUFFERS_READ_SIZE);
         auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{*impl.pool, rwbuf};
-        MONAD_MPT_NAMESPACE::UpdateAux aux(io);
+        MONAD_MPT_NAMESPACE::UpdateAux aux(io, 1);
+
+        if (impl.set_max_seq_chunks.has_value()) {
+            aux.set_max_seq_chunks(*impl.set_max_seq_chunks);
+        }
 
         {
             cout << R"(MPT database on storages:
@@ -1602,13 +1731,40 @@ opened.
             cout << std::setw(default_width) << std::setprecision(default_prec)
                  << std::endl;
 
+            // Show registered DBs
+            {
+                cout << "Pool catalog:";
+                for (uint8_t db_id = 1; db_id <= 4; ++db_id) {
+                    auto const *slot = impl.pool->find_db_slot(db_id);
+                    if (slot == nullptr) {
+                        break;
+                    }
+                    cout << "\n     DB" << db_id << ": metadata=cnv"
+                         << slot->metadata_cnv << ", root_offsets=cnv"
+                         << slot->root_offset_cnv_start << ".."
+                         << (slot->root_offset_cnv_start +
+                             slot->root_offset_cnv_count - 1);
+                }
+                cout << "\n";
+            }
+
             cout << "MPT database internal lists:\n";
             impl.total_used += impl.print_list_info(
                 aux, aux.db_metadata()->fast_list_begin(), "Fast", &impl.fast);
             impl.total_used += impl.print_list_info(
                 aux, aux.db_metadata()->slow_list_begin(), "Slow", &impl.slow);
-            impl.print_list_info(
-                aux, aux.db_metadata()->free_list_begin(), "Free");
+            {
+                auto const limit = aux.db_metadata()->max_seq_chunks;
+                if (limit != 0) {
+                    auto const owned =
+                        aux.num_chunks(MONAD_MPT_NAMESPACE::UpdateAuxImpl::
+                                           chunk_list::fast) +
+                        aux.num_chunks(MONAD_MPT_NAMESPACE::UpdateAuxImpl::
+                                           chunk_list::slow);
+                    cout << "     Seq chunk limit: " << owned << " / " << limit
+                         << "\n";
+                }
+            }
             impl.print_db_history_summary(aux);
 
             if (impl.reset_history_length) {
@@ -1628,7 +1784,7 @@ opened.
                     impl.cli_ask_question(ss.str().c_str());
                 }
                 aux.unset_io();
-                aux.set_io(io, impl.reset_history_length);
+                aux.set_io(io, 1, impl.reset_history_length);
                 cout << "Success! Done resetting history to "
                      << impl.reset_history_length.value() << ".\n";
                 impl.print_db_history_summary(aux);
@@ -1660,8 +1816,6 @@ opened.
                         aux, aux.db_metadata()->fast_list_begin(), "Fast");
                     impl.print_list_info(
                         aux, aux.db_metadata()->slow_list_begin(), "Slow");
-                    impl.print_list_info(
-                        aux, aux.db_metadata()->free_list_begin(), "Free");
                     return 0;
                 }
             }

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -114,6 +114,7 @@ AsyncIOContext::AsyncIOContext(ReadOnlyOnDiskDbConfig const &options)
           read_ring, options.rd_buffers,
           async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE)}
     , io{pool, buffers}
+    , db_id{options.db_id}
 {
     io.set_capture_io_latencies(options.capture_io_latencies);
     io.set_concurrent_read_io_limit(options.concurrent_read_io_limit);
@@ -123,6 +124,8 @@ AsyncIOContext::AsyncIOContext(ReadOnlyOnDiskDbConfig const &options)
 AsyncIOContext::AsyncIOContext(OnDiskDbConfig const &options)
     : pool{[&] -> async::storage_pool {
         async::storage_pool::creation_flags pool_options;
+        // DB1 bootstrap: derive num_cnv_chunks from root_offsets_chunk_count.
+        // Can be removed once callers set num_cnv_chunks directly.
         pool_options.num_cnv_chunks = options.root_offsets_chunk_count + 1;
         auto const len = options.file_size_db * 1024 * 1024 * 1024 + 24576;
         if (options.dbname_paths.empty()) {
@@ -157,7 +160,21 @@ AsyncIOContext::AsyncIOContext(OnDiskDbConfig const &options)
           async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
           async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE)}
     , io{pool, buffers}
+    , db_id{options.db_id}
+    , max_seq_chunks{options.max_seq_chunks}
 {
+    if (!options.append) {
+        MONAD_ASSERT_PRINTF(
+            pool.find_db_slot(options.db_id) == nullptr,
+            "db with id \"%u\" already exists",
+            options.db_id);
+        pool.register_db_slot(async::storage_pool::db_slot{
+            .db_id = options.db_id,
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count =
+                static_cast<uint16_t>(options.root_offsets_chunk_count)});
+    }
     io.set_capture_io_latencies(options.capture_io_latencies);
     io.set_concurrent_read_io_limit(options.concurrent_read_io_limit);
     io.set_eager_completions(options.eager_completions);
@@ -169,7 +186,7 @@ class Db::ROOnDiskBlocking final : public Db::Impl
 
 public:
     explicit ROOnDiskBlocking(AsyncIOContext &io_ctx)
-        : aux_(io_ctx.io)
+        : aux_(io_ctx.io, io_ctx.db_id)
     {
     }
 
@@ -403,7 +420,7 @@ struct OnDiskWithWorkerThreadImpl
             ReadOnlyOnDiskDbConfig const &options)
             : parent(parent)
             , async_io(options)
-            , aux(async_io.io)
+            , aux(async_io.io, async_io.db_id)
         {
         }
 
@@ -412,8 +429,11 @@ struct OnDiskWithWorkerThreadImpl
             OnDiskDbConfig const &options)
             : parent(parent)
             , async_io(options)
-            , aux{async_io.io, options.fixed_history_length}
+            , aux{async_io.io, async_io.db_id, options.fixed_history_length}
         {
+            if (async_io.max_seq_chunks.has_value()) {
+                aux.set_max_seq_chunks(*async_io.max_seq_chunks);
+            }
             if (options.rewind_to_latest_finalized) {
                 auto const latest_block_id = aux.get_latest_finalized_version();
                 if (latest_block_id == INVALID_BLOCK_NUM) {

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -54,6 +54,8 @@ struct AsyncIOContext
     std::optional<io::Ring> write_ring;
     io::Buffers buffers;
     async::AsyncIO io;
+    uint8_t db_id;
+    std::optional<uint32_t> max_seq_chunks;
 
     explicit AsyncIOContext(ReadOnlyOnDiskDbConfig const &options);
     explicit AsyncIOContext(OnDiskDbConfig const &options);

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -62,7 +62,7 @@ namespace detail
     // For the memory map of the first conventional chunk
     struct db_metadata
     {
-        static constexpr char const *MAGIC = "MONAD007";
+        static constexpr char const *MAGIC = "MONAD008";
         static constexpr unsigned MAGIC_STRING_LEN = 8;
 
         friend class MONAD_MPT_NAMESPACE::UpdateAuxImpl;
@@ -77,8 +77,8 @@ namespace detail
         uint64_t unused0_ : 36; // next item MUST be on a byte boundary
         uint64_t reserved_for_is_dirty_ : 8; // for is_dirty below
         // DO NOT INSERT ANYTHING IN HERE
-        uint64_t capacity_in_free_list; // used to detect when free space is
-                                        // running low
+        uint32_t max_seq_chunks; // 0 = unlimited
+        uint32_t reserved_;
 
         // Thread safe ring buffer containing root offsets on disk. One thread
         // is both the producer and the consumer. Other threads may query
@@ -166,13 +166,13 @@ namespace detail
             static_assert(bitfield_layout_check());
 #endif
             return *start_lifetime_as<std::atomic<uint8_t>>(
-                (std::byte *)&capacity_in_free_list - 1);
+                (std::byte *)&max_seq_chunks - 1);
         }
 
         struct id_pair
         {
             uint32_t begin, end;
-        } free_list, fast_list, slow_list;
+        } unused_free_list_, fast_list, slow_list;
 
         struct chunk_info_t
         {
@@ -278,22 +278,6 @@ namespace detail
                 ->load(load_ord);
         }
 
-        chunk_info_t const *free_list_begin() const noexcept
-        {
-            if (free_list.begin == UINT32_MAX) {
-                return nullptr;
-            }
-            return at(free_list.begin);
-        }
-
-        chunk_info_t const *free_list_end() const noexcept
-        {
-            if (free_list.end == UINT32_MAX) {
-                return nullptr;
-            }
-            return at(free_list.end);
-        }
-
         chunk_info_t const *fast_list_begin() const noexcept
         {
             if (fast_list.begin == UINT32_MAX) {
@@ -378,10 +362,8 @@ namespace detail
                 if (i->in_fast_list) {
                     return fast_list;
                 }
-                if (i->in_slow_list) {
-                    return slow_list;
-                }
-                return free_list;
+                MONAD_ASSERT(i->in_slow_list);
+                return slow_list;
             };
             auto const g = hold_dirty();
             if (i->prev_chunk_id == chunk_info_t::INVALID_CHUNK_ID &&
@@ -431,18 +413,6 @@ namespace detail
             i->prev_chunk_id = i->next_chunk_id =
                 chunk_info_t::INVALID_CHUNK_ID;
 #endif
-        }
-
-        void free_capacity_add_(uint64_t bytes) noexcept
-        {
-            auto const g = hold_dirty();
-            capacity_in_free_list += bytes;
-        }
-
-        void free_capacity_sub_(uint64_t bytes) noexcept
-        {
-            auto const g = hold_dirty();
-            capacity_in_free_list -= bytes;
         }
 
         void advance_db_offsets_to_(

--- a/category/mpt/ondisk_db_config.hpp
+++ b/category/mpt/ondisk_db_config.hpp
@@ -43,10 +43,14 @@ struct OnDiskDbConfig
     // fixed history length if contains value, otherwise rely on db to adjust
     // history length upon disk usage
     std::optional<uint64_t> fixed_history_length{std::nullopt};
-    // Number of chunks to allocate for root offsets when initializing the disk.
-    // Each chunk can hold 1 << 24 = 16777216 historical entries.
-    // This field must be power of 2.
+    // Number of CNV chunks for root offsets. Used to compute
+    // num_cnv_chunks and register the DB's catalog slot at open time.
     uint32_t root_offsets_chunk_count{2};
+    // DB identity. Must be registered in the pool catalog.
+    uint8_t db_id{1};
+    // Maximum seq chunks this DB may own. nullopt = leave persisted value,
+    // 0 = unlimited.
+    std::optional<uint32_t> max_seq_chunks{};
 };
 
 struct ReadOnlyOnDiskDbConfig
@@ -63,6 +67,8 @@ struct ReadOnlyOnDiskDbConfig
     std::vector<std::filesystem::path> dbname_paths;
     unsigned concurrent_read_io_limit{600};
     uint64_t node_lru_max_mem{100ul << 20}; // 100MB
+    // See OnDiskDbConfig::db_id for semantics and Phase 0 limitations.
+    uint8_t db_id{1};
 };
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_trie_test(
   PkgConfig::zstd
   PkgConfig::archive)
 add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
+add_trie_test(TARGET pool_catalog_test SOURCES "pool_catalog_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")
 add_trie_test(TARGET update_aux_test SOURCES "update_aux_test.cpp")
 add_trie_test(TARGET db_test SOURCES "db_test.cpp")

--- a/category/mpt/test/blocking_read_concurrency_test.cpp
+++ b/category/mpt/test/blocking_read_concurrency_test.cpp
@@ -119,7 +119,7 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
         monad::io::Buffers rwbuf{monad::io::make_buffers_for_read_only(
             ring, 2, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE)};
         AsyncIO io{pool, rwbuf};
-        monad::test::UpdateAux const ro_aux{io};
+        monad::test::UpdateAux const ro_aux{io, 1};
 
         int count = 0;
         while (!stop_token.stop_requested()) {
@@ -197,7 +197,7 @@ TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
         monad::io::Buffers rwbuf{monad::io::make_buffers_for_read_only(
             ring, 2, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE)};
         AsyncIO io{pool, rwbuf};
-        monad::test::UpdateAux ro_aux{io};
+        monad::test::UpdateAux ro_aux{io, 1};
 
         DummyTraverseMachine traverse{};
         int count = 0;

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -224,7 +224,7 @@ struct cli_tool_fixture
                         1,
                         monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                 monad::async::AsyncIO testio(pool, testrwbuf);
-                monad::mpt::UpdateAux const aux{testio};
+                monad::mpt::UpdateAux const aux{testio, 1};
                 monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
                     aux,
                     aux.get_latest_root_offset(),
@@ -327,7 +327,7 @@ struct cli_tool_fixture
                             1,
                             monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
                     monad::async::AsyncIO testio(pool, testrwbuf);
-                    monad::mpt::UpdateAux const aux{testio};
+                    monad::mpt::UpdateAux const aux{testio, 1};
                     monad::mpt::Node::SharedPtr const root_ptr{
                         read_node_blocking(
                             aux,

--- a/category/mpt/test/db_metadata_test.cpp
+++ b/category/mpt/test/db_metadata_test.cpp
@@ -66,7 +66,7 @@ TEST(db_metadata, DISABLED_copy)
         }
     });
     metadata[1]->chunk_info_count = 6;
-    metadata[1]->capacity_in_free_list = 6;
+    metadata[1]->max_seq_chunks = 6;
     unsigned count = 0;
     auto const begin = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - begin <
@@ -75,14 +75,14 @@ TEST(db_metadata, DISABLED_copy)
             EXPECT_FALSE(true);
         }
         metadata[0]->chunk_info_count = 5;
-        metadata[0]->capacity_in_free_list = 5;
+        metadata[0]->max_seq_chunks = 5;
         latch.store(0, std::memory_order_release);
         do {
             memcpy((void *)metadata[2], metadata[0], 32);
             // If first half copied but not yet second half, dirty bit must be
             // set
             if (metadata[2]->chunk_info_count != 5 &&
-                metadata[2]->capacity_in_free_list == 5) {
+                metadata[2]->max_seq_chunks == 5) {
                 if (!metadata[2]->is_dirty().load(std::memory_order_acquire)) {
                     EXPECT_TRUE(metadata[2]->is_dirty().load(
                         std::memory_order_acquire));

--- a/category/mpt/test/load_all_test.cpp
+++ b/category/mpt/test/load_all_test.cpp
@@ -31,7 +31,7 @@ struct LoadAllTest
 
 TEST_F(LoadAllTest, works)
 {
-    monad::test::UpdateAux aux{state()->io};
+    monad::test::UpdateAux aux{state()->io, 1};
     monad::test::StateMachineAlwaysMerkle sm;
     monad::mpt::Node::SharedPtr const root{monad::mpt::read_node_blocking(
         state()->aux,

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -60,7 +60,7 @@ namespace
 TEST_F(MixedAsyncSyncLoadsTest, works)
 {
     // Make a new empty DB
-    monad::test::UpdateAux aux{state()->io};
+    monad::test::UpdateAux aux{state()->io, 1};
     monad::test::StateMachineAlwaysMerkle const sm;
     // Load its root
     auto const latest_version = aux.db_history_max_version();

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -550,7 +550,8 @@ int main(int argc, char *argv[])
                     }
                 };
 
-                auto aux = in_memory ? UpdateAux() : UpdateAux(io, history_len);
+                auto aux =
+                    in_memory ? UpdateAux() : UpdateAux(io, 1, history_len);
                 monad::test::StateMachineMerkleWithPrefix<prefix_len> sm{};
 
                 Node::SharedPtr root{};
@@ -701,7 +702,7 @@ int main(int argc, char *argv[])
                     Node::SharedPtr &root = std::get<1>(*ret);
                     NodeCursor &state_start = std::get<2>(*ret);
                     if (!in_memory) {
-                        aux.set_io(io, history_len);
+                        aux.set_io(io, 1, history_len);
                     }
                     root = read_node_blocking(
                         aux,

--- a/category/mpt/test/node_writer_test.cpp
+++ b/category/mpt/test/node_writer_test.cpp
@@ -93,7 +93,13 @@ struct NodeWriterTestBase : public ::testing::Test
               ring1, ring2, 2, 4, AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
               AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE)}
         , io{pool, rwbuf}
-        , aux{io}
+        , aux{(pool.register_db_slot(storage_pool::db_slot{
+                   .db_id = 1,
+                   .metadata_cnv = 0,
+                   .root_offset_cnv_start = 1,
+                   .root_offset_cnv_count = 2}),
+               io),
+              1}
     {
     }
 

--- a/category/mpt/test/pool_catalog_test.cpp
+++ b/category/mpt/test/pool_catalog_test.cpp
@@ -1,0 +1,524 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/async/io.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/async/util.hpp>
+#include <category/core/assert.h>
+#include <category/core/io/buffers.hpp>
+#include <category/core/io/ring.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/ondisk_db_config.hpp>
+#include <category/mpt/trie.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <fcntl.h>
+#include <filesystem>
+#include <stdlib.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace monad::mpt;
+using db_slot = MONAD_ASYNC_NAMESPACE::storage_pool::db_slot;
+
+namespace
+{
+    constexpr size_t CHUNK_CAPACITY = 1ul << 28;
+
+    std::filesystem::path make_pool_file(size_t cnv, size_t seq)
+    {
+        auto path = MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+                    "pool_catalog_test_XXXXXX";
+        int const fd = ::mkstemp((char *)path.native().data());
+        MONAD_ASSERT(fd >= 0);
+        auto const bytes = (cnv + seq) * CHUNK_CAPACITY + 24576;
+        MONAD_ASSERT(-1 != ::ftruncate(fd, static_cast<off_t>(bytes)));
+        ::close(fd);
+        return path;
+    }
+
+    void init_db(MONAD_ASYNC_NAMESPACE::storage_pool &pool, uint8_t db_id = 1)
+    {
+        monad::io::Ring rr{monad::io::RingConfig{2}};
+        monad::io::Ring wr{monad::io::RingConfig{4}};
+        auto rwbuf = monad::io::make_buffers_for_segregated_read_write(
+            rr,
+            wr,
+            2,
+            4,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rwbuf};
+        UpdateAux const aux{io, db_id};
+        MONAD_ASSERT(aux.db_metadata() != nullptr);
+    }
+} // namespace
+
+TEST(pool_catalog, db2_register_and_init)
+{
+    auto const f = make_pool_file(6, 20);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 6;
+    MONAD_ASYNC_NAMESPACE::storage_pool pool{
+        {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, flags};
+
+    pool.register_db_slot(db_slot{
+        .db_id = 2,
+        .metadata_cnv = 3,
+        .root_offset_cnv_start = 4,
+        .root_offset_cnv_count = 2});
+
+    auto const *slot = pool.find_db_slot(2);
+    ASSERT_NE(slot, nullptr);
+    EXPECT_EQ(slot->metadata_cnv, 3);
+    EXPECT_EQ(slot->root_offset_cnv_start, 4);
+    EXPECT_EQ(slot->root_offset_cnv_count, 2);
+    for (uint8_t id = 3; id <= 99; ++id) {
+        EXPECT_EQ(pool.find_db_slot(id), nullptr);
+    }
+}
+
+// DB2 can reopen as read-only through AsyncIOContext
+TEST(pool_catalog, db2_can_reopen_as_ro)
+{
+    auto const f = make_pool_file(6, 20);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 6;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate,
+            flags};
+        pool.register_db_slot(db_slot{
+            .db_id = 2,
+            .metadata_cnv = 3,
+            .root_offset_cnv_start = 4,
+            .root_offset_cnv_count = 2});
+    }
+
+    // RW init
+    {
+        OnDiskDbConfig c{};
+        c.dbname_paths = {f};
+        c.append = true;
+        c.db_id = 2;
+        AsyncIOContext ctx{c};
+        UpdateAux const aux{ctx.io, ctx.db_id};
+        EXPECT_NE(aux.db_metadata(), nullptr);
+    }
+    // RO reopen
+    {
+        ReadOnlyOnDiskDbConfig c{};
+        c.dbname_paths = {f};
+        c.db_id = 2;
+        AsyncIOContext ctx{c};
+        UpdateAux const aux{ctx.io, ctx.db_id};
+        EXPECT_NE(aux.db_metadata(), nullptr);
+    }
+}
+
+TEST(pool_catalog, out_of_range_metadata)
+{
+    constexpr size_t pool_cnv = 3;
+    constexpr size_t pool_seq = 10;
+    auto const f = make_pool_file(pool_cnv, pool_seq);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    MONAD_ASYNC_NAMESPACE::storage_pool pool{
+        {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, {}};
+    EXPECT_DEATH(
+        pool.register_db_slot(db_slot{
+            .db_id = 2,
+            .metadata_cnv = 5, // exceeds pool_cnv
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 1}),
+        "out of range");
+    EXPECT_DEATH(
+        pool.register_db_slot(db_slot{
+            .db_id = 2,
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 2,
+            .root_offset_cnv_count = 2}), // range [2,4) exceeds pool_cnv
+        "out of range");
+    // metadata=1, root_offsets=[1,3) — metadata sits inside its own
+    // root offset range
+    EXPECT_DEATH(
+        pool.register_db_slot(db_slot{
+            .db_id = 2,
+            .metadata_cnv = 1,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 2}),
+        "overlaps root_offset");
+}
+
+TEST(pool_catalog, rejects_duplicate_db_id)
+{
+    constexpr size_t pool_cnv = 6;
+    constexpr size_t pool_seq = 10;
+    auto const f = make_pool_file(pool_cnv, pool_seq);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = pool_cnv;
+    MONAD_ASYNC_NAMESPACE::storage_pool pool{
+        {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, flags};
+    pool.register_db_slot(db_slot{
+        .db_id = 2,
+        .metadata_cnv = 3,
+        .root_offset_cnv_start = 4,
+        .root_offset_cnv_count = 2});
+    EXPECT_DEATH(
+        pool.register_db_slot(db_slot{
+            .db_id = 2, // duplicate
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 2}),
+        "Duplicate db_id");
+}
+
+TEST(pool_catalog, rejects_overlapping_slots)
+{
+    constexpr size_t pool_cnv = 6;
+    constexpr size_t pool_seq = 10;
+    auto const f = make_pool_file(pool_cnv, pool_seq);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = pool_cnv;
+    MONAD_ASYNC_NAMESPACE::storage_pool pool{
+        {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, flags};
+    pool.register_db_slot(db_slot{
+        .db_id = 1,
+        .metadata_cnv = 0,
+        .root_offset_cnv_start = 1,
+        .root_offset_cnv_count = 2}); // DB1 occupies cnv [0, 1, 2]
+    EXPECT_DEATH(
+        pool.register_db_slot(db_slot{
+            .db_id = 3,
+            .metadata_cnv = 4,
+            .root_offset_cnv_start = 2, // cnv 2 overlaps DB1's root offsets
+            .root_offset_cnv_count = 2}),
+        "overlaps with existing");
+}
+
+// --- Regression tests ---
+
+// Pre-MND1 pool rejected on create_if_needed instead of silently reinitializing
+TEST(pool_catalog, rejects_old_format_on_create_if_needed)
+{
+    auto const f = make_pool_file(3, 10);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    // Mock an old MND0 pool
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool const pool{
+            {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, {}};
+    }
+    {
+        int const fd = ::open(f.c_str(), O_RDWR);
+        MONAD_ASSERT(fd != -1);
+        struct stat st;
+        ::fstat(fd, &st);
+        // Magic is the last 4 bytes of the file
+        char old_magic[] = "MND0";
+        MONAD_ASSERT(::pwrite(fd, old_magic, 4, st.st_size - 4) == 4);
+        ::close(fd);
+    }
+    EXPECT_DEATH(
+        ({
+            MONAD_ASYNC_NAMESPACE::storage_pool const pool(
+                std::span{&f, 1},
+                MONAD_ASYNC_NAMESPACE::storage_pool::mode::create_if_needed,
+                {});
+        }),
+        "incompatible format");
+}
+
+// Existing pool with DB1 can add DB2 without restating DB1's geometry
+TEST(pool_catalog, add_db2_to_existing_pool)
+{
+    auto const f = make_pool_file(6, 20);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    // Create pool with DB1 only
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 6;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate,
+            flags};
+        pool.register_db_slot(db_slot{
+            .db_id = 1,
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 2});
+        init_db(pool, 1);
+    }
+    // Reopen and add DB2
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 6;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        ASSERT_NE(pool.find_db_slot(1), nullptr);
+        ASSERT_EQ(pool.find_db_slot(2), nullptr);
+        pool.register_db_slot(db_slot{
+            .db_id = 2,
+            .metadata_cnv = 3,
+            .root_offset_cnv_start = 4,
+            .root_offset_cnv_count = 2});
+        ASSERT_NE(pool.find_db_slot(2), nullptr);
+        init_db(pool, 2);
+    }
+    // Verify both survive reopen
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 6;
+        MONAD_ASYNC_NAMESPACE::storage_pool const pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        EXPECT_NE(pool.find_db_slot(1), nullptr);
+        EXPECT_NE(pool.find_db_slot(2), nullptr);
+    }
+}
+
+// Migration simulation: DB1 shrinks, DB2 grows into the freed capacity
+TEST(pool_catalog, migration_simulation)
+{
+    constexpr size_t pool_cnv = 6;
+    constexpr size_t pool_seq = 20;
+    auto const f = make_pool_file(pool_cnv, pool_seq);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = pool_cnv;
+    MONAD_ASYNC_NAMESPACE::storage_pool pool{
+        {&f, 1}, MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate, flags};
+
+    pool.register_db_slot(db_slot{
+        .db_id = 1,
+        .metadata_cnv = 0,
+        .root_offset_cnv_start = 1,
+        .root_offset_cnv_count = 2});
+    pool.register_db_slot(db_slot{
+        .db_id = 2,
+        .metadata_cnv = 3,
+        .root_offset_cnv_start = 4,
+        .root_offset_cnv_count = 2});
+
+    auto const total_free = pool.free_seq_chunk_count();
+
+    constexpr uint32_t db1_limit = 6;
+    std::vector<uint32_t> db1_chunks;
+    {
+        monad::io::Ring rr{monad::io::RingConfig{2}};
+        monad::io::Ring wr{monad::io::RingConfig{4}};
+        auto rwbuf = monad::io::make_buffers_for_segregated_read_write(
+            rr,
+            wr,
+            2,
+            4,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rwbuf};
+        UpdateAux aux{io, 1};
+        aux.set_max_seq_chunks(db1_limit);
+        auto const after_init =
+            aux.num_chunks(UpdateAuxImpl::chunk_list::fast) +
+            aux.num_chunks(UpdateAuxImpl::chunk_list::slow);
+        ASSERT_EQ(after_init, 2u); // fast + slow
+        for (uint32_t i = after_init; i < db1_limit; ++i) {
+            auto const id = pool.allocate_seq_chunk(1);
+            ASSERT_NE(id, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+            aux.append(UpdateAuxImpl::chunk_list::fast, id);
+            pool.commit_seq_chunk(id);
+            db1_chunks.push_back(id);
+        }
+        auto const db1_owned = aux.num_chunks(UpdateAuxImpl::chunk_list::fast) +
+                               aux.num_chunks(UpdateAuxImpl::chunk_list::slow);
+        EXPECT_EQ(db1_owned, db1_limit);
+        EXPECT_GE(aux.disk_usage(), 1.0);
+    }
+    EXPECT_EQ(pool.free_seq_chunk_count(), total_free - db1_limit);
+
+    // DB1 "shrinks": return 4 chunks to pool (simulating compaction)
+    for (auto const id : db1_chunks) {
+        pool.begin_free_seq_chunk(id);
+        pool.free_seq_chunk(id);
+    }
+    EXPECT_EQ(pool.free_seq_chunk_count(), total_free - 2); // fast+slow remain
+
+    // DB2 grows into the capacity DB1 freed
+    {
+        monad::io::Ring rr{monad::io::RingConfig{2}};
+        monad::io::Ring wr{monad::io::RingConfig{4}};
+        auto rwbuf = monad::io::make_buffers_for_segregated_read_write(
+            rr,
+            wr,
+            2,
+            4,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rwbuf};
+        UpdateAux aux{io, 2};
+        auto const db2_after_init =
+            aux.num_chunks(UpdateAuxImpl::chunk_list::fast) +
+            aux.num_chunks(UpdateAuxImpl::chunk_list::slow);
+        ASSERT_EQ(db2_after_init, 2u); // fast + slow
+
+        constexpr uint32_t db2_limit = 6;
+        aux.set_max_seq_chunks(db2_limit);
+
+        for (uint32_t i = db2_after_init; i < db2_limit; ++i) {
+            auto const id = pool.allocate_seq_chunk(2);
+            ASSERT_NE(id, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+            aux.append(UpdateAuxImpl::chunk_list::fast, id);
+            pool.commit_seq_chunk(id);
+        }
+
+        auto const db2_owned = aux.num_chunks(UpdateAuxImpl::chunk_list::fast) +
+                               aux.num_chunks(UpdateAuxImpl::chunk_list::slow);
+        EXPECT_EQ(db2_owned, db2_limit);
+        EXPECT_GE(aux.disk_usage(), 1.0);
+    }
+}
+
+// Simulate crash during allocation: find_reserved_chunk finds orphaned chunks
+TEST(pool_catalog, find_reserved_chunk_after_crash)
+{
+    auto const f = make_pool_file(3, 10);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 3;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate,
+            flags};
+        // Allocate but never commit — simulates crash mid-allocation.
+        auto const id = pool.allocate_seq_chunk(1);
+        ASSERT_NE(id, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+    }
+    // Reopen — find_reserved_chunk should locate the orphan.
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 3;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        auto const reserved = pool.find_reserved_chunk(1);
+        ASSERT_NE(reserved, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        // Not in any DB list → reclaim.
+        pool.free_seq_chunk(reserved);
+        EXPECT_EQ(
+            pool.find_reserved_chunk(1),
+            MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        auto const total_seq =
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+        EXPECT_EQ(pool.free_seq_chunk_count(), total_seq);
+    }
+}
+
+// Simulate crash during free: begin_free leaves chunk RESERVED
+TEST(pool_catalog, find_reserved_chunk_after_crash_during_free)
+{
+    auto const f = make_pool_file(3, 10);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 3;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate,
+            flags};
+        auto const id = pool.allocate_seq_chunk(1);
+        ASSERT_NE(id, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        pool.commit_seq_chunk(id);
+        // Begin free but don't finish — simulates crash mid-free.
+        pool.begin_free_seq_chunk(id);
+    }
+    // Reopen — find_reserved_chunk should locate it.
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 3;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        auto const reserved = pool.find_reserved_chunk(1);
+        ASSERT_NE(reserved, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        // Caller would check DB list and decide. Here, just free it.
+        pool.free_seq_chunk(reserved);
+        auto const total_seq =
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+        EXPECT_EQ(pool.free_seq_chunk_count(), total_seq);
+    }
+}
+
+// Multiple RESERVED chunks (reentrancy crash) are all reconciled on reopen
+TEST(pool_catalog, reconcile_multiple_reserved_chunks)
+{
+    auto const f = make_pool_file(3, 10);
+    auto const cleanup_f =
+        monad::make_scope_exit([&]() noexcept { std::filesystem::remove(f); });
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.num_cnv_chunks = 3;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            {&f, 1},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate,
+            flags};
+        pool.register_db_slot(MONAD_ASYNC_NAMESPACE::storage_pool::db_slot{
+            .db_id = 1,
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 2});
+        init_db(pool, 1);
+        // Simulate reentrancy crash: two chunks allocated but never
+        // committed — both left RESERVED.
+        auto const id1 = pool.allocate_seq_chunk(1);
+        auto const id2 = pool.allocate_seq_chunk(1);
+        ASSERT_NE(id1, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        ASSERT_NE(id2, MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+    }
+    // Reopen writable — set_io should reconcile both RESERVED chunks.
+    {
+        OnDiskDbConfig c{};
+        c.dbname_paths = {f};
+        c.append = true;
+        c.db_id = 1;
+        AsyncIOContext ctx{c};
+        UpdateAux const aux{ctx.io, ctx.db_id};
+        // Both orphaned chunks should have been freed.
+        EXPECT_EQ(
+            ctx.io.storage_pool().find_reserved_chunk(1),
+            MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+    }
+}

--- a/category/mpt/test/rewind_test.cpp
+++ b/category/mpt/test/rewind_test.cpp
@@ -45,7 +45,7 @@ TEST_F(RewindTest, works)
     aux.set_latest_voted(100, monad::bytes32_t{100});
     aux.unset_io();
     std::cout << "Reopening DB ..." << std::endl;
-    aux.set_io(io, 20000);
+    aux.set_io(io, 1, 20000);
     std::cout << "Rewinding DB to latest version " << max_version << "..."
               << std::endl;
     aux.rewind_to_version(max_version);
@@ -70,7 +70,7 @@ TEST_F(RewindTest, works)
     std::cout
         << "Reopening DB to check valid versions are what they should be ..."
         << std::endl;
-    aux.set_io(io);
+    aux.set_io(io, 1);
     EXPECT_EQ(0, aux.db_history_min_valid_version());
     EXPECT_EQ(9990, aux.db_history_max_version());
     // rewind to latest is noop
@@ -80,7 +80,7 @@ TEST_F(RewindTest, works)
     EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
     aux.unset_io();
     std::cout << "Setting max history to 9000 and reopening ..." << std::endl;
-    aux.set_io(io, 9000);
+    aux.set_io(io, 1, 9000);
     EXPECT_EQ(991, aux.db_history_min_valid_version());
     EXPECT_EQ(9990, aux.db_history_max_version());
     EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
@@ -91,7 +91,7 @@ TEST_F(RewindTest, works)
     EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
     EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
     aux.unset_io();
-    aux.set_io(io);
+    aux.set_io(io, 1);
     EXPECT_EQ(991, aux.db_history_min_valid_version());
     EXPECT_EQ(9900, aux.db_history_max_version());
     EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
@@ -144,11 +144,10 @@ TEST_F(
 
     // advance fast writer head to the next chunk
     auto const fast_writer_offset = aux.node_writer_fast->sender().offset();
-    auto const *ci = aux.db_metadata()->free_list_end();
-    ASSERT_TRUE(ci != nullptr);
-    auto const idx = ci->index(aux.db_metadata());
-    aux.remove(idx);
+    auto const idx = this->state()->pool.allocate_seq_chunk(1);
+    ASSERT_NE(idx, monad::async::storage_pool::ALLOC_FAILED);
     aux.append(monad::mpt::UpdateAuxImpl::chunk_list::fast, idx);
+    this->state()->pool.commit_seq_chunk(idx);
     monad::async::chunk_offset_t const new_fast_writer_offset{idx, 0};
     aux.advance_db_offsets_to(
         new_fast_writer_offset, aux.node_writer_slow->sender().offset());
@@ -160,5 +159,5 @@ TEST_F(
     aux.unset_io();
 
     // verifies set_io() succeeds
-    aux.set_io(io);
+    aux.set_io(io, 1);
 }

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -363,7 +363,14 @@ namespace monad::test
                   MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE))
             , io(pool, rwbuf)
             , root()
-            , aux(io, MPT_TEST_HISTORY_LENGTH)
+            , aux((pool.register_db_slot(
+                       MONAD_ASYNC_NAMESPACE::storage_pool::db_slot{
+                           .db_id = 1,
+                           .metadata_cnv = 0,
+                           .root_offset_cnv_start = 1,
+                           .root_offset_cnv_count = 2}),
+                   io),
+                  1, MPT_TEST_HISTORY_LENGTH)
         {
         }
 
@@ -492,7 +499,15 @@ namespace monad::test
             Node::SharedPtr root;
             StateMachineAlwaysMerkle sm;
             UpdateAux aux{
-                io, Config.history_len}; // trie section starts from account
+                (pool.register_db_slot(
+                     MONAD_ASYNC_NAMESPACE::storage_pool::db_slot{
+                         .db_id = 1,
+                         .metadata_cnv = 0,
+                         .root_offset_cnv_start = 1,
+                         .root_offset_cnv_count = 2}),
+                 io),
+                1,
+                Config.history_len};
             monad::small_prng rand;
             std::vector<std::pair<monad::byte_string, size_t>> keys;
             uint64_t version{0};
@@ -551,9 +566,8 @@ namespace monad::test
                               << " has capacity = " << chunk.capacity()
                               << " consumed = " << chunk.size();
                 }
-                std::cout << "\n\n   Free list: "
-                          << aux.db_metadata()->capacity_in_free_list
-                          << " bytes.";
+                std::cout << "\n\n   Pool free chunks: "
+                          << pool.free_seq_chunk_count();
                 auto const ro = aux.root_offsets();
                 auto const most_recent_offset = ro[ro.max_version()];
                 std::cout << "\n\n   DB version history is "

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -46,6 +46,11 @@ namespace
 TEST(update_aux_test, set_io_reader_dirty)
 {
     monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    pool.register_db_slot(monad::async::storage_pool::db_slot{
+        .db_id = 1,
+        .metadata_cnv = 0,
+        .root_offset_cnv_start = 1,
+        .root_offset_cnv_count = 2});
 
     // All this threading nonsense is because we can't have two AsyncIO
     // instances on the same thread.
@@ -64,7 +69,7 @@ TEST(update_aux_test, set_io_reader_dirty)
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testbuf);
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+        aux_writer.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH);
         io_set = true;
 
         while (!token.stop_requested()) {
@@ -117,13 +122,13 @@ TEST(update_aux_test, set_io_reader_dirty)
     ASSERT_DEATH(
         ({
             monad::mpt::UpdateAux aux_reader{};
-            aux_reader.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+            aux_reader.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH);
         }),
         "DB metadata was closed dirty, but not opened for healing");
 
     // TestAux adds instrumentation to turn off the dirty bit. Should not throw.
     TestAux aux_reader(aux_writer);
-    EXPECT_NO_THROW(aux_reader.set_io(testio, AUX_TEST_HISTORY_LENGTH));
+    EXPECT_NO_THROW(aux_reader.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH));
     EXPECT_TRUE(aux_reader.was_dirty) << "target codepath not exercised";
 }
 
@@ -132,6 +137,11 @@ TEST(update_aux_test, root_offsets_fast_slow)
     testing::FLAGS_gtest_death_test_style = "threadsafe";
 
     monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    pool.register_db_slot(monad::async::storage_pool::db_slot{
+        .db_id = 1,
+        .metadata_cnv = 0,
+        .root_offset_cnv_start = 1,
+        .root_offset_cnv_count = 2});
     monad::io::Ring ring1;
     monad::io::Ring ring2;
     monad::io::Buffers testbuf =
@@ -145,7 +155,7 @@ TEST(update_aux_test, root_offsets_fast_slow)
     monad::async::AsyncIO testio(pool, testbuf);
     {
         monad::mpt::UpdateAux aux_writer{};
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+        aux_writer.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH);
 
         // Root offset at 0, fast list offset at 50. This is correct
         auto const start_offset =
@@ -162,7 +172,7 @@ TEST(update_aux_test, root_offsets_fast_slow)
     {
         // verify set_io() succeeds
         monad::mpt::UpdateAux aux_writer{};
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+        aux_writer.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH);
         EXPECT_EQ(aux_writer.root_offsets().max_version(), 0);
 
         // Write version 1. However, append the new root offset without
@@ -180,7 +190,7 @@ TEST(update_aux_test, root_offsets_fast_slow)
     { // Fail to reopen upon calling rewind_to_match_offsets()
         monad::mpt::UpdateAux aux_writer{};
         EXPECT_EXIT(
-            aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH),
+            aux_writer.set_io(testio, 1, AUX_TEST_HISTORY_LENGTH),
             ::testing::KilledBySignal(SIGABRT),
             "Detected corruption");
     }
@@ -214,12 +224,15 @@ TEST(update_aux_test, configurable_root_offset_chunks)
             monad::async::storage_pool::mode::truncate,
             flags);
         EXPECT_EQ(pool.chunks(monad::async::storage_pool::cnv), 5);
+        pool.register_db_slot(monad::async::storage_pool::db_slot{
+            .db_id = 1,
+            .metadata_cnv = 0,
+            .root_offset_cnv_start = 1,
+            .root_offset_cnv_count = 4});
 
         monad::async::AsyncIO testio(pool, testbuf);
-        monad::mpt::UpdateAux const aux(testio);
+        monad::mpt::UpdateAux const aux(testio, 1);
 
-        // Verify that exactly 4 chunks were allocated to hold two copies of
-        // root offsets, since chunk 0 is used for metadata
         EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
         EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
     }
@@ -231,7 +244,7 @@ TEST(update_aux_test, configurable_root_offset_chunks)
             flags);
         EXPECT_EQ(pool.chunks(monad::async::storage_pool::cnv), 5);
         monad::async::AsyncIO testio(pool, testbuf);
-        monad::mpt::UpdateAux const aux(testio);
+        monad::mpt::UpdateAux const aux(testio, 1);
         EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
         EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
     }

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -1381,9 +1381,9 @@ node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
     auto *sender = &node_writer->sender();
     bool const in_fast_list =
         aux.db_metadata()->at(sender->offset().id)->in_fast_list;
-    auto const *ci_ = aux.db_metadata()->free_list_end();
-    MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-    auto const idx = ci_->index(aux.db_metadata());
+    aux.assert_seq_chunk_budget();
+    auto const idx = aux.io->storage_pool().allocate_seq_chunk(aux.db_id_);
+    MONAD_ASSERT(idx != MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
     chunk_offset_t const offset_of_new_writer{idx, 0};
     // Pad buffer of existing node write that is about to get initiated so it's
     // O_DIRECT i/o aligned
@@ -1441,13 +1441,14 @@ node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
             "%d max_count = %d",
             my_reentrancy_count,
             reentrancy_detection.max_count);
+        aux.io->storage_pool().free_seq_chunk(idx);
         return {};
     }
-    aux.remove(idx);
     aux.append(
         in_fast_list ? UpdateAuxImpl::chunk_list::fast
                      : UpdateAuxImpl::chunk_list::slow,
         idx);
+    aux.io->storage_pool().commit_seq_chunk(idx);
     return ret;
 }
 
@@ -1465,14 +1466,15 @@ node_writer_unique_ptr_type replace_node_writer(
     auto const chunk_capacity =
         aux.io->chunk_capacity(offset_of_next_writer.id);
     MONAD_ASSERT(offset <= chunk_capacity);
-    detail::db_metadata::chunk_info_t const *ci_ = nullptr;
+    bool new_chunk = false;
     uint32_t idx;
     if (offset == chunk_capacity) {
         // If after the current write buffer we're hitting chunk capacity, we
         // replace writer to the start of next chunk.
-        ci_ = aux.db_metadata()->free_list_end();
-        MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-        idx = ci_->index(aux.db_metadata());
+        aux.assert_seq_chunk_budget();
+        idx = aux.io->storage_pool().allocate_seq_chunk(aux.db_id_);
+        MONAD_ASSERT(idx != MONAD_ASYNC_NAMESPACE::storage_pool::ALLOC_FAILED);
+        new_chunk = true;
         offset_of_next_writer.id = idx & 0xfffffU;
         offset_of_next_writer.offset = 0;
     }
@@ -1486,15 +1488,17 @@ node_writer_unique_ptr_type replace_node_writer(
         write_operation_io_receiver{bytes_to_write});
     if (node_writer.get() != node_writer_ptr) {
         // We reentered, please retry
+        if (new_chunk) {
+            aux.io->storage_pool().free_seq_chunk(idx);
+        }
         return {};
     }
-    if (ci_ != nullptr) {
-        MONAD_ASSERT(ci_ == aux.db_metadata()->free_list_end());
-        aux.remove(idx);
+    if (new_chunk) {
         aux.append(
             in_fast_list ? UpdateAuxImpl::chunk_list::fast
                          : UpdateAuxImpl::chunk_list::slow,
             idx);
+        aux.io->storage_pool().commit_seq_chunk(idx);
     }
     return ret;
 }

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -248,6 +248,7 @@ public:
 
     // On disk stuff
     MONAD_ASYNC_NAMESPACE::AsyncIO *io{nullptr};
+    uint8_t db_id_{};
     node_writer_unique_ptr_type node_writer_fast{};
     node_writer_unique_ptr_type node_writer_slow{};
 
@@ -258,16 +259,16 @@ public:
 
     // on-disk
     explicit UpdateAuxImpl(
-        MONAD_ASYNC_NAMESPACE::AsyncIO &io_,
+        MONAD_ASYNC_NAMESPACE::AsyncIO &io_, uint8_t db_id,
         std::optional<uint64_t> const history_len = {})
     {
-        set_io(io_, history_len);
+        set_io(io_, db_id, history_len);
     }
 
     virtual ~UpdateAuxImpl();
 
     void set_io(
-        MONAD_ASYNC_NAMESPACE::AsyncIO &,
+        MONAD_ASYNC_NAMESPACE::AsyncIO &, uint8_t db_id,
         std::optional<uint64_t> history_length = {});
 
     void unset_io();
@@ -433,10 +434,6 @@ public:
     // translate between virtual and physical addresses chunk_offset_t
     virtual_chunk_offset_t physical_to_virtual(chunk_offset_t) const noexcept;
 
-    // age is relative to the beginning chunk's count
-    std::pair<chunk_list, detail::unsigned_20>
-    chunk_list_and_age(uint32_t idx) const noexcept;
-
     void append(chunk_list list, uint32_t idx);
     void remove(uint32_t idx) noexcept;
 
@@ -479,6 +476,15 @@ public:
     void rewind_to_version(uint64_t version);
     void clear_ondisk_db();
 
+    void set_max_seq_chunks(uint32_t limit) noexcept;
+    void assert_seq_chunk_budget() const noexcept;
+
+    uint32_t effective_chunk_budget() const noexcept
+    {
+        auto const limit = db_metadata()->max_seq_chunks;
+        return limit != 0 ? limit : static_cast<uint32_t>(io->chunk_count());
+    }
+
     void set_initial_insertion_count_unit_testing_only(uint32_t count)
     {
         initial_insertion_count_on_pool_creation_ = count;
@@ -518,8 +524,9 @@ public:
 
     double disk_usage() const
     {
-        return 1.0 -
-               (double)num_chunks(chunk_list::free) / (double)io->chunk_count();
+        auto const owned =
+            num_chunks(chunk_list::fast) + num_chunks(chunk_list::slow);
+        return (double)owned / (double)effective_chunk_budget();
     }
 
     chunk_offset_t get_latest_root_offset() const noexcept
@@ -563,7 +570,8 @@ public:
     file_offset_t get_lower_bound_free_space() const noexcept
     {
         MONAD_ASSERT(this->is_on_disk());
-        return db_metadata()->capacity_in_free_list;
+        return io->storage_pool().free_seq_chunk_count() *
+               io->chunk_capacity(0);
     }
 
     uint32_t num_chunks(chunk_list const list) const noexcept;
@@ -582,7 +590,7 @@ public:
 };
 
 static_assert(
-    sizeof(UpdateAuxImpl) == 144 + sizeof(detail::TrieUpdateCollectedStats));
+    sizeof(UpdateAuxImpl) == 152 + sizeof(detail::TrieUpdateCollectedStats));
 static_assert(alignof(UpdateAuxImpl) == 8);
 
 class UpdateAux final : public UpdateAuxImpl
@@ -593,9 +601,9 @@ public:
 
     // on-disk
     explicit UpdateAux(
-        MONAD_ASYNC_NAMESPACE::AsyncIO &io_,
+        MONAD_ASYNC_NAMESPACE::AsyncIO &io_, uint8_t db_id,
         std::optional<uint64_t> const history_len = {})
-        : UpdateAuxImpl(io_, history_len)
+        : UpdateAuxImpl(io_, db_id, history_len)
     {
     }
 

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -45,6 +45,7 @@
 #include <functional>
 #include <iterator>
 #include <linux/fs.h>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <span>
@@ -72,12 +73,6 @@ namespace
     }
 }
 
-// Define to avoid randomisation of free list chunks on pool creation
-// This can be useful to discover bugs in code which assume chunks are
-// consecutive
-// #define MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS 1
-#define MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS 1
-
 // Returns a virtual offset on successful translation; returns
 // INVALID_VIRTUAL_OFFSET if the input offset is invalid or the offset refers to
 // a chunk in the free list.
@@ -101,82 +96,42 @@ UpdateAuxImpl::physical_to_virtual(chunk_offset_t const offset) const noexcept
     return INVALID_VIRTUAL_OFFSET;
 }
 
-std::pair<UpdateAuxImpl::chunk_list, detail::unsigned_20>
-UpdateAuxImpl::chunk_list_and_age(uint32_t const idx) const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto const *ci = db_metadata()->at(idx);
-    std::pair<chunk_list, detail::unsigned_20> ret(
-        chunk_list::free, ci->insertion_count());
-    if (ci->in_fast_list) {
-        ret.first = chunk_list::fast;
-        ret.second -= db_metadata()->fast_list_begin()->insertion_count();
-    }
-    else if (ci->in_slow_list) {
-        ret.first = chunk_list::slow;
-        ret.second -= db_metadata()->slow_list_begin()->insertion_count();
-    }
-    else {
-        ret.second -= db_metadata()->free_list_begin()->insertion_count();
-    }
-    return ret;
-}
-
 void UpdateAuxImpl::append(chunk_list const list, uint32_t const idx)
 {
     MONAD_ASSERT(is_on_disk());
+    MONAD_ASSERT(list != chunk_list::free);
     auto do_ = [&](detail::db_metadata *m) {
         switch (list) {
-        case chunk_list::free:
-            m->append_(m->free_list, m->at_(idx));
-            break;
         case chunk_list::fast:
             m->append_(m->fast_list, m->at_(idx));
             break;
         case chunk_list::slow:
             m->append_(m->slow_list, m->at_(idx));
             break;
+        default:
+            MONAD_ABORT("unexpected chunk_list");
         }
     };
     do_(db_metadata_[0].main);
     do_(db_metadata_[1].main);
-    if (list == chunk_list::free) {
-        auto const &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
-        auto const capacity = chunk.capacity();
-        MONAD_ASSERT(chunk.size() == 0);
-        db_metadata_[0].main->free_capacity_add_(capacity);
-        db_metadata_[1].main->free_capacity_add_(capacity);
-    }
-    else {
-        auto const insertion_count = static_cast<uint32_t>(
-            db_metadata_[0].main->at(idx)->insertion_count());
-        if (insertion_count >= virtual_chunk_offset_t::MAX_COUNT * 9 / 10) {
-            LOG_WARNING_CFORMAT(
-                "Virtual offset space is running out "
-                "(insertion count: %u / %u). "
-                "Please perform a database reset.",
-                insertion_count,
-                (uint32_t)virtual_chunk_offset_t::MAX_COUNT);
-        }
+    auto const insertion_count =
+        static_cast<uint32_t>(db_metadata_[0].main->at(idx)->insertion_count());
+    if (insertion_count >= virtual_chunk_offset_t::MAX_COUNT * 9 / 10) {
+        LOG_WARNING_CFORMAT(
+            "Virtual offset space is running out "
+            "(insertion count: %u / %u). "
+            "Please perform a database reset.",
+            insertion_count,
+            (uint32_t)virtual_chunk_offset_t::MAX_COUNT);
     }
 }
 
 void UpdateAuxImpl::remove(uint32_t const idx) noexcept
 {
     MONAD_ASSERT(is_on_disk());
-    bool const is_free_list =
-        (!db_metadata_[0].main->at_(idx)->in_fast_list &&
-         !db_metadata_[0].main->at_(idx)->in_slow_list);
     auto do_ = [&](detail::db_metadata *m) { m->remove_(m->at_(idx)); };
     do_(db_metadata_[0].main);
     do_(db_metadata_[1].main);
-    if (is_free_list) {
-        auto const &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
-        auto const capacity = chunk.capacity();
-        MONAD_ASSERT(chunk.size() == 0);
-        db_metadata_[0].main->free_capacity_sub_(capacity);
-        db_metadata_[1].main->free_capacity_sub_(capacity);
-    }
 }
 
 void UpdateAuxImpl::advance_db_offsets_to(
@@ -382,6 +337,29 @@ void UpdateAuxImpl::set_auto_expire_version_metadata(
     do_(db_metadata_[1].main);
 }
 
+void UpdateAuxImpl::set_max_seq_chunks(uint32_t const limit) noexcept
+{
+    MONAD_ASSERT(is_on_disk());
+    for (auto const i : {0, 1}) {
+        auto const g = db_metadata_[i].main->hold_dirty();
+        db_metadata_[i].main->max_seq_chunks = limit;
+    }
+}
+
+void UpdateAuxImpl::assert_seq_chunk_budget() const noexcept
+{
+    auto const max_seq = db_metadata()->max_seq_chunks;
+    if (max_seq != 0) {
+        auto const owned =
+            num_chunks(chunk_list::fast) + num_chunks(chunk_list::slow);
+        MONAD_ASSERT_PRINTF(
+            owned < max_seq,
+            "DB seq chunk limit reached (%u/%u). Compaction needed.",
+            owned,
+            max_seq);
+    }
+}
+
 int64_t
 UpdateAuxImpl::calc_auto_expire_version(uint64_t const upsert_version) noexcept
 {
@@ -460,9 +438,10 @@ void UpdateAuxImpl::rewind_to_match_offsets()
     auto const *ci = db_metadata()->at(fast_offset.id);
     while (ci != db_metadata()->fast_list_end()) {
         auto const idx = db_metadata()->fast_list.end;
+        io->storage_pool().begin_free_seq_chunk(idx);
         remove(idx);
         io->storage_pool().chunk(storage_pool::seq, idx).destroy_contents();
-        append(chunk_list::free, idx);
+        io->storage_pool().free_seq_chunk(idx);
     }
     auto &fast_offset_chunk =
         io->storage_pool().chunk(storage_pool::seq, fast_offset.id);
@@ -472,9 +451,10 @@ void UpdateAuxImpl::rewind_to_match_offsets()
     auto const *slow_ci = db_metadata()->at(slow_offset.id);
     while (slow_ci != db_metadata()->slow_list_end()) {
         auto const idx = db_metadata()->slow_list.end;
+        io->storage_pool().begin_free_seq_chunk(idx);
         remove(idx);
         io->storage_pool().chunk(storage_pool::seq, idx).destroy_contents();
-        append(chunk_list::free, idx);
+        io->storage_pool().free_seq_chunk(idx);
     }
     auto &slow_offset_chunk =
         io->storage_pool().chunk(storage_pool::seq, slow_offset.id);
@@ -563,17 +543,37 @@ UpdateAuxImpl::~UpdateAuxImpl()
     #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 void UpdateAuxImpl::set_io(
-    AsyncIO &io_, std::optional<uint64_t> const history_len)
+    AsyncIO &io_, uint8_t const db_id,
+    std::optional<uint64_t> const history_len)
 {
     io = &io_;
+    db_id_ = db_id;
     auto const chunk_count = io->chunk_count();
     MONAD_ASSERT(chunk_count >= 3);
     auto const map_size =
         sizeof(detail::db_metadata) +
         chunk_count * sizeof(detail::db_metadata::chunk_info_t);
-    auto &cnv_chunk = io->storage_pool().chunk(storage_pool::cnv, 0);
-    auto const fdr = cnv_chunk.read_fd();
-    auto const fdw = cnv_chunk.write_fd(0);
+
+    uint32_t meta_cnv_id;
+    std::vector<uint32_t> ro_cnv_ids;
+    {
+        auto const *slot = io->storage_pool().find_db_slot(db_id);
+        MONAD_ASSERT_PRINTF(
+            slot != nullptr,
+            "db_id %u not found in pool catalog. "
+            "Use monad-mpt --create to initialize the pool.",
+            db_id);
+        meta_cnv_id = slot->metadata_cnv;
+        // Root offset locations resolved dynamically from pool catalog
+        for (uint16_t i = 0; i < slot->root_offset_cnv_count; ++i) {
+            ro_cnv_ids.push_back(uint32_t(slot->root_offset_cnv_start) + i);
+        }
+    }
+    MONAD_ASSERT(!ro_cnv_ids.empty());
+    auto &meta_chunk = io->storage_pool().chunk(storage_pool::cnv, meta_cnv_id);
+    auto const fdr = meta_chunk.read_fd();
+    auto const fdw = meta_chunk.write_fd(0);
+    auto const cnv_capacity = static_cast<uint64_t>(meta_chunk.capacity());
     /* We keep accidentally running MPT on 4Kb min granularity storage, so
     error out on that early to save everybody time and hassle.
 
@@ -635,7 +635,7 @@ void UpdateAuxImpl::set_io(
         prot,
         mapflags,
         fd.first,
-        off_t(fdr.second + cnv_chunk.capacity() / 2)));
+        off_t(fdr.second + cnv_capacity / 2)));
     MONAD_ASSERT(db_metadata_[1].main != MAP_FAILED);
     /* If on a storage which ignores TRIM, and the user just truncated
     an existing triedb, all the magics will be valid but the pool has
@@ -740,7 +740,7 @@ void UpdateAuxImpl::set_io(
     auto map_root_offsets = [&] {
         // Map in the DB version history storage
         // Firstly reserve address space for each copy
-        size_t const map_bytes_per_chunk = cnv_chunk.capacity() / 2;
+        size_t const map_bytes_per_chunk = cnv_capacity / 2;
         size_t const db_version_history_storage_bytes =
             db_metadata()->root_offsets.storage_.cnv_chunks_len *
             map_bytes_per_chunk;
@@ -761,19 +761,17 @@ void UpdateAuxImpl::set_io(
             -1,
             0);
         MONAD_ASSERT(reservation[1] != MAP_FAILED);
-        // For each chunk, map the first half into the first copy and the
-        // second half into the second copy
+        // For each stored root-offset chunk, look it up directly in the pool.
         for (size_t n = 0;
              n < db_metadata()->root_offsets.storage_.cnv_chunks_len;
              n++) {
-            auto &chunk = io->storage_pool().chunk(
-                storage_pool::cnv,
-                db_metadata()
-                    ->root_offsets.storage_.cnv_chunks[n]
-                    .cnv_chunk_id);
-            auto const fdr = chunk.read_fd();
-            auto const fdw = chunk.write_fd(0);
-            auto const &fd = can_write_to_map ? fdw : fdr;
+            auto const stored_id =
+                db_metadata()->root_offsets.storage_.cnv_chunks[n].cnv_chunk_id;
+            auto &ro_chunk =
+                io->storage_pool().chunk(storage_pool::cnv, stored_id);
+            auto const ro_fdr = ro_chunk.read_fd();
+            auto const ro_fdw = ro_chunk.write_fd(0);
+            auto const &fd = can_write_to_map ? ro_fdw : ro_fdr;
             MONAD_ASSERT(
                 MAP_FAILED != ::mmap(
                                   reservation[0] + n * map_bytes_per_chunk,
@@ -781,7 +779,7 @@ void UpdateAuxImpl::set_io(
                                   prot,
                                   mapflags | MAP_FIXED,
                                   fd.first,
-                                  off_t(fdr.second)));
+                                  off_t(ro_fdr.second)));
             MONAD_ASSERT(
                 MAP_FAILED != ::mmap(
                                   reservation[1] + n * map_bytes_per_chunk,
@@ -789,7 +787,7 @@ void UpdateAuxImpl::set_io(
                                   prot,
                                   mapflags | MAP_FIXED,
                                   fd.first,
-                                  off_t(fdr.second + map_bytes_per_chunk)));
+                                  off_t(ro_fdr.second + map_bytes_per_chunk)));
         }
         db_metadata_[0].root_offsets = {
             start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[0]),
@@ -813,61 +811,44 @@ void UpdateAuxImpl::set_io(
             can_write_to_map,
             "Neither copy of the DB metadata is valid, and not opened for "
             "writing so stopping now.");
-        for (uint32_t n = 0; n < chunk_count; n++) {
-            auto const &chunk = io->storage_pool().chunk(storage_pool::seq, n);
-            MONAD_ASSERT(
-                chunk.size() == 0,
-                "Trying to initialise new DB but storage pool contains "
-                "existing data, stopping now to prevent data loss.");
-        }
+        // Reclaim any orphaned chunks from a previously interrupted init.
+        io->storage_pool().reclaim_all_chunks_for_db(db_id);
         memset(db_metadata_[0].main, 0, map_size);
         MONAD_ASSERT((chunk_count & ~0xfffffU) == 0);
         db_metadata_[0].main->chunk_info_count = chunk_count & 0xfffffU;
-        MONAD_ASSERT(io->storage_pool().chunks(storage_pool::cnv) > 1);
+
         auto &storage = db_metadata_[0].main->root_offsets.storage_;
         memset(&storage, 0xff, sizeof(storage));
         storage.cnv_chunks_len = 0;
-        auto &chunk = io->storage_pool().chunk(storage_pool::cnv, 1);
-        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, chunk.capacity());
-        MONAD_ASSERT(tofill != nullptr);
-        auto const untofill =
-            make_scope_exit([&]() noexcept { ::free(tofill); });
-        memset(tofill, 0xff, chunk.capacity());
-        {
-            auto const fdw = chunk.write_fd(chunk.capacity());
-            MONAD_ASSERT(
-                -1 !=
-                ::pwrite(
-                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-        }
-        storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = 1;
-        db_metadata_[0].main->history_length =
-            chunk.capacity() / 2 / sizeof(chunk_offset_t);
-        // Allocate cnv chunks of the first device - 1 for root offsets,
-        // since chunk 0 is used for db_metadata
-        auto const root_offsets_chunk_count =
-            io->storage_pool().devices()[0].cnv_chunks() -
-            UpdateAuxImpl::cnv_chunks_for_db_metadata;
+        auto const root_offsets_chunk_count = ro_cnv_ids.size();
         MONAD_ASSERT(
             root_offsets_chunk_count > 0 &&
                 (root_offsets_chunk_count & (root_offsets_chunk_count - 1)) ==
                     0,
             "Number of cnv chunks for root offsets must be a power of two");
-        for (uint32_t n = 2; n <= root_offsets_chunk_count; n++) {
-            auto &chunk = io->storage_pool().chunk(storage_pool::cnv, n);
-            auto const fdw = chunk.write_fd(chunk.capacity());
+        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, cnv_capacity);
+        MONAD_ASSERT(tofill != nullptr);
+        auto const untofill =
+            make_scope_exit([&]() noexcept { ::free(tofill); });
+        memset(tofill, 0xff, cnv_capacity);
+        db_metadata_[0].main->history_length = 0;
+        for (uint32_t n = 0;
+             n < static_cast<uint32_t>(root_offsets_chunk_count);
+             n++) {
+            auto &ro_chunk =
+                io->storage_pool().chunk(storage_pool::cnv, ro_cnv_ids[n]);
+            auto const ro_fdw = ro_chunk.write_fd(ro_chunk.capacity());
             MONAD_ASSERT(
-                -1 !=
-                ::pwrite(
-                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-            storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = n;
+                -1 != ::pwrite(
+                          ro_fdw.first,
+                          tofill,
+                          ro_chunk.capacity(),
+                          static_cast<off_t>(ro_fdw.second)));
+            storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id =
+                ro_cnv_ids[n];
             db_metadata_[0].main->history_length +=
-                chunk.capacity() / 2 / sizeof(chunk_offset_t);
+                ro_chunk.capacity() / 2 / sizeof(chunk_offset_t);
         }
-        memset(
-            &db_metadata_[0].main->free_list,
-            0xff,
-            sizeof(db_metadata_[0].main->free_list));
         memset(
             &db_metadata_[0].main->fast_list,
             0xff,
@@ -887,32 +868,12 @@ void UpdateAuxImpl::set_io(
         // magics are not set yet, so memcpy is fine here
         memcpy(db_metadata_[1].main, db_metadata_[0].main, map_size);
 
-        // Insert all chunks into the free list
-        std::vector<uint32_t> chunks;
-        chunks.reserve(chunk_count);
-        for (uint32_t n = 0; n < chunk_count; n++) {
-            auto const chunk = io->storage_pool().chunk(storage_pool::seq, n);
-            MONAD_ASSERT(chunk.zone_id().first == storage_pool::seq);
-            MONAD_ASSERT(chunk.zone_id().second == n);
-            MONAD_ASSERT(chunk.size() == 0); // chunks must actually be free
-            chunks.push_back(n);
-        }
+        // Allocate fast and slow chunks from pool.
+        auto const fast_chunk_id = io->storage_pool().allocate_seq_chunk(db_id);
+        MONAD_ASSERT(fast_chunk_id != storage_pool::ALLOC_FAILED);
+        auto const slow_chunk_id = io->storage_pool().allocate_seq_chunk(db_id);
+        MONAD_ASSERT(slow_chunk_id != storage_pool::ALLOC_FAILED);
 
-#if MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS
-        std::reverse(chunks.begin(), chunks.end());
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in reverse order.",
-            chunk_count);
-#elif MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in random order.", chunk_count);
-        small_prng rand;
-        random_shuffle(chunks.begin(), chunks.end(), rand);
-#else
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in increasing order.",
-            chunk_count);
-#endif
         auto append_with_insertion_count_override = [&](chunk_list list,
                                                         uint32_t id) {
             append(list, id);
@@ -931,27 +892,17 @@ void UpdateAuxImpl::set_io(
                 override_insertion_count(db_metadata_[0].main);
                 override_insertion_count(db_metadata_[1].main);
             }
-            auto *i = db_metadata_[0].main->at_(id);
-            MONAD_ASSERT(i->index(db_metadata()) == id);
         };
-        // root offset is the front of fast list
-        chunk_offset_t const fast_offset(chunks.front(), 0);
+        chunk_offset_t const fast_offset(fast_chunk_id, 0);
         append_with_insertion_count_override(chunk_list::fast, fast_offset.id);
-        LOG_DEBUG_CFORMAT(
-            "Append one chunk to fast list, id: %d", fast_offset.id);
-        // init the first slow chunk and slow_offset
-        chunk_offset_t const slow_offset(chunks[1], 0);
+        io->storage_pool().commit_seq_chunk(fast_chunk_id);
+        chunk_offset_t const slow_offset(slow_chunk_id, 0);
         append_with_insertion_count_override(chunk_list::slow, slow_offset.id);
-        LOG_DEBUG_CFORMAT(
-            "Append one chunk to slow list, id: %d", slow_offset.id);
-        std::span const chunks_after_second(
-            chunks.data() + 2, chunks.size() - 2);
-        // insert the rest of the chunks to free list
-        for (uint32_t const i : chunks_after_second) {
-            append(chunk_list::free, i);
-            auto *i_ = db_metadata_[0].main->at_(i);
-            MONAD_ASSERT(i_->index(db_metadata()) == i);
-        }
+        io->storage_pool().commit_seq_chunk(slow_chunk_id);
+        LOG_INFO_CFORMAT(
+            "Initialized DB with fast=%u, slow=%u from pool.",
+            fast_chunk_id,
+            slow_chunk_id);
 
         // Mark as done, init root offset and history versions for the new
         // database as invalid
@@ -998,6 +949,51 @@ void UpdateAuxImpl::set_io(
         }
     }
     else { // resume from an existing db and underlying storage devices
+        // Reconcile all RESERVED chunks for this DB. Reentrancy in the
+        // node writer can leave more than one RESERVED chunk if a crash
+        // hits during a nested rollover. For each: if it's in our
+        // fast/slow list the append completed — promote to OWNED.
+        // Otherwise reclaim to FREE.
+        // Skip on strict read-only opens (PROT_READ). Allow-dirty
+        // pools use COW mappings and can heal in-memory state.
+        if (!io->storage_pool().is_read_only() ||
+            io->storage_pool().is_read_only_allow_dirty()) {
+            for (;;) {
+                auto const reserved =
+                    io->storage_pool().find_reserved_chunk(db_id);
+                if (reserved == storage_pool::ALLOC_FAILED) {
+                    break;
+                }
+                bool in_list = false;
+                for (auto const *ci = db_metadata()->fast_list_begin();
+                     ci != nullptr;
+                     ci = ci->next(db_metadata())) {
+                    if (ci->index(db_metadata()) == reserved) {
+                        in_list = true;
+                        break;
+                    }
+                }
+                if (!in_list) {
+                    for (auto const *ci = db_metadata()->slow_list_begin();
+                         ci != nullptr;
+                         ci = ci->next(db_metadata())) {
+                        if (ci->index(db_metadata()) == reserved) {
+                            in_list = true;
+                            break;
+                        }
+                    }
+                }
+                if (in_list) {
+                    io->storage_pool().commit_seq_chunk(reserved);
+                }
+                else {
+                    io->storage_pool()
+                        .chunk(storage_pool::seq, reserved)
+                        .destroy_contents();
+                    io->storage_pool().free_seq_chunk(reserved);
+                }
+            }
+        }
         map_root_offsets();
         if (!io->is_read_only()) {
             // Reset/init node writer's offsets, destroy contents after
@@ -1155,16 +1151,15 @@ Node::SharedPtr UpdateAuxImpl::do_update(
         physical_to_virtual(node_writer_slow->sender().offset());
     LOG_INFO_CFORMAT(
         "Finish upserting version %lu. Min valid version %lu. Time elapsed: "
-        "%ld us. Disk usage: %.4f. Chunks: %u fast, %u slow, %u free. Writer "
-        "offsets: fast={%u,%u}, slow={%u,%u}. Compaction head offset fast=%u, "
-        "slow=%u",
+        "%ld us. Disk usage: %.4f. Chunks: %u fast, %u slow. "
+        "Writer offsets: fast={%u,%u}, slow={%u,%u}. Compaction head offset "
+        "fast=%u, slow=%u",
         version,
         db_history_min_valid_version(),
         upsert_duration.count(),
         disk_usage(),
         num_chunks(chunk_list::fast),
         num_chunks(chunk_list::slow),
-        num_chunks(chunk_list::free),
         curr_fast_writer_offset.count,
         curr_fast_writer_offset.offset,
         curr_slow_writer_offset.count,
@@ -1242,7 +1237,8 @@ double UpdateAuxImpl::calculate_disk_usage_if_erased_up_to_and_including(
         fast_list_max_count - min_offsets.fast.get_count() + 1;
     auto const num_slow_chunks =
         slow_list_max_count - min_offsets.slow.get_count() + 1;
-    return (num_fast_chunks + num_slow_chunks) / (double)io->chunk_count();
+    return (num_fast_chunks + num_slow_chunks) /
+           (double)effective_chunk_budget();
 }
 
 void UpdateAuxImpl::adjust_history_length_based_on_disk_usage()
@@ -1411,8 +1407,8 @@ void UpdateAuxImpl::advance_compact_offsets(Node::SharedPtr const prev_root)
         }
     }
 
-    auto const fast_disk_usage =
-        num_chunks(chunk_list::fast) / (double)io->chunk_count();
+    auto const budget = effective_chunk_budget();
+    auto const fast_disk_usage = num_chunks(chunk_list::fast) / (double)budget;
     uint64_t const max_version = db_history_max_version();
     if ((fast_disk_usage < fast_usage_limit_start_compaction &&
          num_chunks(chunk_list::fast) <
@@ -1472,7 +1468,7 @@ void UpdateAuxImpl::advance_compact_offsets(Node::SharedPtr const prev_root)
     constexpr double usage_limit_start_compact_slow = 0.6;
     constexpr double slow_usage_limit_start_compact_slow = 0.2;
     double const slow_disk_usage =
-        num_chunks(chunk_list::slow) / (double)io->chunk_count();
+        num_chunks(chunk_list::slow) / (double)budget;
     double const total_disk_usage = fast_disk_usage + slow_disk_usage;
     // Do not compact slow list until slow list usage and total usage are both
     // above the thresholds
@@ -1566,13 +1562,12 @@ void UpdateAuxImpl::free_compacted_chunks()
                  count = (uint32_t)db_metadata()->at(idx)->insertion_count()) {
                 ci = ci->next(db_metadata()); // must be in this order
                 Stopwatch<std::chrono::microseconds> const timer;
+                io->storage_pool().begin_free_seq_chunk(idx);
                 remove(idx);
                 io->storage_pool()
                     .chunk(monad::async::storage_pool::seq, idx)
                     .destroy_contents();
-                append(
-                    UpdateAuxImpl::chunk_list::free,
-                    idx); // append not prepend
+                io->storage_pool().free_seq_chunk(idx);
                 // NOLINTNEXTLINE(bugprone-lambda-function-name)
                 LOG_INFO_CFORMAT(
                     "Free compacted chunk id %u, time elapsed: %ld us",
@@ -1596,13 +1591,7 @@ uint32_t UpdateAuxImpl::num_chunks(chunk_list const list) const noexcept
 {
     switch (list) {
     case chunk_list::free:
-        // Triggers when out of storage
-        MONAD_ASSERT(db_metadata()->free_list_begin() != nullptr);
-        MONAD_ASSERT(db_metadata()->free_list_end() != nullptr);
-
-        return (uint32_t)(db_metadata()->free_list_end()->insertion_count() -
-                          db_metadata()->free_list_begin()->insertion_count()) +
-               1;
+        MONAD_ABORT("chunk_list::free is not a valid query");
     case chunk_list::fast:
         // Triggers when out of storage
         MONAD_ASSERT(db_metadata()->fast_list_begin() != nullptr);


### PR DESCRIPTION

On main, a single database takes ownership of all the CNV and SEQ chunks in a pool. The pool object on `main` is more of a shim than an allocator.  This branch expands the responsibility of the pool by moving the freelist into the pool. This supports multiple DBs as tenants, each of which can request chunks and recycle them back into a shared pool.

### Core Changes
* Catalog: Each DB gets a `db_id -> CNV layout` entry in the pool footer. This allows for dynamic resolution of CNV chunks to support multiple DB instances.
* The pool owns a freelist of SEQ chunks.
* Per-DB SEQ limits: Each DB can optionally store a `max_seq_chunks` limit in its `db_metadata`. 
* `monad-mpt`: Support for multi-DB pools and per-DB chunk limits

#### Migration Support

The core changes are here to support migrations. Consider two DBs, `DB-primary` and `DB-migration`. `DB-migration` may be allocated a smaller amount of SEQ chunks (during the migration phase). Once complete, `DB-primary` could be deleted, returning all of its chunks to the freelist, and the `DB-migration` can have its usable chunks expanded to contain the whole device. In other words, the shared freelist allows for dynamic up- and downsizing of DB partitions.

* **compaction:** When a DB's chunk limit is reduced during live execution, compaction will begin to target that new disk size. Note that this is not immediate and the new disk size target becomes the target in a P-FF equation that runs every block.

### Compatibility

-   Pool footer format is now  MND1; old  MND0  pools are rejected under  create_if_needed  instead of being silently reformatted.
-   db_metadata  magic is now  MONAD008.
-   Runtime open is now catalog-backed; pools must be initialized with  monad-mpt --create  so DB slots exist.

### CLI examples

```
# Create a pool with two DBs
monad-mpt --storage /dev/triedb --create \
  --num-dbs 2 \
  --root-offsets-chunk-count-db1 2 \
  --root-offsets-chunk-count-db2 2

# At creation, limit both DBs to 32GB
monad-mpt --storage /dev/triedb --create \
  --num-dbs 2 \
  --max-seq-chunks-db1 128 \
  --max-seq-chunks-db2 128

# Increase DB1 to 64GB
monad-mpt --storage /dev/triedb --set-max-seq-chunks 256
```