### PR TITLE
CI: bump Claude Code max-turns from 30 to 60

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-opus-4-7 --max-turns 30 --allowedTools Bash,Read,Glob,Grep"
+          claude_args: "--model claude-opus-4-7 --max-turns 60 --allowedTools Bash,Read,Glob,Grep"
           prompt: "First, read REVIEW.md at the repo root and follow it exactly. Then review this pull request using that document's process, priority scale, comment style, and repo-specific guidance (traits system, FFI boundary, C++ correctness, testing, style, PR hygiene, security). Post findings as inline review comments and end with the overall verdict as specified in REVIEW.md."
 
       - name: Run Claude Code (mention)
@@ -73,4 +73,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-opus-4-7 --max-turns 30"
+          claude_args: "--model claude-opus-4-7 --max-turns 60"


### PR DESCRIPTION
## Summary
- Opus 4.7 uses more parallel exploration and verification per review than 4.6, and 30 turns was already tight on 4.6.
- Reviews have started truncating before the verdict/summary is posted.
- 60 gives comfortable headroom for typical PRs without inviting runaway cost on outliers.

## Test plan
- [ ] Observe the next review run on a real PR and confirm it reaches the overall verdict without hitting the turn cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)