### PR TITLE
[mpt] Extract DbMetadataContext from UpdateAux

### DIFF
--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(
   "db.cpp"
   "db.hpp"
   "db_error.hpp"
+  "db_metadata_context.cpp"
+  "db_metadata_context.hpp"
   "find.cpp"
   "find_notify_fiber.cpp"
   "find_request_sender.hpp"

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -448,7 +448,7 @@ public:
         uint32_t count = 0;
         auto const *item = item_;
         do {
-            auto const chunkid = item->index(aux.db_metadata());
+            auto const chunkid = item->index(aux.metadata_ctx().main());
             count++;
             auto &chunk = pool->chunk(pool->seq, chunkid);
             MONAD_ASSERT(chunk.zone_id().second == chunkid);
@@ -461,7 +461,7 @@ public:
             }
             total_capacity += chunk.capacity();
             total_used += chunk.size();
-            item = item->next(aux.db_metadata());
+            item = item->next(aux.metadata_ctx().main());
         }
         while (item != nullptr);
         cout << "     " << name << ": " << count << " chunks with capacity "
@@ -471,10 +471,10 @@ public:
             std::cerr << "        ";
             item = item_;
             do {
-                auto const chunkid = item->index(aux.db_metadata());
+                auto const chunkid = item->index(aux.metadata_ctx().main());
                 std::cerr << " " << chunkid << " ("
                           << uint32_t(item->insertion_count()) << ")";
-                item = item->next(aux.db_metadata());
+                item = item->next(aux.metadata_ctx().main());
             }
             while (item != nullptr);
             std::cerr << std::endl;
@@ -485,25 +485,29 @@ public:
     void print_db_history_summary(MONAD_MPT_NAMESPACE::UpdateAux &aux)
     {
         cout << "MPT database has "
-             << (1 + aux.db_history_max_version() -
-                 aux.db_history_min_valid_version())
-             << " history, earliest is " << aux.db_history_min_valid_version()
-             << " latest is " << aux.db_history_max_version()
+             << (1 + aux.metadata_ctx().db_history_max_version() -
+                 aux.metadata_ctx().db_history_min_valid_version())
+             << " history, earliest is "
+             << aux.metadata_ctx().db_history_min_valid_version()
+             << " latest is " << aux.metadata_ctx().db_history_max_version()
              << ".\n     It has been configured to retain no more than "
-             << aux.version_history_length() << ".\n     Latest proposed is ("
-             << aux.get_latest_proposed_version() << ", "
+             << aux.metadata_ctx().version_history_length()
+             << ".\n     Latest proposed is ("
+             << aux.metadata_ctx().get_latest_proposed_version() << ", "
              << monad::to_hex(monad::byte_string_view(
-                    aux.get_latest_proposed_block_id().bytes,
+                    aux.metadata_ctx().get_latest_proposed_block_id().bytes,
                     sizeof(monad::bytes32_t)))
-             << ").\n     Latest voted is (" << aux.get_latest_voted_version()
-             << ", "
+             << ").\n     Latest voted is ("
+             << aux.metadata_ctx().get_latest_voted_version() << ", "
              << monad::to_hex(monad::byte_string_view(
-                    aux.get_latest_voted_block_id().bytes,
+                    aux.metadata_ctx().get_latest_voted_block_id().bytes,
                     sizeof(monad::bytes32_t)))
              << ").\n     Latest finalized is "
-             << aux.get_latest_finalized_version() << ", latest verified is "
-             << aux.get_latest_verified_version() << ", auto expire version is "
-             << aux.get_auto_expire_version_metadata() << "\n";
+             << aux.metadata_ctx().get_latest_finalized_version()
+             << ", latest verified is "
+             << aux.metadata_ctx().get_latest_verified_version()
+             << ", auto expire version is "
+             << aux.metadata_ctx().get_auto_expire_version_metadata() << "\n";
     }
 
     void do_restore_database()
@@ -732,33 +736,33 @@ public:
             auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{*pool, rwbuf};
             MONAD_MPT_NAMESPACE::UpdateAux aux(io);
             for (;;) {
-                auto const *item = aux.db_metadata()->fast_list_begin();
+                auto const *item = aux.metadata_ctx().main()->fast_list_begin();
                 if (item == nullptr) {
                     break;
                 }
-                auto const chunkid = item->index(aux.db_metadata());
+                auto const chunkid = item->index(aux.metadata_ctx().main());
                 MONAD_ASSERT(chunkid != UINT32_MAX);
-                aux.remove(chunkid);
+                aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
             for (;;) {
-                auto const *item = aux.db_metadata()->slow_list_begin();
+                auto const *item = aux.metadata_ctx().main()->slow_list_begin();
                 if (item == nullptr) {
                     break;
                 }
-                auto const chunkid = item->index(aux.db_metadata());
+                auto const chunkid = item->index(aux.metadata_ctx().main());
                 MONAD_ASSERT(chunkid != UINT32_MAX);
-                aux.remove(chunkid);
+                aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
             for (;;) {
-                auto const *item = aux.db_metadata()->free_list_begin();
+                auto const *item = aux.metadata_ctx().main()->free_list_begin();
                 if (item == nullptr) {
                     break;
                 }
-                auto const chunkid = item->index(aux.db_metadata());
+                auto const chunkid = item->index(aux.metadata_ctx().main());
                 MONAD_ASSERT(chunkid != UINT32_MAX);
-                aux.remove(chunkid);
+                aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
         }
@@ -997,20 +1001,20 @@ public:
         for (auto const &i : todecompress) {
             if (i.type == monad::async::storage_pool::seq) {
                 if (i.metadata.in_fast_list) {
-                    aux.append(
+                    aux.metadata_ctx().append(
                         monad::mpt::UpdateAux::chunk_list::fast, i.chunk_id);
                     if (0 == fast_chunks_inserted++) {
-                        aux.modify_metadata(
+                        aux.metadata_ctx().modify_metadata(
                             override_insertion_count,
                             monad::mpt::UpdateAux::chunk_list::fast,
                             fast_list_base_insertion_count);
                     }
                 }
                 else if (i.metadata.in_slow_list) {
-                    aux.append(
+                    aux.metadata_ctx().append(
                         monad::mpt::UpdateAux::chunk_list::slow, i.chunk_id);
                     if (0 == slow_chunks_inserted++) {
-                        aux.modify_metadata(
+                        aux.metadata_ctx().modify_metadata(
                             override_insertion_count,
                             monad::mpt::UpdateAux::chunk_list::slow,
                             slow_list_base_insertion_count);
@@ -1029,42 +1033,47 @@ public:
                 max_chunk_id[monad::async::storage_pool::cnv] ==
             todecompress.size() - 1);
         if (fast_chunks_inserted == 0) {
-            aux.append(
+            aux.metadata_ctx().append(
                 monad::mpt::UpdateAux::chunk_list::fast, fast_list_begin_index);
             auto const it =
                 std::find(chunks.begin(), chunks.end(), fast_list_begin_index);
             MONAD_ASSERT(it != chunks.end());
             *it = UINT32_MAX;
             // override the first insertion count
-            aux.modify_metadata(
+            aux.metadata_ctx().modify_metadata(
                 override_insertion_count,
                 monad::mpt::UpdateAux::chunk_list::fast,
                 fast_list_base_insertion_count);
         }
         MONAD_ASSERT(
-            aux.db_metadata()->fast_list.begin == fast_list_begin_index);
-        MONAD_ASSERT(aux.db_metadata()->fast_list.end == fast_list_end_index);
+            aux.metadata_ctx().main()->fast_list.begin ==
+            fast_list_begin_index);
+        MONAD_ASSERT(
+            aux.metadata_ctx().main()->fast_list.end == fast_list_end_index);
 
         if (slow_chunks_inserted == 0) {
-            aux.append(
+            aux.metadata_ctx().append(
                 monad::mpt::UpdateAux::chunk_list::slow, slow_list_begin_index);
             auto const it =
                 std::find(chunks.begin(), chunks.end(), slow_list_begin_index);
             MONAD_ASSERT(it != chunks.end());
             *it = UINT32_MAX;
             // override the first insertion count
-            aux.modify_metadata(
+            aux.metadata_ctx().modify_metadata(
                 override_insertion_count,
                 monad::mpt::UpdateAux::chunk_list::slow,
                 slow_list_base_insertion_count);
         }
         MONAD_ASSERT(
-            aux.db_metadata()->slow_list.begin == slow_list_begin_index);
-        MONAD_ASSERT(aux.db_metadata()->slow_list.end == slow_list_end_index);
+            aux.metadata_ctx().main()->slow_list.begin ==
+            slow_list_begin_index);
+        MONAD_ASSERT(
+            aux.metadata_ctx().main()->slow_list.end == slow_list_end_index);
 
         for (unsigned int const &chunk : chunks) {
             if (chunk != UINT32_MAX) {
-                aux.append(monad::mpt::UpdateAux::chunk_list::free, chunk);
+                aux.metadata_ctx().append(
+                    monad::mpt::UpdateAux::chunk_list::free, chunk);
             }
         }
 
@@ -1599,21 +1608,27 @@ opened.
 
             cout << "MPT database internal lists:\n";
             impl.total_used += impl.print_list_info(
-                aux, aux.db_metadata()->fast_list_begin(), "Fast", &impl.fast);
+                aux,
+                aux.metadata_ctx().main()->fast_list_begin(),
+                "Fast",
+                &impl.fast);
             impl.total_used += impl.print_list_info(
-                aux, aux.db_metadata()->slow_list_begin(), "Slow", &impl.slow);
+                aux,
+                aux.metadata_ctx().main()->slow_list_begin(),
+                "Slow",
+                &impl.slow);
             impl.print_list_info(
-                aux, aux.db_metadata()->free_list_begin(), "Free");
+                aux, aux.metadata_ctx().main()->free_list_begin(), "Free");
             impl.print_db_history_summary(aux);
 
             if (impl.reset_history_length) {
                 // set to fixed history length, database will prune any outdated
                 // versions outside of new history length window
                 cout << "\nResetting history length from "
-                     << aux.version_history_length() << " to "
+                     << aux.metadata_ctx().version_history_length() << " to "
                      << impl.reset_history_length.value() << "... \n";
                 if (impl.reset_history_length.value() <
-                    aux.version_history_length()) {
+                    aux.metadata_ctx().version_history_length()) {
                     std::stringstream ss;
                     ss << "WARNING: --reset-history-length can potentially "
                           "prune "
@@ -1622,8 +1637,7 @@ opened.
                        << " versions. Are you sure?\n";
                     impl.cli_ask_question(ss.str().c_str());
                 }
-                aux.unset_io();
-                aux.set_io(io, impl.reset_history_length);
+                aux.init(io, impl.reset_history_length);
                 cout << "Success! Done resetting history to "
                      << impl.reset_history_length.value() << ".\n";
                 impl.print_db_history_summary(aux);
@@ -1631,32 +1645,40 @@ opened.
             }
             if (impl.rewind_database_to) {
                 if (*impl.rewind_database_to <
-                    aux.db_history_min_valid_version()) {
+                    aux.metadata_ctx().db_history_min_valid_version()) {
                     cout << "\nWARNING: Cannot rewind database to before "
-                         << aux.db_history_min_valid_version()
+                         << aux.metadata_ctx().db_history_min_valid_version()
                          << ", ignoring request.\n";
                 }
                 else if (
-                    *impl.rewind_database_to >= aux.db_history_max_version()) {
+                    *impl.rewind_database_to >=
+                    aux.metadata_ctx().db_history_max_version()) {
                     cout << "\nWARNING: Cannot rewind database to after or "
                             "equal "
-                         << aux.db_history_max_version()
+                         << aux.metadata_ctx().db_history_max_version()
                          << ", ignoring request.\n";
                 }
                 else {
                     std::stringstream ss;
                     ss << "\nWARNING: --rewind-to will destroy history "
                        << (*impl.rewind_database_to + 1) << " - "
-                       << aux.db_history_max_version() << ". Are you sure?\n";
+                       << aux.metadata_ctx().db_history_max_version()
+                       << ". Are you sure?\n";
                     impl.cli_ask_question(ss.str().c_str());
                     aux.rewind_to_version(*impl.rewind_database_to);
                     cout << "\nSuccess! Now:\n";
                     impl.print_list_info(
-                        aux, aux.db_metadata()->fast_list_begin(), "Fast");
+                        aux,
+                        aux.metadata_ctx().main()->fast_list_begin(),
+                        "Fast");
                     impl.print_list_info(
-                        aux, aux.db_metadata()->slow_list_begin(), "Slow");
+                        aux,
+                        aux.metadata_ctx().main()->slow_list_begin(),
+                        "Slow");
                     impl.print_list_info(
-                        aux, aux.db_metadata()->free_list_begin(), "Free");
+                        aux,
+                        aux.metadata_ctx().main()->free_list_begin(),
+                        "Free");
                     return 0;
                 }
             }

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -115,8 +115,8 @@ Node::SharedPtr copy_trie_impl(
     uint64_t const dest_version)
 {
     MONAD_ASSERT(aux.is_on_disk());
-    auto [src_cursor, res] =
-        find_blocking(aux, src_root, src_prefix, aux.db_history_max_version());
+    auto [src_cursor, res] = find_blocking(
+        aux, src_root, src_prefix, aux.metadata_ctx().db_history_max_version());
     MONAD_ASSERT(res == find_result::success);
     Node &src_node = *src_cursor.node;
     if (!dest_root) {
@@ -284,7 +284,8 @@ Node::SharedPtr copy_trie_to_dest(
         dest_version);
     if (write_root) {
         write_new_root_node(aux, *dest_root, dest_version);
-        MONAD_ASSERT(aux.db_history_max_version() >= dest_version);
+        MONAD_ASSERT(
+            aux.metadata_ctx().db_history_max_version() >= dest_version);
     }
     // invariant: copy_trie must preserve compaction offsets
     MONAD_ASSERT(

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -31,6 +31,7 @@
 #include <category/core/result.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_error.hpp>
+#include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/boost_fiber_workarounds.hpp>
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/nibbles_view.hpp>
@@ -173,12 +174,6 @@ public:
     {
     }
 
-    virtual ~ROOnDiskBlocking()
-    {
-        // must be destroyed before aux is destroyed
-        aux_.unset_io();
-    }
-
     virtual UpdateAux &aux() override
     {
         return aux_;
@@ -198,12 +193,12 @@ public:
             return {NodeCursor{}, find_result::root_node_is_null_failure};
         }
         // the root we last loaded does not contain the version we want to find
-        if (!aux().version_is_valid_ondisk(version)) {
+        if (!aux().metadata_ctx().version_is_valid_ondisk(version)) {
             return {NodeCursor{}, find_result::version_no_longer_exist};
         }
         auto const res = find_blocking(aux(), root, key, version);
         // verify version still valid in history after success
-        return aux().version_is_valid_ondisk(version)
+        return aux().metadata_ctx().version_is_valid_ondisk(version)
                    ? res
                    : find_cursor_result_type{
                          NodeCursor{}, find_result::version_no_longer_exist};
@@ -243,7 +238,8 @@ public:
     virtual Node::SharedPtr
     load_root_for_version(uint64_t const version) override
     {
-        auto const root_offset = aux().get_root_offset_at_version(version);
+        auto const root_offset =
+            aux().metadata_ctx().get_root_offset_at_version(version);
         if (root_offset == INVALID_OFFSET) {
             return nullptr;
         }
@@ -415,7 +411,8 @@ struct OnDiskWithWorkerThreadImpl
             , aux{async_io.io, options.fixed_history_length}
         {
             if (options.rewind_to_latest_finalized) {
-                auto const latest_block_id = aux.get_latest_finalized_version();
+                auto const latest_block_id =
+                    aux.metadata_ctx().get_latest_finalized_version();
                 if (latest_block_id == INVALID_BLOCK_NUM) {
                     aux.clear_ondisk_db();
                 }
@@ -472,7 +469,8 @@ struct OnDiskWithWorkerThreadImpl
                             std::move(*req->promise));
                         req->promise = &traverse_promises.back();
                         // verify version is valid
-                        if (aux.version_is_valid_ondisk(req->version)) {
+                        if (aux.metadata_ctx().version_is_valid_ondisk(
+                                req->version)) {
                             req->promise->set_value(preorder_traverse_ondisk(
                                 aux,
                                 std::move(req->root),
@@ -589,7 +587,8 @@ struct OnDiskWithWorkerThreadImpl
                             std::move(*req->promise));
                         req->promise = &traverse_promises.back();
                         // verify version is valid
-                        if (aux.version_is_valid_ondisk(req->version)) {
+                        if (aux.metadata_ctx().version_is_valid_ondisk(
+                                req->version)) {
                             req->promise->set_value(preorder_traverse_ondisk(
                                 aux,
                                 std::move(req->root),
@@ -616,7 +615,8 @@ struct OnDiskWithWorkerThreadImpl
                         upsert_promises.emplace_back(std::move(*req->promise));
                         req->promise = &upsert_promises.back();
                         auto const root_offset =
-                            aux.get_root_offset_at_version(req->version);
+                            aux.metadata_ctx().get_root_offset_at_version(
+                                req->version);
                         MONAD_ASSERT(root_offset != INVALID_OFFSET);
                         req->promise->set_value(
                             read_node_blocking(aux, root_offset, req->version));
@@ -786,7 +786,7 @@ public:
         // lookup, because RWDb never performs upserts concurrently with reads.
         // Skip version check if looking up from an unflushed version
         if (unflushed_version_ != version &&
-            !aux().version_is_valid_ondisk(version)) {
+            !aux().metadata_ctx().version_is_valid_ondisk(version)) {
             return {NodeCursor{}, find_result::version_no_longer_exist};
         }
         threadsafe_boost_fibers_promise<find_cursor_result_type> promise;
@@ -897,7 +897,7 @@ public:
     virtual Node::SharedPtr
     load_root_for_version(uint64_t const version) override
     {
-        if (!aux().version_is_valid_ondisk(version)) {
+        if (!aux().metadata_ctx().version_is_valid_ondisk(version)) {
             return nullptr;
         }
         threadsafe_boost_fibers_promise<Node::SharedPtr> promise;
@@ -981,7 +981,8 @@ struct RODb::Impl final : public OnDiskWithWorkerThreadImpl
 
     NodeCursor load_root_fiber_blocking(uint64_t version)
     {
-        auto const root_offset = aux().get_root_offset_at_version(version);
+        auto const root_offset =
+            aux().metadata_ctx().get_root_offset_at_version(version);
         if (root_offset == INVALID_OFFSET) {
             return {};
         }
@@ -1024,13 +1025,13 @@ RODb::~RODb() = default;
 uint64_t RODb::get_latest_version() const
 {
     MONAD_ASSERT(impl_);
-    return impl_->aux().db_history_max_version();
+    return impl_->aux().metadata_ctx().db_history_max_version();
 }
 
 uint64_t RODb::get_earliest_version() const
 {
     MONAD_ASSERT(impl_);
-    return impl_->aux().db_history_min_valid_version();
+    return impl_->aux().metadata_ctx().db_history_min_valid_version();
 }
 
 DbError find_result_to_db_error(find_result const result) noexcept
@@ -1199,7 +1200,7 @@ void Db::update_finalized_version(uint64_t const version)
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(!is_read_only());
     if (is_on_disk()) {
-        impl_->aux().set_latest_finalized_version(version);
+        impl_->aux().metadata_ctx().set_latest_finalized_version(version);
     } // noop for in memory db
 }
 
@@ -1208,8 +1209,9 @@ void Db::update_verified_version(uint64_t const version)
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(!is_read_only());
     if (is_on_disk()) {
-        MONAD_ASSERT(version <= impl_->aux().db_history_max_version());
-        impl_->aux().set_latest_verified_version(version);
+        MONAD_ASSERT(
+            version <= impl_->aux().metadata_ctx().db_history_max_version());
+        impl_->aux().metadata_ctx().set_latest_verified_version(version);
     } // noop for in memory db
 }
 
@@ -1218,7 +1220,7 @@ void Db::update_voted_metadata(
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk() && !is_read_only());
-    impl_->aux().set_latest_voted(version, block_id);
+    impl_->aux().metadata_ctx().set_latest_voted(version, block_id);
 }
 
 void Db::update_proposed_metadata(
@@ -1226,63 +1228,65 @@ void Db::update_proposed_metadata(
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk() && !is_read_only());
-    impl_->aux().set_latest_proposed(version, block_id);
+    impl_->aux().metadata_ctx().set_latest_proposed(version, block_id);
 }
 
 uint64_t Db::get_latest_finalized_version() const
 {
     MONAD_ASSERT(impl_);
-    return is_on_disk() ? impl_->aux().get_latest_finalized_version()
-                        : INVALID_BLOCK_NUM;
+    return is_on_disk()
+               ? impl_->aux().metadata_ctx().get_latest_finalized_version()
+               : INVALID_BLOCK_NUM;
 }
 
 uint64_t Db::get_latest_verified_version() const
 {
     MONAD_ASSERT(impl_);
-    return is_on_disk() ? impl_->aux().get_latest_verified_version()
-                        : INVALID_BLOCK_NUM;
+    return is_on_disk()
+               ? impl_->aux().metadata_ctx().get_latest_verified_version()
+               : INVALID_BLOCK_NUM;
 }
 
 bytes32_t Db::get_latest_voted_block_id() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().get_latest_voted_block_id();
+    return impl_->aux().metadata_ctx().get_latest_voted_block_id();
 }
 
 uint64_t Db::get_latest_voted_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().get_latest_voted_version();
+    return impl_->aux().metadata_ctx().get_latest_voted_version();
 }
 
 bytes32_t Db::get_latest_proposed_block_id() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().get_latest_proposed_block_id();
+    return impl_->aux().metadata_ctx().get_latest_proposed_block_id();
 }
 
 uint64_t Db::get_latest_proposed_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().get_latest_proposed_version();
+    return impl_->aux().metadata_ctx().get_latest_proposed_version();
 }
 
 uint64_t Db::get_latest_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().db_history_max_version();
+    return impl_->aux().metadata_ctx().db_history_max_version();
 }
 
 uint64_t Db::get_earliest_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().db_history_min_valid_version();
+    return impl_->aux().metadata_ctx().db_history_min_valid_version();
 }
 
 size_t Db::prefetch(Node::SharedPtr const &root)
@@ -1321,7 +1325,8 @@ UpdateAux const &Db::aux() const
 
 uint64_t Db::get_history_length() const
 {
-    return is_on_disk() ? impl_->aux().version_history_length() : 1;
+    return is_on_disk() ? impl_->aux().metadata_ctx().version_history_length()
+                        : 1;
 }
 
 AsyncContext::AsyncContext(Db &db, size_t node_lru_max_mem)
@@ -1383,7 +1388,8 @@ namespace detail
             inflights.erase(it);
             std::shared_ptr<Node> root{};
             bool const block_alive_after_read =
-                sender->context.aux.version_is_valid_ondisk(sender->block_id);
+                sender->context.aux.metadata_ctx().version_is_valid_ondisk(
+                    sender->block_id);
             if (block_alive_after_read) {
                 sender->root = detail::deserialize_node_from_receiver_result(
                     std::move(buffer_), buffer_off, io_state);
@@ -1427,7 +1433,7 @@ namespace detail
                 delete this_io_state;
                 return;
             }
-            get_result = aux.version_is_valid_ondisk(version)
+            get_result = aux.metadata_ctx().version_is_valid_ondisk(version)
                              ? std::move(res).assume_value()
                              : find_result_type<T>{
                                    T{}, find_result::version_no_longer_exist};
@@ -1446,7 +1452,7 @@ namespace detail
         case op_t::op_get_data1:
         case op_t::op_get_node1: {
             chunk_offset_t const offset =
-                context.aux.get_root_offset_at_version(block_id);
+                context.aux.metadata_ctx().get_root_offset_at_version(block_id);
             auto const virt_offset = context.aux.physical_to_virtual(offset);
             NodeCache::ConstAccessor acc;
             if (context.node_cache.find(acc, virt_offset)) {
@@ -1489,7 +1495,7 @@ namespace detail
         case op_t::op_get_data2:
         case op_t::op_get_node2: {
             // verify version is valid in db history before doing anything
-            if (!context.aux.version_is_valid_ondisk(block_id)) {
+            if (!context.aux.metadata_ctx().version_is_valid_ondisk(block_id)) {
                 get_result = {T{}, find_result::version_no_longer_exist};
                 io_state->completed(async::success());
                 return async::success();

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -1,0 +1,775 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/async/io.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/trie.hpp>
+#include <category/mpt/util.hpp>
+
+#include <quill/Quill.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+using namespace MONAD_ASYNC_NAMESPACE;
+
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+DbMetadataContext::DbMetadataContext(AsyncIO &io)
+    : io_(&io)
+{
+    auto const chunk_count = io_->chunk_count();
+    MONAD_ASSERT(chunk_count >= 3);
+    db_map_size_ = sizeof(detail::db_metadata) +
+                   chunk_count * sizeof(detail::db_metadata::chunk_info_t);
+    auto &cnv_chunk = io_->storage_pool().chunk(storage_pool::cnv, 0);
+    auto const fdr = cnv_chunk.read_fd();
+    auto const fdw = cnv_chunk.write_fd(0);
+
+    can_write_to_map_ =
+        (!io_->storage_pool().is_read_only() ||
+         io_->storage_pool().is_read_only_allow_dirty());
+    auto const &fd = can_write_to_map_ ? fdw : fdr;
+    prot_ = can_write_to_map_ ? (PROT_READ | PROT_WRITE) : (PROT_READ);
+    mapflags_ = io_->storage_pool().is_read_only_allow_dirty() ? MAP_PRIVATE
+                                                               : MAP_SHARED;
+
+    // mmap both metadata copies
+    copies_[0].main = start_lifetime_as<detail::db_metadata>(::mmap(
+        nullptr, db_map_size_, prot_, mapflags_, fd.first, off_t(fdr.second)));
+    MONAD_ASSERT(copies_[0].main != MAP_FAILED);
+    copies_[1].main = start_lifetime_as<detail::db_metadata>(::mmap(
+        nullptr,
+        db_map_size_,
+        prot_,
+        mapflags_,
+        fd.first,
+        off_t(fdr.second + cnv_chunk.capacity() / 2)));
+    MONAD_ASSERT(copies_[1].main != MAP_FAILED);
+
+    // Truncation detection
+    if (io_->storage_pool().is_newly_truncated()) {
+        memset(copies_[0].main->magic, 0, sizeof(copies_[0].main->magic));
+        memset(copies_[1].main->magic, 0, sizeof(copies_[1].main->magic));
+    }
+
+    // Magic validation: restore corrupted front copy from backup
+    if (0 != memcmp(
+                 copies_[0].main->magic,
+                 detail::db_metadata::MAGIC,
+                 detail::db_metadata::MAGIC_STRING_LEN)) {
+        if (0 == memcmp(
+                     copies_[1].main->magic,
+                     detail::db_metadata::MAGIC,
+                     detail::db_metadata::MAGIC_STRING_LEN)) {
+            MONAD_ASSERT(
+                can_write_to_map_,
+                "First copy of metadata corrupted, but not opened for "
+                "healing");
+            db_copy(copies_[0].main, copies_[1].main, db_map_size_);
+        }
+    }
+
+    // Version mismatch detection
+    constexpr unsigned magic_version_len = 3;
+    constexpr unsigned magic_prefix_len =
+        detail::db_metadata::MAGIC_STRING_LEN - magic_version_len;
+    if (0 == memcmp(
+                 copies_[0].main->magic,
+                 detail::db_metadata::MAGIC,
+                 magic_prefix_len) &&
+        0 != memcmp(
+                 copies_[0].main->magic + magic_prefix_len,
+                 detail::db_metadata::MAGIC + magic_prefix_len,
+                 magic_version_len)) {
+        MONAD_ABORT_PRINTF(
+            "DB was generated with version %s. The current code base is on "
+            "version %s. Please regenerate with the new DB version.",
+            copies_[0].main->magic + magic_prefix_len,
+            detail::db_metadata::MAGIC + magic_prefix_len);
+    }
+
+    // Dirty recovery
+    if (0 == memcmp(
+                 copies_[0].main->magic,
+                 detail::db_metadata::MAGIC,
+                 detail::db_metadata::MAGIC_STRING_LEN) &&
+        0 == memcmp(
+                 copies_[1].main->magic,
+                 detail::db_metadata::MAGIC,
+                 detail::db_metadata::MAGIC_STRING_LEN)) {
+        if (can_write_to_map_) {
+            if (copies_[0].main->is_dirty().load(std::memory_order_acquire)) {
+                db_copy(copies_[0].main, copies_[1].main, db_map_size_);
+            }
+            else if (copies_[1].main->is_dirty().load(
+                         std::memory_order_acquire)) {
+                db_copy(copies_[1].main, copies_[0].main, db_map_size_);
+            }
+        }
+        else {
+            if (copies_[0].main->is_dirty().load(std::memory_order_acquire) ||
+                copies_[1].main->is_dirty().load(std::memory_order_acquire)) {
+                // Wait a bit to see if they clear before complaining
+                bool dirty;
+                auto const begin = std::chrono::steady_clock::now();
+                do {
+                    dirty = copies_[0].main->is_dirty().load(
+                                std::memory_order_acquire) ||
+                            copies_[1].main->is_dirty().load(
+                                std::memory_order_acquire);
+                    std::this_thread::yield();
+                }
+                while (dirty && (std::chrono::steady_clock::now() - begin <
+                                 std::chrono::seconds(1)));
+
+                MONAD_ASSERT(
+                    !dirty,
+                    "DB metadata was closed dirty, but not opened for "
+                    "healing");
+            }
+        }
+    }
+
+    // Determine if this is a new pool (no valid magic on either copy)
+    if (0 != memcmp(
+                 copies_[0].main->magic,
+                 detail::db_metadata::MAGIC,
+                 detail::db_metadata::MAGIC_STRING_LEN)) {
+        MONAD_ASSERT(
+            can_write_to_map_,
+            "Neither copy of the DB metadata is valid, and not opened for "
+            "writing so stopping now.");
+        for (uint32_t n = 0; n < chunk_count; n++) {
+            auto const &chunk = io_->storage_pool().chunk(storage_pool::seq, n);
+            MONAD_ASSERT(
+                chunk.size() == 0,
+                "Trying to initialise new DB but storage pool contains "
+                "existing data, stopping now to prevent data loss.");
+        }
+        // Zero metadata, set chunk_info_count
+        memset(copies_[0].main, 0, db_map_size_);
+        MONAD_ASSERT((chunk_count & ~0xfffffU) == 0);
+        copies_[0].main->chunk_info_count = chunk_count & 0xfffffU;
+
+        // Init root_offsets storage cnv chunks
+        MONAD_ASSERT(io_->storage_pool().chunks(storage_pool::cnv) > 1);
+        auto &storage = copies_[0].main->root_offsets.storage_;
+        memset(&storage, 0xff, sizeof(storage));
+        storage.cnv_chunks_len = 0;
+        auto &chunk = io_->storage_pool().chunk(storage_pool::cnv, 1);
+        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, chunk.capacity());
+        MONAD_ASSERT(tofill != nullptr);
+        auto const untofill =
+            monad::make_scope_exit([&]() noexcept { ::free(tofill); });
+        memset(tofill, 0xff, chunk.capacity());
+        {
+            auto const fdw = chunk.write_fd(chunk.capacity());
+            MONAD_ASSERT(
+                -1 !=
+                ::pwrite(
+                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
+        }
+        storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = 1;
+        copies_[0].main->history_length =
+            chunk.capacity() / 2 / sizeof(chunk_offset_t);
+        // Allocate cnv chunks of the first device - 1 for root offsets,
+        // since chunk 0 is used for db_metadata
+        auto const root_offsets_chunk_count =
+            io_->storage_pool().devices()[0].cnv_chunks() -
+            UpdateAux::cnv_chunks_for_db_metadata;
+        MONAD_ASSERT(
+            root_offsets_chunk_count > 0 &&
+                (root_offsets_chunk_count & (root_offsets_chunk_count - 1)) ==
+                    0,
+            "Number of cnv chunks for root offsets must be a power of two");
+        for (uint32_t n = 2; n <= root_offsets_chunk_count; n++) {
+            auto &chunk = io_->storage_pool().chunk(storage_pool::cnv, n);
+            auto const fdw = chunk.write_fd(chunk.capacity());
+            MONAD_ASSERT(
+                -1 !=
+                ::pwrite(
+                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
+            storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = n;
+            copies_[0].main->history_length +=
+                chunk.capacity() / 2 / sizeof(chunk_offset_t);
+        }
+
+        is_new_pool_ = true;
+    }
+    else {
+        // Existing pool: map root offsets immediately
+        map_root_offsets();
+    }
+}
+#if defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic pop
+#endif
+
+void DbMetadataContext::map_root_offsets()
+{
+    auto const &cnv_chunk = io_->storage_pool().chunk(storage_pool::cnv, 0);
+    size_t const map_bytes_per_chunk = cnv_chunk.capacity() / 2;
+    size_t const db_version_history_storage_bytes =
+        copies_[0].main->root_offsets.storage_.cnv_chunks_len *
+        map_bytes_per_chunk;
+    std::byte *reservation[2];
+    reservation[0] = (std::byte *)::mmap(
+        nullptr,
+        db_version_history_storage_bytes,
+        PROT_NONE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+        -1,
+        0);
+    MONAD_ASSERT(reservation[0] != MAP_FAILED);
+    reservation[1] = (std::byte *)::mmap(
+        nullptr,
+        db_version_history_storage_bytes,
+        PROT_NONE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+        -1,
+        0);
+    MONAD_ASSERT(reservation[1] != MAP_FAILED);
+
+    for (size_t n = 0;
+         n < copies_[0].main->root_offsets.storage_.cnv_chunks_len;
+         n++) {
+        auto &chunk = io_->storage_pool().chunk(
+            storage_pool::cnv,
+            copies_[0].main->root_offsets.storage_.cnv_chunks[n].cnv_chunk_id);
+        auto const fdr = chunk.read_fd();
+        auto const fdw = chunk.write_fd(0);
+        auto const &fd = can_write_to_map_ ? fdw : fdr;
+        MONAD_ASSERT(
+            MAP_FAILED != ::mmap(
+                              reservation[0] + n * map_bytes_per_chunk,
+                              map_bytes_per_chunk,
+                              prot_,
+                              mapflags_ | MAP_FIXED,
+                              fd.first,
+                              off_t(fdr.second)));
+        MONAD_ASSERT(
+            MAP_FAILED != ::mmap(
+                              reservation[1] + n * map_bytes_per_chunk,
+                              map_bytes_per_chunk,
+                              prot_,
+                              mapflags_ | MAP_FIXED,
+                              fd.first,
+                              off_t(fdr.second + map_bytes_per_chunk)));
+    }
+    copies_[0].root_offsets = {
+        start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[0]),
+        db_version_history_storage_bytes / sizeof(chunk_offset_t)};
+    copies_[1].root_offsets = {
+        start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[1]),
+        db_version_history_storage_bytes / sizeof(chunk_offset_t)};
+
+    LOG_INFO(
+        "Database root offsets ring buffer is configured with {} "
+        "chunks, can hold up to {} historical entries.",
+        copies_[0].main->root_offsets.storage_.cnv_chunks_len,
+        copies_[0].root_offsets.size());
+}
+
+// Version metadata getters
+
+uint64_t DbMetadataContext::get_latest_finalized_version() const noexcept
+{
+    return start_lifetime_as<std::atomic_uint64_t const>(
+               &copies_[0].main->latest_finalized_version)
+        ->load(std::memory_order_acquire);
+}
+
+uint64_t DbMetadataContext::get_latest_verified_version() const noexcept
+{
+    return start_lifetime_as<std::atomic_uint64_t const>(
+               &copies_[0].main->latest_verified_version)
+        ->load(std::memory_order_acquire);
+}
+
+uint64_t DbMetadataContext::get_latest_voted_version() const noexcept
+{
+    return start_lifetime_as<std::atomic_uint64_t const>(
+               &copies_[0].main->latest_voted_version)
+        ->load(std::memory_order_acquire);
+}
+
+bytes32_t DbMetadataContext::get_latest_voted_block_id() const noexcept
+{
+    return copies_[0].main->latest_voted_block_id;
+}
+
+uint64_t DbMetadataContext::get_latest_proposed_version() const noexcept
+{
+    return start_lifetime_as<std::atomic_uint64_t const>(
+               &copies_[0].main->latest_proposed_version)
+        ->load(std::memory_order_acquire);
+}
+
+bytes32_t DbMetadataContext::get_latest_proposed_block_id() const noexcept
+{
+    return copies_[0].main->latest_proposed_block_id;
+}
+
+int64_t DbMetadataContext::get_auto_expire_version_metadata() const noexcept
+{
+    return start_lifetime_as<std::atomic_int64_t const>(
+               &copies_[0].main->auto_expire_version)
+        ->load(std::memory_order_acquire);
+}
+
+// Version metadata setters
+
+void DbMetadataContext::set_latest_finalized_version(
+    uint64_t const version) noexcept
+{
+    auto do_ = [&](detail::db_metadata *m) {
+        auto const g = m->hold_dirty();
+        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_finalized_version)
+            ->store(version, std::memory_order_release);
+    };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+}
+
+void DbMetadataContext::set_latest_verified_version(
+    uint64_t const version) noexcept
+{
+    auto do_ = [&](detail::db_metadata *m) {
+        auto const g = m->hold_dirty();
+        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_verified_version)
+            ->store(version, std::memory_order_release);
+    };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+}
+
+void DbMetadataContext::set_latest_voted(
+    uint64_t const version, bytes32_t const &block_id) noexcept
+{
+    for (auto const i : {0, 1}) {
+        auto *const m = copies_[i].main;
+        auto const g = m->hold_dirty();
+        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_voted_version)
+            ->store(version, std::memory_order_release);
+        m->latest_voted_block_id = block_id;
+    }
+}
+
+void DbMetadataContext::set_latest_proposed(
+    uint64_t const version, bytes32_t const &block_id) noexcept
+{
+    for (auto const i : {0, 1}) {
+        auto *const m = copies_[i].main;
+        auto const g = m->hold_dirty();
+        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_proposed_version)
+            ->store(version, std::memory_order_release);
+        m->latest_proposed_block_id = block_id;
+    }
+}
+
+void DbMetadataContext::set_auto_expire_version_metadata(
+    int64_t const version) noexcept
+{
+    auto do_ = [&](detail::db_metadata *m) {
+        auto const g = m->hold_dirty();
+        reinterpret_cast<std::atomic_int64_t *>(&m->auto_expire_version)
+            ->store(version, std::memory_order_release);
+    };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+}
+
+void DbMetadataContext::update_history_length_metadata(
+    uint64_t const history_len) noexcept
+{
+    auto do_ = [&](unsigned const which) {
+        auto *const m = copies_[which].main;
+        auto const g = m->hold_dirty();
+        auto const ro = root_offsets(which);
+        MONAD_ASSERT(history_len > 0 && history_len <= ro.capacity());
+        reinterpret_cast<std::atomic_uint64_t *>(&m->history_length)
+            ->store(history_len, std::memory_order_relaxed);
+    };
+    do_(0);
+    do_(1);
+}
+
+// Root offsets operations
+
+void DbMetadataContext::append_root_offset(
+    chunk_offset_t const root_offset) noexcept
+{
+    auto do_ = [&](unsigned const which) {
+        auto const g = copies_[which].main->hold_dirty();
+        root_offsets(which).push(root_offset);
+    };
+    do_(0);
+    do_(1);
+}
+
+void DbMetadataContext::update_root_offset(
+    size_t const i, chunk_offset_t const root_offset) noexcept
+{
+    auto do_ = [&](unsigned const which) {
+        auto const g = copies_[which].main->hold_dirty();
+        auto ro = root_offsets(which);
+        ro.assign(i, root_offset);
+        if (root_offset == INVALID_OFFSET && i == db_history_max_version() &&
+            i == db_history_min_valid_version()) {
+            ro.reset_all(0);
+            MONAD_ASSERT(ro.max_version() == INVALID_BLOCK_NUM);
+        }
+    };
+    do_(0);
+    do_(1);
+}
+
+void DbMetadataContext::fast_forward_next_version(
+    uint64_t const new_version) noexcept
+{
+    auto do_ = [&](unsigned const which) {
+        auto const g = copies_[which].main->hold_dirty();
+        auto ro = root_offsets(which);
+        uint64_t curr_version = ro.max_version();
+        MONAD_ASSERT(
+            curr_version == INVALID_BLOCK_NUM || new_version > curr_version);
+
+        if (curr_version == INVALID_BLOCK_NUM ||
+            new_version - curr_version >= ro.capacity()) {
+            ro.reset_all(new_version);
+        }
+        else {
+            while (curr_version + 1 < new_version) {
+                ro.push(INVALID_OFFSET);
+                curr_version = ro.max_version();
+            }
+        }
+    };
+    do_(0);
+    do_(1);
+}
+
+void DbMetadataContext::clear_root_offsets_up_to_and_including(
+    uint64_t const version)
+{
+    for (uint64_t v = db_history_range_lower_bound();
+         v != INVALID_BLOCK_NUM && v <= version;
+         v = db_history_range_lower_bound()) {
+        update_root_offset(v, INVALID_OFFSET);
+    }
+}
+
+// DB offsets
+
+void DbMetadataContext::advance_db_offsets_to(
+    chunk_offset_t const fast_offset, chunk_offset_t const slow_offset) noexcept
+{
+    MONAD_ASSERT(main()->at(fast_offset.id)->in_fast_list);
+    MONAD_ASSERT(main()->at(slow_offset.id)->in_slow_list);
+    auto do_ = [&](unsigned const which) {
+        copies_[which].main->advance_db_offsets_to_(
+            detail::db_metadata::db_offsets_info_t{fast_offset, slow_offset});
+    };
+    do_(0);
+    do_(1);
+}
+
+// History/version queries
+
+uint64_t DbMetadataContext::version_history_max_possible() const noexcept
+{
+    return root_offsets().capacity();
+}
+
+uint64_t DbMetadataContext::version_history_length() const noexcept
+{
+    return start_lifetime_as<std::atomic_uint64_t const>(
+               &copies_[0].main->history_length)
+        ->load(std::memory_order_relaxed);
+}
+
+uint64_t DbMetadataContext::db_history_min_valid_version() const noexcept
+{
+    auto const offsets = root_offsets();
+    auto min_version = db_history_range_lower_bound();
+    for (; min_version != offsets.max_version(); ++min_version) {
+        if (offsets[min_version] != INVALID_OFFSET) {
+            break;
+        }
+    }
+    return min_version;
+}
+
+uint64_t DbMetadataContext::db_history_max_version() const noexcept
+{
+    return root_offsets().max_version();
+}
+
+uint64_t DbMetadataContext::db_history_range_lower_bound() const noexcept
+{
+    auto const max_version = db_history_max_version();
+    if (max_version == INVALID_BLOCK_NUM) {
+        return INVALID_BLOCK_NUM;
+    }
+    else {
+        auto const history_range_min =
+            max_version >= version_history_length()
+                ? (max_version - version_history_length() + 1)
+                : 0;
+        auto const ro_version_lower_bound =
+            copies_[0].main->root_offsets.version_lower_bound_;
+        MONAD_ASSERT(ro_version_lower_bound >= history_range_min);
+        return ro_version_lower_bound;
+    }
+}
+
+chunk_offset_t DbMetadataContext::get_root_offset_at_version(
+    uint64_t const version) const noexcept
+{
+    if (version <= db_history_max_version()) {
+        auto const offset = root_offsets()[version];
+        if (version >= db_history_range_lower_bound()) {
+            return offset;
+        }
+    }
+    return INVALID_OFFSET;
+}
+
+DbMetadataContext::~DbMetadataContext()
+{
+    // munmap root_offsets
+    for (auto &copy : copies_) {
+        if (copy.root_offsets.data() != nullptr) {
+            (void)::munmap(
+                copy.root_offsets.data(), copy.root_offsets.size_bytes());
+            copy.root_offsets = {};
+        }
+    }
+    // munmap db_metadata
+    if (copies_[0].main != nullptr) {
+        (void)::munmap(copies_[0].main, db_map_size_);
+        copies_[0].main = nullptr;
+    }
+    if (copies_[1].main != nullptr) {
+        (void)::munmap(copies_[1].main, db_map_size_);
+        copies_[1].main = nullptr;
+    }
+}
+
+// Define to avoid randomisation of free list chunks on pool creation
+// This can be useful to discover bugs in code which assume chunks are
+// consecutive
+// #define MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS 1
+#define MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS 1
+
+void DbMetadataContext::init_new_pool(
+    std::optional<uint64_t> const history_len,
+    uint32_t const initial_insertion_count)
+{
+    MONAD_ASSERT(is_new_pool_);
+    auto const chunk_count = io_->chunk_count();
+
+    // Init chunk lists
+    memset(
+        &copies_[0].main->free_list, 0xff, sizeof(copies_[0].main->free_list));
+    memset(
+        &copies_[0].main->fast_list, 0xff, sizeof(copies_[0].main->fast_list));
+    memset(
+        &copies_[0].main->slow_list, 0xff, sizeof(copies_[0].main->slow_list));
+    auto *chunk_info =
+        start_lifetime_as_array<detail::db_metadata::chunk_info_t>(
+            copies_[0].main->chunk_info, chunk_count);
+    for (size_t n = 0; n < chunk_count; n++) {
+        auto &ci = chunk_info[n];
+        ci.prev_chunk_id = ci.next_chunk_id =
+            detail::db_metadata::chunk_info_t::INVALID_CHUNK_ID;
+    }
+    // magics are not set yet, so memcpy is fine here
+    memcpy(copies_[1].main, copies_[0].main, db_map_size_);
+
+    // Insert all chunks into the free list
+    std::vector<uint32_t> chunks;
+    chunks.reserve(chunk_count);
+    for (uint32_t n = 0; n < chunk_count; n++) {
+        auto const chunk = io_->storage_pool().chunk(storage_pool::seq, n);
+        MONAD_ASSERT(chunk.zone_id().first == storage_pool::seq);
+        MONAD_ASSERT(chunk.zone_id().second == n);
+        MONAD_ASSERT(chunk.size() == 0); // chunks must actually be free
+        chunks.push_back(n);
+    }
+
+#if MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS
+    std::reverse(chunks.begin(), chunks.end());
+    LOG_INFO_CFORMAT(
+        "Initialize db pool with %zu chunks in reverse order.", chunk_count);
+#elif MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS
+    LOG_INFO_CFORMAT(
+        "Initialize db pool with %zu chunks in random order.", chunk_count);
+    small_prng rand;
+    random_shuffle(chunks.begin(), chunks.end(), rand);
+#else
+    LOG_INFO_CFORMAT(
+        "Initialize db pool with %zu chunks in increasing order.", chunk_count);
+#endif
+    auto append_with_insertion_count_override = [&](chunk_list list,
+                                                    uint32_t id) {
+        append(list, id);
+        if (initial_insertion_count != 0) {
+            auto override_insertion_count = [&](detail::db_metadata *db) {
+                auto const g = db->hold_dirty();
+                auto *i = db->at_(id);
+                i->insertion_count0_ =
+                    uint32_t(initial_insertion_count) & 0x3ff;
+                i->insertion_count1_ =
+                    uint32_t(initial_insertion_count >> 10) & 0x3ff;
+            };
+            override_insertion_count(copies_[0].main);
+            override_insertion_count(copies_[1].main);
+        }
+        auto *i = copies_[0].main->at_(id);
+        MONAD_ASSERT(i->index(copies_[0].main) == id);
+    };
+    // root offset is the front of fast list
+    chunk_offset_t const fast_offset(chunks.front(), 0);
+    append_with_insertion_count_override(chunk_list::fast, fast_offset.id);
+    LOG_DEBUG_CFORMAT("Append one chunk to fast list, id: %d", fast_offset.id);
+    // init the first slow chunk and slow_offset
+    chunk_offset_t const slow_offset(chunks[1], 0);
+    append_with_insertion_count_override(chunk_list::slow, slow_offset.id);
+    LOG_DEBUG_CFORMAT("Append one chunk to slow list, id: %d", slow_offset.id);
+    std::span const chunks_after_second(chunks.data() + 2, chunks.size() - 2);
+    // insert the rest of the chunks to free list
+    for (uint32_t const i : chunks_after_second) {
+        append(chunk_list::free, i);
+        auto *i_ = copies_[0].main->at_(i);
+        MONAD_ASSERT(i_->index(copies_[0].main) == i);
+    }
+
+    // Mark as done, init root offset and history versions for the new
+    // database as invalid
+    advance_db_offsets_to(fast_offset, slow_offset);
+    set_latest_finalized_version(INVALID_BLOCK_NUM);
+    set_latest_verified_version(INVALID_BLOCK_NUM);
+    set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
+    set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
+    set_auto_expire_version_metadata(0);
+
+    for (auto const i : {0, 1}) {
+        auto *const m = copies_[i].main;
+        auto const g = m->hold_dirty();
+        memset(
+            m->future_variables_unused,
+            0xff,
+            sizeof(m->future_variables_unused));
+    }
+
+    std::atomic_signal_fence(
+        std::memory_order_seq_cst); // no compiler reordering here
+    memcpy(
+        copies_[0].main->magic,
+        detail::db_metadata::MAGIC,
+        detail::db_metadata::MAGIC_STRING_LEN);
+    memcpy(
+        copies_[1].main->magic,
+        detail::db_metadata::MAGIC,
+        detail::db_metadata::MAGIC_STRING_LEN);
+
+    map_root_offsets();
+    // Set history length, MUST be after root offsets are mapped
+    if (history_len.has_value()) {
+        update_history_length_metadata(*history_len);
+    }
+}
+
+void DbMetadataContext::append(chunk_list const list, uint32_t const idx)
+{
+    auto do_ = [&](detail::db_metadata *m) {
+        switch (list) {
+        case chunk_list::free:
+            m->append_(m->free_list, m->at_(idx));
+            break;
+        case chunk_list::fast:
+            m->append_(m->fast_list, m->at_(idx));
+            break;
+        case chunk_list::slow:
+            m->append_(m->slow_list, m->at_(idx));
+            break;
+        }
+    };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+    if (list == chunk_list::free) {
+        auto const &chunk = io_->storage_pool().chunk(storage_pool::seq, idx);
+        auto const capacity = chunk.capacity();
+        MONAD_ASSERT(chunk.size() == 0);
+        copies_[0].main->free_capacity_add_(capacity);
+        copies_[1].main->free_capacity_add_(capacity);
+    }
+    else {
+        auto const insertion_count =
+            static_cast<uint32_t>(main(0)->at(idx)->insertion_count());
+        if (insertion_count >= virtual_chunk_offset_t::MAX_COUNT * 9 / 10) {
+            LOG_WARNING_CFORMAT(
+                "Virtual offset space is running out "
+                "(insertion count: %u / %u). "
+                "Please perform a database reset.",
+                insertion_count,
+                (uint32_t)virtual_chunk_offset_t::MAX_COUNT);
+        }
+    }
+}
+
+void DbMetadataContext::remove(uint32_t const idx) noexcept
+{
+    bool const is_free_list =
+        (!copies_[0].main->at_(idx)->in_fast_list &&
+         !copies_[0].main->at_(idx)->in_slow_list);
+    auto do_ = [&](detail::db_metadata *m) { m->remove_(m->at_(idx)); };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+    if (is_free_list) {
+        auto const &chunk = io_->storage_pool().chunk(storage_pool::seq, idx);
+        auto const capacity = chunk.capacity();
+        MONAD_ASSERT(chunk.size() == 0);
+        copies_[0].main->free_capacity_sub_(capacity);
+        copies_[1].main->free_capacity_sub_(capacity);
+    }
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -1,0 +1,305 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/async/config.hpp>
+#include <category/async/io.hpp>
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/util.hpp>
+
+#include <atomic>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <span>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+// Owns mmap'd metadata regions for a single DB within a storage pool.
+// Handles the storage-level lifecycle: mmap, dirty recovery, magic validation,
+// new pool initialization of metadata and root_offsets storage, and munmap.
+//
+// Separated from UpdateAux so that the metadata mmap lifecycle can be
+// managed independently (e.g. by a pool-level owner in multi-DB setups).
+class DbMetadataContext
+{
+    friend class UpdateAux;
+
+public:
+    struct metadata_copy
+    {
+        detail::db_metadata *main{nullptr};
+        std::span<chunk_offset_t> root_offsets;
+    };
+
+    // Construct and mmap metadata from the given AsyncIO's storage pool.
+    explicit DbMetadataContext(MONAD_ASYNC_NAMESPACE::AsyncIO &io);
+
+    ~DbMetadataContext();
+
+    DbMetadataContext(DbMetadataContext const &) = delete;
+    DbMetadataContext &operator=(DbMetadataContext const &) = delete;
+    DbMetadataContext(DbMetadataContext &&) = delete;
+    DbMetadataContext &operator=(DbMetadataContext &&) = delete;
+
+    detail::db_metadata const *main(unsigned const which = 0) const noexcept
+    {
+        return copies_[which].main;
+    }
+
+    bool is_new_pool() const noexcept
+    {
+        return is_new_pool_;
+    }
+
+    enum class chunk_list : uint8_t
+    {
+        free = 0,
+        fast = 1,
+        slow = 2
+    };
+
+    void append(chunk_list list, uint32_t idx);
+    void remove(uint32_t idx) noexcept;
+
+    // Initialize a brand new pool: chunk lists, version markers, magic,
+    // root_offsets mapping, and optionally history length.
+    // initial_insertion_count is for unit testing only (normally 0).
+    void init_new_pool(
+        std::optional<uint64_t> history_len = {},
+        uint32_t initial_insertion_count = 0);
+
+    auto root_offsets(unsigned const which = 0) const
+    {
+        class root_offsets_delegator
+        {
+            std::atomic_ref<uint64_t> version_lower_bound_;
+            std::atomic_ref<uint64_t> next_version_;
+            std::span<chunk_offset_t> root_offsets_chunks_;
+
+            void
+            update_version_lower_bound_(uint64_t lower_bound = uint64_t(-1))
+            {
+                auto const version_lower_bound =
+                    version_lower_bound_.load(std::memory_order_acquire);
+                auto idx = (lower_bound < version_lower_bound)
+                               ? lower_bound
+                               : version_lower_bound;
+                auto const max_version =
+                    next_version_.load(std::memory_order_acquire) - 1;
+                if (max_version == INVALID_BLOCK_NUM) {
+                    return;
+                }
+                while (idx < max_version && (*this)[idx] == INVALID_OFFSET) {
+                    idx++;
+                }
+                if (idx != version_lower_bound) {
+                    version_lower_bound_.store(idx, std::memory_order_release);
+                }
+            }
+
+        public:
+            explicit root_offsets_delegator(metadata_copy const *m)
+                : version_lower_bound_(
+                      m->main->root_offsets.version_lower_bound_)
+                , next_version_(m->main->root_offsets.next_version_)
+                , root_offsets_chunks_(
+                      std::span<chunk_offset_t>(m->root_offsets))
+            {
+                MONAD_ASSERT_PRINTF(
+                    root_offsets_chunks_.size() ==
+                        1ULL
+                            << (63 -
+                                std::countl_zero(root_offsets_chunks_.size())),
+                    "root offsets chunks size is %lu, not a power of 2",
+                    root_offsets_chunks_.size());
+            }
+
+            size_t capacity() const noexcept
+            {
+                return root_offsets_chunks_.size();
+            }
+
+            void push(chunk_offset_t const o) noexcept
+            {
+                auto const wp = next_version_.load(std::memory_order_relaxed);
+                auto const next_wp = wp + 1;
+                MONAD_ASSERT(next_wp != 0);
+                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                    &root_offsets_chunks_
+                        [wp & (root_offsets_chunks_.size() - 1)]);
+                p->store(o, std::memory_order_release);
+                next_version_.store(next_wp, std::memory_order_release);
+                if (o != INVALID_OFFSET) {
+                    update_version_lower_bound_();
+                }
+            }
+
+            void assign(size_t const i, chunk_offset_t const o) noexcept
+            {
+                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                    &root_offsets_chunks_
+                        [i & (root_offsets_chunks_.size() - 1)]);
+                p->store(o, std::memory_order_release);
+                update_version_lower_bound_(
+                    (o != INVALID_OFFSET) ? i : uint64_t(-1));
+            }
+
+            chunk_offset_t operator[](size_t const i) const noexcept
+            {
+                return start_lifetime_as<std::atomic<chunk_offset_t> const>(
+                           &root_offsets_chunks_
+                               [i & (root_offsets_chunks_.size() - 1)])
+                    ->load(std::memory_order_acquire);
+            }
+
+            // return INVALID_BLOCK_NUM indicates that db is empty
+            uint64_t max_version() const noexcept
+            {
+                auto const wp = next_version_.load(std::memory_order_acquire);
+                return wp - 1;
+            }
+
+            void reset_all(uint64_t const version)
+            {
+                version_lower_bound_.store(0, std::memory_order_release);
+                next_version_.store(0, std::memory_order_release);
+                memset(
+                    (void *)root_offsets_chunks_.data(),
+                    0xff,
+                    root_offsets_chunks_.size() * sizeof(chunk_offset_t));
+                version_lower_bound_.store(version, std::memory_order_release);
+                next_version_.store(version, std::memory_order_release);
+            }
+
+            void rewind_to_version(uint64_t const version)
+            {
+                MONAD_ASSERT(version < max_version());
+                MONAD_ASSERT(max_version() - version <= capacity());
+                for (uint64_t i = version + 1; i <= max_version(); i++) {
+                    assign(i, async::INVALID_OFFSET);
+                }
+                if (version <
+                    version_lower_bound_.load(std::memory_order_acquire)) {
+                    version_lower_bound_.store(
+                        version, std::memory_order_release);
+                }
+                next_version_.store(version + 1, std::memory_order_release);
+                update_version_lower_bound_();
+            }
+        };
+
+        return root_offsets_delegator{&copies_[which]};
+    }
+
+    // Version metadata getters/setters
+    uint64_t get_latest_finalized_version() const noexcept;
+    void set_latest_finalized_version(uint64_t version) noexcept;
+    uint64_t get_latest_verified_version() const noexcept;
+    void set_latest_verified_version(uint64_t version) noexcept;
+    uint64_t get_latest_voted_version() const noexcept;
+    bytes32_t get_latest_voted_block_id() const noexcept;
+    void set_latest_voted(uint64_t version, bytes32_t const &block_id) noexcept;
+    uint64_t get_latest_proposed_version() const noexcept;
+    bytes32_t get_latest_proposed_block_id() const noexcept;
+    void
+    set_latest_proposed(uint64_t version, bytes32_t const &block_id) noexcept;
+    int64_t get_auto_expire_version_metadata() const noexcept;
+    void set_auto_expire_version_metadata(int64_t version) noexcept;
+    void update_history_length_metadata(uint64_t history_len) noexcept;
+
+    // Root offsets operations
+    void append_root_offset(chunk_offset_t root_offset) noexcept;
+    void update_root_offset(size_t i, chunk_offset_t root_offset) noexcept;
+    void fast_forward_next_version(uint64_t version) noexcept;
+    void clear_root_offsets_up_to_and_including(uint64_t version);
+
+    // DB offsets
+    void advance_db_offsets_to(
+        chunk_offset_t fast_offset, chunk_offset_t slow_offset) noexcept;
+
+    // History/version queries
+    uint64_t version_history_max_possible() const noexcept;
+    uint64_t version_history_length() const noexcept;
+    uint64_t db_history_min_valid_version() const noexcept;
+    uint64_t db_history_max_version() const noexcept;
+    uint64_t db_history_range_lower_bound() const noexcept;
+
+    // Inline accessors
+    chunk_offset_t get_start_of_wip_fast_offset() const noexcept
+    {
+        return copies_[0].main->db_offsets.start_of_wip_offset_fast;
+    }
+
+    chunk_offset_t get_start_of_wip_slow_offset() const noexcept
+    {
+        return copies_[0].main->db_offsets.start_of_wip_offset_slow;
+    }
+
+    file_offset_t get_lower_bound_free_space() const noexcept
+    {
+        return copies_[0].main->capacity_in_free_list;
+    }
+
+    chunk_offset_t get_latest_root_offset() const noexcept
+    {
+        auto const ro = root_offsets();
+        return ro[ro.max_version()];
+    }
+
+    chunk_offset_t get_root_offset_at_version(uint64_t version) const noexcept;
+
+    bool version_is_valid_ondisk(uint64_t version) const noexcept
+    {
+        return get_root_offset_at_version(version) != INVALID_OFFSET;
+    }
+
+    // Apply a function to both metadata copies
+    template <typename Func, typename... Args>
+        requires std::invocable<
+            std::function<void(detail::db_metadata *, Args...)>,
+            detail::db_metadata *, Args...>
+    void modify_metadata(Func func, Args const &...args) noexcept
+    {
+        func(copies_[0].main, args...);
+        func(copies_[1].main, args...);
+    }
+
+private:
+    // Map root_offsets from cnv chunks. Called by the constructor for existing
+    // pools, and by UpdateAux::init() after writing magic for new pools.
+    void map_root_offsets();
+
+    detail::db_metadata *main_mutable(unsigned const which = 0) noexcept
+    {
+        return copies_[which].main;
+    }
+
+    MONAD_ASYNC_NAMESPACE::AsyncIO *io_{nullptr};
+    metadata_copy copies_[2];
+    size_t db_map_size_{0};
+    bool is_new_pool_{false};
+    bool can_write_to_map_{false};
+    int prot_{0};
+    int mapflags_{0};
+};
+
+MONAD_MPT_NAMESPACE_END

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -30,6 +30,7 @@
 #include <type_traits>
 
 MONAD_MPT_NAMESPACE_BEGIN
+class DbMetadataContext;
 class UpdateAux;
 
 namespace detail
@@ -65,6 +66,7 @@ namespace detail
         static constexpr char const *MAGIC = "MONAD007";
         static constexpr unsigned MAGIC_STRING_LEN = 8;
 
+        friend class MONAD_MPT_NAMESPACE::DbMetadataContext;
         friend class MONAD_MPT_NAMESPACE::UpdateAux;
         friend inline void
         db_copy(db_metadata *dest, db_metadata const *src, size_t bytes);

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -257,7 +257,7 @@ void find_owning_notify_fiber_future(
     threadsafe_boost_fibers_promise<find_owning_cursor_result_type> &promise,
     NodeCursor const &start, NibblesView const key, uint64_t const version)
 {
-    if (!aux.version_is_valid_ondisk(version)) {
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version)) {
         promise.set_value({start, find_result::version_no_longer_exist});
         return;
     }
@@ -300,7 +300,7 @@ void find_owning_notify_fiber_future(
         auto const next_virtual_offset =
             aux.physical_to_virtual(next_node_offset);
         // version validity check must be after the virtual offset translation
-        if (!aux.version_is_valid_ondisk(version) ||
+        if (!aux.metadata_ctx().version_is_valid_ondisk(version) ||
             next_virtual_offset == INVALID_VIRTUAL_OFFSET) {
             promise.set_value({start, find_result::version_no_longer_exist});
             return;
@@ -358,10 +358,11 @@ void load_root_notify_fiber_future(
     threadsafe_boost_fibers_promise<find_owning_cursor_result_type> &promise,
     uint64_t const version)
 {
-    auto const root_offset = aux.get_root_offset_at_version(version);
+    auto const root_offset =
+        aux.metadata_ctx().get_root_offset_at_version(version);
     auto const root_virtual_offset = aux.physical_to_virtual(root_offset);
     // version validity check must be after the virtual offset translation
-    if (!aux.version_is_valid_ondisk(version) ||
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version) ||
         root_virtual_offset == INVALID_VIRTUAL_OFFSET) {
         promise.set_value({NodeCursor{}, find_result::version_no_longer_exist});
         return;

--- a/category/mpt/find_request_sender.hpp
+++ b/category/mpt/find_request_sender.hpp
@@ -250,7 +250,7 @@ inline MONAD_ASYNC_NAMESPACE::result<void> find_request_sender<T>::operator()(
             virtual_chunk_offset_t const virt_offset =
                 aux_.physical_to_virtual(offset);
             // Verify version after translating address
-            if (!aux_.version_is_valid_ondisk(version_)) {
+            if (!aux_.metadata_ctx().version_is_valid_ondisk(version_)) {
                 res_ = {T{}, find_result::version_no_longer_exist};
                 io_state->completed(success());
                 return success();

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -34,7 +34,7 @@ Node::SharedPtr read_node_blocking(
     uint64_t const version)
 {
     MONAD_ASSERT(aux.is_on_disk());
-    if (!aux.version_is_valid_ondisk(version)) {
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version)) {
         return {};
     }
     auto &pool = aux.io->storage_pool();
@@ -67,7 +67,7 @@ Node::SharedPtr read_node_blocking(
             rd_offset,
             strerror(errno));
     }
-    return aux.version_is_valid_ondisk(version)
+    return aux.metadata_ctx().version_is_valid_ondisk(version)
                ? deserialize_node_from_buffer(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)
                : Node::SharedPtr{};

--- a/category/mpt/test/append_test.cpp
+++ b/category/mpt/test/append_test.cpp
@@ -44,12 +44,14 @@ TYPED_TEST_SUITE(AppendTest, AppendTestTypes);
 
 TYPED_TEST(AppendTest, works)
 {
-    auto const last_root_version = this->state()->aux.db_history_max_version();
-    auto const last_root_off = this->state()->aux.get_latest_root_offset();
+    auto const last_root_version =
+        this->state()->aux.metadata_ctx().db_history_max_version();
+    auto const last_root_off =
+        this->state()->aux.metadata_ctx().get_latest_root_offset();
     auto const last_slow_off =
-        this->state()->aux.get_start_of_wip_slow_offset();
+        this->state()->aux.metadata_ctx().get_start_of_wip_slow_offset();
     auto const last_fast_off =
-        this->state()->aux.get_start_of_wip_fast_offset();
+        this->state()->aux.metadata_ctx().get_start_of_wip_fast_offset();
     auto const root_hash_before = this->state()->root_hash();
 
     this->state()->keys.clear();
@@ -62,9 +64,15 @@ TYPED_TEST(AppendTest, works)
     // Reset version, discarding all newer versions
     this->state()->aux.rewind_to_version(last_root_version);
     this->state()->version = last_root_version;
-    EXPECT_EQ(last_root_off, this->state()->aux.get_latest_root_offset());
-    EXPECT_EQ(last_slow_off, this->state()->aux.get_start_of_wip_slow_offset());
-    EXPECT_EQ(last_fast_off, this->state()->aux.get_start_of_wip_fast_offset());
+    EXPECT_EQ(
+        last_root_off,
+        this->state()->aux.metadata_ctx().get_latest_root_offset());
+    EXPECT_EQ(
+        last_slow_off,
+        this->state()->aux.metadata_ctx().get_start_of_wip_slow_offset());
+    EXPECT_EQ(
+        last_fast_off,
+        this->state()->aux.metadata_ctx().get_start_of_wip_fast_offset());
 
     // Get new current root
     this->state()->root = read_node_blocking(
@@ -75,9 +83,15 @@ TYPED_TEST(AppendTest, works)
     // Check number of chunks in use and current starting offsets are of the
     // same as before rewind
     EXPECT_EQ(this->state()->fast_list_ids().size(), 2);
-    EXPECT_EQ(this->state()->aux.get_latest_root_offset(), last_root_off);
-    EXPECT_EQ(this->state()->aux.get_start_of_wip_fast_offset(), last_fast_off);
-    EXPECT_EQ(this->state()->aux.get_start_of_wip_slow_offset(), last_slow_off);
+    EXPECT_EQ(
+        this->state()->aux.metadata_ctx().get_latest_root_offset(),
+        last_root_off);
+    EXPECT_EQ(
+        this->state()->aux.metadata_ctx().get_start_of_wip_fast_offset(),
+        last_fast_off);
+    EXPECT_EQ(
+        this->state()->aux.metadata_ctx().get_start_of_wip_slow_offset(),
+        last_slow_off);
     EXPECT_EQ(
         this->state()->aux.node_writer_fast->sender().offset(), last_fast_off);
     EXPECT_EQ(

--- a/category/mpt/test/blocking_read_concurrency_test.cpp
+++ b/category/mpt/test/blocking_read_concurrency_test.cpp
@@ -97,10 +97,11 @@ struct DbConcurrencyTest1
 TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
 {
     // Load root of most recent version
-    auto const latest_version = state()->aux.db_history_max_version();
+    auto const latest_version =
+        state()->aux.metadata_ctx().db_history_max_version();
     Node::SharedPtr root = read_node_blocking(
         state()->aux,
-        state()->aux.get_root_offset_at_version(latest_version),
+        state()->aux.metadata_ctx().get_root_offset_at_version(latest_version),
         latest_version);
     ASSERT_TRUE(root);
     auto const &key = state()->keys.front().first;
@@ -153,8 +154,10 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
     }
     // Erase the version being read should trigger a find failure and ends the
     // reader thread
-    state()->aux.update_root_offset(latest_version, INVALID_OFFSET);
-    EXPECT_FALSE(state()->aux.version_is_valid_ondisk(latest_version));
+    state()->aux.metadata_ctx().update_root_offset(
+        latest_version, INVALID_OFFSET);
+    EXPECT_FALSE(
+        state()->aux.metadata_ctx().version_is_valid_ondisk(latest_version));
 
     // Wait for completion with timeout
     auto const status = completion_future.wait_for(std::chrono::seconds(5));
@@ -177,10 +180,11 @@ struct DbConcurrencyTest2
 TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
 {
     // Load root of most recent version
-    auto const latest_version = state()->aux.db_history_max_version();
+    auto const latest_version =
+        state()->aux.metadata_ctx().db_history_max_version();
     Node::SharedPtr root = read_node_blocking(
         state()->aux,
-        state()->aux.get_root_offset_at_version(latest_version),
+        state()->aux.metadata_ctx().get_root_offset_at_version(latest_version),
         latest_version);
     ASSERT_TRUE(root);
 
@@ -225,8 +229,10 @@ TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
         cond.wait(g);
     }
     // Erase the version being read should stop traverse in the reader thread
-    state()->aux.update_root_offset(latest_version, INVALID_OFFSET);
-    EXPECT_FALSE(state()->aux.version_is_valid_ondisk(latest_version));
+    state()->aux.metadata_ctx().update_root_offset(
+        latest_version, INVALID_OFFSET);
+    EXPECT_FALSE(
+        state()->aux.metadata_ctx().version_is_valid_ondisk(latest_version));
 
     // Wait for completion with timeout
     auto const status = completion_future.wait_for(std::chrono::seconds(5));

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -227,21 +227,26 @@ struct cli_tool_fixture
                 monad::mpt::UpdateAux const aux{testio};
                 monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
                     aux,
-                    aux.get_latest_root_offset(),
-                    aux.db_history_max_version())};
+                    aux.metadata_ctx().get_latest_root_offset(),
+                    aux.metadata_ctx().db_history_max_version())};
                 monad::mpt::NodeCursor const root(root_ptr);
 
                 for (auto const &key : this->state()->keys) {
                     auto const ret = monad::mpt::find_blocking(
-                        aux, root, key.first, aux.db_history_max_version());
+                        aux,
+                        root,
+                        key.first,
+                        aux.metadata_ctx().db_history_max_version());
                     EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                 }
                 EXPECT_EQ(
-                    this->state()->aux.db_history_min_valid_version(),
-                    aux.db_history_min_valid_version());
+                    this->state()
+                        ->aux.metadata_ctx()
+                        .db_history_min_valid_version(),
+                    aux.metadata_ctx().db_history_min_valid_version());
                 EXPECT_EQ(
-                    this->state()->aux.db_history_max_version(),
-                    aux.db_history_max_version());
+                    this->state()->aux.metadata_ctx().db_history_max_version(),
+                    aux.metadata_ctx().db_history_max_version());
             }).get();
         }
         if (Config.interleave_multiple_sources) {
@@ -331,21 +336,28 @@ struct cli_tool_fixture
                     monad::mpt::Node::SharedPtr const root_ptr{
                         read_node_blocking(
                             aux,
-                            aux.get_latest_root_offset(),
-                            aux.db_history_max_version())};
+                            aux.metadata_ctx().get_latest_root_offset(),
+                            aux.metadata_ctx().db_history_max_version())};
                     monad::mpt::NodeCursor const root(root_ptr);
 
                     for (auto const &key : this->state()->keys) {
                         auto const ret = monad::mpt::find_blocking(
-                            aux, root, key.first, aux.db_history_max_version());
+                            aux,
+                            root,
+                            key.first,
+                            aux.metadata_ctx().db_history_max_version());
                         EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                     }
                     EXPECT_EQ(
-                        this->state()->aux.db_history_min_valid_version(),
-                        aux.db_history_min_valid_version());
+                        this->state()
+                            ->aux.metadata_ctx()
+                            .db_history_min_valid_version(),
+                        aux.metadata_ctx().db_history_min_valid_version());
                     EXPECT_EQ(
-                        this->state()->aux.db_history_max_version(),
-                        aux.db_history_max_version());
+                        this->state()
+                            ->aux.metadata_ctx()
+                            .db_history_max_version(),
+                        aux.metadata_ctx().db_history_max_version());
                 }).get();
             }
         }

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -2232,7 +2232,7 @@ TEST(DbTest, move_trie_version_forward_history_ring_wrap_around)
     Node::SharedPtr root;
 
     uint64_t const root_offsets_ring_capacity =
-        test::DbAccessor::aux(db).root_offsets().capacity();
+        test::DbAccessor::aux(db).metadata_ctx().root_offsets().capacity();
 
     auto const prefix = 0x0012_bytes;
     monad::byte_string const kv = keccak_int_to_string(10);
@@ -2295,7 +2295,7 @@ TEST_F(OnDiskDbWithFileFixture, history_ring_buffer_wrap_around)
     }
 
     uint64_t const root_offsets_ring_capacity =
-        test::DbAccessor::aux(db).root_offsets().capacity();
+        test::DbAccessor::aux(db).metadata_ctx().root_offsets().capacity();
     std::cout << root_offsets_ring_capacity << std::endl;
 
     auto const version_begin = root_offsets_ring_capacity * 2;
@@ -2865,7 +2865,11 @@ TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
         nullptr, db, prefix, 0, make_update(key0, key0));
 
     // After upsert at version 0, auto_expire_version_metadata should be 0
-    EXPECT_EQ(test::DbAccessor::aux(db).get_auto_expire_version_metadata(), 0);
+    EXPECT_EQ(
+        test::DbAccessor::aux(db)
+            .metadata_ctx()
+            .get_auto_expire_version_metadata(),
+        0);
 
     // Move trie from version 0 to version 1000
     constexpr uint64_t start_version = 1000;
@@ -2873,7 +2877,9 @@ TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
 
     // After move, auto_expire_version_metadata should be updated to 1000
     EXPECT_EQ(
-        test::DbAccessor::aux(db).get_auto_expire_version_metadata(),
+        test::DbAccessor::aux(db)
+            .metadata_ctx()
+            .get_auto_expire_version_metadata(),
         start_version)
         << "auto_expire_version_metadata should be moved forward with "
            "move_trie_version_forward";

--- a/category/mpt/test/load_all_test.cpp
+++ b/category/mpt/test/load_all_test.cpp
@@ -35,8 +35,8 @@ TEST_F(LoadAllTest, works)
     monad::test::StateMachineAlwaysMerkle sm;
     monad::mpt::Node::SharedPtr const root{monad::mpt::read_node_blocking(
         state()->aux,
-        aux.get_latest_root_offset(),
-        aux.db_history_max_version())};
+        aux.metadata_ctx().get_latest_root_offset(),
+        aux.metadata_ctx().db_history_max_version())};
     auto nodes_loaded = monad::mpt::load_all(aux, sm, root);
     EXPECT_GE(nodes_loaded, state()->keys.size());
     std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;

--- a/category/mpt/test/merkle_trie_test.cpp
+++ b/category/mpt/test/merkle_trie_test.cpp
@@ -605,17 +605,17 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
         // check db maintain expected historical versions
         if (this->aux.is_on_disk()) {
             if (block_id - start_block_id <
-                this->aux.version_history_length()) {
+                this->aux.metadata_ctx().version_history_length()) {
                 EXPECT_EQ(
-                    this->aux.db_history_max_version() -
-                        this->aux.db_history_min_valid_version(),
+                    this->aux.metadata_ctx().db_history_max_version() -
+                        this->aux.metadata_ctx().db_history_min_valid_version(),
                     block_id - start_block_id);
             }
             else {
                 EXPECT_EQ(
-                    this->aux.db_history_max_version() -
-                        this->aux.db_history_min_valid_version(),
-                    this->aux.version_history_length());
+                    this->aux.metadata_ctx().db_history_max_version() -
+                        this->aux.metadata_ctx().db_history_min_valid_version(),
+                    this->aux.metadata_ctx().version_history_length());
             }
         }
     };

--- a/category/mpt/test/min_truncated_offsets_test.cpp
+++ b/category/mpt/test/min_truncated_offsets_test.cpp
@@ -67,7 +67,8 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                         *(uint32_t *)(key.data() + n) = rand();
                     }
                     keys.emplace_back(
-                        std::move(key), aux.get_latest_root_offset().id);
+                        std::move(key),
+                        aux.metadata_ctx().get_latest_root_offset().id);
                 }
                 updates.push_back(
                     make_update(keys.back().first, keys.back().first));
@@ -76,14 +77,14 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
             root = upsert(
                 aux, block_id, *sm, std::move(root), std::move(update_ls));
             size_t count_fast = 0;
-            for (auto const *ci = aux.db_metadata()->fast_list_begin();
+            for (auto const *ci = aux.metadata_ctx().main()->fast_list_begin();
                  ci != nullptr;
-                 count_fast++, ci = ci->next(aux.db_metadata())) {
+                 count_fast++, ci = ci->next(aux.metadata_ctx().main())) {
             }
             size_t count_slow = 0;
-            for (auto const *ci = aux.db_metadata()->slow_list_begin();
+            for (auto const *ci = aux.metadata_ctx().main()->slow_list_begin();
                  ci != nullptr;
-                 count_slow++, ci = ci->next(aux.db_metadata())) {
+                 count_slow++, ci = ci->next(aux.metadata_ctx().main())) {
             }
             if (count_fast >= fast_chunks &&
                 aux.node_writer_fast->sender().offset().offset >=
@@ -162,7 +163,8 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                 // verify that offset equals calculated one in traversal
                 auto const expected_min_offsets = calc_min_offsets(
                     *const_cast<Node *>(&node),
-                    aux.physical_to_virtual(aux.get_latest_root_offset()));
+                    aux.physical_to_virtual(
+                        aux.metadata_ctx().get_latest_root_offset()));
                 EXPECT_EQ(node_record.test_min_offsets, expected_min_offsets);
             }
             else {

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -63,9 +63,11 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
     monad::test::UpdateAux aux{state()->io};
     monad::test::StateMachineAlwaysMerkle const sm;
     // Load its root
-    auto const latest_version = aux.db_history_max_version();
+    auto const latest_version = aux.metadata_ctx().db_history_max_version();
     monad::mpt::Node::SharedPtr const root{monad::mpt::read_node_blocking(
-        aux, aux.get_root_offset_at_version(latest_version), latest_version)};
+        aux,
+        aux.metadata_ctx().get_root_offset_at_version(latest_version),
+        latest_version)};
     auto const &key = state()->keys.front().first;
     auto const &value = state()->keys.front().first;
 

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -557,11 +557,13 @@ int main(int argc, char *argv[])
                 if (append) {
                     root = read_node_blocking(
                         aux,
-                        aux.get_latest_root_offset(),
-                        aux.db_history_max_version());
+                        aux.metadata_ctx().get_latest_root_offset(),
+                        aux.metadata_ctx().db_history_max_version());
                 }
                 auto block_id =
-                    in_memory ? 0 : (aux.db_history_max_version() + 1);
+                    in_memory
+                        ? 0
+                        : (aux.metadata_ctx().db_history_max_version() + 1);
                 printf("starting block id %lu\n", block_id);
 
                 auto begin_test = std::chrono::steady_clock::now();
@@ -701,14 +703,17 @@ int main(int argc, char *argv[])
                     Node::SharedPtr &root = std::get<1>(*ret);
                     NodeCursor &state_start = std::get<2>(*ret);
                     if (!in_memory) {
-                        aux.set_io(io, history_len);
+                        aux.init(io, history_len);
                     }
                     root = read_node_blocking(
                         aux,
-                        aux.get_latest_root_offset(),
-                        aux.db_history_max_version());
+                        aux.metadata_ctx().get_latest_root_offset(),
+                        aux.metadata_ctx().db_history_max_version());
                     auto [res, errc] = find_blocking(
-                        aux, root, state_nibbles, aux.db_history_max_version());
+                        aux,
+                        root,
+                        state_nibbles,
+                        aux.metadata_ctx().db_history_max_version());
                     MONAD_ASSERT(errc == find_result::success);
                     state_start = res;
                     return ret;
@@ -797,7 +802,7 @@ int main(int argc, char *argv[])
                                 node_cache,
                                 inflights,
                                 NodeCursor{start_node},
-                                aux.db_history_max_version(),
+                                aux.metadata_ctx().db_history_max_version(),
                                 NibblesView{},
                                 true},
                             receiver_t(

--- a/category/mpt/test/node_writer_test.cpp
+++ b/category/mpt/test/node_writer_test.cpp
@@ -138,7 +138,8 @@ struct NodeWriterTestBase : public ::testing::Test
 
     uint32_t get_writer_chunk_count(node_writer_unique_ptr_type &node_writer)
     {
-        return (uint32_t)aux.db_metadata()
+        return (uint32_t)aux.metadata_ctx()
+            .main()
             ->at(get_writer_chunk_id(node_writer))
             ->insertion_count();
     }
@@ -210,7 +211,7 @@ TEST_F(NodeWriterTest, write_node_across_buffers_ends_at_buffer_boundary)
     auto const node_writer_chunk_count_after =
         get_writer_chunk_count(aux.node_writer_fast);
     EXPECT_EQ(
-        aux.db_metadata()->at(new_node_offset.id)->insertion_count(),
+        aux.metadata_ctx().main()->at(new_node_offset.id)->insertion_count(),
         node_writer_chunk_count_after);
     EXPECT_EQ(
         node_writer_chunk_count_before + 1, node_writer_chunk_count_after);
@@ -234,7 +235,7 @@ TEST_F(NodeWriterTest, write_node_at_new_chunk)
     auto const node = make_node_of_size(chunk_remaining_bytes + 1024);
     auto const node_offset = async_write_node_set_spare(aux, *node, true);
     auto const node_offset_chunk_count =
-        aux.db_metadata()->at(node_offset.id)->insertion_count();
+        aux.metadata_ctx().main()->at(node_offset.id)->insertion_count();
     EXPECT_EQ(
         node_offset_chunk_count, node_writer_chunk_count_before_write_node + 1);
     EXPECT_EQ(

--- a/category/mpt/test/rewind_test.cpp
+++ b/category/mpt/test/rewind_test.cpp
@@ -39,70 +39,91 @@ TEST_F(RewindTest, works)
     std::cout << "DB is at " << path << ". Closing DB ..." << std::endl;
     auto &aux = this->state()->aux;
     auto &io = this->state()->io;
-    auto const max_version = aux.db_history_max_version();
-    aux.set_latest_finalized_version(max_version);
-    aux.set_latest_verified_version(max_version);
-    aux.set_latest_voted(100, monad::bytes32_t{100});
-    aux.unset_io();
+    auto const max_version = aux.metadata_ctx().db_history_max_version();
+    aux.metadata_ctx().set_latest_finalized_version(max_version);
+    aux.metadata_ctx().set_latest_verified_version(max_version);
+    aux.metadata_ctx().set_latest_voted(100, monad::bytes32_t{100});
     std::cout << "Reopening DB ..." << std::endl;
-    aux.set_io(io, 20000);
+    aux.init(io, 20000);
     std::cout << "Rewinding DB to latest version " << max_version << "..."
               << std::endl;
     aux.rewind_to_version(max_version);
-    EXPECT_TRUE(aux.version_is_valid_ondisk(max_version));
-    EXPECT_EQ(aux.get_latest_finalized_version(), max_version);
-    EXPECT_EQ(aux.get_latest_verified_version(), max_version);
-    EXPECT_EQ(aux.get_latest_voted_version(), 100);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{100});
+    EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(max_version));
+    EXPECT_EQ(aux.metadata_ctx().get_latest_finalized_version(), max_version);
+    EXPECT_EQ(aux.metadata_ctx().get_latest_verified_version(), max_version);
+    EXPECT_EQ(aux.metadata_ctx().get_latest_voted_version(), 100);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{100});
 
     std::cout << "Rewinding DB to 9990 ..." << std::endl;
     aux.rewind_to_version(9990);
     std::cout << "\nAfter rewind to 9990:\n";
     this->state()->print(std::cout);
-    EXPECT_EQ(0, aux.db_history_min_valid_version());
-    EXPECT_EQ(9990, aux.db_history_max_version());
-    EXPECT_EQ(9990, aux.get_latest_finalized_version());
-    EXPECT_EQ(aux.get_latest_verified_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
+    EXPECT_EQ(0, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(9990, aux.metadata_ctx().db_history_max_version());
+    EXPECT_EQ(9990, aux.metadata_ctx().get_latest_finalized_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_verified_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
     std::cout << "\nClosing DB ..." << std::endl;
-    aux.unset_io();
     std::cout
         << "Reopening DB to check valid versions are what they should be ..."
         << std::endl;
-    aux.set_io(io);
-    EXPECT_EQ(0, aux.db_history_min_valid_version());
-    EXPECT_EQ(9990, aux.db_history_max_version());
+    aux.init(io);
+    EXPECT_EQ(0, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(9990, aux.metadata_ctx().db_history_max_version());
     // rewind to latest is noop
-    EXPECT_EQ(9990, aux.get_latest_finalized_version());
-    EXPECT_EQ(aux.get_latest_verified_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
-    aux.unset_io();
+    EXPECT_EQ(9990, aux.metadata_ctx().get_latest_finalized_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_verified_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
     std::cout << "Setting max history to 9000 and reopening ..." << std::endl;
-    aux.set_io(io, 9000);
-    EXPECT_EQ(991, aux.db_history_min_valid_version());
-    EXPECT_EQ(9990, aux.db_history_max_version());
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
+    aux.init(io, 9000);
+    EXPECT_EQ(991, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(9990, aux.metadata_ctx().db_history_max_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
     aux.rewind_to_version(9900);
-    EXPECT_EQ(991, aux.db_history_min_valid_version());
-    EXPECT_EQ(9900, aux.db_history_max_version());
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
-    aux.unset_io();
-    aux.set_io(io);
-    EXPECT_EQ(991, aux.db_history_min_valid_version());
-    EXPECT_EQ(9900, aux.db_history_max_version());
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
+    EXPECT_EQ(991, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(9900, aux.metadata_ctx().db_history_max_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
+    aux.init(io);
+    EXPECT_EQ(991, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(9900, aux.metadata_ctx().db_history_max_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
     aux.rewind_to_version(991);
-    EXPECT_EQ(991, aux.db_history_min_valid_version());
-    EXPECT_EQ(991, aux.db_history_max_version());
-    EXPECT_EQ(991, aux.get_latest_finalized_version());
-    EXPECT_EQ(aux.get_latest_verified_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_version(), monad::mpt::INVALID_BLOCK_NUM);
-    EXPECT_EQ(aux.get_latest_voted_block_id(), monad::bytes32_t{});
+    EXPECT_EQ(991, aux.metadata_ctx().db_history_min_valid_version());
+    EXPECT_EQ(991, aux.metadata_ctx().db_history_max_version());
+    EXPECT_EQ(991, aux.metadata_ctx().get_latest_finalized_version());
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_verified_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_version(),
+        monad::mpt::INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        aux.metadata_ctx().get_latest_voted_block_id(), monad::bytes32_t{});
 }
 
 TEST_F(RewindTest, clear_db)
@@ -110,12 +131,17 @@ TEST_F(RewindTest, clear_db)
     auto &aux = this->state()->aux;
     aux.clear_ondisk_db();
     EXPECT_EQ(
-        monad::mpt::INVALID_BLOCK_NUM, aux.db_history_min_valid_version());
-    EXPECT_EQ(monad::mpt::INVALID_BLOCK_NUM, aux.db_history_max_version());
+        monad::mpt::INVALID_BLOCK_NUM,
+        aux.metadata_ctx().db_history_min_valid_version());
     EXPECT_EQ(
-        aux.db_metadata()->fast_list.begin, aux.db_metadata()->fast_list.end);
+        monad::mpt::INVALID_BLOCK_NUM,
+        aux.metadata_ctx().db_history_max_version());
     EXPECT_EQ(
-        aux.db_metadata()->slow_list.begin, aux.db_metadata()->slow_list.end);
+        aux.metadata_ctx().main()->fast_list.begin,
+        aux.metadata_ctx().main()->fast_list.end);
+    EXPECT_EQ(
+        aux.metadata_ctx().main()->slow_list.begin,
+        aux.metadata_ctx().main()->slow_list.end);
 }
 
 struct RewindTestFillOne
@@ -136,29 +162,26 @@ TEST_F(
     // chunk than the latest root offset is at
     auto const path = this->state()->pool.devices()[0].current_path();
     auto &aux = this->state()->aux;
-    auto &io = this->state()->io;
-    auto const latest_root_offset = aux.get_latest_root_offset();
+    auto const latest_root_offset = aux.metadata_ctx().get_latest_root_offset();
     std::cout << "DB is at " << path << ". Last root offset ["
               << latest_root_offset.id << ", " << latest_root_offset.offset
               << "]. " << std::endl;
 
     // advance fast writer head to the next chunk
     auto const fast_writer_offset = aux.node_writer_fast->sender().offset();
-    auto const *ci = aux.db_metadata()->free_list_end();
+    auto const *ci = aux.metadata_ctx().main()->free_list_end();
     ASSERT_TRUE(ci != nullptr);
-    auto const idx = ci->index(aux.db_metadata());
-    aux.remove(idx);
-    aux.append(monad::mpt::UpdateAux::chunk_list::fast, idx);
+    auto const idx = ci->index(aux.metadata_ctx().main());
+    aux.metadata_ctx().remove(idx);
+    aux.metadata_ctx().append(monad::mpt::UpdateAux::chunk_list::fast, idx);
     monad::async::chunk_offset_t const new_fast_writer_offset{idx, 0};
-    aux.advance_db_offsets_to(
+    aux.metadata_ctx().advance_db_offsets_to(
         new_fast_writer_offset, aux.node_writer_slow->sender().offset());
     std::cout << "Advanced start of fast list offset on disk from ["
               << fast_writer_offset.id << ", " << fast_writer_offset.offset
               << "] to the beginning of a new chunk, id: " << idx << std::endl;
 
     std::cout << "Closing and reopening Db ...\n" << std::endl;
-    aux.unset_io();
-
-    // verifies set_io() succeeds
-    aux.set_io(io);
+    // verifies reinitialization succeeds
+    aux.init(this->state()->io);
 }

--- a/category/mpt/test/subtrie_version_test.cpp
+++ b/category/mpt/test/subtrie_version_test.cpp
@@ -163,7 +163,7 @@ TEST_F(OnDiskMerkleTrieGTest, recursively_verify_versions)
             this->aux,
             *this->root,
             traverse,
-            this->aux.db_history_max_version());
+            this->aux.metadata_ctx().db_history_max_version());
         EXPECT_EQ(traverse.records.empty(), true);
     }
 
@@ -206,7 +206,7 @@ TEST_F(OnDiskMerkleTrieGTest, recursively_verify_versions)
             this->aux,
             *this->root,
             traverse,
-            this->aux.db_history_max_version());
+            this->aux.metadata_ctx().db_history_max_version());
         EXPECT_EQ(traverse.records.empty(), true);
     }
 }

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -523,42 +523,45 @@ namespace monad::test
                           << " consumed = " << v.second
                           << " chunks = " << pool.chunks(pool.seq);
                 auto const diff =
-                    (int64_t(aux.get_lower_bound_free_space()) -
+                    (int64_t(aux.metadata_ctx().get_lower_bound_free_space()) -
                      int64_t(v.first - v.second));
                 std::cout << "\n   DB thinks there is a lower bound of "
-                          << aux.get_lower_bound_free_space()
+                          << aux.metadata_ctx().get_lower_bound_free_space()
                           << " bytes free whereas the syscall thinks there is "
                           << (v.first - v.second)
                           << " bytes free, which is a difference of " << diff
                           << ".\n";
                 std::cout << "   Fast list:";
-                for (auto const *ci = aux.db_metadata()->fast_list_begin();
+                for (auto const *ci =
+                         aux.metadata_ctx().main()->fast_list_begin();
                      ci != nullptr;
-                     ci = ci->next(aux.db_metadata())) {
-                    auto const idx = ci->index(aux.db_metadata());
+                     ci = ci->next(aux.metadata_ctx().main())) {
+                    auto const idx = ci->index(aux.metadata_ctx().main());
                     auto const &chunk = pool.chunk(pool.seq, idx);
                     std::cout << "\n      Chunk " << idx
                               << " has capacity = " << chunk.capacity()
                               << " consumed = " << chunk.size();
                 }
                 std::cout << "\n\n   Slow list:";
-                for (auto const *ci = aux.db_metadata()->slow_list_begin();
+                for (auto const *ci =
+                         aux.metadata_ctx().main()->slow_list_begin();
                      ci != nullptr;
-                     ci = ci->next(aux.db_metadata())) {
-                    auto const idx = ci->index(aux.db_metadata());
+                     ci = ci->next(aux.metadata_ctx().main())) {
+                    auto const idx = ci->index(aux.metadata_ctx().main());
                     auto const chunk = pool.chunk(pool.seq, idx);
                     std::cout << "\n      Chunk " << idx
                               << " has capacity = " << chunk.capacity()
                               << " consumed = " << chunk.size();
                 }
                 std::cout << "\n\n   Free list: "
-                          << aux.db_metadata()->capacity_in_free_list
+                          << aux.metadata_ctx().main()->capacity_in_free_list
                           << " bytes.";
-                auto const ro = aux.root_offsets();
+                auto const ro = aux.metadata_ctx().root_offsets();
                 auto const most_recent_offset = ro[ro.max_version()];
                 std::cout << "\n\n   DB version history is "
-                          << aux.db_history_min_valid_version() << " - "
-                          << aux.db_history_max_version()
+                          << aux.metadata_ctx().db_history_min_valid_version()
+                          << " - "
+                          << aux.metadata_ctx().db_history_max_version()
                           << ". Most recent DB history is id "
                           << most_recent_offset.id << " offset "
                           << most_recent_offset.offset;
@@ -582,7 +585,7 @@ namespace monad::test
                             }
                             keys.emplace_back(
                                 std::move(key),
-                                aux.get_latest_root_offset().id);
+                                aux.metadata_ctx().get_latest_root_offset().id);
                         }
                         updates.push_back(make_update(
                             keys.back().first, keys.back().first, false));
@@ -595,9 +598,10 @@ namespace monad::test
                         version++,
                         true);
                     size_t count = 0;
-                    for (auto const *ci = aux.db_metadata()->fast_list_begin();
+                    for (auto const *ci =
+                             aux.metadata_ctx().main()->fast_list_begin();
                          ci != nullptr;
-                         count++, ci = ci->next(aux.db_metadata())) {
+                         count++, ci = ci->next(aux.metadata_ctx().main())) {
                     }
                     if (count >= chunks) {
                         break;
@@ -614,11 +618,13 @@ namespace monad::test
                     MONAD_MPT_NAMESPACE::detail::unsigned_20>>
                     ret;
                 ret.reserve(4);
-                for (auto const *ci = aux.db_metadata()->fast_list_begin();
+                for (auto const *ci =
+                         aux.metadata_ctx().main()->fast_list_begin();
                      ci != nullptr;
-                     ci = ci->next(aux.db_metadata())) {
+                     ci = ci->next(aux.metadata_ctx().main())) {
                     ret.emplace_back(
-                        ci->index(aux.db_metadata()), ci->insertion_count());
+                        ci->index(aux.metadata_ctx().main()),
+                        ci->insertion_count());
                 }
                 return ret;
             }
@@ -632,11 +638,13 @@ namespace monad::test
                     MONAD_MPT_NAMESPACE::detail::unsigned_20>>
                     ret;
                 ret.reserve(4);
-                for (auto const *ci = aux.db_metadata()->slow_list_begin();
+                for (auto const *ci =
+                         aux.metadata_ctx().main()->slow_list_begin();
                      ci != nullptr;
-                     ci = ci->next(aux.db_metadata())) {
+                     ci = ci->next(aux.metadata_ctx().main())) {
                     ret.emplace_back(
-                        ci->index(aux.db_metadata()), ci->insertion_count());
+                        ci->index(aux.metadata_ctx().main()),
+                        ci->insertion_count());
                 }
                 return ret;
             }

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -30,10 +30,12 @@
 #include <csignal>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <span>
-#include <stdlib.h>
 #include <stop_token>
 #include <thread>
+
+#include <stdlib.h>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
@@ -43,14 +45,14 @@ namespace
     constexpr uint64_t AUX_TEST_HISTORY_LENGTH = 1000;
 }
 
-TEST(update_aux_test, set_io_reader_dirty)
+TEST(update_aux_test, reader_dirty_aborts)
 {
     monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
 
     // All this threading nonsense is because we can't have two AsyncIO
     // instances on the same thread.
 
-    monad::mpt::UpdateAux aux_writer{};
+    std::unique_ptr<monad::mpt::UpdateAux> aux_writer;
     std::atomic<bool> io_set = false;
     std::jthread const rw_asyncio([&](std::stop_token token) {
         monad::io::Ring ring1;
@@ -64,48 +66,29 @@ TEST(update_aux_test, set_io_reader_dirty)
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
                 monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
         monad::async::AsyncIO testio(pool, testbuf);
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+        aux_writer = std::make_unique<monad::mpt::UpdateAux>(
+            testio, AUX_TEST_HISTORY_LENGTH);
         io_set = true;
 
         while (!token.stop_requested()) {
             std::this_thread::sleep_for(10ms);
         }
-        aux_writer.unset_io();
+        // Destroy before local AsyncIO/Buffers/Rings go out of scope
+        aux_writer.reset();
     });
     while (!io_set) {
         std::this_thread::yield();
     }
 
     // Set both bits dirty
-    aux_writer.modify_metadata([](monad::mpt::detail::db_metadata *m) {
-        m->is_dirty().store(1, std::memory_order_release);
-    });
+    aux_writer->metadata_ctx().modify_metadata(
+        [](monad::mpt::detail::db_metadata *m) {
+            m->is_dirty().store(1, std::memory_order_release);
+        });
 
-    ASSERT_TRUE(
-        const_cast<monad::mpt::detail::db_metadata *>(aux_writer.db_metadata())
-            ->is_dirty());
-
-    struct TestAux : public monad::mpt::UpdateAux
-    {
-        monad::mpt::UpdateAux &write_aux;
-        bool was_dirty{false};
-
-        explicit TestAux(monad::mpt::UpdateAux &write_aux_)
-            : write_aux(write_aux_)
-        {
-        }
-
-        void on_read_only_init_with_dirty_bit() noexcept override
-        {
-            was_dirty = true;
-
-            // Disable the dirty bits. This simulates the writer unsetting dirty
-            // bit.
-            write_aux.modify_metadata([](monad::mpt::detail::db_metadata *m) {
-                m->is_dirty().store(0, std::memory_order_release);
-            });
-        }
-    };
+    ASSERT_TRUE(const_cast<monad::mpt::detail::db_metadata *>(
+                    aux_writer->metadata_ctx().main())
+                    ->is_dirty());
 
     monad::io::Ring ring;
     monad::io::Buffers testrobuf = monad::io::make_buffers_for_read_only(
@@ -113,18 +96,19 @@ TEST(update_aux_test, set_io_reader_dirty)
     auto pool_ro = pool.clone_as_read_only();
     monad::async::AsyncIO testio(pool_ro, testrobuf);
 
-    // This should throw. Dirty bit stays set.
+    // RO open should abort when dirty bits are set and never clear.
     ASSERT_DEATH(
-        ({
-            monad::mpt::UpdateAux aux_reader{};
-            aux_reader.set_io(testio, AUX_TEST_HISTORY_LENGTH);
-        }),
+        ({ monad::mpt::DbMetadataContext{testio}; }),
         "DB metadata was closed dirty, but not opened for healing");
 
-    // TestAux adds instrumentation to turn off the dirty bit. Should not throw.
-    TestAux aux_reader(aux_writer);
-    EXPECT_NO_THROW(aux_reader.set_io(testio, AUX_TEST_HISTORY_LENGTH));
-    EXPECT_TRUE(aux_reader.was_dirty) << "target codepath not exercised";
+    // Clear the dirty bits (simulates writer finishing its update).
+    aux_writer->metadata_ctx().modify_metadata(
+        [](monad::mpt::detail::db_metadata *m) {
+            m->is_dirty().store(0, std::memory_order_release);
+        });
+
+    // RO open should now succeed since dirty bits are clear.
+    EXPECT_NO_THROW(({ monad::mpt::DbMetadataContext{testio}; }));
 }
 
 TEST(update_aux_test, root_offsets_fast_slow)
@@ -144,8 +128,7 @@ TEST(update_aux_test, root_offsets_fast_slow)
             monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
     monad::async::AsyncIO testio(pool, testbuf);
     {
-        monad::mpt::UpdateAux aux_writer{};
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
+        monad::mpt::UpdateAux aux_writer{testio, AUX_TEST_HISTORY_LENGTH};
 
         // Root offset at 0, fast list offset at 50. This is correct
         auto const start_offset =
@@ -155,15 +138,14 @@ TEST(update_aux_test, root_offsets_fast_slow)
             .write_fd(50);
         auto const end_offset =
             aux_writer.node_writer_fast->sender().offset().add_to_offset(50);
-        aux_writer.append_root_offset(start_offset);
-        aux_writer.advance_db_offsets_to(
+        aux_writer.metadata_ctx().append_root_offset(start_offset);
+        aux_writer.metadata_ctx().advance_db_offsets_to(
             end_offset, aux_writer.node_writer_slow->sender().offset());
     }
     {
-        // verify set_io() succeeds
-        monad::mpt::UpdateAux aux_writer{};
-        aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH);
-        EXPECT_EQ(aux_writer.root_offsets().max_version(), 0);
+        // verify construction succeeds
+        monad::mpt::UpdateAux aux_writer{testio, AUX_TEST_HISTORY_LENGTH};
+        EXPECT_EQ(aux_writer.metadata_ctx().root_offsets().max_version(), 0);
 
         // Write version 1. However, append the new root offset without
         // advancing fast list
@@ -174,13 +156,12 @@ TEST(update_aux_test, root_offsets_fast_slow)
             .write_fd(100);
         auto const end_offset =
             aux_writer.node_writer_fast->sender().offset().add_to_offset(100);
-        aux_writer.append_root_offset(end_offset);
+        aux_writer.metadata_ctx().append_root_offset(end_offset);
     }
 
     { // Fail to reopen upon calling rewind_to_match_offsets()
-        monad::mpt::UpdateAux aux_writer{};
         EXPECT_EXIT(
-            aux_writer.set_io(testio, AUX_TEST_HISTORY_LENGTH),
+            ({ monad::mpt::UpdateAux{testio, AUX_TEST_HISTORY_LENGTH}; }),
             ::testing::KilledBySignal(SIGABRT),
             "Detected corruption");
     }
@@ -220,8 +201,9 @@ TEST(update_aux_test, configurable_root_offset_chunks)
 
         // Verify that exactly 4 chunks were allocated to hold two copies of
         // root offsets, since chunk 0 is used for metadata
-        EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
-        EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
+        EXPECT_EQ(
+            aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     {
         // reopen storage_pool
@@ -232,8 +214,9 @@ TEST(update_aux_test, configurable_root_offset_chunks)
         EXPECT_EQ(pool.chunks(monad::async::storage_pool::cnv), 5);
         monad::async::AsyncIO testio(pool, testbuf);
         monad::mpt::UpdateAux const aux(testio);
-        EXPECT_EQ(aux.db_metadata()->root_offsets.storage_.cnv_chunks_len, 4);
-        EXPECT_EQ(aux.root_offsets().capacity(), 2ULL << 25);
+        EXPECT_EQ(
+            aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     remove(filename);
 }

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -163,7 +163,8 @@ namespace detail
                 MONAD_ASSERT(buffer_);
                 --sender->outstanding_reads;
                 if (sender->version_expired_before_complete ||
-                    !sender->aux.version_is_valid_ondisk(sender->version)) {
+                    !sender->aux.metadata_ctx().version_is_valid_ondisk(
+                        sender->version)) {
                     // async read failure or stopping initiated
                     sender->version_expired_before_complete = true;
                     sender->reads_to_initiate.clear();
@@ -313,7 +314,8 @@ namespace detail
                 if (next == nullptr) {
                     MONAD_ASSERT(sender.aux.is_on_disk());
                     // verify version before read
-                    if (!sender.aux.version_is_valid_ondisk(sender.version)) {
+                    if (!sender.aux.metadata_ctx().version_is_valid_ondisk(
+                            sender.version)) {
                         sender.version_expired_before_complete = true;
                         sender.reads_to_initiate.clear();
                         sender.reads_to_initiate_sidx = 0;

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -1391,10 +1391,10 @@ node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
 {
     auto *sender = &node_writer->sender();
     bool const in_fast_list =
-        aux.db_metadata()->at(sender->offset().id)->in_fast_list;
-    auto const *ci_ = aux.db_metadata()->free_list_end();
+        aux.metadata_ctx().main()->at(sender->offset().id)->in_fast_list;
+    auto const *ci_ = aux.metadata_ctx().main()->free_list_end();
     MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-    auto const idx = ci_->index(aux.db_metadata());
+    auto const idx = ci_->index(aux.metadata_ctx().main());
     chunk_offset_t const offset_of_new_writer{idx, 0};
     // Pad buffer of existing node write that is about to get initiated so it's
     // O_DIRECT i/o aligned
@@ -1454,8 +1454,8 @@ node_writer_unique_ptr_type replace_node_writer_to_start_at_new_chunk(
             reentrancy_detection.max_count);
         return {};
     }
-    aux.remove(idx);
-    aux.append(
+    aux.metadata_ctx().remove(idx);
+    aux.metadata_ctx().append(
         in_fast_list ? UpdateAux::chunk_list::fast
                      : UpdateAux::chunk_list::slow,
         idx);
@@ -1469,7 +1469,7 @@ node_writer_unique_ptr_type replace_node_writer(
     // capacity
     auto offset_of_next_writer = node_writer->sender().offset();
     bool const in_fast_list =
-        aux.db_metadata()->at(offset_of_next_writer.id)->in_fast_list;
+        aux.metadata_ctx().main()->at(offset_of_next_writer.id)->in_fast_list;
     file_offset_t offset = offset_of_next_writer.offset;
     offset += node_writer->sender().written_buffer_bytes();
     offset_of_next_writer.offset = offset & chunk_offset_t::max_offset;
@@ -1481,9 +1481,9 @@ node_writer_unique_ptr_type replace_node_writer(
     if (offset == chunk_capacity) {
         // If after the current write buffer we're hitting chunk capacity, we
         // replace writer to the start of next chunk.
-        ci_ = aux.db_metadata()->free_list_end();
+        ci_ = aux.metadata_ctx().main()->free_list_end();
         MONAD_ASSERT(ci_ != nullptr); // we are out of free blocks!
-        idx = ci_->index(aux.db_metadata());
+        idx = ci_->index(aux.metadata_ctx().main());
         offset_of_next_writer.id = idx & 0xfffffU;
         offset_of_next_writer.offset = 0;
     }
@@ -1500,9 +1500,9 @@ node_writer_unique_ptr_type replace_node_writer(
         return {};
     }
     if (ci_ != nullptr) {
-        MONAD_ASSERT(ci_ == aux.db_metadata()->free_list_end());
-        aux.remove(idx);
-        aux.append(
+        MONAD_ASSERT(ci_ == aux.metadata_ctx().main()->free_list_end());
+        aux.metadata_ctx().remove(idx);
+        aux.metadata_ctx().append(
             in_fast_list ? UpdateAux::chunk_list::fast
                          : UpdateAux::chunk_list::slow,
             idx);
@@ -1647,8 +1647,10 @@ async_write_node_set_spare(UpdateAux &aux, Node &node, bool write_to_fast)
                    node)
                    .offset_written_to;
     MONAD_ASSERT(
-        (write_to_fast && aux.db_metadata()->at(off.id)->in_fast_list) ||
-        (!write_to_fast && aux.db_metadata()->at(off.id)->in_slow_list));
+        (write_to_fast &&
+         aux.metadata_ctx().main()->at(off.id)->in_fast_list) ||
+        (!write_to_fast &&
+         aux.metadata_ctx().main()->at(off.id)->in_slow_list));
     unsigned const pages = num_pages(off.offset, node.get_disk_size());
     off.set_spare(static_cast<uint16_t>(node_disk_pages_spare_15{pages}));
     return off;
@@ -1693,41 +1695,45 @@ write_new_root_node(UpdateAux &aux, Node &root, uint64_t const version)
     auto const offset_written_to = async_write_node_set_spare(aux, root, true);
     flush_buffered_writes(aux);
     // advance fast and slow ring's latest offset in db metadata
-    aux.advance_db_offsets_to(
+    aux.metadata_ctx().advance_db_offsets_to(
         aux.node_writer_fast->sender().offset(),
         aux.node_writer_slow->sender().offset());
     // update root offset
-    auto const max_version_in_db = aux.db_history_max_version();
+    auto const max_version_in_db = aux.metadata_ctx().db_history_max_version();
     if (MONAD_UNLIKELY(max_version_in_db == INVALID_BLOCK_NUM)) {
-        aux.fast_forward_next_version(version);
-        aux.append_root_offset(offset_written_to);
-        MONAD_ASSERT(aux.db_history_range_lower_bound() == version);
+        aux.metadata_ctx().fast_forward_next_version(version);
+        aux.metadata_ctx().append_root_offset(offset_written_to);
+        MONAD_ASSERT(
+            aux.metadata_ctx().db_history_range_lower_bound() == version);
     }
     else if (version <= max_version_in_db) {
         MONAD_ASSERT(
             version >=
-            ((max_version_in_db >= aux.version_history_length())
-                 ? max_version_in_db - aux.version_history_length() + 1
+            ((max_version_in_db >= aux.metadata_ctx().version_history_length())
+                 ? max_version_in_db -
+                       aux.metadata_ctx().version_history_length() + 1
                  : 0));
-        auto const prev_lower_bound = aux.db_history_range_lower_bound();
-        aux.update_root_offset(version, offset_written_to);
+        auto const prev_lower_bound =
+            aux.metadata_ctx().db_history_range_lower_bound();
+        aux.metadata_ctx().update_root_offset(version, offset_written_to);
         MONAD_ASSERT(
-            aux.db_history_range_lower_bound() ==
+            aux.metadata_ctx().db_history_range_lower_bound() ==
             std::min(version, prev_lower_bound));
     }
     else {
         MONAD_ASSERT(version == max_version_in_db + 1);
         // Erase the earliest valid version if it is going to be outdated after
         // writing a new version, must happen before appending new root offset
-        if (version - aux.db_history_min_valid_version() >=
-            aux.version_history_length()) { // if exceed history length
+        if (version - aux.metadata_ctx().db_history_min_valid_version() >=
+            aux.metadata_ctx()
+                .version_history_length()) { // if exceed history length
             aux.erase_versions_up_to_and_including(
-                version - aux.version_history_length());
+                version - aux.metadata_ctx().version_history_length());
             MONAD_ASSERT(
-                version - aux.db_history_min_valid_version() <
-                aux.version_history_length());
+                version - aux.metadata_ctx().db_history_min_valid_version() <
+                aux.metadata_ctx().version_history_length());
         }
-        aux.append_root_offset(offset_written_to);
+        aux.metadata_ctx().append_root_offset(offset_written_to);
     }
     return offset_written_to;
 }

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -20,6 +20,7 @@
 #include <category/core/lru/static_lru_cache.hpp>
 #include <category/mpt/compute.hpp>
 #include <category/mpt/config.hpp>
+#include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/collected_stats.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/node.hpp>
@@ -49,6 +50,7 @@
 #include <bit>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -174,16 +176,6 @@ replace_node_writer(UpdateAux &, node_writer_unique_ptr_type const &);
 // \class Auxiliaries for triedb update
 class UpdateAux
 {
-    uint32_t initial_insertion_count_on_pool_creation_{0};
-    bool enable_dynamic_history_length_{true};
-
-    struct db_metadata_
-    {
-        detail::db_metadata *main{nullptr};
-        std::span<chunk_offset_t> root_offsets;
-    } db_metadata_[2]; // two copies, to prevent sudden process
-                       // exits making the DB irretrievable
-
     void reset_node_writers();
 
     void advance_compact_offsets(Node::SharedPtr prev_root);
@@ -209,9 +201,14 @@ class UpdateAux
     varying block loads. */
     int64_t calc_auto_expire_version(uint64_t upsert_version) noexcept;
 
-    void set_auto_expire_version_metadata(int64_t) noexcept;
-
     void update_disk_growth_data();
+
+    uint32_t initial_insertion_count_on_pool_creation_{0};
+    bool enable_dynamic_history_length_{true};
+
+    // Owns the mmap lifecycle for db_metadata. Contains the two copies of
+    // mmap'd db_metadata pointers and root_offsets spans.
+    std::unique_ptr<DbMetadataContext> metadata_ctx_;
 
     /******** Compaction ********/
     uint32_t chunks_to_remove_before_count_fast_{0};
@@ -233,8 +230,6 @@ class UpdateAux
 
     bool alternate_slow_fast_writer_{false};
     bool can_write_to_fast_{true};
-
-    virtual void on_read_only_init_with_dirty_bit() noexcept {};
 
 public:
     // Allocate the first cnv chunk for db metadata copies
@@ -259,16 +254,14 @@ public:
         MONAD_ASYNC_NAMESPACE::AsyncIO &io_,
         std::optional<uint64_t> const history_len = {})
     {
-        set_io(io_, history_len);
+        init(io_, history_len);
     }
 
-    virtual ~UpdateAux();
+    ~UpdateAux();
 
-    void set_io(
-        MONAD_ASYNC_NAMESPACE::AsyncIO &,
+    void init(
+        MONAD_ASYNC_NAMESPACE::AsyncIO &io_,
         std::optional<uint64_t> history_length = {});
-
-    void unset_io();
 
     Node::SharedPtr do_update(
         Node::SharedPtr prev_root, StateMachine &, UpdateList &&,
@@ -290,139 +283,18 @@ public:
 
     void print_update_stats(uint64_t version);
 
-    enum class chunk_list : uint8_t
-    {
-        free = 0,
-        fast = 1,
-        slow = 2
-    };
+    using chunk_list = DbMetadataContext::chunk_list;
 
-    detail::db_metadata const *db_metadata() const noexcept
+    DbMetadataContext &metadata_ctx() noexcept
     {
-        return db_metadata_[0].main;
+        MONAD_ASSERT(metadata_ctx_ != nullptr);
+        return *metadata_ctx_;
     }
 
-    auto root_offsets(unsigned which = 0) const
+    DbMetadataContext const &metadata_ctx() const noexcept
     {
-        class root_offsets_delegator
-        {
-            std::atomic_ref<uint64_t> version_lower_bound_;
-            std::atomic_ref<uint64_t> next_version_;
-            std::span<chunk_offset_t> root_offsets_chunks_;
-
-            void
-            update_version_lower_bound_(uint64_t lower_bound = uint64_t(-1))
-            {
-                auto const version_lower_bound =
-                    version_lower_bound_.load(std::memory_order_acquire);
-                auto idx = (lower_bound < version_lower_bound)
-                               ? lower_bound
-                               : version_lower_bound;
-                auto const max_version =
-                    next_version_.load(std::memory_order_acquire) - 1;
-                if (max_version == INVALID_BLOCK_NUM) {
-                    return;
-                }
-                while (idx < max_version && (*this)[idx] == INVALID_OFFSET) {
-                    idx++;
-                }
-                if (idx != version_lower_bound) {
-                    version_lower_bound_.store(idx, std::memory_order_release);
-                }
-            }
-
-        public:
-            explicit root_offsets_delegator(const struct db_metadata_ *m)
-                : version_lower_bound_(
-                      m->main->root_offsets.version_lower_bound_)
-                , next_version_(m->main->root_offsets.next_version_)
-                , root_offsets_chunks_(
-                      std::span<chunk_offset_t>(m->root_offsets))
-            {
-                MONAD_ASSERT_PRINTF(
-                    root_offsets_chunks_.size() ==
-                        1ULL
-                            << (63 -
-                                std::countl_zero(root_offsets_chunks_.size())),
-                    "root offsets chunks size is %lu, not a power of 2",
-                    root_offsets_chunks_.size());
-            }
-
-            size_t capacity() const noexcept
-            {
-                return root_offsets_chunks_.size();
-            }
-
-            void push(chunk_offset_t const o) noexcept
-            {
-                auto const wp = next_version_.load(std::memory_order_relaxed);
-                auto const next_wp = wp + 1;
-                MONAD_ASSERT(next_wp != 0);
-                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &root_offsets_chunks_
-                        [wp & (root_offsets_chunks_.size() - 1)]);
-                p->store(o, std::memory_order_release);
-                next_version_.store(next_wp, std::memory_order_release);
-                if (o != INVALID_OFFSET) {
-                    update_version_lower_bound_();
-                }
-            }
-
-            void assign(size_t const i, chunk_offset_t const o) noexcept
-            {
-                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &root_offsets_chunks_
-                        [i & (root_offsets_chunks_.size() - 1)]);
-                p->store(o, std::memory_order_release);
-                update_version_lower_bound_(
-                    (o != INVALID_OFFSET) ? i : uint64_t(-1));
-            }
-
-            chunk_offset_t operator[](size_t const i) const noexcept
-            {
-                return start_lifetime_as<std::atomic<chunk_offset_t> const>(
-                           &root_offsets_chunks_
-                               [i & (root_offsets_chunks_.size() - 1)])
-                    ->load(std::memory_order_acquire);
-            }
-
-            // return INVALID_BLOCK_NUM indicates that db is empty
-            uint64_t max_version() const noexcept
-            {
-                auto const wp = next_version_.load(std::memory_order_acquire);
-                return wp - 1;
-            }
-
-            void reset_all(uint64_t const version)
-            {
-                version_lower_bound_.store(0, std::memory_order_release);
-                next_version_.store(0, std::memory_order_release);
-                memset(
-                    (void *)root_offsets_chunks_.data(),
-                    0xff,
-                    root_offsets_chunks_.size() * sizeof(chunk_offset_t));
-                version_lower_bound_.store(version, std::memory_order_release);
-                next_version_.store(version, std::memory_order_release);
-            }
-
-            void rewind_to_version(uint64_t const version)
-            {
-                MONAD_ASSERT(version < max_version());
-                MONAD_ASSERT(max_version() - version <= capacity());
-                for (uint64_t i = version + 1; i <= max_version(); i++) {
-                    assign(i, async::INVALID_OFFSET);
-                }
-                if (version <
-                    version_lower_bound_.load(std::memory_order_acquire)) {
-                    version_lower_bound_.store(
-                        version, std::memory_order_release);
-                }
-                next_version_.store(version + 1, std::memory_order_release);
-                update_version_lower_bound_();
-            }
-        };
-
-        return root_offsets_delegator{&db_metadata_[which]};
+        MONAD_ASSERT(metadata_ctx_ != nullptr);
+        return *metadata_ctx_;
     }
 
     // clear all versions <= version, release unused disk space
@@ -434,42 +306,6 @@ public:
     // age is relative to the beginning chunk's count
     std::pair<chunk_list, detail::unsigned_20>
     chunk_list_and_age(uint32_t idx) const noexcept;
-
-    void append(chunk_list list, uint32_t idx);
-    void remove(uint32_t idx) noexcept;
-
-    template <typename Func, typename... Args>
-        requires std::invocable<
-            std::function<void(detail::db_metadata *, Args...)>,
-            detail::db_metadata *, Args...>
-    void modify_metadata(Func func, Args const &...args) noexcept
-    {
-        func(db_metadata_[0].main, args...);
-        func(db_metadata_[1].main, args...);
-    }
-
-    // This function should only be invoked after completing a upsert
-    void advance_db_offsets_to(
-        chunk_offset_t fast_offset, chunk_offset_t slow_offset) noexcept;
-
-    void append_root_offset(chunk_offset_t root_offset) noexcept;
-    void update_root_offset(size_t i, chunk_offset_t root_offset) noexcept;
-    void fast_forward_next_version(uint64_t version) noexcept;
-
-    void update_history_length_metadata(uint64_t history_len) noexcept;
-    void set_latest_finalized_version(uint64_t version) noexcept;
-    void set_latest_verified_version(uint64_t version) noexcept;
-    void set_latest_voted(uint64_t version, bytes32_t const &block_id) noexcept;
-    void
-    set_latest_proposed(uint64_t version, bytes32_t const &block_id) noexcept;
-    uint64_t get_latest_finalized_version() const noexcept;
-    uint64_t get_latest_verified_version() const noexcept;
-    bytes32_t get_latest_voted_block_id() const noexcept;
-    uint64_t get_latest_voted_version() const noexcept;
-    bytes32_t get_latest_proposed_block_id() const noexcept;
-    uint64_t get_latest_proposed_version() const noexcept;
-
-    int64_t get_auto_expire_version_metadata() const noexcept;
 
     // WARNING: These are destructive, they discard immediately any extraneous
     // data.
@@ -520,67 +356,12 @@ public:
                (double)num_chunks(chunk_list::free) / (double)io->chunk_count();
     }
 
-    chunk_offset_t get_latest_root_offset() const noexcept
-    {
-        MONAD_ASSERT(this->is_on_disk());
-        auto const ro = root_offsets();
-        return ro[ro.max_version()];
-    }
-
-    chunk_offset_t
-    get_root_offset_at_version(uint64_t const version) const noexcept
-    {
-        MONAD_ASSERT(this->is_on_disk());
-        if (version <= db_history_max_version()) {
-            auto const offset = root_offsets()[version];
-            if (version >= db_history_range_lower_bound()) {
-                return offset;
-            }
-        }
-        return INVALID_OFFSET;
-    }
-
-    bool version_is_valid_ondisk(uint64_t const version) const noexcept
-    {
-        MONAD_ASSERT(is_on_disk());
-        return get_root_offset_at_version(version) != INVALID_OFFSET;
-    }
-
-    chunk_offset_t get_start_of_wip_fast_offset() const noexcept
-    {
-        MONAD_ASSERT(this->is_on_disk());
-        return db_metadata()->db_offsets.start_of_wip_offset_fast;
-    }
-
-    chunk_offset_t get_start_of_wip_slow_offset() const noexcept
-    {
-        MONAD_ASSERT(this->is_on_disk());
-        return db_metadata()->db_offsets.start_of_wip_offset_slow;
-    }
-
-    file_offset_t get_lower_bound_free_space() const noexcept
-    {
-        MONAD_ASSERT(this->is_on_disk());
-        return db_metadata()->capacity_in_free_list;
-    }
-
     uint32_t num_chunks(chunk_list const list) const noexcept;
-
-    uint64_t version_history_max_possible() const noexcept;
-    uint64_t version_history_length() const noexcept;
-
-    // Following funcs on db history are for on disk db only. In
-    // memory db does not have any version history.
-    // Db history range, returned version NOT always valid
-    uint64_t db_history_range_lower_bound() const noexcept;
-    uint64_t db_history_max_version() const noexcept;
-    // Returns the first min version with a root offset. On disk db returns
-    // invalid if it contains empty version
-    uint64_t db_history_min_valid_version() const noexcept;
 };
 
+// sizeof changed: db_metadata_[2] replaced by unique_ptr<DbMetadataContext>
 static_assert(
-    sizeof(UpdateAux) == 144 + sizeof(detail::TrieUpdateCollectedStats));
+    sizeof(UpdateAux) == 96 + sizeof(detail::TrieUpdateCollectedStats));
 static_assert(alignof(UpdateAux) == 8);
 
 template <receiver Receiver>

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -14,14 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/async/config.hpp>
-#include <category/async/detail/scope_polyfill.hpp>
 #include <category/async/storage_pool.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
-#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/util/stopwatch.hpp>
 #include <category/mpt/config.hpp>
+#include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/collected_stats.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/unsigned_20.hpp>
@@ -45,16 +44,12 @@
 #include <functional>
 #include <iterator>
 #include <linux/fs.h>
+#include <memory>
 #include <optional>
 #include <ranges>
-#include <span>
 #include <string>
 #include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <thread>
-#include <unistd.h>
 #include <utility>
-#include <vector>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
@@ -72,12 +67,6 @@ namespace
     }
 }
 
-// Define to avoid randomisation of free list chunks on pool creation
-// This can be useful to discover bugs in code which assume chunks are
-// consecutive
-// #define MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS 1
-#define MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS 1
-
 // Returns a virtual offset on successful translation; returns
 // INVALID_VIRTUAL_OFFSET if the input offset is invalid or the offset refers to
 // a chunk in the free list.
@@ -88,7 +77,7 @@ UpdateAux::physical_to_virtual(chunk_offset_t const offset) const noexcept
         return INVALID_VIRTUAL_OFFSET;
     }
     MONAD_ASSERT(offset.id < io->chunk_count());
-    auto const chunk_info = db_metadata()->atomic_load_chunk_info(
+    auto const chunk_info = metadata_ctx_->main()->atomic_load_chunk_info(
         offset.id, std::memory_order_acquire);
     if (chunk_info.in_fast_list || chunk_info.in_slow_list) {
         return virtual_chunk_offset_t{
@@ -105,297 +94,46 @@ std::pair<UpdateAux::chunk_list, detail::unsigned_20>
 UpdateAux::chunk_list_and_age(uint32_t const idx) const noexcept
 {
     MONAD_ASSERT(is_on_disk());
-    auto const *ci = db_metadata()->at(idx);
+    auto const *ci = metadata_ctx_->main()->at(idx);
     std::pair<chunk_list, detail::unsigned_20> ret(
         chunk_list::free, ci->insertion_count());
     if (ci->in_fast_list) {
         ret.first = chunk_list::fast;
-        ret.second -= db_metadata()->fast_list_begin()->insertion_count();
+        ret.second -=
+            metadata_ctx_->main()->fast_list_begin()->insertion_count();
     }
     else if (ci->in_slow_list) {
         ret.first = chunk_list::slow;
-        ret.second -= db_metadata()->slow_list_begin()->insertion_count();
+        ret.second -=
+            metadata_ctx_->main()->slow_list_begin()->insertion_count();
     }
     else {
-        ret.second -= db_metadata()->free_list_begin()->insertion_count();
+        ret.second -=
+            metadata_ctx_->main()->free_list_begin()->insertion_count();
     }
     return ret;
-}
-
-void UpdateAux::append(chunk_list const list, uint32_t const idx)
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        switch (list) {
-        case chunk_list::free:
-            m->append_(m->free_list, m->at_(idx));
-            break;
-        case chunk_list::fast:
-            m->append_(m->fast_list, m->at_(idx));
-            break;
-        case chunk_list::slow:
-            m->append_(m->slow_list, m->at_(idx));
-            break;
-        }
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-    if (list == chunk_list::free) {
-        auto const &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
-        auto const capacity = chunk.capacity();
-        MONAD_ASSERT(chunk.size() == 0);
-        db_metadata_[0].main->free_capacity_add_(capacity);
-        db_metadata_[1].main->free_capacity_add_(capacity);
-    }
-    else {
-        auto const insertion_count = static_cast<uint32_t>(
-            db_metadata_[0].main->at(idx)->insertion_count());
-        if (insertion_count >= virtual_chunk_offset_t::MAX_COUNT * 9 / 10) {
-            LOG_WARNING_CFORMAT(
-                "Virtual offset space is running out "
-                "(insertion count: %u / %u). "
-                "Please perform a database reset.",
-                insertion_count,
-                (uint32_t)virtual_chunk_offset_t::MAX_COUNT);
-        }
-    }
-}
-
-void UpdateAux::remove(uint32_t const idx) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    bool const is_free_list =
-        (!db_metadata_[0].main->at_(idx)->in_fast_list &&
-         !db_metadata_[0].main->at_(idx)->in_slow_list);
-    auto do_ = [&](detail::db_metadata *m) { m->remove_(m->at_(idx)); };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-    if (is_free_list) {
-        auto const &chunk = io->storage_pool().chunk(storage_pool::seq, idx);
-        auto const capacity = chunk.capacity();
-        MONAD_ASSERT(chunk.size() == 0);
-        db_metadata_[0].main->free_capacity_sub_(capacity);
-        db_metadata_[1].main->free_capacity_sub_(capacity);
-    }
-}
-
-void UpdateAux::advance_db_offsets_to(
-    chunk_offset_t const fast_offset, chunk_offset_t const slow_offset) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    // To detect bugs in replacing fast/slow node writer to the wrong chunk
-    // list
-    MONAD_ASSERT(db_metadata()->at(fast_offset.id)->in_fast_list);
-    MONAD_ASSERT(db_metadata()->at(slow_offset.id)->in_slow_list);
-    auto do_ = [&](detail::db_metadata *m) {
-        m->advance_db_offsets_to_(
-            detail::db_metadata::db_offsets_info_t{fast_offset, slow_offset});
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::append_root_offset(chunk_offset_t const root_offset) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        root_offsets(m == db_metadata_[1].main).push(root_offset);
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::update_root_offset(
-    size_t const i, chunk_offset_t const root_offset) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        auto ro = root_offsets(m == db_metadata_[1].main);
-        ro.assign(i, root_offset);
-        if (root_offset == INVALID_OFFSET && i == db_history_max_version() &&
-            i == db_history_min_valid_version()) {
-            ro.reset_all(0);
-            MONAD_ASSERT(ro.max_version() == INVALID_BLOCK_NUM);
-        }
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::fast_forward_next_version(uint64_t const new_version) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        auto ro = root_offsets(m == db_metadata_[1].main);
-        uint64_t curr_version = ro.max_version();
-        MONAD_ASSERT(
-            curr_version == INVALID_BLOCK_NUM || new_version > curr_version);
-
-        if (curr_version == INVALID_BLOCK_NUM ||
-            new_version - curr_version >= ro.capacity()) {
-            ro.reset_all(new_version);
-        }
-        else {
-            while (curr_version + 1 < new_version) {
-                ro.push(INVALID_OFFSET);
-                curr_version = ro.max_version();
-            }
-        }
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::update_history_length_metadata(
-    uint64_t const history_len) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        auto const ro = root_offsets(m == db_metadata_[1].main);
-        MONAD_ASSERT(history_len > 0 && history_len <= ro.capacity());
-        reinterpret_cast<std::atomic_uint64_t *>(&m->history_length)
-            ->store(history_len, std::memory_order_relaxed);
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-uint64_t UpdateAux::get_latest_finalized_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return start_lifetime_as<std::atomic_uint64_t const>(
-               &db_metadata()->latest_finalized_version)
-        ->load(std::memory_order_acquire);
-}
-
-uint64_t UpdateAux::get_latest_verified_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return start_lifetime_as<std::atomic_uint64_t const>(
-               &db_metadata()->latest_verified_version)
-        ->load(std::memory_order_acquire);
-}
-
-uint64_t UpdateAux::get_latest_voted_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return start_lifetime_as<std::atomic_uint64_t const>(
-               &db_metadata()->latest_voted_version)
-        ->load(std::memory_order_acquire);
-}
-
-bytes32_t UpdateAux::get_latest_voted_block_id() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return db_metadata()->latest_voted_block_id;
-}
-
-uint64_t UpdateAux::get_latest_proposed_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return start_lifetime_as<std::atomic_uint64_t const>(
-               &db_metadata()->latest_proposed_version)
-        ->load(std::memory_order_acquire);
-}
-
-bytes32_t UpdateAux::get_latest_proposed_block_id() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return db_metadata()->latest_proposed_block_id;
-}
-
-void UpdateAux::set_latest_finalized_version(uint64_t const version) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_finalized_version)
-            ->store(version, std::memory_order_release);
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::set_latest_verified_version(uint64_t const version) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_verified_version)
-            ->store(version, std::memory_order_release);
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-}
-
-void UpdateAux::set_latest_voted(
-    uint64_t const version, bytes32_t const &block_id) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    for (auto const i : {0, 1}) {
-        auto *const m = db_metadata_[i].main;
-        auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_voted_version)
-            ->store(version, std::memory_order_release);
-        m->latest_voted_block_id = block_id;
-    }
-}
-
-void UpdateAux::set_latest_proposed(
-    uint64_t const version, bytes32_t const &block_id) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    for (auto const i : {0, 1}) {
-        auto *const m = db_metadata_[i].main;
-        auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_proposed_version)
-            ->store(version, std::memory_order_release);
-        m->latest_proposed_block_id = block_id;
-    }
-}
-
-int64_t UpdateAux::get_auto_expire_version_metadata() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return start_lifetime_as<std::atomic_int64_t const>(
-               &db_metadata()->auto_expire_version)
-        ->load(std::memory_order_acquire);
-}
-
-void UpdateAux::set_auto_expire_version_metadata(int64_t const version) noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_int64_t *>(&m->auto_expire_version)
-            ->store(version, std::memory_order_release);
-    };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
 }
 
 int64_t
 UpdateAux::calc_auto_expire_version(uint64_t const upsert_version) noexcept
 {
     MONAD_ASSERT(is_on_disk());
-    if (db_history_max_version() == INVALID_BLOCK_NUM) {
+    if (metadata_ctx_->db_history_max_version() == INVALID_BLOCK_NUM) {
         return static_cast<int64_t>(upsert_version);
     }
-    auto const min_valid_version = db_history_min_valid_version();
+    auto const min_valid_version =
+        metadata_ctx_->db_history_min_valid_version();
     auto const max_version_post_upsert =
-        std::max(db_history_max_version(), upsert_version);
+        std::max(metadata_ctx_->db_history_max_version(), upsert_version);
     uint64_t min_valid_version_post_upsert = min_valid_version;
     if (max_version_post_upsert - min_valid_version + 1 >
-        version_history_length()) {
+        metadata_ctx_->version_history_length()) {
         min_valid_version_post_upsert =
-            max_version_post_upsert - version_history_length() + 1;
+            max_version_post_upsert - metadata_ctx_->version_history_length() +
+            1;
     }
     return std::min(
-        get_auto_expire_version_metadata() + 2,
+        metadata_ctx_->get_auto_expire_version_metadata() + 2,
         static_cast<int64_t>(min_valid_version_post_upsert));
 }
 
@@ -403,20 +141,22 @@ void UpdateAux::rewind_to_match_offsets()
 {
     MONAD_ASSERT(is_on_disk());
 
-    auto const fast_offset = db_metadata()->db_offsets.start_of_wip_offset_fast;
-    MONAD_ASSERT(db_metadata()->at(fast_offset.id)->in_fast_list);
-    auto const slow_offset = db_metadata()->db_offsets.start_of_wip_offset_slow;
-    MONAD_ASSERT(db_metadata()->at(slow_offset.id)->in_slow_list);
+    auto const fast_offset =
+        metadata_ctx_->main()->db_offsets.start_of_wip_offset_fast;
+    MONAD_ASSERT(metadata_ctx_->main()->at(fast_offset.id)->in_fast_list);
+    auto const slow_offset =
+        metadata_ctx_->main()->db_offsets.start_of_wip_offset_slow;
+    MONAD_ASSERT(metadata_ctx_->main()->at(slow_offset.id)->in_slow_list);
 
     // fast/slow list offsets should always be greater than last written root
     // offset.
-    auto const ro = root_offsets();
+    auto const ro = metadata_ctx_->root_offsets();
     auto const last_root_offset = ro[ro.max_version()];
     if (last_root_offset != INVALID_OFFSET) {
         auto const virtual_last_root_offset =
             physical_to_virtual(last_root_offset);
         MONAD_ASSERT(virtual_last_root_offset != INVALID_VIRTUAL_OFFSET);
-        if (db_metadata()->at(last_root_offset.id)->in_fast_list) {
+        if (metadata_ctx_->main()->at(last_root_offset.id)->in_fast_list) {
             auto const virtual_fast_offset = physical_to_virtual(fast_offset);
             MONAD_ASSERT(virtual_fast_offset != INVALID_VIRTUAL_OFFSET);
             MONAD_ASSERT_PRINTF(
@@ -431,7 +171,7 @@ void UpdateAux::rewind_to_match_offsets()
                 fast_offset.offset,
                 virtual_fast_offset.count);
         }
-        else if (db_metadata()->at(last_root_offset.id)->in_slow_list) {
+        else if (metadata_ctx_->main()->at(last_root_offset.id)->in_slow_list) {
             auto const virtual_slow_offset = physical_to_virtual(slow_offset);
             MONAD_ASSERT(virtual_slow_offset != INVALID_VIRTUAL_OFFSET);
             MONAD_ASSERT_PRINTF(
@@ -453,24 +193,24 @@ void UpdateAux::rewind_to_match_offsets()
     }
 
     // Free all chunks after fast_offset.id
-    auto const *ci = db_metadata()->at(fast_offset.id);
-    while (ci != db_metadata()->fast_list_end()) {
-        auto const idx = db_metadata()->fast_list.end;
-        remove(idx);
+    auto const *ci = metadata_ctx_->main()->at(fast_offset.id);
+    while (ci != metadata_ctx_->main()->fast_list_end()) {
+        auto const idx = metadata_ctx_->main()->fast_list.end;
+        metadata_ctx_->remove(idx);
         io->storage_pool().chunk(storage_pool::seq, idx).destroy_contents();
-        append(chunk_list::free, idx);
+        metadata_ctx_->append(chunk_list::free, idx);
     }
     auto &fast_offset_chunk =
         io->storage_pool().chunk(storage_pool::seq, fast_offset.id);
     MONAD_ASSERT(fast_offset_chunk.try_trim_contents(fast_offset.offset));
 
     // Same for slow list
-    auto const *slow_ci = db_metadata()->at(slow_offset.id);
-    while (slow_ci != db_metadata()->slow_list_end()) {
-        auto const idx = db_metadata()->slow_list.end;
-        remove(idx);
+    auto const *slow_ci = metadata_ctx_->main()->at(slow_offset.id);
+    while (slow_ci != metadata_ctx_->main()->slow_list_end()) {
+        auto const idx = metadata_ctx_->main()->slow_list.end;
+        metadata_ctx_->remove(idx);
         io->storage_pool().chunk(storage_pool::seq, idx).destroy_contents();
-        append(chunk_list::free, idx);
+        metadata_ctx_->append(chunk_list::free, idx);
     }
     auto &slow_offset_chunk =
         io->storage_pool().chunk(storage_pool::seq, slow_offset.id);
@@ -483,22 +223,22 @@ void UpdateAux::rewind_to_match_offsets()
 void UpdateAux::clear_ondisk_db()
 {
     MONAD_ASSERT(is_on_disk());
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        root_offsets(m == db_metadata_[1].main).reset_all(0);
+    auto do_ = [&](unsigned const which) {
+        auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
+        metadata_ctx_->root_offsets(which).reset_all(0);
     };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-    set_latest_finalized_version(INVALID_BLOCK_NUM);
-    set_latest_verified_version(INVALID_BLOCK_NUM);
+    do_(0);
+    do_(1);
+    metadata_ctx_->set_latest_finalized_version(INVALID_BLOCK_NUM);
+    metadata_ctx_->set_latest_verified_version(INVALID_BLOCK_NUM);
 
-    set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
-    set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-    set_auto_expire_version_metadata(0);
+    metadata_ctx_->set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
+    metadata_ctx_->set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
+    metadata_ctx_->set_auto_expire_version_metadata(0);
 
-    advance_db_offsets_to(
-        {db_metadata()->fast_list.begin, 0},
-        {db_metadata()->slow_list.begin, 0});
+    metadata_ctx_->advance_db_offsets_to(
+        {metadata_ctx_->main()->fast_list.begin, 0},
+        {metadata_ctx_->main()->slow_list.begin, 0});
     rewind_to_match_offsets();
     return;
 }
@@ -506,26 +246,27 @@ void UpdateAux::clear_ondisk_db()
 void UpdateAux::rewind_to_version(uint64_t const version)
 {
     MONAD_ASSERT(is_on_disk());
-    MONAD_ASSERT(version_is_valid_ondisk(version));
-    if (version == db_history_max_version()) {
+    MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(version));
+    if (version == metadata_ctx_->db_history_max_version()) {
         return;
     }
-    auto do_ = [&](detail::db_metadata *m) {
-        auto const g = m->hold_dirty();
-        root_offsets(m == db_metadata_[1].main).rewind_to_version(version);
+    auto do_ = [&](unsigned const which) {
+        auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
+        metadata_ctx_->root_offsets(which).rewind_to_version(version);
     };
-    do_(db_metadata_[0].main);
-    do_(db_metadata_[1].main);
-    if (auto const latest_finalized = get_latest_finalized_version();
+    do_(0);
+    do_(1);
+    if (auto const latest_finalized =
+            metadata_ctx_->get_latest_finalized_version();
         latest_finalized != INVALID_BLOCK_NUM && latest_finalized > version) {
-        set_latest_finalized_version(version);
+        metadata_ctx_->set_latest_finalized_version(version);
     }
-    set_latest_verified_version(INVALID_BLOCK_NUM);
-    set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
-    set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-    auto last_written_offset = root_offsets()[version];
+    metadata_ctx_->set_latest_verified_version(INVALID_BLOCK_NUM);
+    metadata_ctx_->set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
+    metadata_ctx_->set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
+    auto last_written_offset = metadata_ctx_->root_offsets()[version];
     bool const last_written_offset_is_in_fast_list =
-        db_metadata()->at(last_written_offset.id)->in_fast_list;
+        metadata_ctx_->main()->at(last_written_offset.id)->in_fast_list;
     unsigned const bytes_to_read =
         node_disk_pages_spare_15{last_written_offset}.to_pages()
         << DISK_PAGE_BITS;
@@ -534,12 +275,13 @@ void UpdateAux::rewind_to_version(uint64_t const version)
         last_written_offset = round_down_align<DISK_PAGE_BITS>(
             last_written_offset.add_to_offset(bytes_to_read));
         if (last_written_offset.offset >= chunk_offset_t::max_offset) {
-            last_written_offset.id =
-                db_metadata()->at(last_written_offset.id)->next_chunk_id;
+            last_written_offset.id = metadata_ctx_->main()
+                                         ->at(last_written_offset.id)
+                                         ->next_chunk_id;
             last_written_offset.offset = 0;
         }
-        advance_db_offsets_to(
-            last_written_offset, get_start_of_wip_slow_offset());
+        metadata_ctx_->advance_db_offsets_to(
+            last_written_offset, metadata_ctx_->get_start_of_wip_slow_offset());
     }
     // Discard all chunks no longer in use, and if root is on fast list
     // replace the now partially written chunk with a fresh one able to be
@@ -550,27 +292,27 @@ void UpdateAux::rewind_to_version(uint64_t const version)
 UpdateAux::~UpdateAux()
 {
     if (io != nullptr) {
-        unset_io();
+        node_writer_fast.reset();
+        node_writer_slow.reset();
+        io = nullptr;
+        metadata_ctx_.reset();
     }
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-void UpdateAux::set_io(AsyncIO &io_, std::optional<uint64_t> const history_len)
+void UpdateAux::init(AsyncIO &io_, std::optional<uint64_t> const history_len)
 {
+    // Safe to call on an already-initialized instance: tear down first
+    if (io != nullptr) {
+        io = nullptr;
+        node_writer_fast.reset();
+        node_writer_slow.reset();
+        metadata_ctx_.reset();
+    }
     io = &io_;
-    auto const chunk_count = io->chunk_count();
-    MONAD_ASSERT(chunk_count >= 3);
-    auto const map_size =
-        sizeof(detail::db_metadata) +
-        chunk_count * sizeof(detail::db_metadata::chunk_info_t);
-    auto &cnv_chunk = io->storage_pool().chunk(storage_pool::cnv, 0);
-    auto const fdr = cnv_chunk.read_fd();
-    auto const fdw = cnv_chunk.write_fd(0);
-    /* We keep accidentally running MPT on 4Kb min granularity storage, so
-    error out on that early to save everybody time and hassle.
+
+    /* Block size validation: We keep accidentally running MPT on 4Kb min
+    granularity storage, so error out on that early to save everybody time and
+    hassle.
 
     Linux is unique amongst major OS kernels that it'll let you do 512 byte
     granularity i/o on a device with a higher granularity. Unfortunately, its
@@ -581,13 +323,11 @@ void UpdateAux::set_io(AsyncIO &io_, std::optional<uint64_t> const history_len)
     byte addressable.
     */
     {
+        auto const fdr =
+            io->storage_pool().chunk(storage_pool::cnv, 0).read_fd();
         unsigned int logical_block_size = 0;
         unsigned int physical_block_size = 0;
         unsigned int minimum_io_size = 0;
-        // Filesystems will error on ioctl syscall, so ignore zeros. We don't
-        // run production on filesystems, only the test suite and our own
-        // debugging so we don't care about i/o granularity for our own dev
-        // systems.
         (void)ioctl(fdr.first, BLKSSZGET, &logical_block_size);
         (void)ioctl(fdr.first, BLKPBSZGET, &physical_block_size);
         (void)ioctl(fdr.first, BLKIOMIN, &minimum_io_size);
@@ -608,443 +348,41 @@ void UpdateAux::set_io(AsyncIO &io_, std::optional<uint64_t> const history_len)
                 minimum_io_size);
         }
     }
-    /* If writable, can map maps writable. If read only but allowing
-    dirty, maps are made copy-on-write so writes go into RAM and don't
-    affect the original. This lets us heal any metadata and make forward
-    progress.
-    */
-    bool const can_write_to_map =
-        (!io->storage_pool().is_read_only() ||
-         io->storage_pool().is_read_only_allow_dirty());
-    auto const &fd = can_write_to_map ? fdw : fdr;
-    auto const prot = can_write_to_map ? (PROT_READ | PROT_WRITE) : (PROT_READ);
-    auto const mapflags = io->storage_pool().is_read_only_allow_dirty()
-                              ? MAP_PRIVATE
-                              : MAP_SHARED;
-    db_metadata_[0].main = start_lifetime_as<detail::db_metadata>(
-        ::mmap(nullptr, map_size, prot, mapflags, fd.first, off_t(fdr.second)));
-    MONAD_ASSERT(db_metadata_[0].main != MAP_FAILED);
-    db_metadata_[1].main = start_lifetime_as<detail::db_metadata>(::mmap(
-        nullptr,
-        map_size,
-        prot,
-        mapflags,
-        fd.first,
-        off_t(fdr.second + cnv_chunk.capacity() / 2)));
-    MONAD_ASSERT(db_metadata_[1].main != MAP_FAILED);
-    /* If on a storage which ignores TRIM, and the user just truncated
-    an existing triedb, all the magics will be valid but the pool has
-    been reset. Solve this by detecting when a pool has just been truncated
-    and ensure all triedb structures are also reset.
-    */
-    if (io->storage_pool().is_newly_truncated()) {
-        memset(
-            db_metadata_[0].main->magic,
-            0,
-            sizeof(db_metadata_[0].main->magic));
-        memset(
-            db_metadata_[1].main->magic,
-            0,
-            sizeof(db_metadata_[1].main->magic));
-    }
-    /* If the front copy vanished for some reason ... this can happen
-    if something or someone zaps the front bytes of the partition.
-    */
-    if (0 != memcmp(
-                 db_metadata_[0].main->magic,
-                 detail::db_metadata::MAGIC,
-                 detail::db_metadata::MAGIC_STRING_LEN)) {
-        if (0 == memcmp(
-                     db_metadata_[1].main->magic,
-                     detail::db_metadata::MAGIC,
-                     detail::db_metadata::MAGIC_STRING_LEN)) {
-            // Can't make forward progress if we don't have writable maps
-            MONAD_ASSERT(
-                can_write_to_map,
-                "First copy of metadata corrupted, but not opened for healing");
-            // Overwrite the front copy with the backup copy
-            db_copy(db_metadata_[0].main, db_metadata_[1].main, map_size);
-        }
-    }
-    constexpr unsigned magic_version_len = 3;
-    constexpr unsigned magic_prefix_len =
-        detail::db_metadata::MAGIC_STRING_LEN - magic_version_len;
-    if (0 == memcmp(
-                 db_metadata_[0].main->magic,
-                 detail::db_metadata::MAGIC,
-                 magic_prefix_len) &&
-        0 != memcmp(
-                 db_metadata_[0].main->magic + magic_prefix_len,
-                 detail::db_metadata::MAGIC + magic_prefix_len,
-                 magic_version_len)) {
-        MONAD_ABORT_PRINTF(
-            "DB was generated with version %s. The current code base is on "
-            "version %s. Please regenerate with the new DB version.",
-            db_metadata_[0].main->magic + magic_prefix_len,
-            detail::db_metadata::MAGIC + magic_prefix_len);
-    }
-    // Replace any dirty copy with the non-dirty copy
-    if (0 == memcmp(
-                 db_metadata_[0].main->magic,
-                 detail::db_metadata::MAGIC,
-                 detail::db_metadata::MAGIC_STRING_LEN) &&
-        0 == memcmp(
-                 db_metadata_[1].main->magic,
-                 detail::db_metadata::MAGIC,
-                 detail::db_metadata::MAGIC_STRING_LEN)) {
-        if (can_write_to_map) {
-            // Replace the dirty copy with the non-dirty copy
-            if (db_metadata_[0].main->is_dirty().load(
-                    std::memory_order_acquire)) {
-                db_copy(db_metadata_[0].main, db_metadata_[1].main, map_size);
-            }
-            else if (db_metadata_[1].main->is_dirty().load(
-                         std::memory_order_acquire)) {
-                db_copy(db_metadata_[1].main, db_metadata_[0].main, map_size);
-            }
-        }
-        else {
-            if (db_metadata_[0].main->is_dirty().load(
-                    std::memory_order_acquire) ||
-                db_metadata_[1].main->is_dirty().load(
-                    std::memory_order_acquire)) {
-                on_read_only_init_with_dirty_bit();
 
-                // Wait a bit to see if they clear before complaining
-                bool dirty;
-                auto const begin = std::chrono::steady_clock::now();
-                do {
-                    dirty = db_metadata_[0].main->is_dirty().load(
-                                std::memory_order_acquire) ||
-                            db_metadata_[1].main->is_dirty().load(
-                                std::memory_order_acquire);
-                    std::this_thread::yield();
-                }
-                while (dirty && (std::chrono::steady_clock::now() - begin <
-                                 std::chrono::seconds(1)));
+    metadata_ctx_ = std::make_unique<DbMetadataContext>(io_);
 
-                /* If after one second a dirty bit remains set, and we don't
-                have writable maps, can't forward progress.
-                */
-                MONAD_ASSERT(
-                    !dirty,
-                    "DB metadata was closed dirty, but not opened for healing");
-            }
-        }
-    }
-    auto map_root_offsets = [&] {
-        // Map in the DB version history storage
-        // Firstly reserve address space for each copy
-        size_t const map_bytes_per_chunk = cnv_chunk.capacity() / 2;
-        size_t const db_version_history_storage_bytes =
-            db_metadata()->root_offsets.storage_.cnv_chunks_len *
-            map_bytes_per_chunk;
-        std::byte *reservation[2];
-        reservation[0] = (std::byte *)::mmap(
-            nullptr,
-            db_version_history_storage_bytes,
-            PROT_NONE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
-            -1,
-            0);
-        MONAD_ASSERT(reservation[0] != MAP_FAILED);
-        reservation[1] = (std::byte *)::mmap(
-            nullptr,
-            db_version_history_storage_bytes,
-            PROT_NONE,
-            MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
-            -1,
-            0);
-        MONAD_ASSERT(reservation[1] != MAP_FAILED);
-        // For each chunk, map the first half into the first copy and the
-        // second half into the second copy
-        for (size_t n = 0;
-             n < db_metadata()->root_offsets.storage_.cnv_chunks_len;
-             n++) {
-            auto &chunk = io->storage_pool().chunk(
-                storage_pool::cnv,
-                db_metadata()
-                    ->root_offsets.storage_.cnv_chunks[n]
-                    .cnv_chunk_id);
-            auto const fdr = chunk.read_fd();
-            auto const fdw = chunk.write_fd(0);
-            auto const &fd = can_write_to_map ? fdw : fdr;
-            MONAD_ASSERT(
-                MAP_FAILED != ::mmap(
-                                  reservation[0] + n * map_bytes_per_chunk,
-                                  map_bytes_per_chunk,
-                                  prot,
-                                  mapflags | MAP_FIXED,
-                                  fd.first,
-                                  off_t(fdr.second)));
-            MONAD_ASSERT(
-                MAP_FAILED != ::mmap(
-                                  reservation[1] + n * map_bytes_per_chunk,
-                                  map_bytes_per_chunk,
-                                  prot,
-                                  mapflags | MAP_FIXED,
-                                  fd.first,
-                                  off_t(fdr.second + map_bytes_per_chunk)));
-        }
-        db_metadata_[0].root_offsets = {
-            start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[0]),
-            db_version_history_storage_bytes / sizeof(chunk_offset_t)};
-        db_metadata_[1].root_offsets = {
-            start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[1]),
-            db_version_history_storage_bytes / sizeof(chunk_offset_t)};
-        // NOLINTNEXTLINE(bugprone-lambda-function-name)
-        LOG_INFO(
-            "Database root offsets ring buffer is configured with {} "
-            "chunks, can hold up to {} historical entries.",
-            db_metadata()->root_offsets.storage_.cnv_chunks_len,
-            root_offsets().capacity());
-    };
-    if (0 != memcmp(
-                 db_metadata_[0].main->magic,
-                 detail::db_metadata::MAGIC,
-                 detail::db_metadata::MAGIC_STRING_LEN)) {
-        // Can't make forward progress if We don't have writable maps
-        MONAD_ASSERT(
-            can_write_to_map,
-            "Neither copy of the DB metadata is valid, and not opened for "
-            "writing so stopping now.");
-        for (uint32_t n = 0; n < chunk_count; n++) {
-            auto const &chunk = io->storage_pool().chunk(storage_pool::seq, n);
-            MONAD_ASSERT(
-                chunk.size() == 0,
-                "Trying to initialise new DB but storage pool contains "
-                "existing data, stopping now to prevent data loss.");
-        }
-        memset(db_metadata_[0].main, 0, map_size);
-        MONAD_ASSERT((chunk_count & ~0xfffffU) == 0);
-        db_metadata_[0].main->chunk_info_count = chunk_count & 0xfffffU;
-        MONAD_ASSERT(io->storage_pool().chunks(storage_pool::cnv) > 1);
-        auto &storage = db_metadata_[0].main->root_offsets.storage_;
-        memset(&storage, 0xff, sizeof(storage));
-        storage.cnv_chunks_len = 0;
-        auto &chunk = io->storage_pool().chunk(storage_pool::cnv, 1);
-        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, chunk.capacity());
-        MONAD_ASSERT(tofill != nullptr);
-        auto const untofill =
-            make_scope_exit([&]() noexcept { ::free(tofill); });
-        memset(tofill, 0xff, chunk.capacity());
-        {
-            auto const fdw = chunk.write_fd(chunk.capacity());
-            MONAD_ASSERT(
-                -1 !=
-                ::pwrite(
-                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-        }
-        storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = 1;
-        db_metadata_[0].main->history_length =
-            chunk.capacity() / 2 / sizeof(chunk_offset_t);
-        // Allocate cnv chunks of the first device - 1 for root offsets,
-        // since chunk 0 is used for db_metadata
-        auto const root_offsets_chunk_count =
-            io->storage_pool().devices()[0].cnv_chunks() -
-            UpdateAux::cnv_chunks_for_db_metadata;
-        MONAD_ASSERT(
-            root_offsets_chunk_count > 0 &&
-                (root_offsets_chunk_count & (root_offsets_chunk_count - 1)) ==
-                    0,
-            "Number of cnv chunks for root offsets must be a power of two");
-        for (uint32_t n = 2; n <= root_offsets_chunk_count; n++) {
-            auto &chunk = io->storage_pool().chunk(storage_pool::cnv, n);
-            auto const fdw = chunk.write_fd(chunk.capacity());
-            MONAD_ASSERT(
-                -1 !=
-                ::pwrite(
-                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-            storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = n;
-            db_metadata_[0].main->history_length +=
-                chunk.capacity() / 2 / sizeof(chunk_offset_t);
-        }
-        memset(
-            &db_metadata_[0].main->free_list,
-            0xff,
-            sizeof(db_metadata_[0].main->free_list));
-        memset(
-            &db_metadata_[0].main->fast_list,
-            0xff,
-            sizeof(db_metadata_[0].main->fast_list));
-        memset(
-            &db_metadata_[0].main->slow_list,
-            0xff,
-            sizeof(db_metadata_[0].main->slow_list));
-        auto *chunk_info =
-            start_lifetime_as_array<detail::db_metadata::chunk_info_t>(
-                db_metadata_[0].main->chunk_info, chunk_count);
-        for (size_t n = 0; n < chunk_count; n++) {
-            auto &ci = chunk_info[n];
-            ci.prev_chunk_id = ci.next_chunk_id =
-                detail::db_metadata::chunk_info_t::INVALID_CHUNK_ID;
-        }
-        // magics are not set yet, so memcpy is fine here
-        memcpy(db_metadata_[1].main, db_metadata_[0].main, map_size);
-
-        // Insert all chunks into the free list
-        std::vector<uint32_t> chunks;
-        chunks.reserve(chunk_count);
-        for (uint32_t n = 0; n < chunk_count; n++) {
-            auto const chunk = io->storage_pool().chunk(storage_pool::seq, n);
-            MONAD_ASSERT(chunk.zone_id().first == storage_pool::seq);
-            MONAD_ASSERT(chunk.zone_id().second == n);
-            MONAD_ASSERT(chunk.size() == 0); // chunks must actually be free
-            chunks.push_back(n);
-        }
-
-#if MONAD_MPT_INITIALIZE_POOL_WITH_REVERSE_ORDER_CHUNKS
-        std::reverse(chunks.begin(), chunks.end());
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in reverse order.",
-            chunk_count);
-#elif MONAD_MPT_INITIALIZE_POOL_WITH_RANDOM_SHUFFLED_CHUNKS
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in random order.", chunk_count);
-        small_prng rand;
-        random_shuffle(chunks.begin(), chunks.end(), rand);
-#else
-        LOG_INFO_CFORMAT(
-            "Initialize db pool with %zu chunks in increasing order.",
-            chunk_count);
-#endif
-        auto append_with_insertion_count_override = [&](chunk_list list,
-                                                        uint32_t id) {
-            append(list, id);
-            if (initial_insertion_count_on_pool_creation_ != 0) {
-                auto override_insertion_count = [&](detail::db_metadata *db) {
-                    auto const g = db->hold_dirty();
-                    auto *i = db->at_(id);
-                    i->insertion_count0_ =
-                        uint32_t(initial_insertion_count_on_pool_creation_) &
-                        0x3ff;
-                    i->insertion_count1_ =
-                        uint32_t(
-                            initial_insertion_count_on_pool_creation_ >> 10) &
-                        0x3ff;
-                };
-                override_insertion_count(db_metadata_[0].main);
-                override_insertion_count(db_metadata_[1].main);
-            }
-            auto *i = db_metadata_[0].main->at_(id);
-            MONAD_ASSERT(i->index(db_metadata()) == id);
-        };
-        // root offset is the front of fast list
-        chunk_offset_t const fast_offset(chunks.front(), 0);
-        append_with_insertion_count_override(chunk_list::fast, fast_offset.id);
-        LOG_DEBUG_CFORMAT(
-            "Append one chunk to fast list, id: %d", fast_offset.id);
-        // init the first slow chunk and slow_offset
-        chunk_offset_t const slow_offset(chunks[1], 0);
-        append_with_insertion_count_override(chunk_list::slow, slow_offset.id);
-        LOG_DEBUG_CFORMAT(
-            "Append one chunk to slow list, id: %d", slow_offset.id);
-        std::span const chunks_after_second(
-            chunks.data() + 2, chunks.size() - 2);
-        // insert the rest of the chunks to free list
-        for (uint32_t const i : chunks_after_second) {
-            append(chunk_list::free, i);
-            auto *i_ = db_metadata_[0].main->at_(i);
-            MONAD_ASSERT(i_->index(db_metadata()) == i);
-        }
-
-        // Mark as done, init root offset and history versions for the new
-        // database as invalid
-        advance_db_offsets_to(fast_offset, slow_offset);
-        set_latest_finalized_version(INVALID_BLOCK_NUM);
-        set_latest_verified_version(INVALID_BLOCK_NUM);
-        set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
-        set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-        set_auto_expire_version_metadata(0);
-
-        for (auto const i : {0, 1}) {
-            auto *const m = db_metadata_[i].main;
-            auto const g = m->hold_dirty();
-            memset(
-                m->future_variables_unused,
-                0xff,
-                sizeof(m->future_variables_unused));
-        }
-
-        std::atomic_signal_fence(
-            std::memory_order_seq_cst); // no compiler reordering here
-        memcpy(
-            db_metadata_[0].main->magic,
-            detail::db_metadata::MAGIC,
-            detail::db_metadata::MAGIC_STRING_LEN);
-        memcpy(
-            db_metadata_[1].main->magic,
-            detail::db_metadata::MAGIC,
-            detail::db_metadata::MAGIC_STRING_LEN);
-
-        map_root_offsets();
-        // Set history length, MUST be after root offsets are mapped
+    if (metadata_ctx_->is_new_pool()) {
+        metadata_ctx_->init_new_pool(
+            history_len, initial_insertion_count_on_pool_creation_);
         if (history_len.has_value()) {
-            update_history_length_metadata(*history_len);
             enable_dynamic_history_length_ = false;
         }
-
         if (!io->is_read_only()) {
-            // Default behavior: initialize node writers to start at the
-            // start of available slow and fast list respectively. Make sure
-            // the initial fast/slow offset points into a block in use as a
-            // sanity check
             reset_node_writers();
         }
     }
     else { // resume from an existing db and underlying storage devices
-        map_root_offsets();
         if (!io->is_read_only()) {
             // Reset/init node writer's offsets, destroy contents after
             // fast_offset.id chunck
             rewind_to_match_offsets();
             if (history_len.has_value()) {
                 // reset history length
-                if (history_len < version_history_length() &&
-                    history_len <= db_history_max_version()) {
+                if (history_len < metadata_ctx_->version_history_length() &&
+                    history_len <= metadata_ctx_->db_history_max_version()) {
                     // we invalidate earlier blocks that fall outside of the
                     // history window when shortening history length
                     erase_versions_up_to_and_including(
-                        db_history_max_version() - *history_len);
+                        metadata_ctx_->db_history_max_version() - *history_len);
                 }
-                update_history_length_metadata(*history_len);
+                metadata_ctx_->update_history_length_metadata(*history_len);
                 enable_dynamic_history_length_ = false;
             }
         }
     }
     // If the pool has changed since we configured the metadata, this will
     // fail
-    MONAD_ASSERT(db_metadata()->chunk_info_count == chunk_count);
-}
-#if defined(__GNUC__) && !defined(__clang__)
-    #pragma GCC diagnostic pop
-#endif
-
-void UpdateAux::unset_io()
-{
-    node_writer_fast.reset();
-    node_writer_slow.reset();
-    if (db_metadata_[0].root_offsets.data() != nullptr) {
-        (void)::munmap(
-            db_metadata_[0].root_offsets.data(),
-            db_metadata_[0].root_offsets.size_bytes());
-        db_metadata_[0].root_offsets = {};
-    }
-    if (db_metadata_[1].root_offsets.data() != nullptr) {
-        (void)::munmap(
-            db_metadata_[1].root_offsets.data(),
-            db_metadata_[1].root_offsets.size_bytes());
-        db_metadata_[1].root_offsets = {};
-    }
-    auto const chunk_count = io->chunk_count();
-    auto const map_size =
-        sizeof(detail::db_metadata) +
-        chunk_count * sizeof(detail::db_metadata::chunk_info_t);
-    (void)::munmap(db_metadata_[0].main, map_size);
-    db_metadata_[0].main = nullptr;
-    (void)::munmap(db_metadata_[1].main, map_size);
-    db_metadata_[1].main = nullptr;
-    io = nullptr;
+    MONAD_ASSERT(metadata_ctx_->main()->chunk_info_count == io->chunk_count());
 }
 
 void UpdateAux::reset_node_writers()
@@ -1063,10 +401,10 @@ void UpdateAux::reset_node_writers()
                         write_operation_io_receiver{bytes_to_write})
                   : node_writer_unique_ptr_type{};
     };
-    node_writer_fast =
-        init_node_writer(db_metadata()->db_offsets.start_of_wip_offset_fast);
-    node_writer_slow =
-        init_node_writer(db_metadata()->db_offsets.start_of_wip_offset_slow);
+    node_writer_fast = init_node_writer(
+        metadata_ctx_->main()->db_offsets.start_of_wip_offset_fast);
+    node_writer_slow = init_node_writer(
+        metadata_ctx_->main()->db_offsets.start_of_wip_offset_slow);
 
     last_block_end_offset_fast_ = compact_virtual_chunk_offset_t{
         physical_to_virtual(node_writer_fast->sender().offset())};
@@ -1115,7 +453,7 @@ Node::SharedPtr UpdateAux::do_update(
             // chunks
             adjust_history_length_based_on_disk_usage();
         }
-        if (!version_is_valid_ondisk(version)) {
+        if (!metadata_ctx_->version_is_valid_ondisk(version)) {
             // only advance compaction progress for non existent version
             advance_compact_offsets(prev_root);
         }
@@ -1136,7 +474,8 @@ Node::SharedPtr UpdateAux::do_update(
         std::move(prev_root),
         std::move(root_updates),
         write_root);
-    set_auto_expire_version_metadata(curr_upsert_auto_expire_version);
+    metadata_ctx_->set_auto_expire_version_metadata(
+        curr_upsert_auto_expire_version);
 
     auto const upsert_duration = upsert_timer.elapsed();
     if (compaction) {
@@ -1154,7 +493,7 @@ Node::SharedPtr UpdateAux::do_update(
         "offsets: fast={%u,%u}, slow={%u,%u}. Compaction head offset fast=%u, "
         "slow=%u",
         version,
-        db_history_min_valid_version(),
+        metadata_ctx_->db_history_min_valid_version(),
         upsert_duration.count(),
         disk_usage(),
         num_chunks(chunk_list::fast),
@@ -1171,13 +510,14 @@ Node::SharedPtr UpdateAux::do_update(
 
 void UpdateAux::release_unreferenced_chunks()
 {
-    auto const min_valid_version = db_history_min_valid_version();
+    auto const min_valid_version =
+        metadata_ctx_->db_history_min_valid_version();
     if (min_valid_version == INVALID_BLOCK_NUM) {
         return;
     }
     auto const min_valid_root = read_node_blocking(
         *this,
-        get_root_offset_at_version(min_valid_version),
+        metadata_ctx_->get_root_offset_at_version(min_valid_version),
         min_valid_version);
     auto const min_offsets =
         compact_offset_pair::deserialize(min_valid_root->value());
@@ -1195,7 +535,8 @@ void UpdateAux::release_unreferenced_chunks()
         chunks_to_remove_before_count_fast_,
         chunks_to_remove_before_count_slow_);
     MONAD_ASSERT(
-        db_metadata()->root_offsets.version_lower_bound_ >= min_valid_version);
+        metadata_ctx_->main()->root_offsets.version_lower_bound_ >=
+        min_valid_version);
     free_compacted_chunks();
 }
 
@@ -1210,17 +551,17 @@ double UpdateAux::calculate_disk_usage_if_erased_up_to_and_including(
     uint64_t const version_to_erase) const
 {
     MONAD_ASSERT(is_on_disk());
-    MONAD_ASSERT(db_history_max_version() != INVALID_BLOCK_NUM);
+    MONAD_ASSERT(metadata_ctx_->db_history_max_version() != INVALID_BLOCK_NUM);
     uint64_t min_version_post_erase = version_to_erase + 1;
     MONAD_ASSERT(
-        min_version_post_erase < db_history_max_version(),
+        min_version_post_erase < metadata_ctx_->db_history_max_version(),
         "Must have at least one valid version left after erase.");
-    while (!version_is_valid_ondisk(min_version_post_erase)) {
+    while (!metadata_ctx_->version_is_valid_ondisk(min_version_post_erase)) {
         min_version_post_erase++;
     }
     auto const min_valid_root_post_erase = read_node_blocking(
         *this,
-        get_root_offset_at_version(min_version_post_erase),
+        metadata_ctx_->get_root_offset_at_version(min_version_post_erase),
         min_version_post_erase);
     auto const min_offsets =
         compact_offset_pair::deserialize(min_valid_root_post_erase->value());
@@ -1228,9 +569,9 @@ double UpdateAux::calculate_disk_usage_if_erased_up_to_and_including(
         min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
         min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
     auto const fast_list_max_count =
-        db_metadata()->fast_list_end()->insertion_count();
+        metadata_ctx_->main()->fast_list_end()->insertion_count();
     auto const slow_list_max_count =
-        db_metadata()->slow_list_end()->insertion_count();
+        metadata_ctx_->main()->slow_list_end()->insertion_count();
     MONAD_ASSERT(fast_list_max_count >= min_offsets.fast.get_count());
     MONAD_ASSERT(slow_list_max_count >= min_offsets.slow.get_count());
     auto const num_fast_chunks =
@@ -1248,16 +589,16 @@ void UpdateAux::adjust_history_length_based_on_disk_usage()
     Stopwatch<std::chrono::microseconds> const timer;
 
     // Shorten history length when disk usage is high
-    auto const max_version = db_history_max_version();
+    auto const max_version = metadata_ctx_->db_history_max_version();
     if (max_version == INVALID_BLOCK_NUM) {
         return;
     }
     auto const history_length_before =
-        max_version - db_history_min_valid_version() + 1;
+        max_version - metadata_ctx_->db_history_min_valid_version() + 1;
     auto const current_disk_usage = disk_usage();
     if (current_disk_usage > upper_bound &&
         history_length_before > MIN_HISTORY_LENGTH) {
-        uint64_t const lo = db_history_min_valid_version();
+        uint64_t const lo = metadata_ctx_->db_history_min_valid_version();
         uint64_t const hi = max_version - MIN_HISTORY_LENGTH;
         MONAD_ASSERT(lo <= hi); // always true under the if condition
         uint64_t best_version_to_erase = hi;
@@ -1280,38 +621,38 @@ void UpdateAux::adjust_history_length_based_on_disk_usage()
             }
         }
         erase_versions_up_to_and_including(best_version_to_erase);
-        update_history_length_metadata(
+        metadata_ctx_->update_history_length_metadata(
             std::max(max_version - best_version_to_erase, MIN_HISTORY_LENGTH));
         MONAD_ASSERT(
             disk_usage() <= upper_bound ||
-            version_history_length() == MIN_HISTORY_LENGTH);
+            metadata_ctx_->version_history_length() == MIN_HISTORY_LENGTH);
         LOG_INFO_CFORMAT(
             "Adjust db history length down from %lu to %lu. Current disk "
             "usage: %.4f, Time elapsed: %ld us",
             history_length_before,
-            version_history_length(),
+            metadata_ctx_->version_history_length(),
             disk_usage(),
             timer.elapsed().count());
     }
     // Raise history length limit when disk usage falls low
-    else if (auto const offsets = root_offsets();
+    else if (auto const offsets = metadata_ctx_->root_offsets();
              current_disk_usage < lower_bound &&
-             version_history_length() < offsets.capacity()) {
-        update_history_length_metadata(offsets.capacity());
+             metadata_ctx_->version_history_length() < offsets.capacity()) {
+        metadata_ctx_->update_history_length_metadata(offsets.capacity());
         LOG_INFO_CFORMAT(
             "Adjust db history length up from %lu to %lu. Time elapsed: %ld us",
             history_length_before,
-            version_history_length(),
+            metadata_ctx_->version_history_length(),
             timer.elapsed().count());
     }
 }
 
 void UpdateAux::clear_root_offsets_up_to_and_including(uint64_t const version)
 {
-    for (uint64_t v = db_history_range_lower_bound();
+    for (uint64_t v = metadata_ctx_->db_history_range_lower_bound();
          v != INVALID_BLOCK_NUM && v <= version;
-         v = db_history_range_lower_bound()) {
-        update_root_offset(v, INVALID_OFFSET);
+         v = metadata_ctx_->db_history_range_lower_bound()) {
+        metadata_ctx_->update_root_offset(v, INVALID_OFFSET);
     }
 }
 
@@ -1319,23 +660,26 @@ void UpdateAux::move_trie_version_forward(
     uint64_t const src, uint64_t const dest)
 {
     MONAD_ASSERT(is_on_disk());
-    MONAD_ASSERT(version_is_valid_ondisk(src));
+    MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(src));
     // only allow moving forward
     MONAD_ASSERT(
         dest > src && dest != INVALID_BLOCK_NUM &&
-        dest >= db_history_max_version());
-    auto const offset = get_root_offset_at_version(src);
-    update_root_offset(src, INVALID_OFFSET);
+        dest >= metadata_ctx_->db_history_max_version());
+    auto const offset = metadata_ctx_->get_root_offset_at_version(src);
+    metadata_ctx_->update_root_offset(src, INVALID_OFFSET);
     // Must erase versions that will fall out of history range first
-    if (dest >= version_history_length()) {
-        erase_versions_up_to_and_including(dest - version_history_length());
+    if (dest >= metadata_ctx_->version_history_length()) {
+        erase_versions_up_to_and_including(
+            dest - metadata_ctx_->version_history_length());
     }
-    fast_forward_next_version(dest);
-    append_root_offset(offset);
-    MONAD_ASSERT(dest == db_history_max_version());
-    MONAD_ASSERT(version_is_valid_ondisk(dest));
-    if (get_auto_expire_version_metadata() == static_cast<int64_t>(src)) {
-        set_auto_expire_version_metadata(static_cast<int64_t>(dest));
+    metadata_ctx_->fast_forward_next_version(dest);
+    metadata_ctx_->append_root_offset(offset);
+    MONAD_ASSERT(dest == metadata_ctx_->db_history_max_version());
+    MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(dest));
+    if (metadata_ctx_->get_auto_expire_version_metadata() ==
+        static_cast<int64_t>(src)) {
+        metadata_ctx_->set_auto_expire_version_metadata(
+            static_cast<int64_t>(dest));
     }
 }
 
@@ -1407,7 +751,7 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
 
     auto const fast_disk_usage =
         num_chunks(chunk_list::fast) / (double)io->chunk_count();
-    uint64_t const max_version = db_history_max_version();
+    uint64_t const max_version = metadata_ctx_->db_history_max_version();
     if ((fast_disk_usage < fast_usage_limit_start_compaction &&
          num_chunks(chunk_list::fast) <
              fast_chunk_count_limit_start_compaction) ||
@@ -1424,7 +768,7 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     changes in history length. */
     compact_offset_range_fast_ = MIN_COMPACT_VIRTUAL_OFFSET;
 
-    uint64_t const min_version = db_history_min_valid_version();
+    uint64_t const min_version = metadata_ctx_->db_history_min_valid_version();
     MONAD_ASSERT(min_version != INVALID_BLOCK_NUM);
     compact_virtual_chunk_offset_t const curr_fast_writer_offset{
         physical_to_virtual(node_writer_fast->sender().offset())};
@@ -1433,8 +777,8 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     // back to the last block's growth (e.g. roots from statesync may be on the
     // slow list).
     uint32_t avg_disk_growth_fast = last_block_disk_growth_fast_;
-    auto const min_version_root_virtual_offset =
-        physical_to_virtual(get_root_offset_at_version(min_version));
+    auto const min_version_root_virtual_offset = physical_to_virtual(
+        metadata_ctx_->get_root_offset_at_version(min_version));
     if (min_version_root_virtual_offset.in_fast_list() &&
         max_version > min_version) {
         avg_disk_growth_fast = divide_and_round(
@@ -1497,75 +841,28 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     }
 }
 
-uint64_t UpdateAux::version_history_max_possible() const noexcept
-{
-    return root_offsets().capacity();
-}
-
-uint64_t UpdateAux::version_history_length() const noexcept
-{
-    return start_lifetime_as<std::atomic_uint64_t const>(
-               &db_metadata()->history_length)
-        ->load(std::memory_order_relaxed);
-}
-
-uint64_t UpdateAux::db_history_min_valid_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto const offsets = root_offsets();
-    auto min_version = db_history_range_lower_bound();
-    for (; min_version != offsets.max_version(); ++min_version) {
-        if (offsets[min_version] != INVALID_OFFSET) {
-            break;
-        }
-    }
-    return min_version;
-}
-
-uint64_t UpdateAux::db_history_range_lower_bound() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    auto const max_version = db_history_max_version();
-    if (max_version == INVALID_BLOCK_NUM) {
-        return INVALID_BLOCK_NUM;
-    }
-    else {
-        auto const history_range_min =
-            max_version >= version_history_length()
-                ? (max_version - version_history_length() + 1)
-                : 0;
-        auto const ro_version_lower_bound =
-            db_metadata()->root_offsets.version_lower_bound_;
-        MONAD_ASSERT(ro_version_lower_bound >= history_range_min);
-        return ro_version_lower_bound;
-    }
-}
-
-uint64_t UpdateAux::db_history_max_version() const noexcept
-{
-    MONAD_ASSERT(is_on_disk());
-    return root_offsets().max_version();
-}
-
 void UpdateAux::free_compacted_chunks()
 {
     auto free_chunks_from_ci_till_count =
         [&](detail::db_metadata::chunk_info_t const *ci,
             uint32_t const count_before) {
-            uint32_t idx = ci->index(db_metadata());
+            uint32_t idx = ci->index(metadata_ctx_->main());
             uint32_t count =
-                (uint32_t)db_metadata()->at(idx)->insertion_count();
+                (uint32_t)metadata_ctx_->main()->at(idx)->insertion_count();
             for (; count < count_before && ci != nullptr;
-                 idx = ci->index(db_metadata()),
-                 count = (uint32_t)db_metadata()->at(idx)->insertion_count()) {
-                ci = ci->next(db_metadata()); // must be in this order
+                 idx = ci->index(metadata_ctx_->main()),
+                 count = (uint32_t)metadata_ctx_->main()
+                             ->at(idx)
+                             ->insertion_count()) {
+                ci = ci->next(metadata_ctx_->main()); // must be in this order
                 Stopwatch<std::chrono::microseconds> const timer;
-                remove(idx);
+                metadata_ctx_->remove(idx);
                 io->storage_pool()
                     .chunk(monad::async::storage_pool::seq, idx)
                     .destroy_contents();
-                append(UpdateAux::chunk_list::free,
-                       idx); // append not prepend
+                metadata_ctx_->append(
+                    UpdateAux::chunk_list::free,
+                    idx); // append not prepend
                 // NOLINTNEXTLINE(bugprone-lambda-function-name)
                 LOG_INFO_CFORMAT(
                     "Free compacted chunk id %u, time elapsed: %ld us",
@@ -1575,14 +872,16 @@ void UpdateAux::free_compacted_chunks()
         };
     MONAD_ASSERT(
         chunks_to_remove_before_count_fast_ <=
-        db_metadata()->fast_list_end()->insertion_count());
+        metadata_ctx_->main()->fast_list_end()->insertion_count());
     MONAD_ASSERT(
         chunks_to_remove_before_count_slow_ <=
-        db_metadata()->slow_list_end()->insertion_count());
+        metadata_ctx_->main()->slow_list_end()->insertion_count());
     free_chunks_from_ci_till_count(
-        db_metadata()->fast_list_begin(), chunks_to_remove_before_count_fast_);
+        metadata_ctx_->main()->fast_list_begin(),
+        chunks_to_remove_before_count_fast_);
     free_chunks_from_ci_till_count(
-        db_metadata()->slow_list_begin(), chunks_to_remove_before_count_slow_);
+        metadata_ctx_->main()->slow_list_begin(),
+        chunks_to_remove_before_count_slow_);
 }
 
 uint32_t UpdateAux::num_chunks(chunk_list const list) const noexcept
@@ -1590,27 +889,39 @@ uint32_t UpdateAux::num_chunks(chunk_list const list) const noexcept
     switch (list) {
     case chunk_list::free:
         // Triggers when out of storage
-        MONAD_ASSERT(db_metadata()->free_list_begin() != nullptr);
-        MONAD_ASSERT(db_metadata()->free_list_end() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->free_list_begin() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->free_list_end() != nullptr);
 
-        return (uint32_t)(db_metadata()->free_list_end()->insertion_count() -
-                          db_metadata()->free_list_begin()->insertion_count()) +
+        return (uint32_t)(metadata_ctx_->main()
+                              ->free_list_end()
+                              ->insertion_count() -
+                          metadata_ctx_->main()
+                              ->free_list_begin()
+                              ->insertion_count()) +
                1;
     case chunk_list::fast:
         // Triggers when out of storage
-        MONAD_ASSERT(db_metadata()->fast_list_begin() != nullptr);
-        MONAD_ASSERT(db_metadata()->fast_list_end() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->fast_list_begin() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->fast_list_end() != nullptr);
 
-        return (uint32_t)(db_metadata()->fast_list_end()->insertion_count() -
-                          db_metadata()->fast_list_begin()->insertion_count()) +
+        return (uint32_t)(metadata_ctx_->main()
+                              ->fast_list_end()
+                              ->insertion_count() -
+                          metadata_ctx_->main()
+                              ->fast_list_begin()
+                              ->insertion_count()) +
                1;
     case chunk_list::slow:
         // Triggers when out of storage
-        MONAD_ASSERT(db_metadata()->slow_list_begin() != nullptr);
-        MONAD_ASSERT(db_metadata()->slow_list_end() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->slow_list_begin() != nullptr);
+        MONAD_ASSERT(metadata_ctx_->main()->slow_list_end() != nullptr);
 
-        return (uint32_t)(db_metadata()->slow_list_end()->insertion_count() -
-                          db_metadata()->slow_list_begin()->insertion_count()) +
+        return (uint32_t)(metadata_ctx_->main()
+                              ->slow_list_end()
+                              ->insertion_count() -
+                          metadata_ctx_->main()
+                              ->slow_list_begin()
+                              ->insertion_count()) +
                1;
     }
     return 0;


### PR DESCRIPTION
Separate the metadata mmap lifecycle and db_metadata operations from UpdateAux into a new DbMetadataContext class. This makes UpdateAux focused on trie operations (compaction, node writers, updates) while DbMetadataContext owns:

- mmap/munmap of db_metadata (two copies for crash safety)
- Dirty recovery and magic validation
- root_offsets_delegator and root_offsets ring operations
- New pool initialization (chunk lists, version markers, magic)
- All version metadata getters/setters
- chunk_list append/remove operations

UpdateAux owns a unique_ptr<DbMetadataContext> internally, exposes it via metadata_ctx() accessor. Callers access metadata methods through aux.metadata_ctx().method() instead of aux.method().

This separation prepares for multi-DB support where DbMetadataContext can be owned by a shared DbAsyncWorker while individual UpdateAux instances borrow it.