### PR TITLE
Elide DB fetch in `State::is_touched`

### DIFF
--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -312,8 +312,8 @@ State::get_transient_storage(Address const &address, bytes32_t const &key)
 
 bool State::is_touched(Address const &address)
 {
-    auto const &account_state = recent_account_state(address);
-    return account_state.is_touched();
+    auto const it = current_.find(address);
+    return it != current_.end() && it->second.recent().is_touched();
 }
 
 void State::set_nonce(Address const &address, uint64_t const nonce)


### PR DESCRIPTION
The current definition of `is_touched` potentially fetches an account from triedb if the given address is not in `current_`. Since `touched` is a property that is not actually stored in the db, this is inefficient and causes issues when trying to execute a block against a stateless witness generated by reth, due to the fact that reth (correctly) assumes there is no need for a db fetch for the `touched` flag. Since reth does not include the account in the witness, the witness db (TODO add PR link when ready) throws a runtime error.

This change should be functionally equivalent, however the original code has the side-effect of potentially loading the given account from the db, whereas the new change short-circuits and never attempts a db fetch.