### PR TITLE
[core/runtime] Update informal argument to match Rocq development

### DIFF
--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -1130,39 +1130,36 @@ namespace monad::vm::runtime
             if (MONAD_UNLIKELY(u[ix + n] == v[n - 1])) {
                 q_hat = ~uint64_t{0};
 
-                // In this branch, we have q_hat-1 <= q <= q_hat, therefore only
-                // one adjustment of the quotient is necessary, so we skip the
+                // In this branch q_hat = BASE - 1 where BASE = 2^64.
+                // We claim q_hat - 1 <= q <= q_hat, so at most one quotient
+                // correction can be necessary and we may skip the
                 // pre-adjustment phase.
                 //
-                // Suppose q >= q_hat-2, and let term = BASE*u[ix+n] + u[ix+n-1]
-                //   r_hat = term - q_hat*v[n-1]
-                //        >= term - (q-2)*v[n-1]
-                //         = term - q*v[n-1] + 2*v[n-1]
-                //        >= 2 * v[n-1]
-                //        >= BASE
-                // The last inequality follows from v[n-1] > BASE/2 and
-                // term - q*v[n-1] >= 0 follows from u[ix + n] = v[n - 1],
-                // because
-                //   BASE*u[ix+n] + u[ix+n-1] - q*v[n-1]
-                //     = BASE*v[n-1] + u[ix+n-1] - q*v[n-1]
-                //    >= BASE*v[n-1] - q*v[n-1]
-                //    >= BASE*v[n-1] - BASE*v[n-1]
-                //     = 0
-                // However, if r_hat >= BASE, then q_hat <= q. To this end
-                // it suffices to prove
-                //   u[ix+n .. ix] - v[n-1, .., 0] * q_hat >= 0
-                // because q <= q_hat
-                // and u[ix+n .. ix] - v[n-1, .., 0] * q >= 0,
-                //   u[ix+n .. ix] - v[n-1 .. 0]*q_hat
-                //     = (u[ix+n .. ix+n-1] - v[n-1]*q_hat)*B^(n-1)
-                //       + u[ix+n-2 .. ix] - v[n-2 .. 0]*q_hat
-                //     = r_hat*B^(n-1) + u[ix+n-2 .. ix] - v[n-2 .. 0]*q_hat
-                //    >= B^n + u[ix+n-2 .. ix] - v[n-2 .. 0] * q_hat
-                //    >= B^n - v[n-2 .. 0] * q_hat
-                //    >= B^n - B^(n-1) * B
-                //     = 0
-                // Therefore if q >= q_hat-2 we have q <= q_hat which is a
-                // contradiction.
+                // Let U = u[ix+n .. ix], V = v[n-1 .. 0], a = v[n-1] = u[ix+n]
+                // The upper bound q <= q_hat is immediate because q_hat is the
+                // maximal digit.
+                // For the lower bound, suppose q <= q_hat - 2. Since q is the
+                // quotient digit, we have
+                //   q * V <= U < (q + 1) * V.
+                // Hence
+                //   U < (q + 1) * V <= (q_hat - 1) * V = (BASE - 2) * V.
+                // It remains to show (BASE - 2) * V <= U. For this, note that
+                //   U >= a * BASE^n
+                // because the top digit of U is a, and
+                //   V <= (a + 1) * BASE^(n-1) - 1
+                // because the top digit of V is a. Using a >= BASE/2 (which is
+                // equivalent to Knuth's normalization condition
+                // a >= floor(BASE/2) in the case where BASE is even), we get
+                //   (BASE - 2) * (a + 1) = BASE*a - 2*a + BASE - 2
+                //                        <= BASE * a - 2 * (BASE/2) + BASE - 2
+                //                        <= BASE * a,
+                // hence
+                //   (BASE - 2) * V <= (BASE - 2)*(a + 1)*BASE^(n-1)-(BASE - 2)
+                //                  <= BASE * a * BASE^(n-1) - (BASE - 2)
+                //                  <= a * BASE^n
+                //                  <= U.
+                // Contradiction. Therefore q_hat - 1 <= q <= q_hat, so only one
+                // correction can be necessary.
             }
             else {
                 auto [q_hat0, r_hat0] = div(u[ix + n], u[ix + n - 1], v[n - 1]);


### PR DESCRIPTION
Subtle issues in the previous argument showing that q_hat is within one of the true quotient.

Generated by Codex GPT 5.4 based on Rocq proofs in [cmcl/uint256-rocq-model](https://github.com/category-labs/monad/tree/cmcl/uint256-rocq-model).

The analysis can be summarised as follows:

In [`knuth_div_estimate_bounds`](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2004-L2056), the equal-high-word branch is selected at [L2005-L2007](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2005-L2007), `q_hat = BASE - 1` is established at [L2008-L2024](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2008-L2024), the lower bound behind `q_hat - 1 <= q` is proved at [L2029-L2054](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2029-L2054), and the upper bound is discharged at [L2055-L2056](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2055-L2056). Those estimate bounds are then passed into [`knuth_div_subtract_correct`](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L1565-L1822) at [L2611-L2617](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L2611-L2617); its statement at [L1565-L1576](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L1565-L1576) is exactly the `q_hat - 1 <= q <= q_hat` / `within one` condition, and the split at [L1653-L1654](https://github.com/category-labs/monad/blob/07baf98d0a1b567e53778a475c7ce326d7d0274f/rocq/uint256/theories/DivisionProofs.v#L1653-L1654) is the formal version of the claim that at most one correction is needed.