### PR TITLE
Evm-as: fix PushLabel encoding at offset zero for Pre-Shanghai

### DIFF
--- a/category/vm/utils/evm-as/compiler.hpp
+++ b/category/vm/utils/evm-as/compiler.hpp
@@ -209,6 +209,15 @@ namespace monad::vm::utils::evm_as
                         size_t const offset = it->second;
                         size_t const n =
                             offset == 0 ? offset : byte_width(offset);
+                        if constexpr (traits::evm_rev() < EVMC_SHANGHAI) {
+                            if (n == 0) {
+                                // Special case for zero offset before Shanghai,
+                                // as PUSH0 is not available.
+                                emit_byte(mc::EvmOpCode::PUSH1);
+                                emit_byte(0x00);
+                                return;
+                            }
+                        }
                         emit_byte(
                             mc::EvmOpCode::PUSH0 + static_cast<uint8_t>(n));
                         // Note: assumes we are executing on a
@@ -350,7 +359,10 @@ namespace monad::vm::utils::evm_as
                             }
                             size_t offset = it->second;
                             if (offset == 0) {
-                                std::string const str = std::format("PUSH0");
+                                static constexpr std::string_view str =
+                                    traits::evm_rev() < EVMC_SHANGHAI
+                                        ? "PUSH1 0x00"
+                                        : "PUSH0";
                                 os << str;
                                 return str.size();
                             }

--- a/category/vm/utils/evm-as/compiler.hpp
+++ b/category/vm/utils/evm-as/compiler.hpp
@@ -230,12 +230,14 @@ namespace monad::vm::utils::evm_as
                         static constexpr size_t addr_size = sizeof(Address);
                         // Emit the smallest possible PUSH opcode
                         size_t const least_n = addr_size - countl(push.address);
-                        if (least_n == 0 && traits::evm_rev() < EVMC_SHANGHAI) {
-                            // Special case for zero address before Shanghai, as
-                            // PUSH0 is not available.
-                            emit_byte(mc::EvmOpCode::PUSH1);
-                            emit_byte(0x00);
-                            return;
+                        if constexpr (traits::evm_rev() < EVMC_SHANGHAI) {
+                            if (least_n == 0) {
+                                // Special case for zero address before
+                                // Shanghai, as PUSH0 is not available.
+                                emit_byte(mc::EvmOpCode::PUSH1);
+                                emit_byte(0x00);
+                                return;
+                            }
                         }
                         emit_byte(
                             mc::EvmOpCode::PUSH0 +

--- a/category/vm/utils/evm-as/resolver.hpp
+++ b/category/vm/utils/evm-as/resolver.hpp
@@ -98,6 +98,15 @@ namespace monad::vm::utils::evm_as
                                 size_t const n =
                                     offset == 0 ? 0 : byte_width(offset);
 
+                                if constexpr (
+                                    traits::evm_rev() < EVMC_SHANGHAI) {
+                                    if (n == 0) {
+                                        // Special case for zero offset before
+                                        // Shanghai, as PUSH0 is not available.
+                                        return 2; // PUSH1 0x00
+                                    }
+                                }
+
                                 // Expand to either PUSH0 or
                                 // PUSHn.
                                 return 1 + n;

--- a/test/vm/unit/evm-as_tests.cpp
+++ b/test/vm/unit/evm-as_tests.cpp
@@ -692,6 +692,32 @@ TEST(EvmAs, BytecodeCompile3)
     }
 }
 
+TEST(EvmAs, PushLabelZeroOffsetPreShanghai)
+{
+    auto eb = evm_as::paris();
+
+    eb.jumpdest(".START").jump(".START");
+    ASSERT_TRUE(evm_as::validate(eb));
+
+    auto const label_offsets = resolve_labels(eb);
+    ASSERT_EQ(label_offsets.find(".START")->second, 0);
+
+    std::vector<uint8_t> const expected = {
+        compiler::EvmOpCode::JUMPDEST,
+        compiler::EvmOpCode::PUSH1,
+        0x00,
+        compiler::EvmOpCode::JUMP};
+
+    std::vector<uint8_t> bytecode;
+    evm_as::compile(eb, bytecode);
+    ASSERT_EQ(bytecode, expected);
+
+    std::string const expected_mnemonic = "JUMPDEST\nPUSH1 0x00\nJUMP\n";
+    ASSERT_EQ(
+        evm_as::mcompile(eb, evm_as::mnemonic_config{true, false, 32}),
+        expected_mnemonic);
+}
+
 TEST(EvmAs, BytecodeCompile4)
 {
     auto eb = evm_as::latest();


### PR DESCRIPTION
Closes https://github.com/category-labs/monad-private/issues/37

Fixes pre-Shanghai `PUSH0` calls in `evm-as`.