### PR TITLE
[core] Wire MONAD_CORE_FORCE_DEBUG_ASSERT into assert.h and fix assert usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ function(monad_compile_options target)
 
   if(MONAD_COMPILER_TESTING)
     target_compile_definitions(${target} PUBLIC "MONAD_COMPILER_TESTING=1")
+    target_compile_definitions(${target} PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT=1")
   endif()
 
   if(MONAD_COMPILER_STATS)

--- a/category/core/assert.h
+++ b/category/core/assert.h
@@ -115,14 +115,14 @@ extern "C"
             buf);                                                              \
     }
 
-#ifdef NDEBUG
+#if !defined(NDEBUG) || defined(MONAD_CORE_FORCE_DEBUG_ASSERT)
+    #define MONAD_DEBUG_ASSERT(x) MONAD_ASSERT(x)
+#else
     #define MONAD_DEBUG_ASSERT(x)                                              \
         do {                                                                   \
             (void)sizeof(x);                                                   \
         }                                                                      \
         while (0)
-#else
-    #define MONAD_DEBUG_ASSERT(x) MONAD_ASSERT(x)
 #endif
 
 #ifdef __cplusplus

--- a/category/vm/compiler/ir/local_stacks.cpp
+++ b/category/vm/compiler/ir/local_stacks.cpp
@@ -275,6 +275,7 @@ namespace monad::vm::compiler::local_stacks
             static_assert(sizeof(size_t) <= sizeof(uint64_t));
             MONAD_ASSERT(data <= uint256_t{std::numeric_limits<size_t>::max()});
             param = data[0];
+            break;
         default:
             // do nothing
             break;

--- a/category/vm/llvm/execute.cpp
+++ b/category/vm/llvm/execute.cpp
@@ -225,8 +225,7 @@ namespace monad::vm::llvm
             return load_from_disk_impl<EvmTraits<EVMC_OSAKA>>(fn);
 
         default:
-            MONAD_ASSERT(
-                false && "Tried to load unsupported EVM revision from disk");
+            MONAD_ABORT("Tried to load unsupported EVM revision from disk");
         }
     }
 
@@ -285,7 +284,7 @@ namespace monad::vm::llvm
             return compile_impl<EvmTraits<EVMC_OSAKA>>(code, dbg_nm);
 
         default:
-            MONAD_ASSERT(false && "Tried to compile unsupported EVM revision");
+            MONAD_ABORT("Tried to compile unsupported EVM revision");
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Wire `MONAD_CORE_FORCE_DEBUG_ASSERT` into `assert.h`** — the CMake option existed but was never checked, making it a dead flag. `MONAD_DEBUG_ASSERT` now stays active under `NDEBUG` when the flag is set, and `MONAD_COMPILER_TESTING` automatically enables it, restoring debug assertions lost after the `MONAD_VM_ASSERT` migration (#2187).
- **Fix missing `break`** in `local_stacks.cpp` switch case that fell through to `default`.
- **Replace `MONAD_ASSERT(false && "...")`** with `MONAD_ABORT("...")` in `execute.cpp` for clearer unconditional abort semantics.

## Test plan

- [ ] CI passes (compiler-testing build verifies debug asserts are active under NDEBUG)
- [ ] Verify `local_stacks.cpp` switch no longer falls through
- [ ] Verify `MONAD_ABORT` fires correctly in unreachable paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)