### PR TITLE
DbCache: Support reading finalized state older than latest finalized block

### DIFF
--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -1606,6 +1606,9 @@ TEST_F(OnDiskStateTest, proposal_basics)
     EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
     db_cache.finalize(12, bytes32_t{12});
     EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
+    // read an older block's state
+    db_cache.set_block_and_prefix(11); // set to block 11 finalized
+    EXPECT_EQ(db_cache.read_account(a).value().balance, 30'000);
 }
 
 TEST_F(OnDiskStateTest, undecided_proposals)

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -193,22 +193,19 @@ private:
         int depth = 1;
         bytes32_t block_id = block_id_;
         uint64_t block_number = block_;
+        if (block_id == finalized_block_id_ ||
+            (block_number == finalized_block_ && block_id == bytes32_t{})) {
+            return false;
+        }
+        else if (block_number <= finalized_block_) {
+            truncated = true;
+            return false;
+        }
         while (true) {
             if (block_id == finalized_block_id_) {
+                // stop if reached last finalized without match in proposal map
                 break;
             }
-            MONAD_ASSERT_PRINTF(
-                block_number > finalized_block_,
-                "block_number %lu is not greater than last finalized block "
-                "%lu. block_id = %s, block_ %lu, block_id_ %s, "
-                "finalized_block_id_ = %s, depth = %d",
-                block_number,
-                finalized_block_,
-                to_hex(to_byte_string_view(block_id.bytes)).c_str(),
-                block_,
-                to_hex(to_byte_string_view(block_id_.bytes)).c_str(),
-                to_hex(to_byte_string_view(finalized_block_id_.bytes)).c_str(),
-                depth);
             auto const it =
                 proposal_map_.find(std::make_pair(block_number, block_id));
             if (it == proposal_map_.end()) {


### PR DESCRIPTION
- Fix `Proposals::try_read` assert-fail when reading older than the latest 
   finalized block. Although this scenario doesn't occur in the current                                                     
    execution runloop, `DbCache` should support any read that `mpt::Db` can.                                                         
- Replace the assertion with explicit checks before the chain walk, set correct 
   value to `truncated` so DbCache looks up in LRU cache or fall through to 
   the trie correctly.
- The added test lines in `proposal_basics` work only after the change.