### PR TITLE
Remove inflight read coalescing from rwdb find path

### DIFF
--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -530,7 +530,6 @@ struct OnDiskWithWorkerThreadImpl
         // Runs in the triedb worker thread
         void rwdb_run()
         {
-            inflight_map_t inflights;
             ::boost::container::deque<
                 threadsafe_boost_fibers_promise<find_cursor_result_type>>
                 find_promises;
@@ -558,11 +557,7 @@ struct OnDiskWithWorkerThreadImpl
                         find_promises.emplace_back(std::move(*req->promise));
                         req->promise = &find_promises.back();
                         find_notify_fiber_future(
-                            aux,
-                            inflights,
-                            *req->promise,
-                            req->start,
-                            req->key);
+                            aux, *req->promise, req->start, req->key);
                     }
                     else if (auto *req = std::get_if<2>(&request);
                              req != nullptr) {

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <utility>
 
@@ -48,7 +49,7 @@ namespace
     {
         static constexpr bool lifetime_managed_internally = true;
 
-        inflight_map_t &inflights;
+        std::function<result<void>(NodeCursor const &)> cont;
         Node::SharedPtr parent;
         chunk_offset_t rd_offset; // required for sender
         unsigned bytes_to_read; // required for sender too
@@ -56,9 +57,9 @@ namespace
         unsigned const branch_index;
 
         find_receiver(
-            inflight_map_t &inflights, Node::SharedPtr parent_,
-            unsigned char const branch)
-            : inflights(inflights)
+            std::function<result<void>(NodeCursor const &)> cont_,
+            Node::SharedPtr parent_, unsigned char const branch)
+            : cont(std::move(cont_))
             , parent(std::move(parent_))
             , rd_offset(0, 0)
             , branch_index(parent->to_child_index(branch))
@@ -75,28 +76,19 @@ namespace
             buffer_off = uint16_t(offset.offset - rd_offset.offset);
         }
 
-        //! notify a list of requests pending on this node
         template <class ResultType>
         void set_value(
             MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state,
             ResultType buffer_)
         {
             MONAD_ASSERT(buffer_);
-            auto const offset = parent->fnext(branch_index);
             auto node = parent->next(branch_index);
             if (node == nullptr) {
                 node = detail::deserialize_node_from_receiver_result(
                     std::move(buffer_), buffer_off, io_state);
                 parent->set_next(branch_index, node);
             }
-            auto const it = inflights.find(offset);
-            if (it != inflights.end()) {
-                auto const pendings = std::move(it->second);
-                inflights.erase(it);
-                for (auto const &cont : pendings) {
-                    MONAD_ASSERT(cont(NodeCursor{node}));
-                }
-            }
+            MONAD_ASSERT(cont(NodeCursor{node}));
         }
     };
 
@@ -193,12 +185,8 @@ namespace
     }
 }
 
-// Use a hashtable for inflight requests, it maps a file offset to a list of
-// requests. If a read request exists in the hash table, simply append to an
-// existing inflight read, Otherwise, send a read request and put itself on the
-// map
 void find_notify_fiber_future(
-    UpdateAuxImpl &aux, inflight_map_t &inflights,
+    UpdateAuxImpl &aux,
     threadsafe_boost_fibers_promise<find_cursor_result_type> &promise,
     NodeCursor const &root, NibblesView const key)
 {
@@ -238,7 +226,7 @@ void find_notify_fiber_future(
             key.substr(static_cast<unsigned char>(prefix_index) + 1u);
         auto const child_index = node->to_child_index(branch);
         if (auto const &next = node->next(child_index); next != nullptr) {
-            find_notify_fiber_future(aux, inflights, promise, next, next_key);
+            find_notify_fiber_future(aux, promise, next, next_key);
             return;
         }
         if (aux.io->owning_thread_id() != get_tl_tid()) {
@@ -247,19 +235,12 @@ void find_notify_fiber_future(
                  find_result::need_to_continue_in_io_thread});
             return;
         }
-        chunk_offset_t const offset = node->fnext(child_index);
-        auto cont = [&aux, &inflights, &promise, next_key](
+        auto cont = [&aux, &promise, next_key](
                         NodeCursor const &node_cursor) -> result<void> {
-            find_notify_fiber_future(
-                aux, inflights, promise, node_cursor, next_key);
+            find_notify_fiber_future(aux, promise, node_cursor, next_key);
             return success();
         };
-        if (auto const lt = inflights.find(offset); lt != inflights.end()) {
-            lt->second.emplace_back(cont);
-            return;
-        }
-        inflights[offset].emplace_back(cont);
-        find_receiver receiver(inflights, std::move(node), branch);
+        find_receiver receiver(std::move(cont), std::move(node), branch);
         detail::initiate_async_read_update(
             *aux.io, std::move(receiver), receiver.bytes_to_read);
     }

--- a/category/mpt/test/fiber_future_wrapped_find.cpp
+++ b/category/mpt/test/fiber_future_wrapped_find.cpp
@@ -41,15 +41,13 @@ namespace
     using namespace MONAD_ASYNC_NAMESPACE;
 
     void find(
-        UpdateAuxImpl *aux, inflight_map_t *const inflights,
-        Node::SharedPtr root, monad::byte_string_view const key,
-        monad::byte_string_view const value)
+        UpdateAuxImpl *aux, Node::SharedPtr root,
+        monad::byte_string_view const key, monad::byte_string_view const value)
     {
         monad::threadsafe_boost_fibers_promise<
             monad::mpt::find_cursor_result_type>
             promise;
-        find_notify_fiber_future(
-            *aux, *inflights, promise, NodeCursor{root}, key);
+        find_notify_fiber_future(*aux, promise, NodeCursor{root}, key);
         auto const [it, errc] = promise.get_future().get();
         ASSERT_TRUE(it.is_valid());
         EXPECT_EQ(errc, monad::mpt::find_result::success);
@@ -77,11 +75,9 @@ namespace
             root_hash(),
             0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes);
 
-        inflight_map_t inflights;
         boost::fibers::fiber find_fiber(
             find,
             &this->aux,
-            &inflights,
             root,
             one_hundred_updates[0].first,
             one_hundred_updates[0].second);
@@ -105,11 +101,10 @@ namespace
             root_hash(),
             0xcbb6d81afdc76fec144f6a1a283205d42c03c102a94fc210b3a1bcfdcb625884_bytes);
 
-        inflight_map_t inflights;
         std::vector<boost::fibers::fiber> fibers;
         fibers.reserve(one_hundred_updates.size());
         for (auto const &[key, val] : one_hundred_updates) {
-            fibers.emplace_back(find, &this->aux, &inflights, root, key, val);
+            fibers.emplace_back(find, &this->aux, root, key, val);
         }
 
         bool signal_done = false;

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -849,8 +849,7 @@ int main(int argc, char *argv[])
 
                     uint64_t ops{0};
                     bool signal_done{false};
-                    inflight_map_t inflights;
-                    auto find = [n_slices, &ops, &signal_done, &inflights](
+                    auto find = [n_slices, &ops, &signal_done](
                                     UpdateAuxImpl *aux,
                                     NodeCursor state_start,
                                     unsigned n) {
@@ -866,7 +865,7 @@ int main(int argc, char *argv[])
                                 monad::mpt::find_cursor_result_type>
                                 promise;
                             find_notify_fiber_future(
-                                *aux, inflights, promise, state_start, key);
+                                *aux, promise, state_start, key);
                             auto const [node_cursor, errc] =
                                 promise.get_future().get();
                             MONAD_ASSERT(node_cursor.is_valid());
@@ -975,7 +974,6 @@ int main(int argc, char *argv[])
                     };
 
                     auto poll = [&signal_done, &req](UpdateAuxImpl *aux) {
-                        inflight_map_t inflights;
                         fiber_find_request_t request;
                         for (;;) {
                             boost::this_fiber::yield();
@@ -990,7 +988,6 @@ int main(int argc, char *argv[])
                             if (req.try_dequeue(request)) {
                                 find_notify_fiber_future(
                                     *aux,
-                                    inflights,
                                     *request.promise,
                                     request.start,
                                     request.key);
@@ -1023,12 +1020,10 @@ int main(int argc, char *argv[])
                     while (signal_done <
                            int(random_read_benchmark_threads + 1)) {
                         boost::this_fiber::yield();
-                        inflight_map_t inflights;
                         fiber_find_request_t request;
                         if (req.try_dequeue(request)) {
                             find_notify_fiber_future(
                                 aux,
-                                inflights,
                                 *request.promise,
                                 request.start,
                                 request.key);

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -477,8 +477,7 @@ TYPED_TEST(PlainTrieTest, large_values)
     {
         monad::threadsafe_boost_fibers_promise<find_cursor_result_type> p;
         auto fut = p.get_future();
-        inflight_map_t inflights;
-        find_notify_fiber_future(this->aux, inflights, p, this->root, key1);
+        find_notify_fiber_future(this->aux, p, this->root, key1);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
             this->aux.io->wait_until_done();
@@ -495,8 +494,7 @@ TYPED_TEST(PlainTrieTest, large_values)
     {
         monad::threadsafe_boost_fibers_promise<find_cursor_result_type> p;
         auto fut = p.get_future();
-        inflight_map_t inflights;
-        find_notify_fiber_future(this->aux, inflights, p, this->root, key2);
+        find_notify_fiber_future(this->aux, p, this->root, key2);
         while (fut.wait_for(std::chrono::seconds(0)) !=
                ::boost::fibers::future_status::ready) {
             this->aux.io->wait_until_done();

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -675,12 +675,6 @@ using find_result_type = std::pair<T, find_result>;
 using find_cursor_result_type = find_result_type<NodeCursor>;
 using find_owning_cursor_result_type = find_result_type<NodeCursor>;
 
-using inflight_map_t = ankerl::unordered_dense::segmented_map<
-    chunk_offset_t,
-    std::vector<
-        std::function<MONAD_ASYNC_NAMESPACE::result<void>(NodeCursor const &)>>,
-    chunk_offset_t_hasher>;
-
 using inflight_map_owning_t = ankerl::unordered_dense::segmented_map<
     virtual_chunk_offset_t,
     std::vector<
@@ -705,8 +699,7 @@ class NodeCache;
 // during execution, DO NOT invoke it directly from a transaction fiber, as is
 // not race free.
 void find_notify_fiber_future(
-    UpdateAuxImpl &, inflight_map_t &,
-    threadsafe_boost_fibers_promise<find_cursor_result_type> &,
+    UpdateAuxImpl &, threadsafe_boost_fibers_promise<find_cursor_result_type> &,
     NodeCursor const &start, NibblesView key);
 
 // rodb


### PR DESCRIPTION
The inflight map made sense when the DB used direct IO, where duplicate reads hit storage each time. With buffered IO, duplicates hit the page cache, making the per-read hash map overhead a net negative.

When running 19M for 100k blocks, coalescence took place for only 2.4% of reads, and removing all coalescing infrastructure showed no measurable difference in throughput, latency, or I/O thread utilization.

Concurrent reads to the same uncached node now issue independent io_uring reads. The second completion finds the node already cached via `parent->set_next()` and skips deserialization.

This does not remove inflight coalescing for the RODB. That can probably be removed too but haven't tested with RODB traffic.