### PR TITLE
[vm] style refactors: remove std:: on integer types, add missing const

### DIFF
--- a/category/core/backtrace.cpp
+++ b/category/core/backtrace.cpp
@@ -47,8 +47,8 @@ namespace detail
 
     public:
         using value_type = T;
-        using size_type = std::size_t;
-        using difference_type = std::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
         using propagate_on_container_move_assignment = std::true_type;
         using is_always_equal = std::true_type;
 
@@ -68,7 +68,7 @@ namespace detail
         {
         }
 
-        [[nodiscard]] constexpr value_type *allocate(std::size_t n)
+        [[nodiscard]] constexpr value_type *allocate(size_t n)
         {
             auto *newp = p + sizeof(value_type) * n;
             assert(size_t(newp - buffer.data()) <= buffer.size());
@@ -77,7 +77,7 @@ namespace detail
             return ret;
         }
 
-        constexpr void deallocate(value_type *, std::size_t) {}
+        constexpr void deallocate(value_type *, size_t) {}
     };
 }
 

--- a/category/core/detail/start_lifetime_as_polyfill.hpp
+++ b/category/core/detail/start_lifetime_as_polyfill.hpp
@@ -17,6 +17,8 @@
 
 #include <category/core/config.hpp>
 
+#include <cstddef>
+
 #ifndef MONAD_USE_STD_START_LIFETIME_AS
     #if __cpp_lib_start_lifetime_as >= 202207L
         #define MONAD_USE_STD_START_LIFETIME_AS 1
@@ -60,27 +62,27 @@ namespace monad
     }
 
     template <class T>
-    inline T *start_lifetime_as_array(void *p, std::size_t) noexcept
+    inline T *start_lifetime_as_array(void *p, size_t) noexcept
     {
         return reinterpret_cast<T *>(p);
     }
 
     template <class T>
-    inline T const *start_lifetime_as_array(void const *p, std::size_t) noexcept
+    inline T const *start_lifetime_as_array(void const *p, size_t) noexcept
     {
         return reinterpret_cast<T const *>(p);
     }
 
     template <class T>
     inline T volatile *
-    start_lifetime_as_array(void volatile *p, std::size_t) noexcept
+    start_lifetime_as_array(void volatile *p, size_t) noexcept
     {
         return reinterpret_cast<T volatile *>(p);
     }
 
     template <class T>
     inline T const volatile *
-    start_lifetime_as_array(void const volatile *p, std::size_t) noexcept
+    start_lifetime_as_array(void const volatile *p, size_t) noexcept
     {
         return reinterpret_cast<T const volatile *>(p);
     }

--- a/category/core/event/event_recorder_test.cpp
+++ b/category/core/event/event_recorder_test.cpp
@@ -430,7 +430,7 @@ TEST_F(EventRecorderDefaultFixture, LargePayloads)
 
     // Make a large buffer, 4 times larger than WINDOW_INCR
     auto const big_buffer =
-        std::make_unique<std::uint32_t[]>(MONAD_EVENT_WINDOW_INCR);
+        std::make_unique<uint32_t[]>(MONAD_EVENT_WINDOW_INCR);
     auto const big_buffer_bytes =
         std::as_bytes(std::span{big_buffer.get(), MONAD_EVENT_WINDOW_INCR});
     for (uint32_t i = 0; i < MONAD_EVENT_WINDOW_INCR; ++i) {

--- a/category/core/mem/allocators.hpp
+++ b/category/core/mem/allocators.hpp
@@ -307,8 +307,8 @@ namespace allocators
     struct variable_size_allocator
     {
         using value_type = T;
-        using size_type = std::size_t;
-        using difference_type = std::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
         //! \brief Construct allocator with total storage size
         //! \param storage_bytes Total bytes needed (sizeof(T) + trailing data)

--- a/category/core/runtime/non_temporal_memory.hpp
+++ b/category/core/runtime/non_temporal_memory.hpp
@@ -19,15 +19,16 @@
 
 #include <immintrin.h>
 
+#include <cstddef>
 #include <cstdint>
 
 namespace monad::vm::runtime
 {
-    inline void non_temporal_bzero(void *dest, std::size_t n)
+    inline void non_temporal_bzero(void *dest, size_t n)
     {
         MONAD_ASSERT((reinterpret_cast<uintptr_t>(dest) & 31) == 0);
         MONAD_ASSERT((n & 31) == 0);
-        auto *d = static_cast<std::uint8_t *>(dest);
+        auto *d = static_cast<uint8_t *>(dest);
         auto *const e = d + n;
         __m256i const zero = _mm256_setzero_si256();
         while (d < e) {
@@ -36,13 +37,13 @@ namespace monad::vm::runtime
         }
     }
 
-    inline void non_temporal_memcpy(void *dest, void *src, std::size_t n)
+    inline void non_temporal_memcpy(void *dest, void *src, size_t n)
     {
         MONAD_ASSERT((reinterpret_cast<uintptr_t>(dest) & 31) == 0);
         MONAD_ASSERT((reinterpret_cast<uintptr_t>(src) & 31) == 0);
         MONAD_ASSERT((n & 31) == 0);
-        auto *d = static_cast<std::uint8_t *>(dest);
-        auto *s = static_cast<std::uint8_t *>(src);
+        auto *d = static_cast<uint8_t *>(dest);
+        auto *s = static_cast<uint8_t *>(src);
         auto *const e = d + n;
         while (d < e) {
             _mm256_stream_si256(

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -1432,8 +1432,7 @@ namespace monad::vm::runtime
      * to the right with zero bytes.
      */
     [[gnu::always_inline]]
-    inline uint256_t
-    from_bytes(std::size_t n, std::size_t remaining, uint8_t const *src)
+    inline uint256_t from_bytes(size_t n, size_t remaining, uint8_t const *src)
     {
         MONAD_ASSERT(n <= 32);
 
@@ -1457,7 +1456,7 @@ namespace monad::vm::runtime
      * remaining to be specified.
      */
     [[gnu::always_inline]]
-    inline uint256_t from_bytes(std::size_t const n, uint8_t const *src)
+    inline uint256_t from_bytes(size_t const n, uint8_t const *src)
     {
         return from_bytes(n, n, src);
     }

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -282,7 +282,7 @@ Result<std::vector<Receipt>> execute_block_transactions(
             });
     }
 
-    auto const last = static_cast<std::ptrdiff_t>(transactions.size());
+    auto const last = static_cast<ptrdiff_t>(transactions.size());
     promises[last].get_future().get();
     block_metrics.tx_exec_time =
         std::chrono::duration_cast<std::chrono::microseconds>(

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -185,8 +185,7 @@ uint64_t ExecuteTransactionNoValidation<traits>::process_authorizations(
 
 template <Traits traits>
 evmc_message ExecuteTransactionNoValidation<traits>::to_message(
-    vm::MemoryPool::Ref &msg_memory,
-    std::uint32_t const msg_memory_capacity) const
+    vm::MemoryPool::Ref &msg_memory, uint32_t const msg_memory_capacity) const
 {
     auto const to_address = [this] {
         if (tx_.to) {

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -46,8 +46,7 @@ template <Traits traits>
 class ExecuteTransactionNoValidation
 {
     evmc_message to_message(
-        vm::MemoryPool::Ref &msg_memory,
-        std::uint32_t msg_memory_capacity) const;
+        vm::MemoryPool::Ref &msg_memory, uint32_t msg_memory_capacity) const;
 
     uint64_t process_authorizations(State &, EvmcHost<traits> &);
 

--- a/category/execution/ethereum/precompiles_bls12.cpp
+++ b/category/execution/ethereum/precompiles_bls12.cpp
@@ -74,7 +74,7 @@ namespace bls12
     std::optional<blst_fp> read_fp(uint8_t const *const in)
     {
         static_assert(sizeof(blst_fp) == 48);
-        static constexpr std::size_t fp_encoded_offset = 16;
+        static constexpr size_t fp_encoded_offset = 16;
 
         auto const integer_value = intx::be::unsafe::load<intx::uint512>(in);
 
@@ -150,7 +150,7 @@ namespace bls12
     void write_fp(blst_fp const &point, uint8_t *const buf)
     {
         static_assert(sizeof(blst_fp) == 48);
-        static constexpr std::size_t fp_encoded_offset = 16;
+        static constexpr size_t fp_encoded_offset = 16;
 
         std::memset(buf, 0, fp_encoded_offset);
         blst_bendian_from_fp(buf + fp_encoded_offset, &point);

--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -40,7 +40,7 @@ namespace trace
 {
     using json = nlohmann::json;
 
-    template <std::size_t N>
+    template <size_t N>
     std::string bytes_to_hex(uint8_t const (&input)[N])
     {
         return std::format("0x{}", to_hex(to_byte_string_view(input)));

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1815,7 +1815,7 @@ Result<void> StakingContract::syscall_snapshot(
         std::min(candidates.size(), limits::active_valset_size());
     std::partial_sort(
         candidates.begin(),
-        candidates.begin() + static_cast<std::ptrdiff_t>(n),
+        candidates.begin() + static_cast<ptrdiff_t>(n),
         candidates.end(),
         cmp);
     for (uint64_t i = 0; i < n; ++i) {

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -454,7 +454,7 @@ public:
     {
     public:
         using value_type = std::pair<uint8_t, unsigned char>;
-        using difference_type = std::ptrdiff_t;
+        using difference_type = ptrdiff_t;
         using iterator_category = std::input_iterator_tag;
         using pointer = void;
         using reference = value_type;

--- a/category/vm/code.hpp
+++ b/category/vm/code.hpp
@@ -60,13 +60,13 @@ namespace monad::vm
         Varcode(Varcode const &) = delete;
         Varcode &operator=(Varcode const &) = delete;
 
-        std::uint64_t intercode_gas_used(std::uint64_t gas_used)
+        uint64_t intercode_gas_used(uint64_t gas_used)
         {
             return gas_used + intercode_gas_used_.fetch_add(
                                   gas_used, std::memory_order_acq_rel);
         }
 
-        std::uint64_t get_intercode_gas_used()
+        uint64_t get_intercode_gas_used()
         {
             return intercode_gas_used_.load(std::memory_order_acquire);
         }
@@ -85,7 +85,7 @@ namespace monad::vm
         }
 
     private:
-        std::atomic<std::uint64_t> intercode_gas_used_;
+        std::atomic<uint64_t> intercode_gas_used_;
         SharedIntercode intercode_;
         SharedNativecode nativecode_;
     };

--- a/category/vm/code.hpp
+++ b/category/vm/code.hpp
@@ -60,7 +60,7 @@ namespace monad::vm
         Varcode(Varcode const &) = delete;
         Varcode &operator=(Varcode const &) = delete;
 
-        uint64_t intercode_gas_used(uint64_t gas_used)
+        uint64_t intercode_gas_used(uint64_t const gas_used)
         {
             return gas_used + intercode_gas_used_.fetch_add(
                                   gas_used, std::memory_order_acq_rel);

--- a/category/vm/compiler.cpp
+++ b/category/vm/compiler.cpp
@@ -31,7 +31,8 @@
 
 namespace monad::vm
 {
-    Compiler::Compiler(bool enable_async, size_t compile_job_soft_limit)
+    Compiler::Compiler(
+        bool const enable_async, size_t const compile_job_soft_limit)
         : asmjit_rt_{&asmjit_create_params_}
         , compile_job_lock_{compile_job_mutex_}
         , compile_job_soft_limit_{compile_job_soft_limit}

--- a/category/vm/compiler.hpp
+++ b/category/vm/compiler.hpp
@@ -103,8 +103,8 @@ namespace monad::vm
             }
         }
 
-        std::string
-        print_stats(uint64_t cache_size, uint64_t cache_weight) const
+        std::string print_stats(
+            uint64_t const cache_size, uint64_t const cache_weight) const
         {
             if constexpr (utils::collect_monad_compiler_stats) {
                 return std::format(
@@ -197,7 +197,7 @@ namespace monad::vm
             return varcode_cache_.is_warm();
         }
 
-        void set_varcode_cache_warm_kb_threshold(uint32_t warm_kb)
+        void set_varcode_cache_warm_kb_threshold(uint32_t const warm_kb)
         {
             return varcode_cache_.set_warm_cache_kb(warm_kb);
         }

--- a/category/vm/compiler.hpp
+++ b/category/vm/compiler.hpp
@@ -197,7 +197,7 @@ namespace monad::vm
             return varcode_cache_.is_warm();
         }
 
-        void set_varcode_cache_warm_kb_threshold(std::uint32_t warm_kb)
+        void set_varcode_cache_warm_kb_threshold(uint32_t warm_kb)
         {
             return varcode_cache_.set_warm_cache_kb(warm_kb);
         }

--- a/category/vm/compiler/ir/basic_blocks.cpp
+++ b/category/vm/compiler/ir/basic_blocks.cpp
@@ -38,12 +38,11 @@ namespace monad::vm::compiler::basic_blocks
     // the minimum delta the stack will decrease
     // the overall delta of the stack
     // the maximum delta the stack will increase
-    std::tuple<std::int32_t, std::int32_t, std::int32_t>
-    Block::stack_deltas() const
+    std::tuple<int32_t, int32_t, int32_t> Block::stack_deltas() const
     {
-        std::int32_t min_delta = 0;
-        std::int32_t delta = 0;
-        std::int32_t max_delta = 0;
+        int32_t min_delta = 0;
+        int32_t delta = 0;
+        int32_t max_delta = 0;
 
         for (auto const &instr : instrs) {
             delta -= instr.stack_args();
@@ -53,8 +52,8 @@ namespace monad::vm::compiler::basic_blocks
             max_delta = std::max(delta, max_delta);
         }
 
-        delta -= static_cast<std::int32_t>(
-            basic_blocks::terminator_inputs(terminator));
+        delta -=
+            static_cast<int32_t>(basic_blocks::terminator_inputs(terminator));
         min_delta = std::min(delta, min_delta);
 
         return {min_delta, delta, max_delta};

--- a/category/vm/compiler/ir/basic_blocks.cpp
+++ b/category/vm/compiler/ir/basic_blocks.cpp
@@ -89,19 +89,19 @@ namespace monad::vm::compiler::basic_blocks
      * IR: Private construction methods
      */
 
-    void BasicBlocksIR::add_block(byte_offset offset)
+    void BasicBlocksIR::add_block(byte_offset const offset)
     {
         blocks_.push_back(Block{.offset = offset});
         blocks_.back().instrs.reserve(16);
     }
 
-    void BasicBlocksIR::add_terminator(Terminator t)
+    void BasicBlocksIR::add_terminator(Terminator const t)
     {
         blocks_.back().instrs.shrink_to_fit();
         blocks_.back().terminator = t;
     }
 
-    void BasicBlocksIR::add_fallthrough_terminator(Terminator t)
+    void BasicBlocksIR::add_fallthrough_terminator(Terminator const t)
     {
         add_terminator(t);
         blocks_.back().fallthrough_dest = curr_block_id() + 1;

--- a/category/vm/compiler/ir/basic_blocks.hpp
+++ b/category/vm/compiler/ir/basic_blocks.hpp
@@ -61,10 +61,10 @@ namespace monad::vm::compiler::basic_blocks
 
     struct JumpDest
     {
-        std::uint32_t pc;
+        uint32_t pc;
     };
 
-    constexpr OpCode evm_op_to_opcode(std::uint8_t op)
+    constexpr OpCode evm_op_to_opcode(uint8_t op)
     {
         using enum OpCode;
 
@@ -100,7 +100,7 @@ namespace monad::vm::compiler::basic_blocks
      * Base gas usage for a given terminator.
      */
     template <Traits traits>
-    constexpr std::uint16_t terminator_static_gas(Terminator t)
+    constexpr uint16_t terminator_static_gas(Terminator t)
     {
         using enum Terminator;
         switch (t) {
@@ -135,7 +135,7 @@ namespace monad::vm::compiler::basic_blocks
      * Return the number of input stack elements consumed by each block
      * terminator.
      */
-    constexpr std::size_t terminator_inputs(Terminator t)
+    constexpr size_t terminator_inputs(Terminator t)
     {
         using enum Terminator;
         switch (t) {
@@ -195,8 +195,7 @@ namespace monad::vm::compiler::basic_blocks
          *   `JUMPI` instruction or an implicit fallthrough.
          */
         bool is_valid() const;
-        std::tuple<std::int32_t, std::int32_t, std::int32_t>
-        stack_deltas() const;
+        std::tuple<int32_t, int32_t, int32_t> stack_deltas() const;
     };
 
     bool operator==(Block const &a, Block const &b);
@@ -223,13 +222,13 @@ namespace monad::vm::compiler::basic_blocks
          */
         template <Traits traits = EvmTraits<EVMC_LATEST_STABLE_REVISION>>
         BasicBlocksIR(
-            std::uint8_t const *, interpreter::code_size_t,
+            uint8_t const *, interpreter::code_size_t,
             ChainMarker<traits> = {});
 
         template <Traits traits = EvmTraits<EVMC_LATEST_STABLE_REVISION>>
         [[gnu::always_inline]]
         static constexpr BasicBlocksIR unsafe_from(
-            std::initializer_list<std::uint8_t const> bytes,
+            std::initializer_list<uint8_t const> bytes,
             ChainMarker<traits> rm = {})
         {
             MONAD_ASSERT(bytes.size() <= *interpreter::code_size_t::max());
@@ -242,8 +241,8 @@ namespace monad::vm::compiler::basic_blocks
 
         template <Traits traits = EvmTraits<EVMC_LATEST_STABLE_REVISION>>
         [[gnu::always_inline]]
-        static constexpr BasicBlocksIR unsafe_from(
-            std::span<std::uint8_t const> bytes, ChainMarker<traits> rm = {})
+        static constexpr BasicBlocksIR
+        unsafe_from(std::span<uint8_t const> bytes, ChainMarker<traits> rm = {})
         {
             MONAD_ASSERT(bytes.size() <= *interpreter::code_size_t::max());
             return BasicBlocksIR(
@@ -303,8 +302,8 @@ namespace monad::vm::compiler::basic_blocks
 
     private:
         template <Traits traits>
-        static std::variant<Instruction, Terminator, JumpDest> scan_from(
-            std::span<std::uint8_t const> bytes, std::uint32_t &current_offset);
+        static std::variant<Instruction, Terminator, JumpDest>
+        scan_from(std::span<uint8_t const> bytes, uint32_t &current_offset);
 
         std::vector<Block> blocks_;
         std::unordered_map<byte_offset, block_id> jump_dests_;
@@ -363,7 +362,7 @@ namespace monad::vm::compiler::basic_blocks
 
     template <Traits traits>
     std::variant<Instruction, Terminator, JumpDest> BasicBlocksIR::scan_from(
-        std::span<std::uint8_t const> bytes, std::uint32_t &current_offset)
+        std::span<uint8_t const> bytes, uint32_t &current_offset)
     {
         MONAD_DEBUG_ASSERT(current_offset < bytes.size());
 
@@ -434,7 +433,7 @@ namespace monad::vm::compiler::basic_blocks
 
     template <Traits traits>
     BasicBlocksIR::BasicBlocksIR(
-        std::uint8_t const *bytes, interpreter::code_size_t byte_count,
+        uint8_t const *bytes, interpreter::code_size_t byte_count,
         ChainMarker<traits>)
         : codesize(byte_count)
     {
@@ -450,7 +449,7 @@ namespace monad::vm::compiler::basic_blocks
 
         add_block(0);
 
-        auto current_offset = std::uint32_t{0};
+        auto current_offset = uint32_t{0};
         auto first = true;
 
         while (current_offset < *byte_count) {

--- a/category/vm/compiler/ir/basic_blocks.hpp
+++ b/category/vm/compiler/ir/basic_blocks.hpp
@@ -64,7 +64,7 @@ namespace monad::vm::compiler::basic_blocks
         uint32_t pc;
     };
 
-    constexpr OpCode evm_op_to_opcode(uint8_t op)
+    constexpr OpCode evm_op_to_opcode(uint8_t const op)
     {
         using enum OpCode;
 
@@ -91,7 +91,7 @@ namespace monad::vm::compiler::basic_blocks
      * Return true if this terminator can implicitly fall through to the next
      * block in sequence.
      */
-    constexpr bool is_fallthrough_terminator(Terminator t)
+    constexpr bool is_fallthrough_terminator(Terminator const t)
     {
         return t == Terminator::FallThrough || t == Terminator::JumpI;
     }
@@ -100,7 +100,7 @@ namespace monad::vm::compiler::basic_blocks
      * Base gas usage for a given terminator.
      */
     template <Traits traits>
-    constexpr uint16_t terminator_static_gas(Terminator t)
+    constexpr uint16_t terminator_static_gas(Terminator const t)
     {
         using enum Terminator;
         switch (t) {
@@ -135,7 +135,7 @@ namespace monad::vm::compiler::basic_blocks
      * Return the number of input stack elements consumed by each block
      * terminator.
      */
-    constexpr size_t terminator_inputs(Terminator t)
+    constexpr size_t terminator_inputs(Terminator const t)
     {
         using enum Terminator;
         switch (t) {

--- a/category/vm/compiler/ir/instruction.hpp
+++ b/category/vm/compiler/ir/instruction.hpp
@@ -30,7 +30,7 @@
 
 namespace monad::vm::compiler
 {
-    enum class OpCode : std::uint8_t
+    enum class OpCode : uint8_t
     {
         Add = 0x01,
         Mul = 0x02,
@@ -114,23 +114,23 @@ namespace monad::vm::compiler
     {
     public:
         constexpr Instruction(
-            std::uint32_t pc, OpCode opcode, std::uint32_t static_gas_cost,
-            std::uint8_t stack_args, std::uint8_t index,
-            std::uint8_t stack_increase, bool dynamic_gas);
+            uint32_t pc, OpCode opcode, uint32_t static_gas_cost,
+            uint8_t stack_args, uint8_t index, uint8_t stack_increase,
+            bool dynamic_gas);
 
         constexpr Instruction(
-            std::uint32_t pc, OpCode opcode, runtime::uint256_t immediate_value,
-            std::uint32_t static_gas_cost, std::uint8_t stack_args,
-            std::uint8_t index, std::uint8_t stack_increase, bool dynamic_gas);
+            uint32_t pc, OpCode opcode, runtime::uint256_t immediate_value,
+            uint32_t static_gas_cost, uint8_t stack_args, uint8_t index,
+            uint8_t stack_increase, bool dynamic_gas);
 
         constexpr runtime::uint256_t const &immediate_value() const noexcept;
-        constexpr std::uint32_t pc() const noexcept;
-        constexpr std::uint32_t static_gas_cost() const noexcept;
+        constexpr uint32_t pc() const noexcept;
+        constexpr uint32_t static_gas_cost() const noexcept;
         constexpr OpCode opcode() const noexcept;
-        constexpr std::uint8_t stack_args() const noexcept;
-        constexpr std::uint8_t index() const noexcept;
+        constexpr uint8_t stack_args() const noexcept;
+        constexpr uint8_t index() const noexcept;
         constexpr bool increases_stack() const noexcept;
-        constexpr std::uint8_t stack_increase() const noexcept;
+        constexpr uint8_t stack_increase() const noexcept;
         constexpr bool dynamic_gas() const noexcept;
 
         friend constexpr bool
@@ -140,12 +140,12 @@ namespace monad::vm::compiler
         constexpr auto as_tuple() const noexcept;
 
         runtime::uint256_t immediate_value_;
-        std::uint32_t pc_;
-        std::uint32_t static_gas_cost_;
+        uint32_t pc_;
+        uint32_t static_gas_cost_;
         OpCode opcode_;
-        std::uint8_t stack_args_;
-        std::uint8_t index_;
-        std::uint8_t stack_increase_;
+        uint8_t stack_args_;
+        uint8_t index_;
+        uint8_t stack_increase_;
         bool dynamic_gas_;
     };
 
@@ -154,9 +154,8 @@ namespace monad::vm::compiler
      */
 
     constexpr Instruction::Instruction(
-        std::uint32_t pc, OpCode op, std::uint32_t static_gas_cost,
-        std::uint8_t stack_args, std::uint8_t index,
-        std::uint8_t stack_increase, bool dynamic_gas)
+        uint32_t pc, OpCode op, uint32_t static_gas_cost, uint8_t stack_args,
+        uint8_t index, uint8_t stack_increase, bool dynamic_gas)
         : Instruction(
               pc, op, 0, static_gas_cost, stack_args, index, stack_increase,
               dynamic_gas)
@@ -164,9 +163,9 @@ namespace monad::vm::compiler
     }
 
     constexpr Instruction::Instruction(
-        std::uint32_t pc, OpCode op, runtime::uint256_t immediate_value,
-        std::uint32_t static_gas_cost, std::uint8_t stack_args,
-        std::uint8_t index, std::uint8_t stack_increase, bool dynamic_gas)
+        uint32_t pc, OpCode op, runtime::uint256_t immediate_value,
+        uint32_t static_gas_cost, uint8_t stack_args, uint8_t index,
+        uint8_t stack_increase, bool dynamic_gas)
         : immediate_value_(immediate_value)
         , pc_(pc)
         , static_gas_cost_(static_gas_cost)
@@ -186,12 +185,12 @@ namespace monad::vm::compiler
         return immediate_value_;
     }
 
-    constexpr std::uint32_t Instruction::pc() const noexcept
+    constexpr uint32_t Instruction::pc() const noexcept
     {
         return pc_;
     }
 
-    constexpr std::uint32_t Instruction::static_gas_cost() const noexcept
+    constexpr uint32_t Instruction::static_gas_cost() const noexcept
     {
         return static_gas_cost_;
     }
@@ -201,12 +200,12 @@ namespace monad::vm::compiler
         return opcode_;
     }
 
-    constexpr std::uint8_t Instruction::stack_args() const noexcept
+    constexpr uint8_t Instruction::stack_args() const noexcept
     {
         return stack_args_;
     }
 
-    constexpr std::uint8_t Instruction::index() const noexcept
+    constexpr uint8_t Instruction::index() const noexcept
     {
         MONAD_ASSERT(
             opcode() == OpCode::Push || opcode() == OpCode::Swap ||
@@ -219,7 +218,7 @@ namespace monad::vm::compiler
         return stack_increase_ > 0;
     }
 
-    constexpr std::uint8_t Instruction::stack_increase() const noexcept
+    constexpr uint8_t Instruction::stack_increase() const noexcept
     {
         return stack_increase_;
     }

--- a/category/vm/compiler/ir/instruction.hpp
+++ b/category/vm/compiler/ir/instruction.hpp
@@ -154,8 +154,9 @@ namespace monad::vm::compiler
      */
 
     constexpr Instruction::Instruction(
-        uint32_t pc, OpCode op, uint32_t static_gas_cost, uint8_t stack_args,
-        uint8_t index, uint8_t stack_increase, bool dynamic_gas)
+        uint32_t const pc, OpCode const op, uint32_t const static_gas_cost,
+        uint8_t const stack_args, uint8_t const index,
+        uint8_t const stack_increase, bool const dynamic_gas)
         : Instruction(
               pc, op, 0, static_gas_cost, stack_args, index, stack_increase,
               dynamic_gas)
@@ -163,9 +164,11 @@ namespace monad::vm::compiler
     }
 
     constexpr Instruction::Instruction(
-        uint32_t pc, OpCode op, runtime::uint256_t immediate_value,
-        uint32_t static_gas_cost, uint8_t stack_args, uint8_t index,
-        uint8_t stack_increase, bool dynamic_gas)
+        uint32_t const pc, OpCode const op,
+        runtime::uint256_t const immediate_value,
+        uint32_t const static_gas_cost, uint8_t const stack_args,
+        uint8_t const index, uint8_t const stack_increase,
+        bool const dynamic_gas)
         : immediate_value_(immediate_value)
         , pc_(pc)
         , static_gas_cost_(static_gas_cost)
@@ -247,7 +250,7 @@ namespace monad::vm::compiler
         return a.as_tuple() == b.as_tuple();
     }
 
-    constexpr std::string_view opcode_name(OpCode op)
+    constexpr std::string_view opcode_name(OpCode const op)
     {
         using enum monad::vm::compiler::OpCode;
 

--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -24,7 +24,6 @@
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/interpreter/intercode.hpp>
-#include <category/vm/runtime/bin.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <asmjit/core/jitruntime.h>

--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -394,7 +394,7 @@ namespace
 
     template <Traits traits>
     std::shared_ptr<Nativecode> compile_contract(
-        asmjit::JitRuntime &rt, std::uint8_t const *contract_code,
+        asmjit::JitRuntime &rt, uint8_t const *contract_code,
         code_size_t contract_code_size, CompilerConfig const &config)
     {
         auto const ir =
@@ -407,7 +407,7 @@ namespace monad::vm::compiler::native
 {
     template <Traits traits>
     std::shared_ptr<Nativecode> compile(
-        asmjit::JitRuntime &rt, std::uint8_t const *contract_code,
+        asmjit::JitRuntime &rt, uint8_t const *contract_code,
         code_size_t contract_code_size, CompilerConfig const &config)
     {
         try {

--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -48,7 +48,8 @@ namespace
 
     template <Traits traits>
     void emit_instr(
-        Emitter &emit, Instruction const &instr, int64_t remaining_base_gas)
+        Emitter &emit, Instruction const &instr,
+        int64_t const remaining_base_gas)
     {
         static constexpr auto memory_version =
             traits::mip_3_active() ? runtime::Memory::Version::MIP3
@@ -307,7 +308,7 @@ namespace
 
     [[gnu::always_inline]]
     inline void require_code_size_in_bound(
-        Emitter &emit, native_code_size_t max_native_size)
+        Emitter &emit, native_code_size_t const max_native_size)
     {
         size_t const size_estimate = emit.estimate_size();
         if (MONAD_UNLIKELY(size_estimate > *max_native_size)) {
@@ -330,8 +331,8 @@ namespace
 
     template <Traits traits>
     void emit_instrs(
-        Emitter &emit, Block const &block, int64_t instr_gas,
-        native_code_size_t max_native_size, CompilerConfig const &config)
+        Emitter &emit, Block const &block, int64_t const instr_gas,
+        native_code_size_t const max_native_size, CompilerConfig const &config)
     {
         int64_t remaining_base_gas = instr_gas;
         for (auto const &instr : block.instrs) {
@@ -382,7 +383,7 @@ namespace
 
     void emit_gas_decrement(
         Emitter &emit, BasicBlocksIR const &ir, Block const &block,
-        int64_t block_base_gas)
+        int64_t const block_base_gas)
     {
         if (ir.jump_dests().contains(block.offset)) {
             emit.gas_decrement_unbounded_work(block_base_gas + 1);
@@ -395,7 +396,7 @@ namespace
     template <Traits traits>
     std::shared_ptr<Nativecode> compile_contract(
         asmjit::JitRuntime &rt, uint8_t const *contract_code,
-        code_size_t contract_code_size, CompilerConfig const &config)
+        code_size_t const contract_code_size, CompilerConfig const &config)
     {
         auto const ir =
             basic_blocks::make_ir<traits>(contract_code, contract_code_size);
@@ -408,7 +409,7 @@ namespace monad::vm::compiler::native
     template <Traits traits>
     std::shared_ptr<Nativecode> compile(
         asmjit::JitRuntime &rt, uint8_t const *contract_code,
-        code_size_t contract_code_size, CompilerConfig const &config)
+        code_size_t const contract_code_size, CompilerConfig const &config)
     {
         try {
             return ::compile_contract<traits>(

--- a/category/vm/compiler/ir/x86.hpp
+++ b/category/vm/compiler/ir/x86.hpp
@@ -35,7 +35,7 @@ namespace monad::vm::compiler::native
      */
     template <Traits traits>
     std::shared_ptr<Nativecode> compile(
-        asmjit::JitRuntime &rt, std::uint8_t const *contract_code,
+        asmjit::JitRuntime &rt, uint8_t const *contract_code,
         interpreter::code_size_t contract_code_size,
         CompilerConfig const & = {});
 

--- a/category/vm/compiler/ir/x86.hpp
+++ b/category/vm/compiler/ir/x86.hpp
@@ -51,8 +51,8 @@ namespace monad::vm::compiler::native
      * Upper bound on (estimated) native contract size in bytes.
      */
     constexpr native_code_size_t max_code_size(
-        interpreter::code_size_t offset,
-        interpreter::code_size_t bytecode_size) noexcept
+        interpreter::code_size_t const offset,
+        interpreter::code_size_t const bytecode_size) noexcept
     {
         // A contract will be compiled asynchronously after the accumulated
         // execution gas cost of interpretation reaches this threshold. If

--- a/category/vm/compiler/ir/x86/types.hpp
+++ b/category/vm/compiler/ir/x86/types.hpp
@@ -52,7 +52,7 @@ namespace monad::vm::compiler::native
 
         /// If compilation failed, then `entrypoint` is `nullptr`.
         Nativecode(
-            asmjit::JitRuntime &asmjit_rt, uint64_t chain_id,
+            asmjit::JitRuntime &asmjit_rt, uint64_t const chain_id,
             entrypoint_t entry, CodeSizeEstimate code_size_estimate)
             : asmjit_rt_{asmjit_rt}
             , chain_id_{chain_id}

--- a/category/vm/compiler/ir/x86/virtual_stack.cpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.cpp
@@ -101,7 +101,7 @@ namespace monad::vm::compiler::native
                    : *stack_indices_.begin();
     }
 
-    void StackElem::deferred_comparison(Comparison c)
+    void StackElem::deferred_comparison(Comparison const c)
     {
         MONAD_ASSERT(stack_.deferred_comparison_.stack_elem == nullptr);
         MONAD_DEBUG_ASSERT(
@@ -362,13 +362,13 @@ namespace monad::vm::compiler::native
             this);
     }
 
-    StackElemRef Stack::get(int32_t index)
+    StackElemRef Stack::get(int32_t const index)
     {
         MONAD_ASSERT(index <= top_index_);
         return at(index);
     }
 
-    StackElemRef &Stack::at(int32_t index)
+    StackElemRef &Stack::at(int32_t const index)
     {
         if (index < 0) {
             auto const i = static_cast<size_t>(-index - 1);
@@ -408,7 +408,7 @@ namespace monad::vm::compiler::native
         at(top_index_) = std::move(e);
     }
 
-    void Stack::push_deferred_comparison(Comparison c)
+    void Stack::push_deferred_comparison(Comparison const c)
     {
         top_index_ += 1;
         auto e = new_stack_elem();
@@ -456,13 +456,13 @@ namespace monad::vm::compiler::native
         at(top_index_) = std::move(e);
     }
 
-    void Stack::dup(int32_t stack_index)
+    void Stack::dup(int32_t const stack_index)
     {
         MONAD_ASSERT(stack_index <= top_index_);
         push(at(stack_index));
     }
 
-    void Stack::swap(int32_t swap_index)
+    void Stack::swap(int32_t const swap_index)
     {
         MONAD_ASSERT(swap_index < top_index_);
 
@@ -503,7 +503,7 @@ namespace monad::vm::compiler::native
                deferred_comparison_.negated_stack_elem != nullptr;
     }
 
-    bool Stack::has_deferred_comparison_at(int32_t stack_index) const
+    bool Stack::has_deferred_comparison_at(int32_t const stack_index) const
     {
         auto const &dc = deferred_comparison_;
         if (dc.stack_elem &&
@@ -518,7 +518,7 @@ namespace monad::vm::compiler::native
     }
 
     StackOffset Stack::find_available_stack_offset(
-        int32_t preferred, PrevLoc moved_from) const
+        int32_t const preferred, PrevLoc const moved_from) const
     {
         if (available_stack_offsets_.contains(preferred)) {
             return {preferred, moved_from};
@@ -681,7 +681,7 @@ namespace monad::vm::compiler::native
     }
 
     std::vector<std::pair<AvxReg, StackOffset>>
-    Stack::spill_avx_reg_range(uint8_t first)
+    Stack::spill_avx_reg_range(uint8_t const first)
     {
         std::vector<std::pair<AvxReg, StackOffset>> ret;
         for (uint8_t i = first; i < 16; ++i) {
@@ -710,18 +710,18 @@ namespace monad::vm::compiler::native
     }
 
     void Stack::insert_stack_offset(
-        StackElemRef e, int32_t preferred, PrevLoc moved_from)
+        StackElemRef e, int32_t const preferred, PrevLoc const moved_from)
     {
         insert_stack_offset(*e, preferred, moved_from);
     }
 
-    void Stack::insert_stack_offset(StackElemRef e, PrevLoc moved_from)
+    void Stack::insert_stack_offset(StackElemRef e, PrevLoc const moved_from)
     {
         insert_stack_offset(*e, moved_from);
     }
 
     void Stack::insert_stack_offset(
-        StackElem &e, int32_t preferred, PrevLoc moved_from)
+        StackElem &e, int32_t const preferred, PrevLoc const moved_from)
     {
         if (e.stack_offset_.has_value()) {
             return;
@@ -730,7 +730,7 @@ namespace monad::vm::compiler::native
         e.insert_stack_offset(offset);
     }
 
-    void Stack::insert_stack_offset(StackElem &e, PrevLoc moved_from)
+    void Stack::insert_stack_offset(StackElem &e, PrevLoc const moved_from)
     {
         int32_t const preferred = e.preferred_stack_offset();
         insert_stack_offset(e, preferred, moved_from);
@@ -785,8 +785,8 @@ namespace monad::vm::compiler::native
         return e;
     }
 
-    StackElemRef
-    Stack::alloc_stack_offset(int32_t preferred, PrevLoc expected_prev_loc)
+    StackElemRef Stack::alloc_stack_offset(
+        int32_t const preferred, PrevLoc const expected_prev_loc)
     {
         auto e = new_stack_elem();
         insert_stack_offset(*e, preferred, expected_prev_loc);
@@ -882,7 +882,7 @@ namespace monad::vm::compiler::native
         e.remove_stack_offset();
     }
 
-    bool Stack::is_general_reg_on_stack(GeneralReg reg)
+    bool Stack::is_general_reg_on_stack(GeneralReg const reg)
     {
         auto *e = general_reg_stack_elems_[reg.reg];
         return e != nullptr && e->is_on_stack();

--- a/category/vm/compiler/ir/x86/virtual_stack.cpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.cpp
@@ -94,7 +94,7 @@ namespace monad::vm::compiler::native
     {
     }
 
-    std::int32_t StackElem::preferred_stack_offset() const
+    int32_t StackElem::preferred_stack_offset() const
     {
         return stack_indices_.begin() == stack_indices_.end()
                    ? stack_.min_delta_
@@ -270,7 +270,7 @@ namespace monad::vm::compiler::native
         if (rco) {
             do {
                 utils::RcObject<StackElem> *x = rco;
-                static_assert(sizeof(std::size_t) == sizeof(void *));
+                static_assert(sizeof(size_t) == sizeof(void *));
                 rco = reinterpret_cast<decltype(x)>(x->ref_count);
                 utils::RcObject<StackElem>::default_deallocate(x);
             }
@@ -294,14 +294,14 @@ namespace monad::vm::compiler::native
         auto const [new_min_delta, new_delta, new_max_delta] =
             block.stack_deltas();
 
-        negative_elems_.reserve(static_cast<std::size_t>(-new_min_delta));
+        negative_elems_.reserve(static_cast<size_t>(-new_min_delta));
         for (auto i = -1; i >= new_min_delta; --i) {
             StackElemRef e = new_stack_elem();
             e->stack_offset_ = StackOffset{i, PrevLoc::Unknown};
             e->stack_indices_.insert(i);
             negative_elems_.push_back(std::move(e));
         }
-        positive_elems_.resize(static_cast<std::size_t>(new_max_delta));
+        positive_elems_.resize(static_cast<size_t>(new_max_delta));
         auto it = available_stack_offsets_.end();
         for (auto i = 0; i < new_max_delta; ++i) {
             it = available_stack_offsets_.insert(it, i);
@@ -322,7 +322,7 @@ namespace monad::vm::compiler::native
         auto const new_delta = delta_ + pre_delta;
         auto const new_max_delta = std::max(delta_ + pre_max_delta, max_delta_);
 
-        negative_elems_.reserve(static_cast<std::size_t>(-new_min_delta));
+        negative_elems_.reserve(static_cast<size_t>(-new_min_delta));
         for (auto i = min_delta_ - 1; i >= new_min_delta; --i) {
             StackElemRef e = new_stack_elem();
             e->stack_offset_ = StackOffset{i, PrevLoc::Unknown};
@@ -330,7 +330,7 @@ namespace monad::vm::compiler::native
             negative_elems_.push_back(std::move(e));
         }
 
-        positive_elems_.resize(static_cast<std::size_t>(new_max_delta));
+        positive_elems_.resize(static_cast<size_t>(new_max_delta));
         auto it = available_stack_offsets_.end();
         for (auto i = max_delta_; i < new_max_delta; ++i) {
             it = available_stack_offsets_.insert(it, i);
@@ -349,7 +349,7 @@ namespace monad::vm::compiler::native
             [this]() {
                 if (free_rc_objects_) {
                     utils::RcObject<StackElem> *x = free_rc_objects_;
-                    static_assert(sizeof(std::size_t) == sizeof(void *));
+                    static_assert(sizeof(size_t) == sizeof(void *));
                     free_rc_objects_ =
                         reinterpret_cast<decltype(x)>(x->ref_count);
                     return x;
@@ -362,21 +362,21 @@ namespace monad::vm::compiler::native
             this);
     }
 
-    StackElemRef Stack::get(std::int32_t index)
+    StackElemRef Stack::get(int32_t index)
     {
         MONAD_ASSERT(index <= top_index_);
         return at(index);
     }
 
-    StackElemRef &Stack::at(std::int32_t index)
+    StackElemRef &Stack::at(int32_t index)
     {
         if (index < 0) {
-            auto const i = static_cast<std::size_t>(-index - 1);
+            auto const i = static_cast<size_t>(-index - 1);
             MONAD_ASSERT(i < negative_elems_.size());
             return negative_elems_[i];
         }
         else {
-            auto const i = static_cast<std::size_t>(index);
+            auto const i = static_cast<size_t>(index);
             MONAD_ASSERT(i < positive_elems_.size());
             return positive_elems_[i];
         }
@@ -456,13 +456,13 @@ namespace monad::vm::compiler::native
         at(top_index_) = std::move(e);
     }
 
-    void Stack::dup(std::int32_t stack_index)
+    void Stack::dup(int32_t stack_index)
     {
         MONAD_ASSERT(stack_index <= top_index_);
         push(at(stack_index));
     }
 
-    void Stack::swap(std::int32_t swap_index)
+    void Stack::swap(int32_t swap_index)
     {
         MONAD_ASSERT(swap_index < top_index_);
 
@@ -503,7 +503,7 @@ namespace monad::vm::compiler::native
                deferred_comparison_.negated_stack_elem != nullptr;
     }
 
-    bool Stack::has_deferred_comparison_at(std::int32_t stack_index) const
+    bool Stack::has_deferred_comparison_at(int32_t stack_index) const
     {
         auto const &dc = deferred_comparison_;
         if (dc.stack_elem &&
@@ -518,7 +518,7 @@ namespace monad::vm::compiler::native
     }
 
     StackOffset Stack::find_available_stack_offset(
-        std::int32_t preferred, PrevLoc moved_from) const
+        int32_t preferred, PrevLoc moved_from) const
     {
         if (available_stack_offsets_.contains(preferred)) {
             return {preferred, moved_from};
@@ -530,7 +530,7 @@ namespace monad::vm::compiler::native
     StackElem *Stack::find_stack_elem_for_avx_reg_spill()
     {
         MONAD_ASSERT(free_avx_regs_.empty());
-        for (std::uint8_t i = 0; i < AVX_REG_COUNT; ++i) {
+        for (uint8_t i = 0; i < AVX_REG_COUNT; ++i) {
             auto *e = avx_reg_stack_elems_[i];
             if (e == nullptr || e->reserve_avx_reg_count_ != 0) {
                 continue;
@@ -557,7 +557,7 @@ namespace monad::vm::compiler::native
             e->literal_.has_value()) {
             return nullptr;
         }
-        std::int32_t const preferred = e->preferred_stack_offset();
+        int32_t const preferred = e->preferred_stack_offset();
         StackOffset const offset =
             find_available_stack_offset(preferred, PrevLoc::AvxReg);
         e->insert_stack_offset(offset);
@@ -583,14 +583,14 @@ namespace monad::vm::compiler::native
     StackElem *Stack::spill_general_reg()
     {
         MONAD_ASSERT(free_general_regs_.empty());
-        std::uint8_t best_index = 0;
-        std::int8_t best_score = -1;
-        for (std::uint8_t i = 0; i < GENERAL_REG_COUNT; ++i) {
+        uint8_t best_index = 0;
+        int8_t best_score = -1;
+        for (uint8_t i = 0; i < GENERAL_REG_COUNT; ++i) {
             auto *e = general_reg_stack_elems_[i];
             if (e == nullptr || e->reserve_general_reg_count_ != 0) {
                 continue;
             }
-            std::int8_t score = 0;
+            int8_t score = 0;
             if (e->stack_offset_.has_value()) {
                 score |= 0b100;
             }
@@ -623,7 +623,7 @@ namespace monad::vm::compiler::native
             e->literal_.has_value()) {
             return nullptr;
         }
-        std::int32_t const preferred = e->preferred_stack_offset();
+        int32_t const preferred = e->preferred_stack_offset();
         StackOffset const offset =
             find_available_stack_offset(preferred, PrevLoc::GprReg);
         e->insert_stack_offset(offset);
@@ -655,7 +655,7 @@ namespace monad::vm::compiler::native
     {
         static_assert(CALLEE_SAVE_GENERAL_REG_ID == 0);
         std::vector<std::pair<GeneralReg, StackOffset>> ret;
-        for (std::uint8_t i = 1; i < GENERAL_REG_COUNT; ++i) {
+        for (uint8_t i = 1; i < GENERAL_REG_COUNT; ++i) {
             auto *e = general_reg_stack_elems_[i];
             if (e == nullptr) {
                 continue;
@@ -665,7 +665,7 @@ namespace monad::vm::compiler::native
             e->remove_general_reg();
             if (!e->stack_offset_.has_value() && !e->avx_reg_.has_value() &&
                 !e->literal_.has_value()) {
-                std::int32_t const preferred = e->preferred_stack_offset();
+                int32_t const preferred = e->preferred_stack_offset();
                 StackOffset const offset =
                     find_available_stack_offset(preferred, PrevLoc::GprReg);
                 e->insert_stack_offset(offset);
@@ -684,7 +684,7 @@ namespace monad::vm::compiler::native
     Stack::spill_avx_reg_range(uint8_t first)
     {
         std::vector<std::pair<AvxReg, StackOffset>> ret;
-        for (std::uint8_t i = first; i < 16; ++i) {
+        for (uint8_t i = first; i < 16; ++i) {
             auto *e = avx_reg_stack_elems_[i];
             if (e == nullptr) {
                 continue;
@@ -694,7 +694,7 @@ namespace monad::vm::compiler::native
             e->remove_avx_reg();
             if (!e->stack_offset_.has_value() && !e->general_reg_.has_value() &&
                 !e->literal_.has_value()) {
-                std::int32_t const preferred = e->preferred_stack_offset();
+                int32_t const preferred = e->preferred_stack_offset();
                 StackOffset const offset =
                     find_available_stack_offset(preferred, PrevLoc::AvxReg);
                 e->insert_stack_offset(offset);
@@ -704,13 +704,13 @@ namespace monad::vm::compiler::native
         return ret;
     }
 
-    std::set<std::int32_t> const &Stack::available_stack_offsets()
+    std::set<int32_t> const &Stack::available_stack_offsets()
     {
         return available_stack_offsets_;
     }
 
     void Stack::insert_stack_offset(
-        StackElemRef e, std::int32_t preferred, PrevLoc moved_from)
+        StackElemRef e, int32_t preferred, PrevLoc moved_from)
     {
         insert_stack_offset(*e, preferred, moved_from);
     }
@@ -721,7 +721,7 @@ namespace monad::vm::compiler::native
     }
 
     void Stack::insert_stack_offset(
-        StackElem &e, std::int32_t preferred, PrevLoc moved_from)
+        StackElem &e, int32_t preferred, PrevLoc moved_from)
     {
         if (e.stack_offset_.has_value()) {
             return;
@@ -732,7 +732,7 @@ namespace monad::vm::compiler::native
 
     void Stack::insert_stack_offset(StackElem &e, PrevLoc moved_from)
     {
-        std::int32_t const preferred = e.preferred_stack_offset();
+        int32_t const preferred = e.preferred_stack_offset();
         insert_stack_offset(e, preferred, moved_from);
     }
 
@@ -786,7 +786,7 @@ namespace monad::vm::compiler::native
     }
 
     StackElemRef
-    Stack::alloc_stack_offset(std::int32_t preferred, PrevLoc expected_prev_loc)
+    Stack::alloc_stack_offset(int32_t preferred, PrevLoc expected_prev_loc)
     {
         auto e = new_stack_elem();
         insert_stack_offset(*e, preferred, expected_prev_loc);

--- a/category/vm/compiler/ir/x86/virtual_stack.hpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.hpp
@@ -97,7 +97,7 @@ namespace monad::vm::compiler::native
         NotEqual,
     };
 
-    constexpr Comparison negate_comparison(Comparison c)
+    constexpr Comparison negate_comparison(Comparison const c)
     {
         using enum Comparison;
         switch (c) {

--- a/category/vm/compiler/ir/x86/virtual_stack.hpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.hpp
@@ -30,9 +30,9 @@
 
 namespace monad::vm::compiler::native
 {
-    constexpr std::uint8_t AVX_REG_COUNT = 16;
-    constexpr std::uint8_t GENERAL_REG_COUNT = 3;
-    constexpr std::uint8_t CALLEE_SAVE_GENERAL_REG_ID = 0;
+    constexpr uint8_t AVX_REG_COUNT = 16;
+    constexpr uint8_t GENERAL_REG_COUNT = 3;
+    constexpr uint8_t CALLEE_SAVE_GENERAL_REG_ID = 0;
 
     struct Literal
     {
@@ -50,7 +50,7 @@ namespace monad::vm::compiler::native
 
     struct StackOffset
     {
-        std::int32_t offset;
+        int32_t offset;
         PrevLoc moved_from;
     };
 
@@ -58,7 +58,7 @@ namespace monad::vm::compiler::native
 
     struct AvxReg
     {
-        std::uint8_t reg;
+        uint8_t reg;
     };
 
     std::strong_ordering operator<=>(AvxReg const &a, AvxReg const &b);
@@ -67,7 +67,7 @@ namespace monad::vm::compiler::native
 
     struct GeneralReg
     {
-        std::uint8_t reg;
+        uint8_t reg;
     };
 
     std::strong_ordering operator<=>(GeneralReg const &a, GeneralReg const &b);
@@ -181,7 +181,7 @@ namespace monad::vm::compiler::native
         StackElem &operator=(StackElem const &) = delete;
         ~StackElem();
 
-        std::int32_t preferred_stack_offset() const;
+        int32_t preferred_stack_offset() const;
 
         std::optional<StackOffset> const &stack_offset() const
         {
@@ -203,7 +203,7 @@ namespace monad::vm::compiler::native
             return literal_;
         }
 
-        std::set<std::int32_t> const &stack_indices() const
+        std::set<int32_t> const &stack_indices() const
         {
             return stack_indices_;
         }
@@ -257,9 +257,9 @@ namespace monad::vm::compiler::native
         void remove_literal();
 
         Stack &stack_;
-        std::set<std::int32_t> stack_indices_;
-        std::uint32_t reserve_avx_reg_count_;
-        std::uint32_t reserve_general_reg_count_;
+        std::set<int32_t> stack_indices_;
+        uint32_t reserve_avx_reg_count_;
+        uint32_t reserve_general_reg_count_;
         std::optional<StackOffset> stack_offset_;
         std::optional<AvxReg> avx_reg_;
         std::optional<GeneralReg> general_reg_;
@@ -413,7 +413,7 @@ namespace monad::vm::compiler::native
          * and non-negative indices refer to stack elements on the basic
          * block's stack frame.
          */
-        StackElemRef get(std::int32_t index);
+        StackElemRef get(int32_t index);
 
         /**
          * Obtain a reference to the top item of the stack.
@@ -453,13 +453,13 @@ namespace monad::vm::compiler::native
          * Push a duplicate of the specified stack element to the top of the
          * stack.
          */
-        void dup(std::int32_t stack_index);
+        void dup(int32_t stack_index);
 
         /**
          * Swap the top element of the stack with the one at the specified
          * index.
          */
-        void swap(std::int32_t swap_index);
+        void swap(int32_t swap_index);
 
         /**
          * Clear deferred comparison and insert a stack offset to the
@@ -486,7 +486,7 @@ namespace monad::vm::compiler::native
         /**
          * Whether there is a deferred comparison stack element.
          */
-        bool has_deferred_comparison_at(std::int32_t stack_index) const;
+        bool has_deferred_comparison_at(int32_t stack_index) const;
         bool has_deferred_comparison() const;
 
         /**
@@ -499,7 +499,7 @@ namespace monad::vm::compiler::native
          * virtual stack item at this index, and mark that physical index as
          * allocated. Returns a stack element holding the offset.
          */
-        StackElemRef alloc_stack_offset(std::int32_t stack_index, PrevLoc);
+        StackElemRef alloc_stack_offset(int32_t stack_index, PrevLoc);
 
         /**
          * Allocate an AVX register.
@@ -523,10 +523,10 @@ namespace monad::vm::compiler::native
          * Find a stack offset for the given stack element. The given
          * `preferred_offset` will be used as offset if it is available.
          */
-        void insert_stack_offset(
-            StackElemRef, std::int32_t preferred_offset, PrevLoc);
-        void insert_stack_offset(
-            StackElem &, std::int32_t preferred_offset, PrevLoc);
+        void
+        insert_stack_offset(StackElemRef, int32_t preferred_offset, PrevLoc);
+        void
+        insert_stack_offset(StackElem &, int32_t preferred_offset, PrevLoc);
 
         /**
          * Find a stack offset for the given stack element.
@@ -706,7 +706,7 @@ namespace monad::vm::compiler::native
         spill_avx_reg_range(uint8_t first);
 
         /** Set of available stack offsets. */
-        std::set<std::int32_t> const &available_stack_offsets();
+        std::set<int32_t> const &available_stack_offsets();
 
         /** Whether there is a free avx register. */
         bool has_free_avx_reg()
@@ -733,7 +733,7 @@ namespace monad::vm::compiler::native
          * The relative size of the stack at the *lowest* point during execution
          * of a block.
          */
-        std::int32_t min_delta() const
+        int32_t min_delta() const
         {
             return min_delta_;
         }
@@ -742,7 +742,7 @@ namespace monad::vm::compiler::native
          * The relative size of the stack at the *highest* point during
          * execution of a block.
          */
-        std::int32_t max_delta() const
+        int32_t max_delta() const
         {
             return max_delta_;
         }
@@ -751,7 +751,7 @@ namespace monad::vm::compiler::native
          * The difference between the final and initial stack sizes during
          * execution of a block.
          */
-        std::int32_t delta() const
+        int32_t delta() const
         {
             return delta_;
         }
@@ -778,7 +778,7 @@ namespace monad::vm::compiler::native
          * Index of the top element on the stack. The returned value is only
          * a valid index if the stack is not empty.
          */
-        std::int32_t top_index() const
+        int32_t top_index() const
         {
             return top_index_;
         }
@@ -791,7 +791,7 @@ namespace monad::vm::compiler::native
          * Obtain a mutable reference to an item on the stack, correctly
          * handling negative values to reference input stack elements.
          */
-        StackElemRef &at(std::int32_t index);
+        StackElemRef &at(int32_t index);
 
         /**
          * Identify a stack offset that can be used to spill the specified stack
@@ -803,18 +803,18 @@ namespace monad::vm::compiler::native
          * relocate this item to.
          */
         StackOffset find_available_stack_offset(
-            std::int32_t preferred_offset, PrevLoc moved_from) const;
+            int32_t preferred_offset, PrevLoc moved_from) const;
 
         // Linked list of stack element RC objects, using `ref_count`
         // for "next" pointer:
         utils::RcObject<StackElem> *free_rc_objects_;
-        std::int32_t top_index_;
-        std::int32_t min_delta_;
-        std::int32_t max_delta_;
-        std::int32_t delta_;
+        int32_t top_index_;
+        int32_t min_delta_;
+        int32_t max_delta_;
+        int32_t delta_;
         bool did_min_delta_decrease_;
         bool did_max_delta_increase_;
-        std::set<std::int32_t> available_stack_offsets_;
+        std::set<int32_t> available_stack_offsets_;
         AvxRegQueue free_avx_regs_;
         GeneralRegQueue free_general_regs_;
         // The `avx_reg_stack_elems_` contains all the stack elements with AVX
@@ -836,9 +836,9 @@ namespace monad::vm::compiler::native
     {
         static void destroy(utils::RcObject<StackElem> *x)
         {
-            static_assert(sizeof(std::size_t) == sizeof(void *));
-            x->ref_count = reinterpret_cast<std::size_t>(
-                x->object.stack_.free_rc_objects_);
+            static_assert(sizeof(size_t) == sizeof(void *));
+            x->ref_count =
+                reinterpret_cast<size_t>(x->object.stack_.free_rc_objects_);
             x->object.stack_.free_rc_objects_ = x;
         }
 

--- a/category/vm/compiler/types.hpp
+++ b/category/vm/compiler/types.hpp
@@ -21,9 +21,9 @@
 
 namespace monad::vm::compiler
 {
-    using byte_offset = std::size_t;
+    using byte_offset = size_t;
 
-    using block_id = std::size_t;
+    using block_id = size_t;
 
     using uint256_t = runtime::uint256_t;
 

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -46,17 +46,17 @@ namespace monad::vm::compiler
          * This value is 0 for all instructions other than the `PUSHN` family,
          * each of which expects N bytes to follow.
          */
-        std::uint8_t num_args;
+        uint8_t num_args;
 
         /**
          * The minimum EVM stack size required to execute this instruction.
          */
-        std::uint8_t min_stack;
+        uint8_t min_stack;
 
         /**
          * The EVM stack size increase after executing this instruction.
          */
-        std::uint8_t stack_increase;
+        uint8_t stack_increase;
 
         /**
          * Whether the gas cost of this instruction is determined at runtime.
@@ -69,14 +69,14 @@ namespace monad::vm::compiler
          * Some instructions may also consume additional dynamic gas depending
          * on run-time properties (e.g. memory expansion or storage costs).
          */
-        std::uint32_t min_gas;
+        uint32_t min_gas;
 
         /**
          * The index within a set of related opcodes for this instruction.
          *
          * N for all PUSHN, SWAPN, DUPN and LOGN instructions, and 0 otherwise.
          */
-        std::uint8_t index;
+        uint8_t index;
     };
 
     constexpr bool operator==(OpCodeInfo const &a, OpCodeInfo const &b)
@@ -282,8 +282,7 @@ namespace monad::vm::compiler
         make_opcode_table<traits>();
 
     consteval inline void add_opcode(
-        std::uint8_t opcode, std::array<OpCodeInfo, 256> &table,
-        OpCodeInfo info)
+        uint8_t opcode, std::array<OpCodeInfo, 256> &table, OpCodeInfo info)
     {
         MONAD_DEBUG_ASSERT(table[opcode] == unknown_opcode_info);
         table[opcode] = info;

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -252,7 +252,7 @@ namespace monad::vm::compiler
         SELFDESTRUCT = 0xFF
     };
 
-    consteval evmc_revision previous_evm_revision(evmc_revision rev)
+    consteval evmc_revision previous_evm_revision(evmc_revision const rev)
     {
         MONAD_DEBUG_ASSERT(std::to_underlying(rev) > 0);
         return evmc_revision(std::to_underlying(rev) - 1);
@@ -282,7 +282,8 @@ namespace monad::vm::compiler
         make_opcode_table<traits>();
 
     consteval inline void add_opcode(
-        uint8_t opcode, std::array<OpCodeInfo, 256> &table, OpCodeInfo info)
+        uint8_t const opcode, std::array<OpCodeInfo, 256> &table,
+        OpCodeInfo info)
     {
         MONAD_DEBUG_ASSERT(table[opcode] == unknown_opcode_info);
         table[opcode] = info;

--- a/category/vm/fuzzing/generator/choice.hpp
+++ b/category/vm/fuzzing/generator/choice.hpp
@@ -43,7 +43,7 @@ namespace monad::vm::fuzzing
         double probability;
         Action action;
 
-        Choice(double p, Action a)
+        Choice(double const p, Action a)
             : probability(p)
             , action(std::move(a))
         {

--- a/category/vm/fuzzing/generator/choice.hpp
+++ b/category/vm/fuzzing/generator/choice.hpp
@@ -30,7 +30,7 @@ namespace monad::vm::fuzzing
         template <typename Tuple, typename Func>
         void for_each_tuple(Tuple &&t, Func &&f)
         {
-            [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            [&]<size_t... Is>(std::index_sequence<Is...>) {
                 (std::forward<Func>(f)(std::get<Is>(std::forward<Tuple>(t))),
                  ...);
             }(std::make_index_sequence<std::tuple_size_v<Tuple>>());

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -632,7 +632,8 @@ namespace monad::vm::fuzzing
     }
 
     template <typename Engine>
-    evmc::address generate_precompile_address(Engine &eng, evmc_revision rev)
+    evmc::address
+    generate_precompile_address(Engine &eng, evmc_revision const rev)
     {
         auto addr = [rev, &eng]() {
             if (rev <= EVMC_SPURIOUS_DRAGON) {
@@ -705,7 +706,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_address(
-        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
+        Engine &eng, evmc_revision const rev, std::vector<uint8_t> &program,
         std::vector<evmc::address> const &valid_addresses)
     {
         auto const &addr = [&] {
@@ -736,7 +737,7 @@ namespace monad::vm::fuzzing
         }
     }
 
-    void compile_percent(std::vector<uint8_t> &program, uint8_t pct)
+    void compile_percent(std::vector<uint8_t> &program, uint8_t const pct)
     {
         program.push_back(PUSH1);
         program.push_back(10);
@@ -764,7 +765,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_create(
-        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
+        Engine &eng, evmc_revision const rev, std::vector<uint8_t> &program,
         Create const &c, std::vector<evmc::address> const &valid_addresses)
     {
         if (!c.isTrivial) {
@@ -805,7 +806,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_call(
-        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
+        Engine &eng, evmc_revision const rev, std::vector<uint8_t> &program,
         Call const &call, std::vector<evmc::address> const &valid_addresses)
     {
         bool isTrivial = call.isTrivial;
@@ -883,7 +884,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_block(
-        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
+        Engine &eng, evmc_revision const rev, std::vector<uint8_t> &program,
         std::vector<Instruction> const &block,
         std::vector<evmc::address> const &valid_addresses,
         std::vector<uint32_t> &valid_jumpdests,
@@ -1012,7 +1013,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     std::vector<uint8_t> generate_program(
-        GeneratorFocus const &focus, Engine &eng, evmc_revision rev,
+        GeneratorFocus const &focus, Engine &eng, evmc_revision const rev,
         std::vector<evmc::address> const &valid_addresses)
     {
         auto prog = std::vector<uint8_t>{};
@@ -1148,7 +1149,7 @@ namespace monad::vm::fuzzing
         GeneratorFocus const &focus, Engine &eng,
         std::vector<evmc::address> const &contract_addresses,
         std::vector<evmc::address> const &known_eoas, LookupFunc address_lookup,
-        uint8_t *memory_handle, uint32_t memory_capacity) noexcept
+        uint8_t *memory_handle, uint32_t const memory_capacity) noexcept
     {
         auto const kind = uniform_sample(
             eng, std::array{EVMC_CALL, EVMC_DELEGATECALL, EVMC_CALLCODE});

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -260,13 +260,13 @@ namespace monad::vm::fuzzing
     }
 
     template <typename Engine>
-    std::uint32_t random_uint32(Engine &gen)
+    uint32_t random_uint32(Engine &gen)
     {
-        auto dist = std::uniform_int_distribution<std::uint32_t>();
+        auto dist = std::uniform_int_distribution<uint32_t>();
         return dist(gen);
     }
 
-    template <std::size_t Bits = 256, typename Engine = void>
+    template <size_t Bits = 256, typename Engine = void>
     Constant random_constant(Engine &gen)
         requires(Bits % 64 == 0 && Bits > 0 && Bits <= 256)
     {
@@ -308,7 +308,7 @@ namespace monad::vm::fuzzing
     template <typename Engine>
     Constant memory_constant(Engine &gen)
     {
-        auto dist = std::uniform_int_distribution<std::uint64_t>(0, 1 << 16);
+        auto dist = std::uniform_int_distribution<uint64_t>(0, 1 << 16);
         return Constant{dist(gen)};
     }
 
@@ -361,7 +361,7 @@ namespace monad::vm::fuzzing
 
     struct Call
     {
-        std::uint8_t opcode;
+        uint8_t opcode;
         uint8_t gasPct;
         uint8_t balancePct;
         Constant argsOffset;
@@ -424,7 +424,7 @@ namespace monad::vm::fuzzing
 
     struct Create
     {
-        std::uint8_t opcode;
+        uint8_t opcode;
         uint8_t balancePct;
         Constant offset;
         Constant salt;
@@ -456,12 +456,12 @@ namespace monad::vm::fuzzing
 
     struct NonTerminator
     {
-        std::uint8_t opcode;
+        uint8_t opcode;
     };
 
     struct Terminator
     {
-        std::uint8_t opcode;
+        uint8_t opcode;
     };
 
     using Instruction = std::variant<
@@ -497,7 +497,7 @@ namespace monad::vm::fuzzing
     template <typename Engine>
     NonTerminator generate_random_byte(Engine &eng)
     {
-        auto dist = std::uniform_int_distribution<std::uint8_t>();
+        auto dist = std::uniform_int_distribution<uint8_t>();
         return NonTerminator{dist(eng)};
     }
 
@@ -506,7 +506,7 @@ namespace monad::vm::fuzzing
         GeneratorFocus const &focus, Engine &eng, bool const is_exit,
         bool const is_main)
     {
-        static constexpr std::size_t max_block_insts = 10000;
+        static constexpr size_t max_block_insts = 10000;
 
         auto program = std::vector<Instruction>{};
 
@@ -567,7 +567,7 @@ namespace monad::vm::fuzzing
                 // - roughly 10% chance of 55 or less,
                 // - roughly 10% chance of 75 or more.
                 auto main_pushes_dist =
-                    std::binomial_distribution<std::size_t>(650, 0.1);
+                    std::binomial_distribution<size_t>(650, 0.1);
                 auto const main_initial_pushes = main_pushes_dist(g);
 
                 for (auto i = 0u; i < main_initial_pushes; ++i) {
@@ -705,7 +705,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_address(
-        Engine &eng, evmc_revision rev, std::vector<std::uint8_t> &program,
+        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
         std::vector<evmc::address> const &valid_addresses)
     {
         auto const &addr = [&] {
@@ -726,7 +726,7 @@ namespace monad::vm::fuzzing
         }
     }
 
-    void compile_constant(std::vector<std::uint8_t> &program, Constant const &c)
+    void compile_constant(std::vector<uint8_t> &program, Constant const &c)
     {
         program.push_back(PUSH32);
 
@@ -736,7 +736,7 @@ namespace monad::vm::fuzzing
         }
     }
 
-    void compile_percent(std::vector<std::uint8_t> &program, uint8_t pct)
+    void compile_percent(std::vector<uint8_t> &program, uint8_t pct)
     {
         program.push_back(PUSH1);
         program.push_back(10);
@@ -748,7 +748,7 @@ namespace monad::vm::fuzzing
     }
 
     void compile_returndatacopy(
-        std::vector<std::uint8_t> &program, ReturnDataCopy const &rdc)
+        std::vector<uint8_t> &program, ReturnDataCopy const &rdc)
     {
 
         if (!rdc.isTrivial) {
@@ -764,7 +764,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_create(
-        Engine &eng, evmc_revision rev, std::vector<std::uint8_t> &program,
+        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
         Create const &c, std::vector<evmc::address> const &valid_addresses)
     {
         if (!c.isTrivial) {
@@ -805,7 +805,7 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_call(
-        Engine &eng, evmc_revision rev, std::vector<std::uint8_t> &program,
+        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
         Call const &call, std::vector<evmc::address> const &valid_addresses)
     {
         bool isTrivial = call.isTrivial;
@@ -832,9 +832,9 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_push(
-        Engine &eng, std::vector<std::uint8_t> &program, Push const &push,
+        Engine &eng, std::vector<uint8_t> &program, Push const &push,
         std::vector<evmc::address> const &valid_addresses,
-        std::vector<std::size_t> &jumpdest_patches)
+        std::vector<size_t> &jumpdest_patches)
     {
         std::visit(
             Cases{
@@ -873,26 +873,26 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void compile_push(
-        Engine &eng, std::vector<std::uint8_t> &program, Push const &push,
+        Engine &eng, std::vector<uint8_t> &program, Push const &push,
         std::vector<evmc::address> const &valid_addresses)
     {
-        auto patches = std::vector<std::size_t>{};
+        auto patches = std::vector<size_t>{};
         compile_push(eng, program, push, valid_addresses, patches);
         MONAD_DEBUG_ASSERT(patches.empty());
     }
 
     template <typename Engine>
     void compile_block(
-        Engine &eng, evmc_revision rev, std::vector<std::uint8_t> &program,
+        Engine &eng, evmc_revision rev, std::vector<uint8_t> &program,
         std::vector<Instruction> const &block,
         std::vector<evmc::address> const &valid_addresses,
-        std::vector<std::uint32_t> &valid_jumpdests,
-        std::vector<std::size_t> &jumpdest_patches)
+        std::vector<uint32_t> &valid_jumpdests,
+        std::vector<size_t> &jumpdest_patches)
     {
         auto push_op = [&](auto op) {
             if (op == JUMPDEST) {
                 valid_jumpdests.push_back(
-                    static_cast<std::uint32_t>(program.size()));
+                    static_cast<uint32_t>(program.size()));
             }
 
             for (auto mem_op : memory_operands(op)) {
@@ -903,8 +903,7 @@ namespace monad::vm::fuzzing
                         count_significant_bytes(safe_value.value);
                     MONAD_DEBUG_ASSERT(byte_size <= 32);
 
-                    program.push_back(
-                        PUSH0 + static_cast<std::uint8_t>(byte_size));
+                    program.push_back(PUSH0 + static_cast<uint8_t>(byte_size));
 
                     auto const *bs = safe_value.value.as_bytes();
                     for (auto i = 0u; i < byte_size; ++i) {
@@ -944,9 +943,9 @@ namespace monad::vm::fuzzing
 
     template <typename Engine>
     void patch_jumpdests(
-        Engine &eng, std::vector<std::uint8_t> &program,
-        std::vector<std::size_t> const &jumpdest_patches,
-        std::vector<std::uint32_t> const &valid_jumpdests)
+        Engine &eng, std::vector<uint8_t> &program,
+        std::vector<size_t> const &jumpdest_patches,
+        std::vector<uint32_t> const &valid_jumpdests)
     {
         MONAD_DEBUG_ASSERT(std::ranges::is_sorted(jumpdest_patches));
         MONAD_DEBUG_ASSERT(std::ranges::is_sorted(valid_jumpdests));
@@ -975,7 +974,7 @@ namespace monad::vm::fuzzing
             auto const forward_prob =
                 (forward_jds_begin != forward_jds_end) ? 0.9 : 0.0;
 
-            auto const jd = discrete_choice<std::size_t>(
+            auto const jd = discrete_choice<size_t>(
                 eng,
                 [&](auto &g) {
                     if (valid_jumpdests.size() == 0) {
@@ -1012,11 +1011,11 @@ namespace monad::vm::fuzzing
     }
 
     template <typename Engine>
-    std::vector<std::uint8_t> generate_program(
+    std::vector<uint8_t> generate_program(
         GeneratorFocus const &focus, Engine &eng, evmc_revision rev,
         std::vector<evmc::address> const &valid_addresses)
     {
-        auto prog = std::vector<std::uint8_t>{};
+        auto prog = std::vector<uint8_t>{};
 
         auto const block_dist_p = discrete_choice<double>(
             eng,
@@ -1030,8 +1029,8 @@ namespace monad::vm::fuzzing
         auto exit_blocks_dist = std::uniform_int_distribution(1, n_blocks);
         auto const n_exit_blocks = exit_blocks_dist(eng);
 
-        auto valid_jumpdests = std::vector<std::uint32_t>{};
-        auto jumpdest_patches = std::vector<std::size_t>{};
+        auto valid_jumpdests = std::vector<uint32_t>{};
+        auto jumpdest_patches = std::vector<size_t>{};
 
         for (auto i = 0; i < n_blocks; ++i) {
             auto const is_main = (i == 0);
@@ -1109,15 +1108,15 @@ namespace monad::vm::fuzzing
      * `message_ptr`, or explicitly via `delete[]`).
      */
     template <typename Engine>
-    std::uint8_t const *generate_input_data(
-        GeneratorFocus const &focus, Engine &eng, std::size_t const size,
+    uint8_t const *generate_input_data(
+        GeneratorFocus const &focus, Engine &eng, size_t const size,
         std::vector<evmc::address> const &contract_addresses)
     {
         if (size == 0) {
             return nullptr;
         }
 
-        auto data = std::vector<std::uint8_t>();
+        auto data = std::vector<uint8_t>();
         data.reserve(size);
 
         while (data.size() < size) {
@@ -1125,7 +1124,7 @@ namespace monad::vm::fuzzing
             compile_push(eng, data, next_item, contract_addresses);
         }
 
-        auto *const return_buf = new std::uint8_t[size];
+        auto *const return_buf = new uint8_t[size];
 
         MONAD_DEBUG_ASSERT(data.size() >= size);
         std::copy_n(data.begin(), size, &return_buf[0]);
@@ -1149,7 +1148,7 @@ namespace monad::vm::fuzzing
         GeneratorFocus const &focus, Engine &eng,
         std::vector<evmc::address> const &contract_addresses,
         std::vector<evmc::address> const &known_eoas, LookupFunc address_lookup,
-        std::uint8_t *memory_handle, std::uint32_t memory_capacity) noexcept
+        uint8_t *memory_handle, uint32_t memory_capacity) noexcept
     {
         auto const kind = uniform_sample(
             eng, std::array{EVMC_CALL, EVMC_DELEGATECALL, EVMC_CALLCODE});
@@ -1192,7 +1191,7 @@ namespace monad::vm::fuzzing
             }));
 
         auto const input_size =
-            std::uniform_int_distribution<std::size_t>(0, 1024)(eng);
+            std::uniform_int_distribution<size_t>(0, 1024)(eng);
         auto const *input_data =
             generate_input_data(focus, eng, input_size, contract_addresses);
 

--- a/category/vm/fuzzing/generator/instruction_data.cpp
+++ b/category/vm/fuzzing/generator/instruction_data.cpp
@@ -21,12 +21,11 @@
 
 namespace monad::vm::fuzzing
 {
-    std::vector<std::uint8_t> const &
-    memory_operands(std::uint8_t const opcode) noexcept
+    std::vector<uint8_t> const &memory_operands(uint8_t const opcode) noexcept
     {
-        static auto const empty = std::vector<std::uint8_t>{};
+        static auto const empty = std::vector<uint8_t>{};
         static auto const data =
-            std::unordered_map<std::uint8_t, std::vector<std::uint8_t>>{
+            std::unordered_map<uint8_t, std::vector<uint8_t>>{
                 {SHA3, {0, 1}},
                 {CALLDATACOPY, {0, 2}},
                 {CODECOPY, {0, 2}},
@@ -58,7 +57,7 @@ namespace monad::vm::fuzzing
         return empty;
     }
 
-    bool uses_memory(std::uint8_t const opcode) noexcept
+    bool uses_memory(uint8_t const opcode) noexcept
     {
         return !memory_operands(opcode).empty();
     }

--- a/category/vm/fuzzing/generator/instruction_data.hpp
+++ b/category/vm/fuzzing/generator/instruction_data.hpp
@@ -139,7 +139,7 @@ namespace monad::vm::fuzzing
     constexpr auto jump_terminators =
         make_opcode_array<EvmTraits<EVMC_OSAKA>, jump_terminators_all>();
 
-    constexpr bool is_exit_terminator(uint8_t opcode) noexcept
+    constexpr bool is_exit_terminator(uint8_t const opcode) noexcept
     {
         return std::find(
                    exit_terminators_all.begin(),

--- a/category/vm/fuzzing/generator/instruction_data.hpp
+++ b/category/vm/fuzzing/generator/instruction_data.hpp
@@ -139,7 +139,7 @@ namespace monad::vm::fuzzing
     constexpr auto jump_terminators =
         make_opcode_array<EvmTraits<EVMC_OSAKA>, jump_terminators_all>();
 
-    constexpr bool is_exit_terminator(std::uint8_t opcode) noexcept
+    constexpr bool is_exit_terminator(uint8_t opcode) noexcept
     {
         return std::find(
                    exit_terminators_all.begin(),
@@ -149,8 +149,7 @@ namespace monad::vm::fuzzing
 
     static_assert(is_exit_terminator(STOP));
 
-    std::vector<std::uint8_t> const &
-    memory_operands(std::uint8_t const opcode) noexcept;
+    std::vector<uint8_t> const &memory_operands(uint8_t const opcode) noexcept;
 
-    bool uses_memory(std::uint8_t const opcode) noexcept;
+    bool uses_memory(uint8_t const opcode) noexcept;
 }

--- a/category/vm/interpreter/call_runtime.hpp
+++ b/category/vm/interpreter/call_runtime.hpp
@@ -25,7 +25,7 @@ namespace monad::vm::interpreter
     [[gnu::always_inline]]
     inline void call_runtime(
         void (*f)(FnArgs...), runtime::Context &ctx,
-        runtime::uint256_t *&stack_top, std::int64_t &gas_remaining)
+        runtime::uint256_t *&stack_top, int64_t &gas_remaining)
     {
         constexpr auto use_context = runtime::detail::uses_context_v<FnArgs...>;
         constexpr auto use_result = runtime::detail::uses_result_v<FnArgs...>;
@@ -37,10 +37,9 @@ namespace monad::vm::interpreter
             std::ranges::count(
                 std::array{use_context, use_result, use_base_gas}, true);
 
-        auto const stack_args =
-            [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-                return std::tuple{(stack_top - Is)...};
-            }(std::make_index_sequence<stack_arg_count>());
+        auto const stack_args = [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return std::tuple{(stack_top - Is)...};
+        }(std::make_index_sequence<stack_arg_count>());
 
         auto const with_result_args = [&] {
             if constexpr (use_result) {
@@ -70,7 +69,7 @@ namespace monad::vm::interpreter
         auto const all_args = [&] {
             if constexpr (use_base_gas) {
                 return std::tuple_cat(
-                    with_context_args, std::tuple(std::int64_t{0}));
+                    with_context_args, std::tuple(int64_t{0}));
             }
             else {
                 return with_context_args;
@@ -80,10 +79,9 @@ namespace monad::vm::interpreter
         ctx.gas_remaining = gas_remaining;
         std::apply(f, all_args);
 
-        static_assert(
-            stack_arg_count <= std::numeric_limits<std::ptrdiff_t>::max());
-        constexpr std::ptrdiff_t stack_adjustment =
-            static_cast<std::ptrdiff_t>(stack_arg_count) - (use_result ? 1 : 0);
+        static_assert(stack_arg_count <= std::numeric_limits<ptrdiff_t>::max());
+        constexpr ptrdiff_t stack_adjustment =
+            static_cast<ptrdiff_t>(stack_arg_count) - (use_result ? 1 : 0);
 
         stack_top -= stack_adjustment;
         gas_remaining = ctx.gas_remaining;

--- a/category/vm/interpreter/debug.hpp
+++ b/category/vm/interpreter/debug.hpp
@@ -38,7 +38,7 @@ namespace monad::vm::interpreter
      */
     [[gnu::always_inline]]
     inline void trace(
-        Intercode const &analysis, int64_t gas_remaining,
+        Intercode const &analysis, int64_t const gas_remaining,
         uint8_t const *instr_ptr)
     {
         std::cerr << std::format(

--- a/category/vm/interpreter/debug.hpp
+++ b/category/vm/interpreter/debug.hpp
@@ -38,8 +38,8 @@ namespace monad::vm::interpreter
      */
     [[gnu::always_inline]]
     inline void trace(
-        Intercode const &analysis, std::int64_t gas_remaining,
-        std::uint8_t const *instr_ptr)
+        Intercode const &analysis, int64_t gas_remaining,
+        uint8_t const *instr_ptr)
     {
         std::cerr << std::format(
             "offset: 0x{:02x}  opcode: 0x{:x}  gas_left: {}\n",

--- a/category/vm/interpreter/execute.cpp
+++ b/category/vm/interpreter/execute.cpp
@@ -71,8 +71,7 @@ namespace monad::vm::interpreter
 
     template <Traits traits>
     void execute(
-        runtime::Context &ctx, Intercode const &analysis,
-        std::uint8_t *stack_ptr)
+        runtime::Context &ctx, Intercode const &analysis, uint8_t *stack_ptr)
     {
         monad_vm_interpreter_trampoline(
             static_cast<void *>(&ctx.exit_stack_ptr),

--- a/category/vm/interpreter/execute.hpp
+++ b/category/vm/interpreter/execute.hpp
@@ -26,6 +26,5 @@
 namespace monad::vm::interpreter
 {
     template <Traits traits>
-    void
-    execute(runtime::Context &, Intercode const &, std::uint8_t *stack_ptr);
+    void execute(runtime::Context &, Intercode const &, uint8_t *stack_ptr);
 }

--- a/category/vm/interpreter/instruction_stats.cpp
+++ b/category/vm/interpreter/instruction_stats.cpp
@@ -39,12 +39,12 @@ namespace monad::vm::interpreter::stats
 
         struct OpcodeData
         {
-            std::size_t count = 0;
+            size_t count = 0;
             std::chrono::high_resolution_clock::time_point last_start;
             std::chrono::nanoseconds cumulative_time = 0ns;
         };
 
-        std::optional<std::uint8_t> current_op = std::nullopt;
+        std::optional<uint8_t> current_op = std::nullopt;
         std::array<OpcodeData, 256> data_table = {};
 
         void print_stats()
@@ -70,7 +70,7 @@ namespace monad::vm::interpreter::stats
         auto const print_on_exit = utils::scope_exit(print_stats);
     }
 
-    void begin(std::uint8_t const opcode)
+    void begin(uint8_t const opcode)
     {
         auto &entry = data_table[opcode];
         current_op = opcode;

--- a/category/vm/interpreter/instruction_stats.hpp
+++ b/category/vm/interpreter/instruction_stats.hpp
@@ -20,10 +20,10 @@
 namespace monad::vm::interpreter::stats
 {
 #ifdef MONAD_VM_INTERPRETER_STATS
-    void begin(std::uint8_t const opcode);
+    void begin(uint8_t const opcode);
     void end();
 #else
-    [[gnu::always_inline]] inline void begin(std::uint8_t const) {}
+    [[gnu::always_inline]] inline void begin(uint8_t const) {}
 
     [[gnu::always_inline]] inline void end() {}
 #endif

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -376,11 +376,11 @@ namespace monad::vm::interpreter
     constexpr InstrTable instruction_table = make_instruction_table<traits>();
 
     // Instruction implementations
-    template <std::uint8_t Opcode, Traits traits, typename... FnArgs>
+    template <uint8_t Opcode, Traits traits, typename... FnArgs>
     [[gnu::always_inline]] inline void checked_runtime_call(
         void (*f)(FnArgs...), runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t &gas_remaining, std::uint8_t const *)
+        int64_t &gas_remaining, uint8_t const *)
     {
         check_requirements<Opcode, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -391,7 +391,7 @@ namespace monad::vm::interpreter
     [[gnu::always_inline]]
     inline void fuzz_tstore_stack(
         runtime::Context const &ctx, runtime::uint256_t const *stack_bottom,
-        runtime::uint256_t const *stack_top, std::uint64_t base_offset)
+        runtime::uint256_t const *stack_top, uint64_t base_offset)
     {
         if (!utils::is_fuzzing_monad_vm) {
             return;
@@ -406,7 +406,7 @@ namespace monad::vm::interpreter
 #else
     [[gnu::always_inline]] inline void fuzz_tstore_stack(
         runtime::Context const &, runtime::uint256_t const *,
-        runtime::uint256_t const *, std::uint64_t)
+        runtime::uint256_t const *, uint64_t)
     {
         // nop
     }
@@ -417,7 +417,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     add(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<ADD, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -431,7 +431,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     mul(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MUL, traits>(
             monad_vm_runtime_mul,
@@ -449,7 +449,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     sub(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SUB, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -463,7 +463,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void udiv(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<DIV, traits>(
             runtime::udiv,
@@ -481,7 +481,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void sdiv(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SDIV, traits>(
             runtime::sdiv,
@@ -499,7 +499,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void umod(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MOD, traits>(
             runtime::umod,
@@ -517,7 +517,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void smod(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SMOD, traits>(
             runtime::smod,
@@ -535,7 +535,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void addmod(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<ADDMOD, traits>(
             runtime::addmod,
@@ -553,7 +553,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void mulmod(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MULMOD, traits>(
             runtime::mulmod,
@@ -571,7 +571,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     exp(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<EXP, traits>(
             runtime::exp<traits>,
@@ -589,7 +589,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void signextend(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SIGNEXTEND, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -604,7 +604,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     lt(runtime::Context &ctx, Intercode const &analysis,
        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-       std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+       int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<LT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -618,7 +618,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     gt(runtime::Context &ctx, Intercode const &analysis,
        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-       std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+       int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<GT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -632,7 +632,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     slt(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SLT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -646,7 +646,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     sgt(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SGT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -660,7 +660,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     eq(runtime::Context &ctx, Intercode const &analysis,
        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-       std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+       int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<EQ, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -674,7 +674,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void iszero(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<ISZERO, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -689,7 +689,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void and_(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<AND, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -703,7 +703,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     or_(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<OR, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -717,7 +717,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void xor_(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<XOR, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -731,7 +731,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void not_(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<NOT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -745,7 +745,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void byte(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<BYTE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -759,7 +759,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     shl(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SHL, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -773,7 +773,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     shr(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SHR, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -787,7 +787,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     sar(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SAR, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -801,7 +801,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     clz(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CLZ, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -816,7 +816,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void sha3(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SHA3, traits>(
             runtime::sha3<traits>,
@@ -834,7 +834,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void address(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<ADDRESS, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -847,7 +847,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void balance(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<BALANCE, traits>(
             runtime::balance<traits>,
@@ -865,7 +865,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void origin(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<ORIGIN, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -880,7 +880,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void caller(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CALLER, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -893,7 +893,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void callvalue(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CALLVALUE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -906,7 +906,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void calldataload(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CALLDATALOAD, traits>(
             runtime::calldataload,
@@ -924,7 +924,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void calldatasize(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CALLDATASIZE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -937,7 +937,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void calldatacopy(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CALLDATACOPY, traits>(
             runtime::calldatacopy<traits>,
@@ -955,7 +955,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void codesize(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CODESIZE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -968,7 +968,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void codecopy(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CODECOPY, traits>(
             runtime::codecopy<traits>,
@@ -986,7 +986,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void gasprice(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<GASPRICE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1001,7 +1001,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void extcodesize(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<EXTCODESIZE, traits>(
             runtime::extcodesize<traits>,
@@ -1019,7 +1019,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void extcodecopy(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<EXTCODECOPY, traits>(
             runtime::extcodecopy<traits>,
@@ -1037,7 +1037,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void returndatasize(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<RETURNDATASIZE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1050,7 +1050,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void returndatacopy(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<RETURNDATACOPY, traits>(
             runtime::returndatacopy<traits>,
@@ -1068,7 +1068,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void extcodehash(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<EXTCODEHASH, traits>(
             runtime::extcodehash<traits>,
@@ -1086,7 +1086,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void blockhash(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<BLOCKHASH, traits>(
             runtime::blockhash,
@@ -1104,7 +1104,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void coinbase(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<COINBASE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1119,7 +1119,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void timestamp(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<TIMESTAMP, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1132,7 +1132,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void number(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<NUMBER, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1145,7 +1145,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void prevrandao(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<DIFFICULTY, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1161,7 +1161,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void gaslimit(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<GASLIMIT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1174,7 +1174,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void chainid(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<CHAINID, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1189,7 +1189,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void selfbalance(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SELFBALANCE, traits>(
             runtime::selfbalance,
@@ -1207,7 +1207,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void basefee(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<BASEFEE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1222,7 +1222,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void blobhash(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<BLOBHASH, traits>(
             runtime::blobhash,
@@ -1240,7 +1240,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void blobbasefee(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<BLOBBASEFEE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1256,7 +1256,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void mload(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MLOAD, traits>(
             runtime::mload<traits>,
@@ -1274,7 +1274,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void mstore(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MSTORE, traits>(
             runtime::mstore<traits>,
@@ -1292,7 +1292,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void mstore8(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MSTORE8, traits>(
             runtime::mstore8<traits>,
@@ -1310,7 +1310,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void mcopy(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<MCOPY, traits>(
             runtime::mcopy<traits>,
@@ -1328,7 +1328,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void sstore(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SSTORE, traits>(
             runtime::sstore<traits>,
@@ -1346,7 +1346,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void sload(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<SLOAD, traits>(
             runtime::sload<traits>,
@@ -1364,7 +1364,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void tstore(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<TSTORE, traits>(
             runtime::tstore,
@@ -1382,7 +1382,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void tload(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<TLOAD, traits>(
             runtime::tload,
@@ -1401,7 +1401,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     pc(runtime::Context &ctx, Intercode const &analysis,
        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-       std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+       int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<PC, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1414,7 +1414,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void msize(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<MSIZE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1427,7 +1427,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     gas(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<GAS, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1437,12 +1437,12 @@ namespace monad::vm::interpreter
     }
 
     // Stack
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N <= 32)
     MONAD_VM_INSTRUCTION_CALL void push(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         push_impl<N, traits>::push(
             ctx, analysis, stack_bottom, stack_top, gas_remaining, instr_ptr);
@@ -1454,19 +1454,19 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void
     pop(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<POP, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
         MONAD_VM_NEXT(POP);
     }
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N >= 1)
     MONAD_VM_INSTRUCTION_CALL void
     dup(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<DUP1 + (N - 1), traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1477,12 +1477,12 @@ namespace monad::vm::interpreter
         MONAD_VM_NEXT(DUP1 + (N - 1));
     }
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N >= 1)
     MONAD_VM_INSTRUCTION_CALL void swap(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<SWAP1 + (N - 1), traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1497,16 +1497,15 @@ namespace monad::vm::interpreter
     // Control Flow
     namespace
     {
-        inline std::uint8_t const *jump_impl(
+        inline uint8_t const *jump_impl(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const &target)
         {
-            if (MONAD_UNLIKELY(
-                    target > std::numeric_limits<std::size_t>::max())) {
+            if (MONAD_UNLIKELY(target > std::numeric_limits<size_t>::max())) {
                 ctx.exit(Error);
             }
 
-            auto const jd = static_cast<std::size_t>(target);
+            auto const jd = static_cast<size_t>(target);
             if (MONAD_UNLIKELY(!analysis.is_jumpdest(jd))) {
                 ctx.exit(Error);
             }
@@ -1519,7 +1518,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void jump(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *)
+        int64_t gas_remaining, uint8_t const *)
     {
         check_requirements<JUMP, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1537,7 +1536,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void jumpi(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         check_requirements<JUMPI, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1571,7 +1570,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void jumpdest(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         fuzz_tstore_stack(
             ctx,
@@ -1585,12 +1584,12 @@ namespace monad::vm::interpreter
     }
 
     // Logging
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N <= 4)
     MONAD_VM_INSTRUCTION_CALL void
     log(runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         static constexpr auto impls = std::tuple{
             &runtime::log0<traits>,
@@ -1617,7 +1616,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void create(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CREATE, traits>(
             runtime::create<traits>,
@@ -1635,7 +1634,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void call(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CALL, traits>(
             runtime::call<traits>,
@@ -1653,7 +1652,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void callcode(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CALLCODE, traits>(
             runtime::callcode<traits>,
@@ -1671,7 +1670,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void delegatecall(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<DELEGATECALL, traits>(
             runtime::delegatecall<traits>,
@@ -1689,7 +1688,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void create2(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<CREATE2, traits>(
             runtime::create2<traits>,
@@ -1707,7 +1706,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void staticcall(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         checked_runtime_call<STATICCALL, traits>(
             runtime::staticcall<traits>,
@@ -1726,13 +1725,13 @@ namespace monad::vm::interpreter
     {
         inline void return_impl [[noreturn]] (
             runtime::StatusCode const code, runtime::Context &ctx,
-            runtime::uint256_t *stack_top, std::int64_t gas_remaining)
+            runtime::uint256_t *stack_top, int64_t gas_remaining)
         {
             for (auto *result_loc : {&ctx.result.offset, &ctx.result.size}) {
                 std::copy_n(
                     stack_top->as_bytes(),
                     32,
-                    reinterpret_cast<std::uint8_t *>(result_loc));
+                    reinterpret_cast<uint8_t *>(result_loc));
 
                 --stack_top;
             }
@@ -1746,7 +1745,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void return_(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *)
+        int64_t gas_remaining, uint8_t const *)
     {
         fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
         check_requirements<RETURN, traits>(
@@ -1758,7 +1757,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void revert(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *)
+        int64_t gas_remaining, uint8_t const *)
     {
         check_requirements<REVERT, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -1769,7 +1768,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL void selfdestruct(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *instr_ptr)
+        int64_t gas_remaining, uint8_t const *instr_ptr)
     {
         fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
         checked_runtime_call<SELFDESTRUCT, traits>(
@@ -1785,7 +1784,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL inline void stop(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t gas_remaining, std::uint8_t const *)
+        int64_t gas_remaining, uint8_t const *)
     {
         fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
         ctx.gas_remaining = gas_remaining;
@@ -1794,7 +1793,7 @@ namespace monad::vm::interpreter
 
     MONAD_VM_INSTRUCTION_CALL inline void invalid(
         runtime::Context &ctx, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t gas_remaining, std::uint8_t const *)
+        runtime::uint256_t *, int64_t gas_remaining, uint8_t const *)
     {
         ctx.gas_remaining = gas_remaining;
         ctx.exit(Error);

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -391,7 +391,7 @@ namespace monad::vm::interpreter
     [[gnu::always_inline]]
     inline void fuzz_tstore_stack(
         runtime::Context const &ctx, runtime::uint256_t const *stack_bottom,
-        runtime::uint256_t const *stack_top, uint64_t base_offset)
+        runtime::uint256_t const *stack_top, uint64_t const base_offset)
     {
         if (!utils::is_fuzzing_monad_vm) {
             return;
@@ -406,7 +406,7 @@ namespace monad::vm::interpreter
 #else
     [[gnu::always_inline]] inline void fuzz_tstore_stack(
         runtime::Context const &, runtime::uint256_t const *,
-        runtime::uint256_t const *, uint64_t)
+        runtime::uint256_t const *, uint64_t const)
     {
         // nop
     }
@@ -1725,7 +1725,7 @@ namespace monad::vm::interpreter
     {
         inline void return_impl [[noreturn]] (
             runtime::StatusCode const code, runtime::Context &ctx,
-            runtime::uint256_t *stack_top, int64_t gas_remaining)
+            runtime::uint256_t *stack_top, int64_t const gas_remaining)
         {
             for (auto *result_loc : {&ctx.result.offset, &ctx.result.size}) {
                 std::copy_n(
@@ -1784,7 +1784,7 @@ namespace monad::vm::interpreter
     MONAD_VM_INSTRUCTION_CALL inline void stop(
         runtime::Context &ctx, Intercode const &analysis,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        int64_t gas_remaining, uint8_t const *)
+        int64_t const gas_remaining, uint8_t const *)
     {
         fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
         ctx.gas_remaining = gas_remaining;
@@ -1793,7 +1793,7 @@ namespace monad::vm::interpreter
 
     MONAD_VM_INSTRUCTION_CALL inline void invalid(
         runtime::Context &ctx, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, int64_t gas_remaining, uint8_t const *)
+        runtime::uint256_t *, int64_t const gas_remaining, uint8_t const *)
     {
         ctx.gas_remaining = gas_remaining;
         ctx.exit(Error);

--- a/category/vm/interpreter/instructions_fwd.hpp
+++ b/category/vm/interpreter/instructions_fwd.hpp
@@ -27,431 +27,431 @@ namespace monad::vm::interpreter
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     add(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     mul(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     sub(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void udiv(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void sdiv(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void umod(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void smod(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void addmod(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void mulmod(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     exp(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void signextend(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Boolean
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     lt(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-       runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+       runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     gt(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-       runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+       runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     slt(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     sgt(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     eq(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-       runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+       runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void iszero(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Bitwise
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void and_(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     or_(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void xor_(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void not_(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void byte(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     shl(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     shr(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     sar(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     clz(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Data
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void sha3(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void address(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void balance(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void origin(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void caller(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void callvalue(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void calldataload(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void calldatasize(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void calldatacopy(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void codesize(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void codecopy(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void gasprice(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void extcodesize(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void extcodecopy(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void returndatasize(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void returndatacopy(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void extcodehash(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void blockhash(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void coinbase(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void timestamp(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void number(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void prevrandao(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void gaslimit(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void chainid(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void selfbalance(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void basefee(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void blobhash(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void blobbasefee(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Memory & Storage
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void mload(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void mstore(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void mstore8(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void mcopy(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void sstore(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void sload(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void tstore(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void tload(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Execution Intercode
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     pc(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-       runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+       runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void msize(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     gas(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Stack
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N <= 32)
     MONAD_VM_INSTRUCTION_CALL void push(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void
     pop(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N >= 1)
     MONAD_VM_INSTRUCTION_CALL void
     dup(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N >= 1)
     MONAD_VM_INSTRUCTION_CALL void swap(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void jump(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void jumpi(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void jumpdest(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Logging
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(N <= 4)
     MONAD_VM_INSTRUCTION_CALL void
     log(runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // Call & Create
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void create(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void call(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void callcode(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void delegatecall(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void create2(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void staticcall(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     // VM Control
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void return_(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void revert(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     template <Traits traits>
     MONAD_VM_INSTRUCTION_CALL void selfdestruct(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     MONAD_VM_INSTRUCTION_CALL inline void stop(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     MONAD_VM_INSTRUCTION_CALL inline void invalid(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 }

--- a/category/vm/interpreter/intercode.cpp
+++ b/category/vm/interpreter/intercode.cpp
@@ -25,7 +25,7 @@ using namespace monad::vm::compiler;
 
 namespace monad::vm::interpreter
 {
-    Intercode::Intercode(std::span<std::uint8_t const> const code)
+    Intercode::Intercode(std::span<uint8_t const> const code)
         : padded_code_(pad(code))
         , code_size_(
               code_size_t::unsafe_from(static_cast<uint32_t>(code.size())))
@@ -38,11 +38,11 @@ namespace monad::vm::interpreter
         delete[] (padded_code_ - start_padding_size);
     }
 
-    std::uint8_t const *Intercode::pad(std::span<std::uint8_t const> const code)
+    uint8_t const *Intercode::pad(std::span<uint8_t const> const code)
     {
         MONAD_ASSERT(code.size() <= *code_size_t::max());
-        auto *buffer = new std::uint8_t
-            [start_padding_size + code.size() + end_padding_size];
+        auto *buffer =
+            new uint8_t[start_padding_size + code.size() + end_padding_size];
 
         std::fill_n(&buffer[0], start_padding_size, 0);
         std::copy(code.begin(), code.end(), &buffer[start_padding_size]);
@@ -52,7 +52,7 @@ namespace monad::vm::interpreter
         return buffer + start_padding_size;
     }
 
-    auto Intercode::find_jumpdests(std::span<std::uint8_t const> const code)
+    auto Intercode::find_jumpdests(std::span<uint8_t const> const code)
         -> JumpdestMap
     {
         auto jumpdests = JumpdestMap(code.size(), false);

--- a/category/vm/interpreter/intercode.hpp
+++ b/category/vm/interpreter/intercode.hpp
@@ -32,25 +32,25 @@ namespace monad::vm::interpreter
         // PUSHN opcodes by reading data from _before_ the instruction
         // pointer with a single 32-byte read, then cleaning up any
         // over-read in the result value.
-        static constexpr std::size_t start_padding_size = 30;
+        static constexpr size_t start_padding_size = 30;
 
         // 32 for a truncated PUSH32, 1 for a STOP so that we don't have to
         // worry about going off the end.
-        static constexpr std::size_t end_padding_size = 32 + 1;
+        static constexpr size_t end_padding_size = 32 + 1;
 
     public:
         using JumpdestMap = std::vector<bool>;
 
-        explicit Intercode(std::span<std::uint8_t const> const);
+        explicit Intercode(std::span<uint8_t const> const);
 
-        Intercode(std::uint8_t const *code, std::size_t code_size)
-            : Intercode{std::span<std::uint8_t const>{code, code_size}}
+        Intercode(uint8_t const *code, size_t code_size)
+            : Intercode{std::span<uint8_t const>{code, code_size}}
         {
         }
 
         ~Intercode();
 
-        std::uint8_t const *code() const noexcept
+        uint8_t const *code() const noexcept
         {
             return padded_code_;
         }
@@ -70,20 +70,18 @@ namespace monad::vm::interpreter
             return {padded_code_, size_t{*code_size_}};
         }
 
-        bool is_jumpdest(std::size_t const pc) const noexcept
+        bool is_jumpdest(size_t const pc) const noexcept
         {
             return pc < *code_size_ && jumpdest_map_[pc];
         }
 
     private:
-        std::uint8_t const *padded_code_;
+        uint8_t const *padded_code_;
         code_size_t code_size_;
         JumpdestMap jumpdest_map_;
 
-        static std::uint8_t const *
-        pad(std::span<std::uint8_t const> const code);
+        static uint8_t const *pad(std::span<uint8_t const> const code);
 
-        static JumpdestMap
-        find_jumpdests(std::span<std::uint8_t const> const code);
+        static JumpdestMap find_jumpdests(std::span<uint8_t const> const code);
     };
 }

--- a/category/vm/interpreter/push.hpp
+++ b/category/vm/interpreter/push.hpp
@@ -39,7 +39,7 @@ namespace monad::vm::interpreter
 
     namespace detail
     {
-        consteval bool use_avx2_push(std::size_t const n) noexcept
+        consteval bool use_avx2_push(size_t const n) noexcept
         {
 #ifdef __AVX2__
             return n > 0;
@@ -52,18 +52,18 @@ namespace monad::vm::interpreter
         using subword_t = runtime::uint256_t::word_type;
 
         [[gnu::always_inline]] inline subword_t
-        read_unaligned(std::uint8_t const *ptr)
+        read_unaligned(uint8_t const *ptr)
         {
             return std::byteswap(unaligned_load<subword_t>(ptr));
         }
 
-        template <std::size_t N, Traits traits>
+        template <size_t N, Traits traits>
             requires(!detail::use_avx2_push(N))
         [[gnu::always_inline]] inline void generic_push(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
-            std::uint8_t const *instr_ptr)
+            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            uint8_t const *instr_ptr)
         {
             static constexpr auto whole_words = N / 8;
             static constexpr auto leading_part = N % 8;
@@ -79,8 +79,7 @@ namespace monad::vm::interpreter
                 }
 
                 std::memcpy(
-                    reinterpret_cast<std::uint8_t *>(&word) +
-                        (8 - leading_part),
+                    reinterpret_cast<uint8_t *>(&word) + (8 - leading_part),
                     instr_ptr + 1,
                     leading_part);
 
@@ -134,13 +133,13 @@ namespace monad::vm::interpreter
             }
         }
 
-        template <std::size_t N, Traits traits>
+        template <size_t N, Traits traits>
             requires(detail::use_avx2_push(N))
         [[gnu::always_inline]] inline void avx2_push(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
-            std::uint8_t const *instr_ptr)
+            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            uint8_t const *instr_ptr)
         {
             static constexpr auto whole_words = N / 8;
             static constexpr auto leading_part = N % 8;
@@ -184,14 +183,14 @@ namespace monad::vm::interpreter
         }
     }
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
     struct push_impl
     {
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
-            std::uint8_t const *instr_ptr)
+            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            uint8_t const *instr_ptr)
         {
             detail::generic_push<N, traits>(
                 ctx,
@@ -209,8 +208,8 @@ namespace monad::vm::interpreter
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
-            std::uint8_t const *)
+            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            uint8_t const *)
         {
             check_requirements<PUSH0, traits>(
                 ctx, analysis, stack_bottom, stack_top, gas_remaining);
@@ -218,15 +217,15 @@ namespace monad::vm::interpreter
         }
     };
 
-    template <std::size_t N, Traits traits>
+    template <size_t N, Traits traits>
         requires(detail::use_avx2_push(N))
     struct push_impl<N, traits>
     {
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
             runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, std::int64_t &gas_remaining,
-            std::uint8_t const *instr_ptr)
+            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            uint8_t const *instr_ptr)
         {
             detail::avx2_push<N, traits>(
                 ctx,

--- a/category/vm/interpreter/stack.hpp
+++ b/category/vm/interpreter/stack.hpp
@@ -28,11 +28,11 @@ namespace monad::vm::interpreter
 {
     using enum runtime::StatusCode;
 
-    template <std::uint8_t Instr, Traits traits>
+    template <uint8_t Instr, Traits traits>
     [[gnu::always_inline]] inline void check_requirements(
         runtime::Context &ctx, Intercode const &,
         runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        std::int64_t &gas_remaining)
+        int64_t &gas_remaining)
     {
         static constexpr auto info = compiler::opcode_table<traits>[Instr];
 

--- a/category/vm/interpreter/types.hpp
+++ b/category/vm/interpreter/types.hpp
@@ -64,7 +64,7 @@ namespace monad::vm::interpreter
 {
     using InstrEval = void MONAD_VM_INSTRUCTION_CALL (*)(
         runtime::Context &, Intercode const &, runtime::uint256_t const *,
-        runtime::uint256_t *, std::int64_t, std::uint8_t const *);
+        runtime::uint256_t *, int64_t, uint8_t const *);
 
     using InstrTable = std::array<InstrEval, 256>;
 }

--- a/category/vm/memory_pool.cpp
+++ b/category/vm/memory_pool.cpp
@@ -25,7 +25,7 @@
 
 namespace monad::vm
 {
-    MemoryPool::MemoryPool(uint32_t alloc_capacity)
+    MemoryPool::MemoryPool(uint32_t const alloc_capacity)
         : empty_head_{.next = &empty_head_}
         , head_{&empty_head_}
         , alloc_capacity_{alloc_capacity}

--- a/category/vm/memory_pool.cpp
+++ b/category/vm/memory_pool.cpp
@@ -25,7 +25,7 @@
 
 namespace monad::vm
 {
-    MemoryPool::MemoryPool(std::uint32_t alloc_capacity)
+    MemoryPool::MemoryPool(uint32_t alloc_capacity)
         : empty_head_{.next = &empty_head_}
         , head_{&empty_head_}
         , alloc_capacity_{alloc_capacity}
@@ -43,7 +43,7 @@ namespace monad::vm
         }
     }
 
-    std::uint8_t *MemoryPool::alloc()
+    uint8_t *MemoryPool::alloc()
     {
         Node *old_head;
         {
@@ -56,15 +56,15 @@ namespace monad::vm
             void *const p = std::aligned_alloc(32, alloc_capacity_);
             MONAD_ASSERT(p);
             runtime::non_temporal_bzero(p, alloc_capacity_);
-            return reinterpret_cast<std::uint8_t *>(p);
+            return reinterpret_cast<uint8_t *>(p);
         }
 
         // This clears the memory buffer:
         std::memset(static_cast<void *>(&old_head->next), 0, sizeof(Node *));
-        return reinterpret_cast<std::uint8_t *>(old_head);
+        return reinterpret_cast<uint8_t *>(old_head);
     }
 
-    void MemoryPool::dealloc(std::uint8_t *p)
+    void MemoryPool::dealloc(uint8_t *p)
     {
         MONAD_DEBUG_ASSERT((reinterpret_cast<uintptr_t>(p) & 31) == 0);
         static_assert(alignof(Node) <= 32);
@@ -89,9 +89,9 @@ namespace monad::vm
         return true;
     }
 
-    std::size_t MemoryPool::debug_get_cache_size() const
+    size_t MemoryPool::debug_get_cache_size() const
     {
-        std::size_t x = 0;
+        size_t x = 0;
         Node *n = head_;
         while (n != &empty_head_) {
             ++x;

--- a/category/vm/memory_pool.hpp
+++ b/category/vm/memory_pool.hpp
@@ -33,7 +33,7 @@ namespace monad::vm
         class Ref
         {
             MemoryPool &pool_;
-            std::uint8_t *memory_;
+            uint8_t *memory_;
 
         public:
             explicit Ref(MemoryPool &pool)
@@ -52,14 +52,14 @@ namespace monad::vm
                 pool_.dealloc(memory_);
             }
 
-            std::uint8_t *get()
+            uint8_t *get()
             {
                 return memory_;
             }
         };
 
         // Construct a memory pool with the given `alloc_capacity()`.
-        explicit MemoryPool(std::uint32_t alloc_capacity);
+        explicit MemoryPool(uint32_t alloc_capacity);
 
         MemoryPool(MemoryPool const &) = delete;
         MemoryPool &operator=(MemoryPool const &) = delete;
@@ -67,17 +67,17 @@ namespace monad::vm
         ~MemoryPool();
 
         // Capacity of memory buffer returned by `alloc()` and `alloc_ref()`.
-        std::uint32_t alloc_capacity() const
+        uint32_t alloc_capacity() const
         {
             return alloc_capacity_;
         }
 
         // Allocate zero initialized memory buffer of `alloc_capacity()` size.
-        std::uint8_t *alloc();
+        uint8_t *alloc();
 
         // Deallocate memory previous allocated with `alloc()`. Make sure
         // the entire memory buffer is zeroed before calling `dealloc()`.
-        void dealloc(std::uint8_t *);
+        void dealloc(uint8_t *);
 
         // Allocate zero initialized memory buffer of `alloc_capacity()` size.
         // The entire memory buffer must be zeroed before the `Ref` object is
@@ -89,12 +89,12 @@ namespace monad::vm
 
         // Debugging/testing:
         bool debug_check_uniqueness_invariant() const;
-        std::size_t debug_get_cache_size() const;
+        size_t debug_get_cache_size() const;
 
     private:
         Node empty_head_;
         Node *head_;
-        std::uint32_t alloc_capacity_;
+        uint32_t alloc_capacity_;
         SpinLock mutex_;
     };
 }

--- a/category/vm/runtime/bin.hpp
+++ b/category/vm/runtime/bin.hpp
@@ -30,7 +30,7 @@ namespace monad::vm::runtime
     {
     public:
         [[gnu::always_inline]]
-        static constexpr Bin unsafe_from(uint32_t x) noexcept
+        static constexpr Bin unsafe_from(uint32_t const x) noexcept
         {
             return Bin(x);
         }
@@ -74,7 +74,7 @@ namespace monad::vm::runtime
 
     private:
         [[gnu::always_inline]]
-        constexpr explicit Bin(uint32_t x) noexcept
+        constexpr explicit Bin(uint32_t const x) noexcept
             : value_{x}
         {
             MONAD_DEBUG_ASSERT(x < (1ULL << N));
@@ -89,14 +89,15 @@ namespace monad::vm::runtime
 
     template <size_t M, size_t N>
     [[gnu::always_inline]]
-    constexpr Bin<std::max(M, N) + 1> operator+(Bin<M> x, Bin<N> y) noexcept
+    constexpr Bin<std::max(M, N) + 1>
+    operator+(Bin<M> const x, Bin<N> const y) noexcept
     {
         return Bin<std::max(M, N) + 1>::unsafe_from(*x + *y);
     }
 
     template <size_t M, size_t N>
     [[gnu::always_inline]]
-    constexpr Bin<M + N> operator*(Bin<M> x, Bin<N> y) noexcept
+    constexpr Bin<M + N> operator*(Bin<M> const x, Bin<N> const y) noexcept
     {
         return Bin<M + N>::unsafe_from(*x * *y);
     }
@@ -104,7 +105,7 @@ namespace monad::vm::runtime
     template <uint32_t x, size_t N>
         requires(x < 32)
     [[gnu::always_inline]]
-    constexpr Bin<N - x> shr(Bin<N> y) noexcept
+    constexpr Bin<N - x> shr(Bin<N> const y) noexcept
     {
         return Bin<N - x>::unsafe_from(*y >> x);
     }
@@ -112,7 +113,8 @@ namespace monad::vm::runtime
     template <uint32_t x, size_t N>
         requires(x < 32 && N < 32)
     [[gnu::always_inline]]
-    constexpr Bin<std::max(size_t{x}, N) + 1 - x> shr_ceil(Bin<N> y) noexcept
+    constexpr Bin<std::max(size_t{x}, N) + 1 - x>
+    shr_ceil(Bin<N> const y) noexcept
     {
         return shr<x>(y + bin<Bin<x>::upper>);
     }
@@ -120,21 +122,21 @@ namespace monad::vm::runtime
     template <uint32_t x, size_t N>
         requires(x < 32)
     [[gnu::always_inline]]
-    constexpr Bin<N + x> shl(Bin<N> y) noexcept
+    constexpr Bin<N + x> shl(Bin<N> const y) noexcept
     {
         return Bin<N + x>::unsafe_from(*y << x);
     }
 
     template <size_t M, size_t N>
     [[gnu::always_inline]]
-    constexpr Bin<std::max(M, N)> max(Bin<M> x, Bin<N> y) noexcept
+    constexpr Bin<std::max(M, N)> max(Bin<M> const x, Bin<N> const y) noexcept
     {
         return Bin<std::max(M, N)>::unsafe_from(std::max(*x, *y));
     }
 
     template <size_t M, size_t N>
     [[gnu::always_inline]]
-    constexpr Bin<std::min(M, N)> min(Bin<M> x, Bin<N> y) noexcept
+    constexpr Bin<std::min(M, N)> min(Bin<M> const x, Bin<N> const y) noexcept
     {
         return Bin<std::min(M, N)>::unsafe_from(std::min(*x, *y));
     }

--- a/category/vm/runtime/bin.hpp
+++ b/category/vm/runtime/bin.hpp
@@ -23,20 +23,19 @@
 
 namespace monad::vm::runtime
 {
-    /// Binary `N`-bit integer type with underlying type `std::uint32_t`
-    template <std::size_t N>
+    /// Binary `N`-bit integer type with underlying type `uint32_t`
+    template <size_t N>
         requires(N <= 32)
     class Bin
     {
     public:
         [[gnu::always_inline]]
-        static constexpr Bin unsafe_from(std::uint32_t x) noexcept
+        static constexpr Bin unsafe_from(uint32_t x) noexcept
         {
             return Bin(x);
         }
 
-        static constexpr std::uint32_t upper =
-            static_cast<std::uint32_t>(1ULL << N) - 1;
+        static constexpr uint32_t upper = static_cast<uint32_t>(1ULL << N) - 1;
 
         [[gnu::always_inline]]
         static constexpr Bin max() noexcept
@@ -50,7 +49,7 @@ namespace monad::vm::runtime
         {
         }
 
-        template <std::size_t M>
+        template <size_t M>
             requires(N >= M)
         [[gnu::always_inline]]
         constexpr explicit(false) Bin(Bin<M> const &x) noexcept
@@ -58,7 +57,7 @@ namespace monad::vm::runtime
         {
         }
 
-        template <std::size_t M>
+        template <size_t M>
             requires(N >= M)
         [[gnu::always_inline]]
         constexpr Bin &operator=(Bin<M> const &x) noexcept
@@ -68,41 +67,41 @@ namespace monad::vm::runtime
         }
 
         [[gnu::always_inline]]
-        constexpr std::uint32_t operator*() const noexcept
+        constexpr uint32_t operator*() const noexcept
         {
             return value_;
         }
 
     private:
         [[gnu::always_inline]]
-        constexpr explicit Bin(std::uint32_t x) noexcept
+        constexpr explicit Bin(uint32_t x) noexcept
             : value_{x}
         {
             MONAD_DEBUG_ASSERT(x < (1ULL << N));
         }
 
-        std::uint32_t value_;
+        uint32_t value_;
     };
 
-    template <std::uint32_t x>
+    template <uint32_t x>
     static constexpr Bin<std::bit_width(x)> bin =
         Bin<std::bit_width(x)>::unsafe_from(x);
 
-    template <std::size_t M, std::size_t N>
+    template <size_t M, size_t N>
     [[gnu::always_inline]]
     constexpr Bin<std::max(M, N) + 1> operator+(Bin<M> x, Bin<N> y) noexcept
     {
         return Bin<std::max(M, N) + 1>::unsafe_from(*x + *y);
     }
 
-    template <std::size_t M, std::size_t N>
+    template <size_t M, size_t N>
     [[gnu::always_inline]]
     constexpr Bin<M + N> operator*(Bin<M> x, Bin<N> y) noexcept
     {
         return Bin<M + N>::unsafe_from(*x * *y);
     }
 
-    template <std::uint32_t x, std::size_t N>
+    template <uint32_t x, size_t N>
         requires(x < 32)
     [[gnu::always_inline]]
     constexpr Bin<N - x> shr(Bin<N> y) noexcept
@@ -110,7 +109,7 @@ namespace monad::vm::runtime
         return Bin<N - x>::unsafe_from(*y >> x);
     }
 
-    template <std::uint32_t x, std::size_t N>
+    template <uint32_t x, size_t N>
         requires(x < 32 && N < 32)
     [[gnu::always_inline]]
     constexpr Bin<std::max(size_t{x}, N) + 1 - x> shr_ceil(Bin<N> y) noexcept
@@ -118,7 +117,7 @@ namespace monad::vm::runtime
         return shr<x>(y + bin<Bin<x>::upper>);
     }
 
-    template <std::uint32_t x, std::size_t N>
+    template <uint32_t x, size_t N>
         requires(x < 32)
     [[gnu::always_inline]]
     constexpr Bin<N + x> shl(Bin<N> y) noexcept
@@ -126,14 +125,14 @@ namespace monad::vm::runtime
         return Bin<N + x>::unsafe_from(*y << x);
     }
 
-    template <std::size_t M, std::size_t N>
+    template <size_t M, size_t N>
     [[gnu::always_inline]]
     constexpr Bin<std::max(M, N)> max(Bin<M> x, Bin<N> y) noexcept
     {
         return Bin<std::max(M, N)>::unsafe_from(std::max(*x, *y));
     }
 
-    template <std::size_t M, std::size_t N>
+    template <size_t M, size_t N>
     [[gnu::always_inline]]
     constexpr Bin<std::min(M, N)> min(Bin<M> x, Bin<N> y) noexcept
     {

--- a/category/vm/runtime/call.cpp
+++ b/category/vm/runtime/call.cpp
@@ -34,18 +34,18 @@
 
 namespace monad::vm::runtime
 {
-    inline std::uint32_t message_flags(
-        std::uint32_t env_flags, bool static_call, bool delegation_indicator)
+    inline uint32_t message_flags(
+        uint32_t env_flags, bool static_call, bool delegation_indicator)
     {
         if (static_call) {
-            env_flags = static_cast<std::uint32_t>(EVMC_STATIC);
+            env_flags = static_cast<uint32_t>(EVMC_STATIC);
         }
 
         if (delegation_indicator) {
-            env_flags |= static_cast<std::uint32_t>(EVMC_DELEGATED);
+            env_flags |= static_cast<uint32_t>(EVMC_DELEGATED);
         }
         else {
-            env_flags &= ~static_cast<std::uint32_t>(EVMC_DELEGATED);
+            env_flags &= ~static_cast<uint32_t>(EVMC_DELEGATED);
         }
 
         return env_flags;
@@ -58,7 +58,7 @@ namespace monad::vm::runtime
         uint256_t const &args_offset_word, uint256_t const &args_size_word,
         uint256_t const &ret_offset_word, uint256_t const &ret_size_word,
         evmc_call_kind call_kind, bool static_call,
-        std::int64_t remaining_block_base_gas)
+        int64_t remaining_block_base_gas)
     {
         ctx->env.clear_return_data();
 
@@ -142,7 +142,7 @@ namespace monad::vm::runtime
             ctx->exit(StatusCode::OutOfGas);
         }
 
-        auto gas = clamp_cast<std::int64_t>(gas_word);
+        auto gas = clamp_cast<int64_t>(gas_word);
 
         if constexpr (traits::evm_rev() >= EVMC_TANGERINE_WHISTLE) {
             gas = std::min(gas, gas_left_here - (gas_left_here / 64));
@@ -193,7 +193,7 @@ namespace monad::vm::runtime
         ctx->gas_refund += result.gas_refund;
 
         auto const copy_size =
-            std::min(static_cast<std::size_t>(*ret_size), result.output_size);
+            std::min(static_cast<size_t>(*ret_size), result.output_size);
         std::copy_n(
             result.output_data, copy_size, ctx->memory.data + *ret_offset);
 
@@ -208,7 +208,7 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        std::int64_t remaining_block_base_gas)
+        int64_t remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -233,7 +233,7 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        std::int64_t remaining_block_base_gas)
+        int64_t remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -257,7 +257,7 @@ namespace monad::vm::runtime
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, std::int64_t remaining_block_base_gas)
+        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -281,7 +281,7 @@ namespace monad::vm::runtime
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, std::int64_t remaining_block_base_gas)
+        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas)
     {
         MONAD_DEBUG_ASSERT(traits::evm_rev() >= EVMC_BYZANTIUM);
         *result_ptr = call_impl<traits>(

--- a/category/vm/runtime/call.cpp
+++ b/category/vm/runtime/call.cpp
@@ -35,7 +35,8 @@
 namespace monad::vm::runtime
 {
     inline uint32_t message_flags(
-        uint32_t env_flags, bool static_call, bool delegation_indicator)
+        uint32_t env_flags, bool const static_call,
+        bool const delegation_indicator)
     {
         if (static_call) {
             env_flags = static_cast<uint32_t>(EVMC_STATIC);
@@ -54,11 +55,11 @@ namespace monad::vm::runtime
     template <Traits traits>
     uint256_t call_impl(
         Context *ctx, uint256_t const &gas_word, uint256_t const &address,
-        bool has_value, bytes32_t const &value,
+        bool const has_value, bytes32_t const &value,
         uint256_t const &args_offset_word, uint256_t const &args_size_word,
         uint256_t const &ret_offset_word, uint256_t const &ret_size_word,
-        evmc_call_kind call_kind, bool static_call,
-        int64_t remaining_block_base_gas)
+        evmc_call_kind const call_kind, bool const static_call,
+        int64_t const remaining_block_base_gas)
     {
         ctx->env.clear_return_data();
 
@@ -208,7 +209,7 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        int64_t remaining_block_base_gas)
+        int64_t const remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -233,7 +234,7 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        int64_t remaining_block_base_gas)
+        int64_t const remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -257,7 +258,7 @@ namespace monad::vm::runtime
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas)
+        uint256_t const *ret_size_ptr, int64_t const remaining_block_base_gas)
     {
         *result_ptr = call_impl<traits>(
             ctx,
@@ -281,7 +282,7 @@ namespace monad::vm::runtime
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas)
+        uint256_t const *ret_size_ptr, int64_t const remaining_block_base_gas)
     {
         MONAD_DEBUG_ASSERT(traits::evm_rev() >= EVMC_BYZANTIUM);
         *result_ptr = call_impl<traits>(

--- a/category/vm/runtime/call.hpp
+++ b/category/vm/runtime/call.hpp
@@ -28,7 +28,7 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        std::int64_t remaining_block_base_gas);
+        int64_t remaining_block_base_gas);
 
     template <Traits traits>
     void callcode(
@@ -36,19 +36,19 @@ namespace monad::vm::runtime
         uint256_t const *address_ptr, uint256_t const *value_ptr,
         uint256_t const *args_offset_ptr, uint256_t const *args_size_ptr,
         uint256_t const *ret_offset_ptr, uint256_t const *ret_size_ptr,
-        std::int64_t remaining_block_base_gas);
+        int64_t remaining_block_base_gas);
 
     template <Traits traits>
     void delegatecall(
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, std::int64_t remaining_block_base_gas);
+        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas);
 
     template <Traits traits>
     void staticcall(
         Context *ctx, uint256_t *result_ptr, uint256_t const *gas_ptr,
         uint256_t const *address_ptr, uint256_t const *args_offset_ptr,
         uint256_t const *args_size_ptr, uint256_t const *ret_offset_ptr,
-        uint256_t const *ret_size_ptr, std::int64_t remaining_block_base_gas);
+        uint256_t const *ret_size_ptr, int64_t remaining_block_base_gas);
 }

--- a/category/vm/runtime/context.cpp
+++ b/category/vm/runtime/context.cpp
@@ -43,7 +43,7 @@ static_assert(alignof(Bin<31>) == alignof(uint32_t));
 static_assert(std::is_standard_layout_v<Bin<31>>);
 
 extern "C" void monad_vm_runtime_increase_capacity(
-    Context *ctx, uint32_t old_size, Bin<30> new_size)
+    Context *ctx, uint32_t const old_size, Bin<30> const new_size)
 {
     MONAD_DEBUG_ASSERT((*new_size & 31) == 0);
     MONAD_DEBUG_ASSERT(old_size < *new_size);
@@ -117,7 +117,7 @@ namespace monad::vm::runtime
     }
 
     Context Context::empty(
-        uint8_t *const memory_handle, uint32_t memory_capacity) noexcept
+        uint8_t *const memory_handle, uint32_t const memory_capacity) noexcept
     {
         return Context{
             .host = nullptr,
@@ -145,7 +145,8 @@ namespace monad::vm::runtime
         };
     }
 
-    void Context::increase_capacity(uint32_t old_size, Bin<30> new_size)
+    void
+    Context::increase_capacity(uint32_t const old_size, Bin<30> const new_size)
     {
         monad_vm_runtime_increase_capacity(this, old_size, new_size);
     }

--- a/category/vm/runtime/context.cpp
+++ b/category/vm/runtime/context.cpp
@@ -81,13 +81,13 @@ namespace monad::vm::runtime
         void release_result(evmc_result const *result)
         {
             MONAD_DEBUG_ASSERT(result);
-            std::free(const_cast<std::uint8_t *>(result->output_data));
+            std::free(const_cast<uint8_t *>(result->output_data));
         }
     }
 
     Context Context::from(
         evmc_host_interface const *host, evmc_host_context *context,
-        evmc_message const *msg, std::span<std::uint8_t const> code) noexcept
+        evmc_message const *msg, std::span<uint8_t const> code) noexcept
     {
         return Context{
             .host = host,
@@ -105,9 +105,8 @@ namespace monad::vm::runtime
                     .input_data = msg->input_data,
                     .code = code.data(),
                     .return_data = {},
-                    .input_data_size =
-                        static_cast<std::uint32_t>(msg->input_size),
-                    .code_size = static_cast<std::uint32_t>(code.size()),
+                    .input_data_size = static_cast<uint32_t>(msg->input_size),
+                    .code_size = static_cast<uint32_t>(code.size()),
                     .return_data_size = 0,
                     .tx_context = host->get_tx_context(context),
                 },
@@ -118,8 +117,7 @@ namespace monad::vm::runtime
     }
 
     Context Context::empty(
-        std::uint8_t *const memory_handle,
-        std::uint32_t memory_capacity) noexcept
+        uint8_t *const memory_handle, uint32_t memory_capacity) noexcept
     {
         return Context{
             .host = nullptr,
@@ -167,7 +165,7 @@ namespace monad::vm::runtime
     }
 
     template <Traits traits>
-    std::variant<std::span<std::uint8_t const>, evmc_status_code>
+    std::variant<std::span<uint8_t const>, evmc_status_code>
     Context::copy_result_data()
     {
         if (gas_remaining < 0) {
@@ -182,7 +180,7 @@ namespace monad::vm::runtime
         auto const size =
             Memory::Offset::unsafe_from(static_cast<uint32_t>(size_word));
         if (*size == 0) {
-            return std::span<std::uint8_t const>({});
+            return std::span<uint8_t const>({});
         }
 
         auto const offset_word = std::bit_cast<uint256_t>(result.offset);
@@ -202,9 +200,9 @@ namespace monad::vm::runtime
         // deduplicate the two cases in which we need to allocate an output
         // buffer (when the memory is already big enough, and when we've paid
         // the cost of a necessary expansion).
-        std::uint8_t *output_buf = nullptr;
+        uint8_t *output_buf = nullptr;
         auto allocate_output_buf = [size] {
-            return reinterpret_cast<std::uint8_t *>(std::malloc(*size));
+            return reinterpret_cast<uint8_t *>(std::malloc(*size));
         };
 
         if (*memory_end <= memory.size) {
@@ -261,7 +259,7 @@ namespace monad::vm::runtime
         return std::visit(
             Cases{
                 [](evmc_status_code ec) { return evmc_error_result(ec); },
-                [this](std::span<std::uint8_t const> output) {
+                [this](std::span<uint8_t const> output) {
                     return evmc::Result{evmc_result{
                         .status_code = result.status == Success ? EVMC_SUCCESS
                                                                 : EVMC_REVERT,

--- a/category/vm/runtime/create.cpp
+++ b/category/vm/runtime/create.cpp
@@ -44,7 +44,7 @@ namespace monad::vm::runtime
     uint256_t create_impl(
         Context *ctx, uint256_t const &value, uint256_t const &offset_word,
         uint256_t const &size_word, uint256_t const &salt_word,
-        evmc_call_kind kind, std::int64_t remaining_block_base_gas)
+        evmc_call_kind kind, int64_t remaining_block_base_gas)
     {
         if (MONAD_UNLIKELY(ctx->env.evmc_flags & EVMC_STATIC)) {
             ctx->exit(StatusCode::Error);
@@ -131,7 +131,7 @@ namespace monad::vm::runtime
     void create(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        std::int64_t remaining_block_base_gas)
+        int64_t remaining_block_base_gas)
     {
         *result_ptr = create_impl<traits>(
             ctx,
@@ -149,7 +149,7 @@ namespace monad::vm::runtime
     void create2(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        uint256_t const *salt_ptr, std::int64_t remaining_block_base_gas)
+        uint256_t const *salt_ptr, int64_t remaining_block_base_gas)
     {
         *result_ptr = create_impl<traits>(
             ctx,

--- a/category/vm/runtime/create.cpp
+++ b/category/vm/runtime/create.cpp
@@ -44,7 +44,7 @@ namespace monad::vm::runtime
     uint256_t create_impl(
         Context *ctx, uint256_t const &value, uint256_t const &offset_word,
         uint256_t const &size_word, uint256_t const &salt_word,
-        evmc_call_kind kind, int64_t remaining_block_base_gas)
+        evmc_call_kind const kind, int64_t const remaining_block_base_gas)
     {
         if (MONAD_UNLIKELY(ctx->env.evmc_flags & EVMC_STATIC)) {
             ctx->exit(StatusCode::Error);
@@ -131,7 +131,7 @@ namespace monad::vm::runtime
     void create(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        int64_t remaining_block_base_gas)
+        int64_t const remaining_block_base_gas)
     {
         *result_ptr = create_impl<traits>(
             ctx,
@@ -149,7 +149,7 @@ namespace monad::vm::runtime
     void create2(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        uint256_t const *salt_ptr, int64_t remaining_block_base_gas)
+        uint256_t const *salt_ptr, int64_t const remaining_block_base_gas)
     {
         *result_ptr = create_impl<traits>(
             ctx,

--- a/category/vm/runtime/create.hpp
+++ b/category/vm/runtime/create.hpp
@@ -24,11 +24,11 @@ namespace monad::vm::runtime
     void create(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        std::int64_t remaining_block_base_gas);
+        int64_t remaining_block_base_gas);
 
     template <Traits traits>
     void create2(
         Context *ctx, uint256_t *result_ptr, uint256_t const *value_ptr,
         uint256_t const *offset_ptr, uint256_t const *size_ptr,
-        uint256_t const *salt_ptr, std::int64_t remaining_block_base_gas);
+        uint256_t const *salt_ptr, int64_t remaining_block_base_gas);
 }

--- a/category/vm/runtime/data.cpp
+++ b/category/vm/runtime/data.cpp
@@ -55,7 +55,7 @@ namespace monad::vm::runtime
     void copy_impl(
         Context *ctx, uint256_t const &dest_offset_word,
         uint256_t const &offset_word, uint256_t const &size_word,
-        std::uint8_t const *source, std::uint32_t len)
+        uint8_t const *source, uint32_t len)
     {
         auto const size = ctx->get_memory_offset(size_word);
         if (*size == 0) {
@@ -69,9 +69,9 @@ namespace monad::vm::runtime
         auto const size_in_words = shr_ceil<5>(size);
         ctx->deduct_gas(size_in_words * bin<3>);
 
-        std::uint32_t const start =
+        uint32_t const start =
             is_bounded_by_bits<32>(offset_word)
-                ? std::min(static_cast<std::uint32_t>(offset_word), len)
+                ? std::min(static_cast<uint32_t>(offset_word), len)
                 : len;
 
         auto const copy_size = std::min(*size, len - start);
@@ -143,13 +143,13 @@ namespace monad::vm::runtime
         }
 
         if (*size > 0) {
-            auto const offset = clamp_cast<std::uint32_t>(*offset_ptr);
+            auto const offset = clamp_cast<uint32_t>(*offset_ptr);
 
             auto *dest_ptr = ctx->memory.data + *dest_offset;
             auto const n = ctx->host->copy_code(
                 ctx->context, &address, offset, dest_ptr, *size);
 
-            auto *begin = dest_ptr + static_cast<std::uint32_t>(n);
+            auto *begin = dest_ptr + static_cast<uint32_t>(n);
             auto *end = dest_ptr + *size;
 
             std::fill(begin, end, 0);
@@ -164,9 +164,9 @@ namespace monad::vm::runtime
         uint256_t const *offset_ptr, uint256_t const *size_ptr)
     {
         auto const size = ctx->get_memory_offset(*size_ptr);
-        auto const offset = clamp_cast<std::uint32_t>(*offset_ptr);
+        auto const offset = clamp_cast<uint32_t>(*offset_ptr);
 
-        std::uint32_t end;
+        uint32_t end;
         if (MONAD_UNLIKELY(
                 __builtin_add_overflow(offset, *size, &end) ||
                 end > ctx->env.return_data_size)) {

--- a/category/vm/runtime/data.cpp
+++ b/category/vm/runtime/data.cpp
@@ -55,7 +55,7 @@ namespace monad::vm::runtime
     void copy_impl(
         Context *ctx, uint256_t const &dest_offset_word,
         uint256_t const &offset_word, uint256_t const &size_word,
-        uint8_t const *source, uint32_t len)
+        uint8_t const *source, uint32_t const len)
     {
         auto const size = ctx->get_memory_offset(size_word);
         if (*size == 0) {

--- a/category/vm/runtime/data.hpp
+++ b/category/vm/runtime/data.hpp
@@ -36,7 +36,7 @@ namespace monad::vm::runtime
             return;
         }
 
-        auto const i{static_cast<std::uint32_t>(*i_ptr)};
+        auto const i{static_cast<uint32_t>(*i_ptr)};
         auto const n = int64_t{ctx->env.input_data_size} - int64_t{i};
         if (MONAD_UNLIKELY(n <= 0)) {
             // Prevent undefined behavior from pointer arithmetic out of bounds.

--- a/category/vm/runtime/detail.hpp
+++ b/category/vm/runtime/detail.hpp
@@ -66,7 +66,7 @@ namespace monad::vm::runtime::detail
     template <size_t N, typename... Args>
     struct make_context_arg_t
     {
-        static constexpr std::optional<std::size_t> context_arg{};
+        static constexpr std::optional<size_t> context_arg{};
     };
 
     template <size_t N, typename A, typename... Args>
@@ -94,7 +94,7 @@ namespace monad::vm::runtime::detail
     template <size_t N, typename... Args>
     struct make_result_arg_t
     {
-        static constexpr std::optional<std::size_t> result_arg{};
+        static constexpr std::optional<size_t> result_arg{};
     };
 
     template <size_t N, typename A, typename... Args>
@@ -111,7 +111,7 @@ namespace monad::vm::runtime::detail
     };
 
     template <typename T>
-    struct is_remaining_gas : std::is_same<T, std::int64_t>
+    struct is_remaining_gas : std::is_same<T, int64_t>
     {
     };
 
@@ -121,7 +121,7 @@ namespace monad::vm::runtime::detail
     template <size_t N, typename... Args>
     struct make_remaining_gas_arg_t
     {
-        static constexpr std::optional<std::size_t> remaining_gas_arg{};
+        static constexpr std::optional<size_t> remaining_gas_arg{};
     };
 
     template <size_t N, typename A, typename... Args>

--- a/category/vm/runtime/environment.cpp
+++ b/category/vm/runtime/environment.cpp
@@ -33,7 +33,7 @@ namespace monad::vm::runtime
             return;
         }
 
-        auto const block_number = static_cast<std::int64_t>(*block_number_ptr);
+        auto const block_number = static_cast<int64_t>(*block_number_ptr);
         auto const &tx_context = *ctx->env.tx_context;
 
         auto const first_allowed_block =

--- a/category/vm/runtime/exit.cpp
+++ b/category/vm/runtime/exit.cpp
@@ -33,7 +33,7 @@ namespace monad::vm::runtime
         monad_vm_runtime_exit(exit_stack_ptr);
     }
 
-    void Context::exit [[noreturn]] (StatusCode code) noexcept
+    void Context::exit [[noreturn]] (StatusCode const code) noexcept
     {
         result.status = code;
         monad_vm_runtime_exit(exit_stack_ptr);

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -57,7 +57,7 @@ namespace monad::vm::runtime
     template <Traits traits>
     void sstore(
         Context *ctx, uint256_t const *key_ptr, uint256_t const *value_ptr,
-        std::int64_t remaining_block_base_gas)
+        int64_t remaining_block_base_gas)
     {
         if (MONAD_UNLIKELY(ctx->env.evmc_flags & evmc_flags::EVMC_STATIC)) {
             ctx->exit(StatusCode::Error);

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -57,7 +57,7 @@ namespace monad::vm::runtime
     template <Traits traits>
     void sstore(
         Context *ctx, uint256_t const *key_ptr, uint256_t const *value_ptr,
-        int64_t remaining_block_base_gas)
+        int64_t const remaining_block_base_gas)
     {
         if (MONAD_UNLIKELY(ctx->env.evmc_flags & evmc_flags::EVMC_STATIC)) {
             ctx->exit(StatusCode::Error);
@@ -105,8 +105,8 @@ namespace monad::vm::runtime
 
 #ifdef MONAD_COMPILER_TESTING
     bool debug_tstore_stack(
-        Context const *ctx, uint256_t const *stack, uint64_t stack_size,
-        uint64_t offset, uint64_t base_offset)
+        Context const *ctx, uint256_t const *stack, uint64_t const stack_size,
+        uint64_t const offset, uint64_t const base_offset)
     {
         auto const magic = uint256_t{0xdeb009};
         auto const base = (magic + base_offset) * 1024;
@@ -139,7 +139,8 @@ namespace monad::vm::runtime
     }
 #else
     bool debug_tstore_stack(
-        Context const *, uint256_t const *, uint64_t, uint64_t, uint64_t)
+        Context const *, uint256_t const *, uint64_t const, uint64_t const,
+        uint64_t const)
     {
         std::terminate();
     }

--- a/category/vm/runtime/storage.hpp
+++ b/category/vm/runtime/storage.hpp
@@ -29,7 +29,7 @@ namespace monad::vm::runtime
     template <Traits traits>
     void sstore(
         Context *ctx, uint256_t const *key_ptr, uint256_t const *value_ptr,
-        std::int64_t remaining_block_base_gas);
+        int64_t remaining_block_base_gas);
 
     inline void
     tload(Context *ctx, uint256_t *result_ptr, uint256_t const *key_ptr)

--- a/category/vm/runtime/storage_costs.hpp
+++ b/category/vm/runtime/storage_costs.hpp
@@ -27,8 +27,8 @@ namespace monad::vm::runtime
 {
     struct StoreCost
     {
-        std::int64_t gas_cost;
-        std::int64_t gas_refund;
+        int64_t gas_cost;
+        int64_t gas_refund;
     };
 
     template <Traits traits>
@@ -38,7 +38,7 @@ namespace monad::vm::runtime
     };
 
     template <Traits traits>
-    static consteval std::int64_t minimum_store_gas()
+    static consteval int64_t minimum_store_gas()
     {
         constexpr auto costs = StorageCostTable<traits>::costs;
         constexpr auto min_gas =

--- a/category/vm/runtime/storage_costs.hpp
+++ b/category/vm/runtime/storage_costs.hpp
@@ -52,7 +52,7 @@ namespace monad::vm::runtime
     }
 
     template <Traits traits>
-    constexpr StoreCost store_cost(evmc_storage_status status)
+    constexpr StoreCost store_cost(evmc_storage_status const status)
     {
         return StorageCostTable<traits>::costs[status];
     }

--- a/category/vm/runtime/transmute.hpp
+++ b/category/vm/runtime/transmute.hpp
@@ -44,7 +44,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_le(uint8_t const *bytes, int64_t max_len)
+    uint256_load_bounded_le(uint8_t const *bytes, int64_t const max_len)
     {
         if (MONAD_LIKELY(max_len >= 32)) {
             return uint256_t::load_le_unsafe(bytes);
@@ -54,7 +54,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_be(uint8_t const *bytes, int64_t max_len)
+    uint256_load_bounded_be(uint8_t const *bytes, int64_t const max_len)
     {
         return uint256_load_bounded_le(bytes, max_len).to_be();
     }

--- a/category/vm/runtime/transmute.hpp
+++ b/category/vm/runtime/transmute.hpp
@@ -44,7 +44,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_le(std::uint8_t const *bytes, std::int64_t max_len)
+    uint256_load_bounded_le(uint8_t const *bytes, int64_t max_len)
     {
         if (MONAD_LIKELY(max_len >= 32)) {
             return uint256_t::load_le_unsafe(bytes);
@@ -54,7 +54,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_be(std::uint8_t const *bytes, std::int64_t max_len)
+    uint256_load_bounded_be(uint8_t const *bytes, int64_t max_len)
     {
         return uint256_load_bounded_le(bytes, max_len).to_be();
     }
@@ -72,15 +72,15 @@ namespace monad::vm::runtime
     {
         auto const *bytes = x.as_bytes();
 
-        std::uint64_t t2;
+        uint64_t t2;
         std::memcpy(&t2, bytes, 8);
         t2 = std::byteswap(t2);
 
-        std::uint64_t t1;
+        uint64_t t1;
         std::memcpy(&t1, bytes + 8, 8);
         t1 = std::byteswap(t1);
 
-        std::uint32_t t0;
+        uint32_t t0;
         std::memcpy(&t0, bytes + 16, 4);
         t0 = std::byteswap(t0);
 
@@ -100,15 +100,15 @@ namespace monad::vm::runtime
     [[gnu::always_inline]]
     inline uint256_t uint256_from_address(evmc::address const &addr)
     {
-        std::uint32_t t2;
+        uint32_t t2;
         std::memcpy(&t2, addr.bytes, 4);
         t2 = std::byteswap(t2);
 
-        std::uint64_t t1;
+        uint64_t t1;
         std::memcpy(&t1, addr.bytes + 4, 8);
         t1 = std::byteswap(t1);
 
-        std::uint64_t t0;
+        uint64_t t0;
         std::memcpy(&t0, addr.bytes + 12, 8);
         t0 = std::byteswap(t0);
 
@@ -120,12 +120,12 @@ namespace monad::vm::runtime
         return std::bit_cast<uint256_t>(ret);
     }
 
-    template <std::uint64_t N>
+    template <uint64_t N>
         requires(N < 64)
     [[gnu::always_inline]]
     constexpr bool is_bounded_by_bits(uint256_t const &x)
     {
-        static constexpr std::uint64_t mask = ~((std::uint64_t{1} << N) - 1);
+        static constexpr uint64_t mask = ~((uint64_t{1} << N) - 1);
         return ((x[0] & mask) | x[1] | x[2] | x[3]) == 0;
     }
 

--- a/category/vm/runtime/types.hpp
+++ b/category/vm/runtime/types.hpp
@@ -73,7 +73,8 @@ namespace monad::vm::runtime
         }
 
         [[gnu::always_inline]]
-        void set_return_data(uint8_t const *output_data, size_t output_size)
+        void
+        set_return_data(uint8_t const *output_data, size_t const output_size)
         {
             MONAD_DEBUG_ASSERT(return_data_size == 0);
             return_data = output_data;
@@ -125,7 +126,7 @@ namespace monad::vm::runtime
 
         Memory() = delete;
 
-        explicit Memory(uint8_t *han, uint8_t *dat, uint32_t cap)
+        explicit Memory(uint8_t *han, uint8_t *dat, uint32_t const cap)
             : size{}
             , capacity{cap}
             , data{dat}
@@ -227,7 +228,7 @@ namespace monad::vm::runtime
             evmc_message const *msg, std::span<uint8_t const> code) noexcept;
 
         static Context
-        empty(uint8_t *const memory_handle, uint32_t memory_capacity) noexcept;
+        empty(uint8_t *memory_handle, uint32_t memory_capacity) noexcept;
 
         evmc_host_interface const *host;
         evmc_host_context *context;
@@ -287,14 +288,14 @@ namespace monad::vm::runtime
 
         [[gnu::always_inline]]
         static constexpr Bin<30>
-        word_count_to_memory_size(Bin<25> word_count) noexcept
+        word_count_to_memory_size(Bin<25> const word_count) noexcept
         {
             return shl<5>(word_count);
         }
 
         template <Traits traits>
         [[gnu::always_inline]]
-        bool is_memory_size_in_bound(Bin<30> mem_size)
+        bool is_memory_size_in_bound(Bin<30> const mem_size)
         {
             if constexpr (traits::mip_3_active()) {
                 Bin<31> const total_size =
@@ -308,7 +309,7 @@ namespace monad::vm::runtime
         void increase_capacity(uint32_t old_size, Bin<30> new_size);
 
         template <Traits traits>
-        void expand_memory(Bin<29> min_size)
+        void expand_memory(Bin<29> const min_size)
         {
             if (memory.size < *min_size) {
                 auto const word_count = memory_size_to_word_count(min_size);

--- a/category/vm/runtime/types.hpp
+++ b/category/vm/runtime/types.hpp
@@ -50,20 +50,20 @@ namespace monad::vm::runtime
 
     struct Environment
     {
-        std::uint32_t evmc_flags;
-        std::int32_t depth;
+        uint32_t evmc_flags;
+        int32_t depth;
         evmc::address recipient;
         evmc::address sender;
         bytes32_t value;
         bytes32_t create2_salt;
 
-        std::uint8_t const *input_data;
-        std::uint8_t const *code;
-        std::uint8_t const *return_data;
+        uint8_t const *input_data;
+        uint8_t const *code;
+        uint8_t const *return_data;
 
-        std::uint32_t input_data_size;
-        std::uint32_t code_size;
-        std::size_t return_data_size;
+        uint32_t input_data_size;
+        uint32_t code_size;
+        size_t return_data_size;
 
         evmc_tx_context const *tx_context;
 
@@ -73,8 +73,7 @@ namespace monad::vm::runtime
         }
 
         [[gnu::always_inline]]
-        void set_return_data(
-            std::uint8_t const *output_data, std::size_t output_size)
+        void set_return_data(uint8_t const *output_data, size_t output_size)
         {
             MONAD_DEBUG_ASSERT(return_data_size == 0);
             return_data = output_data;
@@ -93,18 +92,18 @@ namespace monad::vm::runtime
     struct Memory
     {
         // Size of the memory region for current call frame:
-        std::uint32_t size;
+        uint32_t size;
         // Capacity of the memory region for current call frame:
-        std::uint32_t capacity;
+        uint32_t capacity;
         // Start of memory region for current call frame:
-        std::uint8_t *data;
+        uint8_t *data;
         // Current accumulated memory cost for current call frame:
-        std::int64_t cost;
+        int64_t cost;
         // Pointer to the beginning of the transaction wide memory:
-        std::uint8_t *data_handle;
+        uint8_t *data_handle;
         // The `parent_capacity` is the original capacity (the capacity at
         // the beginning of the current call frame).
-        std::uint32_t const parent_capacity;
+        uint32_t const parent_capacity;
         // The `parent_handle` is a pointer to the original transaction wide
         // memory (the transaction wide memory at the beginning of the
         // current call frame).
@@ -112,7 +111,7 @@ namespace monad::vm::runtime
         // memory pointed to by `parent_handle`. This memory is lazily freed,
         // because the call data for the current call frame is potentially a
         // pointer into the `parent_handle` memory.
-        std::uint8_t *const parent_handle;
+        uint8_t *const parent_handle;
 
         static constexpr auto offset_bits = 28;
 
@@ -126,7 +125,7 @@ namespace monad::vm::runtime
 
         Memory() = delete;
 
-        explicit Memory(std::uint8_t *han, std::uint8_t *dat, std::uint32_t cap)
+        explicit Memory(uint8_t *han, uint8_t *dat, uint32_t cap)
             : size{}
             , capacity{cap}
             , data{dat}
@@ -162,7 +161,7 @@ namespace monad::vm::runtime
         {
             MONAD_DEBUG_ASSERT(data >= data_handle);
 
-            auto const x = static_cast<std::uintptr_t>(data - data_handle);
+            auto const x = static_cast<uintptr_t>(data - data_handle);
 
             MONAD_DEBUG_ASSERT((x & 31) == 0);
 
@@ -191,7 +190,7 @@ namespace monad::vm::runtime
             // to fail:
             MONAD_ASSERT(x <= Bin<30>::upper);
 
-            return Bin<30>::unsafe_from(static_cast<std::uint32_t>(x));
+            return Bin<30>::unsafe_from(static_cast<uint32_t>(x));
         }
 
         [[gnu::always_inline]]
@@ -225,18 +224,16 @@ namespace monad::vm::runtime
     {
         static Context from(
             evmc_host_interface const *host, evmc_host_context *context,
-            evmc_message const *msg,
-            std::span<std::uint8_t const> code) noexcept;
+            evmc_message const *msg, std::span<uint8_t const> code) noexcept;
 
-        static Context empty(
-            std::uint8_t *const memory_handle,
-            std::uint32_t memory_capacity) noexcept;
+        static Context
+        empty(uint8_t *const memory_handle, uint32_t memory_capacity) noexcept;
 
         evmc_host_interface const *host;
         evmc_host_context *context;
 
-        std::int64_t gas_remaining;
-        std::int64_t gas_refund;
+        int64_t gas_remaining;
+        int64_t gas_refund;
 
         Environment env;
 
@@ -248,7 +245,7 @@ namespace monad::vm::runtime
         bool is_stack_unwinding_active = false;
 
         [[gnu::always_inline]]
-        constexpr void deduct_gas(std::int64_t const gas) noexcept
+        constexpr void deduct_gas(int64_t const gas) noexcept
         {
             gas_remaining -= gas;
             if (MONAD_UNLIKELY(gas_remaining < 0)) {
@@ -328,7 +325,7 @@ namespace monad::vm::runtime
                 }
 
                 MONAD_DEBUG_ASSERT(new_cost >= memory.cost);
-                std::int64_t const expansion_cost = new_cost - memory.cost;
+                int64_t const expansion_cost = new_cost - memory.cost;
 
                 // Gas check before increasing size or capacity:
                 deduct_gas(expansion_cost);
@@ -393,7 +390,7 @@ namespace monad::vm::runtime
 
     private:
         template <Traits traits>
-        std::variant<std::span<std::uint8_t const>, evmc_status_code>
+        std::variant<std::span<uint8_t const>, evmc_status_code>
         copy_result_data();
     };
 

--- a/category/vm/utils/load_program.hpp
+++ b/category/vm/utils/load_program.hpp
@@ -32,8 +32,7 @@ namespace monad::vm::utils
     std::vector<uint8_t> parse_hex_program(It begin, It end)
     {
         auto hex_size = std::distance(begin, end);
-        auto program =
-            std::vector<uint8_t>(static_cast<std::size_t>(hex_size / 2));
+        auto program = std::vector<uint8_t>(static_cast<size_t>(hex_size / 2));
 
         auto output_it = program.begin();
         auto out_end = program.end();

--- a/category/vm/utils/parser.cpp
+++ b/category/vm/utils/parser.cpp
@@ -194,7 +194,7 @@ namespace monad::vm::utils
         std::stringstream ss;
         auto const &tbl = monad::vm::compiler::make_opcode_table<
             EvmTraits<EVMC_LATEST_STABLE_REVISION>>();
-        for (std::size_t i = 0; i < opcodes.size(); ++i) {
+        for (size_t i = 0; i < opcodes.size(); ++i) {
             auto c = opcodes[i];
             ss << std::format("[{:#x}] {:#x} {}\n", i, c, tbl[opcodes[i]].name);
             if (c >= PUSH1 && c <= PUSH32) {

--- a/category/vm/varcode_cache.cpp
+++ b/category/vm/varcode_cache.cpp
@@ -25,14 +25,13 @@
 
 namespace monad::vm
 {
-    std::uint32_t
-    VarcodeCache::code_size_to_cache_weight(std::uint32_t code_size)
+    uint32_t VarcodeCache::code_size_to_cache_weight(uint32_t code_size)
     {
         // Byte size in kB, plus 3 kB overhead:
         return (code_size >> 10) + 3;
     }
 
-    VarcodeCache::VarcodeCache(std::uint32_t max_kb, std::uint32_t warm_kb)
+    VarcodeCache::VarcodeCache(uint32_t max_kb, uint32_t warm_kb)
         : weight_cache_{max_kb}
         , warm_cache_kb_{warm_kb}
     {

--- a/category/vm/varcode_cache.cpp
+++ b/category/vm/varcode_cache.cpp
@@ -25,13 +25,13 @@
 
 namespace monad::vm
 {
-    uint32_t VarcodeCache::code_size_to_cache_weight(uint32_t code_size)
+    uint32_t VarcodeCache::code_size_to_cache_weight(uint32_t const code_size)
     {
         // Byte size in kB, plus 3 kB overhead:
         return (code_size >> 10) + 3;
     }
 
-    VarcodeCache::VarcodeCache(uint32_t max_kb, uint32_t warm_kb)
+    VarcodeCache::VarcodeCache(uint32_t const max_kb, uint32_t const warm_kb)
         : weight_cache_{max_kb}
         , warm_cache_kb_{warm_kb}
     {

--- a/category/vm/varcode_cache.hpp
+++ b/category/vm/varcode_cache.hpp
@@ -25,18 +25,18 @@ namespace monad::vm
 {
     class VarcodeCache
     {
-        static constexpr std::uint32_t default_max_cache_kb =
-            std::uint32_t{1} << 22; // 4MB * 1kB = 4GB
+        static constexpr uint32_t default_max_cache_kb =
+            uint32_t{1} << 22; // 4MB * 1kB = 4GB
 
-        static constexpr std::uint32_t default_warm_cache_kb =
+        static constexpr uint32_t default_warm_cache_kb =
             (3 * default_max_cache_kb) / 4; // ~75%
 
         using WeightCache = utils::LruWeightCache<bytes32_t, SharedVarcode>;
 
     public:
         explicit VarcodeCache(
-            std::uint32_t max_cache_kb = default_max_cache_kb,
-            std::uint32_t warm_cache_kb = default_warm_cache_kb);
+            uint32_t max_cache_kb = default_max_cache_kb,
+            uint32_t warm_cache_kb = default_warm_cache_kb);
 
         /// Get varcode for given code hash.
         std::optional<SharedVarcode> get(bytes32_t const &code_hash);
@@ -62,13 +62,13 @@ namespace monad::vm
             return weight_cache_.approx_weight() >= warm_cache_kb_;
         }
 
-        void set_warm_cache_kb(std::uint32_t warm_kb)
+        void set_warm_cache_kb(uint32_t warm_kb)
         {
             warm_cache_kb_ = warm_kb;
         }
 
         // Cache weight of the given code size.
-        static std::uint32_t code_size_to_cache_weight(std::uint32_t code_size);
+        static uint32_t code_size_to_cache_weight(uint32_t code_size);
 
         /// Get approximate total weight of the cached elements.
         uint64_t approx_weight() const
@@ -84,6 +84,6 @@ namespace monad::vm
 
     private:
         WeightCache weight_cache_;
-        std::uint32_t warm_cache_kb_;
+        uint32_t warm_cache_kb_;
     };
 }

--- a/category/vm/varcode_cache.hpp
+++ b/category/vm/varcode_cache.hpp
@@ -62,7 +62,7 @@ namespace monad::vm
             return weight_cache_.approx_weight() >= warm_cache_kb_;
         }
 
-        void set_warm_cache_kb(uint32_t warm_kb)
+        void set_warm_cache_kb(uint32_t const warm_kb)
         {
             warm_cache_kb_ = warm_kb;
         }


### PR DESCRIPTION
## Summary

- **Remove `std::` prefix from integer types** to match house style. The VM code originated in a separate repo that used fully-qualified `std::uint8_t`, `std::int64_t`, `std::size_t` etc. The rest of the monad codebase uses bare types. (66 files)
- **Add missing `const` qualifiers on value-type function parameters** throughout the VM runtime, compiler, interpreter, and fuzzing code — `bool`, integer, enum, and small struct parameters that aren't modified in the function body. (39 files)

## Test plan

- [x] Full build succeeds (`cmake --build build --parallel`, 718 targets)
- [x] `clang-format` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)