### PR TITLE
[event] round up payload size before checking for overflow

### DIFF
--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -27,6 +27,7 @@
 #include <category/core/config.hpp>
 #include <category/core/event/event_recorder.h>
 #include <category/core/event/event_ring.h>
+#include <category/core/mem/align.h>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 
 #include <array>
@@ -207,7 +208,8 @@ ReservedExecEvent<T> ExecutionEventRecorder::reserve_block_event(
     // diagnostic truncated payloads on overflow
 
     size_t const payload_size = (size(trailing_bufs) + ... + sizeof(T));
-    if (payload_size > std::numeric_limits<uint32_t>::max()) [[unlikely]] {
+    if (monad_round_size_to_align(payload_size, MONAD_EVENT_PAYLOAD_ALIGN) >
+        std::numeric_limits<uint32_t>::max()) [[unlikely]] {
         std::array<std::span<std::byte const>, sizeof...(trailing_bufs)> const
             trailing_bufs_array = {trailing_bufs...};
         auto const [event, header_buf, seqno] = setup_record_error_event(


### PR DESCRIPTION
This fixes a bug where certain large payload sizes could trigger `MONAD_ASSERT(event != nullptr)`. If a payload size were below 4 GiB before rounding up for alignment, but equal to 4 GiB after rounding, then:

- The pre-alignment check in exec_event_recorder.hpp would pass
- The post-alignment check in monad_event_recorder_reserve would fail and return nullptr

This commit makes both checks the same, preventing `event == nullptr` as intended. This is not severe since it is not possible to manufacture such a large payload with the current gas model.