### PR TITLE
ctest: label throughput benchmarks so fix/build/test cycle can skip them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,12 @@ CC=gcc-15 CXX=g++-15 cmake -G Ninja -B build \
 # Build
 cmake --build build --parallel
 
-# Test
-ctest --test-dir build --output-on-failure --timeout 500 --parallel
-pytest-3 category/core/monad/tests/
+# Test (fast iteration — skips throughput benchmarks labeled "bench")
+ctest --test-dir build --output-on-failure --timeout 500 -j 32 -LE bench
+pytest-3 --pyargs monad
+
+# Test (full — includes benchmarks, use before pushing)
+ctest --test-dir build --output-on-failure --timeout 500 -j 32
 
 # Format
 scripts/apply-clang-format.sh
@@ -202,6 +205,13 @@ New library/executable targets should call `monad_compile_options(target)` to ap
 Test files live in two places:
 - **Alongside source** in `category/` subdirectories (e.g., `category/core/hex_test.cpp`, `category/execution/ethereum/evm_test.cpp`)
 - **In `test/`** for cross-cutting or suite-level tests (e.g., `test/ethereum_test/`, `test/vm/`)
+
+### Throughput benchmarks — the "bench" label
+
+Tests that are primarily throughput/latency measurements (not correctness) should be labeled `bench` so `ctest -LE bench` can skip them during the fix/build/test cycle. Plain `ctest` still runs them for pre-push coverage. Two mechanisms exist:
+
+- **`monad_add_test`** accepts an optional `BENCH_FILTER "<gtest-pattern>"` argument. Tests matching the pattern are excluded from normal discovery and registered as a separate `<target>_bench` ctest entry with the `bench` label.
+- **Manual** — call `add_test(NAME ..._bench COMMAND ... --gtest_filter=...)` + `set_tests_properties(... PROPERTIES LABELS bench ENVIRONMENT "...")`. Use this when one executable has multiple slow benches that should run as separate ctest entries so they parallelize under `-j` (e.g., `category/mpt/test/CMakeLists.txt` does this for the two `DbTest.scalability` fixtures).
 
 Test data paths are available via generated header `test/test_resource_data.h`:
 - `test_resource::test_data_dir` — `test/`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ configure_file(cmake/test_resource_data.h.in test/test_resource_data.h @ONLY)
 
 set(TOP_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 function(monad_add_test target)
-  cmake_parse_arguments(AT "NO_CUSTOM_MAIN" "" "PROPERTIES" ${ARGN})
+  cmake_parse_arguments(AT "NO_CUSTOM_MAIN" "BENCH_FILTER" "PROPERTIES" ${ARGN})
   if(AT_NO_CUSTOM_MAIN)
     add_executable(${target} ${AT_UNPARSED_ARGUMENTS})
   else()
@@ -236,22 +236,55 @@ function(monad_add_test target)
   )# TODO
   target_include_directories(${target} PRIVATE "${TOP_CURRENT_BINARY_DIR}/test")
   target_link_libraries(${target} monad_execution GTest::GTest GTest::Main)
-  gtest_discover_tests(
-    ${target} DISCOVERY_MODE PRE_TEST
-    PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
-               UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
-               TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer
-               ${AT_PROPERTIES})
+  # If BENCH_FILTER is set, exclude matching tests from normal discovery and
+  # register them as a single ctest entry labeled "bench". Plain `ctest`
+  # still runs them; `ctest -LE bench` skips them for fast fix/build/test cycles.
+  if(AT_BENCH_FILTER)
+    gtest_discover_tests(
+      ${target} DISCOVERY_MODE PRE_TEST
+      TEST_FILTER "-${AT_BENCH_FILTER}"
+      PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
+                 UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
+                 TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer
+                 ${AT_PROPERTIES})
+    add_test(
+      NAME ${target}_bench
+      COMMAND ${target} "--gtest_filter=${AT_BENCH_FILTER}")
+    set_tests_properties(
+      ${target}_bench PROPERTIES
+      LABELS bench
+      ENVIRONMENT "ASAN_OPTIONS=abort_on_error=1;UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1;TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer"
+      ${AT_PROPERTIES})
+  else()
+    gtest_discover_tests(
+      ${target} DISCOVERY_MODE PRE_TEST
+      PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT
+                 UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ENVIRONMENT
+                 TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer
+                 ${AT_PROPERTIES})
+  endif()
 endfunction()
 
 function(monad_add_test_folder target)
   cmake_parse_arguments(ATF "" "" "EXCLUDE" ${ARGN})
   file(GLOB_RECURSE test_files CONFIGURE_DEPENDS ${target}/test_*.cpp
        ${target}/*_test.cpp)
-  if(ATF_EXCLUDE)
-    list(REMOVE_ITEM test_files ${ATF_EXCLUDE})
+  # Normalize paths so EXCLUDE lists written with ${CMAKE_CURRENT_SOURCE_DIR}/...
+  # match the `./`-prefixed paths that GLOB_RECURSE returns when target=".".
+  set(normalized_files "")
+  foreach(f ${test_files})
+    get_filename_component(f "${f}" ABSOLUTE)
+    list(APPEND normalized_files "${f}")
+  endforeach()
+  set(normalized_excludes "")
+  foreach(f ${ATF_EXCLUDE})
+    get_filename_component(f "${f}" ABSOLUTE)
+    list(APPEND normalized_excludes "${f}")
+  endforeach()
+  if(normalized_excludes)
+    list(REMOVE_ITEM normalized_files ${normalized_excludes})
   endif()
-  foreach(test_file ${test_files})
+  foreach(test_file ${normalized_files})
     get_filename_component(test_name ${test_file} NAME_WLE)
     monad_add_test(${test_name} ${test_file})
   endforeach()

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -247,5 +247,6 @@ monad_add_test(log_ffi_test NO_CUSTOM_MAIN log_ffi_test.cpp)
 monad_add_test(event_recorder_test event/event_recorder_test.cpp
   PROPERTIES RUN_SERIAL TRUE)
 monad_add_test(priority_pool_test fiber/priority_pool_test.cpp
+  BENCH_FILTER "PriorityPool.benchmark"
   PROPERTIES RUN_SERIAL TRUE)
 target_compile_definitions(event_reader_extra_test PRIVATE "TEST_DATA_DIR=\"${TEST_DATA_DIR}\"")

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -28,7 +28,24 @@ add_trie_test(
 add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")
 add_trie_test(TARGET update_aux_test SOURCES "update_aux_test.cpp")
-add_trie_test(TARGET db_test SOURCES "db_test.cpp")
+add_trie_test(TARGET db_test SOURCES "db_test.cpp"
+              TEST_FILTER "-DbTest/*.scalability")
+
+# scalability is a throughput benchmark (~60 s per fixture). Exclude it from
+# the default test set and register one ctest entry per fixture under the
+# "bench" label so `ctest -LE bench` skips them for fast iteration while
+# plain `ctest` still runs them (in parallel via two separate entries).
+set(_scalability_env
+    "ASAN_OPTIONS=abort_on_error=1;UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1;TSAN_OPTIONS=external_symbolizer_path=/usr/bin/llvm-symbolizer"
+)
+add_test(NAME monad_trie/DbTest.scalability_InMemoryDbFixture_bench
+         COMMAND db_test --gtest_filter=DbTest/0.scalability)
+add_test(NAME monad_trie/DbTest.scalability_OnDiskDbFixture_bench
+         COMMAND db_test --gtest_filter=DbTest/1.scalability)
+set_tests_properties(
+  monad_trie/DbTest.scalability_InMemoryDbFixture_bench
+  monad_trie/DbTest.scalability_OnDiskDbFixture_bench
+  PROPERTIES LABELS bench ENVIRONMENT "${_scalability_env}")
 add_trie_test(TARGET fiber_future_wrapped_find_test SOURCES
               "fiber_future_wrapped_find.cpp")
 add_trie_test(TARGET fiber_future_wrapped_read_test SOURCES

--- a/category/statesync/CMakeLists.txt
+++ b/category/statesync/CMakeLists.txt
@@ -44,7 +44,13 @@ target_include_directories(monad_statesync PUBLIC ${CATEGORY_MAIN_DIR})
 monad_compile_options(monad_statesync)
 target_link_libraries(monad_statesync PUBLIC monad_execution_ethereum)
 
-monad_add_test_folder(".")
+monad_add_test_folder("."
+  EXCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/test/test_statesync.cpp")
+
+# test_statesync contains StateSyncFixture.benchmark (~25 s) — label it as
+# "bench" so `ctest -LE bench` skips it during the fast fix/build/test cycle.
+monad_add_test(test_statesync test/test_statesync.cpp
+  BENCH_FILTER "StateSyncFixture.benchmark")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   add_executable(fuzz_statesync "${PROJECT_SOURCE_DIR}/test/fuzz_statesync.cpp")


### PR DESCRIPTION
Adds a `bench` CTest label for the three throughput benchmarks that sat on the critical path of a default `ctest -j 32` run:

  * DbTest.scalability<InMemoryDbFixture>   ~61 s
  * DbTest.scalability<OnDiskDbFixture>     ~63 s
  * StateSyncFixture.benchmark              ~25 s
  * PriorityPool.benchmark                  ~12 s

Mechanism:

  * monad_add_test / add_trie_test gain an optional BENCH_FILTER "<gtest-pattern>" argument. Matching tests are excluded from gtest_discover_tests via `TEST_FILTER "-<pattern>"` and re-registered as a single `<target>_bench` ctest entry with LABELS bench.
  * category/mpt/test registers the two DbTest.scalability variants as two separate bench entries so they parallelize under -j.
  * monad_add_test_folder's EXCLUDE paths are normalized to absolute form so EXCLUDE lists written with ${CMAKE_CURRENT_SOURCE_DIR}/... match GLOB_RECURSE's `./`-prefixed paths when target=".".

CLAUDE.md quick-reference now shows `ctest -LE bench` (fast iteration) and plain `ctest` (full, includes benches — use before pushing).

Measured on this change's worktree, `ctest -j 32` (RelWithDebInfo):

  baseline  141 s  (std 4,  n=3)
  -LE bench  77 s  (std 1,  n=6)
  full       78 s  (std 0.1, n=2 warm)

The -LE case saves ~64 s by skipping the benches. The full case also drops to ~78 s once cost data is warm: renaming the scalability entries out of their `<(anonymous namespace)::Fixture>` form lets CTestCostData parse them correctly, so ctest finally schedules them first instead of last. The two variants then parallelize with the other long-running tests instead of forming a ~60 s serial tail.