### PR TITLE
[vm] Extract FuzzerBackend abstraction from evmone types

### DIFF
--- a/test/vm/fuzzer/CMakeLists.txt
+++ b/test/vm/fuzzer/CMakeLists.txt
@@ -19,7 +19,12 @@ target_sources(monad-compiler-fuzzer PRIVATE
   assertions.cpp
   assertions.hpp
   compiler_hook.hpp
-  fuzzer.cpp)
+  evmone_backend.hpp
+  evmone_backend.cpp
+  fuzzer.cpp
+  fuzzer_backend.hpp
+  fuzzer_backend.cpp
+  fuzzer_view.hpp)
 
 target_link_libraries(monad-compiler-fuzzer
   PRIVATE evmone::state

--- a/test/vm/fuzzer/assertions.cpp
+++ b/test/vm/fuzzer/assertions.cpp
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "account.hpp"
-#include "state.hpp"
+#include "assertions.hpp"
+#include "fuzzer_view.hpp"
 
 #include <category/core/assert.h>
 
@@ -22,57 +22,11 @@
 #include <evmc/evmc.hpp>
 
 #include <algorithm>
+#include <ranges>
 #include <span>
-
-using namespace evmone::state;
 
 namespace monad::vm::fuzzing
 {
-    void assert_equal(StorageValue const &a, StorageValue const &b)
-    {
-        MONAD_ASSERT(a.current == b.current);
-        MONAD_ASSERT(a.original == b.original);
-        MONAD_ASSERT(a.access_status == b.access_status);
-    }
-
-    void assert_equal(Account const &a, Account const &b)
-    {
-        MONAD_ASSERT(a.transient_storage.size() == b.transient_storage.size());
-        for (auto const &[k, v] : a.transient_storage) {
-            auto const found = b.transient_storage.find(k);
-            MONAD_ASSERT(found != b.transient_storage.end());
-            MONAD_ASSERT(found->second == v);
-        }
-
-        MONAD_ASSERT(a.storage.size() == b.storage.size());
-        for (auto const &[k, v] : a.storage) {
-            auto const found = b.storage.find(k);
-            MONAD_ASSERT(found != b.storage.end());
-            assert_equal(v, found->second);
-        }
-
-        MONAD_ASSERT(a.nonce == b.nonce);
-        MONAD_ASSERT(a.balance == b.balance);
-        MONAD_ASSERT(a.code_hash == b.code_hash);
-        MONAD_ASSERT(a.destructed == b.destructed);
-        MONAD_ASSERT(a.erase_if_empty == b.erase_if_empty);
-        MONAD_ASSERT(a.just_created == b.just_created);
-        MONAD_ASSERT(a.access_status == b.access_status);
-    }
-
-    void assert_equal(State const &a, State const &b)
-    {
-        auto const &a_accs = a.get_modified_accounts();
-        auto const &b_accs = b.get_modified_accounts();
-
-        MONAD_ASSERT(a_accs.size() == b_accs.size());
-        for (auto const &[k, v] : a_accs) {
-            auto const found = b_accs.find(k);
-            MONAD_ASSERT(found != b_accs.end());
-            assert_equal(v, found->second);
-        }
-    }
-
     void assert_equal(
         evmc::Result const &evmone_result, evmc::Result const &compiler_result,
         bool const strict_out_of_gas)
@@ -118,4 +72,46 @@ namespace monad::vm::fuzzing
         }
     }
 
+    void assert_states_equal(SortedStateView const &a, SortedStateView const &b)
+    {
+        MONAD_ASSERT(a.size() == b.size());
+
+        for (auto const &[a_acc, b_acc] : std::views::zip(a, b)) {
+            MONAD_ASSERT(a_acc.addr == b_acc.addr);
+            MONAD_ASSERT(a_acc.nonce == b_acc.nonce);
+            MONAD_ASSERT(a_acc.balance == b_acc.balance);
+            MONAD_ASSERT(a_acc.code_hash == b_acc.code_hash);
+            MONAD_ASSERT(std::ranges::equal(a_acc.code, b_acc.code));
+
+            auto const a_st = a.storage(a_acc.addr);
+            auto const b_st = b.storage(b_acc.addr);
+
+            MONAD_ASSERT(a_st->size() == b_st->size());
+
+            for (auto const &[a_se, b_se] : std::views::zip(*a_st, *b_st)) {
+                MONAD_ASSERT(a_se.key == b_se.key);
+                MONAD_ASSERT(a_se.current == b_se.current);
+                MONAD_ASSERT(a_se.original == b_se.original);
+                MONAD_ASSERT(a_se.access_status == b_se.access_status);
+            }
+
+            auto const a_ts = a.transient_storage(a_acc.addr);
+            auto const b_ts = b.transient_storage(b_acc.addr);
+
+            MONAD_ASSERT(a_ts->size() == b_ts->size());
+
+            for (auto const &[a_te, b_te] : std::views::zip(*a_ts, *b_ts)) {
+                MONAD_ASSERT(a_te.key == b_te.key);
+                MONAD_ASSERT(a_te.value == b_te.value);
+            }
+        }
+    }
+
+    void
+    assert_backend_states_equal(FuzzerBackend const &a, FuzzerBackend const &b)
+    {
+        auto const a_view = a.sorted_view();
+        auto const b_view = b.sorted_view();
+        assert_states_equal(*a_view, *b_view);
+    }
 }

--- a/test/vm/fuzzer/evmone_backend.cpp
+++ b/test/vm/fuzzer/evmone_backend.cpp
@@ -1,0 +1,374 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "evmone_backend.hpp"
+
+#include "account.hpp"
+#include "block.hpp"
+#include "hash_utils.hpp"
+#include "host.hpp"
+#include "state.hpp"
+#include "test_state.hpp"
+#include "transaction.hpp"
+
+#include "fuzzer_view.hpp"
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+
+#include <evmone/constants.hpp>
+
+#include <intx/intx.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace evmone::state;
+
+namespace monad::vm::fuzzing
+{
+    // -- Sorted view types ---------------------------------------------------
+
+    /// Generic sorted view over an unordered_map. ConvertFn is a stateless
+    /// callable that transforms (key, map_value) -> Entry.
+    template <typename Entry, typename MapValue, auto ConvertFn>
+    class EvmoneSortedMapView final : public SortedView<Entry>
+    {
+        std::vector<evmc::bytes32> keys_;
+        std::unordered_map<evmc::bytes32, MapValue> const &map_;
+
+        class CursorImpl final : public Cursor<Entry>
+        {
+            EvmoneSortedMapView const &view_;
+            size_t index_ = 0;
+
+        public:
+            explicit CursorImpl(EvmoneSortedMapView const &v)
+                : view_(v)
+            {
+            }
+
+            bool at_end() const override
+            {
+                return index_ >= view_.keys_.size();
+            }
+
+            Entry current() const override
+            {
+                auto const &key = view_.keys_[index_];
+                return ConvertFn(key, view_.map_.at(key));
+            }
+
+            void advance() override
+            {
+                ++index_;
+            }
+        };
+
+    public:
+        explicit EvmoneSortedMapView(
+            std::unordered_map<evmc::bytes32, MapValue> const &map)
+            : map_(map)
+        {
+            keys_.reserve(map_.size());
+            for (auto const &[k, _] : map_) {
+                keys_.push_back(k);
+            }
+            std::sort(keys_.begin(), keys_.end());
+        }
+
+        size_t size() const override
+        {
+            return keys_.size();
+        }
+
+        std::unique_ptr<Cursor<Entry>> cursor() const override
+        {
+            return std::make_unique<CursorImpl>(*this);
+        }
+    };
+
+    static StorageEntry
+    to_storage_entry(evmc::bytes32 const &key, StorageValue const &val)
+    {
+        return {key, val.current, val.original, val.access_status};
+    }
+
+    static TransientStorageEntry to_transient_storage_entry(
+        evmc::bytes32 const &key, evmc::bytes32 const &val)
+    {
+        return {key, val};
+    }
+
+    class EvmoneSortedStateView final : public SortedStateView
+    {
+        std::vector<evmc::address> addrs_;
+        std::unordered_map<evmc::address, Account> const &accounts_;
+
+    public:
+        explicit EvmoneSortedStateView(
+            std::unordered_map<evmc::address, Account> const &accounts)
+            : accounts_(accounts)
+        {
+            addrs_.reserve(accounts_.size());
+            for (auto const &[addr, _] : accounts_) {
+                addrs_.push_back(addr);
+            }
+            std::sort(addrs_.begin(), addrs_.end());
+        }
+
+        size_t size() const override
+        {
+            return addrs_.size();
+        }
+
+        std::unique_ptr<SortedStorageView>
+        storage(Address const &addr) const override
+        {
+            return std::make_unique<EvmoneSortedMapView<
+                StorageEntry,
+                StorageValue,
+                to_storage_entry>>(accounts_.at(addr).storage);
+        }
+
+        std::unique_ptr<SortedTransientStorageView>
+        transient_storage(Address const &addr) const override
+        {
+            return std::make_unique<EvmoneSortedMapView<
+                TransientStorageEntry,
+                evmc::bytes32,
+                to_transient_storage_entry>>(
+                accounts_.at(addr).transient_storage);
+        }
+
+        std::unique_ptr<Cursor<AccountEntry>> cursor() const override;
+
+    private:
+        class CursorImpl final : public Cursor<AccountEntry>
+        {
+            EvmoneSortedStateView const &view_;
+            size_t index_ = 0;
+
+        public:
+            explicit CursorImpl(EvmoneSortedStateView const &v)
+                : view_(v)
+            {
+            }
+
+            bool at_end() const override
+            {
+                return index_ >= view_.addrs_.size();
+            }
+
+            AccountEntry current() const override
+            {
+                auto const &addr = view_.addrs_[index_];
+                auto const &acc = view_.accounts_.at(addr);
+                return {addr, acc.nonce, acc.balance, acc.code_hash, acc.code};
+            }
+
+            void advance() override
+            {
+                ++index_;
+            }
+        };
+    };
+
+    std::unique_ptr<Cursor<AccountEntry>> EvmoneSortedStateView::cursor() const
+    {
+        return std::make_unique<CursorImpl>(*this);
+    }
+
+    // -- EvmoneBackend implementation ----------------------------------------
+
+    evmone::test::TestState EvmoneBackend::make_initial_state(
+        std::span<GenesisAccount const> const genesis)
+    {
+        auto init = evmone::test::TestState{};
+        for (auto const &account : genesis) {
+            init[account.addr] = {
+                .balance = account.balance, .storage = {}, .code = {}};
+        }
+        return init;
+    }
+
+    EvmoneBackend::EvmoneBackend(
+        evmc::VM vm, std::span<GenesisAccount const> const genesis)
+        : vm_(std::move(vm))
+        , initial_(make_initial_state(genesis))
+        , state_(initial_)
+    {
+    }
+
+    Address
+    EvmoneBackend::deploy(Address const &from, std::span<uint8_t const> code)
+    {
+        auto const code_bytes = evmc::bytes{code.data(), code.size()};
+        auto const create_address =
+            compute_create_address(from, state_.get_or_insert(from).nonce++);
+        MONAD_ASSERT(state_.find(create_address) == nullptr);
+
+        state_.insert(
+            create_address,
+            Account{
+                .nonce = 0,
+                .balance = 0,
+                .code_hash = evmone::keccak256(code_bytes),
+                .storage = {},
+                .transient_storage = {},
+                .code = code_bytes});
+
+        MONAD_ASSERT(state_.find(create_address) != nullptr);
+        return create_address;
+    }
+
+    evmc::Result
+    EvmoneBackend::execute(evmc_message const &msg, evmc_revision rev)
+    {
+        // Pre-transaction clean-up.
+        for (auto &[addr, acc] : state_.get_modified_accounts()) {
+            acc.transient_storage.clear();
+            acc.access_status = EVMC_ACCESS_COLD;
+            acc.just_created = false;
+            for (auto &[key, val] : acc.storage) {
+                val.access_status = EVMC_ACCESS_COLD;
+                val.original = val.current;
+            }
+        }
+
+        auto const block = BlockInfo{};
+        auto const hashes = evmone::test::TestBlockHashes{};
+        auto &sender_acc = state_.get_or_insert(msg.sender);
+        auto tx = Transaction{};
+        tx.gas_limit = block_gas_limit;
+        tx.sender = msg.sender;
+        tx.nonce = sender_acc.nonce;
+        tx.to = msg.recipient;
+
+        constexpr auto effective_gas_price = 10;
+
+        ++sender_acc.nonce;
+        sender_acc.balance -= block_gas_limit * effective_gas_price;
+
+        Host host{rev, vm_, state_, block, hashes, tx};
+
+        sender_acc.access_status = EVMC_ACCESS_WARM;
+        if (tx.to.has_value()) {
+            host.access_account(*tx.to);
+        }
+
+        auto result = host.call(msg);
+        auto gas_used = block_gas_limit - result.gas_left;
+
+        auto const max_refund_quotient = rev >= EVMC_LONDON ? 5 : 2;
+        auto const refund_limit = gas_used / max_refund_quotient;
+        auto const refund = std::min(result.gas_refund, refund_limit);
+        gas_used -= refund;
+
+        sender_acc.balance +=
+            (block_gas_limit - gas_used) * effective_gas_price;
+
+        // Apply destructs.
+        std::erase_if(
+            state_.get_modified_accounts(),
+            [](std::pair<evmc::address const, Account> const &p) noexcept {
+                return p.second.destructed;
+            });
+
+        // Delete empty accounts.
+        if (rev >= EVMC_SPURIOUS_DRAGON) {
+            std::erase_if(
+                state_.get_modified_accounts(),
+                [](std::pair<evmc::address const, Account> const &p) noexcept {
+                    auto const &acc = p.second;
+                    return acc.erase_if_empty && acc.is_empty();
+                });
+        }
+
+        return result;
+    }
+
+    uint64_t EvmoneBackend::checkpoint()
+    {
+        return state_.checkpoint();
+    }
+
+    void EvmoneBackend::rollback(uint64_t id)
+    {
+        state_.rollback(id);
+    }
+
+    byte_string EvmoneBackend::get_code(Address const &addr)
+    {
+        if (auto *found = state_.find(addr); found != nullptr) {
+            return found->code;
+        }
+        return {};
+    }
+
+    void EvmoneBackend::ensure_exists(Address const &addr)
+    {
+        state_.get_or_insert(addr);
+    }
+
+    void EvmoneBackend::normalize()
+    {
+        for (auto &[addr, acc] : state_.get_modified_accounts()) {
+            for (auto it = acc.storage.begin(); it != acc.storage.end();) {
+                auto const &[k, v] = *it;
+                if (v.current == evmc::bytes32{} &&
+                    v.original == evmc::bytes32{} &&
+                    v.access_status == EVMC_ACCESS_COLD) {
+                    it = acc.storage.erase(it);
+                }
+                else {
+                    ++it;
+                }
+            }
+            for (auto it = acc.transient_storage.begin();
+                 it != acc.transient_storage.end();) {
+                auto const &[k, v] = *it;
+                if (v == evmc::bytes32{}) {
+                    it = acc.transient_storage.erase(it);
+                }
+                else {
+                    ++it;
+                }
+            }
+        }
+    }
+
+    std::unique_ptr<SortedStateView> EvmoneBackend::sorted_view() const
+    {
+        return std::make_unique<EvmoneSortedStateView>(
+            state_.get_modified_accounts());
+    }
+
+    size_t EvmoneBackend::max_code_size() const
+    {
+        return evmone::MAX_CODE_SIZE;
+    }
+}

--- a/test/vm/fuzzer/evmone_backend.hpp
+++ b/test/vm/fuzzer/evmone_backend.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "fuzzer_backend.hpp"
+
+#include "state.hpp"
+#include "test_state.hpp"
+
+#include <evmc/evmc.hpp>
+
+namespace monad::vm::fuzzing
+{
+    /// FuzzerBackend implemented over evmone's state types.
+    /// Takes an evmc::VM at construction — the VM is the only thing that
+    /// varies between the reference and subject sides of the differential
+    /// test. Construct a new instance per run; there is no reset().
+    class EvmoneBackend : public FuzzerBackend
+    {
+        evmc::VM vm_;
+        evmone::test::TestState initial_;
+        evmone::state::State state_;
+
+        static evmone::test::TestState
+        make_initial_state(std::span<GenesisAccount const> genesis);
+
+    public:
+        EvmoneBackend(evmc::VM vm, std::span<GenesisAccount const> genesis);
+
+        // Non-movable: state_ holds a reference to the sibling initial_ member.
+        EvmoneBackend(EvmoneBackend const &) = delete;
+        EvmoneBackend(EvmoneBackend &&) = delete;
+        EvmoneBackend &operator=(EvmoneBackend const &) = delete;
+        EvmoneBackend &operator=(EvmoneBackend &&) = delete;
+
+        Address
+        deploy(Address const &from, std::span<uint8_t const> code) override;
+
+        evmc::Result
+        execute(evmc_message const &msg, evmc_revision rev) override;
+
+        uint64_t checkpoint() override;
+        void rollback(uint64_t id) override;
+
+        byte_string get_code(Address const &) override;
+        void ensure_exists(Address const &) override;
+
+        void normalize() override;
+        std::unique_ptr<SortedStateView> sorted_view() const override;
+
+        size_t max_code_size() const override;
+    };
+}

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -14,19 +14,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "assertions.hpp"
-#include "block.hpp"
 #include "compiler_hook.hpp"
+#include "evmone_backend.hpp"
+#include "fuzzer_backend.hpp"
 #include "test_vm.hpp"
 
-#include "account.hpp"
-#include "hash_utils.hpp"
-#include "host.hpp"
-#include "state.hpp"
-#include "test_state.hpp"
-#include "transaction.hpp"
-
-#include <category/core/assert.h>
-#include <category/core/bytes.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
@@ -34,38 +26,29 @@
 #include <category/vm/memory_pool.hpp>
 #include <category/vm/utils/debug.hpp>
 
-#include <evmone/constants.hpp>
 #include <evmone/evmone.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 
 #include <CLI/CLI.hpp>
-#include <intx/intx.hpp>
 
 #include <algorithm>
-#include <array>
-#include <bits/chrono.h>
-#include <cassert>
 #include <chrono>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <format>
-#include <functional>
 #include <iostream>
 #include <limits>
 #include <map>
+#include <optional>
 #include <random>
-#include <span>
+#include <string>
 #include <string_view>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
-using namespace evmone::state;
-using namespace evmc::literals;
 using namespace monad;
 using namespace monad::vm::fuzzing;
 using namespace std::chrono_literals;
@@ -113,191 +96,6 @@ static constexpr std::string_view to_string(evmc_status_code const sc) noexcept
         return "OUT_OF_MEMORY";
     default:
         return "OTHER";
-    }
-}
-
-static constexpr auto genesis_address =
-    0xBEEFCAFE000000000000000000000000BA5EBA11_address;
-
-static constexpr auto block_gas_limit = 300'000'000;
-
-static evmone::test::TestState initial_state()
-{
-    auto init = evmone::test::TestState{};
-    // Genesis account with some large balance, but sufficiently small
-    // so that token supply will not overflow uint256.
-    init[genesis_address] = {
-        .balance = std::numeric_limits<intx::uint256>::max() / 2,
-        .storage = {},
-        .code = {}};
-    return init;
-}
-
-static Transaction tx_from(State &state, evmc::address const &addr) noexcept
-{
-    auto tx = Transaction{};
-    tx.gas_limit = block_gas_limit;
-    tx.sender = addr;
-    tx.nonce = state.get_or_insert(addr).nonce;
-    return tx;
-}
-
-// Derived from the evmone transition implementation; transaction-related
-// book-keeping is elided here to keep the implementation simple and allow us to
-// send arbitrary messages to update the state.
-static evmc::Result transition(
-    State &state, evmc_message const &msg, evmc_revision const rev,
-    evmc::VM &vm, std::int64_t const block_gas_left)
-{
-    // Pre-transaction clean-up.
-    // - Clear transient storage.
-    // - Set accounts and their storage access status to cold.
-    // - Clear the "just created" account flag.
-    for (auto &[addr, acc] : state.get_modified_accounts()) {
-        acc.transient_storage.clear();
-        acc.access_status = EVMC_ACCESS_COLD;
-        acc.just_created = false;
-        for (auto &[key, val] : acc.storage) {
-            val.access_status = EVMC_ACCESS_COLD;
-            val.original = val.current;
-        }
-    }
-
-    // TODO(BSC): fill out block and host context properly; should all work fine
-    // for the moment as zero values from the perspective of the VM
-    // implementations.
-    auto block = BlockInfo{};
-    auto hashes = evmone::test::TestBlockHashes{};
-    auto tx = tx_from(state, msg.sender);
-    tx.to = msg.recipient;
-
-    constexpr auto effective_gas_price = 10;
-
-    auto *sender_ptr = state.find(msg.sender);
-    auto &sender_acc =
-        (sender_ptr != nullptr) ? *sender_ptr : state.insert(msg.sender);
-
-    ++sender_acc.nonce;
-    sender_acc.balance -= block_gas_left * effective_gas_price;
-
-    Host host{rev, vm, state, block, hashes, tx};
-
-    sender_acc.access_status = EVMC_ACCESS_WARM; // Tx sender is always warm.
-    if (tx.to.has_value()) {
-        host.access_account(*tx.to);
-    }
-
-    auto result = host.call(msg);
-    auto gas_used = block_gas_left - result.gas_left;
-
-    auto const max_refund_quotient = rev >= EVMC_LONDON ? 5 : 2;
-    auto const refund_limit = gas_used / max_refund_quotient;
-    auto const refund = std::min(result.gas_refund, refund_limit);
-    gas_used -= refund;
-
-    sender_acc.balance += (block_gas_left - gas_used) * effective_gas_price;
-
-    // Apply destructs.
-    std::erase_if(
-        state.get_modified_accounts(),
-        [](std::pair<address const, Account> const &p) noexcept {
-            return p.second.destructed;
-        });
-
-    // Delete empty accounts after every transaction. This is strictly required
-    // until Byzantium where intermediate state root hashes are part of the
-    // transaction receipt.
-    // TODO: Consider limiting this only to Spurious Dragon.
-    if (rev >= EVMC_SPURIOUS_DRAGON) {
-        std::erase_if(
-            state.get_modified_accounts(),
-            [](std::pair<address const, Account> const &p) noexcept {
-                auto const &acc = p.second;
-                return acc.erase_if_empty && acc.is_empty();
-            });
-    }
-
-    return result;
-}
-
-static evmc::address deploy_contract(
-    State &state, evmc::address const &from,
-    std::span<std::uint8_t const> const code_)
-{
-    auto code = bytes{code_.data(), code_.size()};
-
-    auto const create_address =
-        compute_create_address(from, state.get_or_insert(from).nonce++);
-    MONAD_DEBUG_ASSERT(state.find(create_address) == nullptr);
-
-    state.insert(
-        create_address,
-        Account{
-            .nonce = 0,
-            .balance = 0,
-            .code_hash = evmone::keccak256(code),
-            .storage = {},
-            .transient_storage = {},
-            .code = code});
-
-    MONAD_ASSERT(state.find(create_address) != nullptr);
-
-    return create_address;
-}
-
-static evmc::address deploy_delegated_contract(
-    State &state, evmc::address const &from, evmc::address const &delegatee)
-{
-    std::vector<uint8_t> code = {0xef, 0x01, 0x00};
-    code.append_range(delegatee.bytes);
-    MONAD_ASSERT(code.size() == 23);
-    return deploy_contract(state, from, code);
-}
-
-static evmc::address deploy_delegated_contracts(
-    State &evmone_state, State &monad_state, evmc::address const &from,
-    evmc::address delegatee)
-{
-    auto const a = deploy_delegated_contract(evmone_state, from, delegatee);
-    auto const a1 = deploy_delegated_contract(monad_state, from, delegatee);
-    MONAD_ASSERT(a == a1);
-    assert_equal(evmone_state, monad_state);
-    return a;
-}
-
-// It's possible for the compiler and evmone to reach equivalent-but-not-equal
-// states after both executing. For example, the compiler may exit a block
-// containing an SSTORE early because of unconditional underflow later in the
-// block. Evmone will instead execute the SSTORE, then roll back the change.
-// Because of how rollback is implemented, this produces a state with a mapping
-// `K |-> 0` for some key `K`. This won't directly compare equal to the _empty_
-// state that the compiler has, and so we need to normalise the states after
-// execution to remove cold zero slots.
-static void clean_storage(State &state)
-{
-    for (auto &[addr, acc] : state.get_modified_accounts()) {
-        for (auto it = acc.storage.begin(); it != acc.storage.end();) {
-            auto const &[k, v] = *it;
-
-            if (bytes32_t(v.current) == bytes32_t{} &&
-                bytes32_t(v.original) == bytes32_t{} &&
-                v.access_status == EVMC_ACCESS_COLD) {
-                it = acc.storage.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
-        for (auto it = acc.transient_storage.begin();
-             it != acc.transient_storage.end();) {
-            auto const &[k, v] = *it;
-            if (bytes32_t(v) == bytes32_t{}) {
-                it = acc.transient_storage.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
     }
 }
 
@@ -413,40 +211,34 @@ static arguments parse_args(int const argc, char **const argv)
 }
 
 static evmc_status_code fuzz_iteration(
-    evmc_message const &msg, evmc_revision const rev, State &evmone_state,
-    evmc::VM &evmone_vm, State &monad_state, evmc::VM &monad_vm,
-    BlockchainTestVM::Implementation const impl)
+    evmc_message const &msg, evmc_revision const rev, FuzzerBackend &reference,
+    FuzzerBackend &subject, bool const strict_out_of_gas)
 {
-    for (State &state : {std::ref(evmone_state), std::ref(monad_state)}) {
-        state.get_or_insert(msg.sender);
-        state.get_or_insert(msg.recipient);
+    reference.ensure_exists(msg.sender);
+    reference.ensure_exists(msg.recipient);
+    subject.ensure_exists(msg.sender);
+    subject.ensure_exists(msg.recipient);
+
+    auto const ref_cp = reference.checkpoint();
+    auto const ref_result = reference.execute(msg, rev);
+
+    auto const sub_cp = subject.checkpoint();
+    auto const sub_result = subject.execute(msg, rev);
+
+    assert_equal(ref_result, sub_result, strict_out_of_gas);
+
+    if (ref_result.status_code != EVMC_SUCCESS) {
+        reference.rollback(ref_cp);
     }
+    reference.normalize();
 
-    auto const evmone_checkpoint = evmone_state.checkpoint();
-    auto const evmone_result =
-        transition(evmone_state, msg, rev, evmone_vm, block_gas_limit);
-
-    auto const monad_checkpoint = monad_state.checkpoint();
-    auto const monad_result =
-        transition(monad_state, msg, rev, monad_vm, block_gas_limit);
-
-    assert_equal(
-        evmone_result,
-        monad_result,
-        impl == BlockchainTestVM::Implementation::Interpreter);
-
-    if (evmone_result.status_code != EVMC_SUCCESS) {
-        evmone_state.rollback(evmone_checkpoint);
+    if (sub_result.status_code != EVMC_SUCCESS) {
+        subject.rollback(sub_cp);
     }
-    clean_storage(evmone_state);
+    subject.normalize();
 
-    if (monad_result.status_code != EVMC_SUCCESS) {
-        monad_state.rollback(monad_checkpoint);
-    }
-    clean_storage(monad_state);
-
-    assert_equal(evmone_state, monad_state);
-    return evmone_result.status_code;
+    assert_backend_states_equal(reference, subject);
+    return ref_result.status_code;
 }
 
 static void
@@ -496,7 +288,7 @@ static evmc::VM create_monad_vm(arguments const &args, Engine &engine)
 template <typename Engine>
 static bool toss(Engine &engine, double p)
 {
-    std::bernoulli_distribution dist(p);
+    std::bernoulli_distribution dist(p); // NOLINT(misc-const-correctness)
     return dist(engine);
 }
 
@@ -508,13 +300,14 @@ static void do_run(
 
     auto engine = random_engine_t(args.seed);
 
-    auto evmone_vm = evmc::VM(evmc_create_evmone());
-    auto monad_vm = create_monad_vm(args, engine);
+    constexpr GenesisAccount genesis[] = {genesis_account};
+    auto reference = EvmoneBackend(evmc::VM(evmc_create_evmone()), genesis);
+    auto subject = EvmoneBackend(create_monad_vm(args, engine), genesis);
 
-    auto initial_state_ = initial_state();
-
-    auto evmone_state = State{initial_state_};
-    auto monad_state = State{initial_state_};
+    auto const max_code =
+        std::min(reference.max_code_size(), subject.max_code_size());
+    auto const strict_out_of_gas =
+        args.implementation == BlockchainTestVM::Implementation::Interpreter;
 
     auto contract_addresses = std::vector<evmc::address>{};
     auto known_addresses = std::vector<evmc::address>{};
@@ -522,7 +315,7 @@ static void do_run(
     auto exit_code_stats = std::unordered_map<evmc_status_code, std::size_t>{};
     auto total_messages = std::size_t{0};
 
-    auto start_time = std::chrono::high_resolution_clock::now();
+    auto const start_time = std::chrono::high_resolution_clock::now();
 
     for (auto i = 0; i < args.iterations_per_run; ++i) {
         using monad::vm::fuzzing::GeneratorFocus;
@@ -536,10 +329,14 @@ static void do_run(
                       Choice(0.05, [](auto &) { return dyn_jump_focus; }));
 
         if (rev >= EVMC_PRAGUE && toss(engine, 0.001)) {
-            auto precompile =
+            auto const precompile =
                 monad::vm::fuzzing::generate_precompile_address(engine, rev);
-            auto const a = deploy_delegated_contracts(
-                evmone_state, monad_state, genesis_address, precompile);
+            auto const a =
+                reference.deploy_delegated(genesis_address, precompile);
+            auto const b =
+                subject.deploy_delegated(genesis_address, precompile);
+            MONAD_ASSERT(a == b);
+            assert_backend_states_equal(reference, subject);
             known_addresses.push_back(a);
         }
 
@@ -547,61 +344,48 @@ static void do_run(
             auto const contract = monad::vm::fuzzing::generate_program(
                 focus, engine, rev, known_addresses);
 
-            if (contract.size() > evmone::MAX_CODE_SIZE) {
-                // The evmone host will fail when we attempt to deploy
-                // contracts of this size. It rarely happens that we
-                // generate contract this large.
+            if (contract.size() > max_code) {
+                // It rarely happens that we generate contracts this large.
                 std::cerr << "Skipping contract of size: " << contract.size()
                           << " bytes" << std::endl;
                 continue;
             }
 
-            auto const a =
-                deploy_contract(evmone_state, genesis_address, contract);
-            auto const a1 =
-                deploy_contract(monad_state, genesis_address, contract);
-            MONAD_ASSERT(a == a1);
+            auto const a = reference.deploy(genesis_address, contract);
+            auto const b = subject.deploy(genesis_address, contract);
+            MONAD_ASSERT(a == b);
 
-            assert_equal(evmone_state, monad_state);
+            assert_backend_states_equal(reference, subject);
 
             contract_addresses.push_back(a);
             known_addresses.push_back(a);
 
             if (args.revision >= EVMC_PRAGUE && toss(engine, 0.2)) {
-                auto const b = deploy_delegated_contracts(
-                    evmone_state, monad_state, genesis_address, a);
-                known_addresses.push_back(b);
+                auto const c = reference.deploy_delegated(genesis_address, a);
+                auto const d = subject.deploy_delegated(genesis_address, a);
+                MONAD_ASSERT(c == d);
+                assert_backend_states_equal(reference, subject);
+                known_addresses.push_back(c);
             }
             break;
         }
 
         for (auto j = 0u; j < args.messages; ++j) {
             auto msg_memory = memory_pool.alloc_ref();
-            auto msg = monad::vm::fuzzing::generate_message(
+            auto const msg = monad::vm::fuzzing::generate_message(
                 focus,
                 engine,
                 contract_addresses,
                 {genesis_address},
                 [&](auto const &address) {
-                    if (auto *found = evmone_state.find(address);
-                        found != nullptr) {
-                        return found->code;
-                    }
-
-                    return evmc::bytes{};
+                    return reference.get_code(address);
                 },
                 msg_memory.get(),
                 memory_pool.alloc_capacity());
             ++total_messages;
 
             auto const ec = fuzz_iteration(
-                *msg,
-                rev,
-                evmone_state,
-                evmone_vm,
-                monad_state,
-                monad_vm,
-                args.implementation);
+                *msg, rev, reference, subject, strict_out_of_gas);
             ++exit_code_stats[ec];
         }
     }

--- a/test/vm/fuzzer/fuzzer_backend.cpp
+++ b/test/vm/fuzzer/fuzzer_backend.cpp
@@ -13,25 +13,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#pragma once
-
 #include "fuzzer_backend.hpp"
-#include "fuzzer_view.hpp"
 
-#include <evmc/evmc.hpp>
+#include <category/core/assert.h>
+#include <category/vm/evm/delegation.hpp>
+
+#include <cstdint>
+#include <vector>
 
 namespace monad::vm::fuzzing
 {
-    void assert_equal(
-        evmc::Result const &evmone_result, evmc::Result const &compiler_result,
-        bool strict_out_of_gas);
-
-    /// Walk two state views in lockstep and assert all accounts and storage
-    /// slots are equal. Aborts on the first mismatch.
-    void
-    assert_states_equal(SortedStateView const &a, SortedStateView const &b);
-
-    /// Convenience: construct sorted views from two backends and compare.
-    void
-    assert_backend_states_equal(FuzzerBackend const &a, FuzzerBackend const &b);
+    Address FuzzerBackend::deploy_delegated(
+        Address const &from, Address const &delegatee)
+    {
+        auto const prefix = vm::evm::delegation_indicator_prefix();
+        std::vector<uint8_t> code(prefix.begin(), prefix.end());
+        code.append_range(delegatee.bytes);
+        MONAD_ASSERT(code.size() == 23);
+        return deploy(from, code);
+    }
 }

--- a/test/vm/fuzzer/fuzzer_backend.hpp
+++ b/test/vm/fuzzer/fuzzer_backend.hpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "fuzzer_view.hpp"
+
+#include <category/core/byte_string.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+
+#include <evmc/evmc.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+
+namespace monad::vm::fuzzing
+{
+    using evmc::literals::operator""_address;
+
+    struct GenesisAccount
+    {
+        Address addr;
+        uint256_t balance;
+    };
+
+    constexpr auto genesis_address =
+        0xBEEFCAFE000000000000000000000000BA5EBA11_address;
+
+    constexpr std::int64_t block_gas_limit = 300'000'000;
+
+    // Genesis account with a large balance, sufficiently small so that
+    // token supply will not overflow uint256.
+    constexpr auto genesis_account = GenesisAccount{
+        .addr = genesis_address,
+        .balance = std::numeric_limits<intx::uint256>::max() / 2};
+
+    class FuzzerBackend
+    {
+    public:
+        virtual ~FuzzerBackend() = default;
+
+        // Contract deployment
+        virtual Address
+        deploy(Address const &from, std::span<uint8_t const> code) = 0;
+        Address deploy_delegated(Address const &from, Address const &delegatee);
+
+        // Execution (full transaction semantics handled internally)
+        virtual evmc::Result
+        execute(evmc_message const &msg, evmc_revision rev) = 0;
+
+        // Checkpoint / rollback
+        virtual uint64_t checkpoint() = 0;
+        virtual void rollback(uint64_t id) = 0;
+
+        // State query (for message generation)
+        virtual byte_string get_code(Address const &) = 0;
+        virtual void ensure_exists(Address const &) = 0;
+
+        // State iteration (for comparison)
+        virtual void normalize() = 0;
+        // The returned view borrows the backend's internal state. It must
+        // not outlive any mutation (deploy, execute, rollback, normalize).
+        virtual std::unique_ptr<SortedStateView> sorted_view() const = 0;
+
+        // Constants
+        virtual size_t max_code_size() const = 0;
+    };
+}

--- a/test/vm/fuzzer/fuzzer_view.hpp
+++ b/test/vm/fuzzer/fuzzer_view.hpp
@@ -1,0 +1,183 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/address.hpp>
+
+#include <evmc/evmc.h>
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <ranges>
+#include <span>
+
+namespace monad::vm::fuzzing
+{
+    /// A single storage slot as seen during state comparison.
+    /// Includes access_status so that warm/cold divergences between VMs
+    /// are caught within a transaction.
+    struct StorageEntry
+    {
+        bytes32_t key;
+        bytes32_t current;
+        bytes32_t original;
+        evmc_access_status access_status;
+    };
+
+    /// A single transient storage slot (EIP-1153).
+    struct TransientStorageEntry
+    {
+        bytes32_t key;
+        bytes32_t value;
+    };
+
+    /// A single account as seen during state comparison.
+    /// The `code` span points into the backend's own memory and is valid for
+    /// the lifetime of the view that produced this entry.
+    struct AccountEntry
+    {
+        Address addr;
+        uint64_t nonce;
+        uint256_t balance;
+        bytes32_t code_hash;
+        std::span<uint8_t const> code;
+    };
+
+    /// Virtual cursor over a sequence of entries. Each backend implements this
+    /// to walk its internal data structures in canonical (sorted) order.
+    template <typename T>
+    class Cursor
+    {
+    public:
+        virtual ~Cursor() = default;
+        virtual bool at_end() const = 0;
+        virtual T current() const = 0;
+        virtual void advance() = 0;
+    };
+
+    /// Concrete C++ input iterator that wraps a virtual Cursor<T>.
+    /// Move-only — each iterator exclusively owns its cursor. This is
+    /// sufficient for std::views::zip over input ranges, which never
+    /// copies the underlying iterators.
+    template <typename T>
+    class CursorIterator
+    {
+        std::unique_ptr<Cursor<T>> c_;
+
+    public:
+        using iterator_concept = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+
+        CursorIterator() = default;
+
+        explicit CursorIterator(std::unique_ptr<Cursor<T>> c)
+            : c_(std::move(c))
+        {
+        }
+
+        T operator*() const
+        {
+            return c_->current();
+        }
+
+        CursorIterator &operator++()
+        {
+            c_->advance();
+            return *this;
+        }
+
+        void operator++(int)
+        {
+            c_->advance();
+        }
+
+        bool operator==(std::default_sentinel_t) const
+        {
+            return !c_ || c_->at_end();
+        }
+    };
+
+    /// Ordered view over a collection of entries, yielded in canonical order
+    /// via a virtual cursor. Used for storage, transient storage, and
+    /// potentially other sorted key-value collections.
+    template <typename T>
+    class SortedView
+    {
+    protected:
+        virtual std::unique_ptr<Cursor<T>> cursor() const = 0;
+
+    public:
+        virtual ~SortedView() = default;
+        virtual size_t size() const = 0;
+
+        CursorIterator<T> begin() const
+        {
+            return CursorIterator<T>(cursor());
+        }
+
+        std::default_sentinel_t end() const
+        {
+            return {};
+        }
+    };
+
+    using SortedStorageView = SortedView<StorageEntry>;
+    using SortedTransientStorageView = SortedView<TransientStorageEntry>;
+
+    /// Ordered view over the accounts in a backend's state.
+    /// Accounts are yielded in canonical order (lexicographic by address).
+    /// Storage for each account is accessible via storage() and
+    /// transient_storage().
+    class SortedStateView
+    {
+    protected:
+        virtual std::unique_ptr<Cursor<AccountEntry>> cursor() const = 0;
+
+    public:
+        virtual ~SortedStateView() = default;
+        virtual size_t size() const = 0;
+        virtual std::unique_ptr<SortedStorageView>
+        storage(Address const &) const = 0;
+        virtual std::unique_ptr<SortedTransientStorageView>
+        transient_storage(Address const &) const = 0;
+
+        CursorIterator<AccountEntry> begin() const
+        {
+            return CursorIterator<AccountEntry>(cursor());
+        }
+
+        std::default_sentinel_t end() const
+        {
+            return {};
+        }
+    };
+
+    static_assert(std::input_iterator<CursorIterator<StorageEntry>>);
+    static_assert(std::input_iterator<CursorIterator<TransientStorageEntry>>);
+    static_assert(std::input_iterator<CursorIterator<AccountEntry>>);
+    static_assert(std::ranges::input_range<SortedStorageView>);
+    static_assert(std::ranges::input_range<SortedTransientStorageView>);
+    static_assert(std::ranges::input_range<SortedStateView>);
+    static_assert(!std::copyable<CursorIterator<StorageEntry>>);
+    static_assert(!std::copyable<CursorIterator<TransientStorageEntry>>);
+    static_assert(!std::copyable<CursorIterator<AccountEntry>>);
+}


### PR DESCRIPTION
## Summary

- Introduce a `FuzzerBackend` abstract interface that encapsulates state management and execution, hiding evmone-specific types behind the abstraction
- Implement `EvmoneBackend` as the concrete backend, wrapping `evmone::state::State` and parameterised over an `evmc::VM`
- Rewrite the fuzzer run loop to program against `FuzzerBackend` — evmone types no longer leak into the core logic
- State comparison uses sorted views with virtual cursors wrapped in move-only C++ input iterators, enabling `std::views::zip` for lockstep comparison of storage, transient storage, and account fields

This is step 1 of a multi-step transition to remove evmone as a dependency:
1. **(This PR)** Extract interface, implement evmone backend, rewrite fuzzer core
2. **(Future)** Build a `MonadBackend` using monad's own `BlockState`/`State`/`EvmcHost`/`VM`
3. **(Future)** Build an `OcamlBackend` via C FFI, replacing evmone entirely

## Test plan

- [x] Build with `MONAD_COMPILER_TESTING=ON` (GCC 15, RelWithDebInfo)
- [x] Full project build succeeds (all 386 targets)
- [x] Seed-reproducible fuzzer run produces identical output before and after refactor (`--seed 12345 -i 5 --implementation compiler`)
- [x] Verified with both `--implementation compiler` and `--implementation interpreter`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)