### PR TITLE
[triedb] Preserve in-memory trie state across finalization

### DIFF
--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -138,7 +138,6 @@ public:
             storage_.clear();
         }
         db_.finalize(block_number, block_id);
-        proposals_.set_block_and_prefix(block_number, block_id);
     }
 
     virtual void update_verified_block(uint64_t const block_number) override

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -356,6 +356,70 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     }
 }
 
+// Tests the !is_current_block path in finalize: commit two blocks as proposals,
+// then finalize the earlier one while the in-memory trie is at the later block.
+// Verifies that the in-memory trie is preserved and that set_block_and_prefix
+// correctly reloads the finalized state from disk.
+TEST_F(OnDiskTrieDbFixture, finalize_earlier_block_preserves_in_memory_trie)
+{
+    Account const acct_10{.balance = 100};
+    Account const acct_11{.balance = 200};
+
+    TrieDb tdb{db};
+    load_header({}, db, BlockHeader{.number = 9});
+
+    // Commit block 10 as a proposal
+    tdb.set_block_and_prefix(9);
+    bytes32_t const p10{10};
+    commit_simple(
+        tdb,
+        StateDeltas{{ADDR_A, StateDelta{.account = {std::nullopt, acct_10}}}},
+        Code{},
+        p10,
+        BlockHeader{.number = 10});
+
+    // Finalize block 10 and advance to finalized state
+    tdb.finalize(10, p10);
+    tdb.set_block_and_prefix(10); // finalized
+    EXPECT_EQ(tdb.read_account(ADDR_A).value().balance, 100);
+
+    // Commit block 11 as a proposal — block_number_ becomes 11
+    bytes32_t const p11{11};
+    commit_simple(
+        tdb,
+        StateDeltas{{ADDR_A, StateDelta{.account = {acct_10, acct_11}}}},
+        Code{},
+        p11,
+        BlockHeader{.number = 11});
+    EXPECT_EQ(tdb.get_block_number(), 11);
+
+    // Commit block 12 as a proposal on top of block 11
+    Account const acct_12{.balance = 300};
+    bytes32_t const p12{12};
+    tdb.set_block_and_prefix(11, p11);
+    commit_simple(
+        tdb,
+        StateDeltas{{ADDR_A, StateDelta{.account = {acct_11, acct_12}}}},
+        Code{},
+        p12,
+        BlockHeader{.number = 12});
+    EXPECT_EQ(tdb.get_block_number(), 12);
+
+    // Finalizing a different block (11) than current block (12) should only
+    // persist finalized state to disk without disturbing the in-memory trie for
+    // block 12.
+    tdb.finalize(11, p11);
+    EXPECT_EQ(tdb.get_block_number(), 12);
+
+    // The in-memory trie for block 12 is still valid
+    tdb.set_block_and_prefix(12, p12);
+    EXPECT_EQ(tdb.read_account(ADDR_A).value().balance, 300);
+
+    // set to finalized block 11 should reload from disk
+    tdb.set_block_and_prefix(11);
+    EXPECT_EQ(tdb.read_account(ADDR_A).value().balance, 200);
+}
+
 TYPED_TEST(DBTest, ModifyStorageOfAccount)
 {
     Account acct{.balance = 1'000'000, .code_hash = {}, .nonce = 1337};

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -221,7 +221,17 @@ void TrieDb::set_block_and_prefix(
     proposal_block_id_ = block_id;
 }
 
-// also changes internal state to the finalized state
+// Finalizes the trie for `block_id` by copying its proposal trie into the
+// finalized prefix on disk. Does not modify the internal state used by
+// subsequent reads, such as `prefix_` or `block_number_`.
+//
+// The in-memory trie represented by `curr_root_` is only updated when
+// finalizing the current block, in which case `curr_root_` is updated to keep
+// the cache consistent with disk.
+//
+// For non-current block finalization, the in-memory trie is intentionally left
+// unchanged so that subsequent in-order `set_block_and_prefix` calls can reuse
+// cached top-level nodes instead of cold-loading from disk.
 void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
 {
     // no re-finalization
@@ -235,15 +245,16 @@ void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk()) {
         auto const src_prefix = proposal_prefix(block_id);
-        auto root = (block_number_ == block_number)
-                        ? curr_root_
-                        : db_.load_root_for_version(block_number);
+        bool const is_current_block = block_number_ == block_number;
+        auto root = is_current_block ? curr_root_
+                                     : db_.load_root_for_version(block_number);
         MONAD_ASSERT(db_.find(root, src_prefix, block_number).has_value());
-        curr_root_ = db_.copy_trie(
+        root = db_.copy_trie(
             root, src_prefix, root, finalized_nibbles, block_number, true);
-        prefix_ = finalized_nibbles;
+        if (is_current_block) {
+            curr_root_ = std::move(root);
+        }
     }
-    block_number_ = block_number;
     db_.update_finalized_version(block_number);
 }
 

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -1370,13 +1370,12 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
             bytes32_t{10},
             BlockHeader{.number = 10});
         this->tdb.finalize(10, bytes32_t{10});
-
+        this->tdb.set_block_and_prefix(10);
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
         EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value2);
-
-        this->tdb.set_block_and_prefix(10, bytes32_t{10});
     }
     { // Commit to Block 11 Round 6, on top of block 10 round 5
+        this->tdb.set_block_and_prefix(10, bytes32_t{10});
         BlockState bs{this->tdb, this->vm};
         State cs{bs, Incarnation{2, 1}};
         EXPECT_TRUE(cs.account_exists(a));

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -124,7 +124,8 @@ Node::SharedPtr copy_trie_impl(
             src_node,
             dest_prefix.substr(1),
             src_node.opt_value(),
-            static_cast<int64_t>(dest_version));
+            static_cast<int64_t>(dest_version),
+            false /* copy instead of move */);
         ChildData child{
             .ptr = std::move(new_node), .branch = dest_prefix.get(0)};
         child.subtrie_min_version = calc_min_version(*child.ptr);
@@ -154,8 +155,8 @@ Node::SharedPtr copy_trie_impl(
         parents_and_indexes{std::move(vec_pairs)};
 
     // Insert `dest` to trie, create the `dest` node to have the same
-    // children as node at `src`. Disconnect src_node's in memory children to
-    // avoid double references
+    // children as node at `src`. Child pointers are copied (not moved) so
+    // the in-memory subtrie under `src` remains cached after the call.
     while (prefix_index < dest_prefix.nibble_size()) {
         auto const nibble = dest_prefix.get(prefix_index);
         if (node_prefix_index < node->path_nibbles_len()) {
@@ -177,7 +178,8 @@ Node::SharedPtr copy_trie_impl(
                 dest_prefix.substr(
                     static_cast<unsigned char>(prefix_index) + 1u),
                 src_node.opt_value(),
-                src_node.version);
+                src_node.version,
+                false /* copy instead of move */);
             auto node_latter_half = make_node(
                 *node,
                 node_path.substr(
@@ -220,7 +222,8 @@ Node::SharedPtr copy_trie_impl(
             src_node,
             dest_prefix.substr(static_cast<unsigned char>(prefix_index) + 1u),
             src_node.opt_value(),
-            src_node.version);
+            src_node.version,
+            false /* copy instead of move */);
         new_node = create_node_add_new_branch(
             aux,
             node.get(),
@@ -240,7 +243,8 @@ Node::SharedPtr copy_trie_impl(
             src_node,
             node->path_nibble_view(),
             src_node.opt_value(),
-            static_cast<int64_t>(dest_version));
+            static_cast<int64_t>(dest_version),
+            false /* copy instead of move */);
     }
     if (node.get() == dest_root.get()) {
         MONAD_ASSERT(parents_and_indexes.empty());

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -500,7 +500,8 @@ void ChildData::copy_old_child(Node *const old, unsigned const i)
 
 Node::SharedPtr make_node(
     Node &from, NibblesView const path,
-    std::optional<byte_string_view> const value, int64_t const version)
+    std::optional<byte_string_view> const value, int64_t const version,
+    bool const is_move)
 {
     auto const value_size =
         value.transform(&byte_string_view::size).value_or(0);
@@ -536,7 +537,12 @@ Node::SharedPtr make_node(
     }
     auto const from_ptrs = from.child_next_data();
     for (unsigned i = 0; i < from_ptrs.size(); ++i) {
-        node_ptrs[i] = std::move(from_ptrs[i]);
+        if (is_move) {
+            node_ptrs[i] = std::move(from_ptrs[i]);
+        }
+        else {
+            node_ptrs[i] = from_ptrs[i];
+        }
     }
 
     return node;

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -391,7 +391,7 @@ constexpr size_t MAX_VALUE_LEN_OF_LEAF =
 
 Node::SharedPtr make_node(
     Node &from, NibblesView path, std::optional<byte_string_view> value,
-    int64_t version);
+    int64_t version, bool is_move = true);
 
 Node::SharedPtr make_node(
     uint16_t mask, std::span<ChildData>, NibblesView path,


### PR DESCRIPTION
The possible ordering of db operations that carry in memory state changes:
```
db.set_block_and_prefix(N-1, P-1)
db.commit(N, P)
db.set_block_and_prefix(N, P)
db.commit(N+1, P+1)
db.finalize(N, P)  
db.finalize(N+1, N+1)
...
```
**Current:** 
finalize(N,P) moves in memory proposal subtrie P to finalized prefix, and resets the TrieDb internal in memory trie to of version N. 

**This PR:** 
finalize(N,P) copies the in memory proposal subtrie P instead of a move (increment the refcount), and does not reset the version TrieDb internal in memory trie. So execution along one proposal chain does not invalidate cached trie.

## Commits Summary
**Commit 1:** 
Copy instead of move child pointers in copy_trie to keep src subtrie cached 
after the call. 

**Commit 2:**
  finalize() previously overwrote curr_root_, prefix_, and block_number_
  unconditionally, forcing subsequent set_block_and_prefix calls to
  cold-load all top-level nodes from disk. Now finalize() only updates
  curr_root_ when the finalized block matches the in-memory block
  (block_number_ == block_number), leaving the cached trie intact
  otherwise. This allows the runloop to retain warm top-level nodes
  across sequential block execution.

  Also removes the redundant proposals_.set_block_and_prefix() call
  from DbCache::finalize().
