### PR TITLE
Add bulk down(NibblesView) to StateMachine, replacing per-nibble loops

### DIFF
--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -541,48 +541,13 @@ void MachineBase::down(unsigned char const nibble)
     MONAD_ASSERT(trie_section != TrieType::Undefined);
     auto const prefix_length = prefix_len();
     MONAD_ASSERT(depth <= max_depth(prefix_length));
-    MONAD_ASSERT(
-        (nibble == STATE_NIBBLE || nibble == CODE_NIBBLE ||
-         nibble == RECEIPT_NIBBLE || nibble == CALL_FRAME_NIBBLE ||
-         nibble == TRANSACTION_NIBBLE || nibble == BLOCKHEADER_NIBBLE ||
-         nibble == WITHDRAWAL_NIBBLE || nibble == OMMER_NIBBLE ||
-         nibble == TX_HASH_NIBBLE || nibble == BLOCK_HASH_NIBBLE) ||
-        depth != prefix_length);
     if (MONAD_UNLIKELY(depth == prefix_length)) {
         MONAD_ASSERT(table == TableType::Prefix);
-        if (nibble == STATE_NIBBLE) {
-            table = TableType::State;
-        }
-        else if (nibble == RECEIPT_NIBBLE) {
-            table = TableType::Receipt;
-        }
-        else if (nibble == TRANSACTION_NIBBLE) {
-            table = TableType::Transaction;
-        }
-        else if (nibble == CODE_NIBBLE) {
-            table = TableType::Code;
-        }
-        else if (nibble == WITHDRAWAL_NIBBLE) {
-            table = TableType::Withdrawal;
-        }
-        else if (nibble == TX_HASH_NIBBLE) {
-            table = TableType::TxHash;
-        }
-        else if (nibble == BLOCK_HASH_NIBBLE) {
-            table = TableType::BlockHash;
-        }
-        else if (nibble == BLOCKHEADER_NIBBLE) {
-            table = TableType::BlockHeader;
-        }
-        else if (nibble == OMMER_NIBBLE) {
-            table = TableType::Ommer;
-        }
-        else if (nibble == CALL_FRAME_NIBBLE) {
-            table = TableType::CallFrame;
-        }
-        else {
-            MONAD_ABORT_PRINTF("Invalid nibble %u", (unsigned)nibble);
-        }
+        MONAD_ASSERT_PRINTF(
+            nibble <= CALL_FRAME_NIBBLE,
+            "Invalid nibble %u",
+            static_cast<unsigned>(nibble));
+        table = static_cast<TableType>(nibble + 1);
     }
 }
 

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -551,6 +551,57 @@ void MachineBase::down(unsigned char const nibble)
     }
 }
 
+void MachineBase::down(mpt::NibblesView const path)
+{
+    auto const n = static_cast<unsigned>(path.nibble_size());
+    unsigned i = 0;
+
+    // Handle trie_section nibble (depth == TOP_NIBBLE_PREFIX_LEN)
+    if (MONAD_UNLIKELY(depth < TOP_NIBBLE_PREFIX_LEN && i < n)) {
+        MONAD_ASSERT(trie_section == TrieType::Undefined);
+        MONAD_ASSERT(table == TableType::Prefix);
+        trie_section = (path.get(i) == PROPOSAL_NIBBLE) ? TrieType::Proposal
+                                                        : TrieType::Finalized;
+        MONAD_ASSERT(
+            path.get(i) == PROPOSAL_NIBBLE || path.get(i) == FINALIZED_NIBBLE);
+        ++depth;
+        ++i;
+    }
+
+    // Handle table nibble (depth == prefix_len())
+    MONAD_ASSERT(trie_section != TrieType::Undefined || i == n);
+    auto const pl = prefix_len();
+    if (MONAD_UNLIKELY(depth < pl && i < n)) {
+        auto const nibbles_to_table = static_cast<unsigned>(pl - depth);
+        if (nibbles_to_table <= n - i) {
+            // Bulk-advance intermediate prefix nibbles, then process table
+            // nibble
+            depth += static_cast<uint8_t>(nibbles_to_table - 1);
+            i += nibbles_to_table - 1;
+            MONAD_ASSERT_PRINTF(
+                path.get(i) <= CALL_FRAME_NIBBLE,
+                "Invalid nibble %u",
+                static_cast<unsigned>(path.get(i)));
+            MONAD_ASSERT(table == TableType::Prefix);
+            table = static_cast<TableType>(path.get(i) + 1);
+            ++depth;
+            ++i;
+        }
+        else {
+            // Path ends before reaching table nibble
+            auto const new_depth = static_cast<unsigned>(depth) + (n - i);
+            MONAD_ASSERT(new_depth <= max_depth(pl));
+            depth = static_cast<uint8_t>(new_depth);
+            return;
+        }
+    }
+
+    // Bulk advance: all remaining nibbles just increment depth
+    auto const new_depth = static_cast<unsigned>(depth) + (n - i);
+    MONAD_ASSERT(new_depth <= max_depth(pl));
+    depth = static_cast<uint8_t>(new_depth);
+}
+
 void MachineBase::up(size_t const n)
 {
     MONAD_ASSERT(n <= depth);

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -52,6 +52,7 @@ struct MachineBase : public mpt::StateMachine
         Proposal
     };
 
+    // Order matches nibble values: TableType(nibble + 1)
     enum class TableType : uint8_t
     {
         Prefix,
@@ -59,11 +60,11 @@ struct MachineBase : public mpt::StateMachine
         Code,
         Receipt,
         Transaction,
+        BlockHeader,
         Withdrawal,
+        Ommer,
         TxHash,
         BlockHash,
-        BlockHeader,
-        Ommer,
         CallFrame,
     };
 

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -74,6 +74,7 @@ struct MachineBase : public mpt::StateMachine
 
     virtual mpt::Compute &get_compute() const override;
     virtual void down(unsigned char const nibble) override;
+    virtual void down(mpt::NibblesView path) override;
     virtual void up(size_t const n) override;
     virtual bool is_variable_length() const override;
     constexpr uint8_t prefix_len() const;

--- a/category/mpt/state_machine.hpp
+++ b/category/mpt/state_machine.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <category/mpt/config.hpp>
+#include <category/mpt/nibbles_view.hpp>
 
 #include <memory>
 #include <stddef.h>
@@ -29,6 +30,14 @@ struct StateMachine
     virtual ~StateMachine() = default;
     virtual std::unique_ptr<StateMachine> clone() const = 0;
     virtual void down(unsigned char nibble) = 0;
+
+    virtual void down(NibblesView path)
+    {
+        for (unsigned i = 0; i < path.nibble_size(); ++i) {
+            down(path.get(i));
+        }
+    }
+
     virtual void up(size_t) = 0;
     virtual Compute &get_compute() const = 0;
     virtual bool cache() const = 0;

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -187,9 +187,7 @@ Node::SharedPtr upsert(
         if (updates.empty()) {
             auto const old_path = old->path_nibble_view();
             auto const old_path_nibbles_len = old_path.nibble_size();
-            for (unsigned n = 0; n < old_path_nibbles_len; ++n) {
-                sm.down(old_path.get(n));
-            }
+            sm.down(old_path);
             // simply dispatch empty update and potentially do compaction
             Requests requests;
             Node const &old_node = *old;
@@ -304,9 +302,7 @@ struct load_all_impl_
         for (auto const [idx, i] : NodeChildrenRange(node->mask)) {
             NibblesView const nv =
                 node->path_nibble_view().substr(node_cursor.prefix_index);
-            for (uint8_t n = 0; n < nv.nibble_size(); n++) {
-                sm.down(nv.get(n));
-            }
+            sm.down(nv);
             sm.down(i);
             if (sm.cache()) {
                 auto next = node->next(idx);
@@ -711,9 +707,7 @@ void create_new_trie_(
         Update &update = updates.front();
         MONAD_ASSERT(update.value.has_value());
         auto const path = update.key.substr(prefix_index);
-        for (auto i = 0u; i < path.nibble_size(); ++i) {
-            sm.down(path.get(i));
-        }
+        sm.down(path);
         MONAD_ASSERT(
             !sm.is_variable_length() || update.next.empty(),
             "Invalid update detected: variable-length tables do not "
@@ -1056,9 +1050,7 @@ void mismatch_handler_(
             // nexts[j] is a path-shortened old node, trim prefix
             NibblesView const path_suffix =
                 old.path_nibble_view().substr(old_prefix_index + 1);
-            for (auto i = 0u; i < path_suffix.nibble_size(); ++i) {
-                sm.down(path_suffix.get(i));
-            }
+            sm.down(path_suffix);
             auto &child = children[index];
             child.branch = branch;
             // Updated node inherits the version number directly from old node


### PR DESCRIPTION
Add a down(NibblesView) overload that processes an entire path in one call. MachineBase's override handles the two prefix-sensitive nibbles (trie_section and table type) individually, then bulk-advances depth for all remaining nibbles with a single addition — no per-nibble branching or virtual dispatch.

Replace 4 per-nibble loops in trie.cpp with single sm.down(path) calls. The default StateMachine::down(NibblesView) loops over down(nibble) so test state machines work unchanged.

perf stat on snapshot restore, cumulative with prior TableType arithmetic dispatch:
  branches:      91.2B → 73.0B (-20%)
  instructions:  726B → 651B (-10.4%)
  cycles:        303B → 259B (-14.6%)
  wall time:     55.2s → 47.6s (-13.8%)