### PR TITLE
CI: bump Claude Code max-turns from 60 to 100

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-opus-4-7 --max-turns 60 --allowedTools Bash,Read,Glob,Grep"
+          claude_args: "--model claude-opus-4-7 --max-turns 100 --allowedTools Bash,Read,Glob,Grep"
           prompt: "First, read REVIEW.md at the repo root and follow it exactly. Then review this pull request using that document's process, priority scale, comment style, and repo-specific guidance (traits system, FFI boundary, C++ correctness, testing, style, PR hygiene, security). Post findings as inline review comments and end with the overall verdict as specified in REVIEW.md."
 
       - name: Run Claude Code (mention)
@@ -73,4 +73,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-opus-4-7 --max-turns 60"
+          claude_args: "--model claude-opus-4-7 --max-turns 100"


### PR DESCRIPTION
Post-bump calibration on five PRs: typical reviews use 33-48 of 60 turns; one outlier PR (12 files, +3609/-325 LOC) hit the 60 cap after ~18 min and posted no inline comments before termination. 60 was enough for ordinary PRs but not for large ones.

100 gives ~2x headroom while keeping per-review cost bounded ($13 worst case extrapolated from the failed 60-turn / $7.77 run). Applied to both the review and mention steps so @claude mentions on large PRs don't hit the same ceiling.