### PR TITLE
[mpt] raise MIN_HISTORY_LENGTH floor from 257 to 300

### DIFF
--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -378,6 +378,16 @@ void UpdateAux::init(AsyncIO &io_, std::optional<uint64_t> const history_len)
                 metadata_ctx_->update_history_length_metadata(*history_len);
                 enable_dynamic_history_length_ = false;
             }
+            else if (
+                metadata_ctx_->version_history_length() < MIN_HISTORY_LENGTH) {
+                // A db created by an older binary may have been shrunk to a
+                // floor below the current MIN_HISTORY_LENGTH. Raise the stored
+                // cap so subsequent restarts keep enough history to avoid a
+                // forced statesync. Actual on-disk history will grow back to
+                // the new floor as new blocks come in.
+                metadata_ctx_->update_history_length_metadata(
+                    MIN_HISTORY_LENGTH);
+            }
         }
     }
     // If the pool has changed since we configured the metadata, this will

--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -46,7 +46,11 @@ using MONAD_ASYNC_NAMESPACE::round_up_align;
 static constexpr uint8_t INVALID_BRANCH = 255;
 static constexpr uint8_t INVALID_PATH_INDEX = 255;
 static constexpr uint64_t INVALID_BLOCK_NUM = uint64_t(-1);
-static constexpr uint64_t MIN_HISTORY_LENGTH = 257;
+// Floor for disk-pressure history shrinking. Execution requires 256 history
+// blocks for the block hash buffer, so this must exceed 256 by enough margin
+// that a node rewound to the last finalized block on restart still has
+// sufficient history and can avoid a full statesync.
+static constexpr uint64_t MIN_HISTORY_LENGTH = 300;
 
 static byte_string const empty_trie_hash = [] {
     using namespace ::monad::literals;


### PR DESCRIPTION
MIN_HISTORY_LENGTH is the floor below which disk pressure driven history shrinking refuses to go. Execution requires 256 history blocks on hand for the block hash buffer, so the old floor of 257 left only a one block margin. A node whose history shrunk under disk pressure that then restarts (rewinding the db to the last finalized block) can drop below 256 history and be forced into a full statesync.

Raise the floor to 300 to give ~44 blocks of headroom.

Also bump the stored history_length cap to MIN_HISTORY_LENGTH at read/write init time if it is below the new floor, so dbs carried over from an older binary do not stay pinned at 257. On-disk history grows back organically as new blocks come in.