### PR TITLE
Port SHA256, RIPEMD160 precompiles away from silkpre

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ find_package(Boost REQUIRED COMPONENTS context filesystem json CONFIG)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
 pkg_check_modules(crypto++ REQUIRED IMPORTED_TARGET libcrypto++)
+pkg_check_modules(libcrypto REQUIRED IMPORTED_TARGET libcrypto>=3.0)
 pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
 
 # ankerl

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -118,6 +118,10 @@ add_library(
   "lru/static_lru_cache.hpp"
   "mem/batch_mem_pool.hpp"
   "synchronization/spin_lock.hpp"
+  # crypto
+  "crypto/digest.hpp"
+  "crypto/init.cpp"
+  "crypto/init.hpp"
   # event
   "event/event_iterator.h"
   "event/event_iterator_inline.h"
@@ -214,7 +218,9 @@ else()
 endif()
 
 target_link_libraries(monad_core PUBLIC ankerl_hash)
+target_link_libraries(monad_core PRIVATE blst::blst)
 target_link_libraries(monad_core PUBLIC Boost::fiber TBB::tbb)
+target_link_libraries(monad_core PUBLIC c-kzg-4844)
 target_link_libraries(monad_core PUBLIC komihash)
 target_link_libraries(monad_core PUBLIC blake3)
 target_link_libraries(monad_core PUBLIC ethash::keccak)
@@ -222,6 +228,7 @@ target_link_libraries(monad_core PUBLIC evmc)
 target_link_libraries(monad_core PUBLIC intx)
 target_link_libraries(monad_core PUBLIC quill)
 target_link_libraries(monad_core PUBLIC unordered_dense)
+target_link_libraries(monad_core PUBLIC PkgConfig::libcrypto)
 target_link_libraries(monad_core PUBLIC PkgConfig::zstd)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(monad_core PUBLIC hugetlbfs uring)

--- a/category/core/crypto/digest.hpp
+++ b/category/core/crypto/digest.hpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/assert.h>
+#include <category/core/config.hpp>
+
+#include <openssl/evp.h>
+
+#include <cstddef>
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace detail
+{
+    struct DigestCtx
+    {
+        EVP_MD_CTX *const ptr;
+
+        DigestCtx()
+            : ptr(EVP_MD_CTX_new())
+        {
+            MONAD_ASSERT(ptr != nullptr);
+        }
+
+        ~DigestCtx()
+        {
+            EVP_MD_CTX_free(ptr);
+        }
+
+        DigestCtx(DigestCtx const &) = delete;
+        DigestCtx &operator=(DigestCtx const &) = delete;
+    };
+}
+
+// One thread-local context per digest type: each instantiation of `digest`
+// has its own `thread_local` ctx, so OpenSSL's per-algorithm internal state
+// (allocated on the first EVP_DigestInit_ex) is reused on subsequent calls
+// instead of being torn down and re-allocated when alternating digests on a
+// shared context. The template instantiation is shared across translation
+// units, so callers in different files that pass the same MdGetter share a
+// single per-thread context — and the `EVP_MD const *` returned by MdGetter
+// is itself thread-safe to share globally; only the EVP_MD_CTX is per-thread.
+//
+// Fiber-safety invariant: this function MUST remain fiber-atomic. Boost.Fibers
+// is cooperative and `thread_local` is keyed to the OS thread (not the
+// fiber), so two fibers on the same thread alias the same DigestCtx. A yield
+// between EVP_DigestInit_ex and EVP_DigestFinal_ex would let a co-scheduled
+// fiber re-enter `digest<MdGetter>` and corrupt the in-flight state — and
+// fiber migration to a different OS thread mid-digest would be even worse,
+// since the resumed half would run against a different thread's context.
+// Do not introduce any fiber yield point inside this function, and do not
+// pass an MdGetter that can yield. Calls to `digest` themselves may safely
+// be separated by yields; only the Init→Update→Final sequence inside one
+// call must complete without yielding.
+template <auto MdGetter>
+void digest(
+    uint8_t *const output, unsigned char const *const data, size_t const size)
+{
+    thread_local detail::DigestCtx ctx;
+
+    // Some digest implementations invoke memcpy on the input buffer even
+    // when the length is zero; swap a null data pointer for a pointer to
+    // the empty string to stay out of UB.
+    unsigned char const *const safe_data =
+        data != nullptr ? data : reinterpret_cast<unsigned char const *>("");
+    // EVP_DigestInit_ex re-initializes the context state when called on a
+    // previously-used ctx, so we deliberately skip EVP_MD_CTX_reset.
+    MONAD_ASSERT(EVP_DigestInit_ex(ctx.ptr, MdGetter(), nullptr) == 1);
+    MONAD_ASSERT(EVP_DigestUpdate(ctx.ptr, safe_data, size) == 1);
+    MONAD_ASSERT(EVP_DigestFinal_ex(ctx.ptr, output, nullptr) == 1);
+}
+
+MONAD_NAMESPACE_END

--- a/category/core/crypto/init.cpp
+++ b/category/core/crypto/init.cpp
@@ -1,0 +1,163 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/config.hpp>
+#include <category/core/crypto/init.hpp>
+
+#include <c-kzg-4844/trusted_setup.hpp>
+#include <common/ret.h>
+#include <setup/settings.h>
+#include <setup/setup.h>
+
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+
+#include <quill/Quill.h>
+
+#include <cstdio>
+#include <memory>
+#include <optional>
+#include <stdio.h>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+struct OsslProviderDeleter
+{
+    void operator()(OSSL_PROVIDER *const p) const noexcept
+    {
+        OSSL_PROVIDER_unload(p);
+    }
+};
+
+struct EvpMdDeleter
+{
+    void operator()(EVP_MD const *const p) const noexcept
+    {
+        EVP_MD_free(const_cast<EVP_MD *>(p));
+    }
+};
+
+using OsslProviderPtr = std::unique_ptr<OSSL_PROVIDER, OsslProviderDeleter>;
+using EvpMdPtr = std::unique_ptr<EVP_MD const, EvpMdDeleter>;
+
+constinit std::optional<KZGSettings> g_trusted_setup;
+constinit OsslProviderPtr g_default_provider;
+constinit OsslProviderPtr g_legacy_provider;
+constinit EvpMdPtr g_sha256_md;
+constinit EvpMdPtr g_ripemd160_md;
+
+bool load_trusted_setup()
+{
+    if (!g_trusted_setup.has_value()) {
+        auto const setup = c_kzg_4844::trusted_setup_data();
+        KZGSettings settings;
+        std::unique_ptr<FILE, int (*)(FILE *)> const fp{
+            fmemopen(
+                const_cast<void *>(static_cast<void const *>(setup.data())),
+                setup.size(),
+                "r"),
+            &std::fclose};
+        if (fp) {
+            if (load_trusted_setup_file(&settings, fp.get(), 0) == C_KZG_OK) {
+                g_trusted_setup.emplace(settings);
+            }
+        }
+    }
+    if (!g_trusted_setup.has_value()) {
+        LOG_ERROR("init_crypto: failed to load KZG trusted setup");
+        return false;
+    }
+    return true;
+}
+
+bool load_providers()
+{
+    g_default_provider.reset(OSSL_PROVIDER_load(nullptr, "default"));
+    if (!g_default_provider) {
+        LOG_ERROR("init_crypto: failed to load OpenSSL default provider");
+        return false;
+    }
+    g_legacy_provider.reset(OSSL_PROVIDER_load(nullptr, "legacy"));
+    if (!g_legacy_provider) {
+        LOG_ERROR("init_crypto: failed to load OpenSSL legacy provider");
+        return false;
+    }
+    return true;
+}
+
+// Fetch every digest consumed by consensus-critical code, so the hot
+// precompile path can read a pointer instead of walking providers on every
+// call. We want to fail fast at startup if the local OpenSSL is
+// misconfigured (e.g. FIPS mode disabling a chain-mandated algorithm)
+// rather than discover it mid-block: a runtime digest failure leaves no
+// consensus-safe option, since aborting loses liveness and returning a
+// precompile failure silently forks state away from nodes whose OpenSSL is
+// healthy.
+bool fetch_digests()
+{
+    g_sha256_md.reset(EVP_MD_fetch(nullptr, "SHA256", nullptr));
+    if (!g_sha256_md) {
+        LOG_ERROR("init_crypto: required digest SHA256 is not available");
+        return false;
+    }
+    g_ripemd160_md.reset(EVP_MD_fetch(nullptr, "RIPEMD160", nullptr));
+    if (!g_ripemd160_md) {
+        LOG_ERROR("init_crypto: required digest RIPEMD160 is not available");
+        return false;
+    }
+    return true;
+}
+
+bool init_crypto_impl()
+{
+    return load_trusted_setup() && load_providers() && fetch_digests();
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
+
+// init_crypto runs its side effects exactly once per process via the
+// thread-safe initialization of a function-local static. This both
+// serializes the non-thread-safe mutation of g_trusted_setup against any
+// concurrent FFI callers and makes repeat calls cheap idempotent queries of
+// the cached outcome, so a misconfigured node stays failed rather than
+// re-attempting provider loads and accumulating leaked handles.
+bool init_crypto()
+{
+    static bool const success = init_crypto_impl();
+    return success;
+}
+
+KZGSettings const &kzg_trusted_setup()
+{
+    MONAD_ASSERT(g_trusted_setup.has_value());
+    return g_trusted_setup.value();
+}
+
+EVP_MD const *sha256_md()
+{
+    MONAD_ASSERT(g_sha256_md);
+    return g_sha256_md.get();
+}
+
+EVP_MD const *ripemd160_md()
+{
+    MONAD_ASSERT(g_ripemd160_md);
+    return g_ripemd160_md.get();
+}
+
+MONAD_NAMESPACE_END

--- a/category/core/crypto/init.hpp
+++ b/category/core/crypto/init.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,35 +15,20 @@
 
 #pragma once
 
-#include <gtest/gtest.h>
-
-#include <category/core/assert.h>
 #include <category/core/config.hpp>
-#include <category/core/crypto/init.hpp>
-#include <category/core/log.hpp>
-#include <category/execution/ethereum/trace/event_trace.hpp>
-#include <monad/test/config.hpp>
+
+#include <eip4844/eip4844.h>
+
+#include <openssl/types.h>
 
 MONAD_NAMESPACE_BEGIN
 
-quill::Logger *event_tracer = nullptr;
+bool init_crypto();
+
+// Preconditions for all accessors below: init_crypto() must have been called
+// and returned true.
+KZGSettings const &kzg_trusted_setup();
+EVP_MD const *sha256_md();
+EVP_MD const *ripemd160_md();
 
 MONAD_NAMESPACE_END
-
-MONAD_TEST_NAMESPACE_BEGIN
-
-class Environment : public ::testing::Environment
-{
-public:
-    void SetUp() override
-    {
-        quill::start();
-        MONAD_ASSERT(init_crypto());
-#ifdef ENABLE_EVENT_TRACING
-        event_tracer =
-            quill::create_logger("event_trace", quill::null_handler());
-#endif
-    }
-};
-
-MONAD_TEST_NAMESPACE_END

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -309,6 +309,7 @@ target_link_libraries(
   PUBLIC c-kzg-4844
   PRIVATE PkgConfig::brotli
   PRIVATE PkgConfig::crypto++
+  PRIVATE PkgConfig::libcrypto
   PUBLIC ethash::keccak
   PUBLIC evmc
   PUBLIC immer

--- a/category/execution/ethereum/precompiles.hpp
+++ b/category/execution/ethereum/precompiles.hpp
@@ -31,8 +31,6 @@
 
 MONAD_NAMESPACE_BEGIN
 
-bool init_trusted_setup();
-
 inline constexpr Address ripemd_address{3};
 
 template <Traits traits>

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -16,6 +16,8 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/crypto/digest.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/core/hex.hpp>
 #include <category/execution/ethereum/precompiles.hpp>
 #include <category/execution/ethereum/precompiles_bls12.hpp>
@@ -28,8 +30,6 @@
 
 #include <blst.h>
 
-#include <c-kzg-4844/trusted_setup.hpp>
-
 #include <eip4844/eip4844.h>
 
 #include <evmc/evmc.h>
@@ -40,60 +40,39 @@
 #include <setup/setup.h>
 
 #include <silkpre/precompile.h>
-#include <silkpre/sha256.h>
 
+#include <cstdlib>
 #include <cstring>
 
-namespace
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+bytes32_t kzg_to_version_hashed(KZGCommitment const &commitment)
 {
-    std::optional<KZGSettings> g_trustedSetup;
-
-    monad::bytes32_t kzg_to_version_hashed(KZGCommitment const &commitment)
-    {
-        constexpr uint8_t VERSION_HASH_VERSION_KZG = 1;
-        monad::bytes32_t h;
-        silkpre_sha256(
-            h.bytes,
-            commitment.bytes,
-            sizeof(KZGCommitment),
-            true /* use_cpu_extensions */);
-        h.bytes[0] = VERSION_HASH_VERSION_KZG;
-        return h;
-    }
-
-    struct bytes64_t
-    {
-        uint8_t bytes[64];
-    };
-
-    constexpr bytes64_t blob_precompile_return_value()
-    {
-        constexpr std::string_view v{
-            "0x0000000000000000000000000000000000000000000000000000000000001000"
-            "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"};
-        constexpr auto r = monad::from_hex<bytes64_t>(v);
-        static_assert(r.has_value());
-        return r.value();
-    }
+    constexpr uint8_t VERSION_HASH_VERSION_KZG = 1;
+    bytes32_t h;
+    digest<sha256_md>(h.bytes, commitment.bytes, sizeof(KZGCommitment));
+    h.bytes[0] = VERSION_HASH_VERSION_KZG;
+    return h;
 }
+
+struct bytes64_t
+{
+    uint8_t bytes[64];
+};
+
+constexpr bytes64_t blob_precompile_return_value()
+{
+    constexpr std::string_view v{
+        "0x0000000000000000000000000000000000000000000000000000000000001000"
+        "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"};
+    constexpr auto r = from_hex<bytes64_t>(v);
+    static_assert(r.has_value());
+    return r.value();
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
-
-bool init_trusted_setup()
-{
-    if (!g_trustedSetup.has_value()) {
-        auto const setup = c_kzg_4844::trusted_setup_data();
-        KZGSettings settings;
-        FILE *fp = fmemopen((void *)(setup.data()), setup.size(), "r");
-        if (fp) {
-            if (load_trusted_setup_file(&settings, fp, 0) == C_KZG_OK) {
-                g_trustedSetup.emplace(settings);
-            }
-            fclose(fp);
-        }
-    }
-    return g_trustedSetup.has_value();
-}
 
 template <SilkpreRunFunction Func>
 static inline PrecompileResult silkpre_execute(byte_string_view const input)
@@ -114,20 +93,28 @@ PrecompileResult ecrecover_execute(byte_string_view const input)
 
 PrecompileResult sha256_execute(byte_string_view const input)
 {
-    if (MONAD_UNLIKELY(input.data() == nullptr)) {
-        // Passing a null pointer to the Silkpre sha256 implementation invokes
-        // undefined behaviour. We sidestep the UB here by passing a pointer to
-        // the empty string instead.
-        byte_string_view const nonnull{
-            reinterpret_cast<unsigned char const *>(""), 0UL};
-        return silkpre_execute<silkpre_sha256_run>(nonnull);
-    }
-    return silkpre_execute<silkpre_sha256_run>(input);
+    constexpr size_t SHA256_OUTPUT_SIZE = 32;
+
+    auto *const output =
+        static_cast<uint8_t *>(std::malloc(SHA256_OUTPUT_SIZE));
+    MONAD_ASSERT(output != nullptr);
+    digest<sha256_md>(output, input.data(), input.size());
+    return {EVMC_SUCCESS, output, SHA256_OUTPUT_SIZE};
 }
 
 PrecompileResult ripemd160_execute(byte_string_view const input)
 {
-    return silkpre_execute<silkpre_rip160_run>(input);
+    // The Ethereum RIPEMD-160 precompile returns a 32-byte output with the
+    // 20-byte digest right-aligned and left-padded with zeros.
+    constexpr size_t OUTPUT_SIZE = 32;
+    constexpr size_t RIPEMD160_SIZE = 20;
+
+    auto *const output = static_cast<uint8_t *>(std::malloc(OUTPUT_SIZE));
+    MONAD_ASSERT(output != nullptr);
+    std::memset(output, 0, OUTPUT_SIZE - RIPEMD160_SIZE);
+    digest<ripemd160_md>(
+        output + (OUTPUT_SIZE - RIPEMD160_SIZE), input.data(), input.size());
+    return {EVMC_SUCCESS, output, OUTPUT_SIZE};
 }
 
 PrecompileResult ecadd_execute(byte_string_view const input)
@@ -193,7 +180,7 @@ PrecompileResult point_evaluation_execute(byte_string_view const input)
     }
 
     bool ok{false};
-    verify_kzg_proof(&ok, &commitment, z, y, proof, &g_trustedSetup.value());
+    verify_kzg_proof(&ok, &commitment, z, y, proof, &kzg_trusted_setup());
     if (!ok) {
         return PrecompileResult::failure();
     }

--- a/category/execution/ethereum/precompiles_test.cpp
+++ b/category/execution/ethereum/precompiles_test.cpp
@@ -554,8 +554,6 @@ TYPED_TEST(TraitsTest, point_evaluation)
         EXPECT_FALSE(is_precompile<typename TestFixture::Trait>(0x0a_address));
     }
     else {
-        ASSERT_TRUE(init_trusted_setup());
-
         if constexpr (is_monad_trait_v<typename TestFixture::Trait>) {
             if constexpr (TestFixture::Trait::monad_rev() >= MONAD_SEVEN) {
                 // In MONAD_SEVEN point_evaluation cost is increased by 4x

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/crypto/digest.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -25,8 +27,6 @@
 #include <category/execution/ethereum/validate_block.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
-
-#include <silkpre/sha256.h>
 
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
@@ -141,8 +141,8 @@ bytes32_t compute_requests_hash(
         buf.reserve(1 + data.size());
         buf.push_back(type);
         buf.insert(buf.end(), data.begin(), data.end());
-        silkpre_sha256(
-            inner_hashes_buf + inner_hashes_len, buf.data(), buf.size(), true);
+        digest<sha256_md>(
+            inner_hashes_buf + inner_hashes_len, buf.data(), buf.size());
         inner_hashes_len += 32;
     };
 
@@ -152,7 +152,7 @@ bytes32_t compute_requests_hash(
     hash_request(0x02, consolidation_output);
 
     bytes32_t outer_hash;
-    silkpre_sha256(outer_hash.bytes, inner_hashes_buf, inner_hashes_len, true);
+    digest<sha256_md>(outer_hash.bytes, inner_hashes_buf, inner_hashes_len);
     return outer_hash;
 }
 

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -20,6 +20,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/core/fiber/fiber_group.hpp>
 #include <category/core/fiber/fiber_thread_pool.hpp>
 #include <category/core/fiber/priority_pool.hpp>
@@ -1347,6 +1348,10 @@ monad_executor *monad_executor_create(
     char const *const dbpath)
 {
     MONAD_ASSERT(dbpath);
+    // init_crypto is idempotent; calling it here ensures the FFI consumer
+    // never reaches a precompile handler (e.g. point_evaluation) before the
+    // OpenSSL providers and KZG trusted setup are loaded.
+    MONAD_ASSERT(monad::init_crypto());
     std::string const triedb_path{dbpath};
 
     monad_executor *const e = new monad_executor(

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -21,6 +21,7 @@
 #include <category/core/assert.h>
 #include <category/core/basic_formatter.hpp>
 #include <category/core/config.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/likely.h>
 #include <category/core/log.hpp>
@@ -38,7 +39,6 @@
 #include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
-#include <category/execution/ethereum/precompiles.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/event_trace.hpp>
@@ -256,7 +256,7 @@ try {
     event_tracer = create_event_tracer(trace_log);
 #endif
 
-    MONAD_ASSERT(init_trusted_setup());
+    MONAD_ASSERT(init_crypto());
 
     auto const db_in_memory = dbname_paths.empty();
     [[maybe_unused]] auto const load_start_time =

--- a/scripts/ubuntu-build/install-deps.sh
+++ b/scripts/ubuntu-build/install-deps.sh
@@ -13,6 +13,7 @@ packages=(
   libgmp-dev
   libgtest-dev
   libhugetlbfs-dev
+  libssl-dev
   libtbb-dev
   liburing-dev
   libzstd-dev

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -25,6 +25,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/core/event/event_iterator.h>
 #include <category/core/event/event_ring.h>
 #include <category/core/fiber/priority_pool.hpp>
@@ -640,7 +641,7 @@ MONAD_TEST_NAMESPACE_BEGIN
 void BlockchainTest::SetUpTestSuite()
 {
     pool_ = new fiber::PriorityPool{1, 1};
-    ASSERT_TRUE(monad::init_trusted_setup());
+    ASSERT_TRUE(monad::init_crypto());
 }
 
 void BlockchainTest::TearDownTestSuite()

--- a/test/vm/execution_benchmarks/benchmarks.cpp
+++ b/test/vm/execution_benchmarks/benchmarks.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
+#include <category/core/crypto/init.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 
@@ -397,6 +398,8 @@ namespace
 
 int main(int argc, char **argv)
 {
+    MONAD_ASSERT(monad::init_crypto());
+
     TestMemory test_memory;
     auto const all_bms = benchmarks(test_memory);
 

--- a/test/vm/fuzzer/fuzzer.cpp
+++ b/test/vm/fuzzer/fuzzer.cpp
@@ -28,6 +28,7 @@
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
+#include <category/core/crypto/init.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
@@ -629,6 +630,7 @@ static void run_loop(int argc, char **argv)
 int main(int argc, char **argv)
 {
     if (monad::vm::utils::is_fuzzing_monad_vm) {
+        MONAD_ASSERT(monad::init_crypto());
         run_loop(argc, argv);
         return 0;
     }


### PR DESCRIPTION
Add a `category/core/crypto` module with an `init_crypto()` entry point that loads the KZG trusted setup, registers the OpenSSL default and legacy providers, and probes every digest consumed by consensus-critical code (SHA256, RIPEMD160). Idempotency is provided by the thread-safe initialization of a function-local static, so FFI consumers and the CLI can invoke it freely without racing on provider load or leaking handles on repeat attempts. A misconfigured OpenSSL fails at startup.

Migrate the SHA256 and RIPEMD160 precompiles, and the EIP-7685 requests-hash in `process_requests`, from silkpre to OpenSSL's EVP digest API. The fetched `EVP_MD *` is cached per-algorithm at initialization time. Null-input handling (previously a silkpre-specific workaround in `sha256_execute`) is centralized in the shared `digest()` helper.

Introduce `category/core/crypto/digest.hpp`, a small templated helper that owns one `thread_local EVP_MD_CTX` per digest type and drives it with `EVP_DigestInit_ex` / `EVP_DigestUpdate` / `EVP_DigestFinal_ex`. Each instantiation is shared across translation units, so both the precompile path and `compute_requests_hash` reuse the same warm context on the same thread, and switching algorithms doesn't tear down OpenSSL's per-algorithm internal state. The header documents the fiber-atomic invariant the helper relies on (no fiber yield between Init and Final).

Update `cmd/monad/main.cpp`, `category/rpc/monad_executor.cpp`, the blockchain / precompile tests, and the VM fuzzer / execution benchmark binaries to call `init_crypto()` at startup. Wire `libcrypto>=3.0` into the root, core, and execution CMake targets, and add `libssl-dev` to the Ubuntu deps script.