### PR TITLE
[vm/utils] clang tidy: missing `const`

### DIFF
--- a/category/vm/utils/evm-as/builder.hpp
+++ b/category/vm/utils/evm-as/builder.hpp
@@ -123,7 +123,7 @@ namespace monad::vm::utils::evm_as
 
         EvmBuilder &push(runtime::uint256_t const &imm) noexcept
         {
-            size_t n = byte_width(imm);
+            size_t const n = byte_width(imm);
             MONAD_ASSERT(n <= 32);
             return push(n, imm);
         }


### PR DESCRIPTION
Clang tidy flagged this missing `const` in `evm-as/builder.hpp` in an unrelated patch (https://github.com/category-labs/monad/pull/2060). I am submitting the fix as a separate patch to avoid cluttering the other patch.