### PR TITLE
Add HiveNet to monad-ethcall

### DIFF
--- a/rust/crates/monad-ethcall/src/ffi.rs
+++ b/rust/crates/monad-ethcall/src/ffi.rs
@@ -16,12 +16,13 @@
 pub use self::bindings::monad_executor_pool_config as PoolConfig;
 pub(crate) use self::bindings::{
     add_override_address, monad_chain_config, monad_chain_config_CHAIN_CONFIG_ETHEREUM_MAINNET,
-    monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET, monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET,
-    monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET, monad_executor, monad_executor_create,
-    monad_executor_destroy, monad_executor_eth_call_submit, monad_executor_result,
-    monad_executor_result_release, monad_executor_run_transactions, monad_state_override_create,
-    monad_state_override_destroy, monad_tracer_config_NOOP_TRACER, set_override_balance,
-    set_override_code, set_override_nonce, set_override_state, set_override_state_diff,
+    monad_chain_config_CHAIN_CONFIG_HIVE_NET, monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET,
+    monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET, monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET,
+    monad_executor, monad_executor_create, monad_executor_destroy, monad_executor_eth_call_submit,
+    monad_executor_result, monad_executor_result_release, monad_executor_run_transactions,
+    monad_state_override_create, monad_state_override_destroy, monad_tracer_config_NOOP_TRACER,
+    set_override_balance, set_override_code, set_override_nonce, set_override_state,
+    set_override_state_diff,
 };
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]

--- a/rust/crates/monad-ethcall/src/lib.rs
+++ b/rust/crates/monad-ethcall/src/lib.rs
@@ -38,6 +38,7 @@ pub enum ChainId {
     MonadMainnet,
     MonadTestnet,
     MonadDevnet,
+    HiveNet,
 }
 
 impl ChainId {
@@ -47,6 +48,7 @@ impl ChainId {
             Self::MonadMainnet => ffi::monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET,
             Self::MonadTestnet => ffi::monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET,
             Self::MonadDevnet => ffi::monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET,
+            Self::HiveNet => ffi::monad_chain_config_CHAIN_CONFIG_HIVE_NET,
         }
     }
 }


### PR DESCRIPTION
Continuation of #2103. While rebasing the Rust part, I realized that, while the PR was in review, ethcall was moved from monad-bft to monad