### PR TITLE
Apply east-const to function parameter definitions

### DIFF
--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -98,7 +98,8 @@ struct chunk_offset_t
     }
 
     constexpr chunk_offset_t(
-        uint32_t id_, file_offset_t offset_, file_offset_t spare_ = max_spare)
+        uint32_t const id_, file_offset_t const offset_,
+        file_offset_t const spare_ = max_spare)
         : offset(offset_ & max_offset)
         , id(id_ & max_id)
         , spare{spare_ & max_spare}
@@ -140,7 +141,7 @@ struct chunk_offset_t
                static_cast<file_offset_t>(offset);
     }
 
-    void set_spare(uint16_t value) noexcept
+    void set_spare(uint16_t const value) noexcept
     {
         MONAD_ASSERT(value < max_spare);
         spare = value & max_spare;
@@ -153,7 +154,7 @@ static_assert(std::is_trivially_copyable_v<chunk_offset_t>);
 
 struct chunk_offset_t_hasher
 {
-    constexpr size_t operator()(chunk_offset_t v) const noexcept
+    constexpr size_t operator()(chunk_offset_t const v) const noexcept
     {
         return fnv1a_hash<file_offset_t>()(v.raw());
     }
@@ -185,7 +186,7 @@ static constexpr uint16_t DMA_PAGE_BITS = 6;
 static constexpr uint16_t DMA_PAGE_SIZE = (1U << DMA_PAGE_BITS);
 
 //! Calculate total byte length from an array of iovec buffers
-inline size_t iov_length(std::span<const struct iovec> iovecs)
+inline size_t iov_length(std::span<const struct iovec> const iovecs)
 {
     size_t total = 0;
     for (auto const &iov : iovecs) {
@@ -211,7 +212,7 @@ namespace std
             return v_.is_lock_free();
         }
 
-        constexpr explicit atomic(value_type v) noexcept
+        constexpr explicit atomic(value_type const v) noexcept
             : v_(std::bit_cast<uint64_t>(v))
         {
         }
@@ -222,21 +223,21 @@ namespace std
         atomic &operator=(atomic &&) = delete;
 
         void store(
-            value_type v,
-            std::memory_order ord = std::memory_order_seq_cst) noexcept
+            value_type const v,
+            std::memory_order const ord = std::memory_order_seq_cst) noexcept
         {
             v_.store(std::bit_cast<uint64_t>(v), ord);
         }
 
-        value_type
-        load(std::memory_order ord = std::memory_order_seq_cst) const noexcept
+        value_type load(std::memory_order const ord = std::memory_order_seq_cst)
+            const noexcept
         {
             return std::bit_cast<value_type>(v_.load(ord));
         }
 
         value_type exchange(
-            value_type desired,
-            std::memory_order ord = std::memory_order_seq_cst) noexcept
+            value_type const desired,
+            std::memory_order const ord = std::memory_order_seq_cst) noexcept
         {
             return std::bit_cast<value_type>(
                 v_.exchange(std::bit_cast<uint64_t>(desired), ord));

--- a/category/async/connected_operation.hpp
+++ b/category/async/connected_operation.hpp
@@ -211,7 +211,7 @@ namespace detail
 
         // Overload ambiguity resolver so you can write `completed(success())`
         // without ambiguous overload warnings.
-        void completed(BOOST_OUTCOME_V2_NAMESPACE::success_type<void> _)
+        void completed(BOOST_OUTCOME_V2_NAMESPACE::success_type<void> const _)
         {
             completed(result<void>(_));
         }

--- a/category/async/detail/connected_operation_storage.hpp
+++ b/category/async/detail/connected_operation_storage.hpp
@@ -51,7 +51,7 @@ namespace detail
         }
 
         bool if_within_completions_add_to_pending_initiations(
-            erased_connected_operation *op)
+            erased_connected_operation *const op)
         {
             erased_connected_operation::rbtree_node_traits::set_parent(
                 op,
@@ -149,8 +149,8 @@ namespace detail
         Sender sender_;
         Receiver receiver_;
 
-        virtual initiation_result
-        do_possibly_deferred_initiate_(bool never_defer, bool is_retry) override
+        virtual initiation_result do_possibly_deferred_initiate_(
+            bool const never_defer, bool const is_retry) override
         {
             (void)
                 is_retry; // useful to know how this initiation is coming about

--- a/category/async/erased_connected_operation.hpp
+++ b/category/async/erased_connected_operation.hpp
@@ -41,7 +41,7 @@ namespace detail
     public:
         read_buffer_deleter() = default;
 
-        constexpr explicit read_buffer_deleter(AsyncIO *parent)
+        constexpr explicit read_buffer_deleter(AsyncIO *const parent)
             : parent_(parent)
         {
             MONAD_ASSERT(parent != nullptr);
@@ -57,7 +57,7 @@ namespace detail
     public:
         write_buffer_deleter() = default;
 
-        constexpr explicit write_buffer_deleter(AsyncIO *parent)
+        constexpr explicit write_buffer_deleter(AsyncIO *const parent)
             : parent_(parent)
         {
             MONAD_ASSERT(parent != nullptr);
@@ -120,7 +120,7 @@ public:
     filled_read_buffer &operator=(filled_read_buffer const &) = delete;
     filled_read_buffer &operator=(filled_read_buffer &&) = default;
 
-    constexpr explicit filled_read_buffer(size_t bytes_to_read)
+    constexpr explicit filled_read_buffer(size_t const bytes_to_read)
         : base_((std::byte const *)nullptr, bytes_to_read)
     {
     }
@@ -140,7 +140,7 @@ public:
     }
 
     //! Sets the span length
-    void set_bytes_transferred(size_t bytes) noexcept
+    void set_bytes_transferred(size_t const bytes) noexcept
     {
         auto *span = static_cast<base_ *>(this);
         *span = span->subspan(0, bytes);
@@ -211,7 +211,7 @@ public:
     filled_write_buffer &operator=(filled_write_buffer const &) = delete;
     filled_write_buffer &operator=(filled_write_buffer &&) = default;
 
-    constexpr explicit filled_write_buffer(size_t bytes_to_write)
+    constexpr explicit filled_write_buffer(size_t const bytes_to_write)
         : base_((std::byte const *)nullptr, bytes_to_write)
     {
     }
@@ -231,7 +231,7 @@ public:
     }
 
     //! Sets the span length
-    void set_bytes_transferred(size_t bytes) noexcept
+    void set_bytes_transferred(size_t const bytes) noexcept
     {
         auto *span = static_cast<base_ *>(this);
         *span = span->subspan(0, bytes);
@@ -336,15 +336,16 @@ protected:
     } rbtree_;
 
     constexpr erased_connected_operation(
-        operation_type operation_type, bool lifetime_managed_internally)
+        operation_type const operation_type,
+        bool const lifetime_managed_internally)
         : operation_type_(operation_type)
         , lifetime_managed_internally_(lifetime_managed_internally)
     {
     }
 
     constexpr erased_connected_operation(
-        operation_type operation_type, AsyncIO &io,
-        bool lifetime_managed_internally)
+        operation_type const operation_type, AsyncIO &io,
+        bool const lifetime_managed_internally)
         : operation_type_(operation_type)
         , lifetime_managed_internally_(lifetime_managed_internally)
         , io_(&io)
@@ -407,7 +408,7 @@ public:
             return n->color;
         }
 
-        static void set_color(node_ptr n, color c)
+        static void set_color(node_ptr n, color const c)
         {
             n->color = c;
         }
@@ -427,7 +428,7 @@ public:
             return n->key;
         }
 
-        static void set_key(node_ptr n, file_offset_t v)
+        static void set_key(node_ptr n, file_offset_t const v)
         {
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
             MONAD_ASSERT(v <= max_key);
@@ -435,59 +436,64 @@ public:
         }
 
         static erased_connected_operation *
-        get_parent(erased_connected_operation const *n)
+        get_parent(erased_connected_operation const *const n)
         {
             return n->rbtree_.parent_;
         }
 
         static void set_parent(
-            erased_connected_operation *n, erased_connected_operation *parent)
+            erased_connected_operation *const n,
+            erased_connected_operation *const parent)
         {
             n->rbtree_.parent_ = parent;
         }
 
         static erased_connected_operation *
-        get_left(erased_connected_operation const *n)
+        get_left(erased_connected_operation const *const n)
         {
             return n->rbtree_.left_;
         }
 
         static void set_left(
-            erased_connected_operation *n, erased_connected_operation *left)
+            erased_connected_operation *const n,
+            erased_connected_operation *const left)
         {
             n->rbtree_.left_ = left;
         }
 
         static erased_connected_operation *
-        get_right(erased_connected_operation const *n)
+        get_right(erased_connected_operation const *const n)
         {
             return n->rbtree_.right_;
         }
 
         static void set_right(
-            erased_connected_operation *n, erased_connected_operation *right)
+            erased_connected_operation *const n,
+            erased_connected_operation *const right)
         {
             n->rbtree_.right_ = right;
         }
 
-        static file_offset_t get_key(erased_connected_operation const *n)
+        static file_offset_t get_key(erased_connected_operation const *const n)
         {
             return n->rbtree_.key;
         }
 
-        static void set_key(erased_connected_operation *n, file_offset_t v)
+        static void
+        set_key(erased_connected_operation *const n, file_offset_t const v)
         {
             static constexpr file_offset_t max_key = (1ULL << 63) - 1;
             MONAD_ASSERT(v <= max_key);
             n->rbtree_.key = v & max_key;
         }
 
-        static node_ptr to_node_ptr(erased_connected_operation *n)
+        static node_ptr to_node_ptr(erased_connected_operation *const n)
         {
             return &n->rbtree_;
         }
 
-        static const_node_ptr to_node_ptr(erased_connected_operation const *n)
+        static const_node_ptr
+        to_node_ptr(erased_connected_operation const *const n)
         {
             return &n->rbtree_;
         }
@@ -555,7 +561,7 @@ public:
         return io_priority_;
     }
 
-    void set_io_priority(enum io_priority v) noexcept
+    void set_io_priority(enum io_priority const v) noexcept
     {
         io_priority_ = v;
     }
@@ -587,7 +593,7 @@ public:
 
     // Overload ambiguity resolver so you can write `completed(success())`
     // without ambiguous overload warnings.
-    void completed(BOOST_OUTCOME_V2_NAMESPACE::success_type<void> _)
+    void completed(BOOST_OUTCOME_V2_NAMESPACE::success_type<void> const _)
     {
         completed(result<void>(_));
     }

--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -92,7 +92,8 @@ namespace detail
     {
         AsyncIO_per_thread_state_t *parent;
 
-        explicit within_completions_holder(AsyncIO_per_thread_state_t *parent_)
+        explicit within_completions_holder(
+            AsyncIO_per_thread_state_t *const parent_)
             : parent(parent_)
         {
             parent->within_completions_count++;
@@ -273,7 +274,7 @@ AsyncIO::~AsyncIO()
     MONAD_ASSERT(!io_uring_unregister_files(&uring_.get_ring()));
 }
 
-void AsyncIO::account_read_(size_t size)
+void AsyncIO::account_read_(size_t const size)
 {
     if (++records_.inflight_rd > records_.max_inflight_rd) {
         records_.max_inflight_rd = records_.inflight_rd;
@@ -283,9 +284,9 @@ void AsyncIO::account_read_(size_t size)
 }
 
 void AsyncIO::prepare_read_sqe_(
-    struct io_uring_sqe *sqe, std::span<std::byte> buffer,
-    chunk_offset_t chunk_and_offset, void *uring_data,
-    enum erased_connected_operation::io_priority prio)
+    struct io_uring_sqe *const sqe, std::span<std::byte> const buffer,
+    chunk_offset_t const chunk_and_offset, void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     MONAD_ASSERT(sqe != nullptr);
     MONAD_ASSERT(uring_data != nullptr);
@@ -321,9 +322,9 @@ void AsyncIO::prepare_read_sqe_(
 }
 
 void AsyncIO::prepare_read_sqe_(
-    struct io_uring_sqe *sqe, std::span<const struct iovec> buffers,
-    chunk_offset_t chunk_and_offset, void *uring_data,
-    enum erased_connected_operation::io_priority prio)
+    struct io_uring_sqe *const sqe, std::span<const struct iovec> const buffers,
+    chunk_offset_t const chunk_and_offset, void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     MONAD_ASSERT(sqe != nullptr);
     MONAD_ASSERT(uring_data != nullptr);
@@ -369,8 +370,9 @@ void AsyncIO::prepare_read_sqe_(
 }
 
 void AsyncIO::submit_request_sqe_(
-    std::span<std::byte> buffer, chunk_offset_t chunk_and_offset,
-    void *uring_data, enum erased_connected_operation::io_priority prio)
+    std::span<std::byte> const buffer, chunk_offset_t const chunk_and_offset,
+    void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     struct io_uring_sqe *sqe = io_uring_get_sqe(&uring_.get_ring());
     MONAD_ASSERT(sqe);
@@ -380,8 +382,9 @@ void AsyncIO::submit_request_sqe_(
 }
 
 void AsyncIO::submit_request_(
-    std::span<std::byte> buffer, chunk_offset_t chunk_and_offset,
-    void *uring_data, enum erased_connected_operation::io_priority prio)
+    std::span<std::byte> const buffer, chunk_offset_t const chunk_and_offset,
+    void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     poll_uring_while_submission_queue_full_();
 
@@ -389,8 +392,9 @@ void AsyncIO::submit_request_(
 }
 
 void AsyncIO::submit_request_(
-    std::span<const struct iovec> buffers, chunk_offset_t chunk_and_offset,
-    void *uring_data, enum erased_connected_operation::io_priority prio)
+    std::span<const struct iovec> const buffers,
+    chunk_offset_t const chunk_and_offset, void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     poll_uring_while_submission_queue_full_();
     struct io_uring_sqe *sqe = io_uring_get_sqe(&uring_.get_ring());
@@ -401,8 +405,9 @@ void AsyncIO::submit_request_(
 }
 
 void AsyncIO::submit_request_(
-    std::span<std::byte const> buffer, chunk_offset_t chunk_and_offset,
-    void *uring_data, enum erased_connected_operation::io_priority prio)
+    std::span<std::byte const> const buffer,
+    chunk_offset_t const chunk_and_offset, void *const uring_data,
+    enum erased_connected_operation::io_priority const prio)
 {
     MONAD_ASSERT(uring_data != nullptr);
     MONAD_ASSERT(!rwbuf_.is_read_only());
@@ -489,7 +494,7 @@ void AsyncIO::poll_uring_while_submission_queue_full_()
 
 // return the number of completions processed
 // if blocking is true, will block until at least one completion is processed
-size_t AsyncIO::poll_uring_(bool blocking, unsigned poll_rings_mask)
+size_t AsyncIO::poll_uring_(bool blocking, unsigned const poll_rings_mask)
 {
     // bit 0 in poll_rings_mask blocks read completions, bit 1 blocks write
     // completions
@@ -719,7 +724,7 @@ unsigned AsyncIO::deferred_initiations_in_flight() const noexcept
 }
 
 std::pair<unsigned, unsigned>
-AsyncIO::io_uring_ring_entries_left(bool for_wr_ring) const noexcept
+AsyncIO::io_uring_ring_entries_left(bool const for_wr_ring) const noexcept
 {
     if (for_wr_ring) {
         if (wr_uring_ == nullptr) {
@@ -736,7 +741,7 @@ AsyncIO::io_uring_ring_entries_left(bool for_wr_ring) const noexcept
         *ring->cq.kring_entries - io_uring_cq_ready(ring)};
 }
 
-void AsyncIO::dump_fd_to(size_t which, std::filesystem::path const &path)
+void AsyncIO::dump_fd_to(size_t const which, std::filesystem::path const &path)
 {
     int const tofd = ::creat(path.c_str(), 0600);
     MONAD_ASSERT_PRINTF(
@@ -757,7 +762,7 @@ void AsyncIO::dump_fd_to(size_t which, std::filesystem::path const &path)
         copied != -1, "copy_file_range failed due to %s", std::strerror(errno));
 }
 
-unsigned char *AsyncIO::poll_uring_while_no_io_buffers_(bool is_write)
+unsigned char *AsyncIO::poll_uring_while_no_io_buffers_(bool const is_write)
 {
     /* Prevent any new i/o initiation as we cannot exit until an i/o
     buffer becomes freed.

--- a/category/async/io.hpp
+++ b/category/async/io.hpp
@@ -157,7 +157,7 @@ public:
         return seq_chunks_.size();
     }
 
-    file_offset_t chunk_capacity(size_t id) const noexcept
+    file_offset_t chunk_capacity(size_t const id) const noexcept
     {
         MONAD_ASSERT_PRINTF(
             id < seq_chunks_.size(),
@@ -218,7 +218,7 @@ public:
         return concurrent_read_io_limit_;
     }
 
-    void set_concurrent_read_io_limit(unsigned v) noexcept
+    void set_concurrent_read_io_limit(unsigned const v) noexcept
     {
         concurrent_read_io_limit_ = v;
     }
@@ -228,7 +228,7 @@ public:
         return eager_completions_;
     }
 
-    void set_eager_completions(bool v) noexcept
+    void set_eager_completions(bool const v) noexcept
     {
         eager_completions_ = v;
     }
@@ -238,7 +238,7 @@ public:
         return capture_io_latencies_;
     }
 
-    void set_capture_io_latencies(bool v) noexcept
+    void set_capture_io_latencies(bool const v) noexcept
     {
         capture_io_latencies_ = v;
     }
@@ -253,7 +253,7 @@ public:
 
     // Blocks until at least one completion is processed, returning number
     // of completions processed.
-    size_t poll_blocking(size_t count = 1)
+    size_t poll_blocking(size_t const count = 1)
     {
         size_t n = 0;
         while (n < count) {
@@ -267,7 +267,7 @@ public:
     }
 
     std::optional<size_t>
-    poll_blocking_if_not_within_completions(size_t count = 1)
+    poll_blocking_if_not_within_completions(size_t const count = 1)
     {
         if (detail::AsyncIO_per_thread_state().am_within_completions()) {
             return std::nullopt;
@@ -276,7 +276,7 @@ public:
     }
 
     // Never blocks
-    size_t poll_nonblocking(size_t count = size_t(-1))
+    size_t poll_nonblocking(size_t const count = size_t(-1))
     {
         size_t n = 0;
         while (n < count) {
@@ -290,7 +290,7 @@ public:
     }
 
     std::optional<size_t>
-    poll_nonblocking_if_not_within_completions(size_t count = size_t(-1))
+    poll_nonblocking_if_not_within_completions(size_t const count = size_t(-1))
     {
         if (detail::AsyncIO_per_thread_state().am_within_completions()) {
             return std::nullopt;
@@ -320,8 +320,8 @@ public:
     }
 
     size_t submit_read_request(
-        std::span<std::byte> buffer, chunk_offset_t offset,
-        erased_connected_operation *uring_data)
+        std::span<std::byte> const buffer, chunk_offset_t const offset,
+        erased_connected_operation *const uring_data)
     {
         if (capture_io_latencies_) {
             uring_data->initiated = std::chrono::steady_clock::now();
@@ -342,8 +342,9 @@ public:
     }
 
     size_t submit_read_request(
-        std::span<const struct iovec> buffers, chunk_offset_t offset,
-        erased_connected_operation *uring_data)
+        std::span<const struct iovec> const buffers,
+        chunk_offset_t const offset,
+        erased_connected_operation *const uring_data)
 
     {
         if (capture_io_latencies_) {
@@ -364,8 +365,8 @@ public:
     }
 
     void submit_write_request(
-        std::span<std::byte const> buffer, chunk_offset_t offset,
-        erased_connected_operation *uring_data)
+        std::span<std::byte const> const buffer, chunk_offset_t const offset,
+        erased_connected_operation *const uring_data)
     {
         if (capture_io_latencies_) {
             uring_data->initiated = std::chrono::steady_clock::now();
@@ -415,7 +416,7 @@ public:
 
     struct io_connected_operation_unique_ptr_deleter
     {
-        void operator()(erased_connected_operation *p) const
+        void operator()(erased_connected_operation *const p) const
         {
             auto *io = p->executor();
             p->~erased_connected_operation();
@@ -440,7 +441,7 @@ public:
             std::declval<Receiver>())),
         io_connected_operation_unique_ptr_deleter>;
 
-    void do_free_read_buffer(std::byte *b) noexcept
+    void do_free_read_buffer(std::byte *const b) noexcept
     {
 #ifndef NDEBUG
         memset((void *)b, 0xff, READ_BUFFER_SIZE);
@@ -448,7 +449,7 @@ public:
         rd_pool_.release((unsigned char *)b);
     }
 
-    void do_free_write_buffer(std::byte *b) noexcept
+    void do_free_write_buffer(std::byte *const b) noexcept
     {
 #ifndef NDEBUG
         static_assert(WRITE_BUFFER_SIZE >= CPU_PAGE_SIZE);
@@ -460,7 +461,7 @@ public:
     using read_buffer_ptr = detail::read_buffer_ptr;
     using write_buffer_ptr = detail::write_buffer_ptr;
 
-    read_buffer_ptr get_read_buffer(size_t bytes)
+    read_buffer_ptr get_read_buffer(size_t const bytes)
     {
         MONAD_ASSERT(bytes <= READ_BUFFER_SIZE);
         unsigned char *mem = rd_pool_.alloc();
@@ -651,12 +652,12 @@ static_assert(alignof(AsyncIO) == 8);
 
 namespace detail
 {
-    inline void read_buffer_deleter::operator()(std::byte *b)
+    inline void read_buffer_deleter::operator()(std::byte *const b)
     {
         parent_->do_free_read_buffer(b);
     }
 
-    inline void write_buffer_deleter::operator()(std::byte *b)
+    inline void write_buffer_deleter::operator()(std::byte *const b)
     {
         parent_->do_free_write_buffer(b);
     }

--- a/category/async/io_senders.hpp
+++ b/category/async/io_senders.hpp
@@ -45,14 +45,14 @@ private:
 
 public:
     constexpr read_single_buffer_sender(
-        chunk_offset_t offset, size_t bytes_to_read)
+        chunk_offset_t const offset, size_t const bytes_to_read)
         : offset_(offset)
         , buffer_(bytes_to_read)
     {
     }
 
     constexpr read_single_buffer_sender(
-        chunk_offset_t offset, buffer_type buffer)
+        chunk_offset_t const offset, buffer_type buffer)
         : offset_(offset)
         , buffer_(std::move(buffer))
     {
@@ -73,19 +73,19 @@ public:
         return std::move(buffer_);
     }
 
-    void reset(chunk_offset_t offset, size_t bytes_to_read)
+    void reset(chunk_offset_t const offset, size_t const bytes_to_read)
     {
         offset_ = offset;
         buffer_ = buffer_type(bytes_to_read);
     }
 
-    void reset(chunk_offset_t offset, buffer_type buffer)
+    void reset(chunk_offset_t const offset, buffer_type buffer)
     {
         offset_ = offset;
         buffer_ = std::move(buffer);
     }
 
-    result<void> operator()(erased_connected_operation *io_state)
+    result<void> operator()(erased_connected_operation *const io_state)
     {
         if (!buffer_) {
             buffer_.set_read_buffer(
@@ -161,7 +161,7 @@ private:
 
 public:
     constexpr read_multiple_buffer_sender(
-        chunk_offset_t offset, buffers_type buffers)
+        chunk_offset_t const offset, buffers_type const buffers)
         : offset_(offset)
         , buffers_(buffers)
     {
@@ -177,13 +177,13 @@ public:
         return buffers_;
     }
 
-    void reset(chunk_offset_t offset, buffers_type buffers)
+    void reset(chunk_offset_t const offset, buffers_type const buffers)
     {
         offset_ = offset;
         buffers_ = buffers;
     }
 
-    result<void> operator()(erased_connected_operation *io_state) noexcept
+    result<void> operator()(erased_connected_operation *const io_state) noexcept
     {
         try {
             std::span<const struct iovec> iovecs;
@@ -305,7 +305,7 @@ private:
 
 public:
     constexpr write_single_buffer_sender(
-        chunk_offset_t offset, size_t bytes_to_write)
+        chunk_offset_t const offset, size_t const bytes_to_write)
         : offset_(offset)
         , buffer_(bytes_to_write)
         , append_(const_cast<std::byte *>(buffer_.data()))
@@ -313,7 +313,7 @@ public:
     }
 
     constexpr write_single_buffer_sender(
-        chunk_offset_t offset, buffer_type buffer)
+        chunk_offset_t const offset, buffer_type buffer)
         : offset_(offset)
         , buffer_(std::move(buffer))
         , append_(const_cast<std::byte *>(buffer_.data()))
@@ -335,21 +335,21 @@ public:
         return std::move(buffer_);
     }
 
-    void reset(chunk_offset_t offset, size_t bytes_to_write)
+    void reset(chunk_offset_t const offset, size_t const bytes_to_write)
     {
         offset_ = offset;
         buffer_ = buffer_type(bytes_to_write);
         append_ = const_cast<std::byte *>(buffer_.data());
     }
 
-    void reset(chunk_offset_t offset, buffer_type buffer)
+    void reset(chunk_offset_t const offset, buffer_type buffer)
     {
         offset_ = offset;
         buffer_ = std::move(buffer);
         append_ = const_cast<std::byte *>(buffer_.data());
     }
 
-    result<void> operator()(erased_connected_operation *io_state) noexcept
+    result<void> operator()(erased_connected_operation *const io_state) noexcept
     {
         MONAD_ASSERT(!!buffer_);
         buffer_.set_bytes_transferred(size_t(append_ - buffer_.data()));
@@ -390,7 +390,7 @@ public:
         return static_cast<size_t>(end - append_);
     }
 
-    constexpr std::byte *advance_buffer_append(size_t bytes) noexcept
+    constexpr std::byte *advance_buffer_append(size_t const bytes) noexcept
     {
         if (bytes > remaining_buffer_bytes()) {
             return nullptr;

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -353,6 +353,12 @@ inline nested_sender_errc_with_payload_code make_status_code(
 
 // ADL discovered customisation point, opts into being able to directly use the
 // enum when comparing to status codes.
+//
+// NOLINTNEXTLINE(misc-auto-const-correctness): const on `c` makes `return c;`
+// pick boost::outcome's status_code(T&&) constructor instead of the
+// quick_status_code_from_enum one (the latter is specialized on cv-unqualified
+// `sender_errc`), causing infinite constexpr recursion through ADL back into
+// this function.
 inline constexpr BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::
     quick_status_code_from_enum_code<sender_errc>
     make_status_code(sender_errc c)

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -147,8 +147,8 @@ storage_pool::chunk_t::~chunk_t()
     }
 }
 
-std::pair<int, file_offset_t>
-storage_pool::chunk_t::write_fd(size_t bytes_which_shall_be_written) noexcept
+std::pair<int, file_offset_t> storage_pool::chunk_t::write_fd(
+    size_t const bytes_which_shall_be_written) noexcept
 {
     if (device().is_file() || device().is_block_device()) {
         if (!append_only_) {
@@ -333,9 +333,10 @@ bool storage_pool::chunk_t::try_trim_contents(uint32_t bytes)
 /***************************************************************************/
 
 storage_pool::device_t storage_pool::make_device_(
-    mode op, device_t::type_t_ type, std::filesystem::path const &path, int fd,
+    mode const op, device_t::type_t_ const type,
+    std::filesystem::path const &path, int const fd,
     std::variant<uint64_t, device_t const *> dev_no_or_dev,
-    creation_flags flags)
+    creation_flags const flags)
 {
     int readwritefd = fd;
     uint64_t const chunk_capacity = 1ULL << flags.chunk_capacity;
@@ -653,7 +654,8 @@ void storage_pool::fill_chunks_(creation_flags const &flags)
     }
 }
 
-storage_pool::storage_pool(storage_pool const *src, clone_as_read_only_tag_)
+storage_pool::storage_pool(
+    storage_pool const *const src, clone_as_read_only_tag_)
     : is_read_only_(true)
     , is_read_only_allow_dirty_(false)
     , is_newly_truncated_(false)
@@ -706,8 +708,8 @@ storage_pool::storage_pool(storage_pool const *src, clone_as_read_only_tag_)
 }
 
 storage_pool::storage_pool(
-    std::span<std::filesystem::path const> sources, mode mode,
-    creation_flags flags)
+    std::span<std::filesystem::path const> const sources, mode const mode,
+    creation_flags const flags)
     : is_read_only_(flags.open_read_only || flags.open_read_only_allow_dirty)
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
     , is_newly_truncated_(mode == mode::truncate)
@@ -759,7 +761,7 @@ storage_pool::storage_pool(
     fill_chunks_(flags);
 }
 
-storage_pool::storage_pool(use_anonymous_inode_tag, creation_flags flags)
+storage_pool::storage_pool(use_anonymous_inode_tag, creation_flags const flags)
     : storage_pool::storage_pool(
           use_anonymous_sized_inode_tag{},
           1ULL * 1024 * 1024 * 1024 * 1024 + 24576, flags)
@@ -767,7 +769,7 @@ storage_pool::storage_pool(use_anonymous_inode_tag, creation_flags flags)
 }
 
 storage_pool::storage_pool(
-    use_anonymous_sized_inode_tag, off_t len, creation_flags flags)
+    use_anonymous_sized_inode_tag, off_t const len, creation_flags const flags)
     : is_read_only_(flags.open_read_only || flags.open_read_only_allow_dirty)
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
     , is_newly_truncated_(false)
@@ -823,7 +825,8 @@ storage_pool::~storage_pool()
     devices_.clear();
 }
 
-storage_pool::chunk_t &storage_pool::chunk(chunk_type which, uint32_t id)
+storage_pool::chunk_t &
+storage_pool::chunk(chunk_type const which, uint32_t const id)
 {
     std::unique_lock const g(lock_);
     if (id >= chunks_[which].size()) {

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -119,8 +119,8 @@ public:
             }
 
             // Only used for seq chunks
-            std::span<std::atomic<uint32_t>>
-            chunk_bytes_used(file_offset_t end_of_this_offset) const noexcept
+            std::span<std::atomic<uint32_t>> chunk_bytes_used(
+                file_offset_t const end_of_this_offset) const noexcept
             {
                 static_assert(
                     sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));
@@ -135,7 +135,8 @@ public:
             }
 
             // Bytes used by the pool metadata on this device
-            size_t total_size(file_offset_t end_of_this_offset) const noexcept
+            size_t
+            total_size(file_offset_t const end_of_this_offset) const noexcept
             {
                 auto const count = chunks(end_of_this_offset);
                 return sizeof(metadata_t) + count * sizeof(uint32_t);
@@ -145,8 +146,9 @@ public:
         static_assert(sizeof(metadata_t) == 64);
 
         constexpr device_t(
-            int readwritefd, type_t_ type, uint64_t unique_hash,
-            file_offset_t size_of_file, metadata_t *metadata)
+            int const readwritefd, type_t_ const type,
+            uint64_t const unique_hash, file_offset_t const size_of_file,
+            metadata_t *const metadata)
             : readwritefd_(readwritefd)
             , type_(type)
             , unique_hash_(unique_hash)
@@ -206,10 +208,11 @@ public:
 
     public:
         constexpr chunk_t(
-            device_t &device, int read_fd, int write_fd, file_offset_t offset,
-            file_offset_t capacity, uint32_t chunkid_within_device,
-            uint32_t chunkid_within_zone, bool owns_readfd, bool owns_writefd,
-            bool append_only)
+            device_t &device, int const read_fd, int const write_fd,
+            file_offset_t const offset, file_offset_t const capacity,
+            uint32_t const chunkid_within_device,
+            uint32_t const chunkid_within_zone, bool const owns_readfd,
+            bool const owns_writefd, bool const append_only)
             : device_(device)
             , read_fd_(read_fd)
             , write_fd_(write_fd)
@@ -406,7 +409,7 @@ public:
     }
 
     //! \brief Returns the number of chunks for the specified type
-    size_t chunks(chunk_type which) const noexcept
+    size_t chunks(chunk_type const which) const noexcept
     {
         return chunks_[which].size();
     }

--- a/category/async/test/benchmark_io_test.cpp
+++ b/category/async/test/benchmark_io_test.cpp
@@ -176,7 +176,7 @@ struct shared_state_t
         return ret;
     }
 
-    MONAD_ASYNC_NAMESPACE::chunk_offset_t add_op(uint64_t elapsed_ns)
+    MONAD_ASYNC_NAMESPACE::chunk_offset_t add_op(uint64_t const elapsed_ns)
     {
         ops++;
         if (elapsed_ns < min_ns) {
@@ -204,7 +204,7 @@ struct receiver_t
 
     shared_state_t *shared;
 
-    explicit receiver_t(shared_state_t *shared_)
+    explicit receiver_t(shared_state_t *const shared_)
         : shared(shared_)
     {
     }
@@ -221,8 +221,8 @@ using connected_state_ptr_type =
         MONAD_ASYNC_NAMESPACE::read_single_buffer_sender, receiver_t>;
 
 inline void receiver_t::set_value(
-    MONAD_ASYNC_NAMESPACE::erased_connected_operation *rawstate,
-    MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type buffer)
+    MONAD_ASYNC_NAMESPACE::erased_connected_operation *const rawstate,
+    MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type const buffer)
 {
     if (!buffer) {
         std::cerr << "FATAL: " << buffer.assume_error().message().c_str()
@@ -245,7 +245,7 @@ inline void receiver_t::set_value(
     }
 }
 
-int main(int argc, char *argv[])
+int main(int const argc, char *argv[])
 {
     try {
         CLI::App cli(

--- a/category/async/test/io.cpp
+++ b/category/async/test/io.cpp
@@ -51,7 +51,7 @@ namespace
 
         void set_value(
             monad::async::erased_connected_operation *,
-            monad::async::read_single_buffer_sender::result_type r)
+            monad::async::read_single_buffer_sender::result_type const r)
         {
             MONAD_ASSERT(r);
             // Exactly the same test as the death test, except for this line
@@ -107,7 +107,7 @@ namespace
         {
             void set_value(
                 monad::async::erased_connected_operation *,
-                monad::async::write_single_buffer_sender::result_type r)
+                monad::async::write_single_buffer_sender::result_type const r)
             {
                 MONAD_ASSERT(r);
             }
@@ -165,8 +165,8 @@ namespace
             sqe_exhaustion_does_not_reorder_writes_receiver>;
 
     inline void sqe_exhaustion_does_not_reorder_writes_receiver::set_value(
-        monad::async::erased_connected_operation *io_state,
-        monad::async::write_single_buffer_sender::result_type r)
+        monad::async::erased_connected_operation *const io_state,
+        monad::async::write_single_buffer_sender::result_type const r)
     {
         MONAD_ASSERT(r);
         auto *state = static_cast<
@@ -256,7 +256,7 @@ namespace
 
         void set_value(
             monad::async::erased_connected_operation *,
-            monad::async::read_single_buffer_sender::result_type r)
+            monad::async::read_single_buffer_sender::result_type const r)
         {
             MONAD_ASSERT(r);
             EXPECT_EQ(r.assume_value().get().size(), expected_size);

--- a/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_read_buffer_exhaustion_causes_death.cpp
@@ -62,7 +62,7 @@ namespace
 
             void set_value(
                 monad::async::erased_connected_operation *,
-                monad::async::read_single_buffer_sender::result_type r)
+                monad::async::read_single_buffer_sender::result_type const r)
             {
                 MONAD_ASSERT(r);
                 // Exactly the same test as the death test, except for this line

--- a/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
+++ b/category/async/test/io_death_write_buffer_exhaustion_causes_death.cpp
@@ -58,7 +58,7 @@ namespace
         {
             void set_value(
                 monad::async::erased_connected_operation *,
-                monad::async::write_single_buffer_sender::result_type r)
+                monad::async::write_single_buffer_sender::result_type const r)
             {
                 MONAD_ASSERT(r);
             }

--- a/category/async/test/sender_receiver.cpp
+++ b/category/async/test/sender_receiver.cpp
@@ -134,9 +134,9 @@ public:
     }
 
     virtual bool reinitiate(
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *i,
-        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::buffer_type buffer)
-        override final
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const i,
+        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::buffer_type const
+            buffer) override final
     {
         using namespace MONAD_ASYNC_NAMESPACE;
         auto *state = static_cast<typename io_state_type_::pointer>(i);
@@ -159,12 +159,12 @@ public:
     }
 
     MONAD_ASYNC_NAMESPACE::read_single_buffer_sender &
-    sender(size_t idx) noexcept
+    sender(size_t const idx) noexcept
     {
         return states_[idx]->sender();
     }
 
-    Receiver &receiver(size_t idx) noexcept
+    Receiver &receiver(size_t const idx) noexcept
     {
         return states_[idx]->receiver();
     }
@@ -285,14 +285,15 @@ struct completion_handler_io_receiver
     read_single_buffer_operation_states_base_ *state;
 
     explicit completion_handler_io_receiver(
-        read_single_buffer_operation_states_base_ *s)
+        read_single_buffer_operation_states_base_ *const s)
         : state(s)
     {
     }
 
     void set_value(
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *rawstate,
-        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type buffer)
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const rawstate,
+        MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type const
+            buffer)
     {
         ASSERT_TRUE(buffer);
         state->reinitiate(rawstate, std::move(buffer.assume_value().get()));
@@ -345,7 +346,7 @@ struct cpp_suspend_resume_io_receiver
     }
 
     void set_value(
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *rawstate,
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const rawstate,
         MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type buffer)
     {
         MONAD_ASSERT(!res.has_value());
@@ -366,7 +367,7 @@ struct cpp_suspend_resume_io_receiver
         return res.has_value();
     }
 
-    void await_suspend(std::coroutine_handle<> h)
+    void await_suspend(std::coroutine_handle<> const h)
     {
         MONAD_ASSERT(!res.has_value());
         _h = h;
@@ -445,7 +446,7 @@ struct fiber_suspend_resume_io_receiver
     }
 
     void set_value(
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *rawstate,
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const rawstate,
         MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type buffer)
     {
         promise.set_value({rawstate, std::move(buffer)});
@@ -711,7 +712,7 @@ TEST_F(AsyncIO, immediate_completion_decays_to_bytes_transferred)
                 payload_to_immediately_complete);
         }
 
-        void reset(size_t v)
+        void reset(size_t const v)
         {
             payload_to_immediately_complete = v;
         }
@@ -799,7 +800,7 @@ TEST_F(AsyncIO, immediate_completion_decays_to_void)
                 payload_to_immediately_complete);
         }
 
-        void reset(size_t v)
+        void reset(size_t const v)
         {
             payload_to_immediately_complete = v;
         }

--- a/category/core/assert.c
+++ b/category/core/assert.c
@@ -29,7 +29,7 @@ extern void monad_stack_backtrace_capture_and_print(
 
 void monad_assertion_failed(
     char const *const expr, char const *const function, char const *const file,
-    long const line, char const *msg)
+    long const line, char const *const msg)
 {
     // This NEEDS to remain async signal safe!
     char buffer[16384];

--- a/category/core/backtrace.cpp
+++ b/category/core/backtrace.cpp
@@ -53,7 +53,7 @@ namespace detail
         using is_always_equal = std::true_type;
 
         constexpr FixedBufferAllocator(
-            std::span<std::byte> buffer_, std::byte *&p_)
+            std::span<std::byte> const buffer_, std::byte *&p_)
             : buffer(buffer_)
             , p(p_)
         {
@@ -68,7 +68,7 @@ namespace detail
         {
         }
 
-        [[nodiscard]] constexpr value_type *allocate(size_t n)
+        [[nodiscard]] constexpr value_type *allocate(size_t const n)
         {
             auto *newp = p + sizeof(value_type) * n;
             assert(size_t(newp - buffer.data()) <= buffer.size());
@@ -94,15 +94,15 @@ struct stack_backtrace_impl final : public stack_backtrace
     byte_allocator_type main_alloc;
     stacktrace_implementation_type stacktrace;
 
-    explicit stack_backtrace_impl(std::span<std::byte> storage)
+    explicit stack_backtrace_impl(std::span<std::byte> const storage)
         : main_alloc(storage, storage_end)
         , stacktrace(stacktrace_allocator_type{main_alloc})
     {
     }
 
     virtual void print(
-        int fd, unsigned indent,
-        bool print_async_signal_unsafe_info) const noexcept override
+        int const fd, unsigned const indent,
+        bool const print_async_signal_unsafe_info) const noexcept override
     {
         char indent_buffer[64];
         memset(indent_buffer, ' ', 64);
@@ -148,7 +148,7 @@ struct stack_backtrace_impl final : public stack_backtrace
 };
 
 stack_backtrace::ptr
-stack_backtrace::capture(std::span<std::byte> storage) noexcept
+stack_backtrace::capture(std::span<std::byte> const storage) noexcept
 {
     assert(storage.size() > sizeof(stack_backtrace_impl));
     return ptr(new (storage.data()) stack_backtrace_impl(
@@ -156,8 +156,8 @@ stack_backtrace::capture(std::span<std::byte> storage) noexcept
 }
 
 extern "C" void monad_stack_backtrace_capture_and_print(
-    char *buffer, size_t size, int fd, unsigned indent,
-    bool print_async_unsafe_info)
+    char *const buffer, size_t const size, int const fd, unsigned const indent,
+    bool const print_async_unsafe_info)
 {
     stack_backtrace::capture({reinterpret_cast<std::byte *>(buffer), size})
         ->print(fd, indent, print_async_unsafe_info);

--- a/category/core/backtrace.hpp
+++ b/category/core/backtrace.hpp
@@ -32,7 +32,7 @@ protected:
 
     struct deleter_
     {
-        void operator()(stack_backtrace *p)
+        void operator()(stack_backtrace *const p)
         {
             p->~stack_backtrace();
             // no deallocation needed

--- a/category/core/backtrace_test.cpp
+++ b/category/core/backtrace_test.cpp
@@ -34,13 +34,13 @@
 namespace
 {
     __attribute__((noinline)) monad::stack_backtrace::ptr
-    func_b(std::span<std::byte> storage)
+    func_b(std::span<std::byte> const storage)
     {
         return monad::stack_backtrace::capture(storage);
     }
 
     __attribute__((noinline)) monad::stack_backtrace::ptr
-    func_a(std::span<std::byte> storage)
+    func_a(std::span<std::byte> const storage)
     {
         return func_b(storage);
     }
@@ -78,7 +78,7 @@ namespace
         {
             int *fds;
 
-            explicit unfds_t(int *fds_)
+            explicit unfds_t(int *const fds_)
                 : fds(fds_)
             {
             }

--- a/category/core/bytes.hpp
+++ b/category/core/bytes.hpp
@@ -50,7 +50,7 @@ struct bytes32_t : evmc_bytes32
     {
     }
 
-    explicit constexpr bytes32_t(uint64_t v) noexcept
+    explicit constexpr bytes32_t(uint64_t const v) noexcept
         : evmc_bytes32{}
     {
         for (int i = 0; i < 8; ++i) {

--- a/category/core/event/event_iterator_inline.h
+++ b/category/core/event/event_iterator_inline.h
@@ -39,7 +39,7 @@ extern "C"
 #endif
 
 static inline uint64_t
-monad_event_iterator_sync_wait(struct monad_event_iterator *iter)
+monad_event_iterator_sync_wait(struct monad_event_iterator *const iter)
 {
     uint64_t const MAX_SYNC_SPIN = 100;
     uint64_t write_last_seqno =
@@ -77,8 +77,8 @@ monad_event_iterator_sync_wait(struct monad_event_iterator *iter)
 }
 
 inline enum monad_event_iter_result monad_event_iterator_try_copy(
-    struct monad_event_iterator const *iter,
-    struct monad_event_descriptor *event)
+    struct monad_event_iterator const *const iter,
+    struct monad_event_descriptor *const event)
 {
     struct monad_event_descriptor const *const ring_event =
         &iter->descriptors[iter->read_last_seqno & iter->desc_capacity_mask];
@@ -102,7 +102,8 @@ inline enum monad_event_iter_result monad_event_iterator_try_copy(
 }
 
 inline enum monad_event_iter_result monad_event_iterator_try_next(
-    struct monad_event_iterator *iter, struct monad_event_descriptor *event)
+    struct monad_event_iterator *const iter,
+    struct monad_event_descriptor *const event)
 {
     enum monad_event_iter_result const r =
         monad_event_iterator_try_copy(iter, event);
@@ -113,12 +114,13 @@ inline enum monad_event_iter_result monad_event_iterator_try_next(
 }
 
 inline void monad_event_iterator_set_seqno(
-    struct monad_event_iterator *iter, uint64_t seqno)
+    struct monad_event_iterator *const iter, uint64_t const seqno)
 {
     iter->read_last_seqno = seqno - 1;
 }
 
-inline uint64_t monad_event_iterator_reset(struct monad_event_iterator *iter)
+inline uint64_t
+monad_event_iterator_reset(struct monad_event_iterator *const iter)
 {
     uint64_t const last_available_seqno = monad_event_iterator_sync_wait(iter);
     return iter->read_last_seqno =

--- a/category/core/event/event_recorder_inline.h
+++ b/category/core/event/event_recorder_inline.h
@@ -70,8 +70,8 @@ inline uint64_t monad_event_get_epoch_nanos()
 // the user is finished copying the payload, at atomic store of `seqno` into
 // the descriptor will finish the recording process.
 static inline struct monad_event_descriptor *monad_event_recorder_reserve(
-    struct monad_event_recorder *recorder, size_t payload_size, uint64_t *seqno,
-    uint8_t **payload)
+    struct monad_event_recorder *const recorder, size_t const payload_size,
+    uint64_t *const seqno, uint8_t **const payload)
 {
     struct monad_event_descriptor *event;
     uint64_t buffer_window_start;
@@ -137,7 +137,7 @@ static inline struct monad_event_descriptor *monad_event_recorder_reserve(
 }
 
 inline void monad_event_recorder_commit(
-    struct monad_event_descriptor *event, uint64_t seqno)
+    struct monad_event_descriptor *const event, uint64_t const seqno)
 {
     __atomic_store_n(&event->seqno, seqno, __ATOMIC_RELEASE);
 }

--- a/category/core/event/event_recorder_test.cpp
+++ b/category/core/event/event_recorder_test.cpp
@@ -58,8 +58,9 @@ constexpr uint8_t DEFAULT_DESCRIPTORS_SHIFT = 20;
 constexpr uint8_t DEFAULT_PAYLOAD_BUF_SHIFT = 28;
 
 static void open_event_ring_file(
-    char const *input, uint8_t descriptors_shift, uint8_t payload_buf_shift,
-    monad_event_ring *event_ring, std::string *file_path)
+    char const *const input, uint8_t const descriptors_shift,
+    uint8_t const payload_buf_shift, monad_event_ring *const event_ring,
+    std::string *const file_path)
 {
     int ring_fd;
     char const *error_name;
@@ -127,7 +128,7 @@ static void open_event_ring_file(
     (void)close(ring_fd);
 }
 
-static bool alloc_cpu(cpu_set_t *avail_cpus, cpu_set_t *out)
+static bool alloc_cpu(cpu_set_t *const avail_cpus, cpu_set_t *const out)
 {
     int const n_cpus = CPU_COUNT(avail_cpus);
     CPU_ZERO(out);
@@ -148,8 +149,9 @@ static bool alloc_cpu(cpu_set_t *avail_cpus, cpu_set_t *out)
 // total number of iterations by the number of writers, so that the test doesn't
 // take too long.
 static void writer_main(
-    monad_event_recorder *recorder, std::latch *latch, uint8_t writer_id,
-    uint8_t writer_thread_count, uint32_t payload_size)
+    monad_event_recorder *const recorder, std::latch *const latch,
+    uint8_t const writer_id, uint8_t const writer_thread_count,
+    uint32_t const payload_size)
 {
     using std::chrono::duration_cast, std::chrono::nanoseconds;
     std::byte local_payload_buf[1 << 14]{};
@@ -192,8 +194,8 @@ static void writer_main(
 // that the sequence numbers are in order, that their payload size is correct,
 // etc.)
 [[maybe_unused]] static void reader_main(
-    monad_event_ring const *event_ring, std::latch *latch,
-    uint8_t writer_thread_count, uint32_t expected_len)
+    monad_event_ring const *const event_ring, std::latch *const latch,
+    uint8_t const writer_thread_count, uint32_t const expected_len)
 {
     uint64_t const max_writer_iteration =
         (1UL << PERF_ITER_SHIFT) / writer_thread_count;

--- a/category/core/event/event_ring.c
+++ b/category/core/event/event_ring.c
@@ -42,8 +42,9 @@ static size_t const PAGE_2MB = 1UL << 21, HEADER_SIZE = PAGE_2MB;
         __VA_ARGS__)
 
 int monad_event_ring_init_size(
-    uint8_t descriptors_shift, uint8_t payload_buf_shift,
-    uint16_t context_large_pages, struct monad_event_ring_size *size)
+    uint8_t const descriptors_shift, uint8_t const payload_buf_shift,
+    uint16_t const context_large_pages,
+    struct monad_event_ring_size *const size)
 {
     // Do some basic input validation of the size; our main goal here is to
     // protect the event ring from being too small as it can create certain
@@ -81,8 +82,8 @@ int monad_event_ring_init_size(
     return 0;
 }
 
-size_t
-monad_event_ring_calc_storage(struct monad_event_ring_size const *ring_size)
+size_t monad_event_ring_calc_storage(
+    struct monad_event_ring_size const *const ring_size)
 {
     return PAGE_2MB +
            ring_size->descriptor_capacity *
@@ -103,9 +104,10 @@ monad_event_ring_calc_storage(struct monad_event_ring_size const *ring_size)
 //  |   Context area   |
 //  .------------------.
 int monad_event_ring_init_file(
-    struct monad_event_ring_size const *ring_size,
-    enum monad_event_content_type content_type, uint8_t const *schema_hash,
-    int ring_fd, off_t ring_offset, char const *error_name)
+    struct monad_event_ring_size const *const ring_size,
+    enum monad_event_content_type const content_type,
+    uint8_t const *const schema_hash, int const ring_fd,
+    off_t const ring_offset, char const *error_name)
 {
     size_t ring_bytes;
     void *map_base;
@@ -208,8 +210,9 @@ int monad_event_ring_init_file(
 }
 
 int monad_event_ring_mmap(
-    struct monad_event_ring *event_ring, int mmap_prot, int mmap_extra_flags,
-    int ring_fd, off_t ring_offset, char const *error_name)
+    struct monad_event_ring *const event_ring, int const mmap_prot,
+    int const mmap_extra_flags, int const ring_fd, off_t const ring_offset,
+    char const *error_name)
 {
     int rc;
     char namebuf[64];
@@ -351,7 +354,7 @@ Error:
     return rc;
 }
 
-void monad_event_ring_unmap(struct monad_event_ring *event_ring)
+void monad_event_ring_unmap(struct monad_event_ring *const event_ring)
 {
     struct monad_event_ring_header const *const header = event_ring->header;
     if (header != nullptr) {
@@ -373,8 +376,8 @@ void monad_event_ring_unmap(struct monad_event_ring *event_ring)
 }
 
 int monad_event_ring_init_iterator(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_iterator *iter)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_iterator *const iter)
 {
     memset(iter, 0, sizeof *iter);
     struct monad_event_ring_header const *header = event_ring->header;
@@ -392,8 +395,8 @@ int monad_event_ring_init_iterator(
 }
 
 int monad_event_ring_init_recorder(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_recorder *recorder)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_recorder *const recorder)
 {
     memset(recorder, 0, sizeof *recorder);
     struct monad_event_ring_header *header = event_ring->header;

--- a/category/core/event/event_ring.h
+++ b/category/core/event/event_ring.h
@@ -246,8 +246,8 @@ enum monad_event_record_error_type : uint16_t
  */
 
 inline bool monad_event_ring_try_copy(
-    struct monad_event_ring const *event_ring, uint64_t seqno,
-    struct monad_event_descriptor *event)
+    struct monad_event_ring const *const event_ring, uint64_t const seqno,
+    struct monad_event_descriptor *const event)
 {
     if (MONAD_UNLIKELY(seqno == 0)) {
         return false;
@@ -264,16 +264,16 @@ inline bool monad_event_ring_try_copy(
 }
 
 inline void const *monad_event_ring_payload_peek(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_descriptor const *event)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_descriptor const *const event)
 {
     return event_ring->payload_buf +
            (event->payload_buf_offset & event_ring->payload_buf_mask);
 }
 
 inline bool monad_event_ring_payload_check(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_descriptor const *event)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_descriptor const *const event)
 {
     return event->payload_buf_offset >=
            __atomic_load_n(
@@ -282,8 +282,9 @@ inline bool monad_event_ring_payload_check(
 }
 
 inline void *monad_event_ring_payload_memcpy(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_descriptor const *event, void *dst, size_t n)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_descriptor const *const event, void *const dst,
+    size_t const n)
 {
     if (MONAD_UNLIKELY(!monad_event_ring_payload_check(event_ring, event))) {
         return nullptr;

--- a/category/core/event/event_ring_util.c
+++ b/category/core/event/event_ring_util.c
@@ -66,8 +66,9 @@ static void cleanup_dstream(ZSTD_DStream *const *const ptr)
 }
 
 static int decompress_snapshot(
-    void const *input_base, size_t input_size, int decompfd, size_t max_size,
-    char const *error_name, bool *is_snapshot)
+    void const *const input_base, size_t const input_size, int const decompfd,
+    size_t const max_size, char const *const error_name,
+    bool *const is_snapshot)
 {
     // NOLINTBEGIN(clang-analyzer-unix.Malloc)
     ZSTD_DStream *zds [[gnu::cleanup(cleanup_dstream)]] = nullptr;
@@ -169,8 +170,8 @@ struct decompress_output
 };
 
 static int decompress_snap_buf_to_temp_file(
-    void const *buf, size_t buf_size, size_t max_size, char const *error_name,
-    struct decompress_output *out)
+    void const *const buf, size_t const buf_size, size_t const max_size,
+    char const *error_name, struct decompress_output *const out)
 {
     int rc;
     char error_name_buf[64];
@@ -209,8 +210,8 @@ Done:
 }
 
 static int decompress_snap_fd_to_temp_file(
-    int fd_in, size_t max_size, char const *error_name,
-    struct decompress_output *out)
+    int const fd_in, size_t const max_size, char const *error_name,
+    struct decompress_output *const out)
 {
     int rc;
     struct stat file_stat;
@@ -248,8 +249,8 @@ static int decompress_snap_fd_to_temp_file(
 }
 
 int monad_event_ring_init_simple(
-    struct monad_event_ring_simple_config const *ring_config, int ring_fd,
-    off_t ring_offset, char const *error_name)
+    struct monad_event_ring_simple_config const *const ring_config,
+    int const ring_fd, off_t const ring_offset, char const *const error_name)
 {
     struct monad_event_ring_size ring_size;
     int rc = monad_event_ring_init_size(
@@ -279,8 +280,9 @@ int monad_event_ring_init_simple(
 }
 
 int monad_event_ring_check_content_type(
-    struct monad_event_ring const *event_ring,
-    enum monad_event_content_type content_type, uint8_t const *schema_hash)
+    struct monad_event_ring const *const event_ring,
+    enum monad_event_content_type const content_type,
+    uint8_t const *const schema_hash)
 {
     if (event_ring == nullptr || event_ring->header == nullptr) {
         return FORMAT_ERRC(EFAULT, "event ring is not mapped");
@@ -301,7 +303,7 @@ int monad_event_ring_check_content_type(
     return 0;
 }
 
-int monad_event_ring_query_excl_writer_pid(int ring_fd, pid_t *pid)
+int monad_event_ring_query_excl_writer_pid(int const ring_fd, pid_t *const pid)
 {
     int rc;
     struct monad_event_flock_info fl_info;
@@ -331,7 +333,7 @@ int monad_event_open_hugetlbfs_dir_fd(int *, char *, size_t)
 #else
 
 int monad_event_open_hugetlbfs_dir_fd(
-    int *dirfd, char *pathbuf, size_t pathbuf_size)
+    int *const dirfd, char *const pathbuf, size_t const pathbuf_size)
 {
     struct monad_hugetlbfs_resolve_params const params = {
         .page_size = 1UL << 21,
@@ -353,7 +355,7 @@ int monad_event_open_hugetlbfs_dir_fd(
 #endif
 
 int monad_event_resolve_ring_file(
-    char const *default_path, char const *file, char *pathbuf,
+    char const *const default_path, char const *const file, char *const pathbuf,
     size_t pathbuf_size)
 {
     int rc;
@@ -415,7 +417,7 @@ int monad_event_resolve_ring_file(
 }
 
 int monad_event_is_snapshot_file(
-    int fd, char const *error_name, bool *is_snapshot)
+    int const fd, char const *const error_name, bool *const is_snapshot)
 {
     struct decompress_output out;
     if (is_snapshot == nullptr) {
@@ -442,7 +444,8 @@ int monad_event_is_snapshot_file(
 }
 
 int monad_event_decompress_snapshot_fd(
-    int fd_in, size_t max_size, char const *error_name, int *fd_out)
+    int const fd_in, size_t const max_size, char const *const error_name,
+    int *const fd_out)
 {
     struct decompress_output out;
     if (fd_out == nullptr) {
@@ -456,8 +459,8 @@ int monad_event_decompress_snapshot_fd(
 }
 
 int monad_event_decompress_snapshot_mem(
-    void const *buf, size_t buf_size, size_t max_size, char const *error_name,
-    int *fd_out)
+    void const *const buf, size_t const buf_size, size_t const max_size,
+    char const *const error_name, int *const fd_out)
 {
     struct decompress_output out;
     if (fd_out == nullptr) {

--- a/category/core/event/event_ring_util_linux.c
+++ b/category/core/event/event_ring_util_linux.c
@@ -43,7 +43,8 @@ extern thread_local char _g_monad_event_ring_error_buf[1024];
 
 // Given a path which may not exist, walk backward until we find a parent path
 // that does exist; the caller must free(3) parent_path
-static int find_existing_parent_path(char const *path, char **parent_path)
+static int
+find_existing_parent_path(char const *const path, char **const parent_path)
 {
     struct stat path_stat;
 
@@ -83,8 +84,8 @@ StatAgain:
 }
 
 static bool check_flock_entry(
-    char *lock_line, ino_t const ring_ino,
-    struct monad_event_flock_info *fl_info)
+    char *const lock_line, ino_t const ring_ino,
+    struct monad_event_flock_info *const fl_info)
 {
     char *saveptr;
     ino_t lock_ino = 0;
@@ -139,7 +140,8 @@ static bool check_flock_entry(
 }
 
 int monad_event_ring_query_flocks(
-    int ring_fd, struct monad_event_flock_info *flocks, size_t *size)
+    int const ring_fd, struct monad_event_flock_info *const flocks,
+    size_t *const size)
 {
     struct stat ring_stat;
     struct monad_event_flock_info fl_info_buf;
@@ -166,7 +168,8 @@ int monad_event_ring_query_flocks(
     return 0; // NOLINT(clang-analyzer-unix.Stream)
 }
 
-int monad_check_path_supports_map_hugetlb(char const *path, bool *supported)
+int monad_check_path_supports_map_hugetlb(
+    char const *const path, bool *const supported)
 {
     char *parent_path;
     struct statfs fs_stat;

--- a/category/core/format_err.c
+++ b/category/core/format_err.c
@@ -21,15 +21,16 @@
 #include <category/core/format_err.h>
 #include <category/core/srcloc.h>
 
-static char const *final_path_component(char const *path)
+static char const *final_path_component(char const *const path)
 {
     char const *last = strrchr(path, '/');
     return last == nullptr ? path : last + 1;
 }
 
 extern int monad_vformat_err(
-    char *err_buf, size_t err_buf_size, struct monad_source_location const *src,
-    int err, char const *format, va_list ap)
+    char *const err_buf, size_t const err_buf_size,
+    struct monad_source_location const *const src, int const err,
+    char const *const format, va_list ap)
 {
     size_t len;
     int rc = 0;

--- a/category/core/format_err.h
+++ b/category/core/format_err.h
@@ -84,8 +84,9 @@ int monad_vformat_err(
     int err, char const *format, va_list ap);
 
 __attribute__((format(printf, 5, 6))) static inline int monad_format_err(
-    char *err_buf, size_t err_buf_size, monad_source_location_t const *src,
-    int err, char const *format, ...)
+    char *const err_buf, size_t const err_buf_size,
+    monad_source_location_t const *const src, int const err,
+    char const *const format, ...)
 {
     va_list ap;
     int rc;

--- a/category/core/hex.cpp
+++ b/category/core/hex.cpp
@@ -71,7 +71,7 @@ std::string to_hex(byte_string_view const bytes)
 
 namespace literals
 {
-    byte_string operator""_bytes(char const *s)
+    byte_string operator""_bytes(char const *const s)
     {
         return from_hex(s).value();
     }

--- a/category/core/io/buffers.cpp
+++ b/category/core/io/buffers.cpp
@@ -34,7 +34,7 @@
 MONAD_IO_NAMESPACE_BEGIN
 
 Buffers::Buffers(
-    Ring &ring, Ring *wr_ring, size_t const read_count,
+    Ring &ring, Ring *const wr_ring, size_t const read_count,
     size_t const write_count, size_t const read_size, size_t const write_size)
     : ring_{ring}
     , wr_ring_(wr_ring)

--- a/category/core/io/buffers.hpp
+++ b/category/core/io/buffers.hpp
@@ -127,23 +127,23 @@ public:
     }
 };
 
-[[gnu::always_inline]] inline Buffers
-make_buffers_for_read_only(Ring &ring, size_t read_count, size_t read_size)
+[[gnu::always_inline]] inline Buffers make_buffers_for_read_only(
+    Ring &ring, size_t const read_count, size_t const read_size)
 {
     return Buffers(ring, nullptr, read_count, 0, read_size, 0);
 }
 
 [[gnu::always_inline]] inline Buffers make_buffers_for_mixed_read_write(
-    Ring &ring, size_t read_count, size_t write_count, size_t read_size,
-    size_t write_size)
+    Ring &ring, size_t const read_count, size_t const write_count,
+    size_t const read_size, size_t const write_size)
 {
     return Buffers(
         ring, nullptr, read_count, write_count, read_size, write_size);
 }
 
 [[gnu::always_inline]] inline Buffers make_buffers_for_segregated_read_write(
-    Ring &ring, Ring &wr_ring, size_t read_count, size_t write_count,
-    size_t read_size, size_t write_size)
+    Ring &ring, Ring &wr_ring, size_t const read_count,
+    size_t const write_count, size_t const read_size, size_t const write_size)
 {
     return Buffers(
         ring, &wr_ring, read_count, write_count, read_size, write_size);

--- a/category/core/log_ffi.cpp
+++ b/category/core/log_ffi.cpp
@@ -50,7 +50,7 @@ enum syslog_level : uint8_t
     Debug = 7,
 };
 
-constexpr uint8_t to_syslog_level(quill::LogLevel l)
+constexpr uint8_t to_syslog_level(quill::LogLevel const l)
 {
     using quill::LogLevel;
 
@@ -76,7 +76,7 @@ constexpr uint8_t to_syslog_level(quill::LogLevel l)
     }
 }
 
-constexpr quill::LogLevel to_quill_log_level(syslog_level l)
+constexpr quill::LogLevel to_quill_log_level(syslog_level const l)
 {
     using quill::LogLevel;
 
@@ -115,7 +115,7 @@ class LogCallbackHandler : public quill::Handler
 public:
     LogCallbackHandler(
         monad_log_write_callback *write_fn, monad_log_flush_callback *flush_fn,
-        uintptr_t user)
+        uintptr_t const user)
         : write_fn_{write_fn}
         , flush_fn_{flush_fn}
         , user_{user}
@@ -148,9 +148,9 @@ private:
 };
 
 int monad_log_handler_create(
-    struct monad_log_handler **handler_p, char const *name,
+    struct monad_log_handler **const handler_p, char const *const name,
     monad_log_write_callback *write_fn, monad_log_flush_callback *flush_fn,
-    uintptr_t user)
+    uintptr_t const user)
 {
     if (name == nullptr || std::strlen(name) == 0) {
         *std::format_to(error_buf, "invalid handler name") = '\0';
@@ -177,7 +177,7 @@ int monad_log_handler_create(
 }
 
 int monad_log_handler_create_stdout_handler(
-    struct monad_log_handler **handler_p)
+    struct monad_log_handler **const handler_p)
 {
     *handler_p = nullptr;
     try {
@@ -202,13 +202,14 @@ int monad_log_handler_create_stdout_handler(
     }
 }
 
-void monad_log_handler_destroy(struct monad_log_handler *handler)
+void monad_log_handler_destroy(struct monad_log_handler *const handler)
 {
     delete handler;
 }
 
 int monad_log_init(
-    struct monad_log_handler **handlers, size_t handler_count, uint8_t level)
+    struct monad_log_handler **const handlers, size_t const handler_count,
+    uint8_t const level)
 {
     using std::chrono::duration_cast, std::chrono::nanoseconds,
         std::chrono::microseconds;

--- a/category/core/log_ffi_test.cpp
+++ b/category/core/log_ffi_test.cpp
@@ -28,7 +28,7 @@
 #include <gtest/gtest.h>
 #include <quill/Quill.h>
 
-static void capture_log(monad_log const *input_log, uintptr_t ptr)
+static void capture_log(monad_log const *const input_log, uintptr_t const ptr)
 {
     // The "logging" function makes a copy of the `monad_log` object, to be
     // tested after the logging completes; we also copy the message's string

--- a/category/core/lru/static_lru_cache.hpp
+++ b/category/core/lru/static_lru_cache.hpp
@@ -128,7 +128,7 @@ public:
     }
 
 protected:
-    void update_lru(ListIter it)
+    void update_lru(ListIter const it)
     {
         active_list_.splice(active_list_.begin(), active_list_, it);
     }

--- a/category/core/mem/allocators.hpp
+++ b/category/core/mem/allocators.hpp
@@ -315,7 +315,7 @@ namespace allocators
         //!
         //! The extra_bytes_ member stores the additional bytes beyond sizeof(T)
         //! needed for trailing data (path, value, child data, etc.)
-        explicit variable_size_allocator(size_t storage_bytes) noexcept
+        explicit variable_size_allocator(size_t const storage_bytes) noexcept
             : extra_bytes_(storage_bytes - sizeof(T))
         {
             MONAD_ASSERT(storage_bytes >= sizeof(T));
@@ -339,7 +339,7 @@ namespace allocators
         //! extra_bytes
         //!   (control block already includes sizeof(object), so this gives
         //!   control block + object trailing data)
-        [[nodiscard]] T *allocate(size_type n)
+        [[nodiscard]] T *allocate(size_type const n)
         {
             MONAD_ASSERT(n == 1);
             size_t const bytes = sizeof(T) + extra_bytes_;
@@ -352,7 +352,7 @@ namespace allocators
         }
 
         //! \brief Deallocate memory
-        void deallocate(T *p, size_type) noexcept
+        void deallocate(T *const p, size_type) noexcept
         {
             if constexpr (alignof(T) > alignof(max_align_t)) {
                 ::operator delete(p, std::align_val_t{alignof(T)});

--- a/category/core/mem/allocators_test.cpp
+++ b/category/core/mem/allocators_test.cpp
@@ -48,7 +48,7 @@ namespace
             constructed++;
         }
 
-        explicit Foo(int a)
+        explicit Foo(int const a)
             : x(a)
         {
             constructed++;
@@ -65,13 +65,13 @@ namespace
         using value_type = Foo;
         using size_type = size_t;
 
-        [[nodiscard]] value_type *allocate(size_type n)
+        [[nodiscard]] value_type *allocate(size_type const n)
         {
             allocated++;
             return std::allocator<value_type>().allocate(n);
         }
 
-        void deallocate(value_type *p, size_type n) noexcept
+        void deallocate(value_type *const p, size_type const n) noexcept
         {
             deallocated++;
             std::allocator<value_type>().deallocate(p, n);
@@ -89,13 +89,13 @@ namespace
         using value_type = std::byte;
         using size_type = size_t;
 
-        [[nodiscard]] value_type *allocate(size_type n)
+        [[nodiscard]] value_type *allocate(size_type const n)
         {
             allocated++;
             return (std::byte *)std::malloc(n);
         }
 
-        void deallocate(value_type *p, size_type) noexcept
+        void deallocate(value_type *const p, size_type) noexcept
         {
             deallocated++;
             free(p);

--- a/category/core/mem/hugetlb_path.c
+++ b/category/core/mem/hugetlb_path.c
@@ -38,7 +38,7 @@ thread_local char g_error_buf[PATH_MAX];
         __VA_ARGS__)
 
 int monad_hugetlbfs_open_dir_fd(
-    struct monad_hugetlbfs_resolve_params const *params, int *dirfd,
+    struct monad_hugetlbfs_resolve_params const *const params, int *const dirfd,
     char *pathbuf, size_t pathbuf_size)
 {
     size_t resolve_size;

--- a/category/core/monad_exception.cpp
+++ b/category/core/monad_exception.cpp
@@ -55,7 +55,7 @@ char const *MonadException::message() const noexcept
     return message_;
 }
 
-void MonadException::print(int fd) const noexcept
+void MonadException::print(int const fd) const noexcept
 {
     if (stack_trace_buffer_) {
         stack_trace_->print(fd, 3, true);

--- a/category/core/path_util.c
+++ b/category/core/path_util.c
@@ -26,14 +26,15 @@
 #include <category/core/path_util.h>
 
 // Silence clang-tidy complaining about trying to close AT_FDCWD
-static void tidy_close(int fd)
+static void tidy_close(int const fd)
 {
     if (fd >= 0) {
         (void)close(fd);
     }
 }
 
-int monad_path_append(char **dst, char const *src, size_t *size)
+int monad_path_append(
+    char **const dst, char const *const src, size_t *const size)
 {
     if (dst == nullptr || src == nullptr || size == nullptr) {
         return EFAULT;
@@ -62,8 +63,8 @@ int monad_path_append(char **dst, char const *src, size_t *size)
 }
 
 int monad_path_open_subdir(
-    int const init_dirfd, char const *path_suffix, mode_t mode,
-    int *final_dirfd, char *pathbuf, size_t pathbuf_size)
+    int const init_dirfd, char const *const path_suffix, mode_t const mode,
+    int *const final_dirfd, char *pathbuf, size_t pathbuf_size)
 {
     char *dir_name;
     char *tokctx;

--- a/category/core/test_util/gtest_signal_stacktrace_printer.hpp
+++ b/category/core/test_util/gtest_signal_stacktrace_printer.hpp
@@ -65,8 +65,9 @@ namespace monad::test
             return v;
         }
 
-        static void
-        signal_handler(int signo, ::siginfo_t *siginfo, void *context) noexcept
+        static void signal_handler(
+            int const signo, ::siginfo_t *const siginfo,
+            void *const context) noexcept
         {
             auto const &signal_handlers =
                 SignalStackTracePrinterEnvironment::signal_handlers();

--- a/category/event/example/eventwatch.c
+++ b/category/event/example/eventwatch.c
@@ -58,7 +58,7 @@ constexpr bool PLATFORM_LINUX = false;
 
 constexpr int PIDFD_SNAPSHOT = -2;
 
-static void usage(FILE *out)
+static void usage(FILE *const out)
 {
     extern char const *__progname;
     fprintf(out, "usage: %s [-h] [<exec-event-ring>]\n", __progname);
@@ -88,7 +88,7 @@ struct option const longopts[] = {
     {}
 };
 
-static int parse_options(int argc, char **argv)
+static int parse_options(int const argc, char ** const argv)
 {
     int ch;
 
@@ -115,7 +115,7 @@ static void handle_signal(int)
     g_should_stop = 1;
 }
 
-static bool process_has_exited(int pidfd)
+static bool process_has_exited(int const pidfd)
 {
     if (pidfd == -1) {
         // pidfd being -1 means "disable the detection feature"
@@ -129,8 +129,8 @@ static bool process_has_exited(int pidfd)
 }
 
 static void hexdump_event_payload(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_descriptor const *event, FILE *out)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_descriptor const *const event, FILE *const out)
 {
     static char hexdump_buf[1 << 25];
     char *o = hexdump_buf;
@@ -169,8 +169,8 @@ static void hexdump_event_payload(
 }
 
 static void print_event(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_descriptor const *event, FILE *out)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_descriptor const *const event, FILE *const out)
 {
     static char time_buf[32];
     static time_t last_second = 0;
@@ -259,8 +259,8 @@ static void print_event(
 
 // The main event processing loop of the application
 static void event_loop(
-    struct monad_event_ring const *event_ring,
-    struct monad_event_iterator *iter, int pidfd, FILE *out)
+    struct monad_event_ring const *const event_ring,
+    struct monad_event_iterator *const iter, int const pidfd, FILE *const out)
 {
     struct monad_event_descriptor event;
     uint64_t not_ready_count = 0;
@@ -297,7 +297,8 @@ static void event_loop(
     }
 }
 
-static void find_initial_iteration_point(struct monad_event_iterator *iter)
+static void
+find_initial_iteration_point(struct monad_event_iterator *const iter)
 {
     // This function is not strictly necessary, but it is probably useful for
     // most use cases. When an iterator is initialized via a call to
@@ -330,7 +331,7 @@ static void find_initial_iteration_point(struct monad_event_iterator *iter)
     (void)monad_exec_iter_consensus_prev(iter, MONAD_EXEC_BLOCK_START, nullptr);
 }
 
-int main(int argc, char **argv)
+int main(int const argc, char **const argv)
 {
     char event_ring_pathbuf[PATH_MAX];
     char const *event_ring_input = MONAD_EVENT_DEFAULT_EXEC_FILE_NAME;

--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -82,7 +82,7 @@ namespace
 
     evmc::Result BlockHistoryFixture::call_blockhash_opcode(
         uint64_t const block_number, uint64_t const current_block_number,
-        Address sender)
+        Address const sender)
     {
         MonadDevnet const chain{};
 

--- a/category/execution/ethereum/core/contract/abi_encode.hpp
+++ b/category/execution/ethereum/core/contract/abi_encode.hpp
@@ -111,12 +111,12 @@ class AbiEncoder
     byte_string tail_;
     std::vector<std::pair<size_t, size_t>> unresolved_offsets_;
 
-    void add_static(bytes32_t data)
+    void add_static(bytes32_t const data)
     {
         head_ += data;
     }
 
-    void add_dynamic(byte_string data)
+    void add_dynamic(byte_string const data)
     {
         unresolved_offsets_.emplace_back(head_.size(), tail_.size());
         head_ += bytes32_t{};

--- a/category/execution/ethereum/core/transaction.cpp
+++ b/category/execution/ethereum/core/transaction.cpp
@@ -41,7 +41,7 @@ MONAD_ANONYMOUS_NAMESPACE_BEGIN
 /// @param encoding      The RLP-encoded payload that was signed.
 ///
 std::optional<Address>
-ecrecover(SignatureAndChain const &sc, byte_string_view encoding)
+ecrecover(SignatureAndChain const &sc, byte_string_view const encoding)
 {
     if (sc.y_parity > 1) {
         return std::nullopt;

--- a/category/execution/ethereum/create_contract_address.hpp
+++ b/category/execution/ethereum/create_contract_address.hpp
@@ -24,7 +24,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
-Address create_contract_address(Address const &from, uint64_t const nonce);
+Address create_contract_address(Address const &from, uint64_t nonce);
 Address create2_contract_address(
     Address const &from, bytes32_t const &zeta,
     ethash::hash256 const &code_hash);

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -48,7 +48,8 @@ class DbCache final : public Db
         StorageKey() = default;
 
         StorageKey(
-            Address const &addr, Incarnation incarnation, bytes32_t const &key)
+            Address const &addr, Incarnation const incarnation,
+            bytes32_t const &key)
         {
             memcpy(bytes, addr.bytes, sizeof(Address));
             memcpy(&bytes[sizeof(Address)], &incarnation, sizeof(Incarnation));

--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -167,7 +167,8 @@ private:
     uint8_t length_{0};
 
 public:
-    void append(unsigned char branch, monad::mpt::NibblesView node_path)
+    void
+    append(unsigned char const branch, monad::mpt::NibblesView const node_path)
     {
         using namespace monad::mpt;
         unsigned const src_nibbles = node_path.nibble_size();
@@ -187,7 +188,7 @@ public:
         length_ = static_cast<uint8_t>(length_ + src_nibbles);
     }
 
-    void pop(uint8_t nibble_count)
+    void pop(uint8_t const nibble_count)
     {
         MONAD_ASSERT(length_ >= nibble_count);
         length_ -= nibble_count;
@@ -222,7 +223,8 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
         uint64_t (*write)(
             uint64_t shard, monad_snapshot_type, unsigned char const *bytes,
             size_t len, void *user),
-        void *user, uint64_t const total_shards, uint64_t const shard_number)
+        void *const user, uint64_t const total_shards,
+        uint64_t const shard_number)
         : nibble{monad::mpt::INVALID_BRANCH}
         , path{}
         , account_bytes_written{account_bytes_written}
@@ -536,7 +538,7 @@ void monad_db_snapshot_loader_load(
     monad_db_snapshot_loader_flush(loader);
 }
 
-void monad_db_snapshot_loader_destroy(monad_db_snapshot_loader *loader)
+void monad_db_snapshot_loader_destroy(monad_db_snapshot_loader *const loader)
 {
     using namespace monad;
     using namespace monad::mpt;

--- a/category/execution/ethereum/db/db_snapshot_filesystem.cpp
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.cpp
@@ -71,7 +71,7 @@ monad_db_snapshot_filesystem_write_user_context_create(
 }
 
 void monad_db_snapshot_filesystem_write_user_context_destroy(
-    monad_db_snapshot_filesystem_write_user_context *context)
+    monad_db_snapshot_filesystem_write_user_context *const context)
 {
     for (auto &[_, stream] : context->shard) {
         for (auto &shard : stream) {

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -92,8 +92,8 @@ namespace
     // DB Getters
     ///////////////////////////////////////////
     std::vector<CallFrame> read_call_frame(
-        mpt::Node::SharedPtr root, mpt::Db &db, uint64_t const block_number,
-        uint64_t const txn_idx)
+        mpt::Node::SharedPtr const root, mpt::Db &db,
+        uint64_t const block_number, uint64_t const txn_idx)
     {
         using namespace mpt;
 

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -158,7 +158,7 @@ vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
 void TrieDb::commit(
     bytes32_t const &block_id, CommitBuilder &builder,
     BlockHeader const &header, StateDeltas const &,
-    std::function<void(BlockHeader &)> populate_header_fn)
+    std::function<void(BlockHeader &)> const populate_header_fn)
 {
     auto const block_number = header.number;
     MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -107,7 +107,8 @@ namespace
 
     public:
         BinaryDbLoader(
-            ::monad::mpt::Db &db, size_t buf_size, uint64_t const block_id)
+            ::monad::mpt::Db &db, size_t const buf_size,
+            uint64_t const block_id)
             : db_{db}
             , buf_size_{buf_size}
             , buf_{std::make_unique_for_overwrite<unsigned char[]>(buf_size)}
@@ -197,8 +198,8 @@ namespace
 
         void load(
             std::istream &input,
-            std::function<size_t(byte_string_view, UpdateList &)> fparse,
-            std::function<void(UpdateList)> fwrite)
+            std::function<size_t(byte_string_view, UpdateList &)> const fparse,
+            std::function<void(UpdateList)> const fwrite)
         {
             UpdateList updates;
             size_t total_processed = 0;
@@ -294,7 +295,7 @@ namespace
             return total_processed;
         }
 
-        Update handle_account(byte_string_view curr)
+        Update handle_account(byte_string_view const curr)
         {
             constexpr auto balance_offset = sizeof(bytes32_t);
             constexpr auto nonce_offset = balance_offset + sizeof(uint256_t);
@@ -825,7 +826,8 @@ get_proposal_block_ids(mpt::Db &db, uint64_t const block_number)
             path_ = path_view.substr(0, prefix_size);
         }
 
-        virtual bool should_visit(Node const &, unsigned char branch) override
+        virtual bool
+        should_visit(Node const &, unsigned char const branch) override
         {
             if (path_.nibble_size() == 0) {
                 return branch == PROPOSAL_NIBBLE;

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -73,8 +73,8 @@ struct MachineBase : public mpt::StateMachine
     TableType table{TableType::Prefix};
 
     virtual mpt::Compute &get_compute() const override;
-    virtual void down(unsigned char const nibble) override;
-    virtual void up(size_t const n) override;
+    virtual void down(unsigned char nibble) override;
+    virtual void up(size_t n) override;
     virtual bool is_variable_length() const override;
     constexpr uint8_t prefix_len() const;
 

--- a/category/execution/ethereum/event/exec_event_recorder.cpp
+++ b/category/execution/ethereum/event/exec_event_recorder.cpp
@@ -35,7 +35,8 @@
 MONAD_NAMESPACE_BEGIN
 
 ExecutionEventRecorder::ExecutionEventRecorder(
-    int ring_fd, std::string_view ring_path, monad_event_ring const &exec_ring)
+    int const ring_fd, std::string_view const ring_path,
+    monad_event_ring const &exec_ring)
     : exec_recorder_{}
     , exec_ring_{exec_ring}
     , cur_block_start_seqno_{0}
@@ -62,10 +63,11 @@ ExecutionEventRecorder::~ExecutionEventRecorder()
 
 std::tuple<monad_event_descriptor *, std::byte *, uint64_t>
 ExecutionEventRecorder::setup_record_error_event(
-    monad_exec_event_type event_type, monad_event_record_error_type error_type,
-    size_t header_payload_size,
-    std::span<std::span<std::byte const> const> trailing_payload_bufs,
-    size_t original_payload_size)
+    monad_exec_event_type const event_type,
+    monad_event_record_error_type const error_type,
+    size_t const header_payload_size,
+    std::span<std::span<std::byte const> const> const trailing_payload_bufs,
+    size_t const original_payload_size)
 {
     monad_exec_record_error *error_payload;
     size_t error_payload_size;

--- a/category/execution/ethereum/event/exec_event_recorder.hpp
+++ b/category/execution/ethereum/event/exec_event_recorder.hpp
@@ -306,7 +306,7 @@ void ExecutionEventRecorder::commit(ReservedExecEvent<T> const &exec_event)
 }
 
 inline void ExecutionEventRecorder::record_block_marker_event(
-    monad_exec_event_type event_type)
+    monad_exec_event_type const event_type)
 {
     uint64_t seqno;
     uint8_t *payload_buf;
@@ -320,7 +320,7 @@ inline void ExecutionEventRecorder::record_block_marker_event(
 }
 
 inline void ExecutionEventRecorder::record_txn_marker_event(
-    monad_exec_event_type event_type, uint32_t txn_num)
+    monad_exec_event_type const event_type, uint32_t const txn_num)
 {
     uint64_t seqno;
     uint8_t *payload_buf;
@@ -346,15 +346,15 @@ extern std::unique_ptr<ExecutionEventRecorder> g_exec_event_recorder;
  * Helper free functions for execution event recording
  */
 
-inline void record_block_marker_event(monad_exec_event_type event_type)
+inline void record_block_marker_event(monad_exec_event_type const event_type)
 {
     if (auto *const e = g_exec_event_recorder.get()) {
         e->record_block_marker_event(event_type);
     }
 }
 
-inline void
-record_txn_marker_event(monad_exec_event_type event_type, uint32_t txn_num)
+inline void record_txn_marker_event(
+    monad_exec_event_type const event_type, uint32_t const txn_num)
 {
     if (auto *const e = g_exec_event_recorder.get()) {
         e->record_txn_marker_event(event_type, txn_num);

--- a/category/execution/ethereum/event/record_block_events.cpp
+++ b/category/execution/ethereum/event/record_block_events.cpp
@@ -31,8 +31,8 @@ MONAD_NAMESPACE_BEGIN
 void record_block_start(
     bytes32_t const &bft_block_id, uint256_t const &chain_id,
     BlockHeader const &eth_block_header, bytes32_t const &eth_parent_hash,
-    uint64_t block_round, uint64_t epoch, uint128_t epoch_nano_timestamp,
-    size_t txn_count,
+    uint64_t const block_round, uint64_t const epoch,
+    uint128_t const epoch_nano_timestamp, size_t const txn_count,
     std::optional<monad_c_secp256k1_pubkey> const &opt_block_author,
     std::optional<monad_c_native_block_input> const &opt_monad_input)
 {

--- a/category/execution/ethereum/event/record_consensus_events.cpp
+++ b/category/execution/ethereum/event/record_consensus_events.cpp
@@ -21,7 +21,7 @@
 MONAD_NAMESPACE_BEGIN
 
 void record_mock_consensus_events(
-    bytes32_t const &block_id, uint64_t block_number)
+    bytes32_t const &block_id, uint64_t const block_number)
 {
     if (auto *exec_recorder = g_exec_event_recorder.get()) {
         ReservedExecEvent const block_qc =

--- a/category/execution/ethereum/event/record_txn_events.cpp
+++ b/category/execution/ethereum/event/record_txn_events.cpp
@@ -144,11 +144,13 @@ ReservedExecEvent<T> reserve_event(
 // Records a MONAD_EXEC_STORAGE_ACCESS event for all reads and writes in the
 // AccountState prestate and modified maps
 void record_storage_events(
-    ExecutionEventRecorder *exec_recorder,
-    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
-    uint32_t account_index, Address const *address,
-    AccountState::StorageMap const *prestate_storage,
-    AccountState::StorageMap const *modified_storage, bool is_transient)
+    ExecutionEventRecorder *const exec_recorder,
+    monad_exec_account_access_context const ctx,
+    std::optional<uint32_t> const opt_txn_num, uint32_t const account_index,
+    Address const *const address,
+    AccountState::StorageMap const *const prestate_storage,
+    AccountState::StorageMap const *const modified_storage,
+    bool const is_transient)
 {
     for (size_t index = 0; auto const &[key, value] : *prestate_storage) {
         bool is_modified = false;
@@ -185,9 +187,10 @@ void record_storage_events(
 // record_storage_events to record both the ordinary and transient storage
 // accesses
 void record_account_events(
-    ExecutionEventRecorder *exec_recorder,
-    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
-    uint32_t index, AccountAccessInfo const &account_info)
+    ExecutionEventRecorder *const exec_recorder,
+    monad_exec_account_access_context const ctx,
+    std::optional<uint32_t> const opt_txn_num, uint32_t const index,
+    AccountAccessInfo const &account_info)
 {
     MONAD_ASSERT(account_info.prestate);
     monad_c_eth_account_state initial_state;
@@ -256,9 +259,9 @@ void record_account_events(
 // scope, either the block prologue, block epilogue, or in the scope of some
 // transaction
 void record_account_access_events_internal(
-    ExecutionEventRecorder *exec_recorder,
-    monad_exec_account_access_context ctx, std::optional<uint32_t> opt_txn_num,
-    State const &state)
+    ExecutionEventRecorder *const exec_recorder,
+    monad_exec_account_access_context const ctx,
+    std::optional<uint32_t> const opt_txn_num, State const &state)
 {
     auto const &prestate_map = state.original();
 
@@ -469,7 +472,7 @@ void record_txn_error_event(
 // is called from execute_block.cpp, to record prologue and epilogue accesses;
 // transaction-scope state accesses use record_txn_output_events instead
 void record_account_access_events(
-    monad_exec_account_access_context ctx, State const &state)
+    monad_exec_account_access_context const ctx, State const &state)
 {
     if (ExecutionEventRecorder *const e = g_exec_event_recorder.get()) {
         return record_account_access_events_internal(

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -109,8 +109,8 @@ EvmcHostBase::get_code_hash(evmc::address const &address) const noexcept
 }
 
 size_t EvmcHostBase::copy_code(
-    evmc::address const &address, size_t offset, uint8_t *data,
-    size_t size) const noexcept
+    evmc::address const &address, size_t const offset, uint8_t *const data,
+    size_t const size) const noexcept
 {
     try {
         return state_.copy_code(address, offset, data, size);
@@ -151,8 +151,9 @@ EvmcHostBase::get_block_hash(int64_t const block_number) const noexcept
 }
 
 void EvmcHostBase::emit_log(
-    evmc::address const &address, uint8_t const *data, size_t data_size,
-    evmc::bytes32 const topics[], size_t num_topics) noexcept
+    evmc::address const &address, uint8_t const *const data,
+    size_t const data_size, evmc::bytes32 const topics[],
+    size_t const num_topics) noexcept
 {
     try {
         Receipt::Log log{.data = {data, data_size}, .address = address};

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -60,7 +60,7 @@ protected:
 public:
     EvmcHostBase(
         CallTracerBase &, evmc_tx_context const &, BlockHashBuffer const &,
-        State &, bool const log_native_transfers) noexcept;
+        State &, bool log_native_transfers) noexcept;
 
     virtual ~EvmcHostBase() noexcept = default;
 
@@ -118,8 +118,8 @@ struct EvmcHost final : public EvmcHostBase
     EvmcHost(
         CallTracerBase &call_tracer, evmc_tx_context const &tx_context,
         BlockHashBuffer const &block_hash_buffer, State &state,
-        Transaction const &tx, std::optional<uint256_t> base_fee_per_gas,
-        uint64_t i, ChainContext<traits> const &chain_ctx,
+        Transaction const &tx, std::optional<uint256_t> const base_fee_per_gas,
+        uint64_t const i, ChainContext<traits> const &chain_ctx,
         bool const log_native_transfers = false) noexcept
         : EvmcHostBase{call_tracer, tx_context, block_hash_buffer, state, log_native_transfers}
         , tx_{tx}

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -68,8 +68,8 @@ namespace
     // DB Getters
     ///////////////////////////////////////////
     std::vector<CallFrame> read_call_frame(
-        mpt::Node::SharedPtr root, mpt::Db &db, uint64_t const block_number,
-        uint64_t const txn_idx)
+        mpt::Node::SharedPtr const root, mpt::Db &db,
+        uint64_t const block_number, uint64_t const txn_idx)
     {
         using namespace mpt;
 

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -169,7 +169,7 @@ PrecompileResult blake2bf_execute(byte_string_view const input)
     return silkpre_execute<silkpre_blake2_f_run>(input);
 }
 
-PrecompileResult point_evaluation_execute(byte_string_view input)
+PrecompileResult point_evaluation_execute(byte_string_view const input)
 {
     if (input.size() != 192) {
         return PrecompileResult::failure();

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -1893,7 +1893,7 @@ namespace
         {
         }
 
-        void run(uint64_t iterations)
+        void run(uint64_t const iterations)
         {
             for (uint64_t i = 0; i < iterations; ++i) {
                 LOG_INFO("=== Iteration {}", i + 1);

--- a/category/execution/ethereum/state3/version_stack.hpp
+++ b/category/execution/ethereum/state3/version_stack.hpp
@@ -29,7 +29,7 @@ class VersionStack
     std::deque<std::pair<unsigned, T>> stack_{};
 
 public:
-    explicit VersionStack(T value, unsigned version = 0)
+    explicit VersionStack(T value, unsigned const version = 0)
     {
         stack_.emplace_back(version, std::move(value));
     }

--- a/category/execution/ethereum/trace/state_tracer.hpp
+++ b/category/execution/ethereum/trace/state_tracer.hpp
@@ -93,7 +93,7 @@ namespace trace
         AccessListTracer(
             nlohmann::json &storage, Address const &sender,
             Address const &beneficiary, std::optional<Address> const &to,
-            std::span<std::optional<Address> const> const authorities);
+            std::span<std::optional<Address> const> authorities);
 
         template <Traits traits>
         void encode(State &);

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -33,7 +33,8 @@ MONAD_NAMESPACE_BEGIN
 namespace
 {
     // Approximates `factor * e ** (n/d) using Taylor expansion
-    uint256_t fake_exponential(uint256_t factor, uint256_t n, uint256_t d)
+    uint256_t fake_exponential(
+        uint256_t const factor, uint256_t const n, uint256_t const d)
     {
         int i = 1;
         uint256_t output = 0;

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -53,7 +53,7 @@ uint256_t calculate_txn_award(
     uint64_t gas_used) noexcept;
 
 inline intx::uint512
-max_gas_cost(uint64_t const gas_limit, uint256_t max_fee_per_gas) noexcept
+max_gas_cost(uint64_t const gas_limit, uint256_t const max_fee_per_gas) noexcept
 {
     return intx::umul(uint256_t{gas_limit}, max_fee_per_gas);
 }

--- a/category/execution/monad/event/record_consensus_events.cpp
+++ b/category/execution/monad/event/record_consensus_events.cpp
@@ -73,7 +73,8 @@ EXPLICIT_INSTANTIATE_QC_TEMPLATE(MonadConsensusBlockHeaderV2);
 
 #undef EXPLICIT_INSTANTIATE_QC_TEMPLATE
 
-void record_block_finalized(bytes32_t const &block_id, uint64_t block_number)
+void record_block_finalized(
+    bytes32_t const &block_id, uint64_t const block_number)
 {
     if (auto *const exec_recorder = g_exec_event_recorder.get()) {
         ReservedExecEvent const block_finalized =
@@ -85,7 +86,7 @@ void record_block_finalized(bytes32_t const &block_id, uint64_t block_number)
     }
 }
 
-void record_block_verified(std::span<uint64_t const> verified_blocks)
+void record_block_verified(std::span<uint64_t const> const verified_blocks)
 {
     if (auto *const exec_recorder = g_exec_event_recorder.get()) {
         for (uint64_t b : verified_blocks) {

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -163,7 +163,7 @@ MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
-ReserveBalance::ReserveBalance(State *state)
+ReserveBalance::ReserveBalance(State *const state)
     : state_{state}
 {
 }

--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -73,7 +73,7 @@ public:
 
     void on_pop_reject(FailedSet const &accounts);
 
-    void on_set_code(Address const &address, byte_string_view const code);
+    void on_set_code(Address const &address, byte_string_view code);
 
     template <Traits traits>
     void init_from_tx(

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -213,7 +213,7 @@ void add_spend_code(uint64_t const value_mon, std::vector<uint8_t> &code)
 }
 
 void add_call_code(
-    uint256_t const &gas_fee, Address target, std::vector<uint8_t> &code)
+    uint256_t const &gas_fee, Address const target, std::vector<uint8_t> &code)
 {
     auto const *v = intx::as_bytes(target);
     auto const *g = intx::as_bytes(gas_fee);

--- a/category/execution/monad/staking/fuzzer/staking_contract_fuzzer.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_fuzzer.cpp
@@ -131,7 +131,7 @@ namespace
     }
 }
 
-int main(int argc, char **argv)
+int main(int const argc, char **const argv)
 {
     auto const args = parse_args(argc, argv);
 

--- a/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
@@ -41,7 +41,7 @@ namespace monad::staking::test
 {
     template <Traits traits>
     StakingContractMachine<traits>::StakingContractMachine(
-        seed_t seed, Config const &config)
+        seed_t const seed, Config const &config)
         : engine_{seed}
         , enable_pubkey_assertions_{config.enable_pubkey_assertions}
         , enable_trace_{config.enable_trace}
@@ -611,7 +611,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::for_all_val_ids(
-        std::function<void(u64_be)> f)
+        std::function<void(u64_be)> const f)
     {
         uint64_t n = model_.last_val_id() + 3;
         for (uint64_t i = 0; i < n; ++i) {
@@ -621,7 +621,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::for_all_addresses(
-        std::function<void(Address const &)> f)
+        std::function<void(Address const &)> const f)
     {
         for (auto const &a : all_addresses_) {
             f(a);
@@ -630,7 +630,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::for_all_val_ids_and_addresses(
-        std::function<void(u64_be, Address const &)> f)
+        std::function<void(u64_be, Address const &)> const f)
     {
         for_all_val_ids([&](u64_be v) {
             for_all_addresses([&](Address const &a) { f(v, a); });
@@ -638,7 +638,7 @@ namespace monad::staking::test
     }
 
     template <Traits traits>
-    bool StakingContractMachine<traits>::transition(Transition t)
+    bool StakingContractMachine<traits>::transition(Transition const t)
     {
         if (enable_trace_) {
             std::cout << magic_enum::enum_name(t) << std::endl;
@@ -829,7 +829,7 @@ namespace monad::staking::test
     // lower_bound, lower_bound + 1, upper_bound, upper_bound - 1.
     template <Traits traits>
     uint256_t StakingContractMachine<traits>::gen_bound_biased_uint256(
-        uint256_t lower_bound, uint256_t upper_bound)
+        uint256_t const lower_bound, uint256_t const upper_bound)
     {
         MONAD_ASSERT(lower_bound <= upper_bound);
         return discrete_choice<uint256_t>(
@@ -860,7 +860,7 @@ namespace monad::staking::test
     // code path coverage.
     template <Traits traits>
     uint256_t StakingContractMachine<traits>::gen_stake(
-        uint256_t lower_bound, uint256_t upper_bound)
+        uint256_t const lower_bound, uint256_t const upper_bound)
     {
         MONAD_ASSERT(upper_bound >= lower_bound);
         auto optional_result = [&](uint256_t const &stake) {
@@ -943,7 +943,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     Address
-    StakingContractMachine<traits>::gen_delegator_to_val_id(u64_be val_id)
+    StakingContractMachine<traits>::gen_delegator_to_val_id(u64_be const val_id)
     {
         MONAD_ASSERT(model_.val_execution(val_id).exists());
         auto ds = model_.get_delegators_for_validator(val_id);
@@ -1281,7 +1281,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_delegate(
-        u64_be val_id, Address const &sender, uint256_be_t const &value)
+        u64_be const val_id, Address const &sender, uint256_be_t const &value)
     {
         auto result = model_.precompile_delegate<traits>(val_id, sender, value);
         MONAD_ASSERT(result.has_value());
@@ -1443,8 +1443,8 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_undelegate(
-        u64_be val_id, u256_be stake, u8_be wid, Address const &sender,
-        uint256_be_t const &value)
+        u64_be const val_id, u256_be const stake, u8_be const wid,
+        Address const &sender, uint256_be_t const &value)
     {
         MONAD_ASSERT(model_.val_execution(val_id).exists());
 
@@ -1615,7 +1615,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_compound(
-        u64_be val_id, Address const &sender, uint256_be_t const &value)
+        u64_be const val_id, Address const &sender, uint256_be_t const &value)
     {
         uint256_t const rewards =
             model_.delegator(val_id, sender).rewards().load().native() +
@@ -1753,7 +1753,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_withdraw(
-        u64_be val_id, u8_be wid, Address const &sender,
+        u64_be const val_id, u8_be const wid, Address const &sender,
         uint256_be_t const &value)
     {
         auto result =
@@ -1841,7 +1841,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_claim_rewards(
-        u64_be val_id, Address const &sender, uint256_be_t const &value)
+        u64_be const val_id, Address const &sender, uint256_be_t const &value)
     {
         auto const res =
             model_.precompile_claim_rewards<traits>(val_id, sender, value);
@@ -1893,7 +1893,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_change_commission(
-        u64_be val_id, u256_be const &commission, Address const &sender,
+        u64_be const val_id, u256_be const &commission, Address const &sender,
         uint256_be_t const &value)
     {
         auto const res = model_.precompile_change_commission<traits>(
@@ -1928,7 +1928,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_external_reward(
-        u64_be val_id, Address const &sender, uint256_be_t const &value)
+        u64_be const val_id, Address const &sender, uint256_be_t const &value)
     {
         auto const res =
             model_.precompile_external_reward<traits>(val_id, sender, value);
@@ -2006,7 +2006,7 @@ namespace monad::staking::test
 
     template <Traits traits>
     void StakingContractMachine<traits>::model_precompile_get_delegator(
-        u64_be val_id, Address const &addr, Address const &sender,
+        u64_be const val_id, Address const &addr, Address const &sender,
         uint256_be_t const &value)
     {
         auto const res = model_.precompile_get_delegator<traits>(

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -75,35 +75,37 @@ namespace monad::staking::test
     }
 
     std::unordered_set<uint8_t> const &
-    StakingContractModel::active_withdrawal_ids(u64_be v, Address const &a)
+    StakingContractModel::active_withdrawal_ids(
+        u64_be const v, Address const &a)
     {
         return delegator_to_active_withdrawal_ids_[{v.native(), a}];
     }
 
     uint256_t
-    StakingContractModel::unit_bias_rewards(u64_be v, Address const &a)
+    StakingContractModel::unit_bias_rewards(u64_be const v, Address const &a)
     {
         return unit_bias_rewards_[{v.native(), a}];
     }
 
-    uint256_t
-    StakingContractModel::delegator_stake(u64_be v, Address const &a, u64_be e)
+    uint256_t StakingContractModel::delegator_stake(
+        u64_be const v, Address const &a, u64_be const e)
     {
         return get_delegator_stake(v.native(), a, e.native());
     }
 
-    uint256_t
-    StakingContractModel::withdrawal_stake(u64_be v, Address const &a, u64_be e)
+    uint256_t StakingContractModel::withdrawal_stake(
+        u64_be const v, Address const &a, u64_be const e)
     {
         return get_withdrawal_stake(v.native(), a, e.native());
     }
 
-    uint256_t StakingContractModel::active_consensus_commission(u64_be val_id)
+    uint256_t
+    StakingContractModel::active_consensus_commission(u64_be const val_id)
     {
         return active_consensus_commission_[val_id.native()];
     }
 
-    uint256_t StakingContractModel::active_consensus_stake(u64_be val_id)
+    uint256_t StakingContractModel::active_consensus_stake(u64_be const val_id)
     {
         return active_consensus_stake_[val_id.native()];
     }
@@ -115,14 +117,14 @@ namespace monad::staking::test
 
     StakingContract::RefCountedAccumulator
     StakingContractModel::accumulated_reward_per_token(
-        u64_be epoch, u64_be val_id)
+        u64_be const epoch, u64_be const val_id)
     {
         return contract_.vars.accumulated_reward_per_token(epoch, val_id)
             .load();
     }
 
     uint256_t StakingContractModel::live_accumulated_reward_per_token(
-        u64_be epoch, u64_be val_id)
+        u64_be const epoch, u64_be const val_id)
     {
         if (contract_.vars.epoch.load().native() < epoch.native()) {
             return contract_.vars.val_execution(val_id)
@@ -160,19 +162,19 @@ namespace monad::staking::test
         return contract_.vars.val_id_bls(a).load().native();
     }
 
-    ValExecution StakingContractModel::val_execution(u64_be v)
+    ValExecution StakingContractModel::val_execution(u64_be const v)
     {
         return contract_.vars.val_execution(v);
     }
 
     StorageVariable<StakingContract::WithdrawalRequest>
     StakingContractModel::withdrawal_request(
-        u64_be val_id, Address const &delegator, u8_be wid)
+        u64_be const val_id, Address const &delegator, u8_be const wid)
     {
         return contract_.vars.withdrawal_request(val_id, delegator, wid);
     }
 
-    Delegator StakingContractModel::delegator(u64_be v, Address const &a)
+    Delegator StakingContractModel::delegator(u64_be const v, Address const &a)
     {
         return contract_.vars.delegator(v, a);
     }
@@ -192,23 +194,24 @@ namespace monad::staking::test
         return contract_.vars.valset_consensus;
     }
 
-    ConsensusView StakingContractModel::consensus_view(u64_be v)
+    ConsensusView StakingContractModel::consensus_view(u64_be const v)
     {
         return contract_.vars.consensus_view(v);
     }
 
-    ConsensusView StakingContractModel::snapshot_view(u64_be v)
+    ConsensusView StakingContractModel::snapshot_view(u64_be const v)
     {
         return contract_.vars.snapshot_view(v);
     }
 
-    StorageVariable<u256_be> StakingContractModel::val_bitset_bucket(u64_be v)
+    StorageVariable<u256_be>
+    StakingContractModel::val_bitset_bucket(u64_be const v)
     {
         return contract_.vars.val_bitset_bucket(v);
     }
 
     std::vector<Address>
-    StakingContractModel::get_delegators_for_validator(u64_be val_id)
+    StakingContractModel::get_delegators_for_validator(u64_be const val_id)
     {
         auto const [done, _, ds] = contract_.get_delegators_for_validator(
             val_id, Address{}, std::numeric_limits<uint32_t>::max());
@@ -232,7 +235,7 @@ namespace monad::staking::test
     }
 
     uint256_t StakingContractModel::withdrawal_reward(
-        u64_be val_id, Address const &addr, u8_be id)
+        u64_be const val_id, Address const &addr, u8_be const id)
     {
         auto withdraw =
             contract_.vars.withdrawal_request(val_id, addr, id).load();
@@ -247,8 +250,8 @@ namespace monad::staking::test
         return calculate_rewards(x, q, p);
     }
 
-    uint256_t
-    StakingContractModel::unaccumulated_rewards(u64_be v, Address const &a)
+    uint256_t StakingContractModel::unaccumulated_rewards(
+        u64_be const v, Address const &a)
     {
         auto del = contract_.vars.delegator(v, a);
         auto const epoch = contract_.vars.epoch.load().native();
@@ -298,7 +301,8 @@ namespace monad::staking::test
         return r1 + r2 + r3;
     }
 
-    uint256_t StakingContractModel::pending_rewards(u64_be v, Address const &a)
+    uint256_t
+    StakingContractModel::pending_rewards(u64_be const v, Address const &a)
     {
         uint256_t sum{};
         auto const &is = delegator_to_active_withdrawal_ids_[{v.native(), a}];
@@ -309,7 +313,7 @@ namespace monad::staking::test
     }
 
     Result<void>
-    StakingContractModel::syscall_on_epoch_change(u64_be next_epoch)
+    StakingContractModel::syscall_on_epoch_change(u64_be const next_epoch)
     {
         auto const input = abi_encode_uint(next_epoch);
         pre_call(uint256_be_t{});
@@ -612,7 +616,7 @@ namespace monad::staking::test
     EXPLICIT_MONAD_TRAITS_MEMBER(StakingContractModel::precompile_get_delegator)
 
     uint256_t StakingContractModel::get_delegator_stake(
-        uint64_t val_id, Address const &addr, uint64_t epoch)
+        uint64_t const val_id, Address const &addr, uint64_t const epoch)
     {
         auto const &m = delegator_stake_[{val_id, addr}];
         auto it = m.lower_bound(epoch);
@@ -620,13 +624,13 @@ namespace monad::staking::test
     }
 
     uint256_t StakingContractModel::get_withdrawal_stake(
-        uint64_t val_id, Address const &addr, uint64_t epoch)
+        uint64_t const val_id, Address const &addr, uint64_t const epoch)
     {
         return withdrawal_stake_[{val_id, addr, epoch}];
     }
 
     void StakingContractModel::add_delegator_stake(
-        uint64_t val_id, Address const &addr, uint64_t epoch,
+        uint64_t const val_id, Address const &addr, uint64_t const epoch,
         uint256_t const &delta)
     {
         auto &m = delegator_stake_[{val_id, addr}];
@@ -645,7 +649,7 @@ namespace monad::staking::test
     }
 
     void StakingContractModel::add_withdrawal_stake(
-        uint64_t val_id, Address const &addr, uint64_t end_epoch,
+        uint64_t const val_id, Address const &addr, uint64_t const end_epoch,
         uint256_t const &delta)
     {
         uint64_t const begin_epoch = contract_.vars.epoch.load().native();
@@ -655,7 +659,7 @@ namespace monad::staking::test
     }
 
     void StakingContractModel::distribute_reward(
-        u64_be val_id, u256_be const &reward_be)
+        u64_be const val_id, u256_be const &reward_be)
     {
         auto const v = val_id.native();
         auto const rew = reward_be.native();

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -891,7 +891,7 @@ std::tuple<bool, u32_be, std::vector<u64_be>> StakingContract::get_valset(
 
 std::tuple<bool, Address, std::vector<Address>>
 StakingContract::get_delegators_for_validator(
-    u64_be val_id, Address const &start_delegator, uint32_t const limit)
+    u64_be const val_id, Address const &start_delegator, uint32_t const limit)
 {
     return linked_list_traverse<u64_be, Address>(
         val_id, start_delegator, limit);
@@ -994,24 +994,21 @@ Result<byte_string> StakingContract::get_valset(
 }
 
 Result<byte_string> StakingContract::precompile_get_consensus_valset(
-    byte_string_view const input, Address const &,
-    uint256_be_t const &msg_value)
+    byte_string_view input, Address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     return get_valset(input, vars.valset_consensus);
 }
 
 Result<byte_string> StakingContract::precompile_get_snapshot_valset(
-    byte_string_view const input, Address const &,
-    uint256_be_t const &msg_value)
+    byte_string_view input, Address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     return get_valset(input, vars.valset_snapshot);
 }
 
 Result<byte_string> StakingContract::precompile_get_execution_valset(
-    byte_string_view const input, Address const &,
-    uint256_be_t const &msg_value)
+    byte_string_view input, Address const &, uint256_be_t const &msg_value)
 {
     BOOST_OUTCOME_TRY(function_not_payable(msg_value));
     auto const valset = vars.valset_execution;
@@ -1735,7 +1732,7 @@ Result<void> StakingContract::syscall_reward(
 EXPLICIT_MONAD_TRAITS_MEMBER(StakingContract::syscall_reward);
 
 Result<void> StakingContract::syscall_snapshot(
-    byte_string_view const input, uint256_t const &value)
+    byte_string_view input, uint256_t const &value)
 {
     if (MONAD_UNLIKELY(value != 0)) {
         return StakingError::ValueNonZero;

--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -375,7 +375,7 @@ public:
     // `PAGINATED_RESULTS_SIZE` in a single call. The return types in this call
     // are defined by these pagination limits.
     std::tuple<bool, u32_be, std::vector<u64_be>> get_valset(
-        StorageArray<u64_be> const &valset, uint32_t const start_index,
+        StorageArray<u64_be> const &valset, uint32_t start_index,
         uint32_t limit);
 
     // The two lists are of Type LinkedList[T] where T = Address | u64_be.  The
@@ -494,20 +494,20 @@ private:
     // Sets an existence bit in state that `val_id` is present in the set.
     // Returns `true` if the validator is already in the set. Called in
     // delegate.
-    bool add_to_valset(u64_be const val_id);
+    bool add_to_valset(u64_be val_id);
 
     // Removes the existence bit. Called in the snapshot syscall.
-    void remove_from_valset(u64_be const val_id);
+    void remove_from_valset(u64_be val_id);
 
     Result<void> reward_invariant(ValExecution &, uint256_t const &);
 
     // increments a future accumulator value for a validator.  this value is
     // overriden on epoch change when the accumulator for that epoch is
     // complete. Used by delegate and undelegate.
-    void increment_accumulator_refcount(u64_be const val_id);
+    void increment_accumulator_refcount(u64_be val_id);
 
     // reads an future accumulator from state and decrements the refcount.
-    u256_be decrement_accumulator_refcount(u64_be epoch, u64_be const val_id);
+    u256_be decrement_accumulator_refcount(u64_be epoch, u64_be val_id);
 
     // Returns the epoch when the delegation or undelegation will activate.
     uint64_t get_activation_epoch() const noexcept;

--- a/category/execution/monad/staking/test/input_generation.cpp
+++ b/category/execution/monad/staking/test/input_generation.cpp
@@ -32,7 +32,7 @@ namespace
 
 namespace monad::staking::test
 {
-    std::pair<blst_p1, blst_scalar> gen_bls_keypair(bytes32_t secret)
+    std::pair<blst_p1, blst_scalar> gen_bls_keypair(bytes32_t const secret)
     {
         blst_scalar secret_key;
         blst_p1 public_key;
@@ -42,7 +42,8 @@ namespace monad::staking::test
         return {public_key, secret_key};
     }
 
-    std::pair<secp256k1_pubkey, bytes32_t> gen_secp_keypair(bytes32_t secret)
+    std::pair<secp256k1_pubkey, bytes32_t>
+    gen_secp_keypair(bytes32_t const secret)
     {
         secp256k1_pubkey public_key;
 
@@ -130,7 +131,7 @@ namespace monad::staking::test
     std::tuple<byte_string, byte_string, byte_string, Address>
     craft_add_validator_input_raw(
         Address const &auth_address, uint256_t const &stake,
-        uint256_t const &commission, bytes32_t secret)
+        uint256_t const &commission, bytes32_t const secret)
     {
         auto const [bls_pubkey, bls_seckey] = gen_bls_keypair(secret);
         auto const [secp_pubkey, secp_seckey] = gen_secp_keypair(secret);
@@ -163,7 +164,7 @@ namespace monad::staking::test
 
     std::pair<byte_string, Address> craft_add_validator_input(
         Address const &auth_address, uint256_t const &stake,
-        uint256_t const &commission, bytes32_t secret)
+        uint256_t const &commission, bytes32_t const secret)
     {
         auto const [message, secp_sig, bls_sig, sign_address] =
             craft_add_validator_input_raw(

--- a/category/execution/monad/staking/test/input_generation.hpp
+++ b/category/execution/monad/staking/test/input_generation.hpp
@@ -31,10 +31,10 @@ namespace monad::staking::test
     byte_string_fixed<33> serialize_secp_pubkey(secp256k1_pubkey const &pubkey);
 
     byte_string_fixed<64>
-    sign_secp(byte_string_view const message, bytes32_t const &seckey);
+    sign_secp(byte_string_view message, bytes32_t const &seckey);
 
     byte_string_fixed<96>
-    sign_bls(byte_string_view const message, blst_scalar const &seckey);
+    sign_bls(byte_string_view message, blst_scalar const &seckey);
 
     byte_string_fixed<65>
     serialize_secp_pubkey_uncompressed(secp256k1_pubkey const &pubkey);
@@ -49,12 +49,10 @@ namespace monad::staking::test
         uint256_t const &commission = 0, bytes32_t secret = bytes32_t{0x1000});
 
     byte_string craft_undelegate_input(
-        u64_be const val_id, uint256_t const &amount,
-        u8_be const withdrawal_id);
+        u64_be val_id, uint256_t const &amount, u8_be withdrawal_id);
+
+    byte_string craft_withdraw_input(u64_be val_id, u8_be withdrawal_id);
 
     byte_string
-    craft_withdraw_input(u64_be const val_id, u8_be const withdrawal_id);
-
-    byte_string craft_change_commission_input(
-        u64_be const val_id, uint256_t const &commission);
+    craft_change_commission_input(u64_be val_id, uint256_t const &commission);
 }

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -118,7 +118,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
         contract.vars.epoch.store(start_epoch);
     }
 
-    void post_call(bool err)
+    void post_call(bool const err)
     {
         if (!err) {
             state.pop_accept();
@@ -157,7 +157,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
 
     void check_delegator_c_state(
         ValResult const &val, Address const &delegator,
-        uint256_t expected_stake, uint256_t expected_rewards)
+        uint256_t const expected_stake, uint256_t const expected_rewards)
     {
         auto del = contract.vars.delegator(val.id, delegator);
         pull_delegator_up_to_date(val.id, delegator);

--- a/category/execution/monad/staking/util/delegator.hpp
+++ b/category/execution/monad/staking/util/delegator.hpp
@@ -94,7 +94,7 @@ public:
             epochs + StorageVariable<Epochs_t>::N;
     };
 
-    Delegator(State &state, Address const &address, bytes32_t const key);
+    Delegator(State &state, Address const &address, bytes32_t key);
 
     /////////////
     // Getters //

--- a/category/execution/monad/staking/util/val_execution.hpp
+++ b/category/execution/monad/staking/util/val_execution.hpp
@@ -85,7 +85,7 @@ public:
             address_flags + StorageVariable<AddressFlags_t>::N;
     };
 
-    ValExecution(State &state, Address const &address, bytes32_t const key);
+    ValExecution(State &state, Address const &address, bytes32_t key);
 
     /////////////
     // Getters //

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -133,8 +133,8 @@ public:
     }
 
     TryReadResult try_read_storage(
-        Address const &address, Incarnation incarnation, bytes32_t const &key,
-        bytes32_t &result) const
+        Address const &address, Incarnation const incarnation,
+        bytes32_t const &key, bytes32_t &result) const
     {
         auto const fn =
             [&address, incarnation, &key, &result](ProposalState const &ps) {

--- a/category/mpt/bench/async_read_bench.cpp
+++ b/category/mpt/bench/async_read_bench.cpp
@@ -73,7 +73,7 @@ static monad::byte_string to_key(uint64_t const key)
 }
 
 static uint64_t
-select_rand_version(Db const &db, monad::small_prng &rnd, double bias)
+select_rand_version(Db const &db, monad::small_prng &rnd, double const bias)
 {
     auto const version_range_start =
         static_cast<double>(db.get_earliest_version());
@@ -105,7 +105,7 @@ struct Stats
     OpStats traverse;
 };
 
-int main(int argc, char *const argv[])
+int main(int const argc, char *const argv[])
 {
     unsigned num_async_reader_threads = 1;
     size_t num_async_reads_inflight = 100;
@@ -204,7 +204,7 @@ int main(int argc, char *const argv[])
                 std::vector<Nibbles> &keys;
 
                 virtual bool
-                down(unsigned char branch, Node const &node) override
+                down(unsigned char const branch, Node const &node) override
                 {
                     if (branch != INVALID_BRANCH) {
                         if (path_.empty() && branch != 0x1) {
@@ -337,8 +337,8 @@ int main(int argc, char *const argv[])
                     std::chrono::steady_clock::time_point start_time;
 
                     void set_value(
-                        monad::async::erased_connected_operation *state,
-                        monad::async::result<monad::byte_string> res)
+                        monad::async::erased_connected_operation *const state,
+                        monad::async::result<monad::byte_string> const res)
                     {
                         if (res) {
                             ++(stats.nsuccess);
@@ -436,14 +436,14 @@ int main(int argc, char *const argv[])
                     sig_atomic_t volatile &done;
 
                     explicit VersionValidatorMachine(
-                        size_t num_nodes_, sig_atomic_t volatile &done_)
+                        size_t const num_nodes_, sig_atomic_t volatile &done_)
                         : num_nodes(num_nodes_)
                         , done(done_)
                     {
                     }
 
                     virtual bool
-                    down(unsigned char branch, Node const &node) override
+                    down(unsigned char const branch, Node const &node) override
                     {
                         if (branch == INVALID_BRANCH) {
                             return true;
@@ -471,7 +471,7 @@ int main(int argc, char *const argv[])
                     }
 
                     virtual void
-                    up(unsigned char branch, Node const &node) override
+                    up(unsigned char const branch, Node const &node) override
                     {
                         auto const path_view = NibblesView{path};
                         auto const rem_size = [&] {

--- a/category/mpt/bench/calc_min_version_bench.cpp
+++ b/category/mpt/bench/calc_min_version_bench.cpp
@@ -46,7 +46,8 @@ static int64_t calc_min_version_original(Node const &node)
 }
 
 // Build a node whose mask has exactly `nchildren` bits set (low bits).
-static Node::SharedPtr make_bench_node(unsigned nchildren, int64_t version)
+static Node::SharedPtr
+make_bench_node(unsigned const nchildren, int64_t const version)
 {
     uint16_t const mask = static_cast<uint16_t>((1u << nchildren) - 1u);
 

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -76,7 +76,7 @@
 #include <unistd.h>
 #include <zstd.h>
 
-std::string print_bytes(MONAD_ASYNC_NAMESPACE::file_offset_t bytes_)
+std::string print_bytes(MONAD_ASYNC_NAMESPACE::file_offset_t const bytes_)
 {
     auto bytes = double(bytes_);
     std::stringstream s;
@@ -147,9 +147,11 @@ struct chunk_info_restore_t
     bool done{false};
 
     chunk_info_restore_t(
-        monad::async::storage_pool::chunk_type type_, uint32_t chunk_id_,
-        monad::mpt::detail::db_metadata::chunk_info_t metadata_,
-        std::span<std::byte const> compressed_, bool is_uncompressed_)
+        monad::async::storage_pool::chunk_type const type_,
+        uint32_t const chunk_id_,
+        monad::mpt::detail::db_metadata::chunk_info_t const metadata_,
+        std::span<std::byte const> const compressed_,
+        bool const is_uncompressed_)
         : type(type_)
         , chunk_id(chunk_id_)
         , metadata(metadata_)
@@ -292,7 +294,8 @@ struct chunk_info_archive_t
     std::future<void> compression_thread;
 
     chunk_info_archive_t(
-        monad::async::storage_pool::chunk_t *chunk_ptr_, la_int64_t metadata_)
+        monad::async::storage_pool::chunk_t *chunk_ptr_,
+        la_int64_t const metadata_)
         : chunk_ptr(std::move(chunk_ptr_))
         , metadata(metadata_)
     {
@@ -420,7 +423,7 @@ public:
     {
     }
 
-    void cli_ask_question(char const *msg)
+    void cli_ask_question(char const *const msg)
     {
         if (!no_prompt) {
             auto const answer = tty_ask_question(msg);
@@ -1375,7 +1378,8 @@ public:
 };
 
 int main_impl(
-    std::ostream &cout, std::ostream &cerr, std::span<std::string_view> args)
+    std::ostream &cout, std::ostream &cerr,
+    std::span<std::string_view> const args)
 {
     CLI::App cli("Tool for managing MPT databases", "monad-mpt");
     cli.footer(R"(Suitable sources of block storage:

--- a/category/mpt/cli_tool_main.cpp
+++ b/category/mpt/cli_tool_main.cpp
@@ -20,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-int main(int argc_, char const *argv[])
+int main(int const argc_, char const *argv[])
 {
     size_t const argc = size_t(argc_);
     std::vector<std::string_view> args(argc);

--- a/category/mpt/compute.cpp
+++ b/category/mpt/compute.cpp
@@ -65,7 +65,8 @@ unsigned encode_two_pieces(
     return ret;
 }
 
-std::span<unsigned char> encode_empty_string(std::span<unsigned char> result)
+std::span<unsigned char>
+encode_empty_string(std::span<unsigned char> const result)
 {
     result[0] = RLP_EMPTY_STRING;
     return result.subspan(1);

--- a/category/mpt/compute.hpp
+++ b/category/mpt/compute.hpp
@@ -58,8 +58,8 @@ std::span<unsigned char>
 encode_16_children(Node const &, std::span<unsigned char> result);
 
 unsigned encode_two_pieces(
-    unsigned char *const dest, NibblesView const path,
-    byte_string_view const second, bool const has_value = false);
+    unsigned char *dest, NibblesView path, byte_string_view second,
+    bool has_value = false);
 
 struct Compute
 {
@@ -287,7 +287,7 @@ struct VarLenMerkleCompute : Compute
     }
 
     virtual unsigned
-    set_node_data(unsigned char *buffer, unsigned const max_size) override
+    set_node_data(unsigned char *const buffer, unsigned const max_size) override
     {
         // copy from internal state
         if (state.len == 0) {
@@ -302,7 +302,8 @@ struct VarLenMerkleCompute : Compute
         return len;
     }
 
-    virtual unsigned compute(unsigned char *buffer, Node const &node) override
+    virtual unsigned
+    compute(unsigned char *const buffer, Node const &node) override
     {
         // Ethereum leaf: leaf node hash without child
         if (node.number_of_children() == 0) {
@@ -352,7 +353,8 @@ protected:
         return state.len;
     }
 
-    unsigned compute_branch_reference_(unsigned char *buffer, Node const &node)
+    unsigned
+    compute_branch_reference_(unsigned char *const buffer, Node const &node)
     {
         MONAD_ASSERT(node.number_of_children());
         // compute branch node hash
@@ -385,7 +387,7 @@ struct RootVarLenMerkleCompute : public VarLenMerkleCompute<LeafValueProcessor>
     }
 
     virtual unsigned compute_node_data_len(
-        std::span<ChildData> const children, uint16_t mask, NibblesView,
+        std::span<ChildData> const children, uint16_t const mask, NibblesView,
         std::optional<byte_string_view> const value) override
     {
         MONAD_ASSERT(mask);
@@ -406,7 +408,7 @@ struct RootVarLenMerkleCompute : public VarLenMerkleCompute<LeafValueProcessor>
     }
 
     virtual unsigned
-    set_node_data(unsigned char *buffer, unsigned const max_size) override
+    set_node_data(unsigned char *const buffer, unsigned const max_size) override
     {
         return Base::set_node_data(buffer, max_size);
     }

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -36,7 +36,7 @@ MONAD_MPT_NAMESPACE_BEGIN
 Node::SharedPtr create_node_add_new_branch(
     UpdateAux &aux, Node *const node, unsigned char const new_branch,
     Node::SharedPtr new_child, uint64_t const new_version,
-    std::optional<byte_string_view> opt_value)
+    std::optional<byte_string_view> const opt_value)
 {
     uint16_t const mask =
         static_cast<uint16_t>(node->mask | (1u << new_branch));
@@ -76,7 +76,7 @@ Node::SharedPtr create_node_add_new_branch(
 Node::SharedPtr create_node_with_two_children(
     UpdateAux &aux, NibblesView const path, unsigned char const branch0,
     Node::SharedPtr child0, unsigned char const branch1, Node::SharedPtr child1,
-    uint64_t const new_version, std::optional<byte_string_view> opt_value)
+    uint64_t const new_version, std::optional<byte_string_view> const opt_value)
 {
     // mismatch: split node's path: turn node to a branch node with two
     // children
@@ -110,9 +110,9 @@ Node::SharedPtr create_node_with_two_children(
 }
 
 Node::SharedPtr copy_trie_impl(
-    UpdateAux &aux, Node::SharedPtr src_root, NibblesView const src_prefix,
-    Node::SharedPtr dest_root, NibblesView const dest_prefix,
-    uint64_t const dest_version)
+    UpdateAux &aux, Node::SharedPtr const src_root,
+    NibblesView const src_prefix, Node::SharedPtr dest_root,
+    NibblesView const dest_prefix, uint64_t const dest_version)
 {
     MONAD_ASSERT(aux.is_on_disk());
     auto [src_cursor, res] = find_blocking(

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -298,8 +298,8 @@ public:
     }
 
     virtual bool traverse_fiber_blocking(
-        Node::SharedPtr node, TraverseMachine &machine, uint64_t const block_id,
-        size_t) override
+        Node::SharedPtr const node, TraverseMachine &machine,
+        uint64_t const block_id, size_t) override
     {
         return preorder_traverse_blocking(aux_, *node, machine, block_id);
     }
@@ -979,7 +979,7 @@ struct RODb::Impl final : public OnDiskWithWorkerThreadImpl
         return fut.get();
     }
 
-    NodeCursor load_root_fiber_blocking(uint64_t version)
+    NodeCursor load_root_fiber_blocking(uint64_t const version)
     {
         auto const root_offset =
             aux().metadata_ctx().get_root_offset_at_version(version);
@@ -1329,13 +1329,14 @@ uint64_t Db::get_history_length() const
                         : 1;
 }
 
-AsyncContext::AsyncContext(Db &db, size_t node_lru_max_mem)
+AsyncContext::AsyncContext(Db &db, size_t const node_lru_max_mem)
     : aux(db.impl_->aux())
     , node_cache(node_lru_max_mem)
 {
 }
 
-AsyncContextUniquePtr async_context_create(Db &db, size_t node_lru_max_mem)
+AsyncContextUniquePtr
+async_context_create(Db &db, size_t const node_lru_max_mem)
 {
     return std::make_unique<AsyncContext>(db, node_lru_max_mem);
 }
@@ -1358,8 +1359,8 @@ namespace detail
         uint16_t buffer_off;
 
         constexpr load_root_receiver_t(
-            chunk_offset_t offset_, DbGetSender<T> *sender_,
-            async::erased_connected_operation *io_state_)
+            chunk_offset_t const offset_, DbGetSender<T> *const sender_,
+            async::erased_connected_operation *const io_state_)
             : offset(offset_)
             , sender(sender_)
             , io_state(io_state_)
@@ -1444,8 +1445,8 @@ namespace detail
     };
 
     template <return_type T>
-    async::result<void>
-    DbGetSender<T>::operator()(async::erased_connected_operation *io_state)
+    async::result<void> DbGetSender<T>::operator()(
+        async::erased_connected_operation *const io_state)
     {
         switch (op_type) {
         case op_t::op_get1:

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -234,7 +234,7 @@ namespace detail
         }
 
         constexpr DbGetSender(
-            AsyncContext &context_, op_t const op_type_, NodeCursor cur_,
+            AsyncContext &context_, op_t const op_type_, NodeCursor const cur_,
             NibblesView const n, uint64_t const block_id_)
             : context(context_)
             , op_type(op_type_)

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -95,8 +95,8 @@ public:
             std::atomic_ref<uint64_t> next_version_;
             std::span<chunk_offset_t> root_offsets_chunks_;
 
-            void
-            update_version_lower_bound_(uint64_t lower_bound = uint64_t(-1))
+            void update_version_lower_bound_(
+                uint64_t const lower_bound = uint64_t(-1))
             {
                 auto const version_lower_bound =
                     version_lower_bound_.load(std::memory_order_acquire);
@@ -117,7 +117,7 @@ public:
             }
 
         public:
-            explicit root_offsets_delegator(metadata_copy const *m)
+            explicit root_offsets_delegator(metadata_copy const *const m)
                 : version_lower_bound_(
                       m->main->root_offsets.version_lower_bound_)
                 , next_version_(m->main->root_offsets.next_version_)
@@ -267,7 +267,7 @@ public:
 
     chunk_offset_t get_root_offset_at_version(uint64_t version) const noexcept;
 
-    bool version_is_valid_ondisk(uint64_t version) const noexcept
+    bool version_is_valid_ondisk(uint64_t const version) const noexcept
     {
         return get_root_offset_at_version(version) != INVALID_OFFSET;
     }

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -128,8 +128,8 @@ namespace detail
             ~db_offsets_info_t() = default;
 
             constexpr db_offsets_info_t(
-                chunk_offset_t start_of_wip_offset_fast_,
-                chunk_offset_t start_of_wip_offset_slow_)
+                chunk_offset_t const start_of_wip_offset_fast_,
+                chunk_offset_t const start_of_wip_offset_slow_)
                 : start_of_wip_offset_fast(start_of_wip_offset_fast_)
                 , start_of_wip_offset_slow(start_of_wip_offset_slow_)
             {
@@ -188,7 +188,7 @@ namespace detail
             uint64_t unused0_ : 2;
             uint64_t insertion_count1_ : 10;
 
-            uint32_t index(db_metadata const *parent) const noexcept
+            uint32_t index(db_metadata const *const parent) const noexcept
             {
                 auto const ret = uint32_t(this - parent->chunk_info);
                 MONAD_ASSERT(ret < parent->chunk_info_count);
@@ -201,7 +201,8 @@ namespace detail
                        uint32_t(insertion_count0_);
             }
 
-            chunk_info_t const *prev(db_metadata const *parent) const noexcept
+            chunk_info_t const *
+            prev(db_metadata const *const parent) const noexcept
             {
                 if (prev_chunk_id == INVALID_CHUNK_ID) {
                     return nullptr;
@@ -209,7 +210,8 @@ namespace detail
                 return parent->at(prev_chunk_id);
             }
 
-            chunk_info_t const *next(db_metadata const *parent) const noexcept
+            chunk_info_t const *
+            next(db_metadata const *const parent) const noexcept
             {
                 if (next_chunk_id == INVALID_CHUNK_ID) {
                     return nullptr;
@@ -241,7 +243,7 @@ namespace detail
             {
                 db_metadata *parent;
 
-                explicit holder_t(db_metadata *p)
+                explicit holder_t(db_metadata *const p)
                     : parent(p)
                 {
                     parent->is_dirty().store(1, std::memory_order_release);
@@ -266,14 +268,14 @@ namespace detail
             return holder_t(this);
         }
 
-        chunk_info_t const *at(uint32_t idx) const noexcept
+        chunk_info_t const *at(uint32_t const idx) const noexcept
         {
             MONAD_ASSERT(idx < chunk_info_count);
             return &chunk_info[idx];
         }
 
         chunk_info_t atomic_load_chunk_info(
-            uint32_t const idx, std::memory_order load_ord =
+            uint32_t const idx, std::memory_order const load_ord =
                                     std::memory_order_seq_cst) const noexcept
         {
             return reinterpret_cast<std::atomic<chunk_info_t> const *>(at(idx))
@@ -329,13 +331,13 @@ namespace detail
         }
 
     private:
-        chunk_info_t *at_(uint32_t idx) noexcept
+        chunk_info_t *at_(uint32_t const idx) noexcept
         {
             MONAD_ASSERT(idx < chunk_info_count);
             return &chunk_info[idx];
         }
 
-        void append_(id_pair &list, chunk_info_t *i) noexcept
+        void append_(id_pair &list, chunk_info_t *const i) noexcept
         {
             // Insertion count is assigned to chunk_info_t *i atomically
             auto const g = hold_dirty();
@@ -374,7 +376,7 @@ namespace detail
                 info, std::memory_order_release);
         }
 
-        void remove_(chunk_info_t *i) noexcept
+        void remove_(chunk_info_t *const i) noexcept
         {
             auto get_list = [&]() -> id_pair & {
                 if (i->in_fast_list) {
@@ -435,13 +437,13 @@ namespace detail
 #endif
         }
 
-        void free_capacity_add_(uint64_t bytes) noexcept
+        void free_capacity_add_(uint64_t const bytes) noexcept
         {
             auto const g = hold_dirty();
             capacity_in_free_list += bytes;
         }
 
-        void free_capacity_sub_(uint64_t bytes) noexcept
+        void free_capacity_sub_(uint64_t const bytes) noexcept
         {
             auto const g = hold_dirty();
             capacity_in_free_list -= bytes;
@@ -461,9 +463,10 @@ namespace detail
     static_assert(alignof(db_metadata) == 8);
 
     inline void atomic_memcpy(
-        void *__restrict__ dest_, void const *__restrict__ src_, size_t bytes,
-        std::memory_order load_ord = std::memory_order_acquire,
-        std::memory_order store_ord = std::memory_order_release)
+        void *__restrict__ const dest_, void const *__restrict__ const src_,
+        size_t bytes,
+        std::memory_order const load_ord = std::memory_order_acquire,
+        std::memory_order const store_ord = std::memory_order_release)
     {
         MONAD_ASSERT((((uintptr_t)dest_) & 7) == 0);
         MONAD_ASSERT((((uintptr_t)src_) & 7) == 0);
@@ -497,7 +500,9 @@ namespace detail
     /* A dirty bit setting memcpy implementation, so the dirty bit gets held
     high during the memory copy.
     */
-    inline void db_copy(db_metadata *dest, db_metadata const *src, size_t bytes)
+    inline void db_copy(
+        db_metadata *const dest, db_metadata const *const src,
+        size_t const bytes)
     {
         alignas(db_metadata) std::byte buffer[sizeof(db_metadata)];
         memcpy(buffer, src, sizeof(db_metadata));

--- a/category/mpt/detail/kbhit.hpp
+++ b/category/mpt/detail/kbhit.hpp
@@ -58,7 +58,7 @@ inline int getch()
     return -1;
 }
 
-inline char tty_ask_question(char const *msg, ...)
+inline char tty_ask_question(char const *const msg, ...)
 {
     va_list vl;
     termios term;

--- a/category/mpt/detail/unsigned_20.hpp
+++ b/category/mpt/detail/unsigned_20.hpp
@@ -35,7 +35,7 @@ namespace detail
 
     public:
         // NOLINTNEXTLINE(google-explicit-constructor)
-        constexpr unsigned_20(uint32_t v)
+        constexpr unsigned_20(uint32_t const v)
             : v_(v & 0xfffff)
         {
             MONAD_ASSERT(v == uint32_t(-1) || (v >> 20) == 0);

--- a/category/mpt/find.cpp
+++ b/category/mpt/find.cpp
@@ -27,7 +27,7 @@
 MONAD_MPT_NAMESPACE_BEGIN
 
 find_cursor_result_type find_blocking(
-    UpdateAux const &aux, NodeCursor root, NibblesView const key,
+    UpdateAux const &aux, NodeCursor const root, NibblesView const key,
     uint64_t const version)
 {
     if (!root.is_valid()) {

--- a/category/mpt/find_request_sender.hpp
+++ b/category/mpt/find_request_sender.hpp
@@ -73,8 +73,8 @@ private:
     bool return_value_{true};
 
     MONAD_ASYNC_NAMESPACE::result<void> resume_(
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state,
-        NodeCursor root)
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const io_state,
+        NodeCursor const root)
     {
         if (!root.is_valid()) {
             // Version invalidated during async read
@@ -92,7 +92,7 @@ public:
 
     constexpr find_request_sender(
         UpdateAux &aux, NodeCache &node_cache, AsyncInflightNodes &inflights,
-        NodeCursor root, uint64_t version, NibblesView const key,
+        NodeCursor const root, uint64_t const version, NibblesView const key,
         bool const return_value)
         : aux_(aux)
         , node_cache_(node_cache)
@@ -105,7 +105,7 @@ public:
         MONAD_ASSERT(root_.is_valid());
     }
 
-    void reset(NodeCursor root, NibblesView key)
+    void reset(NodeCursor const root, NibblesView const key)
     {
         root_ = root;
         key_ = key;
@@ -151,8 +151,8 @@ struct find_request_sender<T>::find_receiver
     unsigned const branch;
 
     constexpr find_receiver(
-        find_request_sender *sender_,
-        MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state_,
+        find_request_sender *const sender_,
+        MONAD_ASYNC_NAMESPACE::erased_connected_operation *const io_state_,
         virtual_chunk_offset_t const virt_offset_, unsigned char const branch)
         : sender(sender_)
         , io_state(io_state_)
@@ -201,7 +201,7 @@ struct find_request_sender<T>::find_receiver
 
 template <return_type T>
 inline MONAD_ASYNC_NAMESPACE::result<void> find_request_sender<T>::operator()(
-    MONAD_ASYNC_NAMESPACE::erased_connected_operation *io_state)
+    MONAD_ASYNC_NAMESPACE::erased_connected_operation *const io_state)
 {
     /* This is slightly bold, we basically repeatedly self reenter the Sender's
     initiation function until we complete. It is legal and it is allowed,

--- a/category/mpt/merkle/node_reference.hpp
+++ b/category/mpt/merkle/node_reference.hpp
@@ -26,8 +26,8 @@
 MONAD_MPT_NAMESPACE_BEGIN
 
 // return length of noderef
-inline unsigned
-to_node_reference(byte_string_view rlp, unsigned char *dest) noexcept
+inline unsigned to_node_reference(
+    byte_string_view const rlp, unsigned char *const dest) noexcept
 {
     if (MONAD_LIKELY(rlp.size() >= KECCAK256_SIZE)) {
         keccak256(rlp.data(), rlp.size(), dest);

--- a/category/mpt/nibbles_view.hpp
+++ b/category/mpt/nibbles_view.hpp
@@ -119,8 +119,7 @@ public:
     // Returns a left-aligned Nibbles containing a subrange of nibbles starting
     // at `pos` and up to `count` nibbles (or to the end if count == npos).
     // The returned Nibbles is always left-aligned (begin_nibble_ == 0).
-    inline constexpr Nibbles
-    substr(unsigned const pos, unsigned const count = npos) const;
+    inline constexpr Nibbles substr(unsigned pos, unsigned count = npos) const;
 
     inline constexpr bool operator==(NibblesView const &other) const;
     inline constexpr auto operator<=>(NibblesView const &other) const;

--- a/category/mpt/node.cpp
+++ b/category/mpt/node.cpp
@@ -43,7 +43,7 @@ Node::Node(prevent_public_construction_tag) {}
 
 Node::Node(
     prevent_public_construction_tag, uint16_t const mask,
-    std::optional<byte_string_view> value, size_t const data_size,
+    std::optional<byte_string_view> const value, size_t const data_size,
     NibblesView const path, int64_t const version)
     : mask(mask)
     , path_nibble_index_end(path.end_nibble_)
@@ -361,7 +361,8 @@ unsigned char const *Node::child_data(unsigned const index) const noexcept
     return child_data() + child_data_offset(index);
 }
 
-void Node::set_child_data(unsigned const index, byte_string_view data) noexcept
+void Node::set_child_data(
+    unsigned const index, byte_string_view const data) noexcept
 {
     // called after data_off array is calculated
     std::memcpy(child_data(index), data.data(), data.size());
@@ -415,27 +416,27 @@ std::span<Node::SharedPtr const> Node::child_next_data() const noexcept
         number_of_children()};
 }
 
-Node::SharedPtr *Node::child_ptr(unsigned index) noexcept
+Node::SharedPtr *Node::child_ptr(unsigned const index) noexcept
 {
     return child_next_data().data() + index;
 }
 
-Node::SharedPtr const *Node::child_ptr(unsigned index) const noexcept
+Node::SharedPtr const *Node::child_ptr(unsigned const index) const noexcept
 {
     return child_next_data().data() + index;
 }
 
-Node::SharedPtr &Node::next(unsigned index) noexcept
+Node::SharedPtr &Node::next(unsigned const index) noexcept
 {
     return child_next_data()[index];
 }
 
-Node::SharedPtr const &Node::next(unsigned index) const noexcept
+Node::SharedPtr const &Node::next(unsigned const index) const noexcept
 {
     return child_next_data()[index];
 }
 
-void Node::set_next(unsigned index, Node::SharedPtr p) noexcept
+void Node::set_next(unsigned const index, Node::SharedPtr p) noexcept
 {
     child_next_data()[index] = std::move(p);
 }

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -51,7 +51,7 @@ struct node_disk_pages_spare_15
         uint16_t value;
 
         // NOLINTNEXTLINE(google-explicit-constructor)
-        constexpr spare_dual(uint16_t v)
+        constexpr spare_dual(uint16_t const v)
             : value(v)
         {
         }
@@ -332,7 +332,7 @@ public:
 
     void set_next(unsigned index, SharedPtr p) noexcept;
 
-    SharedPtr move_next(unsigned const index) noexcept;
+    SharedPtr move_next(unsigned index) noexcept;
 };
 
 static_assert(std::is_standard_layout_v<Node>, "required by offsetof");
@@ -411,8 +411,8 @@ void serialize_node_to_buffer(
     unsigned char *write_pos, unsigned bytes_to_write, Node const &,
     uint32_t disk_size, unsigned offset = 0);
 
-inline Node::SharedPtr
-deserialize_node_from_buffer(unsigned char const *read_pos, size_t max_bytes)
+inline Node::SharedPtr deserialize_node_from_buffer(
+    unsigned char const *read_pos, size_t const max_bytes)
 {
     for (size_t n = 0; n < max_bytes; n += 64) {
         __builtin_prefetch(read_pos + n, 0, 0);
@@ -460,7 +460,7 @@ public:
         using reference = value_type;
 
         // NOLINTNEXTLINE(google-explicit-constructor)
-        iterator(uint16_t mask)
+        iterator(uint16_t const mask)
             : index_(0)
             , mask_(mask)
         {
@@ -488,7 +488,7 @@ public:
         uint16_t mask_;
     };
 
-    explicit NodeChildrenRange(uint16_t mask)
+    explicit NodeChildrenRange(uint16_t const mask)
         : mask_(mask)
     {
     }

--- a/category/mpt/node_cursor.hpp
+++ b/category/mpt/node_cursor.hpp
@@ -35,7 +35,7 @@ struct NodeCursor
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     constexpr NodeCursor(
-        std::shared_ptr<Node> node_, unsigned prefix_index_ = 0)
+        std::shared_ptr<Node> node_, unsigned const prefix_index_ = 0)
         : node{std::move(node_)}
         , prefix_index{prefix_index_}
     {

--- a/category/mpt/request.hpp
+++ b/category/mpt/request.hpp
@@ -36,22 +36,22 @@ struct Requests
 
     Requests() = default;
 
-    UpdateList const &operator[](size_t i) const noexcept
+    UpdateList const &operator[](size_t const i) const noexcept
     {
         return sublists[i];
     }
 
-    UpdateList &operator[](size_t i) noexcept
+    UpdateList &operator[](size_t const i) noexcept
     {
         return sublists[i];
     }
 
-    UpdateList const &at(size_t i) const &
+    UpdateList const &at(size_t const i) const &
     {
         return sublists.at(i);
     }
 
-    UpdateList &&at(size_t i) &&
+    UpdateList &&at(size_t const i) &&
     {
         return std::move(sublists.at(i));
     }

--- a/category/mpt/test/blocking_read_concurrency_test.cpp
+++ b/category/mpt/test/blocking_read_concurrency_test.cpp
@@ -49,7 +49,7 @@ namespace
     {
         Nibbles path{};
 
-        virtual bool down(unsigned char branch, Node const &node) override
+        virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
                 return true;
@@ -62,7 +62,7 @@ namespace
             return true;
         }
 
-        virtual void up(unsigned char branch, Node const &node) override
+        virtual void up(unsigned char const branch, Node const &node) override
         {
             auto const path_view = NibblesView{path};
             auto const rem_size = [&] {

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -110,8 +110,9 @@ namespace
         return db.upsert(std::move(root), std::move(ul_prefix), block_id);
     };
 
-    monad::Result<monad::byte_string>
-    db_get(Db &db, NodeCursor const &root, NibblesView key, uint64_t version)
+    monad::Result<monad::byte_string> db_get(
+        Db &db, NodeCursor const &root, NibblesView const key,
+        uint64_t const version)
     {
         auto const res = db.find(root, key, version);
         if (res.has_value()) {
@@ -121,7 +122,8 @@ namespace
     }
 
     monad::Result<monad::byte_string> db_get_data(
-        Db &db, NodeCursor const &root, NibblesView key, uint64_t block_id)
+        Db &db, NodeCursor const &root, NibblesView const key,
+        uint64_t const block_id)
     {
         auto const res = db.find(root, key, block_id);
         if (res.has_value()) {
@@ -178,7 +180,7 @@ namespace
                 std::function<void(result_t<T>)> callback;
 
                 void set_value(
-                    monad::async::erased_connected_operation *state,
+                    monad::async::erased_connected_operation *const state,
                     sender_type::result_type res)
                 {
                     ++parent->cbs;
@@ -193,7 +195,7 @@ namespace
             state->initiate();
         }
 
-        void poll_until(size_t num_callbacks)
+        void poll_until(size_t const num_callbacks)
         {
             while (cbs < num_callbacks) {
                 ro_db.poll(false);
@@ -262,7 +264,7 @@ namespace
         {
         }
 
-        virtual bool down(unsigned char branch, Node const &node) override
+        virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
                 return true;
@@ -279,7 +281,7 @@ namespace
             return true;
         }
 
-        virtual void up(unsigned char branch, Node const &node) override
+        virtual void up(unsigned char const branch, Node const &node) override
         {
             auto const path_view = NibblesView{path};
             auto const rem_size = [&] {
@@ -320,7 +322,7 @@ namespace
     }
 
     std::pair<std::deque<monad::byte_string>, std::deque<Update>>
-    prepare_random_updates(unsigned nkeys, unsigned const offset = 0)
+    prepare_random_updates(unsigned const nkeys, unsigned const offset = 0)
     {
         std::deque<monad::byte_string> bytes_alloc;
         std::deque<Update> updates_alloc;
@@ -889,14 +891,15 @@ TEST_F(OnDiskDbWithFileFixture, read_only_db_traverse_as_version_expire)
         Nibbles path;
         bool has_done_callback;
 
-        explicit TraverseMachinePruneHistory(std::function<void(void)> callback)
+        explicit TraverseMachinePruneHistory(
+            std::function<void(void)> const callback)
             : upsert_callback(callback)
             , path{}
             , has_done_callback{false}
         {
         }
 
-        virtual bool down(unsigned char branch, Node const &node) override
+        virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
                 return true;
@@ -911,7 +914,7 @@ TEST_F(OnDiskDbWithFileFixture, read_only_db_traverse_as_version_expire)
             return true;
         }
 
-        virtual void up(unsigned char branch, Node const &node) override
+        virtual void up(unsigned char const branch, Node const &node) override
         {
             auto const path_view = NibblesView{path};
             auto const rem_size = [&] {
@@ -1082,8 +1085,8 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
         }
 
         void set_value(
-            monad::async::erased_connected_operation *traverse_state,
-            monad::async::result<bool> res)
+            monad::async::erased_connected_operation *const traverse_state,
+            monad::async::result<bool> const res)
         {
             ASSERT_TRUE(res);
             result.traverse_success = res.assume_value();
@@ -1107,7 +1110,8 @@ TEST_F(OnDiskDbWithFileAsyncFixture, async_get_node_then_async_traverse)
         }
 
         void set_value(
-            monad::async::erased_connected_operation *state, ResultType res)
+            monad::async::erased_connected_operation *const state,
+            ResultType const res)
         {
             if (!res) {
                 result.traverse_success = false;
@@ -1576,7 +1580,7 @@ TYPED_TEST(DbTraverseTest, traverse)
             return std::make_unique<SimpleTraverse>(*this);
         }
 
-        Nibbles make_nibbles(std::initializer_list<uint8_t> nibbles)
+        Nibbles make_nibbles(std::initializer_list<uint8_t> const nibbles)
         {
             Nibbles ret{nibbles.size()};
             for (auto const *it = nibbles.begin(); it < nibbles.end(); ++it) {

--- a/category/mpt/test/fiber_future_wrapped_find.cpp
+++ b/category/mpt/test/fiber_future_wrapped_find.cpp
@@ -41,8 +41,8 @@ namespace
     using namespace MONAD_ASYNC_NAMESPACE;
 
     void find(
-        UpdateAux *aux, Node::SharedPtr root, monad::byte_string_view const key,
-        monad::byte_string_view const value)
+        UpdateAux *const aux, Node::SharedPtr const root,
+        monad::byte_string_view const key, monad::byte_string_view const value)
     {
         monad::threadsafe_boost_fibers_promise<
             monad::mpt::find_cursor_result_type>
@@ -54,7 +54,7 @@ namespace
         EXPECT_EQ(it.node->value(), value);
     };
 
-    void poll(AsyncIO *const io, bool *signal_done)
+    void poll(AsyncIO *const io, bool *const signal_done)
     {
         while (!*signal_done) {
             io->poll_nonblocking(1);

--- a/category/mpt/test/fiber_future_wrapped_read.cpp
+++ b/category/mpt/test/fiber_future_wrapped_read.cpp
@@ -61,7 +61,7 @@ namespace
         bool done{false};
 
         receiver_t(
-            FiberFutureWrappedFind::shared_state_t *fixture_shared_state_,
+            FiberFutureWrappedFind::shared_state_t *const fixture_shared_state_,
             ::boost::fibers::promise<
                 MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::buffer_type>
                 &&p,
@@ -74,7 +74,8 @@ namespace
 
         void set_value(
             erased_connected_operation *,
-            MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type res)
+            MONAD_ASYNC_NAMESPACE::read_single_buffer_sender::result_type const
+                res)
         {
             ASSERT_TRUE(res);
             auto &buffer = res.assume_value().get();

--- a/category/mpt/test/many_nested_updates.cpp
+++ b/category/mpt/test/many_nested_updates.cpp
@@ -58,7 +58,7 @@ using TrieTypes =
     ::testing::Types<InMemoryMerkleTrieGTest, OnDiskMerkleTrieGTest>;
 TYPED_TEST_SUITE(ManyNestedUpdates, TrieTypes);
 
-inline ::boost::json::value read_corpus(std::string_view suffix)
+inline ::boost::json::value read_corpus(std::string_view const suffix)
 {
     auto path = std::filesystem::path(__FILE__);
     path = std::filesystem::path(path).remove_filename() /
@@ -74,7 +74,7 @@ inline ::boost::json::value read_corpus(std::string_view suffix)
     return ::boost::json::parse(s);
 }
 
-inline monad::byte_string const &to_byte_string(std::string_view s)
+inline monad::byte_string const &to_byte_string(std::string_view const s)
 {
     static std::map<std::string, monad::byte_string> storage;
     std::string key(s);

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -93,13 +93,13 @@ using concurrent_queue = moodycamel::ConcurrentQueue<T>;
 
 using namespace monad::mpt;
 
-static void ctrl_c_handler(int s)
+static void ctrl_c_handler(int const s)
 {
     (void)s;
     exit(0);
 }
 
-void print_hex_bytes(monad::byte_string_view arr)
+void print_hex_bytes(monad::byte_string_view const arr)
 {
     fprintf(stdout, "0x");
     for (auto const &c : arr) {
@@ -120,11 +120,11 @@ namespace
     nkeys: number of keys to insert in this batch
 */
 Node::SharedPtr batch_upsert_commit(
-    std::ostream &csv_writer, uint64_t block_id, uint64_t const vec_idx,
+    std::ostream &csv_writer, uint64_t const block_id, uint64_t const vec_idx,
     uint64_t const key_offset, uint64_t const nkeys,
     std::vector<monad::byte_string> &keccak_keys,
     std::vector<monad::byte_string> &keccak_values, bool const erase,
-    bool compaction, Node::SharedPtr prev_root, UpdateAux &aux,
+    bool const compaction, Node::SharedPtr prev_root, UpdateAux &aux,
     StateMachine &sm)
 {
 
@@ -191,9 +191,9 @@ Node::SharedPtr batch_upsert_commit(
 }
 
 void prepare_keccak(
-    size_t nkeys, std::vector<monad::byte_string> &keccak_keys,
-    std::vector<monad::byte_string> &keccak_values, size_t key_offset,
-    bool realistic_corpus, bool is_random)
+    size_t const nkeys, std::vector<monad::byte_string> &keccak_keys,
+    std::vector<monad::byte_string> &keccak_values, size_t const key_offset,
+    bool const realistic_corpus, bool const is_random)
 {
     size_t val;
     // prepare keccak
@@ -284,7 +284,7 @@ void prepare_keccak(
     }
 }
 
-int main(int argc, char *argv[])
+int main(int const argc, char *argv[])
 {
     struct sigaction sig;
     sig.sa_handler = &ctrl_c_handler;
@@ -415,7 +415,7 @@ int main(int argc, char *argv[])
                 std::vector<std::byte *> pages;
                 ::monad::small_prng rand;
 
-                explicit cpu_cache_emptier_t(bool enable)
+                explicit cpu_cache_emptier_t(bool const enable)
                 {
                     if (enable) {
                         pages.resize(TLB_ENTRIES);
@@ -743,8 +743,9 @@ int main(int argc, char *argv[])
                         monad::byte_string key;
 
                         explicit receiver_t(
-                            uint64_t &ops_, bool &done_, unsigned n_slices_,
-                            NodeCursor begin, uint32_t id)
+                            uint64_t &ops_, bool &done_,
+                            unsigned const n_slices_, NodeCursor const begin,
+                            uint32_t const id)
                             : ops(ops_)
                             , done(done_)
                             , n_slices(n_slices_)
@@ -756,8 +757,8 @@ int main(int argc, char *argv[])
 
                         void set_value(
                             MONAD_ASYNC_NAMESPACE::erased_connected_operation
-                                *io_state,
-                            find_bytes_request_sender::result_type res)
+                                *const io_state,
+                            find_bytes_request_sender::result_type const res)
                         {
                             MONAD_ASSERT(res);
                             auto const [data, errc] = res.assume_value();

--- a/category/mpt/test/node_test.cpp
+++ b/category/mpt/test/node_test.cpp
@@ -52,7 +52,7 @@ struct DummyCompute final : Compute
         return 0;
     }
 
-    virtual unsigned compute(unsigned char *buffer, Node const &) override
+    virtual unsigned compute(unsigned char *const buffer, Node const &) override
     {
         buffer[0] = 0xa;
         return 1;

--- a/category/mpt/test/read_only_db_stress_test.cpp
+++ b/category/mpt/test/read_only_db_stress_test.cpp
@@ -70,7 +70,7 @@ static monad::byte_string to_key(uint64_t const key)
 }
 
 static uint64_t
-select_rand_version(Db const &db, monad::small_prng &rnd, double bias)
+select_rand_version(Db const &db, monad::small_prng &rnd, double const bias)
 {
     auto const version_range_start =
         static_cast<double>(db.get_earliest_version());
@@ -89,7 +89,7 @@ static void on_signal(int)
     g_done = 1;
 }
 
-int main(int argc, char *const argv[])
+int main(int const argc, char *const argv[])
 {
     unsigned num_sync_reader_threads = 4;
     unsigned num_async_reader_threads = 2;
@@ -310,8 +310,8 @@ int main(int argc, char *const argv[])
                     monad::byte_string version_bytes;
 
                     void set_value(
-                        monad::async::erased_connected_operation *state,
-                        monad::async::result<monad::byte_string> res)
+                        monad::async::erased_connected_operation *const state,
+                        monad::async::result<monad::byte_string> const res)
                     {
                         if (res) {
                             MONAD_ASSERT(res.value() == version_bytes);
@@ -406,14 +406,14 @@ int main(int argc, char *const argv[])
                     sig_atomic_t volatile &done;
 
                     explicit VersionValidatorMachine(
-                        size_t num_nodes_, sig_atomic_t volatile &done_)
+                        size_t const num_nodes_, sig_atomic_t volatile &done_)
                         : num_nodes(num_nodes_)
                         , done(done_)
                     {
                     }
 
                     virtual bool
-                    down(unsigned char branch, Node const &node) override
+                    down(unsigned char const branch, Node const &node) override
                     {
                         if (branch == INVALID_BRANCH) {
                             return true;
@@ -441,7 +441,7 @@ int main(int argc, char *const argv[])
                     }
 
                     virtual void
-                    up(unsigned char branch, Node const &node) override
+                    up(unsigned char const branch, Node const &node) override
                     {
                         auto const path_view = NibblesView{path};
                         auto const rem_size = [&] {

--- a/category/mpt/test/state_machine_test.cpp
+++ b/category/mpt/test/state_machine_test.cpp
@@ -66,7 +66,7 @@ namespace
             return std::make_unique<TestStateMachine>(*this);
         }
 
-        virtual void down(unsigned char nibble) override
+        virtual void down(unsigned char const nibble) override
         {
             EXPECT_LE(nibble, 0xf);
             auto const [_, success] = down_calls.emplace(path, nibble);
@@ -74,7 +74,7 @@ namespace
             path.push_back(nibble);
         }
 
-        virtual void up(size_t n) override
+        virtual void up(size_t const n) override
         {
             EXPECT_LE(n, path.size());
             // can invoke up() at same path for multiple times with async

--- a/category/mpt/test/subtrie_version_test.cpp
+++ b/category/mpt/test/subtrie_version_test.cpp
@@ -56,7 +56,7 @@ TEST_F(OnDiskMerkleTrieGTest, recursively_verify_versions)
 
         explicit TraverseVerifyVersions(
             std::stack<ExpectedSubtrieVersion> &records,
-            bool done_erase_ = false)
+            bool const done_erase_ = false)
             : records(records)
             , done_erase{done_erase_}
         {

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -69,7 +69,7 @@ namespace monad::test
             ++depth;
         }
 
-        virtual void up(size_t n) override
+        virtual void up(size_t const n) override
         {
             MONAD_ASSERT(n <= depth);
             depth -= n;
@@ -128,7 +128,7 @@ namespace monad::test
             ++depth;
         }
 
-        virtual void up(size_t n) override
+        virtual void up(size_t const n) override
         {
             MONAD_ASSERT(n <= depth);
             depth -= n;
@@ -194,7 +194,7 @@ namespace monad::test
             ++depth;
         }
 
-        virtual void up(size_t n) override
+        virtual void up(size_t const n) override
         {
             MONAD_ASSERT(n <= depth);
             depth -= n;
@@ -569,7 +569,7 @@ namespace monad::test
                 return s;
             }
 
-            void ensure_total_chunks(size_t chunks)
+            void ensure_total_chunks(size_t const chunks)
             {
                 std::vector<Update> updates;
                 updates.reserve(Config.updates_per_block);

--- a/category/mpt/test/test_fixtures_gtest.hpp
+++ b/category/mpt/test/test_fixtures_gtest.hpp
@@ -51,7 +51,7 @@ namespace monad::test
         using FillDBWithChunks<Config, ::testing::Test>::FillDBWithChunks;
     };
 
-    inline std::filesystem::path create_temp_file(long size_gb)
+    inline std::filesystem::path create_temp_file(long const size_gb)
     {
         std::filesystem::path const filename{
             MONAD_ASYNC_NAMESPACE::working_temporary_directory() /

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -62,7 +62,7 @@ namespace detail
     void async_parallel_preorder_traverse_impl(
         TraverseSender &sender,
         async::erased_connected_operation *traverse_state, Node const &node,
-        TraverseMachine &machine, unsigned char const branch);
+        TraverseMachine &machine, unsigned char branch);
 
     // current implementation does not contaminate triedb node caching
     inline bool preorder_traverse_blocking_impl(
@@ -135,7 +135,7 @@ namespace detail
             unsigned char const branch;
 
             receiver_t(
-                TraverseSender *sender,
+                TraverseSender *const sender,
                 async::erased_connected_operation *const traverse_state,
                 unsigned char const branch, chunk_offset_t const offset,
                 std::unique_ptr<TraverseMachine> machine)
@@ -228,7 +228,7 @@ namespace detail
         }
 
         async::result<void>
-        operator()(async::erased_connected_operation *traverse_state)
+        operator()(async::erased_connected_operation *const traverse_state)
         {
             MONAD_ASSERT(traverse_root != nullptr);
             async_parallel_preorder_traverse_init(
@@ -273,7 +273,8 @@ namespace detail
 
     inline void async_parallel_preorder_traverse_init(
         TraverseSender &sender,
-        async::erased_connected_operation *traverse_state, Node const &node)
+        async::erased_connected_operation *const traverse_state,
+        Node const &node)
     {
         sender.within_recursion_count++;
         async_parallel_preorder_traverse_impl(
@@ -290,8 +291,8 @@ namespace detail
 
     inline void async_parallel_preorder_traverse_impl(
         TraverseSender &sender,
-        async::erased_connected_operation *traverse_state, Node const &node,
-        TraverseMachine &machine, unsigned char const branch)
+        async::erased_connected_operation *const traverse_state,
+        Node const &node, TraverseMachine &machine, unsigned char const branch)
     {
         // How many children are considered left side for depth first preference
         // Two and four was benchmarked as slightly worse than three, so three
@@ -401,8 +402,8 @@ inline bool preorder_traverse_ondisk(
         }
 
         void set_value(
-            async::erased_connected_operation *traverse_state,
-            async::result<bool> traverse_completed)
+            async::erased_connected_operation *const traverse_state,
+            async::result<bool> const traverse_completed)
         {
             MONAD_ASSERT(traverse_completed);
             version_expired_before_traverse_complete_ =

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -103,8 +103,8 @@ void try_fillin_parent_after_expiration(
 void propagate_upward(UpdateAux &, StateMachine &, TNodeBase *);
 
 void fillin_parent_after_expiration(
-    UpdateAux &, Node::SharedPtr, UpdateExpireBase *const, uint8_t const index,
-    uint8_t const branch, bool const cache_node);
+    UpdateAux &, Node::SharedPtr, UpdateExpireBase *const, uint8_t index,
+    uint8_t branch, bool cache_node);
 
 struct async_write_node_result
 {
@@ -125,7 +125,7 @@ void erase_child_from_parent(UpdateTNode &parent, ChildData &entry)
 }
 
 void erase_child_from_parent(
-    UpdateExpireBase &parent, uint8_t branch, uint8_t index)
+    UpdateExpireBase &parent, uint8_t const branch, uint8_t const index)
 {
     parent.mask &= static_cast<uint16_t>(~(1u << branch));
     if (parent.type == tnode_type::update) {
@@ -257,8 +257,8 @@ struct load_all_impl_
         uint16_t buffer_off;
 
         receiver_t(
-            load_all_impl_ *impl, NodeCursor root, unsigned char const branch,
-            std::unique_ptr<StateMachine> sm)
+            load_all_impl_ *const impl, NodeCursor const root,
+            unsigned char const branch, std::unique_ptr<StateMachine> sm)
             : impl(impl)
             , root(root)
             , branch_index(branch)
@@ -935,9 +935,9 @@ void fillin_entry(
  * and there might be update to the leaf value. */
 void dispatch_updates_impl_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
-    Node::SharedPtr old_ptr, Requests &requests, unsigned const prefix_index,
-    NibblesView const path, std::optional<byte_string_view> const opt_leaf_data,
-    int64_t const version)
+    Node::SharedPtr const old_ptr, Requests &requests,
+    unsigned const prefix_index, NibblesView const path,
+    std::optional<byte_string_view> const opt_leaf_data, int64_t const version)
 {
     Node *old = old_ptr.get();
     uint16_t const orig_mask = old->mask | requests.mask;
@@ -1003,7 +1003,7 @@ void dispatch_updates_impl_(
 // prefix_index to `requests`, which can have 1 or more sublists.
 void mismatch_handler_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
-    Node::SharedPtr old_ptr, Requests &requests, NibblesView const path,
+    Node::SharedPtr const old_ptr, Requests &requests, NibblesView const path,
     unsigned const old_prefix_index, unsigned const prefix_index)
 {
     MONAD_ASSERT(old_ptr);

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -75,7 +75,8 @@ struct write_operation_io_receiver
 
     void set_value(
         MONAD_ASYNC_NAMESPACE::erased_connected_operation *,
-        MONAD_ASYNC_NAMESPACE::write_single_buffer_sender::result_type res)
+        MONAD_ASYNC_NAMESPACE::write_single_buffer_sender::result_type const
+            res)
     {
         MONAD_ASSERT(res);
         MONAD_ASSERT(res.assume_value().get().size() == should_be_written);
@@ -278,7 +279,7 @@ public:
     void collect_compaction_read_stats(
         chunk_offset_t node_offset, unsigned bytes_to_read);
     void collect_compacted_nodes_stats(
-        bool const copy_node_for_fast, bool const rewrite_to_fast,
+        bool copy_node_for_fast, bool rewrite_to_fast,
         virtual_chunk_offset_t node_offset, uint32_t node_disk_size);
 
     void print_update_stats(uint64_t version);
@@ -313,14 +314,14 @@ public:
     void rewind_to_version(uint64_t version);
     void clear_ondisk_db();
 
-    void set_initial_insertion_count_unit_testing_only(uint32_t count)
+    void set_initial_insertion_count_unit_testing_only(uint32_t const count)
     {
         initial_insertion_count_on_pool_creation_ = count;
     }
 
     // WARNING: for unit testing only
     // DO NOT invoke it outside of unit test
-    void alternate_slow_fast_node_writer_unit_testing_only(bool alternate)
+    void alternate_slow_fast_node_writer_unit_testing_only(bool const alternate)
     {
         alternate_slow_fast_writer_ = alternate;
     }
@@ -335,7 +336,7 @@ public:
         return can_write_to_fast_;
     }
 
-    void set_can_write_to_fast(bool v) noexcept
+    void set_can_write_to_fast(bool const v) noexcept
     {
         can_write_to_fast_ = v;
     }
@@ -356,7 +357,7 @@ public:
                (double)num_chunks(chunk_list::free) / (double)io->chunk_count();
     }
 
-    uint32_t num_chunks(chunk_list const list) const noexcept;
+    uint32_t num_chunks(chunk_list list) const noexcept;
 };
 
 // sizeof changed: db_metadata_[2] replaced by unique_ptr<DbMetadataContext>
@@ -502,7 +503,7 @@ inline constexpr unsigned num_pages(file_offset_t const offset, unsigned bytes)
 
 inline compact_offset_pair calc_min_offsets(
     Node &node,
-    virtual_chunk_offset_t node_virtual_offset = INVALID_VIRTUAL_OFFSET)
+    virtual_chunk_offset_t const node_virtual_offset = INVALID_VIRTUAL_OFFSET)
 {
     compact_offset_pair ret;
     if (node_virtual_offset != INVALID_VIRTUAL_OFFSET) {

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -1138,7 +1138,7 @@ void UpdateAux::collect_expire_stats(bool const is_read)
 
 void UpdateAux::collect_compacted_nodes_stats(
     bool const copy_node_for_fast, bool const rewrite_to_fast,
-    virtual_chunk_offset_t node_offset, uint32_t node_disk_size)
+    virtual_chunk_offset_t const node_offset, uint32_t const node_disk_size)
 {
 #if MONAD_MPT_COLLECT_STATS
     if (copy_node_for_fast) {

--- a/category/mpt/upward_tnode.hpp
+++ b/category/mpt/upward_tnode.hpp
@@ -104,7 +104,7 @@ struct UpdateExpireBase : public TNodeBase
 protected:
     UpdateExpireBase(
         TNodeBase *const parent, tnode_type const type, uint8_t const npending,
-        uint8_t branch, uint16_t const mask)
+        uint8_t const branch, uint16_t const mask)
         : TNodeBase(parent, type, npending)
         , branch(branch)
         , mask(mask)
@@ -320,8 +320,8 @@ struct ExpireTNode : public UpdateExpireBase
                          allocator_type, &ExpireTNode::pool>>;
 
     static unique_ptr_type make(
-        UpdateExpireBase *const parent, unsigned const branch, unsigned index,
-        bool const cache_node, Node::SharedPtr node)
+        UpdateExpireBase *const parent, unsigned const branch,
+        unsigned const index, bool const cache_node, Node::SharedPtr node)
     {
         MONAD_ASSERT(parent);
         return allocators::allocate_unique<allocator_type, &ExpireTNode::pool>(

--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -80,8 +80,9 @@ struct virtual_chunk_offset_t
     }
 
     constexpr virtual_chunk_offset_t(
-        uint32_t count_, file_offset_t offset_, file_offset_t is_fast_list_,
-        file_offset_t spare_ = MAX_SPARE)
+        uint32_t const count_, file_offset_t const offset_,
+        file_offset_t const is_fast_list_,
+        file_offset_t const spare_ = MAX_SPARE)
         : offset(offset_ & MAX_OFFSET)
         , count(count_ & MAX_COUNT)
         , spare{spare_ & MAX_SPARE}
@@ -139,7 +140,7 @@ static_assert(INVALID_VIRTUAL_OFFSET.in_fast_list());
 
 struct virtual_chunk_offset_t_hasher
 {
-    constexpr size_t operator()(virtual_chunk_offset_t v) const noexcept
+    constexpr size_t operator()(virtual_chunk_offset_t const v) const noexcept
     {
         return fnv1a_hash<file_offset_t>()(v.hasher_raw());
     }
@@ -172,7 +173,7 @@ public:
     }
 
     constexpr compact_virtual_chunk_offset_t(
-        prevent_public_construction_tag, uint32_t v)
+        prevent_public_construction_tag, uint32_t const v)
         : v_{v}
     {
     }
@@ -185,7 +186,7 @@ public:
         MONAD_ASSERT(offset != INVALID_VIRTUAL_OFFSET);
     }
 
-    void set_value(uint32_t v) noexcept
+    void set_value(uint32_t const v) noexcept
     {
         v_ = v;
     }
@@ -246,13 +247,14 @@ struct compact_offset_pair
     compact_virtual_chunk_offset_t slow{INVALID_COMPACT_VIRTUAL_OFFSET};
 
     // Returns true if either component is below the corresponding threshold
-    constexpr bool any_below(compact_offset_pair threshold) const noexcept
+    constexpr bool any_below(compact_offset_pair const threshold) const noexcept
     {
         return fast < threshold.fast || slow < threshold.slow;
     }
 
     // Returns true if the fast component is below the threshold
-    constexpr bool fast_below(compact_offset_pair threshold) const noexcept
+    constexpr bool
+    fast_below(compact_offset_pair const threshold) const noexcept
     {
         return fast < threshold.fast;
     }

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -1432,14 +1432,16 @@ struct monad_executor_state monad_executor_get_state(monad_executor *const e)
 }
 
 void monad_executor_run_transactions(
-    struct monad_executor *executor, enum monad_chain_config chain_config,
-    uint8_t const *rlp_header, size_t rlp_header_len, uint64_t block_number,
-    uint8_t const *rlp_block_id, size_t rlp_block_id_len,
-    uint8_t const *rlp_parent_block_id, size_t rlp_parent_block_id_len,
-    uint8_t const *rlp_grandparent_block_id,
-    size_t rlp_grandparent_block_id_len, int64_t const transaction_index,
-    void (*complete)(monad_executor_result *, void *user), void *user,
-    enum monad_tracer_config tracer_config)
+    struct monad_executor *const executor,
+    enum monad_chain_config const chain_config, uint8_t const *const rlp_header,
+    size_t const rlp_header_len, uint64_t const block_number,
+    uint8_t const *const rlp_block_id, size_t const rlp_block_id_len,
+    uint8_t const *const rlp_parent_block_id,
+    size_t const rlp_parent_block_id_len,
+    uint8_t const *const rlp_grandparent_block_id,
+    size_t const rlp_grandparent_block_id_len, int64_t const transaction_index,
+    void (*complete)(monad_executor_result *, void *user), void *const user,
+    enum monad_tracer_config const tracer_config)
 {
     MONAD_ASSERT(executor);
 

--- a/category/rpc/monad_executor.h
+++ b/category/rpc/monad_executor.h
@@ -115,7 +115,7 @@ void monad_executor_run_transactions(
     size_t rlp_block_id_len, uint8_t const *rlp_parent_block_id,
     size_t rlp_parent_block_id_len, uint8_t const *rlp_grandparent_block_id,
     size_t rlp_grandparent_block_id_len,
-    int64_t const transaction_index, /* transaction_index >= 0 implies tracing
+    int64_t transaction_index, /* transaction_index >= 0 implies tracing
                                         of a single transaction. */
     void (*complete)(monad_executor_result *, void *user), void *user,
     enum monad_tracer_config);

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -171,7 +171,8 @@ namespace
         }
     };
 
-    void complete_callback(monad_executor_result *result, void *user)
+    void
+    complete_callback(monad_executor_result *const result, void *const user)
     {
         auto *c = (callback_context *)user;
 

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -38,7 +38,7 @@ unsigned const MONAD_SQPOLL_DISABLED = unsigned(-1);
 
 monad_statesync_client_context *monad_statesync_client_context_create(
     char const *const *const dbname_paths, size_t const len,
-    unsigned const sq_thread_cpu, monad_statesync_client *sync,
+    unsigned const sq_thread_cpu, monad_statesync_client *const sync,
     void (*statesync_send_request)(
         monad_statesync_client *, monad_sync_request))
 {

--- a/category/statesync/statesync_server_network.hpp
+++ b/category/statesync/statesync_server_network.hpp
@@ -128,7 +128,8 @@ namespace
 }
 
 inline ssize_t statesync_server_recv(
-    monad_statesync_server_network *const net, unsigned char *buf, size_t n)
+    monad_statesync_server_network *const net, unsigned char *const buf,
+    size_t const n)
 {
     size_t total_received = 0;
 

--- a/category/statesync/statesync_thread.hpp
+++ b/category/statesync/statesync_thread.hpp
@@ -38,7 +38,7 @@ struct StateSyncServerConfig
 
 struct monad_statesync_server_deleter
 {
-    void operator()(monad_statesync_server *server) const
+    void operator()(monad_statesync_server *const server) const
     {
         if (server != nullptr) {
             monad_statesync_server_destroy(server);

--- a/category/statesync/test/test_network_shutdown.cpp
+++ b/category/statesync/test/test_network_shutdown.cpp
@@ -43,7 +43,7 @@ namespace
     // Returns a socket path unique per process to avoid bind() collisions when
     // tests run in parallel. Assumes TMPDIR is short enough that the full path
     // stays within sun_path (108 bytes).
-    std::filesystem::path unique_socket_path(std::string_view name)
+    std::filesystem::path unique_socket_path(std::string_view const name)
     {
         return std::filesystem::temp_directory_path() /
                (std::string(name) + "_" + std::to_string(::getpid()) + ".sock");

--- a/category/vm/code.hpp
+++ b/category/vm/code.hpp
@@ -33,7 +33,7 @@ namespace monad::vm
     }
 
     inline SharedIntercode
-    make_shared_intercode(std::initializer_list<uint8_t> a)
+    make_shared_intercode(std::initializer_list<uint8_t> const a)
     {
         return std::make_shared<Intercode const>(a);
     }

--- a/category/vm/compiler.hpp
+++ b/category/vm/compiler.hpp
@@ -189,7 +189,7 @@ namespace monad::vm
         }
 
         SharedVarcode try_insert_varcode_raw(
-            bytes32_t const &code_hash, std::span<uint8_t const> code)
+            bytes32_t const &code_hash, std::span<uint8_t const> const code)
         {
             return varcode_cache_.try_set_raw(code_hash, code);
         }

--- a/category/vm/compiler/ir/basic_blocks.hpp
+++ b/category/vm/compiler/ir/basic_blocks.hpp
@@ -274,7 +274,7 @@ namespace monad::vm::compiler::basic_blocks
         /**
          * Retrieve a block by its identifier.
          */
-        Block const &block(block_id id) const
+        Block const &block(block_id const id) const
         {
             return blocks_.at(id);
         }

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -110,32 +110,33 @@ namespace
             x86::qword_ptr(x86::rbp, offset.offset * 32 + 24)};
     }
 
-    x86::Mem stack_offset_to_mem(StackOffset offset)
+    x86::Mem stack_offset_to_mem(StackOffset const offset)
     {
         return x86::qword_ptr(x86::rbp, offset.offset * 32);
     }
 
-    x86::Ymm avx_reg_to_ymm(AvxReg reg)
+    x86::Ymm avx_reg_to_ymm(AvxReg const reg)
     {
         MONAD_DEBUG_ASSERT(reg.reg < 32);
         return x86::Ymm(reg.reg);
     }
 
-    x86::Xmm avx_reg_to_xmm(AvxReg reg)
+    x86::Xmm avx_reg_to_xmm(AvxReg const reg)
     {
         MONAD_DEBUG_ASSERT(reg.reg < 32);
         return x86::Xmm(reg.reg);
     }
 
     void runtime_print_gas_remaining_impl(
-        char const *msg, runtime::Context const *ctx)
+        char const *const msg, runtime::Context const *const ctx)
     {
         std::cout << msg << ": gas remaining: " << ctx->gas_remaining
                   << std::endl;
     }
 
     void runtime_print_input_stack_impl(
-        char const *msg, runtime::uint256_t *stack, uint64_t stack_size)
+        char const *const msg, runtime::uint256_t *const stack,
+        uint64_t const stack_size)
     {
         std::cout << msg << ": stack: ";
         for (size_t i = 0; i < stack_size; ++i) {
@@ -145,22 +146,24 @@ namespace
     }
 
     uint64_t runtime_store_input_stack_impl(
-        runtime::Context const *ctx, runtime::uint256_t *stack,
-        uint64_t stack_size, uint64_t offset, uint64_t base_offset)
+        runtime::Context const *const ctx, runtime::uint256_t *const stack,
+        uint64_t const stack_size, uint64_t const offset,
+        uint64_t const base_offset)
     {
         return runtime::debug_tstore_stack(
             ctx, stack, stack_size, offset, base_offset);
     }
 
     void runtime_print_top2_impl(
-        char const *msg, runtime::uint256_t const *x,
-        runtime::uint256_t const *y)
+        char const *const msg, runtime::uint256_t const *const x,
+        runtime::uint256_t const *const y)
     {
         std::cout << msg << ": " << x->to_string() << " and " << y->to_string()
                   << std::endl;
     }
 
-    void runtime_print_top1_impl(char const *msg, runtime::uint256_t const *x)
+    void runtime_print_top1_impl(
+        char const *const msg, runtime::uint256_t const *const x)
     {
         std::cout << msg << ": " << x->to_string() << std::endl;
     }
@@ -223,13 +226,13 @@ namespace monad::vm::compiler::native
     {
     }
 
-    Emitter::Error::Error(char const *msg)
+    Emitter::Error::Error(char const *const msg)
         : std::runtime_error{msg}
     {
     }
 
     void Emitter::EmitErrorHandler::handleError(
-        asmjit::Error, char const *msg, asmjit::BaseEmitter *)
+        asmjit::Error, char const *const msg, asmjit::BaseEmitter *)
     {
         throw Emitter::Error(std::format("x86 emitter error: {}", msg));
     }
@@ -262,7 +265,7 @@ namespace monad::vm::compiler::native
         return true;
     }
 
-    char const *Emitter::location_type_to_string(LocationType loc)
+    char const *Emitter::location_type_to_string(LocationType const loc)
     {
         switch (loc) {
         case Emitter::LocationType::AvxReg:
@@ -302,7 +305,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    Emitter::RoData::RoData(asmjit::Label lbl)
+    Emitter::RoData::RoData(asmjit::Label const lbl)
         : label_{lbl}
     {
     }
@@ -349,7 +352,8 @@ namespace monad::vm::compiler::native
         return x86::qword_ptr(label_, offset);
     }
 
-    asmjit::x86::Mem Emitter::RoData::add16(uint64_t x0, uint64_t x1)
+    asmjit::x86::Mem
+    Emitter::RoData::add16(uint64_t const x0, uint64_t const x1)
     {
         std::array<uint8_t, 16> x;
         std::memcpy(x.data(), &x0, 8);
@@ -357,14 +361,14 @@ namespace monad::vm::compiler::native
         return add<16>(x);
     }
 
-    asmjit::x86::Mem Emitter::RoData::add8(uint64_t x0)
+    asmjit::x86::Mem Emitter::RoData::add8(uint64_t const x0)
     {
         std::array<uint8_t, 8> x;
         std::memcpy(x.data(), &x0, 8);
         return add<8>(x);
     }
 
-    asmjit::x86::Mem Emitter::RoData::add4(uint32_t x0)
+    asmjit::x86::Mem Emitter::RoData::add4(uint32_t const x0)
     {
         std::array<uint8_t, 4> x;
         std::memcpy(x.data(), &x0, 4);
@@ -513,7 +517,7 @@ namespace monad::vm::compiler::native
         return spill_avx_;
     }
 
-    void Emitter::RuntimeImpl::mov_arg(size_t arg_index, RuntimeArg &&arg)
+    void Emitter::RuntimeImpl::mov_arg(size_t const arg_index, RuntimeArg &&arg)
     {
         static_assert(MAX_RUNTIME_ARGS == 12);
         switch (arg_index) {
@@ -570,8 +574,8 @@ namespace monad::vm::compiler::native
             arg);
     }
 
-    void
-    Emitter::RuntimeImpl::mov_stack_arg(int32_t sp_offset, RuntimeArg &&arg)
+    void Emitter::RuntimeImpl::mov_stack_arg(
+        int32_t const sp_offset, RuntimeArg &&arg)
     {
         std::visit(
             Cases{
@@ -590,7 +594,7 @@ namespace monad::vm::compiler::native
     }
 
     Emitter::Emitter(
-        asmjit::JitRuntime const &rt, interpreter::code_size_t codesize,
+        asmjit::JitRuntime const &rt, interpreter::code_size_t const codesize,
         CompilerConfig const &config)
         : runtime_debug_trace_{config.runtime_debug_trace}
         , as_{init_code_holder(rt, config.asm_log_path)}
@@ -715,7 +719,7 @@ namespace monad::vm::compiler::native
     }
 
     asmjit::CodeHolder *Emitter::init_code_holder(
-        asmjit::JitRuntime const &rt, char const *log_path)
+        asmjit::JitRuntime const &rt, char const *const log_path)
     {
         code_holder_.setErrorHandler(&error_handler_);
         if (log_path) {
@@ -810,7 +814,7 @@ namespace monad::vm::compiler::native
      * stack's min_delta, which ensures that we don't save stale values that
      * might have been modified by the current block.
      */
-    void Emitter::runtime_store_input_stack(uint64_t base_offset)
+    void Emitter::runtime_store_input_stack(uint64_t const base_offset)
     {
         if (!utils::is_fuzzing_monad_vm) {
             return;
@@ -955,7 +959,8 @@ namespace monad::vm::compiler::native
         stack_.swap_general_regs(x, y);
     }
 
-    void Emitter::swap_general_reg_indices(GeneralReg r, uint8_t i, uint8_t j)
+    void Emitter::swap_general_reg_indices(
+        GeneralReg const r, uint8_t const i, uint8_t const j)
     {
         MONAD_ASSERT(i < 4);
         MONAD_ASSERT(j < 4);
@@ -972,7 +977,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::fail_with_error(asmjit::Error e)
+    void Emitter::fail_with_error(asmjit::Error const e)
     {
         as_.reportError(e);
         std::unreachable();
@@ -995,7 +1000,7 @@ namespace monad::vm::compiler::native
                rodata_.estimate_size() + (*bytecode_size_ << 2);
     }
 
-    void Emitter::add_jump_dest(byte_offset d)
+    void Emitter::add_jump_dest(byte_offset const d)
     {
         char name[2 * sizeof(byte_offset) + 2];
         static_assert(sizeof(byte_offset) <= sizeof(long));
@@ -1019,7 +1024,7 @@ namespace monad::vm::compiler::native
         return block_prologue(b);
     }
 
-    void Emitter::gas_decrement_static_work(int64_t gas)
+    void Emitter::gas_decrement_static_work(int64_t const gas)
     {
         if (gas) {
             gas_decrement_no_check(gas);
@@ -1029,7 +1034,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::gas_decrement_unbounded_work(int64_t gas)
+    void Emitter::gas_decrement_unbounded_work(int64_t const gas)
     {
         accumulated_static_work_ = 0;
         if (gas) {
@@ -1038,7 +1043,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::spill_caller_save_regs(bool spill_avx)
+    void Emitter::spill_caller_save_regs(bool const spill_avx)
     {
         // Spill general regs first, because if stack element is in both
         // general register and avx register then stack element will be
@@ -1062,7 +1067,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::spill_avx_reg_range(uint8_t start)
+    void Emitter::spill_avx_reg_range(uint8_t const start)
     {
         for (auto const &[reg, off] : stack_.spill_avx_reg_range(start)) {
             as_.vmovaps(stack_offset_to_mem(off), avx_reg_to_ymm(reg));
@@ -1094,7 +1099,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    AvxRegReserv Emitter::insert_avx_reg(StackElemRef elem)
+    AvxRegReserv Emitter::insert_avx_reg(StackElemRef const elem)
     {
         auto [reserv, offset] = stack_.insert_avx_reg(elem);
         if (offset.has_value()) {
@@ -1114,7 +1119,7 @@ namespace monad::vm::compiler::native
         return {elem, reserv};
     }
 
-    GeneralRegReserv Emitter::insert_general_reg(StackElemRef elem)
+    GeneralRegReserv Emitter::insert_general_reg(StackElemRef const elem)
     {
         auto [reserv, offset] = stack_.insert_general_reg(elem);
         if (offset.has_value()) {
@@ -1238,7 +1243,7 @@ namespace monad::vm::compiler::native
         return is_live(reg, live, std::index_sequence_for<LiveSet...>{});
     }
 
-    void Emitter::gas_decrement_no_check(int64_t gas)
+    void Emitter::gas_decrement_no_check(int64_t const gas)
     {
         MONAD_DEBUG_ASSERT(gas > 0);
 
@@ -1265,14 +1270,14 @@ namespace monad::vm::compiler::native
             static_cast<int32_t>(gas));
     }
 
-    void Emitter::gas_decrement_no_check(x86::Gpq gas)
+    void Emitter::gas_decrement_no_check(x86::Gpq const gas)
     {
         as_.sub(
             x86::qword_ptr(reg_context, runtime::context_offset_gas_remaining),
             gas);
     }
 
-    bool Emitter::accumulate_static_work(int64_t work)
+    bool Emitter::accumulate_static_work(int64_t const work)
     {
         MONAD_DEBUG_ASSERT(work >= 0);
         MONAD_DEBUG_ASSERT(
@@ -1647,8 +1652,8 @@ namespace monad::vm::compiler::native
     }
 
     // Does not update eflags
-    void
-    Emitter::discharge_deferred_comparison(StackElem *elem, Comparison comp)
+    void Emitter::discharge_deferred_comparison(
+        StackElem *const elem, Comparison const comp)
     {
         MONAD_DEBUG_ASSERT(
             !elem->general_reg() && !elem->avx_reg() && !elem->literal() &&
@@ -1691,7 +1696,7 @@ namespace monad::vm::compiler::native
         as_.vmovd(x, x86::eax);
     }
 
-    Emitter::Gpq256 &Emitter::general_reg_to_gpq256(GeneralReg reg)
+    Emitter::Gpq256 &Emitter::general_reg_to_gpq256(GeneralReg const reg)
     {
         MONAD_DEBUG_ASSERT(reg.reg <= 2);
         return gpq256_regs_[reg.reg];
@@ -1772,17 +1777,17 @@ namespace monad::vm::compiler::native
         MONAD_ABORT();
     }
 
-    void Emitter::mov_stack_index_to_avx_reg(int32_t stack_index)
+    void Emitter::mov_stack_index_to_avx_reg(int32_t const stack_index)
     {
         mov_stack_elem_to_avx_reg(stack_.get(stack_index));
     }
 
-    void Emitter::mov_stack_index_to_general_reg(int32_t stack_index)
+    void Emitter::mov_stack_index_to_general_reg(int32_t const stack_index)
     {
         mov_stack_elem_to_general_reg(stack_.get(stack_index));
     }
 
-    void Emitter::mov_stack_index_to_stack_offset(int32_t stack_index)
+    void Emitter::mov_stack_index_to_stack_offset(int32_t const stack_index)
     {
         mov_stack_elem_to_stack_offset(stack_.get(stack_index));
     }
@@ -1822,8 +1827,8 @@ namespace monad::vm::compiler::native
             stack_.alloc_literal(lit), mem);
     }
 
-    void
-    Emitter::mov_general_reg_to_mem(GeneralReg reg, asmjit::x86::Mem const &mem)
+    void Emitter::mov_general_reg_to_mem(
+        GeneralReg const reg, asmjit::x86::Mem const &mem)
     {
         x86::Mem temp{mem};
         for (auto const &r : general_reg_to_gpq256(reg)) {
@@ -1858,7 +1863,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::mov_general_reg_to_gpq256(GeneralReg reg, Gpq256 const &gpq)
+    void
+    Emitter::mov_general_reg_to_gpq256(GeneralReg const reg, Gpq256 const &gpq)
     {
         Gpq256 const &temp = general_reg_to_gpq256(reg);
         if (&temp != &gpq) {
@@ -1896,8 +1902,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void
-    Emitter::mov_stack_offset_to_gpq256(StackOffset offset, Gpq256 const &gpq)
+    void Emitter::mov_stack_offset_to_gpq256(
+        StackOffset const offset, Gpq256 const &gpq)
     {
         mov_mem_to_gpq256(stack_offset_to_mem(offset), gpq);
     }
@@ -1928,7 +1934,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::mov_stack_elem_low64_to_gpq(StackElemRef elem, x86::Gpq gp)
+    void Emitter::mov_stack_elem_low64_to_gpq(
+        StackElemRef const elem, x86::Gpq const gp)
     {
         if (elem->general_reg()) {
             auto const &gp256 = general_reg_to_gpq256(*elem->general_reg());
@@ -2011,8 +2018,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void
-    Emitter::mov_stack_elem_to_general_reg(StackElemRef elem, int32_t preferred)
+    void Emitter::mov_stack_elem_to_general_reg(
+        StackElemRef elem, int32_t const preferred)
     {
         if (elem->general_reg()) {
             return;
@@ -2047,7 +2054,7 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::mov_stack_elem_to_stack_offset(
-        StackElemRef elem, int32_t preferred_offset)
+        StackElemRef elem, int32_t const preferred_offset)
     {
         if (elem->stack_offset()) {
             return;
@@ -2064,7 +2071,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::mov_general_reg_to_avx_reg(StackElemRef elem)
+    void Emitter::mov_general_reg_to_avx_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->general_reg().has_value());
         Gpq256 const &gpq = general_reg_to_gpq256(*elem->general_reg());
@@ -2083,14 +2090,14 @@ namespace monad::vm::compiler::native
         as_.vinserti128(ymm0, ymm0, xmm1, 1);
     }
 
-    void Emitter::mov_literal_to_avx_reg(StackElemRef elem)
+    void Emitter::mov_literal_to_avx_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->literal().has_value());
         auto const reserv = insert_avx_reg(elem);
         mov_literal_to_ymm(*elem->literal(), avx_reg_to_ymm(*elem->avx_reg()));
     }
 
-    void Emitter::mov_stack_offset_to_avx_reg(StackElemRef elem)
+    void Emitter::mov_stack_offset_to_avx_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->stack_offset().has_value());
         auto const reserv = insert_avx_reg(elem);
@@ -2105,8 +2112,8 @@ namespace monad::vm::compiler::native
         mov_avx_reg_to_stack_offset(std::move(elem), preferred);
     }
 
-    void
-    Emitter::mov_avx_reg_to_stack_offset(StackElemRef elem, int32_t preferred)
+    void Emitter::mov_avx_reg_to_stack_offset(
+        StackElemRef const elem, int32_t const preferred)
     {
         MONAD_DEBUG_ASSERT(elem->avx_reg().has_value());
         stack_.insert_stack_offset(elem, preferred, PrevLoc::AvxReg);
@@ -2120,14 +2127,14 @@ namespace monad::vm::compiler::native
         mov_general_reg_to_stack_offset(elem, preferred);
     }
 
-    void Emitter::mov_general_reg_to_stack_offset(StackElemRef elem)
+    void Emitter::mov_general_reg_to_stack_offset(StackElemRef const elem)
     {
         int32_t const preferred = elem->preferred_stack_offset();
         mov_general_reg_to_stack_offset(*elem, preferred);
     }
 
-    void
-    Emitter::mov_general_reg_to_stack_offset(StackElem &elem, int32_t preferred)
+    void Emitter::mov_general_reg_to_stack_offset(
+        StackElem &elem, int32_t const preferred)
     {
         MONAD_DEBUG_ASSERT(elem.general_reg().has_value());
         stack_.insert_stack_offset(elem, preferred, PrevLoc::GprReg);
@@ -2136,7 +2143,7 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::mov_general_reg_to_stack_offset(
-        StackElemRef elem, int32_t preferred)
+        StackElemRef const elem, int32_t const preferred)
     {
         return mov_general_reg_to_stack_offset(*elem, preferred);
     }
@@ -2147,8 +2154,8 @@ namespace monad::vm::compiler::native
         mov_literal_to_stack_offset(std::move(elem), preferred);
     }
 
-    void
-    Emitter::mov_literal_to_stack_offset(StackElemRef elem, int32_t preferred)
+    void Emitter::mov_literal_to_stack_offset(
+        StackElemRef const elem, int32_t const preferred)
     {
         MONAD_DEBUG_ASSERT(elem->literal().has_value());
         // mov_literal_to_mem stores literals by first loading them into an avx
@@ -2165,14 +2172,14 @@ namespace monad::vm::compiler::native
         mov_avx_reg_to_general_reg(std::move(elem), preferred);
     }
 
-    void
-    Emitter::mov_avx_reg_to_general_reg(StackElemRef elem, int32_t preferred)
+    void Emitter::mov_avx_reg_to_general_reg(
+        StackElemRef const elem, int32_t const preferred)
     {
         mov_avx_reg_to_stack_offset(elem, preferred);
         mov_stack_offset_to_general_reg(elem);
     }
 
-    void Emitter::mov_literal_to_general_reg(StackElemRef elem)
+    void Emitter::mov_literal_to_general_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->literal().has_value());
         auto const reserv = insert_general_reg(elem);
@@ -2180,7 +2187,7 @@ namespace monad::vm::compiler::native
             *elem->literal(), general_reg_to_gpq256(*elem->general_reg()));
     }
 
-    void Emitter::mov_stack_offset_to_general_reg(StackElemRef elem)
+    void Emitter::mov_stack_offset_to_general_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->stack_offset().has_value());
         auto const reserv = insert_general_reg(elem);
@@ -2189,7 +2196,7 @@ namespace monad::vm::compiler::native
     }
 
     StackElem *
-    Emitter::revertible_mov_stack_offset_to_general_reg(StackElemRef elem)
+    Emitter::revertible_mov_stack_offset_to_general_reg(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(elem->stack_offset().has_value());
         StackElem *spill_elem = stack_.has_free_general_reg()
@@ -2215,7 +2222,7 @@ namespace monad::vm::compiler::native
         return spill_elem;
     }
 
-    void Emitter::mov_mem_be_to_general_reg(x86::Mem m, StackElemRef e)
+    void Emitter::mov_mem_be_to_general_reg(x86::Mem m, StackElemRef const e)
     {
         MONAD_DEBUG_ASSERT(e->general_reg().has_value());
         auto const &gpq = general_reg_to_gpq256(*e->general_reg());
@@ -2226,8 +2233,8 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::bswap_to_ymm(
-        std::variant<asmjit::x86::Ymm, asmjit::x86::Mem> src,
-        asmjit::x86::Ymm dst)
+        std::variant<asmjit::x86::Ymm, asmjit::x86::Mem> const src,
+        asmjit::x86::Ymm const dst)
     {
         // Permute qwords:
         // {b0, ..., b7, b8, ..., b15, b16, ..., b23, b24, ..., b31} ->
@@ -2250,13 +2257,13 @@ namespace monad::vm::compiler::native
         as_.vpshufb(dst, dst, t);
     }
 
-    void Emitter::mov_mem_be_to_avx_reg(x86::Mem m, StackElemRef e)
+    void Emitter::mov_mem_be_to_avx_reg(x86::Mem const m, StackElemRef const e)
     {
         MONAD_DEBUG_ASSERT(e->avx_reg().has_value());
         bswap_to_ymm(m, avx_reg_to_ymm(*e->avx_reg()));
     }
 
-    StackElemRef Emitter::read_mem_be(x86::Mem m)
+    StackElemRef Emitter::read_mem_be(x86::Mem const m)
     {
         if (stack_.has_free_general_reg()) {
             auto [dst, _] = alloc_general_reg();
@@ -2270,7 +2277,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::mov_stack_elem_to_mem_be(StackElemRef e, x86::Mem m)
+    void Emitter::mov_stack_elem_to_mem_be(StackElemRef const e, x86::Mem m)
     {
         if (e->literal()) {
             auto const x =
@@ -2311,14 +2318,14 @@ namespace monad::vm::compiler::native
     }
 
     // No discharge
-    void Emitter::dup(uint8_t dup_ix)
+    void Emitter::dup(uint8_t const dup_ix)
     {
         MONAD_ASSERT(dup_ix > 0);
         stack_.dup(stack_.top_index() + 1 - static_cast<int32_t>(dup_ix));
     }
 
     // No discharge
-    void Emitter::swap(uint8_t swap_ix)
+    void Emitter::swap(uint8_t const swap_ix)
     {
         MONAD_ASSERT(swap_ix > 0);
         stack_.swap(stack_.top_index() - static_cast<int32_t>(swap_ix));
@@ -2879,7 +2886,8 @@ namespace monad::vm::compiler::native
     }
 
     // Discharge when returning Comparison
-    std::variant<Comparison, StackElemRef> Emitter::iszero(StackElemRef elem)
+    std::variant<Comparison, StackElemRef>
+    Emitter::iszero(StackElemRef const elem)
     {
         if (elem->literal()) {
             return stack_.alloc_literal({!elem->literal()->value});
@@ -2934,7 +2942,7 @@ namespace monad::vm::compiler::native
     // Discharge
     // Returns null without discharging when `e` is deferred comparison,
     // which cannot be signed.
-    std::optional<Comparison> Emitter::issigned(StackElemRef e)
+    std::optional<Comparison> Emitter::issigned(StackElemRef const e)
     {
         // Unimplemented for literal, because it is not needed.
         MONAD_DEBUG_ASSERT(!e->literal().has_value());
@@ -3010,7 +3018,7 @@ namespace monad::vm::compiler::native
     }
 
     // Discharge
-    void Emitter::gas(int64_t remaining_base_gas)
+    void Emitter::gas(int64_t const remaining_base_gas)
     {
         MONAD_DEBUG_ASSERT(remaining_base_gas >= 0);
         discharge_deferred_comparison();
@@ -3314,7 +3322,7 @@ namespace monad::vm::compiler::native
     template void Emitter::mstore8<runtime::Memory::Version::V1>();
     template void Emitter::mstore8<runtime::Memory::Version::MIP3>();
 
-    void Emitter::mul(int64_t remaining_base_gas)
+    void Emitter::mul(int64_t const remaining_base_gas)
     {
         if (mul_optimized()) {
             return;
@@ -3322,7 +3330,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, false, runtime::mul);
     }
 
-    void Emitter::udiv(int64_t remaining_base_gas)
+    void Emitter::udiv(int64_t const remaining_base_gas)
     {
         if (div_optimized<false>()) {
             return;
@@ -3330,7 +3338,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, true, runtime::udiv);
     }
 
-    void Emitter::sdiv(int64_t remaining_base_gas)
+    void Emitter::sdiv(int64_t const remaining_base_gas)
     {
         if (div_optimized<true>()) {
             return;
@@ -3338,7 +3346,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, true, runtime::sdiv);
     }
 
-    void Emitter::umod(int64_t remaining_base_gas)
+    void Emitter::umod(int64_t const remaining_base_gas)
     {
         if (mod_optimized<false>()) {
             return;
@@ -3346,7 +3354,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, true, runtime::umod);
     }
 
-    void Emitter::smod(int64_t remaining_base_gas)
+    void Emitter::smod(int64_t const remaining_base_gas)
     {
         if (mod_optimized<true>()) {
             return;
@@ -3354,7 +3362,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, true, runtime::smod);
     }
 
-    void Emitter::addmod(int64_t remaining_base_gas)
+    void Emitter::addmod(int64_t const remaining_base_gas)
     {
         if (addmod_opt()) {
             return;
@@ -3362,7 +3370,7 @@ namespace monad::vm::compiler::native
         call_runtime(remaining_base_gas, true, runtime::addmod);
     }
 
-    void Emitter::mulmod(int64_t remaining_base_gas)
+    void Emitter::mulmod(int64_t const remaining_base_gas)
     {
         if (mulmod_opt()) {
             return;
@@ -3451,7 +3459,7 @@ namespace monad::vm::compiler::native
         return_with_status_code(runtime::StatusCode::Revert);
     }
 
-    void Emitter::status_code(runtime::StatusCode status)
+    void Emitter::status_code(runtime::StatusCode const status)
     {
         int32_t const c = static_cast<int32_t>(status);
         as_.mov(
@@ -3459,7 +3467,8 @@ namespace monad::vm::compiler::native
             c);
     }
 
-    void Emitter::error_block(asmjit::Label &lbl, runtime::StatusCode status)
+    void
+    Emitter::error_block(asmjit::Label &lbl, runtime::StatusCode const status)
     {
         as_.align(asmjit::AlignMode::kCode, 16);
         as_.bind(lbl);
@@ -3467,7 +3476,7 @@ namespace monad::vm::compiler::native
         as_.jmp(epilogue_label_);
     }
 
-    void Emitter::return_with_status_code(runtime::StatusCode status)
+    void Emitter::return_with_status_code(runtime::StatusCode const status)
     {
         auto const offset = stack_.pop();
         RegReserv const offset_avx_reserv{offset};
@@ -3501,7 +3510,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    uint256_t Emitter::literal_jump_dest_operand(StackElemRef dest)
+    uint256_t Emitter::literal_jump_dest_operand(StackElemRef const dest)
     {
         return dest->literal()->value;
     }
@@ -3564,8 +3573,8 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::jump_non_literal_dest(
-        StackElemRef dest, Operand const &dest_op,
-        std::optional<StackElem *> spill_elem)
+        StackElemRef const dest, Operand const &dest_op,
+        std::optional<StackElem *> const spill_elem)
     {
         if (spill_elem.has_value()) {
             MONAD_DEBUG_ASSERT(dest->general_reg().has_value());
@@ -3624,7 +3633,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::conditional_jmp(asmjit::Label const &lbl, Comparison comp)
+    void
+    Emitter::conditional_jmp(asmjit::Label const &lbl, Comparison const comp)
     {
         switch (comp) {
         case Comparison::Below:
@@ -3660,7 +3670,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    Comparison Emitter::jumpi_comparison(StackElemRef cond, StackElemRef dest)
+    Comparison
+    Emitter::jumpi_comparison(StackElemRef const cond, StackElemRef const dest)
     {
         auto const dc = stack_.discharge_deferred_comparison();
         if (dc.stack_elem && (dc.stack_elem == dest.get() ||
@@ -3799,7 +3810,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::read_context_address(int32_t offset)
+    void Emitter::read_context_address(int32_t const offset)
     {
         x86::Mem m = x86::qword_ptr(reg_context, offset);
         auto [dst, _] = alloc_general_reg();
@@ -3820,7 +3831,7 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::read_evmc_tx_context_address(int32_t offset)
+    void Emitter::read_evmc_tx_context_address(int32_t const offset)
     {
         auto [dst, _] = alloc_general_reg();
         Gpq256 const &gpq = general_reg_to_gpq256(*dst->general_reg());
@@ -3845,12 +3856,12 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::read_context_word(int32_t offset)
+    void Emitter::read_context_word(int32_t const offset)
     {
         stack_.push(read_mem_be(x86::qword_ptr(reg_context, offset)));
     }
 
-    void Emitter::read_evmc_tx_context_word(int32_t offset)
+    void Emitter::read_evmc_tx_context_word(int32_t const offset)
     {
         as_.mov(
             x86::rax,
@@ -3859,7 +3870,7 @@ namespace monad::vm::compiler::native
         stack_.push(read_mem_be(x86::qword_ptr(x86::rax, offset)));
     }
 
-    void Emitter::read_context_uint32_to_word(int32_t offset)
+    void Emitter::read_context_uint32_to_word(int32_t const offset)
     {
         auto [dst, _] = alloc_general_reg();
         Gpq256 const &gpq = general_reg_to_gpq256(*dst->general_reg());
@@ -3877,7 +3888,7 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::read_evmc_tx_context_uint64_to_word(int32_t offset)
+    void Emitter::read_evmc_tx_context_uint64_to_word(int32_t const offset)
     {
         auto [dst, _] = alloc_general_reg();
         Gpq256 const &gpq = general_reg_to_gpq256(*dst->general_reg());
@@ -4090,8 +4101,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void
-    Emitter::byte_literal_ix_stack_offset_src(StackElemRef ix, StackElemRef src)
+    void Emitter::byte_literal_ix_stack_offset_src(
+        StackElemRef ix, StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(ix->literal().has_value());
         MONAD_DEBUG_ASSERT(src->stack_offset().has_value());
@@ -4288,7 +4299,8 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::byte_literal_ix_avx_reg_src(StackElemRef ix, StackElemRef src)
+    void Emitter::byte_literal_ix_avx_reg_src(
+        StackElemRef ix, StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(ix->literal().has_value());
         MONAD_DEBUG_ASSERT(src->avx_reg().has_value());
@@ -4382,7 +4394,8 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::signextend_avx_reg_by_int8(int8_t ix, StackElemRef src)
+    void
+    Emitter::signextend_avx_reg_by_int8(int8_t const ix, StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(ix >= 0 && ix < 31);
         MONAD_DEBUG_ASSERT(src->avx_reg().has_value());
@@ -4568,7 +4581,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::signextend_avx_reg_by_bounded_rax(StackElemRef src)
+    void Emitter::signextend_avx_reg_by_bounded_rax(StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(src->avx_reg().has_value());
 
@@ -4607,7 +4620,7 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void Emitter::signextend_general_reg_by_bounded_rax(StackElemRef src)
+    void Emitter::signextend_general_reg_by_bounded_rax(StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(src->general_reg().has_value());
 
@@ -4736,8 +4749,8 @@ namespace monad::vm::compiler::native
         stack_.push(std::move(dst));
     }
 
-    void
-    Emitter::signextend_stack_offset_or_literal_by_bounded_rax(StackElemRef src)
+    void Emitter::signextend_stack_offset_or_literal_by_bounded_rax(
+        StackElemRef const src)
     {
         MONAD_DEBUG_ASSERT(
             src->stack_offset().has_value() || src->literal().has_value());
@@ -5557,7 +5570,8 @@ namespace monad::vm::compiler::native
     }
 
     Emitter::Operand Emitter::get_operand(
-        StackElemRef elem, LocationType loc, bool always_add_literal)
+        StackElemRef const elem, LocationType const loc,
+        bool const always_add_literal)
     {
         switch (loc) {
         case LocationType::StackOffset:
@@ -6185,7 +6199,7 @@ namespace monad::vm::compiler::native
         }
     }
 
-    StackElemRef Emitter::negate_by_sub(StackElemRef elem)
+    StackElemRef Emitter::negate_by_sub(StackElemRef const elem)
     {
         MONAD_DEBUG_ASSERT(!elem->literal().has_value());
 
@@ -6362,8 +6376,8 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::mul_with_bit_size_by_rax(
-        size_t bit_size, x86::Gpq const *dst, Operand const &left,
-        std::optional<uint64_t> value_of_rax)
+        size_t const bit_size, x86::Gpq const *const dst, Operand const &left,
+        std::optional<uint64_t> const value_of_rax)
     {
         if ((bit_size & 63) && (bit_size & 63) <= 32) {
             mul_with_bit_size_and_has_32_bit_by_rax<true>(
@@ -6446,8 +6460,9 @@ namespace monad::vm::compiler::native
     }
 
     Emitter::MulEmitter::MulEmitter(
-        size_t bit_size, Emitter &em, Operand const &left,
-        RightMulArg const &right, x86::Gpq const *dst, x86::Gpq const *tmp)
+        size_t const bit_size, Emitter &em, Operand const &left,
+        RightMulArg const &right, x86::Gpq const *const dst,
+        x86::Gpq const *const tmp)
         : bit_size_{bit_size}
         , em_{em}
         , left_{left}
@@ -6458,7 +6473,8 @@ namespace monad::vm::compiler::native
     {
     }
 
-    void Emitter::MulEmitter::init_mul_dst(size_t sub_size, x86::Gpq *mul_dst)
+    void Emitter::MulEmitter::init_mul_dst(
+        size_t const sub_size, x86::Gpq *const mul_dst)
     {
         size_t const N = div64_ceil(sub_size);
         if (is_dst_initialized_) {
@@ -7454,8 +7470,8 @@ namespace monad::vm::compiler::native
             LocationType::StackOffset};
     }
 
-    void
-    Emitter::mov_stack_offset_to_general_reg_mod2(StackElemRef elem, size_t exp)
+    void Emitter::mov_stack_offset_to_general_reg_mod2(
+        StackElemRef const elem, size_t const exp)
     {
         MONAD_DEBUG_ASSERT(exp > 0);
         MONAD_DEBUG_ASSERT(elem->stack_offset().has_value());
@@ -7479,7 +7495,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void Emitter::mov_literal_to_general_reg_mod2(StackElemRef elem, size_t exp)
+    void Emitter::mov_literal_to_general_reg_mod2(
+        StackElemRef const elem, size_t const exp)
     {
         MONAD_DEBUG_ASSERT(exp > 0);
         MONAD_DEBUG_ASSERT(elem->literal().has_value());
@@ -7505,8 +7522,8 @@ namespace monad::vm::compiler::native
         }
     }
 
-    void
-    Emitter::mov_stack_elem_to_general_reg_mod2(StackElemRef elem, size_t exp)
+    void Emitter::mov_stack_elem_to_general_reg_mod2(
+        StackElemRef elem, size_t const exp)
     {
         MONAD_DEBUG_ASSERT(exp > 0);
         if (elem->general_reg()) {
@@ -7670,7 +7687,8 @@ namespace monad::vm::compiler::native
         return modop_optimized<runtime::addmod, 0, 0, &Emitter::add_mod2>();
     }
 
-    void Emitter::add_mod2(StackElemRef a_elem, StackElemRef b_elem, size_t exp)
+    void Emitter::add_mod2(
+        StackElemRef const a_elem, StackElemRef const b_elem, size_t const exp)
     {
         {
             RegReserv const a_reserv{a_elem};
@@ -7969,7 +7987,8 @@ namespace monad::vm::compiler::native
         return modop_optimized<runtime::mulmod, 1, 0, &Emitter::mul_mod2>();
     }
 
-    void Emitter::mul_mod2(StackElemRef a_elem, StackElemRef b_elem, size_t exp)
+    void Emitter::mul_mod2(
+        StackElemRef a_elem, StackElemRef b_elem, size_t const exp)
     {
         {
             RegReserv const a_reserv{a_elem};
@@ -8137,7 +8156,7 @@ namespace monad::vm::compiler::native
     }
 
     // Compute byte width of stack element, stores the result in x86::eax.
-    void Emitter::stack_elem_byte_width(StackElemRef elem)
+    void Emitter::stack_elem_byte_width(StackElemRef const elem)
     {
         if (elem->general_reg()) {
             auto const &gpq = general_reg_to_gpq256(*elem->general_reg());
@@ -8166,7 +8185,7 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::exp_emit_gas_decrement_by_literal(
-        uint256_t exp, uint32_t gas_factor)
+        uint256_t const exp, uint32_t const gas_factor)
     {
         discharge_deferred_comparison();
 
@@ -8180,7 +8199,7 @@ namespace monad::vm::compiler::native
     }
 
     void Emitter::exp_emit_gas_decrement_by_stack_elem(
-        StackElemRef exponent_elem, uint32_t gas_factor)
+        StackElemRef const exponent_elem, uint32_t const gas_factor)
     {
         MONAD_ASSERT(!exponent_elem->literal().has_value());
 
@@ -8198,7 +8217,8 @@ namespace monad::vm::compiler::native
     // Discharge via exp_emit_gas_decrement_*.
     // It is assumed that the work of optimized EXP does not exceed the static
     // work cost of the EXP instruction. See `static_assert` in `Emitter::exp`.
-    bool Emitter::exp_optimized(int64_t remaining_base_gas, uint32_t gas_factor)
+    bool Emitter::exp_optimized(
+        int64_t const remaining_base_gas, uint32_t const gas_factor)
     {
         auto base_elem = stack_.get(stack_.top_index());
         auto exp_elem = stack_.get(stack_.top_index() - 1);

--- a/category/vm/compiler/ir/x86/emitter.hpp
+++ b/category/vm/compiler/ir/x86/emitter.hpp
@@ -188,13 +188,13 @@ namespace monad::vm::compiler::native
         {
         public:
             Runtime(
-                Emitter *e, int64_t remaining_base_gas, bool spill_avx,
-                void (*f)(Args...))
+                Emitter *const e, int64_t const remaining_base_gas,
+                bool const spill_avx, void (*f)(Args...))
                 : RuntimeImpl(e, remaining_base_gas, spill_avx, f)
             {
             }
 
-            Runtime(Emitter *e, bool spill_avx, void (*f)(Args...))
+            Runtime(Emitter *const e, bool const spill_avx, void (*f)(Args...))
                 : Runtime(e, 0, spill_avx, f)
             {
             }
@@ -760,7 +760,7 @@ namespace monad::vm::compiler::native
         void error_block(asmjit::Label &, runtime::StatusCode);
         void return_with_status_code(runtime::StatusCode);
 
-        static constexpr size_t div64_ceil(size_t x)
+        static constexpr size_t div64_ceil(size_t const x)
         {
             return (x >> 6) + ((x & 63) != 0);
         }

--- a/category/vm/compiler/ir/x86/types.hpp
+++ b/category/vm/compiler/ir/x86/types.hpp
@@ -53,7 +53,7 @@ namespace monad::vm::compiler::native
         /// If compilation failed, then `entrypoint` is `nullptr`.
         Nativecode(
             asmjit::JitRuntime &asmjit_rt, uint64_t const chain_id,
-            entrypoint_t entry, CodeSizeEstimate code_size_estimate)
+            entrypoint_t entry, CodeSizeEstimate const code_size_estimate)
             : asmjit_rt_{asmjit_rt}
             , chain_id_{chain_id}
             , entrypoint_{entry}

--- a/category/vm/compiler/ir/x86/virtual_stack.cpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.cpp
@@ -87,7 +87,7 @@ namespace monad::vm::compiler::native
     std::array<GeneralReg, GENERAL_REG_COUNT> ALL_GENERAL_REGS = {
         GeneralReg(0), GeneralReg(1), GeneralReg(2)};
 
-    StackElem::StackElem(Stack *s)
+    StackElem::StackElem(Stack *const s)
         : stack_{*s}
         , reserve_avx_reg_count_{}
         , reserve_general_reg_count_{}
@@ -147,13 +147,13 @@ namespace monad::vm::compiler::native
         stack_.deferred_comparison_.negated_stack_elem = nullptr;
     }
 
-    void StackElem::insert_literal(Literal x)
+    void StackElem::insert_literal(Literal const x)
     {
         MONAD_ASSERT(!literal_.has_value());
         literal_ = x;
     }
 
-    void StackElem::insert_stack_offset(StackOffset x)
+    void StackElem::insert_stack_offset(StackOffset const x)
     {
         MONAD_ASSERT(!stack_offset_.has_value());
         stack_offset_ = x;
@@ -417,7 +417,7 @@ namespace monad::vm::compiler::native
         at(top_index_) = std::move(e);
     }
 
-    StackElemRef Stack::negate_if_deferred_comparison(StackElemRef e)
+    StackElemRef Stack::negate_if_deferred_comparison(StackElemRef const e)
     {
         auto const &dc = deferred_comparison_;
         if (dc.stack_elem == e.get()) {
@@ -545,12 +545,12 @@ namespace monad::vm::compiler::native
         return spill_avx_reg(find_stack_elem_for_avx_reg_spill());
     }
 
-    StackElem *Stack::spill_avx_reg(StackElemRef e)
+    StackElem *Stack::spill_avx_reg(StackElemRef const e)
     {
         return spill_avx_reg(e.get());
     }
 
-    StackElem *Stack::spill_avx_reg(StackElem *e)
+    StackElem *Stack::spill_avx_reg(StackElem *const e)
     {
         e->remove_avx_reg();
         if (e->stack_offset_.has_value() || e->general_reg_.has_value() ||
@@ -564,7 +564,7 @@ namespace monad::vm::compiler::native
         return e;
     }
 
-    void Stack::spill_stack_offset(StackElemRef e)
+    void Stack::spill_stack_offset(StackElemRef const e)
     {
         MONAD_ASSERT(
             e->avx_reg_.has_value() || e->general_reg_.has_value() ||
@@ -572,7 +572,7 @@ namespace monad::vm::compiler::native
         e->remove_stack_offset();
     }
 
-    void Stack::spill_literal(StackElemRef e)
+    void Stack::spill_literal(StackElemRef const e)
     {
         MONAD_ASSERT(
             e->avx_reg_.has_value() || e->general_reg_.has_value() ||
@@ -611,12 +611,12 @@ namespace monad::vm::compiler::native
         return spill_general_reg(general_reg_stack_elems_[best_index]);
     }
 
-    StackElem *Stack::spill_general_reg(StackElemRef e)
+    StackElem *Stack::spill_general_reg(StackElemRef const e)
     {
         return spill_general_reg(e.get());
     }
 
-    StackElem *Stack::spill_general_reg(StackElem *e)
+    StackElem *Stack::spill_general_reg(StackElem *const e)
     {
         e->remove_general_reg();
         if (e->stack_offset_.has_value() || e->avx_reg_.has_value() ||
@@ -710,12 +710,13 @@ namespace monad::vm::compiler::native
     }
 
     void Stack::insert_stack_offset(
-        StackElemRef e, int32_t const preferred, PrevLoc const moved_from)
+        StackElemRef const e, int32_t const preferred, PrevLoc const moved_from)
     {
         insert_stack_offset(*e, preferred, moved_from);
     }
 
-    void Stack::insert_stack_offset(StackElemRef e, PrevLoc const moved_from)
+    void
+    Stack::insert_stack_offset(StackElemRef const e, PrevLoc const moved_from)
     {
         insert_stack_offset(*e, moved_from);
     }
@@ -737,7 +738,7 @@ namespace monad::vm::compiler::native
     }
 
     std::pair<AvxRegReserv, std::optional<StackOffset>>
-    Stack::insert_avx_reg(StackElemRef e)
+    Stack::insert_avx_reg(StackElemRef const e)
     {
         if (e->avx_reg_.has_value()) {
             return {AvxRegReserv{e}, std::nullopt};
@@ -765,7 +766,7 @@ namespace monad::vm::compiler::native
     }
 
     std::pair<GeneralRegReserv, std::optional<StackOffset>>
-    Stack::insert_general_reg(StackElemRef e)
+    Stack::insert_general_reg(StackElemRef const e)
     {
         if (e->general_reg_.has_value()) {
             return {GeneralRegReserv{e}, std::nullopt};
@@ -778,7 +779,7 @@ namespace monad::vm::compiler::native
         return {GeneralRegReserv{e}, spill_offset};
     }
 
-    StackElemRef Stack::alloc_literal(Literal lit)
+    StackElemRef Stack::alloc_literal(Literal const lit)
     {
         auto e = new_stack_elem();
         e->insert_literal(lit);
@@ -809,7 +810,7 @@ namespace monad::vm::compiler::native
         return {std::move(e), reserv, spill};
     }
 
-    StackElemRef Stack::release_stack_offset(StackElemRef elem)
+    StackElemRef Stack::release_stack_offset(StackElemRef const elem)
     {
         auto dst = new_stack_elem();
         dst->stack_offset_ = elem->stack_offset_;
@@ -817,7 +818,7 @@ namespace monad::vm::compiler::native
         return dst;
     }
 
-    StackElemRef Stack::release_avx_reg(StackElemRef elem)
+    StackElemRef Stack::release_avx_reg(StackElemRef const elem)
     {
         auto dst = new_stack_elem();
         move_avx_reg(*elem, *dst);
@@ -840,7 +841,7 @@ namespace monad::vm::compiler::native
         return dst;
     }
 
-    StackElemRef Stack::release_general_reg(StackElemRef elem)
+    StackElemRef Stack::release_general_reg(StackElemRef const elem)
     {
         return release_general_reg(*elem);
     }

--- a/category/vm/compiler/ir/x86/virtual_stack.hpp
+++ b/category/vm/compiler/ir/x86/virtual_stack.hpp
@@ -721,7 +721,7 @@ namespace monad::vm::compiler::native
         }
 
         /** Null or the stack element holding the general reg. */
-        StackElem *general_reg_stack_elem(GeneralReg r)
+        StackElem *general_reg_stack_elem(GeneralReg const r)
         {
             return general_reg_stack_elems_[r.reg];
         }
@@ -834,7 +834,7 @@ namespace monad::vm::compiler::native
 
     struct StackElemDeleter
     {
-        static void destroy(utils::RcObject<StackElem> *x)
+        static void destroy(utils::RcObject<StackElem> *const x)
         {
             static_assert(sizeof(size_t) == sizeof(void *));
             x->ref_count =

--- a/category/vm/evm/delegation.cpp
+++ b/category/vm/evm/delegation.cpp
@@ -44,7 +44,7 @@ namespace monad::vm::evm
             delegation_indicator_prefix_bytes.size()};
     }
 
-    bool is_delegated(std::span<uint8_t const> code)
+    bool is_delegated(std::span<uint8_t const> const code)
     {
         if (code.size() != delegation_indicator_size) {
             return false;
@@ -55,7 +55,7 @@ namespace monad::vm::evm
     }
 
     std::optional<Address> resolve_delegation(
-        evmc_host_interface const *host, evmc_host_context *ctx,
+        evmc_host_interface const *const host, evmc_host_context *const ctx,
         Address const &addr)
     {
         // Copy up to |code_size| bytes of the bytecode. Then test

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -283,7 +283,7 @@ namespace monad::vm::compiler
 
     consteval inline void add_opcode(
         uint8_t const opcode, std::array<OpCodeInfo, 256> &table,
-        OpCodeInfo info)
+        OpCodeInfo const info)
     {
         MONAD_DEBUG_ASSERT(table[opcode] == unknown_opcode_info);
         table[opcode] = info;

--- a/category/vm/fuzzing/generator/instruction_data.hpp
+++ b/category/vm/fuzzing/generator/instruction_data.hpp
@@ -149,7 +149,7 @@ namespace monad::vm::fuzzing
 
     static_assert(is_exit_terminator(STOP));
 
-    std::vector<uint8_t> const &memory_operands(uint8_t const opcode) noexcept;
+    std::vector<uint8_t> const &memory_operands(uint8_t opcode) noexcept;
 
-    bool uses_memory(uint8_t const opcode) noexcept;
+    bool uses_memory(uint8_t opcode) noexcept;
 }

--- a/category/vm/host.hpp
+++ b/category/vm/host.hpp
@@ -70,7 +70,8 @@ namespace monad::vm
         }
 
         [[gnu::always_inline]]
-        runtime::Context *set_runtime_context(runtime::Context *ctx) noexcept
+        runtime::Context *
+        set_runtime_context(runtime::Context *const ctx) noexcept
         {
             auto *const prev = runtime_context_;
             runtime_context_ = ctx;

--- a/category/vm/interpreter/debug.hpp
+++ b/category/vm/interpreter/debug.hpp
@@ -39,7 +39,7 @@ namespace monad::vm::interpreter
     [[gnu::always_inline]]
     inline void trace(
         Intercode const &analysis, int64_t const gas_remaining,
-        uint8_t const *instr_ptr)
+        uint8_t const *const instr_ptr)
     {
         std::cerr << std::format(
             "offset: 0x{:02x}  opcode: 0x{:x}  gas_left: {}\n",

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -1783,8 +1783,9 @@ namespace monad::vm::interpreter
 
     MONAD_VM_INSTRUCTION_CALL inline void stop(
         runtime::Context &ctx, Intercode const &analysis,
-        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        int64_t const gas_remaining, uint8_t const *)
+        runtime::uint256_t const *const stack_bottom,
+        runtime::uint256_t *const stack_top, int64_t const gas_remaining,
+        uint8_t const *)
     {
         fuzz_tstore_stack(ctx, stack_bottom, stack_top, analysis.size());
         ctx.gas_remaining = gas_remaining;

--- a/category/vm/interpreter/intercode.hpp
+++ b/category/vm/interpreter/intercode.hpp
@@ -43,7 +43,7 @@ namespace monad::vm::interpreter
 
         explicit Intercode(std::span<uint8_t const> const);
 
-        Intercode(uint8_t const *code, size_t code_size)
+        Intercode(uint8_t const *const code, size_t const code_size)
             : Intercode{std::span<uint8_t const>{code, code_size}}
         {
         }
@@ -80,8 +80,8 @@ namespace monad::vm::interpreter
         code_size_t code_size_;
         JumpdestMap jumpdest_map_;
 
-        static uint8_t const *pad(std::span<uint8_t const> const code);
+        static uint8_t const *pad(std::span<uint8_t const> code);
 
-        static JumpdestMap find_jumpdests(std::span<uint8_t const> const code);
+        static JumpdestMap find_jumpdests(std::span<uint8_t const> code);
     };
 }

--- a/category/vm/interpreter/push.hpp
+++ b/category/vm/interpreter/push.hpp
@@ -52,7 +52,7 @@ namespace monad::vm::interpreter
         using subword_t = runtime::uint256_t::word_type;
 
         [[gnu::always_inline]] inline subword_t
-        read_unaligned(uint8_t const *ptr)
+        read_unaligned(uint8_t const *const ptr)
         {
             return std::byteswap(unaligned_load<subword_t>(ptr));
         }
@@ -61,9 +61,9 @@ namespace monad::vm::interpreter
             requires(!detail::use_avx2_push(N))
         [[gnu::always_inline]] inline void generic_push(
             runtime::Context &ctx, Intercode const &analysis,
-            runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, int64_t &gas_remaining,
-            uint8_t const *instr_ptr)
+            runtime::uint256_t const *const stack_bottom,
+            runtime::uint256_t *const stack_top, int64_t &gas_remaining,
+            uint8_t const *const instr_ptr)
         {
             static constexpr auto whole_words = N / 8;
             static constexpr auto leading_part = N % 8;
@@ -137,9 +137,9 @@ namespace monad::vm::interpreter
             requires(detail::use_avx2_push(N))
         [[gnu::always_inline]] inline void avx2_push(
             runtime::Context &ctx, Intercode const &analysis,
-            runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, int64_t &gas_remaining,
-            uint8_t const *instr_ptr)
+            runtime::uint256_t const *const stack_bottom,
+            runtime::uint256_t *const stack_top, int64_t &gas_remaining,
+            uint8_t const *const instr_ptr)
         {
             static constexpr auto whole_words = N / 8;
             static constexpr auto leading_part = N % 8;
@@ -188,9 +188,9 @@ namespace monad::vm::interpreter
     {
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
-            runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, int64_t &gas_remaining,
-            uint8_t const *instr_ptr)
+            runtime::uint256_t const *const stack_bottom,
+            runtime::uint256_t *const stack_top, int64_t &gas_remaining,
+            uint8_t const *const instr_ptr)
         {
             detail::generic_push<N, traits>(
                 ctx,
@@ -207,8 +207,8 @@ namespace monad::vm::interpreter
     {
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
-            runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, int64_t &gas_remaining,
+            runtime::uint256_t const *const stack_bottom,
+            runtime::uint256_t *const stack_top, int64_t &gas_remaining,
             uint8_t const *)
         {
             check_requirements<PUSH0, traits>(
@@ -223,9 +223,9 @@ namespace monad::vm::interpreter
     {
         [[gnu::always_inline]] static inline void push(
             runtime::Context &ctx, Intercode const &analysis,
-            runtime::uint256_t const *stack_bottom,
-            runtime::uint256_t *stack_top, int64_t &gas_remaining,
-            uint8_t const *instr_ptr)
+            runtime::uint256_t const *const stack_bottom,
+            runtime::uint256_t *const stack_top, int64_t &gas_remaining,
+            uint8_t const *const instr_ptr)
         {
             detail::avx2_push<N, traits>(
                 ctx,

--- a/category/vm/interpreter/stack.hpp
+++ b/category/vm/interpreter/stack.hpp
@@ -31,8 +31,8 @@ namespace monad::vm::interpreter
     template <uint8_t Instr, Traits traits>
     [[gnu::always_inline]] inline void check_requirements(
         runtime::Context &ctx, Intercode const &,
-        runtime::uint256_t const *stack_bottom, runtime::uint256_t *stack_top,
-        int64_t &gas_remaining)
+        runtime::uint256_t const *const stack_bottom,
+        runtime::uint256_t *const stack_top, int64_t &gas_remaining)
     {
         static constexpr auto info = compiler::opcode_table<traits>[Instr];
 
@@ -74,7 +74,7 @@ namespace monad::vm::interpreter
     }
 
     [[gnu::always_inline]] inline void
-    push(runtime::uint256_t *stack_top, runtime::uint256_t const &x)
+    push(runtime::uint256_t *const stack_top, runtime::uint256_t const &x)
     {
         *(stack_top + 1) = x;
     }

--- a/category/vm/memory_pool.cpp
+++ b/category/vm/memory_pool.cpp
@@ -64,7 +64,7 @@ namespace monad::vm
         return reinterpret_cast<uint8_t *>(old_head);
     }
 
-    void MemoryPool::dealloc(uint8_t *p)
+    void MemoryPool::dealloc(uint8_t *const p)
     {
         MONAD_DEBUG_ASSERT((reinterpret_cast<uintptr_t>(p) & 31) == 0);
         static_assert(alignof(Node) <= 32);

--- a/category/vm/runtime/cached_allocator.hpp
+++ b/category/vm/runtime/cached_allocator.hpp
@@ -55,7 +55,7 @@ namespace monad::vm::runtime
             return empty() ? 0 : elements->idx;
         }
 
-        void push(CachedAllocatorElement *e)
+        void push(CachedAllocatorElement *const e)
         {
             e->next = elements;
             e->idx = size() + 1;
@@ -106,7 +106,8 @@ namespace monad::vm::runtime
         /// `max_cache_byte_size_per_thread` number of bytes being
         /// consumed by each (thread local) cache.
         constexpr explicit CachedAllocator(
-            size_t max_cache_byte_size_per_thread = DEFAULT_MAX_CACHE_BYTE_SIZE)
+            size_t const max_cache_byte_size_per_thread =
+                DEFAULT_MAX_CACHE_BYTE_SIZE)
         {
             max_slots_in_cache = max_cache_byte_size_per_thread / alloc_size;
         };
@@ -132,7 +133,7 @@ namespace monad::vm::runtime
         }
 
         /// Free memory allocated with `aligned_alloc_cached`.
-        void free_cached(uint8_t *ptr) const
+        void free_cached(uint8_t *const ptr) const
         {
             if (T::cache_list.size() >= max_slots_in_cache) {
                 std::free(ptr);

--- a/category/vm/runtime/context.cpp
+++ b/category/vm/runtime/context.cpp
@@ -44,7 +44,7 @@ static_assert(alignof(Bin<31>) == alignof(uint32_t));
 static_assert(std::is_standard_layout_v<Bin<31>>);
 
 extern "C" void monad_vm_runtime_increase_capacity(
-    Context *ctx, uint32_t const old_size, Bin<30> const new_size)
+    Context *const ctx, uint32_t const old_size, Bin<30> const new_size)
 {
     MONAD_DEBUG_ASSERT((*new_size & 31) == 0);
     MONAD_DEBUG_ASSERT(old_size < *new_size);
@@ -79,7 +79,7 @@ namespace monad::vm::runtime
 {
     namespace
     {
-        void release_result(evmc_result const *result)
+        void release_result(evmc_result const *const result)
         {
             MONAD_DEBUG_ASSERT(result);
             std::free(const_cast<uint8_t *>(result->output_data));
@@ -87,8 +87,9 @@ namespace monad::vm::runtime
     }
 
     Context Context::from(
-        evmc_host_interface const *host, evmc_host_context *context,
-        evmc_message const *msg, std::span<uint8_t const> code) noexcept
+        evmc_host_interface const *const host, evmc_host_context *const context,
+        evmc_message const *const msg,
+        std::span<uint8_t const> const code) noexcept
     {
         return Context{
             .host = host,

--- a/category/vm/runtime/create.cpp
+++ b/category/vm/runtime/create.cpp
@@ -31,12 +31,12 @@
 
 namespace monad::vm::runtime
 {
-    consteval Bin<2> create_code_word_cost(evmc_revision rev)
+    consteval Bin<2> create_code_word_cost(evmc_revision const rev)
     {
         return (rev >= EVMC_SHANGHAI) ? bin<2> : bin<0>;
     }
 
-    consteval Bin<4> create2_code_word_cost(evmc_revision rev)
+    consteval Bin<4> create2_code_word_cost(evmc_revision const rev)
     {
         return (rev >= EVMC_SHANGHAI) ? bin<8> : bin<6>;
     }

--- a/category/vm/runtime/data.hpp
+++ b/category/vm/runtime/data.hpp
@@ -28,8 +28,9 @@ namespace monad::vm::runtime
     void
     balance(Context *ctx, uint256_t *result_ptr, uint256_t const *address_ptr);
 
-    inline void
-    calldataload(Context *ctx, uint256_t *result_ptr, uint256_t const *i_ptr)
+    inline void calldataload(
+        Context *const ctx, uint256_t *const result_ptr,
+        uint256_t const *const i_ptr)
     {
         if (MONAD_UNLIKELY(!is_bounded_by_bits<32>(*i_ptr))) {
             *result_ptr = 0;

--- a/category/vm/runtime/environment.cpp
+++ b/category/vm/runtime/environment.cpp
@@ -26,7 +26,8 @@
 namespace monad::vm::runtime
 {
     void blockhash(
-        Context *ctx, uint256_t *result_ptr, uint256_t const *block_number_ptr)
+        Context *const ctx, uint256_t *const result_ptr,
+        uint256_t const *const block_number_ptr)
     {
         if (!is_bounded_by_bits<63>(*block_number_ptr)) {
             *result_ptr = 0;
@@ -49,14 +50,16 @@ namespace monad::vm::runtime
         }
     }
 
-    void selfbalance(Context *ctx, uint256_t *result_ptr)
+    void selfbalance(Context *const ctx, uint256_t *const result_ptr)
     {
         auto const balance = static_cast<bytes32_t>(
             ctx->host->get_balance(ctx->context, &ctx->env.recipient));
         *result_ptr = uint256_from_bytes32(balance);
     }
 
-    void blobhash(Context *ctx, uint256_t *result_ptr, uint256_t const *index)
+    void blobhash(
+        Context *const ctx, uint256_t *const result_ptr,
+        uint256_t const *const index)
     {
         auto const &c = *ctx->env.tx_context;
         *result_ptr = (*index < c.blob_hashes_count)

--- a/category/vm/runtime/exit.cpp
+++ b/category/vm/runtime/exit.cpp
@@ -18,7 +18,7 @@
 extern "C" void monad_vm_runtime_exit [[noreturn]] (void *);
 
 extern "C" void monad_vm_runtime_context_out_of_gas_exit
-    [[noreturn]] (monad::vm::runtime::Context *ctx)
+    [[noreturn]] (monad::vm::runtime::Context *const ctx)
 {
     ctx->result.status = monad::vm::runtime::StatusCode::OutOfGas;
     monad_vm_runtime_exit(ctx->exit_stack_ptr);

--- a/category/vm/runtime/math.hpp
+++ b/category/vm/runtime/math.hpp
@@ -43,8 +43,8 @@ namespace monad::vm::runtime
         uint256_t const *) noexcept = monad_vm_runtime_mul;
 
     constexpr void udiv(
-        uint256_t *result_ptr, uint256_t const *a_ptr,
-        uint256_t const *b_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr) noexcept
     {
         if (*b_ptr == 0) {
             *result_ptr = 0;
@@ -55,8 +55,8 @@ namespace monad::vm::runtime
     }
 
     constexpr void sdiv(
-        uint256_t *result_ptr, uint256_t const *a_ptr,
-        uint256_t const *b_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr) noexcept
     {
         if (*b_ptr == 0) {
             *result_ptr = 0;
@@ -67,8 +67,8 @@ namespace monad::vm::runtime
     }
 
     constexpr void umod(
-        uint256_t *result_ptr, uint256_t const *a_ptr,
-        uint256_t const *b_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr) noexcept
     {
         if (*b_ptr == 0) {
             *result_ptr = 0;
@@ -79,8 +79,8 @@ namespace monad::vm::runtime
     }
 
     constexpr void smod(
-        uint256_t *result_ptr, uint256_t const *a_ptr,
-        uint256_t const *b_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr) noexcept
     {
         if (*b_ptr == 0) {
             *result_ptr = 0;
@@ -91,8 +91,8 @@ namespace monad::vm::runtime
     }
 
     constexpr void addmod(
-        uint256_t *result_ptr, uint256_t const *a_ptr, uint256_t const *b_ptr,
-        uint256_t const *n_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr, uint256_t const *const n_ptr) noexcept
     {
         if (*n_ptr == 0) {
             *result_ptr = 0;
@@ -103,8 +103,8 @@ namespace monad::vm::runtime
     }
 
     constexpr void mulmod(
-        uint256_t *result_ptr, uint256_t const *a_ptr, uint256_t const *b_ptr,
-        uint256_t const *n_ptr) noexcept
+        uint256_t *const result_ptr, uint256_t const *const a_ptr,
+        uint256_t const *const b_ptr, uint256_t const *const n_ptr) noexcept
     {
         if (*n_ptr == 0) {
             *result_ptr = 0;

--- a/category/vm/runtime/storage.hpp
+++ b/category/vm/runtime/storage.hpp
@@ -31,8 +31,9 @@ namespace monad::vm::runtime
         Context *ctx, uint256_t const *key_ptr, uint256_t const *value_ptr,
         int64_t remaining_block_base_gas);
 
-    inline void
-    tload(Context *ctx, uint256_t *result_ptr, uint256_t const *key_ptr)
+    inline void tload(
+        Context *const ctx, uint256_t *const result_ptr,
+        uint256_t const *const key_ptr)
     {
         auto key = static_cast<evmc::bytes32>(bytes32_from_uint256(*key_ptr));
 
@@ -43,8 +44,9 @@ namespace monad::vm::runtime
         *result_ptr = uint256_from_bytes32(value);
     }
 
-    inline void
-    tstore(Context *ctx, uint256_t const *key_ptr, uint256_t const *val_ptr)
+    inline void tstore(
+        Context *const ctx, uint256_t const *const key_ptr,
+        uint256_t const *const val_ptr)
     {
         if (MONAD_UNLIKELY(ctx->env.evmc_flags & evmc_flags::EVMC_STATIC)) {
             ctx->exit(StatusCode::Error);

--- a/category/vm/runtime/transmute.hpp
+++ b/category/vm/runtime/transmute.hpp
@@ -45,7 +45,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_le(uint8_t const *bytes, int64_t const max_len)
+    uint256_load_bounded_le(uint8_t const *const bytes, int64_t const max_len)
     {
         if (MONAD_LIKELY(max_len >= 32)) {
             return uint256_t::load_le_unsafe(bytes);
@@ -55,7 +55,7 @@ namespace monad::vm::runtime
 
     [[gnu::always_inline]]
     inline uint256_t
-    uint256_load_bounded_be(uint8_t const *bytes, int64_t const max_len)
+    uint256_load_bounded_be(uint8_t const *const bytes, int64_t const max_len)
     {
         return uint256_load_bounded_le(bytes, max_len).to_be();
     }

--- a/category/vm/runtime/types.hpp
+++ b/category/vm/runtime/types.hpp
@@ -74,8 +74,8 @@ namespace monad::vm::runtime
         }
 
         [[gnu::always_inline]]
-        void
-        set_return_data(uint8_t const *output_data, size_t const output_size)
+        void set_return_data(
+            uint8_t const *const output_data, size_t const output_size)
         {
             MONAD_DEBUG_ASSERT(return_data_size == 0);
             return_data = output_data;
@@ -127,7 +127,8 @@ namespace monad::vm::runtime
 
         Memory() = delete;
 
-        explicit Memory(uint8_t *han, uint8_t *dat, uint32_t const cap)
+        explicit Memory(
+            uint8_t *const han, uint8_t *const dat, uint32_t const cap)
             : size{}
             , capacity{cap}
             , data{dat}

--- a/category/vm/utils/evm-as/builder.hpp
+++ b/category/vm/utils/evm-as/builder.hpp
@@ -53,7 +53,7 @@ namespace monad::vm::utils::evm_as
         }
 
         compiler::OpCodeInfo const &
-        lookup(compiler::EvmOpCode opcode) const noexcept
+        lookup(compiler::EvmOpCode const opcode) const noexcept
         {
             return compiler::opcode_table<traits>[opcode];
         }
@@ -85,13 +85,13 @@ namespace monad::vm::utils::evm_as
             return ins_.size();
         }
 
-        Instruction::T const &operator[](size_t index) const
+        Instruction::T const &operator[](size_t const index) const
         {
             return ins_[index];
         }
 
         // Inserts a nullary opcode
-        EvmBuilder &ins(compiler::EvmOpCode opcode) noexcept
+        EvmBuilder &ins(compiler::EvmOpCode const opcode) noexcept
         {
             if (compiler::is_unknown_opcode_info<traits>(
                     compiler::opcode_table<traits>[opcode])) {
@@ -129,7 +129,8 @@ namespace monad::vm::utils::evm_as
             return push(n, imm);
         }
 
-        EvmBuilder &push(size_t n_bytes, runtime::uint256_t const &imm) noexcept
+        EvmBuilder &
+        push(size_t const n_bytes, runtime::uint256_t const &imm) noexcept
         {
             if (n_bytes > 32) {
                 return insert(InvalidI{std::format("PUSH{}", n_bytes)});
@@ -184,7 +185,7 @@ namespace monad::vm::utils::evm_as
             return ins(compiler::EvmOpCode::JUMPI);
         }
 
-        EvmBuilder &dup(size_t n) noexcept
+        EvmBuilder &dup(size_t const n) noexcept
         {
             if (n == 0 || n > 16) {
                 return insert(InvalidI{std::format("DUP{}", n)});
@@ -194,7 +195,7 @@ namespace monad::vm::utils::evm_as
             return ins(static_cast<compiler::EvmOpCode>(opcode));
         }
 
-        EvmBuilder &swap(size_t n) noexcept
+        EvmBuilder &swap(size_t const n) noexcept
         {
             if (n == 0 || n > 16) {
                 return insert(InvalidI{std::format("SWAP{}", n)});
@@ -264,7 +265,7 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &call(
-            uint64_t gas, Address const &address,
+            uint64_t const gas, Address const &address,
             runtime::uint256_t const &value,
             runtime::uint256_t const &args_offset,
             runtime::uint256_t const &args_size,
@@ -282,7 +283,7 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &callcode(
-            uint64_t gas, Address const &address,
+            uint64_t const gas, Address const &address,
             runtime::uint256_t const &value,
             runtime::uint256_t const &args_offset,
             runtime::uint256_t const &args_size,
@@ -300,7 +301,7 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &delegatecall(
-            uint64_t gas, Address const &address,
+            uint64_t const gas, Address const &address,
             runtime::uint256_t const &args_offset,
             runtime::uint256_t const &args_size,
             runtime::uint256_t const &ret_offset,
@@ -316,7 +317,7 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &staticcall(
-            uint64_t gas, Address const &address,
+            uint64_t const gas, Address const &address,
             runtime::uint256_t const &args_offset,
             runtime::uint256_t const &args_size,
             runtime::uint256_t const &ret_offset,
@@ -331,21 +332,21 @@ namespace monad::vm::utils::evm_as
             return staticcall();
         }
 
-        EvmBuilder &return_(uint64_t offset, uint64_t size) noexcept
+        EvmBuilder &return_(uint64_t const offset, uint64_t const size) noexcept
         {
             push(size);
             push(offset);
             return return_();
         }
 
-        EvmBuilder &revert(uint64_t offset, uint64_t size) noexcept
+        EvmBuilder &revert(uint64_t const offset, uint64_t const size) noexcept
         {
             push(size);
             push(offset);
             return revert();
         }
 
-        EvmBuilder &log0(uint64_t offset, uint64_t size) noexcept
+        EvmBuilder &log0(uint64_t const offset, uint64_t const size) noexcept
         {
             push(size);
             push(offset);
@@ -353,7 +354,7 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &log1(
-            uint64_t offset, uint64_t size,
+            uint64_t const offset, uint64_t const size,
             runtime::uint256_t const &topic1) noexcept
         {
             push(topic1);
@@ -363,7 +364,8 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &log2(
-            uint64_t offset, uint64_t size, runtime::uint256_t const &topic1,
+            uint64_t const offset, uint64_t const size,
+            runtime::uint256_t const &topic1,
             runtime::uint256_t const &topic2) noexcept
         {
             push(topic2);
@@ -374,8 +376,8 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &log3(
-            uint64_t offset, uint64_t size, runtime::uint256_t const &topic1,
-            runtime::uint256_t const &topic2,
+            uint64_t const offset, uint64_t const size,
+            runtime::uint256_t const &topic1, runtime::uint256_t const &topic2,
             runtime::uint256_t const &topic3) noexcept
         {
             push(topic3);
@@ -387,8 +389,9 @@ namespace monad::vm::utils::evm_as
         }
 
         EvmBuilder &log4(
-            uint64_t offset, uint64_t size, runtime::uint256_t const &topic1,
-            runtime::uint256_t const &topic2, runtime::uint256_t const &topic3,
+            uint64_t const offset, uint64_t const size,
+            runtime::uint256_t const &topic1, runtime::uint256_t const &topic2,
+            runtime::uint256_t const &topic3,
             runtime::uint256_t const &topic4) noexcept
         {
             push(topic4);
@@ -400,28 +403,28 @@ namespace monad::vm::utils::evm_as
             return log4();
         }
 
-        EvmBuilder &mload(uint64_t offset) noexcept
+        EvmBuilder &mload(uint64_t const offset) noexcept
         {
             push(offset);
             return mload();
         }
 
         EvmBuilder &
-        mstore(uint64_t offset, runtime::uint256_t const &value) noexcept
+        mstore(uint64_t const offset, runtime::uint256_t const &value) noexcept
         {
             push(value);
             push(offset);
             return mstore();
         }
 
-        EvmBuilder &sload(uint64_t key) noexcept
+        EvmBuilder &sload(uint64_t const key) noexcept
         {
             push(key);
             return sload();
         }
 
         EvmBuilder &
-        sstore(uint64_t key, runtime::uint256_t const &value) noexcept
+        sstore(uint64_t const key, runtime::uint256_t const &value) noexcept
         {
             push(value);
             push(key);

--- a/category/vm/utils/evm-as/compiler.cpp
+++ b/category/vm/utils/evm-as/compiler.cpp
@@ -30,7 +30,7 @@ namespace monad::vm::utils::evm_as::internal
     static std::array<char, 6> var_letters = {'X', 'Y', 'Z', 'A', 'B', 'C'};
 
     void emit_annotation(
-        annot_context &ctx, size_t prefix_len, size_t desired_offset,
+        annot_context &ctx, size_t prefix_len, size_t const desired_offset,
         std::ostream &os)
     {
         // Emit whitespace to align annotations

--- a/category/vm/utils/evm-as/compiler.hpp
+++ b/category/vm/utils/evm-as/compiler.hpp
@@ -302,7 +302,7 @@ namespace monad::vm::utils::evm_as
         }
 
         constexpr mnemonic_config(
-            bool resolve_labels, bool annotate, size_t offset)
+            bool const resolve_labels, bool const annotate, size_t const offset)
             : resolve_labels(resolve_labels)
             , annotate(annotate)
             , desired_annotation_offset(offset)

--- a/category/vm/utils/evm-as/instruction.hpp
+++ b/category/vm/utils/evm-as/instruction.hpp
@@ -31,7 +31,7 @@ namespace monad::vm::utils::evm_as
 {
     struct PlainI
     {
-        constexpr explicit PlainI(compiler::EvmOpCode opcode)
+        constexpr explicit PlainI(compiler::EvmOpCode const opcode)
             : opcode(opcode)
         {
         }
@@ -43,7 +43,7 @@ namespace monad::vm::utils::evm_as
     {
 
         constexpr explicit PushI(
-            compiler::EvmOpCode opcode, runtime::uint256_t const &imm)
+            compiler::EvmOpCode const opcode, runtime::uint256_t const &imm)
             : opcode(opcode)
             , imm(imm)
         {
@@ -250,62 +250,62 @@ namespace monad::vm::utils::evm_as
             PlainI, PushI, JumpdestI, PushLabelI, PushAddressI, CommentI,
             InvalidI>;
 
-        static bool is_jumpdest(T ins)
+        static bool is_jumpdest(T const ins)
         {
             return std::holds_alternative<JumpdestI>(ins);
         }
 
-        static bool is_comment(T ins)
+        static bool is_comment(T const ins)
         {
             return std::holds_alternative<CommentI>(ins);
         }
 
-        static bool is_plain(T ins)
+        static bool is_plain(T const ins)
         {
             return std::holds_alternative<PlainI>(ins);
         }
 
-        static bool is_push(T ins)
+        static bool is_push(T const ins)
         {
             return std::holds_alternative<PushI>(ins);
         }
 
-        static bool is_push_label(T ins)
+        static bool is_push_label(T const ins)
         {
             return std::holds_alternative<PushLabelI>(ins);
         }
 
-        static bool is_push_address(T ins)
+        static bool is_push_address(T const ins)
         {
             return std::holds_alternative<PushAddressI>(ins);
         }
 
-        static bool is_invalid(T ins)
+        static bool is_invalid(T const ins)
         {
             return std::holds_alternative<InvalidI>(ins);
         }
 
-        static PushI as_push(T ins)
+        static PushI as_push(T const ins)
         {
             return std::get<PushI>(ins);
         }
 
-        static PlainI as_plain(T ins)
+        static PlainI as_plain(T const ins)
         {
             return std::get<PlainI>(ins);
         }
 
-        static PushLabelI as_push_label(T ins)
+        static PushLabelI as_push_label(T const ins)
         {
             return std::get<PushLabelI>(ins);
         }
 
-        static PushAddressI as_push_address(T ins)
+        static PushAddressI as_push_address(T const ins)
         {
             return std::get<PushAddressI>(ins);
         }
 
-        static InvalidI as_invalid(T ins)
+        static InvalidI as_invalid(T const ins)
         {
             return std::get<InvalidI>(ins);
         }

--- a/category/vm/utils/evm-as/validator.hpp
+++ b/category/vm/utils/evm-as/validator.hpp
@@ -53,7 +53,7 @@ namespace monad::vm::utils::evm_as::internal
     {
 
         EvmDebugValidator(
-            std::vector<ValidationError> &errors, bool allow_invalid)
+            std::vector<ValidationError> &errors, bool const allow_invalid)
             : errors(errors)
             , vstack_size(0)
             , pos(0)
@@ -192,7 +192,7 @@ namespace monad::vm::utils::evm_as::internal
             return true;
         }
 
-        void error(size_t pos, std::string &&msg)
+        void error(size_t const pos, std::string &&msg)
         {
             result = false;
             if constexpr (collect_errors) {

--- a/category/vm/utils/log_utils.hpp
+++ b/category/vm/utils/log_utils.hpp
@@ -28,7 +28,7 @@ namespace monad::vm::utils
         std::atomic<T> running_avg_{0};
         std::atomic<T> count_{0};
 
-        void update(T new_value) noexcept
+        void update(T const new_value) noexcept
         {
             auto count = count_.load(std::memory_order_acquire);
             auto running_avg = running_avg_.load(std::memory_order_acquire);
@@ -51,7 +51,7 @@ namespace monad::vm::utils
         std::atomic<T> running_avg_{0};
         std::atomic<T> count_{0};
 
-        void update(T new_value) noexcept
+        void update(T const new_value) noexcept
         {
             auto count = count_.load(std::memory_order_acquire);
             auto running_avg = running_avg_.load(std::memory_order_acquire);

--- a/category/vm/utils/lru_weight_cache.hpp
+++ b/category/vm/utils/lru_weight_cache.hpp
@@ -53,8 +53,9 @@ namespace monad::vm::utils
         using ConstAccessor = HashMap::const_accessor;
 
         explicit LruWeightCache(
-            uint32_t max_weight, std::chrono::nanoseconds lru_update_duration =
-                                     std::chrono::milliseconds{200})
+            uint32_t const max_weight,
+            std::chrono::nanoseconds const lru_update_duration =
+                std::chrono::milliseconds{200})
             : max_weight_(max_weight)
             , weight_(0)
             , lru_{lru_update_duration.count()}
@@ -75,7 +76,7 @@ namespace monad::vm::utils
 
         /// Insert `value` with `weight` under `key`. Overwrites if there is
         /// already a value under `key`.
-        bool insert(Key const &key, Value const &value, uint32_t weight)
+        bool insert(Key const &key, Value const &value, uint32_t const weight)
         {
             int64_t delta_weight = weight;
             bool is_new_key = true;
@@ -101,7 +102,7 @@ namespace monad::vm::utils
         /// Like insert, but does not overwrite an existing value in the cache.
         /// Instead if a value already exists under `key` then it will
         /// overwrite the `value` argument with the existing value.
-        bool try_insert(Key const &key, Value &value, uint32_t weight)
+        bool try_insert(Key const &key, Value &value, uint32_t const weight)
         {
             ConstAccessor acc;
             if (!hmap_.insert(acc, {key, HashMapValue{value, weight}})) {
@@ -137,7 +138,7 @@ namespace monad::vm::utils
         }
 
     private:
-        void adjust_by_delta_weight(int64_t delta_weight)
+        void adjust_by_delta_weight(int64_t const delta_weight)
         {
             int64_t const pre_weight =
                 weight_.fetch_add(delta_weight, std::memory_order_acq_rel);
@@ -155,14 +156,14 @@ namespace monad::vm::utils
             }
         }
 
-        void try_update_lru(ListNode const *node)
+        void try_update_lru(ListNode const *const node)
         {
             if (node->second.check_lru_time()) {
                 lru_.update_lru(node);
             }
         }
 
-        uint32_t evict(ListNode const *target)
+        uint32_t evict(ListNode const *const target)
         {
             Accessor acc;
             bool const found = hmap_.find(acc, target->first);
@@ -183,7 +184,7 @@ namespace monad::vm::utils
 
             HashMapValue() = default;
 
-            HashMapValue(Value const &value, uint32_t weight)
+            HashMapValue(Value const &value, uint32_t const weight)
                 : value_{value}
                 , cache_weight_{weight}
             {
@@ -204,7 +205,7 @@ namespace monad::vm::utils
                 return prev_ != nullptr;
             }
 
-            void update_lru_time(int64_t update_period) const
+            void update_lru_time(int64_t const update_period) const
             {
                 lru_time_.store(
                     cur_time() + update_period, std::memory_order_release);
@@ -231,14 +232,14 @@ namespace monad::vm::utils
             int64_t lru_update_period_;
 
         public:
-            explicit LruList(int64_t lru_update_period)
+            explicit LruList(int64_t const lru_update_period)
                 : lru_update_period_{lru_update_period}
             {
                 base_.second.next_ = &base_;
                 base_.second.prev_ = &base_;
             }
 
-            void update_lru(ListNode const *node)
+            void update_lru(ListNode const *const node)
             {
                 std::unique_lock const l(mutex_);
                 if (node->second.is_in_list()) {
@@ -248,7 +249,7 @@ namespace monad::vm::utils
                 } // else item is being evicted or inserted, don't update LRU
             }
 
-            void push_front(ListNode const *node)
+            void push_front(ListNode const *const node)
             {
                 std::unique_lock const l(mutex_);
                 front_link(node);
@@ -267,7 +268,8 @@ namespace monad::vm::utils
                 return target;
             }
 
-            bool unsafe_check_consistent(HashMap const &hmap, int64_t weight)
+            bool
+            unsafe_check_consistent(HashMap const &hmap, int64_t const weight)
             {
                 std::unordered_set<Key> keys;
                 std::unique_lock l(mutex_);
@@ -288,7 +290,7 @@ namespace monad::vm::utils
             }
 
         private:
-            void delink(ListNode const *node)
+            void delink(ListNode const *const node)
             {
                 ListNode const *const prev = node->second.prev_;
                 ListNode const *const next = node->second.next_;
@@ -296,7 +298,7 @@ namespace monad::vm::utils
                 next->second.prev_ = prev;
             }
 
-            void front_link(ListNode const *node)
+            void front_link(ListNode const *const node)
             {
                 ListNode const *const head = base_.second.next_;
                 node->second.prev_ = &base_;

--- a/category/vm/utils/parser.cpp
+++ b/category/vm/utils/parser.cpp
@@ -115,7 +115,7 @@ namespace monad::vm::utils
         return input;
     }
 
-    void err(std::string_view msg, std::string_view value)
+    void err(std::string_view const msg, std::string_view const value)
     {
         std::cerr << "error: " << msg << ": " << value << '\n';
         exit(1);
@@ -161,19 +161,19 @@ namespace monad::vm::utils
         return input;
     }
 
-    bool is_push_with_arg(std::string_view op)
+    bool is_push_with_arg(std::string_view const op)
     {
         return (
             find(push_ops_with_arg.begin(), push_ops_with_arg.end(), op) !=
             push_ops_with_arg.end());
     }
 
-    void warn(std::string_view msg, std::string_view value)
+    void warn(std::string_view const msg, std::string_view const value)
     {
         std::cerr << "warning: " << msg << ": " << value << '\n';
     }
 
-    std::optional<uint8_t> find_opcode(std::string_view op)
+    std::optional<uint8_t> find_opcode(std::string_view const op)
     {
         auto const &tbl = monad::vm::compiler::make_opcode_table<
             EvmTraits<EVMC_LATEST_STABLE_REVISION>>();

--- a/category/vm/utils/rc_ptr.hpp
+++ b/category/vm/utils/rc_ptr.hpp
@@ -33,7 +33,7 @@ namespace monad::vm::utils
             return std::allocator<RcObject<T>>().allocate(1);
         }
 
-        static void default_deallocate(RcObject<T> *rco)
+        static void default_deallocate(RcObject<T> *const rco)
         {
             std::allocator<RcObject<T>>().deallocate(rco, 1);
         }
@@ -45,7 +45,7 @@ namespace monad::vm::utils
                 // nop
             }
 
-            static void deallocate(RcObject<T> *rco)
+            static void deallocate(RcObject<T> *const rco)
             {
                 default_deallocate(rco);
             }
@@ -152,7 +152,7 @@ namespace monad::vm::utils
         }
 
     private:
-        explicit RcPtr(RcObject<T> *rco)
+        explicit RcPtr(RcObject<T> *const rco)
             : rc_object{rco}
         {
         }

--- a/category/vm/varcode_cache.cpp
+++ b/category/vm/varcode_cache.cpp
@@ -69,7 +69,7 @@ namespace monad::vm
     }
 
     SharedVarcode VarcodeCache::try_set_raw(
-        bytes32_t const &code_hash, std::span<uint8_t const> code)
+        bytes32_t const &code_hash, std::span<uint8_t const> const code)
     {
         WeightCache::ConstAccessor acc;
         if (!weight_cache_.find(acc, code_hash)) {

--- a/category/vm/vm.hpp
+++ b/category/vm/vm.hpp
@@ -152,7 +152,7 @@ namespace monad::vm
         }
 
         SharedVarcode try_insert_varcode_raw(
-            bytes32_t const &code_hash, std::span<uint8_t const> code)
+            bytes32_t const &code_hash, std::span<uint8_t const> const code)
         {
             return compiler_.try_insert_varcode_raw(code_hash, code);
         }

--- a/cmd/monad/event.cpp
+++ b/cmd/monad/event.cpp
@@ -178,7 +178,7 @@ int allocate_event_ring_file(
 //   3. Finally, we rename the init file to its correct filename
 int create_owned_event_ring(
     fs::path const &ring_file_path,
-    monad_event_ring_simple_config const &simple_cfg, int *ring_fd)
+    monad_event_ring_simple_config const &simple_cfg, int *const ring_fd)
 {
     fs::path init_file_path = ring_file_path;
     init_file_path.replace_filename(
@@ -220,7 +220,7 @@ int create_owned_event_ring(
 // signals prior to returning
 int create_owned_event_ring_nointr(
     fs::path const &ring_file_path,
-    monad_event_ring_simple_config const &simple_cfg, int *ring_fd)
+    monad_event_ring_simple_config const &simple_cfg, int *const ring_fd)
 {
     sigset_t to_block;
     sigset_t old_mask;
@@ -249,7 +249,7 @@ extern std::unique_ptr<ExecutionEventRecorder> g_exec_event_recorder;
 // A shift can be empty, e.g., <descriptor-shift> in `my-file::30`, in which
 // case the default value is used
 std::expected<EventRingConfig, std::string>
-try_parse_event_ring_config(std::string_view s)
+try_parse_event_ring_config(std::string_view const s)
 {
     std::vector<std::string_view> tokens;
     EventRingConfig cfg;
@@ -287,7 +287,7 @@ try_parse_event_ring_config(std::string_view s)
     return cfg;
 }
 
-int init_execution_event_recorder(EventRingConfig ring_config)
+int init_execution_event_recorder(EventRingConfig const ring_config)
 {
     char ring_path[PATH_MAX];
     MONAD_ASSERT(!g_exec_event_recorder, "recorder initialized twice?");

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -85,12 +85,13 @@ MONAD_ANONYMOUS_NAMESPACE_BEGIN
 // CLI input parsing helpers
 ////////////////////////////////////////
 
-bool is_numeric(std::string_view str)
+bool is_numeric(std::string_view const str)
 {
     return !str.empty() && std::all_of(str.begin(), str.end(), ::isdigit);
 }
 
-std::vector<std::string> tokenize(std::string_view input, char delim = ' ')
+std::vector<std::string>
+tokenize(std::string_view const input, char const delim = ' ')
 {
     std::ispanstream iss(input);
     std::vector<std::string> tokens;
@@ -107,7 +108,7 @@ std::vector<std::string> tokenize(std::string_view input, char delim = ' ')
 // TrieDb Helpers
 ////////////////////////////////////////
 
-std::string_view table_as_string(unsigned char table_id)
+std::string_view table_as_string(unsigned char const table_id)
 {
     switch (table_id) {
     case STATE_NIBBLE:
@@ -141,7 +142,7 @@ void print_receipt(Receipt const &receipt)
     fmt::print("{}\n\n", receipt);
 }
 
-void print_storage(bytes32_t key, bytes32_t val)
+void print_storage(bytes32_t const key, bytes32_t const val)
 {
     fmt::print("Storage{{key={},value={}}}\n\n", key, val);
 }
@@ -283,7 +284,7 @@ struct DbStateMachine
         }
     }
 
-    void set_table(unsigned char table_id)
+    void set_table(unsigned char const table_id)
     {
         if (state != DbState::proposal_or_finalize) {
             fmt::println("Error: at wrong part of trie, only allow set table "
@@ -788,7 +789,7 @@ int interactive_impl(Db &db)
 
 MONAD_ANONYMOUS_NAMESPACE_END
 
-int main(int argc, char *argv[])
+int main(int const argc, char *argv[])
 {
     std::vector<std::filesystem::path> dbname_paths;
     std::optional<unsigned> sq_thread_cpu = std::nullopt;

--- a/cmd/vm/parser/parser_tool.cpp
+++ b/cmd/vm/parser/parser_tool.cpp
@@ -122,7 +122,7 @@ void do_binary(
     std::cout << show_opcodes(opcodes) << '\n';
 }
 
-int main(int argc, char **argv)
+int main(int const argc, char **const argv)
 {
     auto args = parse_args(argc, argv);
 

--- a/test/ethereum_test/include/blockchain_test.hpp
+++ b/test/ethereum_test/include/blockchain_test.hpp
@@ -60,7 +60,7 @@ public:
         std::filesystem::path const &file,
         std::optional<std::variant<evmc_revision, monad_revision>> const
             &revision,
-        bool enable_tracing) noexcept
+        bool const enable_tracing) noexcept
         : file_{file}
         , revision_{revision}
         , enable_tracing_{enable_tracing}

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -623,7 +623,7 @@ void process_test(
 void process_test(
     std::variant<evmc_revision, monad_revision> const &revision,
     std::string const &name, nlohmann::json const &j_contents,
-    bool enable_tracing)
+    bool const enable_tracing)
 {
     if (std::holds_alternative<evmc_revision>(revision)) {
         auto const rev = std::get<evmc_revision>(revision);
@@ -690,7 +690,7 @@ void BlockchainTest::TestBody()
 void register_blockchain_tests_path(
     std::filesystem::path const &root,
     std::optional<std::variant<evmc_revision, monad_revision>> const &revision,
-    bool enable_tracing)
+    bool const enable_tracing)
 {
     namespace fs = std::filesystem;
     MONAD_ASSERT(fs::exists(root));
@@ -733,7 +733,7 @@ void register_blockchain_tests_path(
 
 void register_blockchain_tests(
     std::optional<std::variant<evmc_revision, monad_revision>> const &revision,
-    bool enable_tracing)
+    bool const enable_tracing)
 {
     // skip slow tests
     testing::FLAGS_gtest_filter +=

--- a/test/ethereum_test/src/event.cpp
+++ b/test/ethereum_test/src/event.cpp
@@ -62,8 +62,8 @@ namespace
 MONAD_TEST_NAMESPACE_BEGIN
 
 void find_execution_events(
-    monad_event_ring const *event_ring, monad_event_iterator *iter,
-    ExecutionEvents *exec_events)
+    monad_event_ring const *const event_ring, monad_event_iterator *const iter,
+    ExecutionEvents *const exec_events)
 {
     monad_event_descriptor event;
 
@@ -127,7 +127,7 @@ ConsumeMore:
     goto ConsumeMore;
 }
 
-void init_exec_event_recorder(std::string event_ring_path)
+void init_exec_event_recorder(std::string const event_ring_path)
 {
     constexpr uint8_t DESCRIPTORS_SHIFT = 20;
     constexpr uint8_t PAYLOAD_BUF_SHIFT = 28; // 256 MiB

--- a/test/unit/common/src/test/main.cpp
+++ b/test/unit/common/src/test/main.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include <monad/test/environment.hpp>
 
-int main(int argc, char **argv)
+int main(int argc, char **const argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     testing::AddGlobalTestEnvironment(new monad::test::Environment);

--- a/test/vm/unit/async_compile_tests.cpp
+++ b/test/vm/unit/async_compile_tests.cpp
@@ -43,7 +43,7 @@ using namespace monad::vm::compiler;
 
 namespace
 {
-    std::vector<uint8_t> test_code(uint64_t index)
+    std::vector<uint8_t> test_code(uint64_t const index)
     {
         std::vector<uint8_t> code = {PUSH1, 1, PUSH8};
         for (uint64_t i = 0; i < 8; ++i) {
@@ -53,7 +53,7 @@ namespace
         return code;
     }
 
-    bytes32_t test_hash(uint64_t index)
+    bytes32_t test_hash(uint64_t const index)
     {
         bytes32_t h{};
         for (uint64_t i = 0; i < 8; ++i) {

--- a/test/vm/unit/emitter_tests.cpp
+++ b/test/vm/unit/emitter_tests.cpp
@@ -73,7 +73,8 @@ namespace
 
         std::string log_path_storage_;
 
-        CompilerConfig add_asm_log_path(CompilerConfig c, std::string log_path)
+        CompilerConfig
+        add_asm_log_path(CompilerConfig c, std::string const log_path)
         {
             if (!c.asm_log_path &&
                 monad::vm::compiler::test::params.dump_asm_on_failure) {
@@ -86,7 +87,7 @@ namespace
         // to have this constructor is so that the lifetime of the
         // new_emitter_asm_log_path extends to after the Emitter constructor.
         TestEmitter(
-            asmjit::JitRuntime const &rt, code_size_t bytecode_size,
+            asmjit::JitRuntime const &rt, code_size_t const bytecode_size,
             CompilerConfig const &c = {},
             std::string const &log_path = new_emitter_asm_log_path())
             : Emitter(rt, bytecode_size, add_asm_log_path(c, log_path))
@@ -136,8 +137,8 @@ namespace
     }
 
     monad::vm::test::TestContext test_context(
-        evmc_tx_context const *tx_context,
-        int64_t gas_remaining = (uint64_t{1} << 63) - 1)
+        evmc_tx_context const *const tx_context,
+        int64_t const gas_remaining = (uint64_t{1} << 63) - 1)
     {
         return monad::vm::test::TestContext{[&](auto &x) {
             x.gas_remaining = gas_remaining;
@@ -152,7 +153,7 @@ namespace
 
     struct TestStackMemoryDeleter
     {
-        void operator()(uint8_t *p) const
+        void operator()(uint8_t *const p) const
         {
             std::free(p);
         }
@@ -172,7 +173,8 @@ namespace
         Emitter::LocationType::StackOffset};
 
     void mov_literal_to_location_type(
-        Emitter &emit, int32_t stack_index, Emitter::LocationType loc)
+        Emitter &emit, int32_t const stack_index,
+        Emitter::LocationType const loc)
     {
         StackElem *spill;
         Stack &stack = emit.get_stack();
@@ -211,7 +213,8 @@ namespace
     }
 
     void copy_stack_offset_to_location_type(
-        Emitter &emit, int32_t stack_index, Emitter::LocationType loc)
+        Emitter &emit, int32_t const stack_index,
+        Emitter::LocationType const loc)
     {
         Stack &stack = emit.get_stack();
         auto elem = stack.get(stack_index);
@@ -243,11 +246,11 @@ namespace
     using PureEmitterInstrPtr = void (Emitter::*)();
 
     void pure_bin_instr_test_instance(
-        asmjit::JitRuntime &rt, PureEmitterInstr instr,
-        runtime::uint256_t const &left, Emitter::LocationType left_loc,
-        runtime::uint256_t const &right, Emitter::LocationType right_loc,
+        asmjit::JitRuntime &rt, PureEmitterInstr const instr,
+        runtime::uint256_t const &left, Emitter::LocationType const left_loc,
+        runtime::uint256_t const &right, Emitter::LocationType const right_loc,
         runtime::uint256_t const &result, basic_blocks::BasicBlocksIR const &ir,
-        bool dup)
+        bool const dup)
     {
 #if 0
         if (left_loc != Emitter::LocationType::Literal || right_loc != Emitter::LocationType::AvxReg || dup) {
@@ -389,9 +392,9 @@ namespace
     }
 
     void pure_bin_instr_test(
-        asmjit::JitRuntime &rt, EvmOpCode opcode, PureEmitterInstr instr,
-        runtime::uint256_t const &left, runtime::uint256_t const &right,
-        runtime::uint256_t const &result)
+        asmjit::JitRuntime &rt, EvmOpCode const opcode,
+        PureEmitterInstr const instr, runtime::uint256_t const &left,
+        runtime::uint256_t const &right, runtime::uint256_t const &result)
     {
         std::vector<uint8_t> bytecode1{PUSH0, PUSH0, opcode, PUSH0, RETURN};
         auto ir1 =
@@ -442,9 +445,9 @@ namespace
     }
 
     void dynamic_gas_bin_instr_test_instance(
-        asmjit::JitRuntime &rt, PureEmitterInstr instr,
-        runtime::uint256_t const &left, Emitter::LocationType left_loc,
-        runtime::uint256_t const &right, Emitter::LocationType right_loc,
+        asmjit::JitRuntime &rt, PureEmitterInstr const instr,
+        runtime::uint256_t const &left, Emitter::LocationType const left_loc,
+        runtime::uint256_t const &right, Emitter::LocationType const right_loc,
         runtime::uint256_t const &expected_gas,
         basic_blocks::BasicBlocksIR const &ir)
     {
@@ -492,9 +495,9 @@ namespace
     }
 
     void dynamic_gas_test(
-        asmjit::JitRuntime &rt, EvmOpCode opcode, PureEmitterInstr instr,
-        runtime::uint256_t const &left, runtime::uint256_t const &right,
-        runtime::uint256_t const &expected_gas)
+        asmjit::JitRuntime &rt, EvmOpCode const opcode,
+        PureEmitterInstr const instr, runtime::uint256_t const &left,
+        runtime::uint256_t const &right, runtime::uint256_t const &expected_gas)
     {
         std::vector<uint8_t> bytecode1{
             GAS, PUSH0, PUSH0, opcode, SWAP1, GAS, SUB, RETURN};
@@ -516,9 +519,9 @@ namespace
     }
 
     void pure_bin_instr_test(
-        asmjit::JitRuntime &rt, EvmOpCode opcode, PureEmitterInstrPtr instr,
-        runtime::uint256_t const &left, runtime::uint256_t const &right,
-        runtime::uint256_t const &result)
+        asmjit::JitRuntime &rt, EvmOpCode const opcode,
+        PureEmitterInstrPtr instr, runtime::uint256_t const &left,
+        runtime::uint256_t const &right, runtime::uint256_t const &result)
     {
         pure_bin_instr_test(
             rt, opcode, [&](Emitter &e) { (e.*instr)(); }, left, right, result);
@@ -548,16 +551,17 @@ namespace
     }
 
     void pure_una_instr_test(
-        asmjit::JitRuntime &rt, EvmOpCode opcode, PureEmitterInstrPtr instr,
-        runtime::uint256_t const &input, runtime::uint256_t const &result)
+        asmjit::JitRuntime &rt, EvmOpCode const opcode,
+        PureEmitterInstrPtr instr, runtime::uint256_t const &input,
+        runtime::uint256_t const &result)
     {
         pure_una_instr_test(
             rt, opcode, [&](Emitter &e) { (e.*instr)(); }, input, result);
     }
 
     void jump_test(
-        Emitter::LocationType loc1, Emitter::LocationType loc2,
-        Emitter::LocationType loc_dest, bool swap)
+        Emitter::LocationType const loc1, Emitter::LocationType const loc2,
+        Emitter::LocationType const loc_dest, bool const swap)
     {
 #if 0
         if (swap || loc1 != Emitter::LocationType::Literal || loc2 != Emitter::LocationType::AvxReg || loc_dest != Emitter::LocationType::Literal) {
@@ -618,8 +622,8 @@ namespace
     }
 
     basic_blocks::BasicBlocksIR get_jumpi_ir(
-        bool deferred_comparison, bool swap, bool dup,
-        bool jumpdest_fallthrough)
+        bool const deferred_comparison, bool const swap, bool const dup,
+        bool const jumpdest_fallthrough)
     {
         std::vector<uint8_t> bytecode;
         if (deferred_comparison && swap) {
@@ -665,11 +669,11 @@ namespace
     }
 
     void jumpi_test(
-        asmjit::JitRuntime &rt, Emitter::LocationType loc1,
-        Emitter::LocationType loc2, Emitter::LocationType loc_cond,
-        Emitter::LocationType loc_dest, bool take_jump,
-        bool deferred_comparison, bool swap, bool dup,
-        bool jumpdest_fallthrough)
+        asmjit::JitRuntime &rt, Emitter::LocationType const loc1,
+        Emitter::LocationType const loc2, Emitter::LocationType const loc_cond,
+        Emitter::LocationType const loc_dest, bool const take_jump,
+        bool const deferred_comparison, bool const swap, bool const dup,
+        bool const jumpdest_fallthrough)
     {
 #if 0
         if (!take_jump || deferred_comparison || swap || dup || !jumpdest_fallthrough || loc1 != Emitter::LocationType::GeneralReg || loc2 != Emitter::LocationType::GeneralReg || loc_cond != Emitter::LocationType::GeneralReg || loc_dest != Emitter::LocationType::StackOffset) {
@@ -768,9 +772,9 @@ namespace
     }
 
     void block_epilogue_test(
-        Emitter::LocationType loc1, Emitter::LocationType loc2,
-        Emitter::LocationType loc3, Emitter::LocationType loc4,
-        Emitter::LocationType loc5)
+        Emitter::LocationType const loc1, Emitter::LocationType const loc2,
+        Emitter::LocationType const loc3, Emitter::LocationType const loc4,
+        Emitter::LocationType const loc5)
     {
 #if 0
         if (loc1 != Emitter::LocationType::StackOffset || loc2 != Emitter::LocationType::StackOffset || loc3 != Emitter::LocationType::StackOffset || loc4 != Emitter::LocationType::StackOffset || loc5 != Emitter::LocationType::StackOffset) {
@@ -854,12 +858,12 @@ namespace
     }
 
     void runtime_test_12_arg_fun(
-        runtime::Context *ctx, runtime::uint256_t *result,
-        runtime::uint256_t const *a, runtime::uint256_t const *b,
-        runtime::uint256_t const *c, runtime::uint256_t const *d,
-        runtime::uint256_t const *e, runtime::uint256_t const *f,
-        runtime::uint256_t const *g, runtime::uint256_t const *h,
-        runtime::uint256_t const *i, int64_t remaining_base_gas)
+        runtime::Context *const ctx, runtime::uint256_t *const result,
+        runtime::uint256_t const *const a, runtime::uint256_t const *const b,
+        runtime::uint256_t const *const c, runtime::uint256_t const *const d,
+        runtime::uint256_t const *const e, runtime::uint256_t const *const f,
+        runtime::uint256_t const *const g, runtime::uint256_t const *const h,
+        runtime::uint256_t const *const i, int64_t const remaining_base_gas)
     {
         *result = runtime::uint256_t{ctx->gas_remaining} -
                   (runtime::uint256_t{remaining_base_gas} -
@@ -867,12 +871,12 @@ namespace
     }
 
     void runtime_test_11_arg_fun(
-        runtime::Context *ctx, runtime::uint256_t *result,
-        runtime::uint256_t const *a, runtime::uint256_t const *b,
-        runtime::uint256_t const *c, runtime::uint256_t const *d,
-        runtime::uint256_t const *e, runtime::uint256_t const *f,
-        runtime::uint256_t const *g, runtime::uint256_t const *h,
-        int64_t remaining_base_gas)
+        runtime::Context *const ctx, runtime::uint256_t *const result,
+        runtime::uint256_t const *const a, runtime::uint256_t const *const b,
+        runtime::uint256_t const *const c, runtime::uint256_t const *const d,
+        runtime::uint256_t const *const e, runtime::uint256_t const *const f,
+        runtime::uint256_t const *const g, runtime::uint256_t const *const h,
+        int64_t const remaining_base_gas)
     {
         *result = runtime::uint256_t{ctx->gas_remaining} -
                   (runtime::uint256_t{remaining_base_gas} -

--- a/test/vm/unit/evm-as_tests.cpp
+++ b/test/vm/unit/evm-as_tests.cpp
@@ -97,7 +97,7 @@ namespace
     }
 
     monad::vm::test::TestContext
-    test_context(int64_t gas_remaining = 10'000'000)
+    test_context(int64_t const gas_remaining = 10'000'000)
     {
         return monad::vm::test::TestContext{[&](auto &x) {
             x.gas_remaining = gas_remaining;
@@ -111,7 +111,7 @@ namespace
 
     struct TestStackMemoryDeleter
     {
-        void operator()(uint8_t *p) const
+        void operator()(uint8_t *const p) const
         {
             std::free(p);
         }
@@ -154,7 +154,7 @@ namespace
         }
     };
 
-    std::vector<uint8_t> kernel_base_calldata(size_t args_size)
+    std::vector<uint8_t> kernel_base_calldata(size_t const args_size)
     {
         auto const sz = 3000 * 32 * (args_size == 0 ? 1 : args_size);
         std::vector<uint8_t> ret(sz, 0);

--- a/test/vm/unit/lru_weight_cache_tests.cpp
+++ b/test/vm/unit/lru_weight_cache_tests.cpp
@@ -83,7 +83,7 @@ namespace
         WeightCache weight_cache_{max_weight, update_period};
         std::atomic<uint64_t> current_weight_{0};
 
-        std::optional<uint32_t> weight_cache_find(Key k)
+        std::optional<uint32_t> weight_cache_find(Key const k)
         {
             WeightCache::ConstAccessor acc;
             if (!weight_cache_.find(acc, k)) {
@@ -93,8 +93,8 @@ namespace
         }
 
         std::vector<TestThread> make_readers(
-            size_t reader_count, std::function<void()> p,
-            size_t upper_weight = max_weight)
+            size_t const reader_count, std::function<void()> const p,
+            size_t const upper_weight = max_weight)
         {
             auto r = [=, this](size_t start_index) {
                 size_t i = start_index;
@@ -114,7 +114,7 @@ namespace
 
         std::vector<TestThread> make_rereaders(
             std::unordered_map<Key, std::atomic_flag> &is_updated,
-            size_t rereader_count)
+            size_t const rereader_count)
         {
             for (auto &[_, b] : is_updated) {
                 MONAD_ASSERT(!b.test());
@@ -142,8 +142,9 @@ namespace
         }
 
         std::vector<TestThread> make_writers(
-            size_t writer_count, std::function<void()> p,
-            std::function<Value(Key)> f, size_t upper_weight = max_weight)
+            size_t const writer_count, std::function<void()> const p,
+            std::function<Value(Key)> const f,
+            size_t const upper_weight = max_weight)
         {
             auto w = [=, this](size_t start_index) {
                 size_t i = start_index;

--- a/test/vm/unit/monad_vm_interface_tests.cpp
+++ b/test/vm/unit/monad_vm_interface_tests.cpp
@@ -44,7 +44,8 @@ using TestTraits = EvmTraits<constants::EARLIEST_SUPPORTED_EVM_FORK>;
 
 namespace
 {
-    std::pair<std::vector<uint8_t>, bytes32_t> make_bytecode(uint32_t bytes)
+    std::pair<std::vector<uint8_t>, bytes32_t>
+    make_bytecode(uint32_t const bytes)
     {
         std::vector<uint8_t> bytecode{
             PUSH1,
@@ -91,7 +92,7 @@ namespace
         };
 
         HostMock(
-            size_t calls_before_exception,
+            size_t const calls_before_exception,
             std::function<evmc::Result(Host &, evmc_message const &)> call_impl)
             : calls_before_exception_{calls_before_exception}
             , call_impl_{std::move(call_impl)}
@@ -475,7 +476,7 @@ TEST(MonadVmInterface, execute_native_entrypoint_raw)
     ASSERT_EQ(result.gas_left, 4);
 }
 
-static void test_execute_raw(VM::Mode mode)
+static void test_execute_raw(VM::Mode const mode)
 {
     VM vm{mode};
     evmc::MockedHost host;

--- a/test/vm/unit/rc_ptr_tests.cpp
+++ b/test/vm/unit/rc_ptr_tests.cpp
@@ -27,7 +27,7 @@ namespace
         int value;
         int *ptr;
 
-        explicit TestInt(int *x)
+        explicit TestInt(int *const x)
         {
             value = *x;
             ptr = x;
@@ -42,7 +42,7 @@ namespace
 
     using TestIntRcPtr = RcPtr<TestInt, RcObject<TestInt>::DefaultDeleter>;
 
-    TestIntRcPtr make_test_int(int *ptr)
+    TestIntRcPtr make_test_int(int *const ptr)
     {
         return TestIntRcPtr::make(RcObject<TestInt>::default_allocate, ptr);
     }

--- a/test/vm/unit/runtime/fixture.cpp
+++ b/test/vm/unit/runtime/fixture.cpp
@@ -101,7 +101,7 @@ namespace monad::vm::compiler::test
     }
 
     evmc_result RuntimeTestBase::success_result(
-        std::int64_t gas_left, std::int64_t gas_refund)
+        std::int64_t const gas_left, std::int64_t const gas_refund)
     {
         auto output_data = result_data();
         return {
@@ -117,7 +117,8 @@ namespace monad::vm::compiler::test
     }
 
     evmc_result RuntimeTestBase::create_result(
-        Address prog_addr, std::int64_t gas_left, std::int64_t gas_refund)
+        Address const prog_addr, std::int64_t const gas_left,
+        std::int64_t const gas_refund)
     {
         auto output_data = result_data();
         return {
@@ -132,7 +133,7 @@ namespace monad::vm::compiler::test
         };
     }
 
-    evmc_result RuntimeTestBase::failure_result(evmc_status_code sc)
+    evmc_result RuntimeTestBase::failure_result(evmc_status_code const sc)
     {
         auto output_data = result_data();
         return {
@@ -147,7 +148,8 @@ namespace monad::vm::compiler::test
         };
     }
 
-    void RuntimeTestBase::set_balance(uint256_t addr, uint256_t balance)
+    void
+    RuntimeTestBase::set_balance(uint256_t const addr, uint256_t const balance)
     {
         host_.accounts[address_from_uint256(addr)].balance =
             bytes32_from_uint256(balance);
@@ -163,7 +165,7 @@ namespace monad::vm::compiler::test
     }
 
     void RuntimeTestBase::add_account_at(
-        uint256_t addr, std::span<uint8_t> const code)
+        uint256_t const addr, std::span<uint8_t> const code)
     {
         auto const contract_addr = address_from_uint256(addr);
         auto const codehash = ethash::keccak256(code.data(), code.size());

--- a/test/vm/unit/runtime/fixture.hpp
+++ b/test/vm/unit/runtime/fixture.hpp
@@ -173,7 +173,7 @@ namespace monad::vm::compiler::test
 
         std::basic_string_view<uint8_t> result_data();
 
-        void add_account_at(uint256_t addr, std::span<uint8_t> const code);
+        void add_account_at(uint256_t addr, std::span<uint8_t> code);
     };
 
     class RuntimeTest

--- a/test/vm/unit/runtime/memory_tests.cpp
+++ b/test/vm/unit/runtime/memory_tests.cpp
@@ -45,7 +45,7 @@ namespace
         {
         }
 
-        void call(std::function<void(Context &)> continuation)
+        void call(std::function<void(Context &)> const continuation)
         {
             evmc_message msg{};
             if (prev_rt_ctx_) {
@@ -97,7 +97,7 @@ namespace
             2 * (parent_total_size + capacity_before + 32) - parent_total_size);
     }
 
-    void set_memory(Context &ctx, uint8_t depth, bool full)
+    void set_memory(Context &ctx, uint8_t const depth, bool const full)
     {
         if (full) {
             ctx.memory.size = ctx.memory.capacity;
@@ -109,7 +109,7 @@ namespace
         std::memset(ctx.memory.data, depth, ctx.memory.size);
     }
 
-    void invariant_check(Context &ctx, uint8_t depth)
+    void invariant_check(Context &ctx, uint8_t const depth)
     {
         uint8_t const *const data_handle = ctx.memory.data_handle;
         uint8_t const *const data = ctx.memory.data;

--- a/test/vm/unit/stack_tests.cpp
+++ b/test/vm/unit/stack_tests.cpp
@@ -37,25 +37,25 @@ namespace
         {
         }
 
-        StackElemTestData &with_stack_offset(std::int32_t offset)
+        StackElemTestData &with_stack_offset(std::int32_t const offset)
         {
             stack_offset = {offset, PrevLoc::Unknown};
             return *this;
         }
 
-        StackElemTestData &with_avx_reg(AvxReg x)
+        StackElemTestData &with_avx_reg(AvxReg const x)
         {
             avx_reg = x;
             return *this;
         }
 
-        StackElemTestData &with_general_reg(GeneralReg x)
+        StackElemTestData &with_general_reg(GeneralReg const x)
         {
             general_reg = x;
             return *this;
         }
 
-        StackElemTestData &with_literal(Literal x)
+        StackElemTestData &with_literal(Literal const x)
         {
             literal = x;
             return *this;
@@ -68,7 +68,7 @@ namespace
         std::set<std::int32_t> stack_indices;
     };
 
-    bool test_stack_element(StackElemRef e, StackElemTestData t)
+    bool test_stack_element(StackElemRef const e, StackElemTestData const t)
     {
         return e->stack_offset() == t.stack_offset &&
                e->avx_reg() == t.avx_reg && e->general_reg() == t.general_reg &&

--- a/test/vm/unit/test_params.hpp
+++ b/test/vm/unit/test_params.hpp
@@ -22,7 +22,7 @@ namespace monad::vm::compiler::test
     public:
         bool dump_asm_on_failure = false;
 
-        TestParams(bool dump_asm_on_failure = false)
+        TestParams(bool const dump_asm_on_failure = false)
             : dump_asm_on_failure(dump_asm_on_failure)
         {
         }

--- a/test/vm/unit/uint256_tests.cpp
+++ b/test/vm/unit/uint256_tests.cpp
@@ -160,7 +160,7 @@ TEST(uint256, bit_width)
     test_bit_width<255>();
 }
 
-::intx::uint256 from_words(std::array<uint64_t, 4> words)
+::intx::uint256 from_words(std::array<uint64_t, 4> const words)
 {
     return ::intx::uint256{words[0], words[1], words[2], words[3]};
 }

--- a/test/vm/utils/evm-as_utils.hpp
+++ b/test/vm/utils/evm-as_utils.hpp
@@ -28,16 +28,16 @@ namespace monad::vm::test
             uint8_t dims[32]{};
         };
 
-        explicit KernelCalldata(size_t calldata_size)
+        explicit KernelCalldata(size_t const calldata_size)
             : data_(calldata_size >> 5){MONAD_ASSERT((calldata_size & 31) == 0)}
 
             uint8_t
-            & operator[](size_t i)
+            & operator[](size_t const i)
         {
             return data_[i >> 5].dims[i & 31];
         }
 
-        uint8_t const &operator[](size_t i) const
+        uint8_t const &operator[](size_t const i) const
         {
             return data_[i >> 5].dims[i & 31];
         }

--- a/test/vm/utils/test_context.hpp
+++ b/test/vm/utils/test_context.hpp
@@ -30,7 +30,7 @@ namespace monad::vm::test
 
         using Builder = std::function<void(runtime::Context &)>;
 
-        TestContext(Builder build = [](auto &) {})
+        TestContext(Builder const build = [](auto &) {})
             : ctx{runtime::Context::empty(
                   test_memory.data, test_memory.capacity)}
         {


### PR DESCRIPTION
## Summary

Mechanical pass that adds `const` (east-const) to function parameter **definitions** across the codebase, covering both value parameters (`int x` → `int const x`) and the pointer itself for pointer parameters (`T *p` → `T *const p`, leaving any pointee qualifier alone).

A small number of **declarations** are also touched (~19, all in headers) — in each case a leftover top-level `const` on a by-value parameter is removed so the declaration matches the codebase's existing no-top-level-qualifier convention for declarations. The language ignores top-level qualifiers on parameters in declarations, so there's no behavioral or ABI effect; the normalization came out of the AST tooling re-emitting these headers.

References (`T&`, `T&&`), typedefs that hide pointers (e.g. `va_list`), parameters that are mutated in the body or member-initializer list, and move-only parameters consumed via `std::move(name)` are deliberately left non-const.

### Scope

- `category/`, `cmd/`, `test/`
- 198 files, +1,231 / -1,084

### Tooling

A libclang-based Python tool walked every TU in `compile_commands.json`, collected the candidate edits from the AST, deduplicated across TUs, and emitted a single JSON patch set that an applier script then rewrote on disk. Compile errors from each subsystem surfaced the cases where a parameter was actually mutated (read-only assignment, discarded qualifier, reference-to-non-const binding, std::move silently falling back to copy); those were reverted by hand so the build stays green.

### Notable exceptions

- `category/async/sender_errc.hpp` is left unchanged: adding `const` to `make_status_code(sender_errc)` causes boost::outcome's `quick_status_code_from_enum` machinery to recurse into itself as a constexpr expansion.
- A handful of params that are legitimately mutated (e.g. `event_ring_init_file`'s `error_name`, `stack_top` in `call_runtime.hpp`, several `bytes`/`prefix_index` counters in the MPT code, `int argc` in test `main`s) stay non-const.

## Test plan

- [x] `cmake --build build --parallel` — clean
- [x] `ctest --test-dir build --output-on-failure --timeout 500` — 3520 / 3520 pass
- [x] `scripts/apply-clang-format.sh` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)