### PR TITLE
[dual-timeline 3/N] Add monad-mpt --upgrade and gate MONAD007 migration

### DIFF
--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -657,6 +657,7 @@ storage_pool::storage_pool(
     storage_pool const *const src, clone_as_read_only_tag_)
     : is_read_only_(true)
     , is_read_only_allow_dirty_(false)
+    , is_migration_allowed_(false)
     , is_newly_truncated_(false)
 {
     devices_.reserve(src->devices_.size());
@@ -711,6 +712,7 @@ storage_pool::storage_pool(
     creation_flags const flags)
     : is_read_only_(flags.open_read_only || flags.open_read_only_allow_dirty)
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
+    , is_migration_allowed_(flags.allow_migration)
     , is_newly_truncated_(mode == mode::truncate)
 {
     devices_.reserve(sources.size());
@@ -771,6 +773,7 @@ storage_pool::storage_pool(
     use_anonymous_sized_inode_tag, off_t const len, creation_flags const flags)
     : is_read_only_(flags.open_read_only || flags.open_read_only_allow_dirty)
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
+    , is_migration_allowed_(flags.allow_migration)
     , is_newly_truncated_(false)
 {
     int const fd = make_temporary_inode();

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -327,6 +327,11 @@ public:
         //! can cause pool data loss, as well as system data loss as it will
         //! happily use any partition you feed it, including the system drive.
         uint32_t disable_mismatching_storage_pool_check : 1;
+        //! Whether to permit on-disk format migration on open. Default false;
+        //! only monad-mpt --upgrade sets this to true. When false, a
+        //! DbMetadataContext ctor that observes PREVIOUS_MAGIC aborts with a
+        //! message directing the operator to run monad-mpt --upgrade.
+        uint32_t allow_migration : 1;
 
         //! Number of conventional chunks to allocate per device. Default is 3.
         uint32_t num_cnv_chunks;
@@ -337,13 +342,15 @@ public:
             , open_read_only(false)
             , open_read_only_allow_dirty(false)
             , disable_mismatching_storage_pool_check(false)
+            , allow_migration(false)
             , num_cnv_chunks(3)
         {
         }
     };
 
 private:
-    bool const is_read_only_, is_read_only_allow_dirty_, is_newly_truncated_;
+    bool const is_read_only_, is_read_only_allow_dirty_, is_migration_allowed_,
+        is_newly_truncated_;
     std::vector<device_t> devices_;
 
     // Lock protects everything below this
@@ -393,6 +400,15 @@ public:
     bool is_read_only_allow_dirty() const noexcept
     {
         return is_read_only_allow_dirty_;
+    }
+
+    //! \brief True if the storage pool was opened with allow_migration set.
+    //! Consulted by DbMetadataContext to decide whether a PREVIOUS_MAGIC
+    //! pool should be migrated or rejected with a "run monad-mpt --upgrade"
+    //! message.
+    bool is_migration_allowed() const noexcept
+    {
+        return is_migration_allowed_;
     }
 
     //! \brief True if the storage pool was just truncated, and structures may

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -29,6 +29,7 @@
 #include <category/mpt/config.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/kbhit.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/detail/unsigned_20.hpp>
 #include <category/mpt/trie.hpp>
 
@@ -509,7 +510,12 @@ public:
              << ", latest verified is "
              << aux.metadata_ctx().get_latest_verified_version()
              << ", auto expire version is "
-             << aux.metadata_ctx().get_auto_expire_version_metadata() << "\n";
+             << aux.metadata_ctx().get_auto_expire_version_metadata(
+                    monad::mpt::timeline_id::primary)
+             << " (primary), "
+             << aux.metadata_ctx().get_auto_expire_version_metadata(
+                    monad::mpt::timeline_id::secondary)
+             << " (secondary)\n";
     }
 
     void do_restore_database()
@@ -891,10 +897,43 @@ public:
                             old_metadata->latest_verified_version;
                         metadata->latest_voted_version =
                             old_metadata->latest_voted_version;
+                        metadata->latest_proposed_version =
+                            old_metadata->latest_proposed_version;
                         metadata->latest_voted_block_id =
                             old_metadata->latest_voted_block_id;
-                        metadata->auto_expire_version =
-                            old_metadata->auto_expire_version;
+                        metadata->latest_proposed_block_id =
+                            old_metadata->latest_proposed_block_id;
+                        metadata->root_offsets.auto_expire_version_ =
+                            old_metadata->root_offsets.auto_expire_version_;
+                        // Dual-timeline role + secondary ring header.
+                        // Without primary_ring_idx the restored DB would
+                        // route the primary role at ring_a even when the
+                        // source DB had promoted ring_b — silent data
+                        // loss. Copy the secondary ring header so its
+                        // chunks (restored under the same cnv ids) are
+                        // mapped by map_ring_b_storage at reopen.
+                        metadata->primary_ring_idx =
+                            old_metadata->primary_ring_idx;
+                        metadata->secondary_timeline_active_ =
+                            old_metadata->secondary_timeline_active_;
+                        metadata->secondary_timeline.next_version_ =
+                            old_metadata->secondary_timeline.next_version_;
+                        metadata->secondary_timeline.version_lower_bound_ =
+                            old_metadata->secondary_timeline
+                                .version_lower_bound_;
+                        memcpy(
+                            &metadata->secondary_timeline.storage_,
+                            &old_metadata->secondary_timeline.storage_,
+                            sizeof(metadata->secondary_timeline.storage_));
+                        metadata->secondary_timeline.auto_expire_version_ =
+                            old_metadata->secondary_timeline
+                                .auto_expire_version_;
+                        // Deliberately NOT copied: shrink_grow_seq_ and
+                        // pending_shrink_grow. Both stay at their zero-
+                        // initialised values (seq even, op_kind NONE) so
+                        // the restored DB starts in a quiescent state and
+                        // does not attempt to replay an in-flight op
+                        // against freshly-restored ring data.
                     });
                     fast_list_base_insertion_count =
                         old_metadata->fast_list_begin()->insertion_count();

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -402,6 +402,7 @@ struct impl_t
     bool create_database = false;
     bool truncate_database = false;
     bool create_empty_database = false;
+    bool upgrade_database = false;
     std::optional<uint64_t> rewind_database_to;
     std::optional<uint64_t> reset_history_length;
     bool create_chunk_increasing = false;
@@ -1478,6 +1479,13 @@ opened.
                 "--rewind-to",
                 impl.rewind_database_to,
                 "rewind database to an earlier point in its history.");
+            cli_ops_group->add_flag(
+                "--upgrade",
+                impl.upgrade_database,
+                "migrate the database metadata to the current on-disk "
+                "format (MONAD008) and ensure it is durable on disk "
+                "before exiting. Run after upgrading the monad apt "
+                "package and before starting monad services.");
             cli.add_option(
                 "--archive",
                 impl.archive_database,
@@ -1592,6 +1600,12 @@ opened.
                 impl.flags.open_read_only = false;
                 impl.flags.open_read_only_allow_dirty = false;
             }
+            else if (impl.upgrade_database) {
+                mode = MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
+                impl.flags.open_read_only = false;
+                impl.flags.open_read_only_allow_dirty = false;
+                impl.flags.allow_migration = true;
+            }
             if (mode == MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate) {
                 MONAD_ASYNC_NAMESPACE::storage_pool const pool{
                     {impl.storage_paths}, mode, impl.flags};
@@ -1662,6 +1676,26 @@ opened.
             impl.print_list_info(
                 aux, aux.metadata_ctx().main()->free_list_begin(), "Free");
             impl.print_db_history_summary(aux);
+
+            if (impl.upgrade_database) {
+                if (aux.metadata_ctx().is_new_pool()) {
+                    cout << "\nWARNING: --upgrade found no existing DB "
+                            "metadata; a fresh MONAD008 pool was created. "
+                            "Use --create for an explicit new-pool "
+                            "workflow.\n";
+                }
+                else {
+                    // Neutral wording — when the ctor migrated from
+                    // MONAD007, the quill LOG_INFO inside the ctor has
+                    // already reported that; the tool's job here is just
+                    // to confirm the final state and flush.
+                    cout << "\nDB is on version MONAD008; flushing "
+                            "metadata...\n";
+                }
+                aux.metadata_ctx().sync_metadata_to_disk();
+                cout << "Success.\n";
+                return 0;
+            }
 
             if (impl.reset_history_length) {
                 // set to fixed history length, database will prune any outdated

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -520,6 +520,25 @@ public:
              << aux.metadata_ctx().get_auto_expire_version_metadata(
                     monad::mpt::timeline_id::secondary)
              << " (secondary)\n";
+
+        if (aux.metadata_ctx().timeline_active(
+                monad::mpt::timeline_id::secondary)) {
+            auto const max_v = aux.metadata_ctx().db_history_max_version(
+                monad::mpt::timeline_id::secondary);
+            cout << "Secondary timeline is active: ";
+            if (max_v == monad::mpt::INVALID_BLOCK_NUM) {
+                cout << "empty (no roots written yet — version_lower_bound "
+                        "and next_version are seeded by the first secondary "
+                        "upsert).\n";
+            }
+            else {
+                auto const min_v =
+                    aux.metadata_ctx().db_history_min_valid_version(
+                        monad::mpt::timeline_id::secondary);
+                cout << (1 + max_v - min_v) << " history, earliest is " << min_v
+                     << ", latest is " << max_v << ".\n";
+            }
+        }
     }
 
     void do_restore_database()

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -403,6 +403,9 @@ struct impl_t
     bool truncate_database = false;
     bool create_empty_database = false;
     bool upgrade_database = false;
+    bool activate_secondary_timeline = false;
+    bool promote_secondary_timeline = false;
+    bool deactivate_secondary_timeline = false;
     std::optional<uint64_t> rewind_database_to;
     std::optional<uint64_t> reset_history_length;
     bool create_chunk_increasing = false;
@@ -1486,6 +1489,26 @@ opened.
                 "format (MONAD008) and ensure it is durable on disk "
                 "before exiting. Run after upgrading the monad apt "
                 "package and before starting monad services.");
+            cli_ops_group->add_flag(
+                "--activate-secondary-timeline",
+                impl.activate_secondary_timeline,
+                "activate the secondary timeline. It starts empty; "
+                "version_lower_bound and next_version are seeded by the "
+                "first secondary upsert. The secondary remains attached "
+                "to the primary until --promote-secondary-timeline or "
+                "--deactivate-secondary-timeline is run.");
+            cli_ops_group->add_flag(
+                "--promote-secondary-timeline",
+                impl.promote_secondary_timeline,
+                "atomically swap primary and secondary roles. The "
+                "previous secondary becomes the primary on disk; the "
+                "previous primary is dropped. Requires the secondary to "
+                "be currently active.");
+            cli_ops_group->add_flag(
+                "--deactivate-secondary-timeline",
+                impl.deactivate_secondary_timeline,
+                "drop the secondary timeline. Metadata returns to "
+                "single-timeline state.");
             cli.add_option(
                 "--archive",
                 impl.archive_database,
@@ -1606,6 +1629,14 @@ opened.
                 impl.flags.open_read_only_allow_dirty = false;
                 impl.flags.allow_migration = true;
             }
+            else if (
+                impl.activate_secondary_timeline ||
+                impl.promote_secondary_timeline ||
+                impl.deactivate_secondary_timeline) {
+                mode = MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
+                impl.flags.open_read_only = false;
+                impl.flags.open_read_only_allow_dirty = false;
+            }
             if (mode == MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate) {
                 MONAD_ASYNC_NAMESPACE::storage_pool const pool{
                     {impl.storage_paths}, mode, impl.flags};
@@ -1694,6 +1725,48 @@ opened.
                 }
                 aux.metadata_ctx().sync_metadata_to_disk();
                 cout << "Success.\n";
+                return 0;
+            }
+
+            if (impl.activate_secondary_timeline) {
+                if (aux.metadata_ctx().timeline_active(
+                        MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                    cerr << "\nERROR: secondary timeline is already active. "
+                            "Run --deactivate-secondary-timeline first to "
+                            "re-fork.\n";
+                    return 1;
+                }
+                aux.activate_secondary_timeline();
+                aux.metadata_ctx().sync_metadata_to_disk();
+                cout << "\nActivated secondary timeline.\n";
+                return 0;
+            }
+
+            if (impl.promote_secondary_timeline) {
+                if (!aux.metadata_ctx().timeline_active(
+                        MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                    cerr << "\nERROR: --promote-secondary-timeline requires "
+                            "an active secondary; none is currently "
+                            "active.\n";
+                    return 1;
+                }
+                aux.promote_secondary_to_primary();
+                aux.metadata_ctx().sync_metadata_to_disk();
+                cout << "\nPromoted secondary timeline to primary.\n";
+                return 0;
+            }
+
+            if (impl.deactivate_secondary_timeline) {
+                if (!aux.metadata_ctx().timeline_active(
+                        MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                    cerr << "\nERROR: --deactivate-secondary-timeline "
+                            "requires an active secondary; none is "
+                            "currently active.\n";
+                    return 1;
+                }
+                aux.deactivate_secondary_timeline();
+                aux.metadata_ctx().sync_metadata_to_disk();
+                cout << "\nDeactivated secondary timeline.\n";
                 return 0;
             }
 

--- a/category/mpt/copy_trie.cpp
+++ b/category/mpt/copy_trie.cpp
@@ -16,6 +16,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/trie.hpp>
@@ -112,11 +113,16 @@ Node::SharedPtr create_node_with_two_children(
 Node::SharedPtr copy_trie_impl(
     UpdateAux &aux, Node::SharedPtr const src_root,
     NibblesView const src_prefix, Node::SharedPtr dest_root,
-    NibblesView const dest_prefix, uint64_t const dest_version)
+    NibblesView const dest_prefix, uint64_t const dest_version,
+    timeline_id const tid)
 {
     MONAD_ASSERT(aux.is_on_disk());
     auto [src_cursor, res] = find_blocking(
-        aux, src_root, src_prefix, aux.metadata_ctx().db_history_max_version());
+        aux,
+        src_root,
+        src_prefix,
+        aux.metadata_ctx().db_history_max_version(tid),
+        tid);
     MONAD_ASSERT(res == find_result::success);
     Node &src_node = *src_cursor.node;
     if (!dest_root) {
@@ -201,8 +207,8 @@ Node::SharedPtr copy_trie_impl(
         if (node->mask & (1u << nibble)) {
             auto const index = node->to_child_index(nibble);
             if (node->next(index) == nullptr) {
-                auto next_node_ondisk =
-                    read_node_blocking(aux, node->fnext(index), dest_version);
+                auto next_node_ondisk = read_node_blocking(
+                    aux, node->fnext(index), dest_version, tid);
                 MONAD_ASSERT(next_node_ondisk != nullptr);
                 node->set_next(index, std::move(next_node_ondisk));
             }
@@ -269,7 +275,7 @@ Node::SharedPtr copy_trie_impl(
 Node::SharedPtr copy_trie_to_dest(
     UpdateAux &aux, Node::SharedPtr src_root, NibblesView const src_prefix,
     Node::SharedPtr dest_root, NibblesView const dest_prefix,
-    uint64_t const dest_version, bool const write_root)
+    uint64_t const dest_version, timeline_id const tid, bool const write_root)
 {
     MONAD_ASSERT(aux.is_on_disk());
     auto const expected_compact_offset =
@@ -281,11 +287,12 @@ Node::SharedPtr copy_trie_to_dest(
         src_prefix,
         std::move(dest_root),
         dest_prefix,
-        dest_version);
+        dest_version,
+        tid);
     if (write_root) {
-        write_new_root_node(aux, *dest_root, dest_version);
+        write_new_root_node(aux, *dest_root, dest_version, tid);
         MONAD_ASSERT(
-            aux.metadata_ctx().db_history_max_version() >= dest_version);
+            aux.metadata_ctx().db_history_max_version(tid) >= dest_version);
     }
     // invariant: copy_trie must preserve compaction offsets
     MONAD_ASSERT(

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -33,6 +33,7 @@
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_error.hpp>
 #include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
@@ -57,6 +58,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <utility>
 #include <variant>
@@ -76,6 +78,7 @@ struct Db::Impl
     virtual ~Impl() = default;
 
     virtual UpdateAux &aux() = 0;
+
     virtual Node::SharedPtr upsert_fiber_blocking(
         Node::SharedPtr, UpdateList &&, uint64_t, bool enable_compaction,
         bool can_write_to_fast, bool write_root) = 0;
@@ -86,12 +89,14 @@ struct Db::Impl
         NodeCursor const &root, NibblesView const &key, uint64_t version) = 0;
     virtual size_t prefetch_fiber_blocking(Node::SharedPtr const &) = 0;
     virtual Node::SharedPtr load_root_for_version(uint64_t version) = 0;
+
     virtual size_t poll(bool blocking, size_t count) = 0;
     virtual bool traverse_fiber_blocking(
         Node::SharedPtr, TraverseMachine &, uint64_t version,
         size_t concurrency_limit) = 0;
     virtual void
     move_trie_version_fiber_blocking(uint64_t src, uint64_t dest) = 0;
+    virtual timeline_id tid() const = 0;
 };
 
 AsyncIOContext::AsyncIOContext(ReadOnlyOnDiskDbConfig const &options)
@@ -164,12 +169,16 @@ AsyncIOContext::AsyncIOContext(OnDiskDbConfig const &options)
 class Db::ROOnDiskBlocking final : public Db::Impl
 {
     UpdateAux aux_;
+    timeline_id const tid_;
 
 public:
-    explicit ROOnDiskBlocking(AsyncIOContext &io_ctx)
+    ROOnDiskBlocking(AsyncIOContext &io_ctx, timeline_id const tid)
         : aux_(io_ctx.io)
+        , tid_{tid}
     {
     }
+
+    virtual ~ROOnDiskBlocking() = default;
 
     virtual UpdateAux &aux() override
     {
@@ -190,12 +199,12 @@ public:
             return {NodeCursor{}, find_result::root_node_is_null_failure};
         }
         // the root we last loaded does not contain the version we want to find
-        if (!aux().metadata_ctx().version_is_valid_ondisk(version)) {
+        if (!aux().metadata_ctx().version_is_valid_ondisk(version, tid_)) {
             return {NodeCursor{}, find_result::version_no_longer_exist};
         }
-        auto const res = find_blocking(aux(), root, key, version);
+        auto const res = find_blocking(aux(), root, key, version, tid_);
         // verify version still valid in history after success
-        return aux().metadata_ctx().version_is_valid_ondisk(version)
+        return aux().metadata_ctx().version_is_valid_ondisk(version, tid_)
                    ? res
                    : find_cursor_result_type{
                          NodeCursor{}, find_result::version_no_longer_exist};
@@ -236,12 +245,17 @@ public:
     load_root_for_version(uint64_t const version) override
     {
         auto const root_offset =
-            aux().metadata_ctx().get_root_offset_at_version(version);
+            aux().metadata_ctx().get_root_offset_at_version(version, tid_);
         if (root_offset == INVALID_OFFSET) {
             return nullptr;
         }
 
-        return read_node_blocking(aux(), root_offset, version);
+        return read_node_blocking(aux(), root_offset, version, tid_);
+    }
+
+    virtual timeline_id tid() const override
+    {
+        return tid_;
     }
 };
 
@@ -252,8 +266,7 @@ class Db::InMemory final : public Db::Impl
 
 public:
     explicit InMemory(StateMachine &machine)
-        : aux_{}
-        , machine_{machine}
+        : machine_{machine}
     {
     }
 
@@ -267,7 +280,14 @@ public:
         bool, bool) override
     {
         return aux_.do_update(
-            std::move(root), machine_, std::move(list), version, false);
+            std::move(root),
+            machine_,
+            std::move(list),
+            version,
+            /*compaction=*/false,
+            /*can_write_to_fast=*/true,
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     virtual Node::SharedPtr copy_trie_fiber_blocking(
@@ -281,7 +301,7 @@ public:
         NodeCursor const &root, NibblesView const &key,
         uint64_t const version) override
     {
-        return find_blocking(aux(), root, key, version);
+        return find_blocking(aux(), root, key, version, timeline_id::primary);
     }
 
     virtual size_t prefetch_fiber_blocking(Node::SharedPtr const &) override
@@ -310,6 +330,11 @@ public:
     {
         return nullptr;
     }
+
+    virtual timeline_id tid() const override
+    {
+        return timeline_id::primary;
+    }
 };
 
 class OnDiskDbServiceThread
@@ -325,6 +350,7 @@ public:
         bool enable_compaction;
         bool can_write_to_fast;
         bool write_root;
+        timeline_id tid;
     };
 
     struct FiberCopyTrieRequest
@@ -335,6 +361,7 @@ public:
         Node::SharedPtr dest_root;
         NibblesView dest;
         uint64_t dest_version;
+        timeline_id tid;
         bool write_root;
     };
 
@@ -365,6 +392,7 @@ public:
     {
         ::boost::fibers::promise<Node::SharedPtr> promise;
         uint64_t version;
+        timeline_id tid;
     };
 
     struct RODbFiberFindOwningNodeRequest
@@ -518,7 +546,8 @@ private:
                             req->version,
                             req->enable_compaction,
                             req->can_write_to_fast,
-                            req->write_root));
+                            req->write_root,
+                            req->tid));
                     }
                     else if (auto *req = std::get_if<3>(&request);
                              req != nullptr) {
@@ -550,10 +579,14 @@ private:
                              req != nullptr) {
                         auto const root_offset =
                             aux.metadata_ctx().get_root_offset_at_version(
-                                req->version);
-                        MONAD_ASSERT(root_offset != INVALID_OFFSET);
-                        req->promise.set_value(
-                            read_node_blocking(aux, root_offset, req->version));
+                                req->version, req->tid);
+                        if (root_offset == INVALID_OFFSET) {
+                            req->promise.set_value(nullptr);
+                        }
+                        else {
+                            req->promise.set_value(read_node_blocking(
+                                aux, root_offset, req->version, req->tid));
+                        }
                     }
                     else if (auto *req = std::get_if<7>(&request);
                              req != nullptr) {
@@ -564,6 +597,7 @@ private:
                             std::move(req->dest_root),
                             req->dest,
                             req->dest_version,
+                            req->tid,
                             req->write_root);
                         req->promise.set_value(std::move(root));
                     }
@@ -675,21 +709,49 @@ public:
 class Db::RWOnDisk final : public Impl
 {
     std::shared_ptr<OnDiskDbServiceThread> worker_thread_;
-    StateMachine &machine_;
+    // Pointer (not reference) so promote_secondary_to_primary can null it:
+    // the promoted trie was written with the sibling's machine, so any upsert
+    // on this Db before close+reopen would corrupt hashes.
+    StateMachine *machine_;
+    timeline_id const tid_;
     bool const compaction_;
 
+    // A write_root=false upsert leaves V unflushed on this RWOnDisk's
+    // timeline. Per-RWOnDisk because tid_ is fixed at construction.
     uint64_t unflushed_version_{INVALID_BLOCK_NUM};
 
 public:
     RWOnDisk(
         std::shared_ptr<OnDiskDbServiceThread> worker_thread,
-        StateMachine &machine, bool compaction)
+        StateMachine &machine, timeline_id const tid, bool const compaction)
         : worker_thread_(std::move(worker_thread))
-        , machine_{machine}
-        , compaction_(compaction)
-        , unflushed_version_{INVALID_BLOCK_NUM}
+        , machine_{&machine}
+        , tid_{tid}
+        , compaction_{compaction}
     {
         MONAD_ASSERT(worker_thread_ != nullptr);
+    }
+
+    void clear_machine() noexcept
+    {
+        machine_ = nullptr;
+    }
+
+    // Returns a fresh RWOnDisk wired to the same worker thread (and thus the
+    // same UpdateAux, AsyncIO, and storage pool) but bound to a different
+    // machine + timeline. Used to mint a secondary Db that shares the
+    // primary's underlying service thread.
+    std::unique_ptr<RWOnDisk>
+    spawn_sibling(StateMachine &machine, timeline_id const tid) const
+    {
+        MONAD_ASSERT(machine_ != nullptr);
+        return std::make_unique<RWOnDisk>(
+            worker_thread_, machine, tid, compaction_);
+    }
+
+    long worker_thread_use_count() const noexcept
+    {
+        return worker_thread_.use_count();
     }
 
     virtual UpdateAux &aux() override
@@ -702,11 +764,11 @@ public:
         NodeCursor const &start, NibblesView const &key,
         uint64_t const version) override
     {
-        // It's sufficient to validate the version once before starting the
-        // lookup, because RWDb never performs upserts concurrently with reads.
-        // Skip version check if looking up from an unflushed version
+        // Validating once suffices — RWDb does not interleave upserts and
+        // reads. An unflushed-version hit on this timeline bypasses the
+        // ondisk check since the version is in-memory only.
         if (unflushed_version_ != version &&
-            !aux().metadata_ctx().version_is_valid_ondisk(version)) {
+            !aux().metadata_ctx().version_is_valid_ondisk(version, tid_)) {
             return {NodeCursor{}, find_result::version_no_longer_exist};
         }
         ::boost::fibers::promise<find_cursor_result_type> promise;
@@ -722,6 +784,7 @@ public:
         bool const enable_compaction, bool const can_write_to_fast,
         bool const write_root) override
     {
+        MONAD_ASSERT(machine_ != nullptr);
         if (unflushed_version_ != INVALID_BLOCK_NUM &&
             unflushed_version_ != version) {
             LOG_WARNING_CFORMAT(
@@ -737,12 +800,13 @@ public:
         worker_thread_->submit(OnDiskDbServiceThread::FiberUpsertRequest{
             .promise = std::move(promise),
             .prev_root = std::move(root),
-            .sm = machine_,
+            .sm = *machine_,
             .updates = std::move(updates),
             .version = version,
             .enable_compaction = enable_compaction && compaction_,
             .can_write_to_fast = can_write_to_fast,
-            .write_root = write_root});
+            .write_root = write_root,
+            .tid = tid_});
         return fut.get();
     }
 
@@ -759,13 +823,14 @@ public:
     // threadsafe
     virtual size_t prefetch_fiber_blocking(Node::SharedPtr const &root) override
     {
+        MONAD_ASSERT(machine_ != nullptr);
         ::boost::fibers::promise<size_t> promise;
         auto fut = promise.get_future();
         worker_thread_->submit(
             OnDiskDbServiceThread::FiberLoadAllFromBlockRequest{
                 .promise = std::move(promise),
                 .root = NodeCursor{root},
-                .sm = machine_});
+                .sm = *machine_});
         return fut.get();
     }
 
@@ -793,14 +858,20 @@ public:
     virtual Node::SharedPtr
     load_root_for_version(uint64_t const version) override
     {
-        if (!aux().metadata_ctx().version_is_valid_ondisk(version)) {
+        if (!aux().metadata_ctx().timeline_active(tid_)) {
+            return nullptr;
+        }
+        if (tid_ == timeline_id::primary &&
+            !aux().metadata_ctx().version_is_valid_ondisk(version)) {
             return nullptr;
         }
         ::boost::fibers::promise<Node::SharedPtr> promise;
         auto fut = promise.get_future();
         worker_thread_->submit(
             OnDiskDbServiceThread::FiberLoadRootVersionRequest{
-                .promise = std::move(promise), .version = version});
+                .promise = std::move(promise),
+                .version = version,
+                .tid = tid_});
         return fut.get();
     }
 
@@ -829,8 +900,14 @@ public:
             .dest_root = std::move(dest_root),
             .dest = dest_prefix,
             .dest_version = dest_version,
+            .tid = tid_,
             .write_root = write_root});
         return fut.get();
+    }
+
+    virtual timeline_id tid() const override
+    {
+        return tid_;
     }
 };
 
@@ -980,16 +1057,24 @@ Db::Db(StateMachine &machine)
 Db::Db(StateMachine &machine, OnDiskDbConfig const &config)
     : impl_{std::make_unique<RWOnDisk>(
           std::make_shared<OnDiskDbServiceThread>(config), machine,
-          config.compaction)}
+          timeline_id::primary, config.compaction)}
 {
     MONAD_ASSERT(impl_->aux().is_on_disk());
 }
 
 Db::Db(AsyncIOContext &io_ctx)
-    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx)}
+    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, timeline_id::primary)}
 {
 }
 
+Db::Db(std::unique_ptr<Impl> impl)
+    : impl_{std::move(impl)}
+{
+    MONAD_ASSERT(impl_);
+}
+
+Db::Db(Db &&) noexcept = default;
+Db &Db::operator=(Db &&) noexcept = default;
 Db::~Db() = default;
 
 Result<NodeCursor> Db::find(
@@ -1092,7 +1177,8 @@ void Db::update_verified_version(uint64_t const version)
     MONAD_ASSERT(!is_read_only());
     if (is_on_disk()) {
         MONAD_ASSERT(
-            version <= impl_->aux().metadata_ctx().db_history_max_version());
+            version <=
+            impl_->aux().metadata_ctx().db_history_max_version(tid()));
         impl_->aux().metadata_ctx().set_latest_verified_version(version);
     } // noop for in memory db
 }
@@ -1161,14 +1247,14 @@ uint64_t Db::get_latest_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().metadata_ctx().db_history_max_version();
+    return impl_->aux().metadata_ctx().db_history_max_version(tid());
 }
 
 uint64_t Db::get_earliest_version() const
 {
     MONAD_ASSERT(impl_);
     MONAD_ASSERT(is_on_disk());
-    return impl_->aux().metadata_ctx().db_history_min_valid_version();
+    return impl_->aux().metadata_ctx().db_history_min_valid_version(tid());
 }
 
 size_t Db::prefetch(Node::SharedPtr const &root)
@@ -1203,6 +1289,58 @@ UpdateAux const &Db::aux() const
 {
     MONAD_ASSERT(impl_);
     return impl_->aux();
+}
+
+Db Db::activate_secondary_timeline(StateMachine &secondary_machine)
+{
+    MONAD_ASSERT(impl_);
+    auto *const rw = static_cast<RWOnDisk *>(impl_.get());
+    MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    rw->aux().activate_secondary_timeline();
+    return Db{rw->spawn_sibling(secondary_machine, timeline_id::secondary)};
+}
+
+std::optional<Db> Db::open_secondary_timeline(StateMachine &secondary_machine)
+{
+    MONAD_ASSERT(impl_);
+    auto *const rw = static_cast<RWOnDisk *>(impl_.get());
+    MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    if (!rw->aux().metadata_ctx().timeline_active(timeline_id::secondary)) {
+        return std::nullopt;
+    }
+    return Db{rw->spawn_sibling(secondary_machine, timeline_id::secondary)};
+}
+
+void Db::promote_secondary_to_primary()
+{
+    MONAD_ASSERT(impl_);
+    auto *const rw = static_cast<RWOnDisk *>(impl_.get());
+    MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    rw->aux().promote_secondary_to_primary();
+    // The promoted trie was written with the secondary's machine; clear
+    // this Db's binding so any stray upsert before the expected
+    // close+reopen traps instead of silently corrupting hashes.
+    rw->clear_machine();
+}
+
+void Db::deactivate_secondary_timeline()
+{
+    MONAD_ASSERT(impl_);
+    auto *const rw = static_cast<RWOnDisk *>(impl_.get());
+    MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    rw->aux().deactivate_secondary_timeline();
+}
+
+bool Db::timeline_active(timeline_id const tid) const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux().metadata_ctx().timeline_active(tid);
+}
+
+timeline_id Db::tid() const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->tid();
 }
 
 uint64_t Db::get_history_length() const

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -33,6 +33,7 @@
 #include <category/mpt/update.hpp>
 
 #include <memory>
+#include <optional>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
@@ -84,7 +85,10 @@ public:
         size_t concurrency_limit = 4096);
 };
 
-// RW, ROBlocking, InMemory
+// A Db is bound to one timeline. The constructors below produce a primary
+// Db; a secondary Db is obtained from activate_secondary_timeline /
+// open_secondary_timeline. Both instances share the underlying UpdateAux
+// and worker thread via the on-disk service thread held inside the Impl.
 class Db
 {
 private:
@@ -97,20 +101,22 @@ private:
 
     std::unique_ptr<Impl> impl_;
 
+    explicit Db(std::unique_ptr<Impl> impl);
+
 public:
-    explicit Db(StateMachine &); // In-memory mode
-    Db(StateMachine &, OnDiskDbConfig const &);
-    explicit Db(AsyncIOContext &);
+    explicit Db(StateMachine &); // in-memory
+    Db(StateMachine &, OnDiskDbConfig const &); // on-disk RW
+    explicit Db(AsyncIOContext &); // on-disk RO blocking
 
     Db(Db const &) = delete;
-    Db(Db &&) = delete;
+    Db(Db &&) noexcept;
     Db &operator=(Db const &) = delete;
-    Db &operator=(Db &&) = delete;
+    Db &operator=(Db &&) noexcept;
     ~Db();
 
-    // The `block_id` parameter specify the version to read from, and is also
-    // used for version control validation. These calls may wait on a fiber
-    // future.
+    // `block_id` is both the version to read and the validity check.
+    // These calls may block on a fiber future and read from this Db's
+    // bound timeline.
     Result<NodeCursor>
     find(NodeCursor const &, NibblesView, uint64_t block_id) const;
     Result<NodeCursor> find(NibblesView prefix, uint64_t block_id) const;
@@ -166,6 +172,40 @@ public:
 
     bool is_on_disk() const;
     bool is_read_only() const;
+
+    // Timeline lifecycle (callable on the primary Db only).
+    //
+    // All three require the secondary Db (if one was issued) to be
+    // destroyed first; that invariant is asserted via the worker
+    // thread's shared_ptr refcount.
+
+    // Activate the secondary ring and return a Db bound to it. The
+    // secondary timeline starts empty; its compaction state and version
+    // bounds are seeded by the first secondary upsert.
+    [[nodiscard]] Db
+    activate_secondary_timeline(StateMachine &secondary_machine);
+
+    // Attach to a secondary ring that was activated in a prior process
+    // and persisted on disk. Returns nullopt if no secondary is active.
+    [[nodiscard]] std::optional<Db>
+    open_secondary_timeline(StateMachine &secondary_machine);
+
+    // Swap primary and secondary slots. Clears the primary Db's
+    // StateMachine binding so a missed close+reopen (the expected next
+    // step) traps on the next upsert instead of silently using the old
+    // machine on the promoted trie.
+    void promote_secondary_to_primary();
+
+    void deactivate_secondary_timeline();
+
+    bool timeline_active(timeline_id tid) const;
+
+    // Returns the timeline this Db instance is bound to. Primary Dbs
+    // constructed via the public ctors return timeline_id::primary;
+    // Dbs returned from activate_secondary_timeline /
+    // open_secondary_timeline return timeline_id::secondary. In-memory
+    // Dbs are always primary.
+    timeline_id tid() const;
 
 private:
     friend struct test::DbAccessor;

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -176,6 +176,14 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
     };
     if (is_previous_magic(copies_[0].main) ||
         is_previous_magic(copies_[1].main)) {
+        if (!io_->storage_pool().is_migration_allowed()) {
+            MONAD_ABORT_PRINTF(
+                "DB is on older format (magic=%s) and this binary expects "
+                "%s. Run 'monad-mpt --upgrade --storage <path>' before "
+                "starting monad services.",
+                detail::db_metadata::PREVIOUS_MAGIC,
+                detail::db_metadata::MAGIC);
+        }
         if (!can_write_to_map_) {
             MONAD_ABORT_PRINTF(
                 "Detected pre-dual-timeline DB (magic=%s), which requires "
@@ -937,6 +945,11 @@ void DbMetadataContext::replay_pending_shrink_grow_()
     sync_ring_data_to_disk_();
     sync_metadata_to_disk_();
     clear_pending_shrink_grow_();
+    sync_metadata_to_disk_();
+}
+
+void DbMetadataContext::sync_metadata_to_disk()
+{
     sync_metadata_to_disk_();
 }
 

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -24,11 +24,13 @@
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
 
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -49,13 +51,31 @@ using namespace MONAD_ASYNC_NAMESPACE;
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
+// Under MONAD007 (main pre-dual-timeline), sizeof(db_metadata) was 528512
+// bytes because root_offsets_ring_t::SIZE_ was 65536. MONAD008 dropped it
+// to 32, shrinking the fixed header to 4480 bytes. The flexible
+// chunk_info[] array therefore moved from on-disk offset 528512 to offset
+// 4480. A MONAD008 binary opening a MONAD007 pool must relocate
+// chunk_info[] and the db_offsets/consensus block before the rest of the
+// ctor (and downstream code) reads them at the new offsets. See
+// migrate_monad007_to_monad008_.
+static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+// OLD offsets of fields that moved between MONAD007 and MONAD008.
+// db_offsets sat immediately after root_offsets_ring_t (SIZE_=65536), at
+// 24 + sizeof(old root_offsets_ring_t) = 24 + 524304 = 524328. The
+// db_offsets..latest_proposed_block_id block is 16 + 48 + 64 = 128 bytes
+// long. free/fast/slow list triple sits in the last 24 bytes of the old
+// header (528488..528512). chunk_info[] starts at 528512.
+static constexpr size_t MONAD007_DB_OFFSETS_OFFSET = 524328;
+static constexpr size_t MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES = 128;
+static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
+static constexpr size_t DB_METADATA_LIST_TRIPLE_BYTES = 24;
+
 DbMetadataContext::DbMetadataContext(AsyncIO &io)
     : io_(&io)
 {
     auto const chunk_count = io_->chunk_count();
     MONAD_ASSERT(chunk_count >= 3);
-    db_map_size_ = sizeof(detail::db_metadata) +
-                   chunk_count * sizeof(detail::db_metadata::chunk_info_t);
     auto &cnv_chunk = io_->storage_pool().chunk(storage_pool::cnv, 0);
     auto const fdr = cnv_chunk.read_fd();
     auto const fdw = cnv_chunk.write_fd(0);
@@ -68,13 +88,34 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
     mapflags_ = io_->storage_pool().is_read_only_allow_dirty() ? MAP_PRIVATE
                                                                : MAP_SHARED;
 
+    // Each copy gets its own half of cnv chunk 0. metadata does not span
+    // across cnv chunks, so mapping the full half-chunk always fits any
+    // layout — MONAD007's 528 KiB header and MONAD008's 4.4 KiB header
+    // both sit inside it. Keeping the mapping sized to the half-chunk
+    // avoids a pre-mmap magic peek for migration sizing and also gives
+    // any future layout change room to grow without adjusting this code.
+    metadata_mmap_size_ = cnv_chunk.capacity() / 2;
+    db_map_size_ = sizeof(detail::db_metadata) +
+                   chunk_count * sizeof(detail::db_metadata::chunk_info_t);
+    MONAD_ASSERT(
+        metadata_mmap_size_ >=
+            MONAD007_DB_METADATA_SIZE +
+                chunk_count * sizeof(detail::db_metadata::chunk_info_t),
+        "cnv chunk 0 is too small to hold a MONAD007 metadata header plus "
+        "chunk_info[]; pool configuration is incompatible with this build");
+
     // mmap both metadata copies
     copies_[0].main = start_lifetime_as<detail::db_metadata>(::mmap(
-        nullptr, db_map_size_, prot_, mapflags_, fd.first, off_t(fdr.second)));
+        nullptr,
+        metadata_mmap_size_,
+        prot_,
+        mapflags_,
+        fd.first,
+        off_t(fdr.second)));
     MONAD_ASSERT(copies_[0].main != MAP_FAILED);
     copies_[1].main = start_lifetime_as<detail::db_metadata>(::mmap(
         nullptr,
-        db_map_size_,
+        metadata_mmap_size_,
         prot_,
         mapflags_,
         fd.first,
@@ -104,7 +145,145 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
         }
     }
 
-    // Version mismatch detection
+    // Migration: MONAD007 -> MONAD008. MONAD008 shrank
+    // root_offsets_ring_t::SIZE_ from 65536 to 32, taking sizeof(db_metadata)
+    // from 528512 bytes to 4480. Fields that were adjacent to root_offsets
+    // or at the end of the fixed header therefore moved:
+    //
+    //   chunk_info[]              528512 -> 4480
+    //   free/fast/slow_list triple 528488 -> 4456  (last 24B of header)
+    //   db_offsets..latest_proposed_block_id (128B)  524328 -> 296
+    //
+    // The root_offsets header and its cnv_chunks[0..30] survive in place
+    // (same byte offsets in both layouts; SIZE_ shrink only drops
+    // cnv_chunks[31..65534], which real pools never populated). The
+    // block now occupied by secondary_timeline + identity bytes +
+    // shrink_grow_seq_ + pending_shrink_grow + new future_variables_unused
+    // (offsets 424..4456) was MONAD007's cnv_chunks[~47..~556] and must
+    // be zeroed so new fields start at their idle defaults.
+    //
+    // Crash-safety: each copy is migrated under hold_dirty, so a crash
+    // mid-migration leaves is_dirty=1 on that copy. On reopen, the
+    // magic-validation step above heals from whichever copy already
+    // advanced to MONAD008, and any remaining MONAD007 copies run
+    // through the loop below again. The individual memmove/memcpy/memset
+    // operations never destroy their sources, so a replay is idempotent.
+    auto const is_previous_magic = [](detail::db_metadata const *m) {
+        return 0 == memcmp(
+                        m->magic,
+                        detail::db_metadata::PREVIOUS_MAGIC,
+                        detail::db_metadata::MAGIC_STRING_LEN);
+    };
+    if (is_previous_magic(copies_[0].main) ||
+        is_previous_magic(copies_[1].main)) {
+        if (!can_write_to_map_) {
+            MONAD_ABORT_PRINTF(
+                "Detected pre-dual-timeline DB (magic=%s), which requires "
+                "writable mapping to migrate to %s. Open with write access.",
+                detail::db_metadata::PREVIOUS_MAGIC,
+                detail::db_metadata::MAGIC);
+        }
+        for (auto const &copy : copies_) {
+            auto *const m = copy.main;
+            if (!is_previous_magic(m)) {
+                continue;
+            }
+            auto const g = m->hold_dirty();
+            auto *const m_bytes = reinterpret_cast<std::byte *>(m);
+
+            // A MONAD007 cnv_chunks_len > 31 would require entries that no
+            // longer fit under SIZE_=32. Production pools use single-digit
+            // chunk counts, so this should never fire; still assert so a
+            // truly pathological migration doesn't silently truncate.
+            MONAD_ASSERT(
+                m->root_offsets.storage_.cnv_chunks_len <
+                    detail::db_metadata::root_offsets_ring_t::SIZE_,
+                "MONAD007 pool has more primary cnv chunks than MONAD008's "
+                "SIZE_ cap allows — cannot migrate");
+
+            // 1. Relocate chunk_info[]. Source and destination are disjoint
+            //    for any reasonable chunk_count (< (528512-4480)/8 = 65504
+            //    entries), but use memmove to be safe against pathologies.
+            (void)memmove(
+                m_bytes + sizeof(detail::db_metadata),
+                m_bytes + MONAD007_DB_METADATA_SIZE,
+                size_t(chunk_count) *
+                    sizeof(detail::db_metadata::chunk_info_t));
+
+            // 2. Relocate the free/fast/slow list triple from the end of
+            //    the MONAD007 fixed header to the end of the MONAD008
+            //    fixed header.
+            (void)memcpy(
+                m_bytes + offsetof(detail::db_metadata, free_list),
+                m_bytes + MONAD007_LIST_TRIPLE_OFFSET,
+                DB_METADATA_LIST_TRIPLE_BYTES);
+
+            // 3. Relocate the db_offsets..latest_proposed_block_id block.
+            //    MONAD007 had a single global auto_expire_version sandwiched
+            //    between latest_proposed_version and latest_voted_block_id;
+            //    MONAD008 promotes it to a per-timeline field at the end of
+            //    each ring header. Save the old value first, then split the
+            //    relocation into the two halves either side of the gap so
+            //    the destination layout (which has no gap) lines up.
+            static_assert(offsetof(detail::db_metadata, db_offsets) == 304);
+            static_assert(
+                offsetof(detail::db_metadata, secondary_timeline) == 424);
+            constexpr size_t MONAD007_AUTO_EXPIRE_OFFSET =
+                MONAD007_DB_OFFSETS_OFFSET + 16 + 5 * 8; // 524384
+            constexpr size_t MONAD007_PRE_AUTO_EXPIRE_BYTES =
+                MONAD007_AUTO_EXPIRE_OFFSET - MONAD007_DB_OFFSETS_OFFSET; // 56
+            constexpr size_t MONAD007_POST_AUTO_EXPIRE_BYTES =
+                MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES -
+                MONAD007_PRE_AUTO_EXPIRE_BYTES - 8; // 64
+            int64_t saved_auto_expire = 0;
+            (void)memcpy(
+                &saved_auto_expire,
+                m_bytes + MONAD007_AUTO_EXPIRE_OFFSET,
+                sizeof(saved_auto_expire));
+            (void)memcpy(
+                m_bytes + offsetof(detail::db_metadata, db_offsets),
+                m_bytes + MONAD007_DB_OFFSETS_OFFSET,
+                MONAD007_PRE_AUTO_EXPIRE_BYTES);
+            (void)memcpy(
+                m_bytes + offsetof(detail::db_metadata, latest_voted_block_id),
+                m_bytes + MONAD007_AUTO_EXPIRE_OFFSET + 8,
+                MONAD007_POST_AUTO_EXPIRE_BYTES);
+            // Seed root_offsets.auto_expire_version_ with the saved global
+            // value (no secondary timeline existed pre-MONAD008, so all
+            // upserts had been on what is now the primary).
+            m->root_offsets.auto_expire_version_ = saved_auto_expire;
+
+            // 4. Zero the new-in-MONAD008 region (secondary_timeline +
+            //    identity bytes + shrink_grow_seq_ + pending_shrink_grow
+            //    + future_variables_unused). Leaves the live block list
+            //    immediately after (relocated in step 2) untouched.
+            auto *const new_fields_begin =
+                m_bytes + offsetof(detail::db_metadata, secondary_timeline);
+            auto *const new_fields_end =
+                m_bytes + offsetof(detail::db_metadata, free_list);
+            memset(
+                new_fields_begin, 0, size_t(new_fields_end - new_fields_begin));
+
+            // 5. Bump magic. The signal_fence orders the earlier non-atomic
+            //    writes before the magic bump under single-threaded ctor
+            //    semantics; durability is enforced by the follow-up msync
+            //    outside the loop.
+            std::atomic_signal_fence(std::memory_order_seq_cst);
+            memcpy(
+                m->magic,
+                detail::db_metadata::MAGIC,
+                detail::db_metadata::MAGIC_STRING_LEN);
+        }
+        // Force the relocated layout + new magic to durable storage
+        // before any downstream ctor code reads through the new offsets.
+        sync_metadata_to_disk_();
+        LOG_INFO(
+            "Migrated DB metadata from {} to {}.",
+            detail::db_metadata::PREVIOUS_MAGIC,
+            detail::db_metadata::MAGIC);
+    }
+
+    // Version mismatch detection (for any other version that we don't migrate)
     constexpr unsigned magic_version_len = 3;
     constexpr unsigned magic_prefix_len =
         detail::db_metadata::MAGIC_STRING_LEN - magic_version_len;
@@ -186,123 +365,98 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
         MONAD_ASSERT((chunk_count & ~0xfffffU) == 0);
         copies_[0].main->chunk_info_count = chunk_count & 0xfffffU;
 
-        // Init root_offsets storage cnv chunks
-        MONAD_ASSERT(io_->storage_pool().chunks(storage_pool::cnv) > 1);
-        auto &storage = copies_[0].main->root_offsets.storage_;
-        memset(&storage, 0xff, sizeof(storage));
-        storage.cnv_chunks_len = 0;
-        auto &chunk = io_->storage_pool().chunk(storage_pool::cnv, 1);
-        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, chunk.capacity());
+        // All cnv ring chunks go to ring_a (the primary). Ring_b starts
+        // empty and gets its chunks on activate_secondary_header via an
+        // atomic shrink of ring_a (chunks returned on deactivate). Ring
+        // count must be a power of 2 — the version-index mask relies on it.
+        uint32_t const cnv_chunks_total = static_cast<uint32_t>(
+            io_->storage_pool().devices()[0].cnv_chunks());
+        MONAD_ASSERT(cnv_chunks_total > UpdateAux::cnv_chunks_for_db_metadata);
+        uint32_t const ring_total =
+            cnv_chunks_total - UpdateAux::cnv_chunks_for_db_metadata;
+        MONAD_ASSERT(
+            ring_total > 0 && (ring_total & (ring_total - 1)) == 0,
+            "Number of cnv chunks for root offsets must be a power of two");
+
+        auto &a_storage = copies_[0].main->root_offsets.storage_;
+        auto &b_storage = copies_[0].main->secondary_timeline.storage_;
+        memset(&a_storage, 0xff, sizeof(a_storage));
+        memset(&b_storage, 0xff, sizeof(b_storage));
+        a_storage.cnv_chunks_len = 0;
+        b_storage.cnv_chunks_len = 0;
+
+        auto const &first_chunk =
+            io_->storage_pool().chunk(storage_pool::cnv, 1);
+        auto *tofill = aligned_alloc(DISK_PAGE_SIZE, first_chunk.capacity());
         MONAD_ASSERT(tofill != nullptr);
         auto const untofill =
             monad::make_scope_exit([&]() noexcept { ::free(tofill); });
-        memset(tofill, 0xff, chunk.capacity());
-        {
-            auto const fdw = chunk.write_fd(chunk.capacity());
-            MONAD_ASSERT(
-                -1 !=
-                ::pwrite(
-                    fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-        }
-        storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = 1;
-        copies_[0].main->history_length =
-            chunk.capacity() / 2 / sizeof(chunk_offset_t);
-        // Allocate cnv chunks of the first device - 1 for root offsets,
-        // since chunk 0 is used for db_metadata
-        auto const root_offsets_chunk_count =
-            io_->storage_pool().devices()[0].cnv_chunks() -
-            UpdateAux::cnv_chunks_for_db_metadata;
-        MONAD_ASSERT(
-            root_offsets_chunk_count > 0 &&
-                (root_offsets_chunk_count & (root_offsets_chunk_count - 1)) ==
-                    0,
-            "Number of cnv chunks for root offsets must be a power of two");
-        for (uint32_t n = 2; n <= root_offsets_chunk_count; n++) {
+        memset(tofill, 0xff, first_chunk.capacity());
+
+        for (uint32_t n = 1; n <= ring_total; n++) {
             auto &chunk = io_->storage_pool().chunk(storage_pool::cnv, n);
             auto const fdw = chunk.write_fd(chunk.capacity());
             MONAD_ASSERT(
                 -1 !=
                 ::pwrite(
                     fdw.first, tofill, chunk.capacity(), (off_t)fdw.second));
-            storage.cnv_chunks[storage.cnv_chunks_len++].cnv_chunk_id = n;
-            copies_[0].main->history_length +=
-                chunk.capacity() / 2 / sizeof(chunk_offset_t);
+            a_storage.cnv_chunks[a_storage.cnv_chunks_len++].cnv_chunk_id = n;
         }
+
+        copies_[0].main->history_length =
+            static_cast<uint64_t>(ring_total) *
+            (first_chunk.capacity() / 2 / sizeof(chunk_offset_t));
 
         is_new_pool_ = true;
     }
     else {
-        // Existing pool: map root offsets immediately
-        map_root_offsets();
+        // Existing pool: map both physical rings immediately
+        map_ring_a_storage();
+        map_ring_b_storage();
+        // If a shrink/grow was in flight when the process exited, finish
+        // it before readers see the DB. The intent log (pending_shrink_grow)
+        // was stamped and msync'd before any ring data was touched, so
+        // its presence means the op may have written ring slots but its
+        // commit is not guaranteed durable; replay re-runs the idempotent
+        // body and commits.
+        replay_pending_shrink_grow_();
     }
 }
 #if defined(__GNUC__) && !defined(__clang__)
     #pragma GCC diagnostic pop
 #endif
 
-void DbMetadataContext::map_root_offsets()
+void DbMetadataContext::map_ring_a_storage()
 {
-    auto const &cnv_chunk = io_->storage_pool().chunk(storage_pool::cnv, 0);
-    size_t const map_bytes_per_chunk = cnv_chunk.capacity() / 2;
-    size_t const db_version_history_storage_bytes =
-        copies_[0].main->root_offsets.storage_.cnv_chunks_len *
-        map_bytes_per_chunk;
-    std::byte *reservation[2];
-    reservation[0] = (std::byte *)::mmap(
-        nullptr,
-        db_version_history_storage_bytes,
-        PROT_NONE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
-        -1,
-        0);
-    MONAD_ASSERT(reservation[0] != MAP_FAILED);
-    reservation[1] = (std::byte *)::mmap(
-        nullptr,
-        db_version_history_storage_bytes,
-        PROT_NONE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
-        -1,
-        0);
-    MONAD_ASSERT(reservation[1] != MAP_FAILED);
-
-    for (size_t n = 0;
-         n < copies_[0].main->root_offsets.storage_.cnv_chunks_len;
-         n++) {
-        auto &chunk = io_->storage_pool().chunk(
-            storage_pool::cnv,
-            copies_[0].main->root_offsets.storage_.cnv_chunks[n].cnv_chunk_id);
-        auto const fdr = chunk.read_fd();
-        auto const fdw = chunk.write_fd(0);
-        auto const &fd = can_write_to_map_ ? fdw : fdr;
-        MONAD_ASSERT(
-            MAP_FAILED != ::mmap(
-                              reservation[0] + n * map_bytes_per_chunk,
-                              map_bytes_per_chunk,
-                              prot_,
-                              mapflags_ | MAP_FIXED,
-                              fd.first,
-                              off_t(fdr.second)));
-        MONAD_ASSERT(
-            MAP_FAILED != ::mmap(
-                              reservation[1] + n * map_bytes_per_chunk,
-                              map_bytes_per_chunk,
-                              prot_,
-                              mapflags_ | MAP_FIXED,
-                              fd.first,
-                              off_t(fdr.second + map_bytes_per_chunk)));
-    }
-    copies_[0].root_offsets = {
-        start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[0]),
-        db_version_history_storage_bytes / sizeof(chunk_offset_t)};
-    copies_[1].root_offsets = {
-        start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[1]),
-        db_version_history_storage_bytes / sizeof(chunk_offset_t)};
-
+    map_ring_storage_(
+        copies_[0].main->root_offsets.storage_, &metadata_copy::ring_a_span);
     LOG_INFO(
-        "Database root offsets ring buffer is configured with {} "
-        "chunks, can hold up to {} historical entries.",
+        "Database ring_a is configured with {} chunks (of {} max)",
         copies_[0].main->root_offsets.storage_.cnv_chunks_len,
-        copies_[0].root_offsets.size());
+        ring_max_chunks_());
+}
+
+void DbMetadataContext::map_ring_b_storage()
+{
+    map_ring_storage_(
+        copies_[0].main->secondary_timeline.storage_,
+        &metadata_copy::ring_b_span);
+    LOG_INFO(
+        "Database ring_b is configured with {} chunks (of {} max)",
+        copies_[0].main->secondary_timeline.storage_.cnv_chunks_len,
+        ring_max_chunks_());
+}
+
+uint32_t DbMetadataContext::ring_max_chunks_() const noexcept
+{
+    return static_cast<uint32_t>(
+               io_->storage_pool().devices()[0].cnv_chunks()) -
+           1 /* chunk 0 holds db_metadata */;
+}
+
+size_t DbMetadataContext::map_bytes_per_chunk_() const noexcept
+{
+    return io_->storage_pool().chunk(storage_pool::cnv, 0).capacity() / 2;
 }
 
 // Version metadata getters
@@ -345,11 +499,18 @@ bytes32_t DbMetadataContext::get_latest_proposed_block_id() const noexcept
     return copies_[0].main->latest_proposed_block_id;
 }
 
-int64_t DbMetadataContext::get_auto_expire_version_metadata() const noexcept
+int64_t DbMetadataContext::get_auto_expire_version_metadata(
+    timeline_id const tid) const noexcept
 {
-    return start_lifetime_as<std::atomic_int64_t const>(
-               &copies_[0].main->auto_expire_version)
-        ->load(std::memory_order_acquire);
+    auto const *const m = copies_[0].main;
+    uint8_t const ring_idx = (tid == timeline_id::primary)
+                                 ? primary_ring_idx()
+                                 : (primary_ring_idx() ^ 1u);
+    auto const *const slot = (ring_idx == 0)
+                                 ? &m->root_offsets.auto_expire_version_
+                                 : &m->secondary_timeline.auto_expire_version_;
+    return start_lifetime_as<std::atomic_int64_t const>(slot)->load(
+        std::memory_order_acquire);
 }
 
 // Version metadata setters
@@ -403,12 +564,18 @@ void DbMetadataContext::set_latest_proposed(
 }
 
 void DbMetadataContext::set_auto_expire_version_metadata(
-    int64_t const version) noexcept
+    timeline_id const tid, int64_t const version) noexcept
 {
+    uint8_t const ring_idx = (tid == timeline_id::primary)
+                                 ? primary_ring_idx()
+                                 : (primary_ring_idx() ^ 1u);
     auto do_ = [&](detail::db_metadata *m) {
         auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_int64_t *>(&m->auto_expire_version)
-            ->store(version, std::memory_order_release);
+        auto *const slot = (ring_idx == 0)
+                               ? &m->root_offsets.auto_expire_version_
+                               : &m->secondary_timeline.auto_expire_version_;
+        start_lifetime_as<std::atomic_int64_t>(slot)->store(
+            version, std::memory_order_release);
     };
     do_(copies_[0].main);
     do_(copies_[1].main);
@@ -523,70 +690,860 @@ uint64_t DbMetadataContext::version_history_length() const noexcept
         ->load(std::memory_order_relaxed);
 }
 
-uint64_t DbMetadataContext::db_history_min_valid_version() const noexcept
+// Compute the effective range lower bound from a root_offsets_delegator
+// snapshot. Extracted so callers can capture the delegator once at entry
+// and avoid reloading primary_ring_idx mid-function (which a concurrent
+// promote could change, mixing max_version from one physical ring with
+// offsets read from the other).
+uint64_t DbMetadataContext::range_lower_bound_from_ro_(
+    root_offsets_delegator const &ro) const noexcept
 {
-    auto const offsets = root_offsets();
-    auto min_version = db_history_range_lower_bound();
-    for (; min_version != offsets.max_version(); ++min_version) {
-        if (offsets[min_version] != INVALID_OFFSET) {
-            break;
-        }
+    auto const max_version = ro.max_version();
+    if (max_version == INVALID_BLOCK_NUM) {
+        return INVALID_BLOCK_NUM;
     }
-    return min_version;
-}
-
-uint64_t DbMetadataContext::db_history_max_version() const noexcept
-{
-    return root_offsets().max_version();
+    auto const history_length = version_history_length();
+    auto const history_range_min =
+        max_version >= history_length ? (max_version - history_length + 1) : 0;
+    auto const ro_version_lower_bound = ro.version_lower_bound();
+    MONAD_ASSERT(ro_version_lower_bound >= history_range_min);
+    return ro_version_lower_bound;
 }
 
 uint64_t DbMetadataContext::db_history_range_lower_bound() const noexcept
 {
-    auto const max_version = db_history_max_version();
-    if (max_version == INVALID_BLOCK_NUM) {
-        return INVALID_BLOCK_NUM;
+    return range_lower_bound_from_ro_(root_offsets());
+}
+
+bool DbMetadataContext::timeline_active(timeline_id const tid) const noexcept
+{
+    if (tid == timeline_id::primary) {
+        return true;
     }
-    else {
-        auto const history_range_min =
-            max_version >= version_history_length()
-                ? (max_version - version_history_length() + 1)
-                : 0;
-        auto const ro_version_lower_bound =
-            copies_[0].main->root_offsets.version_lower_bound_;
-        MONAD_ASSERT(ro_version_lower_bound >= history_range_min);
-        return ro_version_lower_bound;
+    return start_lifetime_as<std::atomic<uint8_t> const>(
+               &copies_[0].main->secondary_timeline_active_)
+               ->load(std::memory_order_acquire) != 0;
+}
+
+chunk_offset_t DbMetadataContext::get_root_offset_at_version(
+    uint64_t const version, timeline_id const tid) const noexcept
+{
+    // Seqlock retry: activate/deactivate_secondary_header run the
+    // ring-buffer shrink/grow under a shrink_grow_seq_ bracket. If a
+    // reader arrives during that bracket (odd seq) it spins-yields until
+    // the bracket closes; after reading it reconfirms the seq and retries
+    // if it moved. Under steady state (no activate/deactivate) the seq is
+    // stable and the loop body runs exactly once.
+    for (;;) {
+        uint64_t const seq1 = shrink_grow_seq_acquire();
+        if (seq1 & 1u) {
+            std::this_thread::yield();
+            continue;
+        }
+        chunk_offset_t result = INVALID_OFFSET;
+        do {
+            if (!timeline_active(tid)) {
+                break;
+            }
+            auto const ro = root_offsets(tid);
+            if (ro.empty()) {
+                break;
+            }
+            auto const max_version = ro.max_version();
+            if (max_version == INVALID_BLOCK_NUM || version > max_version) {
+                break;
+            }
+            uint64_t lower_bound;
+            if (tid == timeline_id::primary) {
+                lower_bound = range_lower_bound_from_ro_(ro);
+                if (lower_bound == INVALID_BLOCK_NUM) {
+                    break;
+                }
+            }
+            else {
+                // Secondary's valid range is bounded by ring capacity
+                // (wrap) and by the header's version_lower_bound_.
+                auto const capacity_min_version =
+                    max_version >= ro.capacity()
+                        ? max_version - ro.capacity() + 1
+                        : 0;
+                auto const header_lower_bound = ro.version_lower_bound();
+                lower_bound =
+                    std::max(capacity_min_version, header_lower_bound);
+            }
+            if (version < lower_bound) {
+                break;
+            }
+            result = ro[version];
+        }
+        while (false);
+        if (seq1 == shrink_grow_seq_acquire()) {
+            return result;
+        }
     }
 }
 
 chunk_offset_t DbMetadataContext::get_root_offset_at_version(
     uint64_t const version) const noexcept
 {
-    if (version <= db_history_max_version()) {
-        auto const offset = root_offsets()[version];
-        if (version >= db_history_range_lower_bound()) {
-            return offset;
-        }
+    return get_root_offset_at_version(version, timeline_id::primary);
+}
+
+uint64_t
+DbMetadataContext::db_history_max_version(timeline_id const tid) const noexcept
+{
+    if (!timeline_active(tid)) {
+        return INVALID_BLOCK_NUM;
     }
-    return INVALID_OFFSET;
+    return root_offsets(tid).max_version();
+}
+
+uint64_t DbMetadataContext::db_history_max_version() const noexcept
+{
+    return db_history_max_version(timeline_id::primary);
+}
+
+uint64_t DbMetadataContext::db_history_min_valid_version(
+    timeline_id const tid) const noexcept
+{
+    if (!timeline_active(tid)) {
+        return INVALID_BLOCK_NUM;
+    }
+    auto const ro = root_offsets(tid);
+    if (ro.empty() || ro.max_version() == INVALID_BLOCK_NUM) {
+        return INVALID_BLOCK_NUM;
+    }
+    if (tid == timeline_id::primary) {
+        auto min_version = range_lower_bound_from_ro_(ro);
+        if (min_version == INVALID_BLOCK_NUM) {
+            return INVALID_BLOCK_NUM;
+        }
+        auto const max_version = ro.max_version();
+        for (; min_version != max_version; ++min_version) {
+            if (ro[min_version] != INVALID_OFFSET) {
+                break;
+            }
+        }
+        return min_version;
+    }
+    return ro.version_lower_bound();
+}
+
+uint64_t DbMetadataContext::db_history_min_valid_version() const noexcept
+{
+    return db_history_min_valid_version(timeline_id::primary);
+}
+
+namespace
+{
+    // MAP_FIXED a single cnv chunk into the next free slot of the ring's
+    // pre-reserved VA. The chunk may already be mapped into this VA (from
+    // a previous activate/deactivate cycle or from map_ring_*_storage at
+    // startup); MAP_FIXED is idempotent in that case and just re-installs
+    // the same backing page.
+    void install_chunk_mapping_(
+        MONAD_ASYNC_NAMESPACE::AsyncIO &io, std::span<chunk_offset_t> ring_span,
+        size_t slot_index, uint32_t cnv_chunk_id, size_t map_bytes, int prot,
+        int mapflags, bool can_write, bool second_copy)
+    {
+        auto &chunk = io.storage_pool().chunk(
+            MONAD_ASYNC_NAMESPACE::storage_pool::cnv, cnv_chunk_id);
+        auto const fdr = chunk.read_fd();
+        auto const fdw = chunk.write_fd(0);
+        auto const &fd = can_write ? fdw : fdr;
+        auto *target = reinterpret_cast<std::byte *>(ring_span.data()) +
+                       slot_index * map_bytes;
+        auto const file_offset =
+            second_copy ? off_t(fdr.second + map_bytes) : off_t(fdr.second);
+        MONAD_ASSERT_PRINTF(
+            MAP_FAILED != ::mmap(
+                              target,
+                              map_bytes,
+                              prot,
+                              mapflags | MAP_FIXED,
+                              fd.first,
+                              file_offset),
+            "MAP_FIXED failed for cnv chunk %u slot %zu (second_copy=%d): %s "
+            "(errno=%d)",
+            cnv_chunk_id,
+            slot_index,
+            int(second_copy),
+            strerror(errno),
+            errno);
+    }
+}
+
+void DbMetadataContext::replay_pending_shrink_grow_()
+{
+    auto const op0 = copies_[0].main->pending_shrink_grow.op_kind;
+    auto const op1 = copies_[1].main->pending_shrink_grow.op_kind;
+    if (op0 == detail::db_metadata::PENDING_OP_NONE &&
+        op1 == detail::db_metadata::PENDING_OP_NONE) {
+        return;
+    }
+    MONAD_ASSERT(
+        can_write_to_map_,
+        "DB metadata has a pending shrink/grow op from a prior crash, but "
+        "the DB was not opened for healing. Reopen read-write to recover.");
+    // Defend against disagreement: the stamp writes identical values to
+    // both copies, so any mismatch between non-NONE records is out-of-
+    // band corruption or a protocol regression. Abort rather than
+    // silently picking one copy's params and applying them to ring data
+    // that the other copy might have already committed under different
+    // params.
+    if (op0 != detail::db_metadata::PENDING_OP_NONE &&
+        op1 != detail::db_metadata::PENDING_OP_NONE) {
+        MONAD_ASSERT(
+            0 == memcmp(
+                     &copies_[0].main->pending_shrink_grow,
+                     &copies_[1].main->pending_shrink_grow,
+                     sizeof(detail::db_metadata::pending_shrink_grow_t)),
+            "pending_shrink_grow disagrees between metadata copies");
+    }
+    // Use whichever copy has the flag set. The single-side case arises
+    // when a crash landed between the two per-copy hold_dirty scopes in
+    // either set_pending_shrink_grow_ (the first scope finished, the
+    // second hadn't started) or clear_pending_shrink_grow_ (one scope
+    // cleared, the other hadn't), and neither copy was dirty at crash
+    // time so the dirty-bit path didn't propagate. Replay is idempotent
+    // and clears the flag on both copies at the end.
+    auto const &pending = (op0 != detail::db_metadata::PENDING_OP_NONE)
+                              ? copies_[0].main->pending_shrink_grow
+                              : copies_[1].main->pending_shrink_grow;
+    auto const op_kind = pending.op_kind;
+    auto const target = pending.target_primary_chunks;
+    if (op_kind == detail::db_metadata::PENDING_OP_ACTIVATE) {
+        LOG_INFO(
+            "Replaying in-flight activate_secondary_header (target primary "
+            "chunks = {}) after unclean shutdown",
+            target);
+        do_activate_secondary_body_(target);
+    }
+    else if (op_kind == detail::db_metadata::PENDING_OP_DEACTIVATE) {
+        LOG_INFO(
+            "Replaying in-flight deactivate_secondary_header (target "
+            "primary chunks = {}) after unclean shutdown",
+            target);
+        do_deactivate_secondary_body_(target);
+    }
+    else {
+        MONAD_ABORT_PRINTF(
+            "Unknown pending_shrink_grow op_kind %u in metadata; DB may be "
+            "from a newer code version",
+            op_kind);
+    }
+    sync_ring_data_to_disk_();
+    sync_metadata_to_disk_();
+    clear_pending_shrink_grow_();
+    sync_metadata_to_disk_();
+}
+
+void DbMetadataContext::sync_metadata_to_disk_()
+{
+    MONAD_ASSERT(can_write_to_map_);
+    for (unsigned which = 0; which < 2; which++) {
+        MONAD_ASSERT_PRINTF(
+            0 == ::msync(copies_[which].main, db_map_size_, MS_SYNC),
+            "msync of metadata copy %u failed: %s (errno=%d)",
+            which,
+            strerror(errno),
+            errno);
+    }
+    // Also fsync the underlying cnv chunk 0 FD so the filesystem journal
+    // commits the msync'd pages (msync's durability guarantees across
+    // filesystems/kernels are narrower than fsync's).
+    auto &cnv_chunk_0 =
+        io_->storage_pool().chunk(MONAD_ASYNC_NAMESPACE::storage_pool::cnv, 0);
+    auto const fdw = cnv_chunk_0.write_fd(0);
+    MONAD_ASSERT_PRINTF(
+        0 == ::fsync(fdw.first),
+        "fsync of cnv chunk 0 failed: %s (errno=%d)",
+        strerror(errno),
+        errno);
+}
+
+void DbMetadataContext::sync_ring_data_to_disk_()
+{
+    MONAD_ASSERT(can_write_to_map_);
+    // Sync only the currently-live prefix of each ring. Tail slots are
+    // PROT_NONE anonymous reservations and need not be msync'd. If a
+    // ring has chunks but the span is null, that's a construction-time
+    // invariant violation — assert rather than silently skipping.
+    auto const sync_ring = [this](
+                               std::span<chunk_offset_t> span,
+                               uint32_t chunks_len,
+                               char const *ring_name,
+                               unsigned which) {
+        if (chunks_len == 0) {
+            return;
+        }
+        MONAD_ASSERT_PRINTF(
+            span.data() != nullptr,
+            "%s has %u chunks but no mapping on copy %u",
+            ring_name,
+            chunks_len,
+            which);
+        auto const bytes = uint64_t(chunks_len) * map_bytes_per_chunk_();
+        MONAD_ASSERT_PRINTF(
+            0 == ::msync(span.data(), bytes, MS_SYNC),
+            "msync of %s on copy %u (%lu bytes) failed: %s (errno=%d)",
+            ring_name,
+            which,
+            bytes,
+            strerror(errno),
+            errno);
+    };
+    for (unsigned which = 0; which < 2; which++) {
+        auto *const m = copies_[which].main;
+        sync_ring(
+            copies_[which].ring_a_span,
+            m->root_offsets.storage_.cnv_chunks_len,
+            "ring_a",
+            which);
+        sync_ring(
+            copies_[which].ring_b_span,
+            m->secondary_timeline.storage_.cnv_chunks_len,
+            "ring_b",
+            which);
+    }
+    // Ring data lives in cnv chunks 1..N. Issue fsync on each chunk's FD
+    // that currently backs any ring slot. We consult copy 0's cnv_chunks
+    // lists as the source of truth (both copies are synchronised under
+    // the dual-copy protocol; any chunk id that is valid in one copy is
+    // valid in the other too).
+    auto const fsync_chunks =
+        [this](detail::db_metadata::root_offsets_ring_t const &ring) {
+            auto const len = ring.storage_.cnv_chunks_len;
+            for (uint32_t k = 0; k < len; k++) {
+                auto const id = ring.storage_.cnv_chunks[k].cnv_chunk_id;
+                if (id == uint32_t(-1)) {
+                    continue;
+                }
+                auto &chunk = io_->storage_pool().chunk(
+                    MONAD_ASYNC_NAMESPACE::storage_pool::cnv, id);
+                auto const fdw = chunk.write_fd(0);
+                MONAD_ASSERT_PRINTF(
+                    0 == ::fsync(fdw.first),
+                    "fsync of cnv chunk %u failed: %s (errno=%d)",
+                    id,
+                    strerror(errno),
+                    errno);
+            }
+        };
+    fsync_chunks(copies_[0].main->root_offsets);
+    fsync_chunks(copies_[0].main->secondary_timeline);
+}
+
+void DbMetadataContext::set_pending_shrink_grow_(
+    detail::db_metadata::pending_op_kind const op_kind,
+    uint32_t const target_primary_chunks)
+{
+    MONAD_ASSERT(op_kind != detail::db_metadata::PENDING_OP_NONE);
+    // Two crash windows this design tolerates:
+    //   (a) Inside a single copy's hold_dirty scope: that copy is dirty,
+    //       dirty-bit recovery on reopen restores it from the other
+    //       (clean) copy, yielding "both not-stamped" or "both stamped"
+    //       depending on which was mid-write.
+    //   (b) Between the two per-copy scopes (copy 0 stamped and clean,
+    //       copy 1 unstamped and clean): neither is dirty, dirty-bit
+    //       recovery does nothing, but replay fires whenever EITHER
+    //       copy has op_kind != NONE. Replay is idempotent, and the
+    //       clear_pending step at the end normalises both copies'
+    //       shrink_grow_seq_ to even regardless of their starting
+    //       parity.
+    for (auto const &copy : copies_) {
+        auto *const m = copy.main;
+        auto const g = m->hold_dirty();
+        m->pending_shrink_grow.op_kind = static_cast<uint32_t>(op_kind);
+        m->pending_shrink_grow.target_primary_chunks = target_primary_chunks;
+        // Bump shrink_grow_seq_ to odd under the same hold_dirty so
+        // dirty-bit recovery restores it alongside the rest of the
+        // header. (cur + 1) | 1 is the smallest odd value strictly
+        // greater than cur — correct whether cur was even (normal
+        // entry) or odd (abnormal leftover from a prior partial
+        // stamp that clear_pending will normalise anyway).
+        auto *const seq =
+            start_lifetime_as<std::atomic<uint64_t>>(&m->shrink_grow_seq_);
+        seq->store(
+            (seq->load(std::memory_order_acquire) + 1) | 1ULL,
+            std::memory_order_release);
+    }
+}
+
+void DbMetadataContext::clear_pending_shrink_grow_()
+{
+    for (auto const &copy : copies_) {
+        auto *const m = copy.main;
+        auto const g = m->hold_dirty();
+        m->pending_shrink_grow.op_kind = detail::db_metadata::PENDING_OP_NONE;
+        m->pending_shrink_grow.target_primary_chunks = 0;
+        // Normalise shrink_grow_seq_ to even. A blind fetch_add would
+        // flip parity — correct for the common "both copies odd
+        // entering clear" path but wrong after a partial-stamp crash
+        // where one copy arrived here at odd (stamped) and the other
+        // at even (unstamped, because its set scope didn't run). The
+        // `(cur + 2) & ~1ULL` expression is the smallest even value
+        // strictly greater than cur, so both copies end even and
+        // each copy's generation counter strictly advances.
+        auto *const seq =
+            start_lifetime_as<std::atomic<uint64_t>>(&m->shrink_grow_seq_);
+        seq->store(
+            (seq->load(std::memory_order_acquire) + 2) & ~1ULL,
+            std::memory_order_release);
+    }
+}
+
+void DbMetadataContext::do_activate_secondary_body_(uint32_t const new_chunks)
+{
+    uint8_t const primary_idx = primary_ring_idx();
+    uint8_t const secondary_idx = primary_idx ^ 1u;
+
+    auto const entries_per_chunk =
+        map_bytes_per_chunk_() / sizeof(chunk_offset_t);
+    uint64_t const new_cap = uint64_t(new_chunks) * entries_per_chunk;
+
+    for (unsigned which = 0; which < 2; which++) {
+        auto *const m = copies_[which].main;
+        auto const g = m->hold_dirty();
+        auto &pstore = (primary_idx == 0) ? m->root_offsets.storage_
+                                          : m->secondary_timeline.storage_;
+        auto &sstore = (primary_idx == 0) ? m->secondary_timeline.storage_
+                                          : m->root_offsets.storage_;
+        auto *pver_lb = (primary_idx == 0)
+                            ? &m->root_offsets.version_lower_bound_
+                            : &m->secondary_timeline.version_lower_bound_;
+        auto *pver_nv = (primary_idx == 0)
+                            ? &m->root_offsets.next_version_
+                            : &m->secondary_timeline.next_version_;
+        auto *sver_lb = (primary_idx == 0)
+                            ? &m->secondary_timeline.version_lower_bound_
+                            : &m->root_offsets.version_lower_bound_;
+        auto *sver_nv = (primary_idx == 0)
+                            ? &m->secondary_timeline.next_version_
+                            : &m->root_offsets.next_version_;
+        auto const &pring = copies_[which];
+        auto const primary_span =
+            (primary_idx == 0) ? pring.ring_a_span : pring.ring_b_span;
+        auto const secondary_span =
+            (secondary_idx == 0) ? pring.ring_a_span : pring.ring_b_span;
+
+        // Derive old_chunks from this copy's current primary cnv_chunks_len.
+        // Under replay, this may already equal new_chunks (commit durable)
+        // or still equal new_chunks * 2 (pre-commit); both are handled
+        // uniformly by the step-by-step idempotency guards below.
+        uint32_t const cur_primary_chunks = pstore.cnv_chunks_len;
+        MONAD_ASSERT(
+            cur_primary_chunks == new_chunks ||
+            cur_primary_chunks == new_chunks * 2);
+        uint32_t const old_chunks = (cur_primary_chunks == new_chunks)
+                                        ? new_chunks * 2
+                                        : cur_primary_chunks;
+        uint64_t const old_cap = uint64_t(old_chunks) * entries_per_chunk;
+
+        // 1. Bump primary's version_lower_bound_ if the new (smaller)
+        //    capacity excludes older versions (idempotent: std::max is a
+        //    fixed point under repeated application).
+        uint64_t const nv =
+            start_lifetime_as<std::atomic_uint64_t const>(pver_nv)->load(
+                std::memory_order_acquire);
+        uint64_t const cur_lb =
+            start_lifetime_as<std::atomic_uint64_t const>(pver_lb)->load(
+                std::memory_order_acquire);
+        uint64_t const new_lb =
+            std::max(cur_lb, (nv >= new_cap) ? (nv - new_cap) : uint64_t{0});
+        if (new_lb > cur_lb) {
+            start_lifetime_as<std::atomic_uint64_t>(pver_lb)->store(
+                new_lb, std::memory_order_release);
+        }
+        // 2. Under replay, the primary's tail slots [new_chunks, old_chunks)
+        //    may have been left PROT_NONE by map_ring_a/b_storage if a
+        //    prior crashed run cleared pstore.cnv_chunks[k].cnv_chunk_id
+        //    (step 4 below) before the cnv_chunks_len commit (step 6). The
+        //    ring-copy loop at step 3 reads from those slots, so remap
+        //    them here first — derive each chunk id from pstore (if still
+        //    populated) or sstore (if already swapped over). MAP_FIXED is
+        //    idempotent on the fresh-run path where pstore is fully
+        //    populated and the VA is already mapped.
+        if (cur_primary_chunks == old_chunks) {
+            for (uint32_t k = new_chunks; k < old_chunks; k++) {
+                uint32_t chunk_id = pstore.cnv_chunks[k].cnv_chunk_id;
+                if (chunk_id == uint32_t(-1)) {
+                    chunk_id = sstore.cnv_chunks[k - new_chunks].cnv_chunk_id;
+                }
+                MONAD_ASSERT(chunk_id != uint32_t(-1));
+                install_chunk_mapping_(
+                    *io_,
+                    primary_span,
+                    k,
+                    chunk_id,
+                    map_bytes_per_chunk_(),
+                    prot_,
+                    mapflags_,
+                    can_write_to_map_,
+                    /*second_copy=*/which == 1);
+            }
+        }
+        // 3. Copy kept entries from old positions to new positions on the
+        //    primary ring. Source range [new_cap, old_cap) and destination
+        //    range [0, new_cap) are disjoint and sources are never written,
+        //    so the loop is idempotent under replay.
+        if (cur_primary_chunks == old_chunks) {
+            for (uint64_t v = new_lb; v < nv; v++) {
+                uint64_t const old_pos = v & (old_cap - 1);
+                uint64_t const new_pos = v & (new_cap - 1);
+                if (old_pos == new_pos) {
+                    continue;
+                }
+                auto *src = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                    &primary_span[old_pos]);
+                auto *dst = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                    &primary_span[new_pos]);
+                dst->store(
+                    src->load(std::memory_order_acquire),
+                    std::memory_order_release);
+            }
+        }
+        // 4. Install MAP_FIXED mappings for secondary's chunks BEFORE the
+        //    cnv_chunks[] swap. If a mmap failure aborts us here,
+        //    cnv_chunks[] state is still whole, so recovery remains
+        //    unambiguous. MAP_FIXED is idempotent. Derive each chunk id
+        //    either from sstore (already moved by a prior partial run)
+        //    or from pstore's tail (not yet moved).
+        for (uint32_t k = 0; k < new_chunks; k++) {
+            uint32_t chunk_id = sstore.cnv_chunks[k].cnv_chunk_id;
+            if (chunk_id == uint32_t(-1)) {
+                chunk_id = pstore.cnv_chunks[new_chunks + k].cnv_chunk_id;
+            }
+            MONAD_ASSERT(chunk_id != uint32_t(-1));
+            install_chunk_mapping_(
+                *io_,
+                secondary_span,
+                k,
+                chunk_id,
+                map_bytes_per_chunk_(),
+                prot_,
+                mapflags_,
+                can_write_to_map_,
+                /*second_copy=*/which == 1);
+        }
+        // 5. Transfer the second half of chunks from primary to secondary.
+        //    Idempotent: a destination slot that already holds a valid
+        //    chunk id is the "already moved" signal — skip it.
+        for (uint32_t k = 0; k < new_chunks; k++) {
+            if (sstore.cnv_chunks[k].cnv_chunk_id != uint32_t(-1)) {
+                continue;
+            }
+            auto const moved_id =
+                pstore.cnv_chunks[new_chunks + k].cnv_chunk_id;
+            MONAD_ASSERT(moved_id != uint32_t(-1));
+            sstore.cnv_chunks[k].high_bits_all_set = uint32_t(-1);
+            sstore.cnv_chunks[k].cnv_chunk_id = moved_id;
+            pstore.cnv_chunks[new_chunks + k].cnv_chunk_id = uint32_t(-1);
+        }
+        // 6. Initialise the secondary ring (INVALID_OFFSET fill, then
+        //    zero version fields). The secondary timeline starts empty —
+        //    next_version_ == 0 maps to INVALID_BLOCK_NUM, which signals
+        //    fast_forward_next_version to seed both version fields when the
+        //    secondary writes its first root. Safe to re-run during replay
+        //    because replay executes in the constructor before any client
+        //    thread can observe the DB, and the live-path
+        //    `activate_secondary_header` is synchronous — no client can
+        //    push to the secondary ring until the public call has returned,
+        //    at which point the pending flag has already been cleared +
+        //    msync'd.
+        auto const secondary_live_bytes =
+            uint64_t(new_chunks) * map_bytes_per_chunk_();
+        memset((void *)secondary_span.data(), 0xff, secondary_live_bytes);
+        start_lifetime_as<std::atomic_uint64_t>(sver_lb)->store(
+            0, std::memory_order_release);
+        start_lifetime_as<std::atomic_uint64_t>(sver_nv)->store(
+            0, std::memory_order_release);
+        // 7. Commit cnv_chunks_len (idempotent store of the same value).
+        start_lifetime_as<std::atomic<uint32_t>>(&pstore.cnv_chunks_len)
+            ->store(new_chunks, std::memory_order_release);
+        start_lifetime_as<std::atomic<uint32_t>>(&sstore.cnv_chunks_len)
+            ->store(new_chunks, std::memory_order_release);
+        // 8. Flip secondary_timeline_active_ (idempotent).
+        start_lifetime_as<std::atomic<uint8_t>>(&m->secondary_timeline_active_)
+            ->store(1, std::memory_order_release);
+    }
+}
+
+void DbMetadataContext::activate_secondary_header()
+{
+    MONAD_ASSERT(!timeline_active(timeline_id::secondary));
+    MONAD_ASSERT(
+        copies_[0].main->pending_shrink_grow.op_kind ==
+            detail::db_metadata::PENDING_OP_NONE &&
+        copies_[1].main->pending_shrink_grow.op_kind ==
+            detail::db_metadata::PENDING_OP_NONE);
+
+    uint8_t const primary_idx = primary_ring_idx();
+    auto const &primary_storage =
+        (primary_idx == 0) ? copies_[0].main->root_offsets.storage_
+                           : copies_[0].main->secondary_timeline.storage_;
+    auto const old_chunks = primary_storage.cnv_chunks_len;
+    MONAD_ASSERT(
+        old_chunks >= 2 && (old_chunks & (old_chunks - 1)) == 0,
+        "activate_secondary_header requires the primary ring to have at "
+        "least 2 chunks (power of 2) so it can be split in half");
+    uint32_t const new_chunks = old_chunks / 2;
+
+    // Stamp the intent log and make it durable before touching anything.
+    // On crash anywhere below, replay in the constructor will run the
+    // idempotent body again and clear the flag. Without this the kernel
+    // could flush ring-chunk pages before the metadata page, producing
+    // a durable "new ring data + old capacity" state that is corrupt
+    // (readers mask with old_cap into destinations holding new data).
+    set_pending_shrink_grow_(
+        detail::db_metadata::PENDING_OP_ACTIVATE, new_chunks);
+    sync_metadata_to_disk_();
+
+    do_activate_secondary_body_(new_chunks);
+
+    // Make the body durable before clearing the intent flag. If the
+    // flag-clear reached disk before the ring data, a crash here would
+    // produce "new metadata, stale ring data" with no flag to trigger
+    // replay.
+    sync_ring_data_to_disk_();
+    sync_metadata_to_disk_();
+
+    clear_pending_shrink_grow_();
+    sync_metadata_to_disk_();
+
+    LOG_INFO(
+        "Activated secondary timeline (primary ring shrunk from {} to {} "
+        "chunks; secondary gained {} chunks)",
+        old_chunks,
+        new_chunks,
+        new_chunks);
+}
+
+void DbMetadataContext::do_deactivate_secondary_body_(
+    uint32_t const primary_new_chunks)
+{
+    uint8_t const primary_idx = primary_ring_idx();
+
+    auto const entries_per_chunk =
+        map_bytes_per_chunk_() / sizeof(chunk_offset_t);
+    uint64_t const new_cap = uint64_t(primary_new_chunks) * entries_per_chunk;
+
+    for (unsigned which = 0; which < 2; which++) {
+        auto *const m = copies_[which].main;
+        auto const g = m->hold_dirty();
+        auto &pstore = (primary_idx == 0) ? m->root_offsets.storage_
+                                          : m->secondary_timeline.storage_;
+        auto &sstore = (primary_idx == 0) ? m->secondary_timeline.storage_
+                                          : m->root_offsets.storage_;
+        auto *pver_lb = (primary_idx == 0)
+                            ? &m->root_offsets.version_lower_bound_
+                            : &m->secondary_timeline.version_lower_bound_;
+        auto *pver_nv = (primary_idx == 0)
+                            ? &m->root_offsets.next_version_
+                            : &m->secondary_timeline.next_version_;
+        auto const &pring = copies_[which];
+        auto const primary_span =
+            (primary_idx == 0) ? pring.ring_a_span : pring.ring_b_span;
+
+        // Under replay, pstore.cnv_chunks_len is either the pre-op size
+        // (commit not yet durable) or primary_new_chunks (already
+        // committed). The pre-op size is always exactly half of
+        // primary_new_chunks because deactivate always doubles a
+        // power-of-two primary ring by returning the secondary's chunks
+        // that activate symmetrically split off. Any other value
+        // indicates metadata corruption — abort rather than compute ring
+        // masks from a non-power-of-two capacity.
+        uint32_t const cur_primary_chunks = pstore.cnv_chunks_len;
+        MONAD_ASSERT(
+            cur_primary_chunks == primary_new_chunks ||
+            cur_primary_chunks * 2 == primary_new_chunks);
+        uint32_t const primary_old_chunks =
+            (cur_primary_chunks == primary_new_chunks) ? primary_new_chunks
+                                                       : cur_primary_chunks;
+        uint32_t const returning_chunks =
+            primary_new_chunks - primary_old_chunks;
+        uint64_t const old_cap =
+            uint64_t(primary_old_chunks) * entries_per_chunk;
+
+        // 1. Install MAP_FIXED mappings for returning chunks BEFORE the
+        //    cnv_chunks[] swap. If a mmap failure aborts us here, the swap
+        //    state is still whole, so recovery remains unambiguous.
+        //    Derive each chunk id either from pstore's tail (already
+        //    returned by a prior partial run) or from sstore (not yet
+        //    returned).
+        for (uint32_t k = 0; k < returning_chunks; k++) {
+            uint32_t chunk_id =
+                pstore.cnv_chunks[primary_old_chunks + k].cnv_chunk_id;
+            if (chunk_id == uint32_t(-1)) {
+                chunk_id = sstore.cnv_chunks[k].cnv_chunk_id;
+            }
+            MONAD_ASSERT(chunk_id != uint32_t(-1));
+            install_chunk_mapping_(
+                *io_,
+                primary_span,
+                primary_old_chunks + k,
+                chunk_id,
+                map_bytes_per_chunk_(),
+                prot_,
+                mapflags_,
+                can_write_to_map_,
+                /*second_copy=*/which == 1);
+        }
+        // 2. Move chunks from secondary's list to primary's tail.
+        //    Idempotent: skip if destination already holds a valid id.
+        for (uint32_t k = 0; k < returning_chunks; k++) {
+            if (pstore.cnv_chunks[primary_old_chunks + k].cnv_chunk_id !=
+                uint32_t(-1)) {
+                continue;
+            }
+            auto const moved_id = sstore.cnv_chunks[k].cnv_chunk_id;
+            MONAD_ASSERT(moved_id != uint32_t(-1));
+            pstore.cnv_chunks[primary_old_chunks + k].high_bits_all_set =
+                uint32_t(-1);
+            pstore.cnv_chunks[primary_old_chunks + k].cnv_chunk_id = moved_id;
+            sstore.cnv_chunks[k].cnv_chunk_id = uint32_t(-1);
+        }
+        // 3. Initialise the freshly-added tail positions on primary to
+        //    INVALID_OFFSET, then copy any valid entries into their new
+        //    positions under the grown capacity. The copy is idempotent
+        //    (sources in [0, old_cap), destinations in [old_cap, new_cap),
+        //    ranges disjoint, sources not written). The memset is safe to
+        //    re-run during replay for the same reason as activate's step
+        //    5: replay runs in the constructor before any client can
+        //    observe the DB, and live-path deactivate is synchronous, so
+        //    no push can have touched the tail positions we're clearing.
+        if (cur_primary_chunks == primary_old_chunks && returning_chunks > 0) {
+            auto const tail_bytes =
+                uint64_t(returning_chunks) * map_bytes_per_chunk_();
+            memset(
+                (void *)(reinterpret_cast<std::byte *>(primary_span.data()) +
+                         old_cap * sizeof(chunk_offset_t)),
+                0xff,
+                tail_bytes);
+            uint64_t const nv =
+                start_lifetime_as<std::atomic_uint64_t const>(pver_nv)->load(
+                    std::memory_order_acquire);
+            uint64_t const lb =
+                start_lifetime_as<std::atomic_uint64_t const>(pver_lb)->load(
+                    std::memory_order_acquire);
+            if (nv != lb) {
+                for (uint64_t v = lb; v < nv; v++) {
+                    uint64_t const old_pos = v & (old_cap - 1);
+                    uint64_t const new_pos = v & (new_cap - 1);
+                    if (old_pos == new_pos) {
+                        continue;
+                    }
+                    auto *src = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                        &primary_span[old_pos]);
+                    auto *dst = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                        &primary_span[new_pos]);
+                    dst->store(
+                        src->load(std::memory_order_acquire),
+                        std::memory_order_release);
+                }
+            }
+        }
+        // 4. Commit the grow / shrink (primary grows, secondary shrinks
+        //    to 0). Idempotent stores.
+        start_lifetime_as<std::atomic<uint32_t>>(&pstore.cnv_chunks_len)
+            ->store(primary_new_chunks, std::memory_order_release);
+        start_lifetime_as<std::atomic<uint32_t>>(&sstore.cnv_chunks_len)
+            ->store(0, std::memory_order_release);
+        // 5. Mark secondary inactive (idempotent).
+        start_lifetime_as<std::atomic<uint8_t>>(&m->secondary_timeline_active_)
+            ->store(0, std::memory_order_release);
+    }
+}
+
+void DbMetadataContext::deactivate_secondary_header()
+{
+    MONAD_ASSERT(timeline_active(timeline_id::secondary));
+    MONAD_ASSERT(
+        copies_[0].main->pending_shrink_grow.op_kind ==
+            detail::db_metadata::PENDING_OP_NONE &&
+        copies_[1].main->pending_shrink_grow.op_kind ==
+            detail::db_metadata::PENDING_OP_NONE);
+
+    uint8_t const primary_idx = primary_ring_idx();
+    uint8_t const secondary_idx = primary_idx ^ 1u;
+
+    auto const &primary_storage =
+        (primary_idx == 0) ? copies_[0].main->root_offsets.storage_
+                           : copies_[0].main->secondary_timeline.storage_;
+    auto const &secondary_storage =
+        (secondary_idx == 0) ? copies_[0].main->root_offsets.storage_
+                             : copies_[0].main->secondary_timeline.storage_;
+    uint32_t const primary_old_chunks = primary_storage.cnv_chunks_len;
+    uint32_t const returning_chunks = secondary_storage.cnv_chunks_len;
+    MONAD_ASSERT(
+        returning_chunks > 0 && primary_old_chunks > 0,
+        "deactivate_secondary_header needs both rings to hold at least one "
+        "chunk");
+    uint32_t const primary_new_chunks = primary_old_chunks + returning_chunks;
+    MONAD_ASSERT(
+        (primary_new_chunks & (primary_new_chunks - 1)) == 0,
+        "Grown primary ring size must remain a power of two");
+
+    set_pending_shrink_grow_(
+        detail::db_metadata::PENDING_OP_DEACTIVATE, primary_new_chunks);
+    sync_metadata_to_disk_();
+
+    do_deactivate_secondary_body_(primary_new_chunks);
+
+    sync_ring_data_to_disk_();
+    sync_metadata_to_disk_();
+
+    clear_pending_shrink_grow_();
+    sync_metadata_to_disk_();
+
+    LOG_INFO(
+        "Deactivated secondary timeline (primary ring grew from {} to {} "
+        "chunks)",
+        primary_old_chunks,
+        primary_new_chunks);
+}
+
+void DbMetadataContext::promote_secondary_to_primary_header() noexcept
+{
+    MONAD_ASSERT(timeline_active(timeline_id::secondary));
+    // Flip primary_ring_idx on both copies. No header fields move, no
+    // in-memory spans swap — role routing at query time picks the new
+    // primary via primary_ring_idx(). Holding both dirty bits across the
+    // two flips makes the operation cleanly rollback-safe under crash:
+    // if either copy is dirty on reopen, db_copy propagates the clean
+    // copy's contents, yielding an internally consistent (possibly
+    // rolled-back) state.
+    auto const g0 = copies_[0].main->hold_dirty();
+    auto const g1 = copies_[1].main->hold_dirty();
+    for (auto const &copy : copies_) {
+        auto *const slot = start_lifetime_as<std::atomic<uint8_t>>(
+            &copy.main->primary_ring_idx);
+        uint8_t const cur = slot->load(std::memory_order_acquire);
+        slot->store(static_cast<uint8_t>(cur ^ 1u), std::memory_order_release);
+    }
 }
 
 DbMetadataContext::~DbMetadataContext()
 {
-    // munmap root_offsets
     for (auto &copy : copies_) {
-        if (copy.root_offsets.data() != nullptr) {
+        if (copy.ring_a_span.data() != nullptr) {
             (void)::munmap(
-                copy.root_offsets.data(), copy.root_offsets.size_bytes());
-            copy.root_offsets = {};
+                copy.ring_a_span.data(), copy.ring_a_span.size_bytes());
+            copy.ring_a_span = {};
+        }
+        if (copy.ring_b_span.data() != nullptr) {
+            (void)::munmap(
+                copy.ring_b_span.data(), copy.ring_b_span.size_bytes());
+            copy.ring_b_span = {};
         }
     }
     // munmap db_metadata
     if (copies_[0].main != nullptr) {
-        (void)::munmap(copies_[0].main, db_map_size_);
+        (void)::munmap(copies_[0].main, metadata_mmap_size_);
         copies_[0].main = nullptr;
     }
     if (copies_[1].main != nullptr) {
-        (void)::munmap(copies_[1].main, db_map_size_);
+        (void)::munmap(copies_[1].main, metadata_mmap_size_);
         copies_[1].main = nullptr;
     }
 }
@@ -687,15 +1644,18 @@ void DbMetadataContext::init_new_pool(
     set_latest_verified_version(INVALID_BLOCK_NUM);
     set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
     set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-    set_auto_expire_version_metadata(0);
+    set_auto_expire_version_metadata(timeline_id::primary, 0);
+    set_auto_expire_version_metadata(timeline_id::secondary, 0);
 
+    // Zero the padding so any future field carved from it sees a
+    // consistent initial value on both fresh pools and pools migrated
+    // from earlier on-disk formats (the MONAD007->008 migration also
+    // zeros this region).
     for (auto const i : {0, 1}) {
         auto *const m = copies_[i].main;
         auto const g = m->hold_dirty();
         memset(
-            m->future_variables_unused,
-            0xff,
-            sizeof(m->future_variables_unused));
+            m->future_variables_unused, 0, sizeof(m->future_variables_unused));
     }
 
     std::atomic_signal_fence(
@@ -709,7 +1669,12 @@ void DbMetadataContext::init_new_pool(
         detail::db_metadata::MAGIC,
         detail::db_metadata::MAGIC_STRING_LEN);
 
-    map_root_offsets();
+    map_ring_a_storage();
+    map_ring_b_storage();
+    // New pool: primary_ring_idx defaults to 0 (ring_a primary) and
+    // secondary_timeline_active_ = 0 (inactive) from the initial zeroing.
+    // Ring_b has no chunks yet (cnv_chunks_len == 0); activate_secondary
+    // will allocate chunks to it, map them, and fill with INVALID_OFFSET.
     // Set history length, MUST be after root offsets are mapped
     if (history_len.has_value()) {
         update_history_length_metadata(*history_len);

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -599,24 +599,26 @@ void DbMetadataContext::update_history_length_metadata(
 // Root offsets operations
 
 void DbMetadataContext::append_root_offset(
-    chunk_offset_t const root_offset) noexcept
+    chunk_offset_t const root_offset, timeline_id const tid) noexcept
 {
     auto do_ = [&](unsigned const which) {
         auto const g = copies_[which].main->hold_dirty();
-        root_offsets(which).push(root_offset);
+        root_offsets(tid, which).push(root_offset);
     };
     do_(0);
     do_(1);
 }
 
 void DbMetadataContext::update_root_offset(
-    size_t const i, chunk_offset_t const root_offset) noexcept
+    size_t const i, chunk_offset_t const root_offset,
+    timeline_id const tid) noexcept
 {
     auto do_ = [&](unsigned const which) {
         auto const g = copies_[which].main->hold_dirty();
-        auto ro = root_offsets(which);
+        auto ro = root_offsets(tid, which);
         ro.assign(i, root_offset);
-        if (root_offset == INVALID_OFFSET && i == db_history_max_version() &&
+        if (tid == timeline_id::primary && root_offset == INVALID_OFFSET &&
+            i == db_history_max_version() &&
             i == db_history_min_valid_version()) {
             ro.reset_all(0);
             MONAD_ASSERT(ro.max_version() == INVALID_BLOCK_NUM);
@@ -627,11 +629,11 @@ void DbMetadataContext::update_root_offset(
 }
 
 void DbMetadataContext::fast_forward_next_version(
-    uint64_t const new_version) noexcept
+    uint64_t const new_version, timeline_id const tid) noexcept
 {
     auto do_ = [&](unsigned const which) {
         auto const g = copies_[which].main->hold_dirty();
-        auto ro = root_offsets(which);
+        auto ro = root_offsets(tid, which);
         uint64_t curr_version = ro.max_version();
         MONAD_ASSERT(
             curr_version == INVALID_BLOCK_NUM || new_version > curr_version);
@@ -657,7 +659,7 @@ void DbMetadataContext::clear_root_offsets_up_to_and_including(
     for (uint64_t v = db_history_range_lower_bound();
          v != INVALID_BLOCK_NUM && v <= version;
          v = db_history_range_lower_bound()) {
-        update_root_offset(v, INVALID_OFFSET);
+        update_root_offset(v, INVALID_OFFSET, timeline_id::primary);
     }
 }
 

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -216,6 +216,11 @@ public:
         return is_new_pool_;
     }
 
+    //! \brief Force both metadata copies to durable storage. Public entry
+    //! point for monad-mpt --upgrade's post-migration flush. Requires the
+    //! pool to have been opened writable (asserts can_write_to_map_).
+    void sync_metadata_to_disk();
+
     enum class chunk_list : uint8_t
     {
         free = 0,

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -275,10 +275,14 @@ public:
     set_auto_expire_version_metadata(timeline_id tid, int64_t version) noexcept;
     void update_history_length_metadata(uint64_t history_len) noexcept;
 
-    // Root offsets operations
-    void append_root_offset(chunk_offset_t root_offset) noexcept;
-    void update_root_offset(size_t i, chunk_offset_t root_offset) noexcept;
-    void fast_forward_next_version(uint64_t version) noexcept;
+    // Root offsets operations. All wrap the two-copy mutation in
+    // per-copy hold_dirty() scopes so crash recovery can roll back a
+    // half-written update. tid selects which ring to mutate.
+    void
+    append_root_offset(chunk_offset_t root_offset, timeline_id tid) noexcept;
+    void update_root_offset(
+        size_t i, chunk_offset_t root_offset, timeline_id tid) noexcept;
+    void fast_forward_next_version(uint64_t version, timeline_id tid) noexcept;
     void clear_root_offsets_up_to_and_including(uint64_t version);
 
     // DB offsets

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -22,6 +22,7 @@
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/util.hpp>
 
 #include <atomic>
@@ -30,6 +31,7 @@
 #include <cstdint>
 #include <cstring>
 #include <span>
+#include <sys/mman.h>
 
 MONAD_MPT_NAMESPACE_BEGIN
 
@@ -44,10 +46,154 @@ class DbMetadataContext
     friend class UpdateAux;
 
 public:
+    // Each metadata_copy describes one of the two redundant db_metadata
+    // instances. `ring_a_span` / `ring_b_span` are in-memory spans over the
+    // physical storage of ring_a (cnv chunks listed in
+    // db_metadata::root_offsets.storage_.cnv_chunks[]) and ring_b (cnv
+    // chunks listed in the secondary timeline's storage_.cnv_chunks). These
+    // spans are tied to physical rings, not timeline roles — role routing
+    // happens at query time via db_metadata::primary_ring_idx.
     struct metadata_copy
     {
         detail::db_metadata *main{nullptr};
-        std::span<chunk_offset_t> root_offsets;
+        std::span<chunk_offset_t> ring_a_span;
+        std::span<chunk_offset_t> ring_b_span;
+    };
+
+    // Ring delegator for the root-offsets ring buffer. Bound to the
+    // header/span of one physical ring plus a snapshot of its current
+    // capacity (entries, not chunks). Capacity can change at runtime via
+    // activate_secondary_header / deactivate_secondary_header; readers
+    // that care about atomicity bracket their lookups with the
+    // shrink_grow_seq_ seqlock. Inside a seqlock bracket the capacity
+    // snapshot is stable.
+    class root_offsets_delegator
+    {
+        std::atomic_ref<uint64_t> version_lower_bound_;
+        std::atomic_ref<uint64_t> next_version_;
+        std::span<chunk_offset_t> root_offsets_chunks_;
+        size_t capacity_; // entries in the *live* portion of the ring
+
+        void update_version_lower_bound_(uint64_t lower_bound = uint64_t(-1))
+        {
+            auto const version_lower_bound =
+                version_lower_bound_.load(std::memory_order_acquire);
+            auto idx = (lower_bound < version_lower_bound)
+                           ? lower_bound
+                           : version_lower_bound;
+            auto const max_version =
+                next_version_.load(std::memory_order_acquire) - 1;
+            if (max_version == INVALID_BLOCK_NUM) {
+                return;
+            }
+            while (idx < max_version && (*this)[idx] == INVALID_OFFSET) {
+                idx++;
+            }
+            if (idx != version_lower_bound) {
+                version_lower_bound_.store(idx, std::memory_order_release);
+            }
+        }
+
+    public:
+        root_offsets_delegator(
+            uint64_t &version_lower_bound, uint64_t &next_version,
+            std::span<chunk_offset_t> root_offsets_chunks,
+            size_t const capacity)
+            : version_lower_bound_(version_lower_bound)
+            , next_version_(next_version)
+            , root_offsets_chunks_(root_offsets_chunks)
+            , capacity_(capacity)
+        {
+            MONAD_ASSERT(capacity_ <= root_offsets_chunks_.size());
+            MONAD_ASSERT_PRINTF(
+                capacity_ == 0 ||
+                    capacity_ == 1ULL << (63 - std::countl_zero(capacity_)),
+                "root offsets capacity %lu is not a power of 2",
+                capacity_);
+        }
+
+        bool empty() const noexcept
+        {
+            return capacity_ == 0;
+        }
+
+        size_t capacity() const noexcept
+        {
+            return capacity_;
+        }
+
+        void push(chunk_offset_t const o) noexcept
+        {
+            MONAD_ASSERT(capacity_ != 0);
+            auto const wp = next_version_.load(std::memory_order_relaxed);
+            auto const next_wp = wp + 1;
+            MONAD_ASSERT(next_wp != 0);
+            auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                &root_offsets_chunks_[wp & (capacity_ - 1)]);
+            p->store(o, std::memory_order_release);
+            next_version_.store(next_wp, std::memory_order_release);
+            if (o != INVALID_OFFSET) {
+                update_version_lower_bound_();
+            }
+        }
+
+        void assign(size_t const i, chunk_offset_t const o) noexcept
+        {
+            MONAD_ASSERT(capacity_ != 0);
+            auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
+                &root_offsets_chunks_[i & (capacity_ - 1)]);
+            p->store(o, std::memory_order_release);
+            update_version_lower_bound_(
+                (o != INVALID_OFFSET) ? i : uint64_t(-1));
+        }
+
+        chunk_offset_t operator[](size_t const i) const noexcept
+        {
+            MONAD_ASSERT(capacity_ != 0);
+            return start_lifetime_as<std::atomic<chunk_offset_t> const>(
+                       &root_offsets_chunks_[i & (capacity_ - 1)])
+                ->load(std::memory_order_acquire);
+        }
+
+        // return INVALID_BLOCK_NUM indicates that db is empty
+        uint64_t max_version() const noexcept
+        {
+            auto const wp = next_version_.load(std::memory_order_acquire);
+            return wp - 1;
+        }
+
+        uint64_t version_lower_bound() const noexcept
+        {
+            return version_lower_bound_.load(std::memory_order_acquire);
+        }
+
+        void reset_all(uint64_t const version)
+        {
+            MONAD_ASSERT(capacity_ != 0);
+            version_lower_bound_.store(0, std::memory_order_release);
+            next_version_.store(0, std::memory_order_release);
+            memset(
+                (void *)root_offsets_chunks_.data(),
+                0xff,
+                capacity_ * sizeof(chunk_offset_t));
+            version_lower_bound_.store(version, std::memory_order_release);
+            next_version_.store(version, std::memory_order_release);
+        }
+
+        void rewind_to_version(uint64_t const version)
+        {
+            MONAD_ASSERT(version < max_version());
+            MONAD_ASSERT(max_version() - version <= capacity_);
+            for (uint64_t i = version + 1; i <= max_version(); i++) {
+                assign(i, async::INVALID_OFFSET);
+            }
+            if (version <
+                version_lower_bound_.load(std::memory_order_acquire)) {
+                version_lower_bound_.store(version, std::memory_order_release);
+            }
+            next_version_.store(version + 1, std::memory_order_release);
+            update_version_lower_bound_();
+        }
     };
 
     // Construct and mmap metadata from the given AsyncIO's storage pool.
@@ -87,127 +233,29 @@ public:
         std::optional<uint64_t> history_len = {},
         uint32_t initial_insertion_count = 0);
 
-    auto root_offsets(unsigned const which = 0) const
+    // Which physical ring is currently the logical primary. 0 = ring_a,
+    // 1 = ring_b. Atomic acquire load so callers that branch on it pair
+    // naturally with a promote flip done under release.
+    uint8_t primary_ring_idx() const noexcept
     {
-        class root_offsets_delegator
-        {
-            std::atomic_ref<uint64_t> version_lower_bound_;
-            std::atomic_ref<uint64_t> next_version_;
-            std::span<chunk_offset_t> root_offsets_chunks_;
+        return start_lifetime_as<std::atomic<uint8_t> const>(
+                   &copies_[0].main->primary_ring_idx)
+            ->load(std::memory_order_acquire);
+    }
 
-            void update_version_lower_bound_(
-                uint64_t const lower_bound = uint64_t(-1))
-            {
-                auto const version_lower_bound =
-                    version_lower_bound_.load(std::memory_order_acquire);
-                auto idx = (lower_bound < version_lower_bound)
-                               ? lower_bound
-                               : version_lower_bound;
-                auto const max_version =
-                    next_version_.load(std::memory_order_acquire) - 1;
-                if (max_version == INVALID_BLOCK_NUM) {
-                    return;
-                }
-                while (idx < max_version && (*this)[idx] == INVALID_OFFSET) {
-                    idx++;
-                }
-                if (idx != version_lower_bound) {
-                    version_lower_bound_.store(idx, std::memory_order_release);
-                }
-            }
+    root_offsets_delegator
+    root_offsets(timeline_id const tid, unsigned const which = 0) const
+    {
+        auto const primary_idx = primary_ring_idx();
+        auto const ring_idx = (tid == timeline_id::primary)
+                                  ? primary_idx
+                                  : static_cast<uint8_t>(primary_idx ^ 1u);
+        return ring_delegator_(ring_idx, which);
+    }
 
-        public:
-            explicit root_offsets_delegator(metadata_copy const *const m)
-                : version_lower_bound_(
-                      m->main->root_offsets.version_lower_bound_)
-                , next_version_(m->main->root_offsets.next_version_)
-                , root_offsets_chunks_(
-                      std::span<chunk_offset_t>(m->root_offsets))
-            {
-                MONAD_ASSERT_PRINTF(
-                    root_offsets_chunks_.size() ==
-                        1ULL
-                            << (63 -
-                                std::countl_zero(root_offsets_chunks_.size())),
-                    "root offsets chunks size is %lu, not a power of 2",
-                    root_offsets_chunks_.size());
-            }
-
-            size_t capacity() const noexcept
-            {
-                return root_offsets_chunks_.size();
-            }
-
-            void push(chunk_offset_t const o) noexcept
-            {
-                auto const wp = next_version_.load(std::memory_order_relaxed);
-                auto const next_wp = wp + 1;
-                MONAD_ASSERT(next_wp != 0);
-                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &root_offsets_chunks_
-                        [wp & (root_offsets_chunks_.size() - 1)]);
-                p->store(o, std::memory_order_release);
-                next_version_.store(next_wp, std::memory_order_release);
-                if (o != INVALID_OFFSET) {
-                    update_version_lower_bound_();
-                }
-            }
-
-            void assign(size_t const i, chunk_offset_t const o) noexcept
-            {
-                auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &root_offsets_chunks_
-                        [i & (root_offsets_chunks_.size() - 1)]);
-                p->store(o, std::memory_order_release);
-                update_version_lower_bound_(
-                    (o != INVALID_OFFSET) ? i : uint64_t(-1));
-            }
-
-            chunk_offset_t operator[](size_t const i) const noexcept
-            {
-                return start_lifetime_as<std::atomic<chunk_offset_t> const>(
-                           &root_offsets_chunks_
-                               [i & (root_offsets_chunks_.size() - 1)])
-                    ->load(std::memory_order_acquire);
-            }
-
-            // return INVALID_BLOCK_NUM indicates that db is empty
-            uint64_t max_version() const noexcept
-            {
-                auto const wp = next_version_.load(std::memory_order_acquire);
-                return wp - 1;
-            }
-
-            void reset_all(uint64_t const version)
-            {
-                version_lower_bound_.store(0, std::memory_order_release);
-                next_version_.store(0, std::memory_order_release);
-                memset(
-                    (void *)root_offsets_chunks_.data(),
-                    0xff,
-                    root_offsets_chunks_.size() * sizeof(chunk_offset_t));
-                version_lower_bound_.store(version, std::memory_order_release);
-                next_version_.store(version, std::memory_order_release);
-            }
-
-            void rewind_to_version(uint64_t const version)
-            {
-                MONAD_ASSERT(version < max_version());
-                MONAD_ASSERT(max_version() - version <= capacity());
-                for (uint64_t i = version + 1; i <= max_version(); i++) {
-                    assign(i, async::INVALID_OFFSET);
-                }
-                if (version <
-                    version_lower_bound_.load(std::memory_order_acquire)) {
-                    version_lower_bound_.store(
-                        version, std::memory_order_release);
-                }
-                next_version_.store(version + 1, std::memory_order_release);
-                update_version_lower_bound_();
-            }
-        };
-
-        return root_offsets_delegator{&copies_[which]};
+    root_offsets_delegator root_offsets(unsigned const which = 0) const
+    {
+        return root_offsets(timeline_id::primary, which);
     }
 
     // Version metadata getters/setters
@@ -222,8 +270,9 @@ public:
     bytes32_t get_latest_proposed_block_id() const noexcept;
     void
     set_latest_proposed(uint64_t version, bytes32_t const &block_id) noexcept;
-    int64_t get_auto_expire_version_metadata() const noexcept;
-    void set_auto_expire_version_metadata(int64_t version) noexcept;
+    int64_t get_auto_expire_version_metadata(timeline_id tid) const noexcept;
+    void
+    set_auto_expire_version_metadata(timeline_id tid, int64_t version) noexcept;
     void update_history_length_metadata(uint64_t history_len) noexcept;
 
     // Root offsets operations
@@ -265,12 +314,74 @@ public:
         return ro[ro.max_version()];
     }
 
+    // Timeline-aware queries. The single-arg overloads delegate to these
+    // with timeline_id::primary. For timeline_id::secondary they return
+    // INVALID / INVALID_BLOCK_NUM when the timeline is inactive, so
+    // callers don't need to guard with timeline_active() separately.
+    bool timeline_active(timeline_id tid) const noexcept;
+    chunk_offset_t get_root_offset_at_version(
+        uint64_t version, timeline_id tid) const noexcept;
+
+    bool
+    version_is_valid_ondisk(uint64_t version, timeline_id tid) const noexcept
+    {
+        return get_root_offset_at_version(version, tid) != INVALID_OFFSET;
+    }
+
+    uint64_t db_history_max_version(timeline_id tid) const noexcept;
+    uint64_t db_history_min_valid_version(timeline_id tid) const noexcept;
+
     chunk_offset_t get_root_offset_at_version(uint64_t version) const noexcept;
 
     bool version_is_valid_ondisk(uint64_t const version) const noexcept
     {
-        return get_root_offset_at_version(version) != INVALID_OFFSET;
+        return version_is_valid_ondisk(version, timeline_id::primary);
     }
+
+    // Secondary timeline lifecycle — metadata portion only. Callers in
+    // UpdateAux pair these with updates to the per-timeline compaction state.
+    //
+    // activate_secondary_header: atomically shrinks the current primary
+    // ring to half its chunks; the freed chunks are added to the non-
+    // primary ring's cnv_chunks[] list, mmapped into that ring's VA, and
+    // initialised to INVALID_OFFSET. The new ring's header is left at
+    // its zero/INVALID_BLOCK_NUM defaults — version_lower_bound and
+    // next_version are seeded by the first call to fast_forward_next_version
+    // when the secondary timeline writes its first root. The
+    // secondary_timeline_active_ flag flips to 1. The entire sequence is
+    // bracketed by an odd/even transition on shrink_grow_seq_ so concurrent
+    // readers doing a seqlock-protected query retry once over the shrink.
+    //
+    // deactivate_secondary_header: reverse direction. Takes the non-
+    // primary ring's chunks back, adds them to the primary ring's
+    // storage_, and grows the primary ring. Readers similarly retry.
+    void activate_secondary_header();
+    void deactivate_secondary_header();
+
+    // Seqlock accessor. Readers of ring data that want a consistent
+    // snapshot across concurrent shrink/grow operations should:
+    //   do {
+    //     seq = shrink_grow_seq_acquire();
+    //     if (seq & 1) { yield(); continue; }
+    //     /* read ring state */
+    //   } while (seq != shrink_grow_seq_acquire());
+    // Writers bracket mutations with pairs of shrink_grow_seq_fetch_add(1).
+    uint64_t shrink_grow_seq_acquire() const noexcept
+    {
+        return start_lifetime_as<std::atomic<uint64_t> const>(
+                   &copies_[0].main->shrink_grow_seq_)
+            ->load(std::memory_order_acquire);
+    }
+
+    // Flips primary_ring_idx on both metadata copies, swapping which
+    // physical ring is the logical primary. Persistent across restart
+    // because the byte is on-disk metadata; map_ring_a_storage /
+    // map_ring_b_storage always map their physical rings from fixed
+    // locations, and role routing in root_offsets(timeline_id) reads the
+    // byte at query time. Cross-copy crash behavior matches other metadata
+    // fields: either both copies end up flipped, or one does — in either
+    // case the DB is internally consistent because the flip is idempotent.
+    void promote_secondary_to_primary_header() noexcept;
 
     // Apply a function to both metadata copies
     template <typename Func, typename... Args>
@@ -284,18 +395,186 @@ public:
     }
 
 private:
-    // Map root_offsets from cnv chunks. Called by the constructor for existing
-    // pools, and by UpdateAux::init() after writing magic for new pools.
-    void map_root_offsets();
+    // Map ring storage from cnv chunks. Called by the constructor for
+    // existing pools, and by init_new_pool after writing magic for new
+    // pools. Each reserves a max-sized virtual address range sized for
+    // `ring_max_chunks_()`; currently-present chunks (per
+    // root_offsets/secondary_timeline.storage_.cnv_chunks[]) are MAP_FIXED
+    // into their slots. Unoccupied tail slots remain anonymous PROT_NONE
+    // until a future grow maps a chunk into them. Pre-reservation keeps
+    // the span pointer stable across shrink/grow.
+    void map_ring_a_storage();
+    void map_ring_b_storage();
+
+    // Shared helper for the two map_* functions above. The `span_field`
+    // member pointer selects which span slot on metadata_copy gets the
+    // reservation pointer. Defined in the header because Storage is the
+    // unnameable anonymous nested type inside root_offsets_ring_t.
+    template <typename Storage>
+    void map_ring_storage_(
+        Storage const &storage,
+        std::span<chunk_offset_t> metadata_copy::*span_field)
+    {
+        auto const max_chunks = ring_max_chunks_();
+        auto const map_bytes = map_bytes_per_chunk_();
+        auto const reservation_bytes = max_chunks * map_bytes;
+        auto const entries_per_chunk = map_bytes / sizeof(chunk_offset_t);
+
+        std::byte *reservation[2];
+        for (auto &r : reservation) {
+            r = (std::byte *)::mmap(
+                nullptr,
+                reservation_bytes,
+                PROT_NONE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+                -1,
+                0);
+            MONAD_ASSERT(r != MAP_FAILED);
+        }
+
+        for (size_t n = 0; n < storage.cnv_chunks_len; n++) {
+            auto const cnv_chunk_id = storage.cnv_chunks[n].cnv_chunk_id;
+            // Tolerate partial-move state: a crash during the cnv_chunks[]
+            // swap in activate/deactivate can leave a slot at uint32_t(-1)
+            // while cnv_chunks_len still includes it. The tail VA is
+            // PROT_NONE from the initial reservation; leave it alone and
+            // let replay_pending_shrink_grow_ install the correct mapping
+            // after reconstructing the swap.
+            if (cnv_chunk_id == uint32_t(-1)) {
+                continue;
+            }
+            auto &chunk = io_->storage_pool().chunk(
+                MONAD_ASYNC_NAMESPACE::storage_pool::cnv, cnv_chunk_id);
+            auto const fdr = chunk.read_fd();
+            auto const fdw = chunk.write_fd(0);
+            auto const &fd = can_write_to_map_ ? fdw : fdr;
+            MONAD_ASSERT(
+                MAP_FAILED != ::mmap(
+                                  reservation[0] + n * map_bytes,
+                                  map_bytes,
+                                  prot_,
+                                  mapflags_ | MAP_FIXED,
+                                  fd.first,
+                                  off_t(fdr.second)));
+            MONAD_ASSERT(
+                MAP_FAILED != ::mmap(
+                                  reservation[1] + n * map_bytes,
+                                  map_bytes,
+                                  prot_,
+                                  mapflags_ | MAP_FIXED,
+                                  fd.first,
+                                  off_t(fdr.second + map_bytes)));
+        }
+
+        copies_[0].*span_field = {
+            start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[0]),
+            max_chunks * entries_per_chunk};
+        copies_[1].*span_field = {
+            start_lifetime_as<chunk_offset_t>((chunk_offset_t *)reservation[1]),
+            max_chunks * entries_per_chunk};
+    }
+
+    // MAX chunks any single ring could hold = total cnv chunks - 1 (the
+    // first cnv chunk stores db_metadata). Computed from the storage pool
+    // at call time; constant for the life of the pool.
+    uint32_t ring_max_chunks_() const noexcept;
+
+    // Virtual address range size per cnv chunk, i.e. half a cnv chunk's
+    // capacity (the other half holds the second metadata copy's ring
+    // data). Constant for the life of the pool.
+    size_t map_bytes_per_chunk_() const noexcept;
+
+    // Construct a delegator bound to physical ring `ring_idx` (0 = ring_a,
+    // 1 = ring_b) on metadata copy `which`. Capacity snapshot comes from
+    // the ring's cnv_chunks_len × entries_per_chunk; readers that want
+    // capacity consistent with the ring's data should bracket the call
+    // with a shrink_grow_seq_ acquire/check.
+    root_offsets_delegator
+    ring_delegator_(uint8_t ring_idx, unsigned which) const
+    {
+        auto const *m = &copies_[which];
+        auto const entries_per_chunk =
+            map_bytes_per_chunk_() / sizeof(chunk_offset_t);
+        if (ring_idx == 0) {
+            return root_offsets_delegator{
+                m->main->root_offsets.version_lower_bound_,
+                m->main->root_offsets.next_version_,
+                m->ring_a_span,
+                start_lifetime_as<std::atomic<uint32_t> const>(
+                    &m->main->root_offsets.storage_.cnv_chunks_len)
+                        ->load(std::memory_order_acquire) *
+                    entries_per_chunk};
+        }
+        return root_offsets_delegator{
+            m->main->secondary_timeline.version_lower_bound_,
+            m->main->secondary_timeline.next_version_,
+            m->ring_b_span,
+            start_lifetime_as<std::atomic<uint32_t> const>(
+                &m->main->secondary_timeline.storage_.cnv_chunks_len)
+                    ->load(std::memory_order_acquire) *
+                entries_per_chunk};
+    }
 
     detail::db_metadata *main_mutable(unsigned const which = 0) noexcept
     {
         return copies_[which].main;
     }
 
+    // Force metadata chunk 0 (both copies) to durable storage. Called at
+    // the start and end of every activate/deactivate_secondary_header so
+    // that the pending_shrink_grow intent log state is committed to disk
+    // before and after the body runs.
+    void sync_metadata_to_disk_();
+
+    // Force the currently-occupied portions of ring_a and ring_b to durable
+    // storage. Called at the end of activate/deactivate body before the
+    // pending flag is cleared, so that by the time the cleared flag
+    // becomes durable, the ring data it describes is also durable.
+    void sync_ring_data_to_disk_();
+
+    // Stamp / clear the pending-op intent log on both metadata copies.
+    // Both stamp the flag and bump shrink_grow_seq_ (odd on set, even on
+    // clear) under hold_dirty so the dirty-bit recovery path rolls back
+    // any mid-stamp crash cleanly.
+    void set_pending_shrink_grow_(
+        detail::db_metadata::pending_op_kind op_kind,
+        uint32_t target_primary_chunks);
+    void clear_pending_shrink_grow_();
+
+    // Inner body of activate_secondary_header. Idempotent under replay.
+    // Expects the pending flag to already be stamped.
+    void do_activate_secondary_body_(uint32_t new_chunks);
+
+    // Inner body of deactivate_secondary_header. Idempotent under replay.
+    // Expects the pending flag to already be stamped.
+    void do_deactivate_secondary_body_(uint32_t primary_new_chunks);
+
+    // Called from the constructor after map_ring_a/b_storage. If either
+    // metadata copy has pending_shrink_grow.op_kind != NONE, replays the
+    // operation to completion before the constructor returns.
+    void replay_pending_shrink_grow_();
+
+    // Compute the range lower bound for the primary timeline from a
+    // root_offsets_delegator snapshot. Extracted so callers can capture
+    // the delegator once at entry and pass it in, avoiding a
+    // per-sub-call reload of primary_ring_idx that a concurrent promote
+    // could flip — which would otherwise mix max_version from one ring
+    // with offsets read from the other within a single query.
+    uint64_t
+    range_lower_bound_from_ro_(root_offsets_delegator const &ro) const noexcept;
+
     MONAD_ASYNC_NAMESPACE::AsyncIO *io_{nullptr};
     metadata_copy copies_[2];
+    // db_map_size_ is the logical bytes of live metadata (header +
+    // chunk_info[]); metadata_mmap_size_ is the total VA reservation
+    // (cnv chunk 0 half-capacity). The latter is always >= the former
+    // and >= MONAD007_DB_METADATA_SIZE + chunk_info[], so migration
+    // from a MONAD007 pool can read and relocate chunk_info[] without
+    // remapping. Use metadata_mmap_size_ for mmap/munmap and
+    // db_map_size_ for msync/db_copy to avoid syncing megabytes of
+    // dead bytes beyond the logical metadata.
     size_t db_map_size_{0};
+    size_t metadata_mmap_size_{0};
     bool is_new_pool_{false};
     bool can_write_to_map_{false};
     int prot_{0};

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -63,8 +63,11 @@ namespace detail
     // For the memory map of the first conventional chunk
     struct db_metadata
     {
-        static constexpr char const *MAGIC = "MONAD007";
+        static constexpr char const *MAGIC = "MONAD008";
         static constexpr unsigned MAGIC_STRING_LEN = 8;
+        // Previous magic supported via on-the-fly migration (see
+        // DbMetadataContext constructor).
+        static constexpr char const *PREVIOUS_MAGIC = "MONAD007";
 
         friend class MONAD_MPT_NAMESPACE::DbMetadataContext;
         friend class MONAD_MPT_NAMESPACE::UpdateAux;
@@ -88,9 +91,15 @@ namespace detail
         // design works well, because this min is always known to be stored N
         // elements before the max, so no special handling is required when the
         // ring buffer is under capacity.
+        //
+        // Two physically-distinct rings of this type live in db_metadata:
+        // `root_offsets` (ring_a) and `secondary_timeline` (ring_b). Which one
+        // is the logical primary is selected by `primary_ring_idx` below.
+        // SIZE_-1 caps the per-ring cnv_chunks[] list length (vastly over-
+        // provisioned vs. real pools that use at most a handful per ring).
         struct root_offsets_ring_t
         {
-            static constexpr size_t SIZE_ = 65536;
+            static constexpr size_t SIZE_ = 32;
 
             uint64_t version_lower_bound_;
             uint64_t
@@ -109,6 +118,13 @@ namespace detail
                     uint32_t cnv_chunk_id; // The read-write chunk id
                 } cnv_chunks[SIZE_ - 1];
             } storage_;
+
+            // Last upsert's auto-expire version threshold for this timeline.
+            // Persisted per-ring so it travels with the physical data on
+            // promote (the role label flips, but the value stays attached
+            // to the data). Read/written under hold_dirty atomically as
+            // std::atomic_int64_t via start_lifetime_as.
+            int64_t auto_expire_version_;
         } root_offsets;
 
         struct db_offsets_info_t
@@ -152,12 +168,66 @@ namespace detail
         uint64_t latest_verified_version;
         uint64_t latest_voted_version;
         uint64_t latest_proposed_version;
-        int64_t auto_expire_version;
         bytes32_t latest_voted_block_id;
         bytes32_t latest_proposed_block_id;
 
+        // Ring B: second physical root-offsets ring, structurally identical
+        // to root_offsets (ring_a). Both rings have the same header type,
+        // but physically ring_a's cnv_chunks list is populated at pool init
+        // (all ring chunks go to it) while ring_b starts empty. On
+        // activate_secondary_header, ring_a atomically shrinks and the
+        // freed chunks are handed to ring_b; on deactivate they return.
+        root_offsets_ring_t secondary_timeline;
+
+        // Which physical ring is the logical primary:
+        //   0 = root_offsets (ring_a), 1 = secondary_timeline (ring_b).
+        // Promote flips this byte atomically on both metadata copies. Headers
+        // and physical storage stay attached to their rings — only the role
+        // label moves.
+        uint8_t primary_ring_idx;
+        // 1 = secondary role is currently active (the non-primary ring holds
+        // valid data and is being read/written). 0 = inactive; the non-
+        // primary ring's header/data are garbage.
+        uint8_t secondary_timeline_active_;
+        uint8_t reserved_timeline_[6]; // alignment
+
+        // Sequence lock guarding ring shrink/grow. Even = idle; odd = a
+        // shrink or grow is in progress. Readers of the ring (looking up a
+        // root offset for a version + timeline_id) bracket their snapshot
+        // with loads of this field, retrying if it moved or is odd. Written
+        // only by the writer thread around activate/deactivate_secondary.
+        uint64_t shrink_grow_seq_;
+
+        // Intent log for crash-safe ring shrink/grow. The ring data lives
+        // in different backing files from the metadata, so kernel pagecache
+        // writeback can interleave ring writes against metadata writes in
+        // either order. Before touching anything, activate/deactivate
+        // stamps op_kind + target_primary_chunks on both metadata copies
+        // and msyncs; on open, if op_kind is nonzero, the constructor
+        // replays the operation to completion before returning control.
+        // The ring-copy loop and cnv_chunks[] moves are idempotent under
+        // replay, so re-running is safe. Cleared and msync'd before
+        // activate/deactivate returns, so writers never see a durable
+        // "in-progress" flag once the public API call has completed.
+        enum pending_op_kind : uint32_t
+        {
+            PENDING_OP_NONE = 0,
+            PENDING_OP_ACTIVATE = 1, // activate_secondary_header
+            PENDING_OP_DEACTIVATE = 2, // deactivate_secondary_header
+        };
+
+        struct pending_shrink_grow_t
+        {
+            uint32_t op_kind; // pending_op_kind
+            uint32_t target_primary_chunks; // target cnv_chunks_len for primary
+        } pending_shrink_grow;
+
+        static_assert(sizeof(pending_shrink_grow_t) == 8);
+
         // padding for adding future atomics without requiring DB reset
-        uint8_t future_variables_unused[4032];
+        uint8_t future_variables_unused
+            [4032 - sizeof(root_offsets_ring_t) - 8 - 8 -
+             sizeof(pending_shrink_grow_t)];
 
         // used to know if the metadata was being
         // updated when the process suddenly exited
@@ -459,7 +529,13 @@ namespace detail
 
     static_assert(std::is_trivially_copyable_v<db_metadata>);
     static_assert(std::is_trivially_copy_assignable_v<db_metadata>);
-    static_assert(sizeof(db_metadata) == 528512);
+    // The fixed-header size is pinned so that adding or shrinking a
+    // field in the header is a conscious decision. The actual mmap
+    // region is sizeof(db_metadata) + chunk_count * sizeof(chunk_info_t)
+    // and must fit in cnv.capacity()/2 (copy 0 at offset 0, copy 1 at
+    // cnv.capacity()/2); enlarging the fixed header eats into the
+    // chunk_info[] budget for any given chunk_count.
+    static_assert(sizeof(db_metadata) == 4480);
     static_assert(alignof(db_metadata) == 8);
 
     inline void atomic_memcpy(
@@ -513,6 +589,9 @@ namespace detail
         dest->root_offsets.next_version_ = 0; // INVALID_BLOCK_NUM
         auto const old_next_version = intr->root_offsets.next_version_;
         intr->root_offsets.next_version_ = 0; // INVALID_BLOCK_NUM
+        dest->secondary_timeline.next_version_ = 0;
+        auto const old_secondary_next = intr->secondary_timeline.next_version_;
+        intr->secondary_timeline.next_version_ = 0;
         atomic_memcpy((void *)dest, buffer, sizeof(db_metadata));
         atomic_memcpy(
             ((std::byte *)dest) + sizeof(db_metadata),
@@ -520,6 +599,8 @@ namespace detail
             bytes - sizeof(db_metadata));
         std::atomic_ref<uint64_t>(dest->root_offsets.next_version_)
             .store(old_next_version, std::memory_order_release);
+        std::atomic_ref<uint64_t>(dest->secondary_timeline.next_version_)
+            .store(old_secondary_next, std::memory_order_release);
     };
 }
 

--- a/category/mpt/detail/timeline.hpp
+++ b/category/mpt/detail/timeline.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/mpt/config.hpp>
+#include <category/mpt/util.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+enum class timeline_id : uint8_t
+{
+    primary = 0,
+    secondary = 1
+};
+
+static constexpr unsigned NUM_TIMELINES = 2;
+static_assert(
+    static_cast<unsigned>(timeline_id::secondary) + 1 == NUM_TIMELINES);
+
+/// Per-timeline compaction state. Each timeline maintains its own compaction
+/// boundary and stride. Disk growth tracking remains global since both
+/// timelines share the same fast/slow append rings.
+struct timeline_compaction_state
+{
+    compact_offset_pair compact_offsets{
+        MIN_COMPACT_VIRTUAL_OFFSET, MIN_COMPACT_VIRTUAL_OFFSET};
+    compact_virtual_chunk_offset_t compact_offset_range_fast_{
+        MIN_COMPACT_VIRTUAL_OFFSET};
+    compact_virtual_chunk_offset_t compact_offset_range_slow_{
+        MIN_COMPACT_VIRTUAL_OFFSET};
+    int64_t curr_upsert_auto_expire_version{0};
+};
+
+static_assert(std::is_trivially_copyable_v<timeline_compaction_state>);
+
+MONAD_MPT_NAMESPACE_END

--- a/category/mpt/find.cpp
+++ b/category/mpt/find.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/assert.h>
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
@@ -28,7 +29,7 @@ MONAD_MPT_NAMESPACE_BEGIN
 
 find_cursor_result_type find_blocking(
     UpdateAux const &aux, NodeCursor const root, NibblesView const key,
-    uint64_t const version)
+    uint64_t const version, timeline_id const tid)
 {
     if (!root.is_valid()) {
         return {NodeCursor{}, find_result::root_node_is_null_failure};
@@ -49,7 +50,7 @@ find_cursor_result_type find_blocking(
                 !node->next(idx)) {
                 MONAD_ASSERT(aux.is_on_disk());
                 auto next_node_ondisk =
-                    read_node_blocking(aux, node->fnext(idx), version);
+                    read_node_blocking(aux, node->fnext(idx), version, tid);
                 if (!next_node_ondisk) {
                     return {NodeCursor{}, find_result::version_no_longer_exist};
                 }

--- a/category/mpt/ondisk_db_config.hpp
+++ b/category/mpt/ondisk_db_config.hpp
@@ -43,9 +43,12 @@ struct OnDiskDbConfig
     // fixed history length if contains value, otherwise rely on db to adjust
     // history length upon disk usage
     std::optional<uint64_t> fixed_history_length{std::nullopt};
-    // Number of chunks to allocate for root offsets when initializing the disk.
-    // Each chunk can hold 1 << 24 = 16777216 historical entries.
-    // This field must be power of 2.
+    // Number of cnv chunks allocated for root-offset ring storage. All are
+    // assigned to the primary ring at pool init (secondary ring starts
+    // empty). On activating the secondary timeline, the primary ring shrinks
+    // in half and the freed chunk(s) are handed to the secondary. On
+    // deactivation the chunks are returned to the primary. Must be a power
+    // of 2. Each chunk can hold 1 << 24 = 16777216 historical entries.
     uint32_t root_offsets_chunk_count{2};
 };
 

--- a/category/mpt/read_node_blocking.cpp
+++ b/category/mpt/read_node_blocking.cpp
@@ -16,6 +16,7 @@
 #include <category/async/detail/scope_polyfill.hpp>
 #include <category/core/assert.h>
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
@@ -31,10 +32,10 @@ MONAD_MPT_NAMESPACE_BEGIN
 
 Node::SharedPtr read_node_blocking(
     UpdateAux const &aux, chunk_offset_t const node_offset,
-    uint64_t const version)
+    uint64_t const version, timeline_id const tid)
 {
     MONAD_ASSERT(aux.is_on_disk());
-    if (!aux.metadata_ctx().version_is_valid_ondisk(version)) {
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version, tid)) {
         return {};
     }
     auto &pool = aux.io->storage_pool();
@@ -67,7 +68,7 @@ Node::SharedPtr read_node_blocking(
             rd_offset,
             strerror(errno));
     }
-    return aux.metadata_ctx().version_is_valid_ondisk(version)
+    return aux.metadata_ctx().version_is_valid_ondisk(version, tid)
                ? deserialize_node_from_buffer(
                      buffer + buffer_off, size_t(bytes_read) - buffer_off)
                : Node::SharedPtr{};

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")
 add_trie_test(TARGET update_aux_test SOURCES "update_aux_test.cpp")
 add_trie_test(TARGET db_test SOURCES "db_test.cpp")
+add_trie_test(TARGET dual_timeline_test SOURCES "dual_timeline_test.cpp")
 add_trie_test(TARGET load_all_test SOURCES "load_all_test.cpp")
 add_trie_test(TARGET many_nested_updates SOURCES "many_nested_updates.cpp"
               LINK_LIBRARIES Boost::json)

--- a/category/mpt/test/append_test.cpp
+++ b/category/mpt/test/append_test.cpp
@@ -19,6 +19,7 @@
 #include <category/async/config.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/update.hpp>
 
 #include <iostream>
@@ -76,7 +77,10 @@ TYPED_TEST(AppendTest, works)
 
     // Get new current root
     this->state()->root = read_node_blocking(
-        this->state()->aux, last_root_off, last_root_version);
+        this->state()->aux,
+        last_root_off,
+        last_root_version,
+        timeline_id::primary);
 
     std::cout << "\nAfter rewind:";
     this->state()->print(std::cout);
@@ -123,7 +127,11 @@ TYPED_TEST(AppendTest, works)
             std::move(this->state()->root),
             this->state()->sm,
             std::move(update_ls),
-            this->state()->version++);
+            this->state()->version++,
+            /*compaction=*/false,
+            /*can_write_to_fast=*/true,
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     auto const root_hash_after2 = this->state()->root_hash();

--- a/category/mpt/test/blocking_read_concurrency_test.cpp
+++ b/category/mpt/test/blocking_read_concurrency_test.cpp
@@ -23,6 +23,7 @@
 #include <category/core/keccak.h>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/test/test_fixtures_base.hpp>
@@ -102,7 +103,8 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
     Node::SharedPtr root = read_node_blocking(
         state()->aux,
         state()->aux.metadata_ctx().get_root_offset_at_version(latest_version),
-        latest_version);
+        latest_version,
+        timeline_id::primary);
     ASSERT_TRUE(root);
     auto const &key = state()->keys.front().first;
     auto const &value = state()->keys.front().first;
@@ -128,8 +130,12 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
             for (unsigned idx = 0; idx < root->number_of_children(); ++idx) {
                 root->move_next(idx).reset();
             }
-            auto [node_cursor, res] =
-                find_blocking(ro_aux, NodeCursor{root}, key, latest_version);
+            auto [node_cursor, res] = find_blocking(
+                ro_aux,
+                NodeCursor{root},
+                key,
+                latest_version,
+                timeline_id::primary);
             if (res != find_result::success) {
                 ASSERT_EQ(res, find_result::version_no_longer_exist);
                 completion_promise.set_value(count);
@@ -155,7 +161,7 @@ TEST_F(DbConcurrencyTest1, version_outdated_during_blocking_find)
     // Erase the version being read should trigger a find failure and ends the
     // reader thread
     state()->aux.metadata_ctx().update_root_offset(
-        latest_version, INVALID_OFFSET);
+        latest_version, INVALID_OFFSET, timeline_id::primary);
     EXPECT_FALSE(
         state()->aux.metadata_ctx().version_is_valid_ondisk(latest_version));
 
@@ -185,7 +191,8 @@ TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
     Node::SharedPtr root = read_node_blocking(
         state()->aux,
         state()->aux.metadata_ctx().get_root_offset_at_version(latest_version),
-        latest_version);
+        latest_version,
+        timeline_id::primary);
     ASSERT_TRUE(root);
 
     // Create a promise/future pair to track completion
@@ -230,7 +237,7 @@ TEST_F(DbConcurrencyTest2, version_outdated_during_blocking_traverse)
     }
     // Erase the version being read should stop traverse in the reader thread
     state()->aux.metadata_ctx().update_root_offset(
-        latest_version, INVALID_OFFSET);
+        latest_version, INVALID_OFFSET, timeline_id::primary);
     EXPECT_FALSE(
         state()->aux.metadata_ctx().version_is_valid_ondisk(latest_version));
 

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -24,6 +24,8 @@
 #include <category/core/io/ring.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/cli_tool_impl.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
@@ -31,6 +33,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <future>
 #include <iostream>
@@ -416,4 +420,209 @@ struct cli_tool_non_one_one_chunk_ids
 TEST_F(cli_tool_non_one_one_chunk_ids, cli_tool_non_one_one_chunk_ids)
 {
     run_test();
+}
+
+// --upgrade on a pool created with --create and thus already on MONAD008.
+// Must be idempotent: exit 0, print "DB is on version MONAD008".
+TEST(cli_tool, upgrade_idempotent_on_current_pool)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--upgrade"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_EQ(0, retcode);
+        EXPECT_NE(
+            std::string::npos, cout.str().find("DB is on version MONAD008"));
+    }
+}
+
+// --upgrade combined with --create must be rejected at CLI parse time
+// because cli_ops_group enforces require_option(0, 1).
+TEST(cli_tool, upgrade_rejects_combined_mutation)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt", "--storage", temppath, "--upgrade", "--create"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_NE(0, retcode);
+    EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+}
+
+// Full end-to-end: create a fresh MONAD008 pool, overwrite cnv chunk 0
+// with a MONAD007 layout via the storage_pool's own chunk API (so the
+// file offset is correct regardless of pool internal layout), then run
+// monad-mpt --upgrade and verify the metadata is now MONAD008 and the
+// history_length survived at its new offset.
+TEST(cli_tool, upgrade_migrates_monad007_pool)
+{
+    using monad::mpt::detail::db_metadata;
+    static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+    static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
+
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+
+    // Provision the file as a MONAD008 pool via --create.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    // Overwrite cnv chunk 0 (both halves) with a MONAD007 layout. Open
+    // the pool writable (allow_migration = false because the pool is
+    // already MONAD008 — the ctor won't try to migrate), use the chunk
+    // API to get the correct file offset for chunk 0 and the pool's
+    // real chunk_count, then pwrite MONAD007 bytes over both halves.
+    // Close the pool without writing metadata.
+    //
+    // The chunk_info[] array at MONAD007's offset MONAD007_DB_METADATA_SIZE
+    // is zero-filled — zeros decode as INVALID_CHUNK_ID entries per
+    // db_metadata convention, so relocation is a pure byte move and the
+    // resulting MONAD008 pool passes UpdateAux::init's chunk_info_count
+    // check.
+    uint64_t const test_history_length = 9999;
+    {
+        std::vector<std::filesystem::path> paths{temppath};
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags const flags;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            std::span{paths},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        // chunk_info_count stored on disk must equal io->chunk_count(),
+        // which returns seq_chunks.size() only (see AsyncIO::chunk_count
+        // and the new-pool init in DbMetadataContext ctor). The
+        // chunk_info[] flexible array is sized to match.
+        uint32_t const chunk_count = static_cast<uint32_t>(
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq));
+        auto &cnv_chunk =
+            pool.chunk(MONAD_ASYNC_NAMESPACE::storage_pool::cnv, 0);
+        auto const [write_fd, base_offset] = cnv_chunk.write_fd(0);
+        off_t const half_capacity = // NOLINT(misc-include-cleaner)
+            static_cast<off_t>(cnv_chunk.capacity() / 2);
+
+        std::vector<uint8_t> buf(
+            MONAD007_DB_METADATA_SIZE +
+                size_t(chunk_count) * sizeof(db_metadata::chunk_info_t),
+            0);
+        memcpy(
+            buf.data(),
+            db_metadata::PREVIOUS_MAGIC,
+            db_metadata::MAGIC_STRING_LEN);
+        uint64_t const bitfield =
+            static_cast<uint64_t>(chunk_count) & 0xfffffULL;
+        memcpy(buf.data() + 8, &bitfield, 8);
+        uint32_t const high_bits_all_set = uint32_t(-1);
+        uint32_t const cnv_len = 0;
+        memcpy(buf.data() + 40, &high_bits_all_set, 4);
+        memcpy(buf.data() + 44, &cnv_len, 4);
+        memcpy(buf.data() + 524344, &test_history_length, 8);
+        uint32_t const invalid = UINT32_MAX;
+        for (int i = 0; i < 6; i++) {
+            memcpy(
+                buf.data() + MONAD007_LIST_TRIPLE_OFFSET + i * 4, &invalid, 4);
+        }
+
+        for (off_t copy_idx = 0; copy_idx < 2;
+             copy_idx++) { // NOLINT(misc-include-cleaner)
+            ssize_t const written = ::pwrite( // NOLINT(misc-include-cleaner)
+                write_fd,
+                buf.data(),
+                buf.size(),
+                off_t(base_offset) + copy_idx * half_capacity);
+            ASSERT_EQ(ssize_t(buf.size()), written);
+        }
+        ASSERT_EQ(0, ::fsync(write_fd));
+    }
+
+    // Run --upgrade. Expect exit 0 and "Success." on stdout.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--upgrade"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_EQ(0, retcode) << "stderr: " << cerr.str();
+        EXPECT_NE(std::string::npos, cout.str().find("Success."));
+    }
+
+    // Reopen read-only; magic must now be MONAD008 and history_length
+    // must survive at its new offset.
+    {
+        std::vector<std::filesystem::path> paths{temppath};
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.open_read_only = true;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            std::span{paths},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        monad::io::Ring ring;
+        monad::io::Buffers rbuf = monad::io::make_buffers_for_read_only(
+            ring,
+            2,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rbuf};
+        monad::mpt::DbMetadataContext const ctx{io};
+        auto const *const m = ctx.main();
+        EXPECT_EQ(
+            0,
+            memcmp(
+                m->magic, db_metadata::MAGIC, db_metadata::MAGIC_STRING_LEN));
+        EXPECT_EQ(m->history_length, test_history_length);
+    }
+}
+
+TEST(cli_tool, upgrade_requires_storage)
+{
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {"monad-mpt", "--upgrade"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_NE(0, retcode);
+    EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
 }

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -24,6 +24,7 @@
 #include <category/core/io/ring.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/cli_tool_impl.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
 #include <category/mpt/trie.hpp>
@@ -238,7 +239,8 @@ struct cli_tool_fixture
                 monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
                     aux,
                     aux.metadata_ctx().get_latest_root_offset(),
-                    aux.metadata_ctx().db_history_max_version())};
+                    aux.metadata_ctx().db_history_max_version(),
+                    monad::mpt::timeline_id::primary)};
                 monad::mpt::NodeCursor const root(root_ptr);
 
                 for (auto const &key : this->state()->keys) {
@@ -246,7 +248,8 @@ struct cli_tool_fixture
                         aux,
                         root,
                         key.first,
-                        aux.metadata_ctx().db_history_max_version());
+                        aux.metadata_ctx().db_history_max_version(),
+                        monad::mpt::timeline_id::primary);
                     EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                 }
                 EXPECT_EQ(
@@ -347,7 +350,8 @@ struct cli_tool_fixture
                         read_node_blocking(
                             aux,
                             aux.metadata_ctx().get_latest_root_offset(),
-                            aux.metadata_ctx().db_history_max_version())};
+                            aux.metadata_ctx().db_history_max_version(),
+                            monad::mpt::timeline_id::primary)};
                     monad::mpt::NodeCursor const root(root_ptr);
 
                     for (auto const &key : this->state()->keys) {
@@ -355,7 +359,8 @@ struct cli_tool_fixture
                             aux,
                             root,
                             key.first,
-                            aux.metadata_ctx().db_history_max_version());
+                            aux.metadata_ctx().db_history_max_version(),
+                            monad::mpt::timeline_id::primary);
                         EXPECT_EQ(ret.second, monad::mpt::find_result::success);
                     }
                     EXPECT_EQ(

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -626,3 +626,290 @@ TEST(cli_tool, upgrade_requires_storage)
     ASSERT_NE(0, retcode);
     EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
 }
+
+namespace
+{
+    // RAII temp file sized for monad-mpt's expected pool layout.
+    class TempPool
+    {
+        char path_[sizeof("cli_tool_test_XXXXXX")] = "cli_tool_test_XXXXXX";
+
+    public:
+        TempPool()
+        {
+            int const fd = mkstemp(path_);
+            if (fd == -1) {
+                abort();
+            }
+            ::close(fd);
+            if (truncate(path_, 6ULL * 1024 * 1024 * 1024) == -1) {
+                abort();
+            }
+        }
+
+        ~TempPool() noexcept
+        {
+            unlink(path_);
+        }
+
+        TempPool(TempPool const &) = delete;
+        TempPool &operator=(TempPool const &) = delete;
+
+        char const *path() const noexcept
+        {
+            return path_;
+        }
+    };
+
+    void create_pool(char const *const path)
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {"monad-mpt", "--storage", path, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    bool secondary_timeline_active(char const *const path)
+    {
+        std::vector<std::filesystem::path> paths{path};
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.open_read_only = true;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            std::span{paths},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        monad::io::Ring ring;
+        monad::io::Buffers rbuf = monad::io::make_buffers_for_read_only(
+            ring,
+            2,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rbuf};
+        monad::mpt::DbMetadataContext const ctx{io};
+        return ctx.timeline_active(monad::mpt::timeline_id::secondary);
+    }
+
+    uint8_t primary_ring_idx(char const *const path)
+    {
+        std::vector<std::filesystem::path> paths{path};
+        MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags flags;
+        flags.open_read_only = true;
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{
+            std::span{paths},
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing,
+            flags};
+        monad::io::Ring ring;
+        monad::io::Buffers rbuf = monad::io::make_buffers_for_read_only(
+            ring,
+            2,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, rbuf};
+        monad::mpt::DbMetadataContext const ctx{io};
+        return ctx.primary_ring_idx();
+    }
+}
+
+// --activate-secondary-timeline marks the secondary active in metadata.
+TEST(cli_tool, activate_secondary_timeline_creates_secondary)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--activate-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_EQ(0, retcode) << "stderr: " << cerr.str();
+        EXPECT_NE(
+            std::string::npos, cout.str().find("Activated secondary timeline"));
+    }
+    EXPECT_TRUE(secondary_timeline_active(tp.path()));
+}
+
+// Activating a second time without deactivating fails with a clear error.
+TEST(cli_tool, activate_secondary_rejects_when_already_active)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--activate-secondary-timeline"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--activate-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_NE(0, retcode);
+        EXPECT_NE(
+            std::string::npos,
+            cerr.str().find("secondary timeline is already active"));
+    }
+}
+
+// --deactivate-secondary-timeline drops a previously activated secondary.
+TEST(cli_tool, deactivate_secondary_timeline_removes_secondary)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--activate-secondary-timeline"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    EXPECT_TRUE(secondary_timeline_active(tp.path()));
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--deactivate-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_EQ(0, retcode) << "stderr: " << cerr.str();
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Deactivated secondary timeline"));
+    }
+    EXPECT_FALSE(secondary_timeline_active(tp.path()));
+}
+
+// Deactivating without an active secondary fails.
+TEST(cli_tool, deactivate_without_active_secondary_fails)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt", "--storage", tp.path(), "--deactivate-secondary-timeline"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_NE(0, retcode);
+    EXPECT_NE(
+        std::string::npos, cerr.str().find("requires an active secondary"));
+}
+
+// Promoting without an active secondary fails.
+TEST(cli_tool, promote_without_active_secondary_fails)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt", "--storage", tp.path(), "--promote-secondary-timeline"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_NE(0, retcode);
+    EXPECT_NE(
+        std::string::npos, cerr.str().find("requires an active secondary"));
+}
+
+// --promote-secondary-timeline flips the on-disk primary_ring_idx.
+TEST(cli_tool, promote_secondary_timeline_swaps_roles)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    uint8_t const idx_before_activate = primary_ring_idx(tp.path());
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--activate-secondary-timeline"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    EXPECT_EQ(idx_before_activate, primary_ring_idx(tp.path()))
+        << "activate alone should not change primary_ring_idx";
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            tp.path(),
+            "--promote-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_EQ(0, retcode) << "stderr: " << cerr.str();
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Promoted secondary timeline to primary"));
+    }
+    EXPECT_NE(idx_before_activate, primary_ring_idx(tp.path()))
+        << "promote should flip primary_ring_idx";
+}
+
+// CLI11's require_option(0, 1) on the mutating-ops group rejects pairs.
+TEST(cli_tool, secondary_timeline_flags_mutually_exclusive)
+{
+    TempPool const tp;
+    ASSERT_NO_FATAL_FAILURE(create_pool(tp.path()));
+
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt",
+        "--storage",
+        tp.path(),
+        "--activate-secondary-timeline",
+        "--deactivate-secondary-timeline"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_NE(0, retcode);
+    EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+}
+
+TEST(cli_tool, secondary_timeline_flags_require_storage)
+{
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--activate-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_NE(0, retcode);
+        EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {"monad-mpt", "--promote-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_NE(0, retcode);
+        EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--deactivate-secondary-timeline"};
+        int const retcode = main_impl(cout, cerr, args);
+        ASSERT_NE(0, retcode);
+        EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+    }
+}

--- a/category/mpt/test/compaction_test.cpp
+++ b/category/mpt/test/compaction_test.cpp
@@ -19,6 +19,7 @@
 #include <category/async/config.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
@@ -63,7 +64,11 @@ TEST_F(CompactionTest, first_chunk_is_compacted)
         std::move(state()->root),
         state()->sm,
         std::move(update_ls),
-        state()->version++);
+        state()->version++,
+        /*compaction=*/false,
+        /*can_write_to_fast=*/true,
+        /*write_root=*/true,
+        timeline_id::primary);
     std::cout << "\nBefore compaction:";
     state()->print(std::cout);
     // TODO DO COMPACTION

--- a/category/mpt/test/db_metadata_test.cpp
+++ b/category/mpt/test/db_metadata_test.cpp
@@ -22,12 +22,14 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <ostream>
 #include <stop_token>
 #include <thread>
+#include <utility>
 
 TEST(db_metadata, DISABLED_copy)
 {
@@ -96,4 +98,145 @@ TEST(db_metadata, DISABLED_copy)
     thread.join();
     EXPECT_GT(count, 0);
     std::cout << count << std::endl;
+}
+
+// -------------------------------------------------------------------
+// secondary_timeline_header_t layout and semantics
+// -------------------------------------------------------------------
+
+TEST(db_metadata, total_size)
+{
+    // Both rings now use the same ring-header type. The total metadata size
+    // is dominated by the cnv_chunks lists in each ring (SIZE_=32).
+    EXPECT_EQ(sizeof(monad::mpt::detail::db_metadata), 4480u);
+}
+
+TEST(db_metadata, ring_b_layout_matches_ring_a)
+{
+    using md = monad::mpt::detail::db_metadata;
+    // Both physical rings use the same header type, so promote is a mere
+    // label flip — no structural asymmetry between the rings.
+    EXPECT_EQ(
+        sizeof(md::root_offsets_ring_t),
+        sizeof(std::declval<md &>().root_offsets));
+    EXPECT_EQ(
+        sizeof(md::root_offsets_ring_t),
+        sizeof(std::declval<md &>().secondary_timeline));
+
+    // Layout order: root_offsets → ... → secondary_timeline →
+    // primary_ring_idx → secondary_timeline_active_ → reserved_timeline_[6]
+    // → shrink_grow_seq_ → pending_shrink_grow → future_variables_unused.
+    auto const offset_secondary = offsetof(md, secondary_timeline);
+    auto const offset_primary_ring_idx = offsetof(md, primary_ring_idx);
+    auto const offset_active = offsetof(md, secondary_timeline_active_);
+    auto const offset_reserved = offsetof(md, reserved_timeline_);
+    auto const offset_seq = offsetof(md, shrink_grow_seq_);
+    auto const offset_pending = offsetof(md, pending_shrink_grow);
+    auto const offset_future = offsetof(md, future_variables_unused);
+    EXPECT_EQ(
+        offset_primary_ring_idx - offset_secondary,
+        sizeof(md::root_offsets_ring_t));
+    EXPECT_EQ(offset_active, offset_primary_ring_idx + 1);
+    EXPECT_EQ(offset_reserved, offset_active + 1);
+    EXPECT_EQ(offset_seq, offset_reserved + 6);
+    EXPECT_EQ(offset_pending, offset_seq + 8);
+    EXPECT_EQ(
+        offset_future, offset_pending + sizeof(md::pending_shrink_grow_t));
+}
+
+TEST(db_metadata, role_bytes_zero_initialized)
+{
+    // A freshly created (zeroed) db_metadata has ring_a as primary and
+    // the secondary role inactive. Backward-compat: older DBs opened by
+    // new code see the secondary as inactive and ring_a as primary.
+    auto *m = (monad::mpt::detail::db_metadata *)calloc(
+        1, sizeof(monad::mpt::detail::db_metadata));
+    auto const cleanup = monad::make_scope_exit([&]() noexcept { free(m); });
+
+    EXPECT_EQ(m->secondary_timeline.version_lower_bound_, 0u);
+    EXPECT_EQ(m->secondary_timeline.next_version_, 0u);
+    EXPECT_EQ(m->primary_ring_idx, 0u);
+    EXPECT_EQ(m->secondary_timeline_active_, 0u);
+}
+
+TEST(db_metadata, secondary_timeline_header_read_write)
+{
+    using md = monad::mpt::detail::db_metadata;
+    // Verify fields can be set and read back through the metadata struct.
+    auto *m = static_cast<md *>(calloc(1, sizeof(md)));
+    auto const cleanup = monad::make_scope_exit([&]() noexcept { free(m); });
+
+    m->secondary_timeline.version_lower_bound_ = 42;
+    m->secondary_timeline.next_version_ = 43;
+    m->secondary_timeline_active_ = 1;
+    m->primary_ring_idx = 1;
+
+    EXPECT_EQ(m->secondary_timeline.version_lower_bound_, 42u);
+    EXPECT_EQ(m->secondary_timeline.next_version_, 43u);
+    EXPECT_EQ(m->secondary_timeline_active_, 1u);
+    EXPECT_EQ(m->primary_ring_idx, 1u);
+}
+
+TEST(db_metadata, secondary_timeline_header_survives_metadata_copy)
+{
+    using md = monad::mpt::detail::db_metadata;
+    // The dual-copy crash-safety mechanism uses raw memcpy between the two
+    // metadata copies. The secondary header and top-level role bytes must
+    // survive this.
+    auto *src = static_cast<md *>(calloc(1, sizeof(md)));
+    auto const cleanup_src =
+        monad::make_scope_exit([&]() noexcept { free(src); });
+    src->secondary_timeline.version_lower_bound_ = 100;
+    src->secondary_timeline.next_version_ = 200;
+    src->secondary_timeline_active_ = 1;
+    src->primary_ring_idx = 1;
+
+    auto *dst = static_cast<md *>(calloc(1, sizeof(md)));
+    auto const cleanup_dst =
+        monad::make_scope_exit([&]() noexcept { free(dst); });
+    std::memcpy(dst, src, sizeof(md));
+
+    EXPECT_EQ(dst->secondary_timeline.version_lower_bound_, 100u);
+    EXPECT_EQ(dst->secondary_timeline.next_version_, 200u);
+    EXPECT_EQ(dst->secondary_timeline_active_, 1u);
+    EXPECT_EQ(dst->primary_ring_idx, 1u);
+}
+
+TEST(db_metadata, secondary_timeline_does_not_overlap_consensus_fields)
+{
+    using md = monad::mpt::detail::db_metadata;
+    // The secondary header must not overlap with consensus fields that
+    // precede it.
+    auto const end_of_proposed_block_id =
+        offsetof(md, latest_proposed_block_id) +
+        sizeof(std::declval<md &>().latest_proposed_block_id);
+    auto const start_of_secondary = offsetof(md, secondary_timeline);
+    EXPECT_GE(start_of_secondary, end_of_proposed_block_id);
+}
+
+// db_copy zeroes next_version_ on dest before the bulk memcpy, then atomically
+// restores both root_offsets.next_version_ and secondary_timeline.next_version_
+// after, so concurrent readers never observe a half-copied ring with a stale
+// advance cursor. Verify the secondary cursor is preserved.
+TEST(db_metadata, db_copy_preserves_secondary_next_version)
+{
+    using md = monad::mpt::detail::db_metadata;
+    auto *src = static_cast<md *>(calloc(1, sizeof(md)));
+    auto *dst = static_cast<md *>(calloc(1, sizeof(md)));
+    auto const cleanup = monad::make_scope_exit([&]() noexcept {
+        free(src);
+        free(dst);
+    });
+
+    src->secondary_timeline.version_lower_bound_ = 7;
+    src->secondary_timeline.next_version_ = 42;
+    src->secondary_timeline_active_ = 1;
+    src->primary_ring_idx = 1;
+
+    monad::mpt::detail::db_copy(dst, src, sizeof(md));
+
+    EXPECT_EQ(dst->secondary_timeline.version_lower_bound_, 7u);
+    EXPECT_EQ(dst->secondary_timeline.next_version_, 42u);
+    EXPECT_EQ(dst->secondary_timeline_active_, 1u);
+    EXPECT_EQ(dst->primary_ring_idx, 1u);
 }

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -32,6 +32,7 @@
 #include <category/mpt/compute.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/db_error.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
@@ -2884,7 +2885,7 @@ TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
     EXPECT_EQ(
         test::DbAccessor::aux(db)
             .metadata_ctx()
-            .get_auto_expire_version_metadata(),
+            .get_auto_expire_version_metadata(monad::mpt::timeline_id::primary),
         0);
 
     // Move trie from version 0 to version 1000
@@ -2895,7 +2896,7 @@ TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
     EXPECT_EQ(
         test::DbAccessor::aux(db)
             .metadata_ctx()
-            .get_auto_expire_version_metadata(),
+            .get_auto_expire_version_metadata(monad::mpt::timeline_id::primary),
         start_version)
         << "auto_expire_version_metadata should be moved forward with "
            "move_trie_version_forward";

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -2901,3 +2901,74 @@ TEST_F(OnDiskDbWithFileFixture, move_trie_version_forward_updates_auto_expire)
         << "auto_expire_version_metadata should be moved forward with "
            "move_trie_version_forward";
 }
+
+TEST_F(OnDiskDbWithFileFixture, timeline_lifecycle_activate_deactivate)
+{
+    // Insert data on primary timeline
+    auto const k1 = 0x12345678_bytes;
+    auto u1 = make_update(k1, k1);
+    UpdateList ul;
+    ul.push_front(u1);
+    root = db.upsert(std::move(root), std::move(ul), 0);
+    ASSERT_NE(root, nullptr);
+
+    // Initially only primary is active
+    EXPECT_TRUE(db.timeline_active(timeline_id::primary));
+    EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+
+    // Activate secondary timeline (starts empty; first upsert seeds it)
+    StateMachineAlwaysEmpty secondary_machine;
+    {
+        auto const secondary_db =
+            db.activate_secondary_timeline(secondary_machine);
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+    }
+
+    // Deactivate
+    db.deactivate_secondary_timeline();
+    EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+}
+
+TEST_F(OnDiskDbWithFileFixture, timeline_lifecycle_dual_upsert)
+{
+    // Insert data on primary timeline
+    auto const k1 = 0x12345678_bytes;
+    auto u1 = make_update(k1, k1);
+    UpdateList ul;
+    ul.push_front(u1);
+    root = db.upsert(std::move(root), std::move(ul), 0);
+    ASSERT_NE(root, nullptr);
+
+    // Activate secondary with a different compute
+    StateMachineAlwaysEmpty secondary_machine;
+    auto secondary_db = db.activate_secondary_timeline(secondary_machine);
+
+    // Upsert the same data on secondary timeline
+    auto const k2 = 0x22345678_bytes;
+    auto u2 = make_update(k2, k2);
+    UpdateList ul2;
+    ul2.push_front(u2);
+
+    // Upsert to primary
+    auto const primary_root = db.upsert(root, std::move(ul2), 1);
+    ASSERT_NE(primary_root, nullptr);
+
+    // Upsert same data to secondary
+    auto u3 = make_update(k2, k2);
+    UpdateList ul3;
+    ul3.push_front(u3);
+    Node::SharedPtr secondary_root;
+    secondary_root =
+        secondary_db.upsert(std::move(secondary_root), std::move(ul3), 1);
+    ASSERT_NE(secondary_root, nullptr);
+
+    // Both roots should exist
+    EXPECT_NE(primary_root.get(), secondary_root.get());
+
+    // Cleanup: destroy secondary Db first, then deactivate
+    {
+        Db const moved_out = std::move(secondary_db);
+        (void)moved_out;
+    }
+    db.deactivate_secondary_timeline();
+}

--- a/category/mpt/test/dual_timeline_test.cpp
+++ b/category/mpt/test/dual_timeline_test.cpp
@@ -1,0 +1,1015 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "test_fixtures_base.hpp"
+#include "test_fixtures_gtest.hpp"
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/hex.hpp>
+#include <category/core/result.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/db_error.hpp>
+#include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/node.hpp>
+#include <category/mpt/node_cursor.hpp>
+#include <category/mpt/update.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <utility>
+
+using namespace monad::mpt;
+using namespace monad::test;
+using namespace monad::literals;
+
+namespace
+{
+
+    // Helper: create an update inserting key=value
+    Update make_kv(monad::byte_string_view key, monad::byte_string_view value)
+    {
+        return make_update(key, value);
+    }
+
+    // Helper: look up a key from a root on the given Db and return the value
+    monad::Result<monad::byte_string>
+    db_get(Db &db, NodeCursor const &root, NibblesView key, uint64_t version)
+    {
+        auto const res = db.find(root, key, version);
+        if (res.has_value()) {
+            return monad::byte_string{res.value().node->value()};
+        }
+        return monad::mpt::DbError(res.error().value());
+    }
+
+    struct DualTimelineFixture : public ::testing::Test
+    {
+        std::filesystem::path const dbname{create_temp_file(8)};
+        StateMachineAlwaysMerkle primary_machine;
+        StateMachineAlwaysMerkle secondary_machine;
+        OnDiskDbConfig config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        Db db{primary_machine, config};
+        std::optional<Db> secondary_db;
+
+        Node::SharedPtr primary_root;
+        Node::SharedPtr secondary_root;
+
+        ~DualTimelineFixture()
+        {
+            std::filesystem::remove(dbname);
+        }
+
+        Db &db_for(timeline_id tid)
+        {
+            if (tid == timeline_id::secondary) {
+                MONAD_ASSERT(secondary_db.has_value());
+                return *secondary_db;
+            }
+            return db;
+        }
+
+        void activate_secondary(uint64_t /*fork_version*/)
+        {
+            // The fork_version arg is preserved for test readability — it
+            // tags the version that callers will subsequently upsert to.
+            // It is no longer pre-seeded into the secondary's version
+            // fields; fast_forward_next_version on the first secondary
+            // upsert seeds them.
+            secondary_db.emplace(
+                db.activate_secondary_timeline(secondary_machine));
+        }
+
+        void deactivate_secondary()
+        {
+            secondary_db.reset();
+            db.deactivate_secondary_timeline();
+        }
+
+        void promote_secondary()
+        {
+            secondary_db.reset();
+            db.promote_secondary_to_primary();
+        }
+
+        // Close and reopen the primary Db against the same file, as
+        // production would after promote.
+        void reopen_primary_with(StateMachine &machine)
+        {
+            {
+                Db const expired = std::move(db);
+            }
+            OnDiskDbConfig reopen_config = config;
+            reopen_config.append = true;
+            db = Db{machine, reopen_config};
+        }
+
+        Node::SharedPtr upsert_kv(
+            Node::SharedPtr root, monad::byte_string_view key,
+            monad::byte_string_view value, uint64_t version,
+            timeline_id tid = timeline_id::primary)
+        {
+            auto u = make_kv(key, value);
+            UpdateList ul;
+            ul.push_front(u);
+            return db_for(tid).upsert(std::move(root), std::move(ul), version);
+        }
+    };
+
+    // -------------------------------------------------------------------
+    // Test: Activate and deactivate without any upserts on secondary
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, activate_deactivate_empty)
+    {
+        // Seed primary with a few versions
+        auto const k1 = 0x11111111_bytes;
+        auto const k2 = 0x22222222_bytes;
+        primary_root = upsert_kv(primary_root, k1, k1, 0);
+        primary_root = upsert_kv(primary_root, k2, k2, 1);
+        ASSERT_NE(primary_root, nullptr);
+
+        // Activate secondary at version 2 (after primary has 0,1)
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+        activate_secondary(2);
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        // Deactivate without doing anything on secondary
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+
+        // Primary should be unaffected
+        auto const res = db_get(db, primary_root, NibblesView{k1}, 1);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value(), k1);
+    }
+
+    // -------------------------------------------------------------------
+    // Test: open_secondary_timeline attaches to an active secondary
+    // without modifying metadata; returns nullopt when inactive.
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, open_secondary_timeline_factory)
+    {
+        // No secondary yet
+        EXPECT_FALSE(db.open_secondary_timeline(secondary_machine).has_value());
+
+        activate_secondary(0);
+
+        // Drop the Db returned by activate_secondary_timeline — mimicking
+        // a process restart where the secondary metadata persists on disk
+        // but the secondary Db instance is gone.
+        secondary_db.reset();
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        // Reattach via open_secondary_timeline
+        auto reopened = db.open_secondary_timeline(secondary_machine);
+        ASSERT_TRUE(reopened.has_value());
+
+        // The reattached Db can upsert and read secondary data
+        auto const k = 0xAAAAAAAA_bytes;
+        auto u = make_update(k, k);
+        UpdateList ul;
+        ul.push_front(u);
+        auto const sroot = reopened->upsert(nullptr, std::move(ul), 0);
+        ASSERT_NE(sroot, nullptr);
+        auto const res = db_get(*reopened, sroot, NibblesView{k}, 0);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value(), k);
+
+        // Destroy the reopened Db, then deactivate via primary
+        reopened.reset();
+        db.deactivate_secondary_timeline();
+
+        // After deactivate, open returns nullopt again
+        EXPECT_FALSE(db.open_secondary_timeline(secondary_machine).has_value());
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Seed primary, activate secondary, replay same updates on both
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, replay_identical_updates)
+    {
+        // Seed primary with versions 0-4
+        auto const keys = std::array{
+            0x11111111_bytes,
+            0x22222222_bytes,
+            0x33333333_bytes,
+            0x44444444_bytes,
+            0x55555555_bytes};
+
+        for (uint64_t v = 0; v < keys.size(); v++) {
+            primary_root = upsert_kv(primary_root, keys[v], keys[v], v);
+            ASSERT_NE(primary_root, nullptr);
+        }
+
+        // Activate secondary at version 0
+        activate_secondary(0);
+
+        // Replay same updates on secondary timeline
+        for (uint64_t v = 0; v < keys.size(); v++) {
+            secondary_root = upsert_kv(
+                secondary_root, keys[v], keys[v], v, timeline_id::secondary);
+            ASSERT_NE(secondary_root, nullptr);
+        }
+
+        // Both timelines should have all 5 keys at their latest root
+        for (auto const &key : keys) {
+            auto const pres = db_get(db, primary_root, NibblesView{key}, 4);
+            ASSERT_TRUE(pres.has_value()) << "primary missing key";
+            EXPECT_EQ(pres.value(), key);
+
+            auto const sres = db_get(
+                db_for(timeline_id::secondary),
+                secondary_root,
+                NibblesView{key},
+                4);
+            ASSERT_TRUE(sres.has_value()) << "secondary missing key";
+            EXPECT_EQ(sres.value(), key);
+        }
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Concurrent updates — both timelines advance with different data
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, concurrent_updates_different_data)
+    {
+        // Seed primary with versions 0-2
+        auto const seed_key = 0xAAAAAAAA_bytes;
+        primary_root = upsert_kv(primary_root, seed_key, seed_key, 0);
+        primary_root = upsert_kv(primary_root, seed_key, seed_key, 1);
+        primary_root = upsert_kv(primary_root, seed_key, seed_key, 2);
+
+        // Activate secondary at version 3
+        activate_secondary(3);
+        // Give secondary the same seed
+        secondary_root = upsert_kv(
+            secondary_root, seed_key, seed_key, 3, timeline_id::secondary);
+
+        // Now advance both timelines with DIFFERENT keys at version 4+
+        auto const primary_key = 0xBBBBBBBB_bytes;
+        auto const secondary_key = 0xCCCCCCCC_bytes;
+
+        for (uint64_t v = 3; v <= 5; v++) {
+            primary_root = upsert_kv(primary_root, primary_key, primary_key, v);
+            secondary_root = upsert_kv(
+                secondary_root,
+                secondary_key,
+                secondary_key,
+                v,
+                timeline_id::secondary);
+        }
+
+        // Primary should have primary_key but NOT secondary_key
+        auto const pres = db_get(db, primary_root, NibblesView{primary_key}, 5);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(pres.value(), primary_key);
+        auto const pres2 =
+            db_get(db, primary_root, NibblesView{secondary_key}, 5);
+        EXPECT_FALSE(pres2.has_value());
+
+        // Secondary should have secondary_key but NOT primary_key
+        auto const sres = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{secondary_key},
+            5);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(sres.value(), secondary_key);
+        auto const sres2 = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{primary_key},
+            5);
+        EXPECT_FALSE(sres2.has_value());
+
+        // Both should have the seed key
+        auto const pseed = db_get(db, primary_root, NibblesView{seed_key}, 5);
+        ASSERT_TRUE(pseed.has_value());
+        auto const sseed = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{seed_key},
+            5);
+        ASSERT_TRUE(sseed.has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Primary ahead of secondary by several versions
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, primary_ahead_of_secondary)
+    {
+        // Seed primary with versions 0-9
+        auto const k1 = 0x11111111_bytes;
+        for (uint64_t v = 0; v < 10; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            primary_root = upsert_kv(primary_root, k1, val, v);
+        }
+
+        // Activate secondary at version 5 — primary is at version 9
+        activate_secondary(5);
+
+        // Secondary catches up from version 5 to 7 (still behind primary at 9)
+        for (uint64_t v = 5; v <= 7; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            secondary_root =
+                upsert_kv(secondary_root, k1, val, v, timeline_id::secondary);
+        }
+
+        // Primary is at version 9, secondary is at version 7
+        auto const pres = db_get(db, primary_root, NibblesView{k1}, 9);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(pres.value()[0], 9);
+
+        auto const sres = db_get(
+            db_for(timeline_id::secondary), secondary_root, NibblesView{k1}, 7);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(sres.value()[0], 7);
+
+        // Continue: primary advances to 12, secondary catches up to 12
+        for (uint64_t v = 10; v <= 12; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            primary_root = upsert_kv(primary_root, k1, val, v);
+        }
+        for (uint64_t v = 8; v <= 12; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            secondary_root =
+                upsert_kv(secondary_root, k1, val, v, timeline_id::secondary);
+        }
+
+        // Both at version 12 with same value
+        auto const pres12 = db_get(db, primary_root, NibblesView{k1}, 12);
+        ASSERT_TRUE(pres12.has_value());
+        EXPECT_EQ(pres12.value()[0], 12);
+        auto const sres12 = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{k1},
+            12);
+        ASSERT_TRUE(sres12.has_value());
+        EXPECT_EQ(sres12.value()[0], 12);
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Promote secondary to primary
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, promote_secondary)
+    {
+        // Seed primary with versions 0-3
+        auto const k1 = 0x11111111_bytes;
+        auto const v1 = 0xAA_bytes;
+        auto const k2 = 0x22222222_bytes;
+        auto const v2 = 0xBB_bytes;
+
+        primary_root = upsert_kv(primary_root, k1, v1, 0);
+        primary_root = upsert_kv(primary_root, k2, v2, 1);
+        primary_root = upsert_kv(primary_root, k1, v1, 2);
+        primary_root = upsert_kv(primary_root, k2, v2, 3);
+
+        // Activate secondary at version 2, replay
+        activate_secondary(2);
+        secondary_root =
+            upsert_kv(secondary_root, k1, v1, 2, timeline_id::secondary);
+        secondary_root =
+            upsert_kv(secondary_root, k2, v2, 3, timeline_id::secondary);
+
+        // Now advance both with version 4
+        auto const k3 = 0x33333333_bytes;
+        auto const v3_primary = 0xCC_bytes;
+        auto const v3_secondary = 0xDD_bytes;
+        primary_root = upsert_kv(primary_root, k3, v3_primary, 4);
+        secondary_root = upsert_kv(
+            secondary_root, k3, v3_secondary, 4, timeline_id::secondary);
+
+        // Promote secondary to primary. This clears the primary Db's
+        // StateMachine binding; callers must close and reopen with the
+        // correct machine before further writes.
+        promote_secondary();
+
+        // Simulate production close+reopen: drop the current (now
+        // machine-less) Db and reopen bound to secondary_machine, which
+        // is the authoritative machine for what is now the primary trie.
+        reopen_primary_with(secondary_machine);
+
+        // After promotion:
+        // - What was secondary is now primary (has v3_secondary for k3)
+        // - What was primary is now secondary (has v3_primary for k3)
+        // The in-memory root variables don't change — they're node
+        // pointers into an on-disk trie whose metadata slot has swapped.
+        EXPECT_TRUE(db.timeline_active(timeline_id::primary));
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        // The secondary root's data is accessible
+        auto const sres = db_get(db, secondary_root, NibblesView{k3}, 4);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(sres.value(), v3_secondary);
+
+        // The primary root's data is also accessible
+        auto const pres = db_get(db, primary_root, NibblesView{k3}, 4);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(pres.value(), v3_primary);
+
+        // After promotion+reopen, we can continue upserts on the new
+        // primary (which was the secondary timeline).
+        auto const k4 = 0x44444444_bytes;
+        auto const v4 = 0xEE_bytes;
+        secondary_root = upsert_kv(secondary_root, k4, v4, 5);
+        ASSERT_NE(secondary_root, nullptr);
+
+        auto const res4 = db_get(db, secondary_root, NibblesView{k4}, 5);
+        ASSERT_TRUE(res4.has_value());
+        EXPECT_EQ(res4.value(), v4);
+
+        // Deactivate the old primary (now secondary)
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Multiple keys across many versions with concurrent timelines
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, many_versions_concurrent)
+    {
+        constexpr uint64_t N_VERSIONS = 20;
+
+        // Build primary with N versions, each inserting a new key
+        for (uint64_t v = 0; v < N_VERSIONS; v++) {
+            monad::byte_string key(4, 0);
+            key[0] = static_cast<uint8_t>(v >> 8);
+            key[1] = static_cast<uint8_t>(v & 0xff);
+            key[2] = 0x01; // primary marker
+            primary_root = upsert_kv(primary_root, key, key, v);
+            ASSERT_NE(primary_root, nullptr);
+        }
+
+        // Activate secondary at version N
+        uint64_t const fork_version = N_VERSIONS;
+        activate_secondary(fork_version);
+
+        // Advance both timelines from fork_version to N_VERSIONS + 5
+        for (uint64_t v = fork_version; v < N_VERSIONS + 5; v++) {
+            monad::byte_string pkey(4, 0);
+            pkey[0] = static_cast<uint8_t>(v >> 8);
+            pkey[1] = static_cast<uint8_t>(v & 0xff);
+            pkey[2] = 0x01; // primary
+            primary_root = upsert_kv(primary_root, pkey, pkey, v);
+
+            monad::byte_string skey(4, 0);
+            skey[0] = static_cast<uint8_t>(v >> 8);
+            skey[1] = static_cast<uint8_t>(v & 0xff);
+            skey[2] = 0x02; // secondary
+            secondary_root = upsert_kv(
+                secondary_root, skey, skey, v, timeline_id::secondary);
+        }
+
+        uint64_t const final_version = N_VERSIONS + 4;
+
+        // Verify primary has all primary keys
+        for (uint64_t v = fork_version; v < N_VERSIONS + 5; v++) {
+            monad::byte_string pkey(4, 0);
+            pkey[0] = static_cast<uint8_t>(v >> 8);
+            pkey[1] = static_cast<uint8_t>(v & 0xff);
+            pkey[2] = 0x01;
+            auto const res =
+                db_get(db, primary_root, NibblesView{pkey}, final_version);
+            ASSERT_TRUE(res.has_value()) << "primary missing key at v=" << v;
+        }
+
+        // Verify secondary has all secondary keys
+        for (uint64_t v = fork_version; v < N_VERSIONS + 5; v++) {
+            monad::byte_string skey(4, 0);
+            skey[0] = static_cast<uint8_t>(v >> 8);
+            skey[1] = static_cast<uint8_t>(v & 0xff);
+            skey[2] = 0x02;
+            auto const res = db_get(
+                db_for(timeline_id::secondary),
+                secondary_root,
+                NibblesView{skey},
+                final_version);
+            ASSERT_TRUE(res.has_value()) << "secondary missing key at v=" << v;
+        }
+
+        // Primary should NOT have secondary-only keys
+        {
+            monad::byte_string skey(4, 0);
+            skey[0] = 0;
+            skey[1] = static_cast<uint8_t>(fork_version);
+            skey[2] = 0x02;
+            auto const res =
+                db_get(db, primary_root, NibblesView{skey}, final_version);
+            EXPECT_FALSE(res.has_value());
+        }
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Activate at version 0 (edge case for the active_ flag)
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, activate_at_version_zero)
+    {
+        activate_secondary(0);
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        // Upsert on both
+        auto const key = 0x12345678_bytes;
+        primary_root = upsert_kv(primary_root, key, key, 0);
+        secondary_root =
+            upsert_kv(secondary_root, key, key, 0, timeline_id::secondary);
+
+        ASSERT_NE(primary_root, nullptr);
+        ASSERT_NE(secondary_root, nullptr);
+
+        auto const pres = db_get(db, primary_root, NibblesView{key}, 0);
+        ASSERT_TRUE(pres.has_value());
+        auto const sres = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{key},
+            0);
+        ASSERT_TRUE(sres.has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Full lifecycle — activate, concurrent, promote, cleanup
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, full_lifecycle)
+    {
+        // Phase 1: Seed primary with versions 0-2
+        auto const k1 = 0x11111111_bytes;
+        primary_root = upsert_kv(primary_root, k1, k1, 0);
+        primary_root = upsert_kv(primary_root, k1, 0xAA_bytes, 1);
+        primary_root = upsert_kv(primary_root, k1, k1, 2);
+
+        // Phase 2: Activate secondary at version 3
+        activate_secondary(3);
+        secondary_root =
+            upsert_kv(secondary_root, k1, k1, 3, timeline_id::secondary);
+
+        // Phase 3: Concurrent operation — both advance versions 4-6
+        auto const k2 = 0x22222222_bytes;
+        for (uint64_t v = 3; v <= 6; v++) {
+            primary_root = upsert_kv(primary_root, k2, k2, v);
+        }
+        for (uint64_t v = 4; v <= 6; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, k2, k2, v, timeline_id::secondary);
+        }
+
+        // Phase 4: Promote secondary, then reopen RWDb bound to the
+        // secondary_machine (authoritative for the now-primary trie).
+        promote_secondary();
+        reopen_primary_with(secondary_machine);
+        EXPECT_TRUE(db.timeline_active(timeline_id::primary));
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        // Phase 5: Continue operating on the new primary (was secondary)
+        auto const k3 = 0x33333333_bytes;
+        secondary_root = upsert_kv(secondary_root, k3, k3, 7);
+        ASSERT_NE(secondary_root, nullptr);
+        auto const res = db_get(db, secondary_root, NibblesView{k3}, 7);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value(), k3);
+
+        // Phase 6: Deactivate old primary (now secondary)
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+
+        // New primary still works
+        secondary_root = upsert_kv(secondary_root, k3, 0xFF_bytes, 8);
+        ASSERT_NE(secondary_root, nullptr);
+    }
+
+    // -------------------------------------------------------------------
+    // Test: load_root_for_version with timeline_id
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, load_root_for_version_by_timeline)
+    {
+        // Seed primary with versions 0-3
+        auto const k1 = 0x11111111_bytes;
+        for (uint64_t v = 0; v <= 3; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            primary_root = upsert_kv(primary_root, k1, val, v);
+        }
+
+        // Activate secondary at version 2, upsert versions 2-3
+        activate_secondary(2);
+        auto const k2 = 0x22222222_bytes;
+        for (uint64_t v = 2; v <= 3; v++) {
+            auto const val =
+                monad::byte_string(4, static_cast<uint8_t>(v + 10));
+            secondary_root =
+                upsert_kv(secondary_root, k2, val, v, timeline_id::secondary);
+        }
+
+        // load_root_for_version on primary returns the primary root
+        auto const loaded_primary = db.load_root_for_version(3);
+        ASSERT_NE(loaded_primary, nullptr);
+        auto const res = db_get(db, loaded_primary, NibblesView{k1}, 3);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value()[0], 3);
+
+        // load_root_for_version on secondary returns the secondary root
+        auto const loaded_secondary = secondary_db->load_root_for_version(3);
+        ASSERT_NE(loaded_secondary, nullptr);
+        auto const res2 =
+            db_get(*secondary_db, loaded_secondary, NibblesView{k2}, 3);
+        ASSERT_TRUE(res2.has_value());
+        EXPECT_EQ(res2.value()[0], 13);
+
+        // Primary root should NOT have k2 (secondary-only key)
+        auto const res3 = db_get(db, loaded_primary, NibblesView{k2}, 3);
+        EXPECT_FALSE(res3.has_value());
+
+        // Secondary root should NOT have k1 (primary-only key)
+        auto const res4 =
+            db_get(*secondary_db, loaded_secondary, NibblesView{k1}, 3);
+        EXPECT_FALSE(res4.has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Two TrieDb-like instances sharing one mpt::Db
+    // Demonstrates the pattern for execution-layer dual-timeline
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, two_independent_root_trees)
+    {
+        // Build a shared key set on primary: versions 0-4
+        auto const shared_key = 0xAAAAAAAA_bytes;
+        for (uint64_t v = 0; v <= 4; v++) {
+            primary_root = upsert_kv(primary_root, shared_key, shared_key, v);
+        }
+
+        // Activate secondary at version 5
+        activate_secondary(5);
+
+        // Each "TrieDb" instance holds its own root and advances independently
+        // Primary TrieDb: inserts primary-only data at versions 5-7
+        auto const pk = 0xBBBBBBBB_bytes;
+        for (uint64_t v = 5; v <= 7; v++) {
+            primary_root = upsert_kv(primary_root, pk, pk, v);
+        }
+
+        // Secondary TrieDb: inserts secondary-only data at versions 5-7
+        auto const sk = 0xCCCCCCCC_bytes;
+        for (uint64_t v = 5; v <= 7; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, sk, sk, v, timeline_id::secondary);
+        }
+
+        // Load roots from the ring at version 7 — each gets its own root
+        auto const p7 = db.load_root_for_version(7);
+        auto const s7 = secondary_db->load_root_for_version(7);
+        ASSERT_NE(p7, nullptr);
+        ASSERT_NE(s7, nullptr);
+        EXPECT_NE(p7.get(), s7.get());
+
+        // Primary root at v7 has pk, not sk
+        EXPECT_TRUE(db_get(db, p7, NibblesView{pk}, 7).has_value());
+        EXPECT_FALSE(db_get(db, p7, NibblesView{sk}, 7).has_value());
+
+        // Secondary root at v7 has sk, not pk
+        EXPECT_TRUE(db_get(db, s7, NibblesView{sk}, 7).has_value());
+        EXPECT_FALSE(db_get(db, s7, NibblesView{pk}, 7).has_value());
+
+        // Both have the shared key from pre-fork (since both were built on
+        // top of the primary's pre-fork state... but here secondary started
+        // from nullptr, so it only has sk)
+        EXPECT_TRUE(db_get(db, p7, NibblesView{shared_key}, 7).has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Fixture with short history length for GC/compaction tests
+    // -------------------------------------------------------------------
+    struct DualTimelineShortHistoryFixture : public ::testing::Test
+    {
+        static constexpr uint64_t SHORT_HISTORY = 20;
+
+        std::filesystem::path const dbname{create_temp_file(8)};
+        StateMachineAlwaysMerkle primary_machine;
+        StateMachineAlwaysMerkle secondary_machine;
+        OnDiskDbConfig config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname},
+            .fixed_history_length = SHORT_HISTORY};
+        Db db{primary_machine, config};
+        std::optional<Db> secondary_db;
+
+        Node::SharedPtr primary_root;
+        Node::SharedPtr secondary_root;
+
+        ~DualTimelineShortHistoryFixture()
+        {
+            std::filesystem::remove(dbname);
+        }
+
+        Db &db_for(timeline_id tid)
+        {
+            if (tid == timeline_id::secondary) {
+                MONAD_ASSERT(secondary_db.has_value());
+                return *secondary_db;
+            }
+            return db;
+        }
+
+        void activate_secondary(uint64_t /*fork_version*/)
+        {
+            // The fork_version arg is preserved for test readability — it
+            // tags the version that callers will subsequently upsert to.
+            // It is no longer pre-seeded into the secondary's version
+            // fields; fast_forward_next_version on the first secondary
+            // upsert seeds them.
+            secondary_db.emplace(
+                db.activate_secondary_timeline(secondary_machine));
+        }
+
+        void deactivate_secondary()
+        {
+            secondary_db.reset();
+            db.deactivate_secondary_timeline();
+        }
+
+        Node::SharedPtr upsert_kv(
+            Node::SharedPtr root, monad::byte_string_view key,
+            monad::byte_string_view value, uint64_t version,
+            timeline_id tid = timeline_id::primary)
+        {
+            auto u = make_kv(key, value);
+            UpdateList ul;
+            ul.push_front(u);
+            return db_for(tid).upsert(std::move(root), std::move(ul), version);
+        }
+    };
+
+    // -------------------------------------------------------------------
+    // Test: GC protects secondary's chunks during primary history expiration
+    // -------------------------------------------------------------------
+    TEST_F(
+        DualTimelineShortHistoryFixture,
+        gc_protects_secondary_during_primary_history_expiration)
+    {
+        // Phase 1: Build primary up to SHORT_HISTORY.
+        auto const shared_key = 0xAAAAAAAA_bytes;
+        for (uint64_t v = 0; v <= SHORT_HISTORY; v++) {
+            auto const val = monad::byte_string(4, static_cast<uint8_t>(v));
+            primary_root = upsert_kv(primary_root, shared_key, val, v);
+        }
+
+        // Phase 2: Activate secondary. Both timelines advance together,
+        // exercising the combined GC boundary from the first block onward.
+        uint64_t const fork_version = SHORT_HISTORY + 1;
+        activate_secondary(fork_version);
+
+        auto const secondary_key = 0xBBBBBBBB_bytes;
+
+        // Phase 3: Drive both timelines well past the history window.
+        // Primary's erase_versions_up_to_and_including fires each block,
+        // release_unreferenced_chunks must compute the combined-min across
+        // both timelines and protect secondary's chunks.
+        auto const final_version = fork_version + SHORT_HISTORY * 3;
+        for (uint64_t v = fork_version; v <= final_version; v++) {
+            auto const pval =
+                monad::byte_string(4, static_cast<uint8_t>(v & 0xFF));
+            primary_root = upsert_kv(primary_root, shared_key, pval, v);
+
+            auto const sval =
+                monad::byte_string(4, static_cast<uint8_t>(v & 0xFF));
+            secondary_root = upsert_kv(
+                secondary_root, secondary_key, sval, v, timeline_id::secondary);
+        }
+
+        // Phase 4: Verify secondary's data survived GC.
+        // Use final_version which is within primary's history window.
+        auto const sres = db_get(
+            db, secondary_root, NibblesView{secondary_key}, final_version);
+        ASSERT_TRUE(sres.has_value())
+            << "Secondary data lost after primary history expiration";
+
+        // Also verify via load_root_for_version
+        auto const loaded_secondary =
+            secondary_db->load_root_for_version(final_version);
+        ASSERT_NE(loaded_secondary, nullptr)
+            << "Secondary root lost after primary history expiration";
+        auto const sres2 = db_get(
+            db, loaded_secondary, NibblesView{secondary_key}, final_version);
+        ASSERT_TRUE(sres2.has_value());
+
+        // Primary's latest data should also be intact
+        auto const pres =
+            db_get(db, primary_root, NibblesView{shared_key}, final_version);
+        ASSERT_TRUE(pres.has_value());
+
+        // Verify timeline isolation: keys are independent
+        auto const cross =
+            db_get(db, primary_root, NibblesView{secondary_key}, final_version);
+        EXPECT_FALSE(cross.has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: Reactivate secondary after deactivation
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, reactivate_after_deactivate)
+    {
+        // Round 1: activate, upsert, deactivate
+        auto const k1 = 0x11111111_bytes;
+        primary_root = upsert_kv(primary_root, k1, k1, 0);
+        primary_root = upsert_kv(primary_root, k1, k1, 1);
+
+        activate_secondary(0);
+        auto const round1_key = 0xAAAAAAAA_bytes;
+        secondary_root = upsert_kv(
+            secondary_root, round1_key, round1_key, 0, timeline_id::secondary);
+        secondary_root = upsert_kv(
+            secondary_root, round1_key, round1_key, 1, timeline_id::secondary);
+
+        // Verify round 1 data
+        auto const res1 = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{round1_key},
+            1);
+        ASSERT_TRUE(res1.has_value());
+
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+
+        // Round 2: reactivate at a later version, upsert new data
+        primary_root = upsert_kv(primary_root, k1, k1, 2);
+        primary_root = upsert_kv(primary_root, k1, k1, 3);
+
+        activate_secondary(2);
+        EXPECT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        auto const round2_key = 0xBBBBBBBB_bytes;
+        secondary_root = nullptr; // fresh secondary
+        secondary_root = upsert_kv(
+            secondary_root, round2_key, round2_key, 2, timeline_id::secondary);
+        secondary_root = upsert_kv(
+            secondary_root, round2_key, round2_key, 3, timeline_id::secondary);
+
+        // Verify round 2 data
+        auto const res2 = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{round2_key},
+            3);
+        ASSERT_TRUE(res2.has_value());
+        EXPECT_EQ(res2.value(), round2_key);
+
+        // Round 1 key should NOT be in round 2 secondary (fresh start)
+        auto const res1_in_r2 = db_get(
+            db_for(timeline_id::secondary),
+            secondary_root,
+            NibblesView{round1_key},
+            3);
+        EXPECT_FALSE(res1_in_r2.has_value());
+
+        // Primary unaffected throughout
+        auto const pres = db_get(db, primary_root, NibblesView{k1}, 3);
+        ASSERT_TRUE(pres.has_value());
+
+        // Full lifecycle: promote round 2 secondary, then deactivate old
+        promote_secondary();
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+    }
+
+    // -------------------------------------------------------------------
+    // Test: load_root_for_version boundary conditions on secondary
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, load_root_boundary_conditions)
+    {
+        // Seed primary with versions 0-5
+        auto const k1 = 0x11111111_bytes;
+        for (uint64_t v = 0; v <= 5; v++) {
+            primary_root = upsert_kv(primary_root, k1, k1, v);
+        }
+
+        // Activate secondary at version 3, upsert versions 3-5
+        activate_secondary(3);
+        auto const k2 = 0x22222222_bytes;
+        for (uint64_t v = 3; v <= 5; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, k2, k2, v, timeline_id::secondary);
+        }
+
+        // Valid: load secondary at version within range
+        auto const loaded = secondary_db->load_root_for_version(4);
+        ASSERT_NE(loaded, nullptr);
+        auto const res = db_get(*secondary_db, loaded, NibblesView{k2}, 4);
+        ASSERT_TRUE(res.has_value());
+
+        // Below fork_version: secondary should return nullptr
+        auto const below_fork = secondary_db->load_root_for_version(2);
+        EXPECT_EQ(below_fork, nullptr)
+            << "load_root_for_version below fork_version should return nullptr";
+
+        // Above max_version: secondary should return nullptr
+        auto const above_max = secondary_db->load_root_for_version(6);
+        EXPECT_EQ(above_max, nullptr)
+            << "load_root_for_version above max_version should return nullptr";
+
+        // After deactivation the secondary Db is gone; verify via
+        // timeline_active that the secondary slot is inactive.
+        deactivate_secondary();
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+    }
+
+    // -------------------------------------------------------------------
+    // Test: find on secondary root after its version expires from primary
+    // -------------------------------------------------------------------
+    TEST_F(
+        DualTimelineShortHistoryFixture,
+        find_on_secondary_after_version_expires_from_primary)
+    {
+        // Phase 1: Build primary up to the history window.
+        auto const shared_key = 0xAAAAAAAA_bytes;
+        for (uint64_t v = 0; v <= SHORT_HISTORY; v++) {
+            primary_root = upsert_kv(primary_root, shared_key, shared_key, v);
+        }
+
+        // Phase 2: Activate secondary and insert secondary-only data.
+        uint64_t const fork_version = SHORT_HISTORY + 1;
+        activate_secondary(fork_version);
+
+        auto const secondary_key = 0xBBBBBBBB_bytes;
+        secondary_root = upsert_kv(
+            secondary_root,
+            secondary_key,
+            secondary_key,
+            fork_version,
+            timeline_id::secondary);
+        // Advance primary at fork_version too
+        primary_root =
+            upsert_kv(primary_root, shared_key, shared_key, fork_version);
+
+        // Phase 3: Drive primary past the history window so fork_version
+        // is erased from the primary ring.
+        for (uint64_t v = fork_version + 1;
+             v <= fork_version + SHORT_HISTORY + 5;
+             v++) {
+            primary_root = upsert_kv(primary_root, shared_key, shared_key, v);
+        }
+
+        // Sanity: fork_version is no longer in primary's history window
+        auto const primary_load = db.load_root_for_version(fork_version);
+        EXPECT_EQ(primary_load, nullptr)
+            << "fork_version should have been expired from primary";
+
+        // Phase 4: find on the secondary root MUST still work.
+        // The secondary root's version (fork_version) is expired from
+        // primary but valid in the secondary ring.
+        auto const sres = db_get(
+            *secondary_db,
+            secondary_root,
+            NibblesView{secondary_key},
+            fork_version);
+        ASSERT_TRUE(sres.has_value())
+            << "find on secondary root failed after its version expired "
+               "from primary";
+        EXPECT_EQ(sres.value(), secondary_key);
+
+        // Also verify load_root_for_version still works for secondary
+        auto const loaded = secondary_db->load_root_for_version(fork_version);
+        ASSERT_NE(loaded, nullptr);
+        auto const sres2 = db_get(
+            *secondary_db, loaded, NibblesView{secondary_key}, fork_version);
+        ASSERT_TRUE(sres2.has_value());
+        EXPECT_EQ(sres2.value(), secondary_key);
+
+        deactivate_secondary();
+    }
+
+} // namespace

--- a/category/mpt/test/load_all_test.cpp
+++ b/category/mpt/test/load_all_test.cpp
@@ -16,6 +16,7 @@
 #include "test_fixtures_gtest.hpp"
 
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/test/test_fixtures_base.hpp>
 #include <category/mpt/trie.hpp>
@@ -36,7 +37,8 @@ TEST_F(LoadAllTest, works)
     monad::mpt::Node::SharedPtr const root{monad::mpt::read_node_blocking(
         state()->aux,
         aux.metadata_ctx().get_latest_root_offset(),
-        aux.metadata_ctx().db_history_max_version())};
+        aux.metadata_ctx().db_history_max_version(),
+        monad::mpt::timeline_id::primary)};
     auto nodes_loaded = monad::mpt::load_all(aux, sm, root);
     EXPECT_GE(nodes_loaded, state()->keys.size());
     std::cout << "   nodes_loaded = " << nodes_loaded << std::endl;

--- a/category/mpt/test/merkle_trie_test.cpp
+++ b/category/mpt/test/merkle_trie_test.cpp
@@ -19,6 +19,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
@@ -239,29 +240,29 @@ TYPED_TEST(TrieTest, insert_unrelated_leaves_then_read)
         this->root_hash(),
         0xd339cf4033aca65996859d35da4612b642664cc40734dbdd40738aa47f1e3e44_bytes);
 
-    auto [leaf_it, res] =
-        find_blocking(this->aux, this->root, kv[0].first, version);
+    auto [leaf_it, res] = find_blocking(
+        this->aux, this->root, kv[0].first, version, timeline_id::primary);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[0].second);
-    std::tie(leaf_it, res) =
-        find_blocking(this->aux, this->root, kv[1].first, version);
+    std::tie(leaf_it, res) = find_blocking(
+        this->aux, this->root, kv[1].first, version, timeline_id::primary);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[1].second);
-    std::tie(leaf_it, res) =
-        find_blocking(this->aux, this->root, kv[2].first, version);
+    std::tie(leaf_it, res) = find_blocking(
+        this->aux, this->root, kv[2].first, version, timeline_id::primary);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
             leaf_it.node->value_data(), leaf_it.node->value_len}),
         kv[2].second);
-    std::tie(leaf_it, res) =
-        find_blocking(this->aux, this->root, kv[3].first, version);
+    std::tie(leaf_it, res) = find_blocking(
+        this->aux, this->root, kv[3].first, version, timeline_id::primary);
     EXPECT_EQ(res, monad::mpt::find_result::success);
     EXPECT_EQ(
         (monad::byte_string_view{
@@ -595,9 +596,12 @@ TYPED_TEST(TrieTest, aux_do_update_fixed_history_len)
             *this->sm,
             std::move(ul_prefix),
             block_id,
-            true /*compaction*/);
-        auto [state_it, res] =
-            find_blocking(this->aux, this->root, prefix, block_id);
+            true /*compaction*/,
+            /*can_write_to_fast=*/true,
+            /*write_root=*/true,
+            timeline_id::primary);
+        auto [state_it, res] = find_blocking(
+            this->aux, this->root, prefix, block_id, timeline_id::primary);
         EXPECT_EQ(res, find_result::success);
         EXPECT_EQ(
             state_it.node->data(),
@@ -680,14 +684,15 @@ TYPED_TEST(TrieTest, variable_length_trie)
 
     // find
     {
-        auto [node0, res] = find_blocking(this->aux, this->root, key0, version);
+        auto [node0, res] = find_blocking(
+            this->aux, this->root, key0, version, timeline_id::primary);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), long_value);
     }
 
     {
-        auto [node_long, res] =
-            find_blocking(this->aux, this->root, keylong, version);
+        auto [node_long, res] = find_blocking(
+            this->aux, this->root, keylong, version, timeline_id::primary);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), long_value);
     }
@@ -723,7 +728,14 @@ TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
     u_prefix.next = std::move(updates);
     UpdateList ul_prefix;
     ul_prefix.push_front(u_prefix);
-    this->root = upsert(this->aux, 0, *this->sm, {}, std::move(ul_prefix));
+    this->root = upsert(
+        this->aux,
+        0,
+        *this->sm,
+        {},
+        std::move(ul_prefix),
+        /*write_root=*/true,
+        timeline_id::primary);
 
     EXPECT_EQ(
         this->root->data(),
@@ -731,15 +743,23 @@ TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
 
     // find
     {
-        auto [node0, res] =
-            find_blocking(this->aux, this->root, prefix + key0, version);
+        auto [node0, res] = find_blocking(
+            this->aux,
+            this->root,
+            prefix + key0,
+            version,
+            timeline_id::primary);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node0.node->value(), value);
     }
 
     {
-        auto [node_long, res] =
-            find_blocking(this->aux, this->root, prefix + keylong, version);
+        auto [node_long, res] = find_blocking(
+            this->aux,
+            this->root,
+            prefix + keylong,
+            version,
+            timeline_id::primary);
         EXPECT_EQ(res, monad::mpt::find_result::success);
         EXPECT_EQ(node_long.node->value(), value);
     }
@@ -761,7 +781,14 @@ TYPED_TEST(TrieTest, single_value_variable_length_trie_with_prefix)
     u_prefix.next = std::move(updates);
     UpdateList ul_prefix;
     ul_prefix.push_front(u_prefix);
-    this->root = upsert(this->aux, 0, *this->sm, {}, std::move(ul_prefix));
+    this->root = upsert(
+        this->aux,
+        0,
+        *this->sm,
+        {},
+        std::move(ul_prefix),
+        /*write_root=*/true,
+        timeline_id::primary);
 
     EXPECT_EQ(
         this->root->data(),

--- a/category/mpt/test/min_truncated_offsets_test.cpp
+++ b/category/mpt/test/min_truncated_offsets_test.cpp
@@ -21,6 +21,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/small_prng.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
@@ -75,7 +76,13 @@ TEST_F(OnDiskMerkleTrieGTest, min_truncated_offsets)
                 update_ls.push_front(updates.back());
             }
             root = upsert(
-                aux, block_id, *sm, std::move(root), std::move(update_ls));
+                aux,
+                block_id,
+                *sm,
+                std::move(root),
+                std::move(update_ls),
+                /*write_root=*/true,
+                timeline_id::primary);
             size_t count_fast = 0;
             for (auto const *ci = aux.metadata_ctx().main()->fast_list_begin();
                  ci != nullptr;

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -20,6 +20,7 @@
 #include <category/core/assert.h>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/test/test_fixtures_base.hpp>
@@ -67,7 +68,8 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
     monad::mpt::Node::SharedPtr const root{monad::mpt::read_node_blocking(
         aux,
         aux.metadata_ctx().get_root_offset_at_version(latest_version),
-        latest_version)};
+        latest_version,
+        monad::mpt::timeline_id::primary)};
     auto const &key = state()->keys.front().first;
     auto const &value = state()->keys.front().first;
 
@@ -90,7 +92,12 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
 
     // Synchronously load the same key
     EXPECT_EQ(
-        find_blocking(aux, NodeCursor{root}, key, latest_version)
+        find_blocking(
+            aux,
+            NodeCursor{root},
+            key,
+            latest_version,
+            monad::mpt::timeline_id::primary)
             .first.node->value(),
         value);
 

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -30,6 +30,7 @@
 #include <category/core/keccak.h>
 #include <category/core/log.hpp>
 #include <category/core/small_prng.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
@@ -151,7 +152,14 @@ Node::SharedPtr batch_upsert_commit(
 
     auto const ts_before = std::chrono::steady_clock::now();
     auto new_root = aux.do_update(
-        std::move(prev_root), sm, std::move(updates), block_id, compaction);
+        std::move(prev_root),
+        sm,
+        std::move(updates),
+        block_id,
+        compaction,
+        /*can_write_to_fast=*/true,
+        /*write_root=*/true,
+        timeline_id::primary);
     auto const ts_after = std::chrono::steady_clock::now();
     double const tm_ram =
         static_cast<double>(
@@ -556,7 +564,8 @@ int main(int const argc, char *argv[])
                     root = read_node_blocking(
                         aux,
                         aux.metadata_ctx().get_latest_root_offset(),
-                        aux.metadata_ctx().db_history_max_version());
+                        aux.metadata_ctx().db_history_max_version(),
+                        timeline_id::primary);
                 }
                 auto block_id =
                     in_memory
@@ -706,12 +715,14 @@ int main(int const argc, char *argv[])
                     root = read_node_blocking(
                         aux,
                         aux.metadata_ctx().get_latest_root_offset(),
-                        aux.metadata_ctx().db_history_max_version());
+                        aux.metadata_ctx().db_history_max_version(),
+                        timeline_id::primary);
                     auto [res, errc] = find_blocking(
                         aux,
                         root,
                         state_nibbles,
-                        aux.metadata_ctx().db_history_max_version());
+                        aux.metadata_ctx().db_history_max_version(),
+                        timeline_id::primary);
                     MONAD_ASSERT(errc == find_result::success);
                     state_start = res;
                     return ret;

--- a/category/mpt/test/plain_trie_test.cpp
+++ b/category/mpt/test/plain_trie_test.cpp
@@ -21,6 +21,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/compute.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
@@ -124,53 +125,65 @@ TYPED_TEST(PlainTrieTest, var_length_trie)
         make_update(kv[7].first, kv[7].second));
 
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[0].first, version)
+        find_blocking(
+            this->aux, this->root, kv[0].first, version, timeline_id::primary)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[2].first, version)
+        find_blocking(
+            this->aux, this->root, kv[2].first, version, timeline_id::primary)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[3].first, version)
+        find_blocking(
+            this->aux, this->root, kv[3].first, version, timeline_id::primary)
             .first.node->value(),
         kv[3].second);
 
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[0].first, version)
+        find_blocking(
+            this->aux, this->root, kv[0].first, version, timeline_id::primary)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[2].first, version)
+        find_blocking(
+            this->aux, this->root, kv[2].first, version, timeline_id::primary)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[3].first, version)
+        find_blocking(
+            this->aux, this->root, kv[3].first, version, timeline_id::primary)
             .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[4].first, version)
+        find_blocking(
+            this->aux, this->root, kv[4].first, version, timeline_id::primary)
             .first.node->value(),
         kv[4].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[5].first, version)
+        find_blocking(
+            this->aux, this->root, kv[5].first, version, timeline_id::primary)
             .first.node->value(),
         kv[5].second);
 
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[6].first, version)
+        find_blocking(
+            this->aux, this->root, kv[6].first, version, timeline_id::primary)
             .first.node->value(),
         kv[6].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[7].first, version)
+        find_blocking(
+            this->aux, this->root, kv[7].first, version, timeline_id::primary)
             .first.node->value(),
         kv[7].second);
 
@@ -240,15 +253,18 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[1].first, kv[1].second),
         make_update(kv[2].first, kv[2].second));
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[0].first, version)
+        find_blocking(
+            this->aux, this->root, kv[0].first, version, timeline_id::primary)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[2].first, version)
+        find_blocking(
+            this->aux, this->root, kv[2].first, version, timeline_id::primary)
             .first.node->value(),
         kv[2].second);
 
@@ -275,19 +291,23 @@ TYPED_TEST(PlainTrieTest, mismatch)
         make_update(kv[3].first, kv[3].second),
         make_update(kv[4].first, kv[4].second));
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[2].first, version)
+        find_blocking(
+            this->aux, this->root, kv[2].first, version, timeline_id::primary)
             .first.node->value(),
         kv[2].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[3].first, version)
+        find_blocking(
+            this->aux, this->root, kv[3].first, version, timeline_id::primary)
             .first.node->value(),
         kv[3].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[4].first, version)
+        find_blocking(
+            this->aux, this->root, kv[4].first, version, timeline_id::primary)
             .first.node->value(),
         kv[4].second);
 
@@ -385,16 +405,22 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
                 std::move(nested)));
     }
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[0].first, version)
+        find_blocking(
+            this->aux, this->root, kv[0].first, version, timeline_id::primary)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, this->root, kv[1].first + nested_kv[0].first, version)
+            this->aux,
+            this->root,
+            kv[1].first + nested_kv[0].first,
+            version,
+            timeline_id::primary)
             .first.node->value(),
         nested_kv[0].second);
 
@@ -410,21 +436,31 @@ TYPED_TEST(PlainTrieTest, delete_with_incarnation)
             make_update(kv[1].first, kv[1].second, true, std::move(nested)));
     }
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[0].first, version)
+        find_blocking(
+            this->aux, this->root, kv[0].first, version, timeline_id::primary)
             .first.node->value(),
         kv[0].second);
     EXPECT_EQ(
-        find_blocking(this->aux, this->root, kv[1].first, version)
+        find_blocking(
+            this->aux, this->root, kv[1].first, version, timeline_id::primary)
             .first.node->value(),
         kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, this->root, kv[1].first + nested_kv[1].first, version)
+            this->aux,
+            this->root,
+            kv[1].first + nested_kv[1].first,
+            version,
+            timeline_id::primary)
             .first.node->value(),
         nested_kv[1].second);
     EXPECT_EQ(
         find_blocking(
-            this->aux, this->root, kv[1].first + nested_kv[0].first, version)
+            this->aux,
+            this->root,
+            kv[1].first + nested_kv[0].first,
+            version,
+            timeline_id::primary)
             .second,
         find_result::key_mismatch_failure);
 }
@@ -449,8 +485,8 @@ TYPED_TEST(PlainTrieTest, large_values)
 
     same_upsert_to_clear_nodes_outside_cache_level();
     {
-        auto [leaf_it, res] =
-            find_blocking(this->aux, this->root, key1, version);
+        auto [leaf_it, res] = find_blocking(
+            this->aux, this->root, key1, version, timeline_id::primary);
         auto const &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
@@ -460,8 +496,8 @@ TYPED_TEST(PlainTrieTest, large_values)
 
     same_upsert_to_clear_nodes_outside_cache_level();
     {
-        auto [leaf_it, res] =
-            find_blocking(this->aux, this->root, key2, version);
+        auto [leaf_it, res] = find_blocking(
+            this->aux, this->root, key2, version, timeline_id::primary);
         auto const &leaf = leaf_it.node;
         EXPECT_EQ(res, find_result::success);
         EXPECT_NE(leaf, nullptr);
@@ -534,26 +570,30 @@ TYPED_TEST(PlainTrieTest, multi_level_find_blocking)
             std::move(this->root),
             make_update(prefix, top_value, false, std::move(updates)));
         // find blocking on multi-level trie
-        auto [begin, errc] =
-            find_blocking(this->aux, this->root, prefix, version);
+        auto [begin, errc] = find_blocking(
+            this->aux, this->root, prefix, version, timeline_id::primary);
         EXPECT_EQ(errc, find_result::success);
         EXPECT_EQ(begin.node->number_of_children(), 2);
         EXPECT_EQ(begin.node->value(), top_value);
 
+        // appears to be a bug in the checker
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage)
         EXPECT_EQ(
-            // appears to be a bug in the checker
-            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-            find_blocking(this->aux, begin, kv[0].first, version)
+            find_blocking(
+                this->aux, begin, kv[0].first, version, timeline_id::primary)
                 .first.node->value(),
             kv[0].second);
         EXPECT_EQ(
-            find_blocking(this->aux, begin, kv[1].first, version)
+            find_blocking(
+                this->aux, begin, kv[1].first, version, timeline_id::primary)
                 .first.node->value(),
             kv[1].second);
         EXPECT_EQ(
-            find_blocking(this->aux, begin, kv[2].first, version)
+            find_blocking(
+                this->aux, begin, kv[2].first, version, timeline_id::primary)
                 .first.node->value(),
             kv[2].second);
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
     };
 
     upsert_and_find_with_prefix(0x000001_bytes, 0xdeadbeef_bytes);
@@ -593,7 +633,8 @@ TYPED_TEST(PlainTrieTest, node_version)
 
     auto read_child = [&](Node &parent,
                           unsigned const index) -> Node::SharedPtr {
-        return read_node_blocking(this->aux, parent.fnext(index), 0);
+        return read_node_blocking(
+            this->aux, parent.fnext(index), 0, timeline_id::primary);
     };
     if (this->root->next(0)) {
         EXPECT_EQ(this->root->next(0)->version, 0);

--- a/category/mpt/test/subtrie_version_test.cpp
+++ b/category/mpt/test/subtrie_version_test.cpp
@@ -20,6 +20,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/keccak.h>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
@@ -150,7 +151,14 @@ TEST_F(OnDiskMerkleTrieGTest, recursively_verify_versions)
             i++;
         }
         this->root = this->aux.do_update(
-            std::move(this->root), *this->sm, std::move(updates), block_id);
+            std::move(this->root),
+            *this->sm,
+            std::move(updates),
+            block_id,
+            /*compaction=*/false,
+            /*can_write_to_fast=*/true,
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     {
@@ -193,7 +201,14 @@ TEST_F(OnDiskMerkleTrieGTest, recursively_verify_versions)
             i++;
         }
         this->root = this->aux.do_update(
-            std::move(this->root), *this->sm, std::move(updates), block_id);
+            std::move(this->root),
+            *this->sm,
+            std::move(updates),
+            block_id,
+            /*compaction=*/false,
+            /*can_write_to_fast=*/true,
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     {

--- a/category/mpt/test/test_fixtures_base.hpp
+++ b/category/mpt/test/test_fixtures_base.hpp
@@ -243,7 +243,14 @@ namespace monad::test
         for (auto &it : update_vec) {
             update_ls.push_front(it);
         }
-        return upsert(aux, version, sm, std::move(old), std::move(update_ls));
+        return upsert(
+            aux,
+            version,
+            sm,
+            std::move(old),
+            std::move(update_ls),
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     template <class... Updates>
@@ -253,7 +260,14 @@ namespace monad::test
     {
         UpdateList update_ls;
         (update_ls.push_front(updates), ...);
-        return upsert(aux, version, sm, std::move(old), std::move(update_ls));
+        return upsert(
+            aux,
+            version,
+            sm,
+            std::move(old),
+            std::move(update_ls),
+            /*write_root=*/true,
+            timeline_id::primary);
     }
 
     template <class... Updates>
@@ -596,7 +610,10 @@ namespace monad::test
                         sm,
                         std::move(update_ls),
                         version++,
-                        true);
+                        /*compaction=*/true,
+                        /*can_write_to_fast=*/true,
+                        /*write_root=*/true,
+                        timeline_id::primary);
                     size_t count = 0;
                     for (auto const *ci =
                              aux.metadata_ctx().main()->fast_list_begin();

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -18,9 +18,11 @@
 #include <category/async/storage_pool.hpp>
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
+#include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
 
@@ -29,20 +31,64 @@
 #include <atomic>
 #include <csignal>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <span>
 #include <stop_token>
 #include <thread>
+#include <vector>
 
 #include <stdlib.h>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
+using namespace monad::mpt;
 
 namespace
 {
     constexpr uint64_t AUX_TEST_HISTORY_LENGTH = 1000;
+
+    // Helper: set up a writable UpdateAux on a background thread, run a
+    // callback, then tear down.  The callback receives the aux reference
+    // and runs on the caller's thread after init completes.
+    template <typename F>
+    void with_rw_aux(F &&fn)
+    {
+        monad::async::storage_pool pool(
+            monad::async::use_anonymous_inode_tag{});
+        UpdateAux aux{};
+        std::atomic<bool> io_set = false;
+        std::atomic<bool> done = false;
+        std::jthread const rw_asyncio([&](std::stop_token) {
+            monad::io::Ring ring1;
+            monad::io::Ring ring2;
+            monad::io::Buffers testbuf =
+                monad::io::make_buffers_for_segregated_read_write(
+                    ring1,
+                    ring2,
+                    2,
+                    4,
+                    monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                    monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+            monad::async::AsyncIO testio(pool, testbuf);
+            aux.init(testio, AUX_TEST_HISTORY_LENGTH);
+            io_set = true;
+
+            while (!done.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(10ms);
+            }
+            // Re-init tears down the old metadata_ctx before testio
+            // goes out of scope on this thread's stack.
+            aux.~UpdateAux();
+            new (&aux) UpdateAux{};
+        });
+        while (!io_set) {
+            std::this_thread::yield();
+        }
+        fn(aux);
+        done.store(true, std::memory_order_release);
+    }
 }
 
 TEST(update_aux_test, reader_dirty_aborts)
@@ -189,7 +235,8 @@ TEST(update_aux_test, configurable_root_offset_chunks)
     monad::async::storage_pool::creation_flags flags;
     flags.num_cnv_chunks = 5;
     {
-        // Create storage pool with 5 conventional chunks
+        // Create storage pool with 5 cnv chunks: 1 for metadata, 4 for
+        // ring_a at init (ring_b has 0 chunks until secondary activates).
         monad::async::storage_pool pool(
             std::span{&filename, 1},
             monad::async::storage_pool::mode::truncate,
@@ -199,10 +246,13 @@ TEST(update_aux_test, configurable_root_offset_chunks)
         monad::async::AsyncIO testio(pool, testbuf);
         monad::mpt::UpdateAux const aux(testio);
 
-        // Verify that exactly 4 chunks were allocated to hold two copies of
-        // root offsets, since chunk 0 is used for metadata
         EXPECT_EQ(
             aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(
+            aux.metadata_ctx()
+                .main()
+                ->secondary_timeline.storage_.cnv_chunks_len,
+            0);
         EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     {
@@ -216,7 +266,1365 @@ TEST(update_aux_test, configurable_root_offset_chunks)
         monad::mpt::UpdateAux const aux(testio);
         EXPECT_EQ(
             aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(
+            aux.metadata_ctx()
+                .main()
+                ->secondary_timeline.storage_.cnv_chunks_len,
+            0);
         EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     remove(filename);
+}
+
+// -------------------------------------------------------------------
+// Secondary timeline ring and lifecycle tests (UpdateAux-level)
+// -------------------------------------------------------------------
+
+TEST(update_aux_test, secondary_ring_empty_after_init)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // Secondary ring is empty at init — it has no cnv chunks yet and
+        // will be allocated chunks on activate_secondary_timeline via an
+        // atomic shrink of ring_a.
+        auto const ro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        EXPECT_TRUE(ro.empty());
+        EXPECT_EQ(ro.capacity(), 0u);
+        EXPECT_EQ(
+            aux.metadata_ctx()
+                .main()
+                ->secondary_timeline.storage_.cnv_chunks_len,
+            0u);
+    });
+}
+
+TEST(update_aux_test, secondary_inactive_by_default)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::primary));
+        EXPECT_FALSE(
+            aux.metadata_ctx().timeline_active(timeline_id::secondary));
+    });
+}
+
+// Simulates opening a DB created by pre-dual-timeline code (MONAD007), whose
+// future_variables_unused region — now overlapping secondary_timeline — was
+// filled with 0xff. On reopen the constructor must rewrite the magic and zero
+// the header so the secondary timeline reads as inactive.
+// Byte-level test for the MONAD007 -> MONAD008 layout-shift migration.
+// MONAD008 shrank root_offsets_ring_t::SIZE_ from 65536 to 32, moving
+// sizeof(db_metadata) from 528512 to 4480. Any real MONAD007 pool has
+// chunk_info[], the list triple, and the db_offsets + consensus fields
+// at byte offsets that the MONAD008 layout no longer uses. The ctor's
+// migration must relocate those blocks before downstream code reads
+// through the new offsets.
+//
+// This test writes a real MONAD007 layout directly to cnv chunk 0 (both
+// copies), opens a DbMetadataContext, and asserts that survivable
+// fields (consensus versions, cnv_chunks list, list triple, chunk_info
+// entries) landed at their MONAD008 offsets with the right values and
+// that new-in-MONAD008 fields initialised to their idle state.
+TEST(update_aux_test, migrates_monad007_layout_to_monad008)
+{
+    using monad::mpt::detail::db_metadata;
+    static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+    static constexpr size_t MONAD007_DB_OFFSETS_OFFSET = 524328;
+    static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
+
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+
+    // Values that must survive the migration with bit-for-bit fidelity.
+    uint64_t const test_history_length = 12345;
+    uint64_t const test_latest_finalized = 42;
+    uint64_t const test_latest_verified = 41;
+    uint64_t const test_latest_voted = 40;
+    uint64_t const test_latest_proposed = 43;
+    int64_t const test_auto_expire_version = 999;
+    uint64_t const test_capacity_in_free_list = 1'000'000;
+    uint32_t const test_cnv_chunks_len = 2;
+    uint32_t const test_cnv_chunk_id_0 = 1;
+    uint32_t const test_cnv_chunk_id_1 = 2;
+    uint32_t const test_free_list_begin = 5;
+    uint32_t const test_free_list_end = 7;
+    uint32_t const test_chunk_count = static_cast<uint32_t>(
+        pool.chunks(monad::async::storage_pool::seq) +
+        pool.chunks(monad::async::storage_pool::cnv));
+
+    auto &cnv_chunk = pool.chunk(monad::async::storage_pool::cnv, 0);
+    auto const [write_fd, base_offset] = cnv_chunk.write_fd(0);
+    auto const half_capacity = cnv_chunk.capacity() / 2;
+
+    auto const build_monad007_buffer = [&] {
+        std::vector<uint8_t> buf(
+            MONAD007_DB_METADATA_SIZE +
+                size_t(test_chunk_count) * sizeof(db_metadata::chunk_info_t),
+            0);
+        // magic
+        memcpy(
+            buf.data(),
+            db_metadata::PREVIOUS_MAGIC,
+            db_metadata::MAGIC_STRING_LEN);
+        // chunk_info_count bitfield (20 low bits)
+        uint64_t const bitfield =
+            static_cast<uint64_t>(test_chunk_count) & 0xfffffULL;
+        memcpy(buf.data() + 8, &bitfield, 8);
+        // capacity_in_free_list
+        memcpy(buf.data() + 16, &test_capacity_in_free_list, 8);
+        // root_offsets: version_lower_bound_ and next_version_ both 0
+        // (buf is zeroed). storage_.high_bits_all_set = -1,
+        // storage_.cnv_chunks_len = test_cnv_chunks_len.
+        uint32_t const high_bits_all_set = uint32_t(-1);
+        memcpy(buf.data() + 40, &high_bits_all_set, 4);
+        memcpy(buf.data() + 44, &test_cnv_chunks_len, 4);
+        // cnv_chunks[0] + [1] populated; the rest of the huge
+        // MONAD007 cnv_chunks[] array filled with 0xff as MONAD007 did.
+        memcpy(buf.data() + 48, &high_bits_all_set, 4);
+        memcpy(buf.data() + 52, &test_cnv_chunk_id_0, 4);
+        memcpy(buf.data() + 56, &high_bits_all_set, 4);
+        memcpy(buf.data() + 60, &test_cnv_chunk_id_1, 4);
+        memset(buf.data() + 64, 0xff, MONAD007_DB_OFFSETS_OFFSET - 64);
+        // db_offsets at 524328 (16 bytes) — leave as zero.
+        // history_length at 524344, then finalized/verified/voted/proposed.
+        memcpy(buf.data() + 524344, &test_history_length, 8);
+        memcpy(buf.data() + 524352, &test_latest_finalized, 8);
+        memcpy(buf.data() + 524360, &test_latest_verified, 8);
+        memcpy(buf.data() + 524368, &test_latest_voted, 8);
+        memcpy(buf.data() + 524376, &test_latest_proposed, 8);
+        // auto_expire_version at 524384 — MONAD008 promotes this global
+        // field into the root_offsets ring header (per-timeline). The
+        // migration must read this slot and seed
+        // root_offsets.auto_expire_version_ with it.
+        memcpy(buf.data() + 524384, &test_auto_expire_version, 8);
+        // block_ids at 524392, 524424 — zero. future_variables_unused
+        // 524456..528488: 0xff (MONAD007 convention).
+        memset(buf.data() + 524456, 0xff, MONAD007_LIST_TRIPLE_OFFSET - 524456);
+        // free_list (begin, end) at MONAD007_LIST_TRIPLE_OFFSET.
+        memcpy(
+            buf.data() + MONAD007_LIST_TRIPLE_OFFSET, &test_free_list_begin, 4);
+        memcpy(
+            buf.data() + MONAD007_LIST_TRIPLE_OFFSET + 4,
+            &test_free_list_end,
+            4);
+        // fast_list and slow_list (begin=UINT32_MAX, end=UINT32_MAX —
+        // empty).
+        uint32_t const invalid = UINT32_MAX;
+        memcpy(buf.data() + MONAD007_LIST_TRIPLE_OFFSET + 8, &invalid, 4);
+        memcpy(buf.data() + MONAD007_LIST_TRIPLE_OFFSET + 12, &invalid, 4);
+        memcpy(buf.data() + MONAD007_LIST_TRIPLE_OFFSET + 16, &invalid, 4);
+        memcpy(buf.data() + MONAD007_LIST_TRIPLE_OFFSET + 20, &invalid, 4);
+        // chunk_info[] left at zero — valid, means all INVALID_CHUNK_IDs
+        // except encoded by convention; the test doesn't need to verify
+        // specific values, just that the bytes survive the relocation.
+        return buf;
+    };
+    auto const buffer = build_monad007_buffer();
+    // Write to both copies on disk.
+    for (unsigned copy_idx = 0; copy_idx < 2; copy_idx++) {
+        ssize_t const written = ::pwrite(
+            write_fd,
+            buffer.data(),
+            buffer.size(),
+            off_t(base_offset) + off_t(copy_idx) * off_t(half_capacity));
+        ASSERT_EQ(ssize_t(buffer.size()), written)
+            << "pwrite of copy " << copy_idx << " failed";
+    }
+
+    // Open DB. Ctor should migrate both copies.
+    {
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        for (unsigned i = 0; i < 2; i++) {
+            auto const *const m = ctx.main(i);
+            EXPECT_EQ(
+                0,
+                memcmp(
+                    m->magic,
+                    db_metadata::MAGIC,
+                    db_metadata::MAGIC_STRING_LEN))
+                << "copy " << i << " magic should be migrated to MONAD008";
+            // Root_offsets header stayed at the same byte offset across
+            // layouts — the cnv_chunks_len cap + the first two chunk ids
+            // must survive with no relocation needed.
+            EXPECT_EQ(
+                m->root_offsets.storage_.cnv_chunks_len, test_cnv_chunks_len);
+            EXPECT_EQ(
+                m->root_offsets.storage_.cnv_chunks[0].cnv_chunk_id,
+                test_cnv_chunk_id_0);
+            EXPECT_EQ(
+                m->root_offsets.storage_.cnv_chunks[1].cnv_chunk_id,
+                test_cnv_chunk_id_1);
+            // Consensus fields relocated from offset 524344+ to 312+.
+            EXPECT_EQ(m->history_length, test_history_length);
+            EXPECT_EQ(m->latest_finalized_version, test_latest_finalized);
+            EXPECT_EQ(m->latest_verified_version, test_latest_verified);
+            EXPECT_EQ(m->latest_voted_version, test_latest_voted);
+            EXPECT_EQ(m->latest_proposed_version, test_latest_proposed);
+            // MONAD007's global auto_expire_version was migrated into the
+            // primary ring's auto_expire_version_; secondary's stays zero.
+            EXPECT_EQ(
+                m->root_offsets.auto_expire_version_, test_auto_expire_version);
+            EXPECT_EQ(m->secondary_timeline.auto_expire_version_, 0);
+            // List triple relocated from offset 528488 to 4456.
+            EXPECT_EQ(m->free_list.begin, test_free_list_begin);
+            EXPECT_EQ(m->free_list.end, test_free_list_end);
+            EXPECT_EQ(m->fast_list.begin, UINT32_MAX);
+            EXPECT_EQ(m->fast_list.end, UINT32_MAX);
+            EXPECT_EQ(m->slow_list.begin, UINT32_MAX);
+            EXPECT_EQ(m->slow_list.end, UINT32_MAX);
+            // New-in-MONAD008 fields must start at idle values
+            // regardless of what was in the overlapping MONAD007 bytes
+            // (the migration explicitly zeros them).
+            EXPECT_EQ(m->secondary_timeline.version_lower_bound_, 0u);
+            EXPECT_EQ(m->secondary_timeline.next_version_, 0u);
+            EXPECT_EQ(m->secondary_timeline.storage_.cnv_chunks_len, 0u);
+            EXPECT_EQ(m->primary_ring_idx, 0u);
+            EXPECT_EQ(m->secondary_timeline_active_, 0u);
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE);
+        }
+        EXPECT_FALSE(ctx.timeline_active(timeline_id::secondary));
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::primary));
+    }
+}
+
+// Simulates a crash mid-migration: copy 0 finished migrating to MONAD008 in
+// a prior run; copy 1 still tagged MONAD007 with 0xff padding. The magic-
+// validation heal does nothing (copy 0 is valid), so the migration loop's
+// per-copy branch is the path that actually fixes copy 1.
+TEST(update_aux_test, migrates_monad007_resumes_after_partial_migration)
+{
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    using monad::mpt::detail::db_metadata;
+
+    {
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        UpdateAux aux{testio, AUX_TEST_HISTORY_LENGTH};
+
+        // Corrupt copy 1 only. Copy 0 stays MONAD008, so on reopen the
+        // magic-validation heal at the top of the ctor sees copy 0 as
+        // valid and takes no action — the fix must come from the
+        // per-copy migration loop.
+        auto *const m1 = const_cast<db_metadata *>(aux.metadata_ctx().main(1));
+        auto const g = m1->hold_dirty();
+        memcpy(
+            m1->magic,
+            db_metadata::PREVIOUS_MAGIC,
+            db_metadata::MAGIC_STRING_LEN);
+        memset(&m1->secondary_timeline, 0xff, sizeof(m1->secondary_timeline));
+        m1->primary_ring_idx = 0xff;
+        m1->secondary_timeline_active_ = 0xff;
+        memset(m1->reserved_timeline_, 0xff, sizeof(m1->reserved_timeline_));
+    }
+
+    {
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        UpdateAux aux{testio, AUX_TEST_HISTORY_LENGTH};
+
+        for (unsigned i = 0; i < 2; i++) {
+            auto const *const m = aux.metadata_ctx().main(i);
+            EXPECT_EQ(
+                0,
+                memcmp(
+                    m->magic,
+                    db_metadata::MAGIC,
+                    db_metadata::MAGIC_STRING_LEN))
+                << "copy " << i << " magic should be MONAD008 after migration";
+            EXPECT_EQ(m->secondary_timeline_active_, 0u);
+            EXPECT_EQ(m->primary_ring_idx, 0u);
+            EXPECT_EQ(m->secondary_timeline.next_version_, 0u);
+            EXPECT_EQ(m->secondary_timeline.version_lower_bound_, 0u);
+            // These fields overlap MONAD007's 0xff padding. If migration
+            // ever stops zeroing them, shrink_grow_seq_ goes odd (readers
+            // spin) and pending_shrink_grow.op_kind goes nonzero (replay
+            // hits MONAD_ABORT on reopen).
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u)
+                << "copy " << i << " shrink_grow_seq_ must be even after "
+                << "migration (was 0xff padding under MONAD007)";
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE)
+                << "copy " << i << " pending_shrink_grow.op_kind must be "
+                << "NONE after migration";
+        }
+    }
+}
+
+TEST(update_aux_test, activate_deactivate_secondary)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        EXPECT_FALSE(
+            aux.metadata_ctx().timeline_active(timeline_id::secondary));
+
+        aux.activate_secondary_timeline();
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
+
+        // Header version fields are zeroed on activate so the secondary
+        // timeline starts completely empty; fast_forward_next_version on
+        // the first secondary write seeds them. With no prior promote,
+        // primary_ring_idx==0 so secondary routes to ring_b
+        // (secondary_timeline).
+        auto const *md = aux.metadata_ctx().main();
+        EXPECT_EQ(md->primary_ring_idx, 0u);
+        EXPECT_EQ(md->secondary_timeline.version_lower_bound_, 0u);
+        EXPECT_EQ(md->secondary_timeline.next_version_, 0u);
+        EXPECT_EQ(md->secondary_timeline_active_, 1u);
+
+        aux.deactivate_secondary_timeline();
+        EXPECT_FALSE(
+            aux.metadata_ctx().timeline_active(timeline_id::secondary));
+        EXPECT_EQ(md->secondary_timeline_active_, 0u);
+    });
+}
+
+TEST(update_aux_test, activate_initializes_secondary_compaction_to_default)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // Mutate primary's compaction state away from defaults so the test
+        // can prove the secondary does NOT inherit it.
+        aux.tl(timeline_id::primary).compact_offsets.fast.set_value(0x1234);
+        aux.tl(timeline_id::primary).compact_offsets.slow.set_value(0x5678);
+
+        aux.activate_secondary_timeline();
+
+        // Secondary must start empty regardless of primary's state. Its
+        // compaction values are initialised on the first secondary upsert
+        // by deserialising prev_root's compact_offsets.
+        timeline_compaction_state const default_state{};
+        auto const &secondary = aux.tl(timeline_id::secondary);
+        EXPECT_EQ(
+            secondary.compact_offsets.fast, default_state.compact_offsets.fast);
+        EXPECT_EQ(
+            secondary.compact_offsets.slow, default_state.compact_offsets.slow);
+        EXPECT_EQ(
+            secondary.compact_offset_range_fast_,
+            default_state.compact_offset_range_fast_);
+        EXPECT_EQ(
+            secondary.compact_offset_range_slow_,
+            default_state.compact_offset_range_slow_);
+
+        aux.deactivate_secondary_timeline();
+
+        // Deactivation also returns to default.
+        auto const &reset = aux.tl(timeline_id::secondary);
+        EXPECT_EQ(
+            reset.compact_offsets.fast, default_state.compact_offsets.fast);
+        EXPECT_EQ(
+            reset.compact_offsets.slow, default_state.compact_offsets.slow);
+    });
+}
+
+TEST(update_aux_test, promote_swaps_compaction_state)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        auto pro = aux.metadata_ctx().root_offsets(timeline_id::primary);
+        pro.push(chunk_offset_t{1, 0});
+
+        aux.activate_secondary_timeline();
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        sro.push(chunk_offset_t{2, 0});
+
+        // Set distinguishable auto-expire values
+        aux.tl(timeline_id::primary).curr_upsert_auto_expire_version = 111;
+        aux.tl(timeline_id::secondary).curr_upsert_auto_expire_version = 222;
+
+        aux.promote_secondary_to_primary();
+
+        // Compaction state should be swapped
+        EXPECT_EQ(
+            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version, 222);
+        EXPECT_EQ(
+            aux.tl(timeline_id::secondary).curr_upsert_auto_expire_version,
+            111);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, lifecycle_updates_both_metadata_copies)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        aux.activate_secondary_timeline();
+
+        // Verify both metadata copies have matching secondary header
+        auto ro0 = aux.metadata_ctx().root_offsets(timeline_id::secondary, 0);
+        auto ro1 = aux.metadata_ctx().root_offsets(timeline_id::secondary, 1);
+        EXPECT_EQ(ro0.max_version(), ro1.max_version());
+        EXPECT_FALSE(ro0.empty());
+        EXPECT_FALSE(ro1.empty());
+
+        // Push a root and verify both copies. The first push lands at
+        // version 0 because next_version_ starts zero post-activate.
+        chunk_offset_t const offset{3, 42};
+        ro0.push(offset);
+        ro1.push(offset);
+        EXPECT_EQ(ro0[0].id, offset.id);
+        EXPECT_EQ(ro1[0].id, offset.id);
+
+        // Promote and verify both copies swapped
+        aux.promote_secondary_to_primary();
+        auto const new_pro0 =
+            aux.metadata_ctx().root_offsets(timeline_id::primary, 0);
+        auto const new_pro1 =
+            aux.metadata_ctx().root_offsets(timeline_id::primary, 1);
+        EXPECT_EQ(new_pro0.max_version(), new_pro1.max_version());
+        EXPECT_EQ(new_pro0[0].id, offset.id);
+        EXPECT_EQ(new_pro1[0].id, offset.id);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, activate_at_version_zero)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        aux.activate_secondary_timeline();
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
+
+        // Before any push, next_version_ == 0 so max_version() is
+        // INVALID_BLOCK_NUM — min_valid correctly reports INVALID
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_min_valid_version(
+                timeline_id::secondary),
+            INVALID_BLOCK_NUM);
+
+        // After pushing at version 0, the ring is populated
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        sro.push(chunk_offset_t{1, 0});
+        EXPECT_EQ(sro.max_version(), 0u);
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            0, timeline_id::secondary));
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_min_valid_version(
+                timeline_id::secondary),
+            0u);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, reactivate_after_deactivate)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // First activation. First push lands at version 0.
+        aux.activate_secondary_timeline();
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        chunk_offset_t const first_offset{3, 100};
+        sro.push(first_offset);
+        EXPECT_EQ(sro[0].id, first_offset.id);
+        aux.deactivate_secondary_timeline();
+
+        // Reactivate; next_version_ has been re-zeroed.
+        aux.activate_secondary_timeline();
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
+
+        // Old data is wiped — ring slots are INVALID_OFFSET, version
+        // fields are zero (max_version() == INVALID_BLOCK_NUM).
+        auto sro2 = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        EXPECT_EQ(sro2.max_version(), INVALID_BLOCK_NUM);
+        EXPECT_EQ(sro2[0], monad::async::INVALID_OFFSET)
+            << "Stale data from first activation should be cleared";
+
+        // New push works; lands at version 0 again.
+        chunk_offset_t const second_offset{4, 200};
+        sro2.push(second_offset);
+        EXPECT_EQ(sro2[0].id, second_offset.id);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, secondary_ring_initialized_to_invalid_offset_on_activate)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // After activation, the secondary ring has been allocated chunks
+        // (taken from the shrunk primary) and initialised to
+        // INVALID_OFFSET by activate_secondary_header.
+        aux.activate_secondary_timeline();
+        auto const ro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        ASSERT_FALSE(ro.empty());
+        // Sample a few positions including 0 (which would be a valid index
+        // once next_version_ advances past 0).
+        EXPECT_EQ(ro[1], monad::async::INVALID_OFFSET);
+        EXPECT_EQ(ro[100], monad::async::INVALID_OFFSET);
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, secondary_ring_push_and_read)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        aux.activate_secondary_timeline();
+
+        // Post-activate the secondary starts empty: next_version_ == 0,
+        // so max_version() reports INVALID_BLOCK_NUM.
+        auto ro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        EXPECT_EQ(ro.max_version(), INVALID_BLOCK_NUM);
+
+        // First push lands at version 0.
+        chunk_offset_t const test_offset{3, 42};
+        ro.push(test_offset);
+        EXPECT_EQ(ro.max_version(), 0u);
+        EXPECT_EQ(ro[0].id, test_offset.id);
+        EXPECT_EQ(ro[0].offset, test_offset.offset);
+
+        // Primary ring unaffected
+        auto const pro = aux.metadata_ctx().root_offsets(timeline_id::primary);
+        EXPECT_EQ(pro.max_version(), INVALID_BLOCK_NUM);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, promote_secondary_to_primary)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // Set up primary with a root at version 0
+        auto pro = aux.metadata_ctx().root_offsets(timeline_id::primary);
+        chunk_offset_t const primary_offset{1, 100};
+        pro.push(primary_offset);
+        EXPECT_EQ(pro.max_version(), 0u);
+
+        // Activate secondary and push a root. Post-activate the secondary
+        // starts empty so the first push lands at version 0.
+        aux.activate_secondary_timeline();
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        chunk_offset_t const secondary_offset{2, 200};
+        sro.push(secondary_offset);
+        EXPECT_EQ(sro.max_version(), 0u);
+
+        // Promote
+        aux.promote_secondary_to_primary();
+
+        // After promotion: what was secondary is now primary
+        auto const new_pro =
+            aux.metadata_ctx().root_offsets(timeline_id::primary);
+        EXPECT_EQ(new_pro.max_version(), 0u);
+        EXPECT_EQ(new_pro[0].id, secondary_offset.id);
+
+        // What was primary is now secondary
+        auto const new_sro =
+            aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        EXPECT_EQ(new_sro.max_version(), 0u);
+        EXPECT_EQ(new_sro[0].id, primary_offset.id);
+
+        // Both timelines are active after promotion
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::primary));
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+TEST(update_aux_test, db_history_version_queries_per_timeline)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // Primary starts empty
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_max_version(timeline_id::primary),
+            INVALID_BLOCK_NUM);
+
+        // Activate secondary. It starts empty (next_version_ == 0), so
+        // both min_valid and max_version report INVALID_BLOCK_NUM.
+        aux.activate_secondary_timeline();
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_min_valid_version(
+                timeline_id::secondary),
+            INVALID_BLOCK_NUM);
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_max_version(timeline_id::secondary),
+            INVALID_BLOCK_NUM);
+
+        // First push lands at version 0.
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        sro.push(chunk_offset_t{1, 0});
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_max_version(timeline_id::secondary),
+            0u);
+
+        // Primary queries are independent
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_max_version(timeline_id::primary),
+            INVALID_BLOCK_NUM);
+
+        aux.deactivate_secondary_timeline();
+    });
+}
+
+// Promote must be persistent across restart. The on-disk
+// primary_ring_idx byte selects which physical ring is the logical
+// primary at reopen time; without it, map_ring_a_storage /
+// map_ring_b_storage would always pair ring_a with the primary role
+// regardless of whether promote had run, producing a silent
+// header/data mismatch against ring_b's header state.
+//
+// Exercises DbMetadataContext directly — skips UpdateAux::init's
+// rewind_to_match_offsets path which requires a consistent node-writer
+// state and is orthogonal to this test's scope.
+TEST(update_aux_test, promote_persists_across_reopen)
+{
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_update_aux_promote_persist_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30)); // 8GB
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    chunk_offset_t const primary_before{1, 0};
+    chunk_offset_t const secondary_before{2, 0};
+
+    // Session 1: init pool, activate + push to both rings, promote.
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        EXPECT_EQ(ctx.primary_ring_idx(), 0u);
+
+        ctx.root_offsets(timeline_id::primary).push(primary_before);
+        ctx.activate_secondary_header();
+        ctx.root_offsets(timeline_id::secondary).push(secondary_before);
+        ctx.promote_secondary_to_primary_header();
+
+        EXPECT_EQ(ctx.primary_ring_idx(), 1u);
+        auto const new_pro = ctx.root_offsets(timeline_id::primary);
+        EXPECT_EQ(new_pro[0].id, secondary_before.id);
+    }
+
+    // Session 2: reopen. primary_ring_idx must survive.
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        EXPECT_EQ(ctx.primary_ring_idx(), 1u);
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+
+        auto const new_pro = ctx.root_offsets(timeline_id::primary);
+        EXPECT_EQ(new_pro.max_version(), 0u);
+        EXPECT_EQ(new_pro[0].id, secondary_before.id);
+
+        auto const new_sro = ctx.root_offsets(timeline_id::secondary);
+        EXPECT_EQ(new_sro.max_version(), 0u);
+        EXPECT_EQ(new_sro[0].id, primary_before.id);
+    }
+
+    remove(filename);
+}
+
+// Crash-recovery test for activate_secondary_header. Simulates the
+// window where the pending intent flag has been stamped and msync'd
+// to disk but the activate body hasn't run yet. (Partial-body replay
+// is covered separately by replay_completes_partial_cnv_chunks_move.)
+// On reopen, the constructor must replay the activate to completion
+// and clear the flag.
+TEST(update_aux_test, replay_completes_pending_activate_after_crash)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_pending_activate_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    // Session 1: init pool; stamp pending activate flag manually (as if a
+    // crash happened right after set_pending_shrink_grow_ + msync but
+    // before do_activate_secondary_body_ started).
+    uint32_t target_chunks = 0;
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        // Primary ring has num_cnv_chunks - 1 = 4 chunks; activate would
+        // shrink it to 2. Record the target so session 2 can verify.
+        auto const old_chunks =
+            ctx.main()->root_offsets.storage_.cnv_chunks_len;
+        ASSERT_GE(old_chunks, 2u);
+        ASSERT_EQ(old_chunks & (old_chunks - 1), 0u);
+        target_chunks = old_chunks / 2;
+
+        // Stamp pending flag on both copies under hold_dirty. Also bump
+        // shrink_grow_seq_ odd on both to match the real code path.
+        for (unsigned which = 0; which < 2; which++) {
+            auto *const m = const_cast<db_metadata *>(ctx.main(which));
+            auto const g = m->hold_dirty();
+            m->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_ACTIVATE;
+            m->pending_shrink_grow.target_primary_chunks = target_chunks;
+            monad::start_lifetime_as<std::atomic<uint64_t>>(
+                &m->shrink_grow_seq_)
+                ->fetch_add(1, std::memory_order_acq_rel);
+        }
+        // Dtor runs: DbMetadataContext unmaps without clearing the flag,
+        // simulating a crash before clear_pending_shrink_grow_.
+    }
+
+    // Session 2: reopen. Replay must finish the activate.
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        // Flag cleared on both copies.
+        for (unsigned which = 0; which < 2; which++) {
+            auto const *const m = ctx.main(which);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE);
+            // seq should be even (replay's clear_pending_shrink_grow_
+            // bumps it back).
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u);
+        }
+        // Activate completed: primary shrunk to target, secondary active.
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+        EXPECT_EQ(
+            ctx.main()->root_offsets.storage_.cnv_chunks_len, target_chunks);
+        EXPECT_EQ(
+            ctx.main()->secondary_timeline.storage_.cnv_chunks_len,
+            target_chunks);
+        // Secondary version fields stay zero through replay — first
+        // upsert seeds them via fast_forward_next_version.
+        EXPECT_EQ(ctx.main()->secondary_timeline.version_lower_bound_, 0u);
+        EXPECT_EQ(ctx.main()->secondary_timeline.next_version_, 0u);
+    }
+
+    remove(filename);
+}
+
+// Replay against a state where the activate body has already fully
+// committed — the crash happened between the post-body sync and the
+// flag-clear msync. Replay re-runs the body (idempotent), notices the
+// commit is already done, and clears the flag. In production this
+// corresponds to a crash after sync_ring_data_to_disk_ +
+// sync_metadata_to_disk_ but before clear_pending_shrink_grow_'s msync
+// reached disk; at that moment the writer is still inside
+// activate_secondary_header (no pushes have resumed), so the replay's
+// secondary-ring memset + version-field rewrite cannot clobber live
+// data. The test reconstructs that state synthetically by running
+// activate to completion and then re-stamping the flag.
+TEST(update_aux_test, replay_is_noop_when_activate_already_committed)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_already_committed_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    uint32_t target_chunks = 0;
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        target_chunks = ctx.main()->root_offsets.storage_.cnv_chunks_len / 2;
+
+        // Fully activate. No subsequent pushes — in production the
+        // modelled crash happens while the writer is still inside
+        // activate_secondary_header (post-body-sync, pre-flag-clear-
+        // msync), so no push has ever touched the post-activate state.
+        ctx.activate_secondary_header();
+
+        // Stamp the pending flag back on — simulates a crash after the
+        // body finished but before the flag-clear msync completed.
+        for (unsigned which = 0; which < 2; which++) {
+            auto *const m = const_cast<db_metadata *>(ctx.main(which));
+            auto const g = m->hold_dirty();
+            m->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_ACTIVATE;
+            m->pending_shrink_grow.target_primary_chunks = target_chunks;
+            monad::start_lifetime_as<std::atomic<uint64_t>>(
+                &m->shrink_grow_seq_)
+                ->fetch_add(1, std::memory_order_acq_rel);
+        }
+    }
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        for (unsigned which = 0; which < 2; which++) {
+            auto const *const m = ctx.main(which);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE);
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u);
+        }
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+        EXPECT_EQ(
+            ctx.main()->root_offsets.storage_.cnv_chunks_len, target_chunks);
+        EXPECT_EQ(
+            ctx.main()->secondary_timeline.storage_.cnv_chunks_len,
+            target_chunks);
+    }
+
+    remove(filename);
+}
+
+// Replay for pending deactivate. DB starts in the post-activate state
+// (secondary active, primary shrunk); simulates a crash after the
+// deactivate intent flag was stamped but before the deactivate body
+// ran. Replay must restore the primary to full size and mark secondary
+// inactive.
+TEST(update_aux_test, replay_completes_pending_deactivate_after_crash)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_pending_deactivate_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    uint32_t target_chunks = 0;
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        ctx.activate_secondary_header();
+        auto const primary_after_activate =
+            ctx.main()->root_offsets.storage_.cnv_chunks_len;
+        auto const secondary_after_activate =
+            ctx.main()->secondary_timeline.storage_.cnv_chunks_len;
+        target_chunks = primary_after_activate + secondary_after_activate;
+
+        // Stamp pending deactivate flag on both copies.
+        for (unsigned which = 0; which < 2; which++) {
+            auto *const m = const_cast<db_metadata *>(ctx.main(which));
+            auto const g = m->hold_dirty();
+            m->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_DEACTIVATE;
+            m->pending_shrink_grow.target_primary_chunks = target_chunks;
+            monad::start_lifetime_as<std::atomic<uint64_t>>(
+                &m->shrink_grow_seq_)
+                ->fetch_add(1, std::memory_order_acq_rel);
+        }
+    }
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        for (unsigned which = 0; which < 2; which++) {
+            auto const *const m = ctx.main(which);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE);
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u);
+        }
+        EXPECT_FALSE(ctx.timeline_active(timeline_id::secondary));
+        EXPECT_EQ(
+            ctx.main()->root_offsets.storage_.cnv_chunks_len, target_chunks);
+        EXPECT_EQ(ctx.main()->secondary_timeline.storage_.cnv_chunks_len, 0u);
+    }
+
+    remove(filename);
+}
+
+// Replay exercises the cnv_chunks[] idempotency guard. We stamp the
+// pending flag and then hand-apply a partial chunk move (one of two
+// expected moves), simulating a crash in the middle of step 4 of
+// do_activate_secondary_body_. Replay on reopen must finish the
+// remaining move without clobbering the already-moved entry.
+TEST(update_aux_test, replay_completes_partial_cnv_chunks_move)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_partial_cnv_chunks_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5; // 4 ring chunks → activate shrinks to 2
+
+    uint32_t target_chunks = 0;
+    uint32_t already_moved_id = uint32_t(-1);
+    uint32_t not_yet_moved_id = uint32_t(-1);
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        auto const old_chunks =
+            ctx.main()->root_offsets.storage_.cnv_chunks_len;
+        ASSERT_EQ(old_chunks, 4u);
+        target_chunks = old_chunks / 2;
+        ASSERT_EQ(target_chunks, 2u);
+
+        // Snapshot which chunks activate would move (the second half of
+        // the primary ring's cnv_chunks list).
+        already_moved_id =
+            ctx.main()
+                ->root_offsets.storage_.cnv_chunks[target_chunks + 0]
+                .cnv_chunk_id;
+        not_yet_moved_id =
+            ctx.main()
+                ->root_offsets.storage_.cnv_chunks[target_chunks + 1]
+                .cnv_chunk_id;
+        ASSERT_NE(already_moved_id, uint32_t(-1));
+        ASSERT_NE(not_yet_moved_id, uint32_t(-1));
+        ASSERT_NE(already_moved_id, not_yet_moved_id);
+
+        for (unsigned which = 0; which < 2; which++) {
+            auto *const m = const_cast<db_metadata *>(ctx.main(which));
+            auto const g = m->hold_dirty();
+            m->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_ACTIVATE;
+            m->pending_shrink_grow.target_primary_chunks = target_chunks;
+            monad::start_lifetime_as<std::atomic<uint64_t>>(
+                &m->shrink_grow_seq_)
+                ->fetch_add(1, std::memory_order_acq_rel);
+
+            // Hand-apply the first move only (primary→secondary for k=0).
+            // Leave k=1 at pristine pre-move state.
+            auto &pstore = m->root_offsets.storage_;
+            auto &sstore = m->secondary_timeline.storage_;
+            sstore.cnv_chunks[0].high_bits_all_set = uint32_t(-1);
+            sstore.cnv_chunks[0].cnv_chunk_id = already_moved_id;
+            pstore.cnv_chunks[target_chunks + 0].cnv_chunk_id = uint32_t(-1);
+        }
+    }
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        for (unsigned which = 0; which < 2; which++) {
+            auto const *const m = ctx.main(which);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE);
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u);
+            auto const &pstore = m->root_offsets.storage_;
+            auto const &sstore = m->secondary_timeline.storage_;
+
+            // The already-moved entry survived — the idempotency guard's
+            // "skip if destination already has a valid id" branch didn't
+            // re-move it or wipe it.
+            EXPECT_EQ(sstore.cnv_chunks[0].cnv_chunk_id, already_moved_id);
+            // The not-yet-moved entry was completed by replay.
+            EXPECT_EQ(sstore.cnv_chunks[1].cnv_chunk_id, not_yet_moved_id);
+            // Source slots on primary are cleared.
+            EXPECT_EQ(
+                pstore.cnv_chunks[target_chunks + 0].cnv_chunk_id,
+                uint32_t(-1));
+            EXPECT_EQ(
+                pstore.cnv_chunks[target_chunks + 1].cnv_chunk_id,
+                uint32_t(-1));
+            EXPECT_EQ(pstore.cnv_chunks_len, target_chunks);
+            EXPECT_EQ(sstore.cnv_chunks_len, target_chunks);
+        }
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+    }
+
+    remove(filename);
+}
+
+// Replay preserves primary ring-data at slots outside the shrink/grow
+// rewrite region. We push a real chunk_offset_t to version 0 on
+// primary, stamp the pending activate flag without running the body,
+// reopen, and confirm the offset at version 0 is still readable after
+// replay completes the shrink. Position 0 under both old_cap and
+// new_cap maps to the same slot, so this validates that the replay
+// body does not corrupt low positions.
+TEST(update_aux_test, replay_preserves_primary_low_positions)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_preserves_primary_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    chunk_offset_t const pushed{7, 12345};
+    uint32_t target_chunks = 0;
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        // Push a real offset to primary at version 0.
+        ctx.root_offsets(timeline_id::primary).push(pushed);
+        EXPECT_EQ(ctx.root_offsets(timeline_id::primary)[0].id, pushed.id);
+
+        target_chunks = ctx.main()->root_offsets.storage_.cnv_chunks_len / 2;
+        for (unsigned which = 0; which < 2; which++) {
+            auto *const m = const_cast<db_metadata *>(ctx.main(which));
+            auto const g = m->hold_dirty();
+            m->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_ACTIVATE;
+            m->pending_shrink_grow.target_primary_chunks = target_chunks;
+            monad::start_lifetime_as<std::atomic<uint64_t>>(
+                &m->shrink_grow_seq_)
+                ->fetch_add(1, std::memory_order_acq_rel);
+        }
+    }
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        // Replay ran, flag cleared, secondary active, primary shrunk.
+        EXPECT_EQ(
+            ctx.main()->pending_shrink_grow.op_kind,
+            db_metadata::PENDING_OP_NONE);
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+        EXPECT_EQ(
+            ctx.main()->root_offsets.storage_.cnv_chunks_len, target_chunks);
+
+        // The pushed offset at version 0 survived replay.
+        EXPECT_EQ(ctx.root_offsets(timeline_id::primary)[0].id, pushed.id);
+        EXPECT_EQ(ctx.root_offsets(timeline_id::primary).max_version(), 0u);
+    }
+
+    remove(filename);
+}
+
+// Replay recovers from a crash that landed between the two per-copy
+// stamp scopes in set_pending_shrink_grow_: copy 0 has the flag set
+// and shrink_grow_seq_ bumped to odd, copy 1 is still pristine. Both
+// copies are clean (neither dirty), so dirty-bit recovery does
+// nothing. Replay must still fire (because copy 0 carries a pending
+// op) and must leave both copies with shrink_grow_seq_ even —
+// otherwise copy 1 could be durably odd, and a later db_copy from
+// copy 1 would wedge readers on the seqlock spin.
+TEST(update_aux_test, replay_handles_single_copy_pending_stamp)
+{
+    using monad::mpt::detail::db_metadata;
+    std::filesystem::path const filename{
+        MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+        "monad_replay_single_copy_pending_XXXXXX"};
+    int const fd = ::mkstemp((char *)filename.native().data());
+    MONAD_ASSERT(fd != -1);
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 8UL << 30));
+
+    monad::async::storage_pool::creation_flags flags;
+    flags.num_cnv_chunks = 5;
+
+    uint32_t target_chunks = 0;
+    uint64_t copy1_seq_before = 0;
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext ctx{testio};
+        ASSERT_TRUE(ctx.is_new_pool());
+        ctx.init_new_pool(AUX_TEST_HISTORY_LENGTH);
+
+        target_chunks = ctx.main()->root_offsets.storage_.cnv_chunks_len / 2;
+        copy1_seq_before = ctx.main(1)->shrink_grow_seq_;
+
+        // Stamp pending + bump seq on copy 0 ONLY. Leave copy 1 entirely
+        // unmodified (op_kind == NONE, seq even).
+        auto *const m0 = const_cast<db_metadata *>(ctx.main(0));
+        auto const g0 = m0->hold_dirty();
+        m0->pending_shrink_grow.op_kind = db_metadata::PENDING_OP_ACTIVATE;
+        m0->pending_shrink_grow.target_primary_chunks = target_chunks;
+        monad::start_lifetime_as<std::atomic<uint64_t>>(&m0->shrink_grow_seq_)
+            ->fetch_add(1, std::memory_order_acq_rel);
+        // Sanity: copy 0 now has seq odd, copy 1 still even.
+        ASSERT_EQ(ctx.main(0)->shrink_grow_seq_ & 1u, 1u);
+        ASSERT_EQ(ctx.main(1)->shrink_grow_seq_ & 1u, 0u);
+    }
+
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1,
+                ring2,
+                2,
+                4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO testio(pool, testbuf);
+        DbMetadataContext const ctx{testio};
+
+        for (unsigned which = 0; which < 2; which++) {
+            auto const *const m = ctx.main(which);
+            EXPECT_EQ(
+                m->pending_shrink_grow.op_kind, db_metadata::PENDING_OP_NONE)
+                << "copy " << which << " op_kind should be NONE after replay";
+            EXPECT_EQ(m->shrink_grow_seq_ & 1u, 0u)
+                << "copy " << which
+                << " shrink_grow_seq_ must be even after replay — the "
+                   "clear path must normalise parity regardless of which "
+                   "copies had the seq bumped during stamp";
+        }
+        // Copy 1's seq must have advanced strictly (generation bump),
+        // so a reader that had observed it pre-crash would see the
+        // change.
+        EXPECT_GT(ctx.main(1)->shrink_grow_seq_, copy1_seq_before);
+        EXPECT_TRUE(ctx.timeline_active(timeline_id::secondary));
+    }
+
+    remove(filename);
+}
+
+TEST(update_aux_test, version_is_valid_ondisk_per_timeline)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        // Push to primary at version 0; advance to version 1 to leave a
+        // version 0 valid on primary that the secondary lacks.
+        auto pro = aux.metadata_ctx().root_offsets(timeline_id::primary);
+        pro.push(chunk_offset_t{1, 0});
+        pro.push(chunk_offset_t{1, 100}); // version 1
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            0, timeline_id::primary));
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            1, timeline_id::primary));
+        EXPECT_FALSE(aux.metadata_ctx().version_is_valid_ondisk(
+            2, timeline_id::primary));
+
+        // Activate secondary; first push lands at version 0.
+        aux.activate_secondary_timeline();
+        auto sro = aux.metadata_ctx().root_offsets(timeline_id::secondary);
+        sro.push(chunk_offset_t{2, 0});
+
+        // Version 0 valid on both timelines now.
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            0, timeline_id::secondary));
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            0, timeline_id::primary));
+
+        // Version 1 valid on primary, not on secondary.
+        EXPECT_TRUE(aux.metadata_ctx().version_is_valid_ondisk(
+            1, timeline_id::primary));
+        EXPECT_FALSE(aux.metadata_ctx().version_is_valid_ondisk(
+            1, timeline_id::secondary));
+
+        aux.deactivate_secondary_timeline();
+    });
 }

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -332,7 +332,10 @@ TEST(update_aux_test, migrates_monad007_layout_to_monad008)
     static constexpr size_t MONAD007_DB_OFFSETS_OFFSET = 524328;
     static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
 
-    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    monad::async::storage_pool::creation_flags flags;
+    flags.allow_migration = true;
+    monad::async::storage_pool pool(
+        monad::async::use_anonymous_inode_tag{}, flags);
 
     // Values that must survive the migration with bit-for-bit fidelity.
     uint64_t const test_history_length = 12345;
@@ -506,7 +509,10 @@ TEST(update_aux_test, migrates_monad007_layout_to_monad008)
 // per-copy branch is the path that actually fixes copy 1.
 TEST(update_aux_test, migrates_monad007_resumes_after_partial_migration)
 {
-    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    monad::async::storage_pool::creation_flags flags;
+    flags.allow_migration = true;
+    monad::async::storage_pool pool(
+        monad::async::use_anonymous_inode_tag{}, flags);
     using monad::mpt::detail::db_metadata;
 
     {
@@ -579,6 +585,64 @@ TEST(update_aux_test, migrates_monad007_resumes_after_partial_migration)
                 << "NONE after migration";
         }
     }
+}
+
+// A binary that opens a MONAD007 pool without setting allow_migration must
+// abort with a message directing operators to monad-mpt --upgrade. This is
+// the race-closer: services never migrate on their own, so two services
+// starting in parallel after an apt bump cannot observe a half-migrated
+// layout.
+TEST(update_aux_death_test, aborts_on_monad007_without_allow_migration)
+{
+    using monad::mpt::detail::db_metadata;
+    static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+
+    // Open anonymous pool without allow_migration set (default = false).
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+
+    // Write minimal MONAD007 magic to cnv chunk 0 (both copies).
+    auto &cnv_chunk = pool.chunk(monad::async::storage_pool::cnv, 0);
+    auto const [write_fd, base_offset] = cnv_chunk.write_fd(0);
+    auto const half_capacity = cnv_chunk.capacity() / 2;
+
+    // chunk_info_count convention mirrors AsyncIO::chunk_count(), which
+    // returns seq_chunks.size() only. Although the ctor aborts on
+    // PREVIOUS_MAGIC before consulting chunk_info_count, encoding the
+    // correct value keeps the fixture robust against ctor refactors.
+    uint32_t const chunk_count =
+        static_cast<uint32_t>(pool.chunks(monad::async::storage_pool::seq));
+    std::vector<uint8_t> buf(
+        MONAD007_DB_METADATA_SIZE +
+            size_t(chunk_count) * sizeof(db_metadata::chunk_info_t),
+        0);
+    memcpy(
+        buf.data(), db_metadata::PREVIOUS_MAGIC, db_metadata::MAGIC_STRING_LEN);
+    uint64_t const bitfield = static_cast<uint64_t>(chunk_count) & 0xfffffULL;
+    memcpy(buf.data() + 8, &bitfield, 8);
+
+    for (unsigned copy_idx = 0; copy_idx < 2; copy_idx++) {
+        ssize_t const written = ::pwrite(
+            write_fd,
+            buf.data(),
+            buf.size(),
+            off_t(base_offset) + off_t(copy_idx) * off_t(half_capacity));
+        ASSERT_EQ(ssize_t(buf.size()), written);
+    }
+
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers testbuf =
+        monad::io::make_buffers_for_segregated_read_write(
+            ring1,
+            ring2,
+            2,
+            4,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    monad::async::AsyncIO testio(pool, testbuf);
+
+    ASSERT_DEATH(
+        { DbMetadataContext const ctx{testio}; }, "monad-mpt --upgrade");
 }
 
 TEST(update_aux_test, activate_deactivate_secondary)

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -184,7 +184,8 @@ TEST(update_aux_test, root_offsets_fast_slow)
             .write_fd(50);
         auto const end_offset =
             aux_writer.node_writer_fast->sender().offset().add_to_offset(50);
-        aux_writer.metadata_ctx().append_root_offset(start_offset);
+        aux_writer.metadata_ctx().append_root_offset(
+            start_offset, timeline_id::primary);
         aux_writer.metadata_ctx().advance_db_offsets_to(
             end_offset, aux_writer.node_writer_slow->sender().offset());
     }
@@ -202,7 +203,8 @@ TEST(update_aux_test, root_offsets_fast_slow)
             .write_fd(100);
         auto const end_offset =
             aux_writer.node_writer_fast->sender().offset().add_to_offset(100);
-        aux_writer.metadata_ctx().append_root_offset(end_offset);
+        aux_writer.metadata_ctx().append_root_offset(
+            end_offset, timeline_id::primary);
     }
 
     { // Fail to reopen upon calling rewind_to_match_offsets()
@@ -1626,5 +1628,244 @@ TEST(update_aux_test, version_is_valid_ondisk_per_timeline)
             1, timeline_id::secondary));
 
         aux.deactivate_secondary_timeline();
+    });
+}
+
+// -------------------------------------------------------------------
+// rewind_to_version + clear_ondisk_db dual-timeline behavior
+// -------------------------------------------------------------------
+
+namespace
+{
+    // Burn BYTES bytes on the current fast writer chunk and return the
+    // chunk_offset_t (with spare bits set to BYTES/DISK_PAGE_SIZE) that points
+    // at where the write started. Caller appends this to a ring and advances
+    // db_offsets so rewind_to_match_offsets's invariants hold.
+    constexpr size_t FAKE_ROOT_BYTES = 1024;
+
+    chunk_offset_t
+    fake_root_write(monad::async::storage_pool &pool, UpdateAux &aux)
+    {
+        chunk_offset_t const off_before =
+            aux.node_writer_fast->sender().offset();
+        (void)pool.chunk(monad::async::storage_pool::seq, off_before.id)
+            .write_fd(FAKE_ROOT_BYTES);
+        chunk_offset_t off_with_spare = off_before; // mutated by set_spare
+        off_with_spare.set_spare(FAKE_ROOT_BYTES / DISK_PAGE_SIZE);
+        auto const off_after = off_before.add_to_offset(FAKE_ROOT_BYTES);
+        aux.metadata_ctx().advance_db_offsets_to(
+            off_after, aux.metadata_ctx().get_start_of_wip_slow_offset());
+        return off_with_spare;
+    }
+
+    void primary_write(
+        monad::async::storage_pool &pool, UpdateAux &aux, uint64_t version)
+    {
+        auto const off = fake_root_write(pool, aux);
+        auto &mctx = aux.metadata_ctx();
+        auto const max_ver = mctx.db_history_max_version();
+        if (max_ver == INVALID_BLOCK_NUM) {
+            mctx.fast_forward_next_version(version, timeline_id::primary);
+            mctx.append_root_offset(off, timeline_id::primary);
+        }
+        else if (version <= max_ver) {
+            mctx.update_root_offset(version, off, timeline_id::primary);
+        }
+        else {
+            MONAD_ASSERT(version == max_ver + 1);
+            mctx.append_root_offset(off, timeline_id::primary);
+        }
+    }
+
+    void secondary_write(
+        monad::async::storage_pool &pool, UpdateAux &aux, uint64_t version)
+    {
+        auto const off = fake_root_write(pool, aux);
+        auto &mctx = aux.metadata_ctx();
+        auto const max_ver =
+            mctx.db_history_max_version(timeline_id::secondary);
+        if (max_ver == INVALID_BLOCK_NUM) {
+            mctx.fast_forward_next_version(version, timeline_id::secondary);
+            mctx.append_root_offset(off, timeline_id::secondary);
+        }
+        else if (version <= max_ver) {
+            mctx.update_root_offset(version, off, timeline_id::secondary);
+        }
+        else {
+            MONAD_ASSERT(version == max_ver + 1);
+            mctx.append_root_offset(off, timeline_id::secondary);
+        }
+    }
+}
+
+// Secondary lags primary (lower max_version); primary rewind must not
+// touch secondary's ring or destroy chunks holding secondary's nodes.
+TEST(update_aux_test, rewind_preserves_lagging_secondary)
+{
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers testbuf =
+        monad::io::make_buffers_for_segregated_read_write(
+            ring1,
+            ring2,
+            2,
+            4,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    monad::async::AsyncIO testio(pool, testbuf);
+    UpdateAux aux{testio, AUX_TEST_HISTORY_LENGTH};
+    auto &mctx = aux.metadata_ctx();
+
+    // Primary versions 0..4.
+    for (uint64_t v = 0; v <= 4; ++v) {
+        primary_write(pool, aux, v);
+    }
+    // Activate secondary; secondary versions 0..1 (lagging).
+    aux.activate_secondary_timeline();
+    secondary_write(pool, aux, 0);
+    secondary_write(pool, aux, 1);
+    // More primary versions 5..9.
+    for (uint64_t v = 5; v <= 9; ++v) {
+        primary_write(pool, aux, v);
+    }
+    mctx.set_latest_finalized_version(7);
+
+    auto const secondary_v0_before =
+        mctx.root_offsets(timeline_id::secondary)[0];
+    auto const secondary_v1_before =
+        mctx.root_offsets(timeline_id::secondary)[1];
+
+    aux.rewind_to_version(7);
+
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::primary), 7u);
+    EXPECT_TRUE(mctx.timeline_active(timeline_id::secondary));
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::secondary), 1u);
+    EXPECT_EQ(
+        mctx.root_offsets(timeline_id::secondary)[0], secondary_v0_before);
+    EXPECT_EQ(
+        mctx.root_offsets(timeline_id::secondary)[1], secondary_v1_before);
+    EXPECT_TRUE(mctx.version_is_valid_ondisk(1, timeline_id::secondary));
+    EXPECT_FALSE(mctx.version_is_valid_ondisk(2, timeline_id::secondary));
+    EXPECT_FALSE(mctx.version_is_valid_ondisk(8, timeline_id::primary));
+
+    aux.deactivate_secondary_timeline();
+}
+
+// Secondary caught up past the rewind point; both rings must discard
+// speculative entries above the target.
+TEST(update_aux_test, rewind_discards_speculative_on_both_timelines)
+{
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers testbuf =
+        monad::io::make_buffers_for_segregated_read_write(
+            ring1,
+            ring2,
+            2,
+            4,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    monad::async::AsyncIO testio(pool, testbuf);
+    UpdateAux aux{testio, AUX_TEST_HISTORY_LENGTH};
+    auto &mctx = aux.metadata_ctx();
+
+    // Primary versions 0..4.
+    for (uint64_t v = 0; v <= 4; ++v) {
+        primary_write(pool, aux, v);
+    }
+    aux.activate_secondary_timeline();
+    // Both timelines write versions 5..9. Interleaved real-time order.
+    for (uint64_t v = 5; v <= 9; ++v) {
+        primary_write(pool, aux, v);
+        secondary_write(pool, aux, v - 5); // secondary maps blocks 0..4
+    }
+    // Secondary now has versions 0..4 (corresponds to primary 5..9 blocks
+    // in the migration model — exact mapping doesn't matter here, just that
+    // secondary's max > rewind target).
+    mctx.set_latest_finalized_version(7);
+
+    aux.rewind_to_version(7);
+
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::primary), 7u);
+    // Secondary's max was 4, and 4 < 7, so secondary is unchanged.
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::secondary), 4u);
+
+    // Now write 3 more secondary versions to push it past the rewind target,
+    // then rewind primary again to 2 (lower than secondary's max).
+    secondary_write(pool, aux, 5);
+    secondary_write(pool, aux, 6);
+    secondary_write(pool, aux, 7);
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::secondary), 7u);
+
+    aux.rewind_to_version(2);
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::primary), 2u);
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::secondary), 2u);
+    EXPECT_FALSE(mctx.version_is_valid_ondisk(3, timeline_id::primary));
+    EXPECT_FALSE(mctx.version_is_valid_ondisk(3, timeline_id::secondary));
+
+    aux.deactivate_secondary_timeline();
+}
+
+// Both timelines must persist across an UpdateAux re-init (simulates a
+// node restart that triggers rewind_to_latest_finalized internally).
+TEST(update_aux_test, rewind_state_survives_reopen)
+{
+    monad::async::storage_pool pool(monad::async::use_anonymous_inode_tag{});
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers testbuf =
+        monad::io::make_buffers_for_segregated_read_write(
+            ring1,
+            ring2,
+            2,
+            4,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    monad::async::AsyncIO testio(pool, testbuf);
+
+    chunk_offset_t secondary_root_at_v1 = INVALID_OFFSET;
+    {
+        UpdateAux aux{testio, AUX_TEST_HISTORY_LENGTH};
+        auto &mctx = aux.metadata_ctx();
+        for (uint64_t v = 0; v <= 4; ++v) {
+            primary_write(pool, aux, v);
+        }
+        aux.activate_secondary_timeline();
+        secondary_write(pool, aux, 0);
+        secondary_write(pool, aux, 1);
+        for (uint64_t v = 5; v <= 9; ++v) {
+            primary_write(pool, aux, v);
+        }
+        mctx.set_latest_finalized_version(7);
+        secondary_root_at_v1 = mctx.root_offsets(timeline_id::secondary)[1];
+        aux.rewind_to_version(7);
+    }
+
+    // Reopen the pool with a fresh UpdateAux.
+    UpdateAux aux2{testio, AUX_TEST_HISTORY_LENGTH};
+    auto const &mctx2 = aux2.metadata_ctx();
+    EXPECT_EQ(mctx2.db_history_max_version(timeline_id::primary), 7u);
+    EXPECT_TRUE(mctx2.timeline_active(timeline_id::secondary));
+    EXPECT_EQ(mctx2.db_history_max_version(timeline_id::secondary), 1u);
+    EXPECT_EQ(
+        mctx2.root_offsets(timeline_id::secondary)[1], secondary_root_at_v1);
+    aux2.deactivate_secondary_timeline();
+}
+
+// clear_ondisk_db must deactivate secondary at entry — otherwise the
+// chunk-trim path would destroy secondary's data.
+TEST(update_aux_test, clear_ondisk_db_deactivates_secondary)
+{
+    with_rw_aux([](UpdateAux &aux) {
+        aux.activate_secondary_timeline();
+        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
+        aux.clear_ondisk_db();
+        EXPECT_FALSE(
+            aux.metadata_ctx().timeline_active(timeline_id::secondary));
+        EXPECT_EQ(
+            aux.metadata_ctx().db_history_max_version(timeline_id::primary),
+            INVALID_BLOCK_NUM);
     });
 }

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -87,8 +87,8 @@ namespace detail
                     continue;
                 }
                 MONAD_ASSERT(aux.is_on_disk());
-                auto const next_node_ondisk =
-                    read_node_blocking(aux, node.fnext(idx), version);
+                auto const next_node_ondisk = read_node_blocking(
+                    aux, node.fnext(idx), version, timeline_id::primary);
                 if (!next_node_ondisk || !preorder_traverse_blocking_impl(
                                              aux,
                                              next_branch,

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -25,6 +25,7 @@
 #include <category/core/log.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/deserialize_node_from_receiver_result.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
@@ -146,7 +147,8 @@ void maybe_expire_or_compact_child(
         }
     }
     if (sm.auto_expire() &&
-        subtrie_min_version < aux.curr_upsert_auto_expire_version) {
+        subtrie_min_version <
+            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version) {
         bool const cache = child_ptr != nullptr;
         expire_(
             aux,
@@ -159,7 +161,8 @@ void maybe_expire_or_compact_child(
             cache);
         return;
     }
-    if (sm.compact() && min_offsets.any_below(aux.compact_offsets)) {
+    if (sm.compact() &&
+        min_offsets.any_below(aux.tl(timeline_id::primary).compact_offsets)) {
         compact_(
             aux,
             sm,
@@ -167,7 +170,8 @@ void maybe_expire_or_compact_child(
             index,
             std::move(child_ptr),
             child_offset,
-            min_offsets.fast_below(aux.compact_offsets));
+            min_offsets.fast_below(
+                aux.tl(timeline_id::primary).compact_offsets));
     }
     else {
         tnode.child_done();
@@ -505,7 +509,9 @@ std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
         node_fast[j] = orig_fast[orig_j];
         node_slow[j] = orig_slow[orig_j];
         auto const ver = orig_ver[orig_j];
-        MONAD_ASSERT(ver >= aux.curr_upsert_auto_expire_version);
+        MONAD_ASSERT(
+            ver >=
+            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
         node_ver[j] = ver;
         if (tnode->cache_mask & (1u << orig_j)) {
             node_ptrs[j] = std::exchange(orig_ptrs[orig_j], Node::SharedPtr{});
@@ -566,7 +572,8 @@ Node::SharedPtr create_node_from_children_if_any(
                     calc_min_offsets(*child.ptr, child_virtual_offset);
                 MONAD_ASSERT(
                     !(sm.compact() &&
-                      child.min_offsets.any_below(aux.compact_offsets)));
+                      child.min_offsets.any_below(
+                          aux.tl(timeline_id::primary).compact_offsets)));
             }
             // apply cache based on state machine state, always cache node that
             // is a single child
@@ -642,7 +649,7 @@ void create_node_compute_data_possibly_async(
         if (sm.auto_expire()) {
             MONAD_ASSERT(
                 entry.subtrie_min_version >=
-                aux.curr_upsert_auto_expire_version);
+                aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
         }
         parent.child_done();
     }
@@ -803,7 +810,8 @@ void create_new_trie_from_requests_(
     entry.finalize(std::move(node), sm.get_compute(), sm.cache());
     if (sm.auto_expire()) {
         MONAD_ASSERT(
-            entry.subtrie_min_version >= aux.curr_upsert_auto_expire_version);
+            entry.subtrie_min_version >=
+            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
     }
 }
 
@@ -1113,7 +1121,8 @@ void expire_(
         return;
     }
     MONAD_ASSERT(sm.auto_expire() == true && sm.compact() == true);
-    if (node->version < aux.curr_upsert_auto_expire_version) {
+    if (node->version <
+        aux.tl(timeline_id::primary).curr_upsert_auto_expire_version) {
         // entire subtrie is expired, erase from parent
         erase_child_from_parent(
             parent, static_cast<uint8_t>(branch), static_cast<uint8_t>(index));
@@ -1163,7 +1172,9 @@ void fillin_parent_after_expiration(
             min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET ||
             min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
         auto const min_version = calc_min_version(*new_node);
-        MONAD_ASSERT(min_version >= aux.curr_upsert_auto_expire_version);
+        MONAD_ASSERT(
+            min_version >=
+            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
         if (parent->type == tnode_type::update) {
             auto &child = static_cast<UpdateTNode *>(parent)->children[index];
             MONAD_ASSERT(!child.ptr); // been transferred to tnode
@@ -1249,9 +1260,10 @@ void compact_(
     if (virtual_node_offset != INVALID_VIRTUAL_OFFSET) {
         compact_virtual_chunk_offset_t const compacted_virtual_offset{
             virtual_node_offset};
-        auto const threshold = virtual_node_offset.in_fast_list()
-                                   ? aux.compact_offsets.fast
-                                   : aux.compact_offsets.slow;
+        auto const threshold =
+            virtual_node_offset.in_fast_list()
+                ? aux.tl(timeline_id::primary).compact_offsets.fast
+                : aux.tl(timeline_id::primary).compact_offsets.slow;
         rewrite_to_fast = compacted_virtual_offset >= threshold;
     }
 
@@ -1273,7 +1285,8 @@ void compact_(
     for (unsigned j = 0; j < n; ++j) {
         auto child_ptr = std::exchange(ptrs[j], Node::SharedPtr{});
         compact_offset_pair const child_min_offsets{fast[j], slow[j]};
-        if (sm.compact() && child_min_offsets.any_below(aux.compact_offsets)) {
+        if (sm.compact() && child_min_offsets.any_below(
+                                aux.tl(timeline_id::primary).compact_offsets)) {
             compact_(
                 aux,
                 sm,
@@ -1281,7 +1294,8 @@ void compact_(
                 j,
                 std::move(child_ptr),
                 fnext[j],
-                child_min_offsets.fast_below(aux.compact_offsets));
+                child_min_offsets.fast_below(
+                    aux.tl(timeline_id::primary).compact_offsets));
         }
         else {
             tnode->child_done();
@@ -1319,7 +1333,8 @@ void try_fillin_parent_with_rewritten_node(
         min_offsets.slow =
             std::min(min_offsets.slow, truncated_new_virtual_offset);
     }
-    MONAD_ASSERT(!min_offsets.any_below(aux.compact_offsets));
+    MONAD_ASSERT(
+        !min_offsets.any_below(aux.tl(timeline_id::primary).compact_offsets));
     TNodeBase *parent = tnode->parent();
     auto const index = tnode->index;
     if (parent->type == tnode_type::update) {

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -59,52 +59,56 @@ using namespace MONAD_ASYNC_NAMESPACE;
 void dispatch_updates_impl_(
     UpdateAux &, StateMachine &, UpdateTNode &parent, ChildData &,
     Node::SharedPtr old, Requests &, unsigned prefix_index, NibblesView path,
-    std::optional<byte_string_view> opt_leaf_data, int64_t version);
+    std::optional<byte_string_view> opt_leaf_data, int64_t version,
+    timeline_id tid);
 
 void mismatch_handler_(
     UpdateAux &, StateMachine &, UpdateTNode &parent, ChildData &,
     Node::SharedPtr old, Requests &, NibblesView path,
-    unsigned old_prefix_index, unsigned prefix_index);
+    unsigned old_prefix_index, unsigned prefix_index, timeline_id tid);
 
 void create_new_trie_(
     UpdateAux &aux, StateMachine &sm, int64_t &parent_version, ChildData &entry,
-    UpdateList &&updates, unsigned prefix_index = 0);
+    UpdateList &&updates, timeline_id tid, unsigned prefix_index = 0);
 
 void create_new_trie_from_requests_(
     UpdateAux &, StateMachine &, int64_t &parent_version, ChildData &,
     Requests &, NibblesView path, unsigned prefix_index,
-    std::optional<byte_string_view> opt_leaf_data, int64_t version);
+    std::optional<byte_string_view> opt_leaf_data, int64_t version,
+    timeline_id tid);
 
 void upsert_(
     UpdateAux &, StateMachine &, UpdateTNode &parent, ChildData &,
-    Node::SharedPtr old, chunk_offset_t offset, UpdateList &&,
+    Node::SharedPtr old, chunk_offset_t offset, UpdateList &&, timeline_id tid,
     unsigned prefix_index = 0, unsigned old_prefix_index = 0);
 
 void create_node_compute_data_possibly_async(
     UpdateAux &, StateMachine &, UpdateTNode &parent, ChildData &,
-    tnode_unique_ptr, bool might_on_disk = true);
+    tnode_unique_ptr, timeline_id tid, bool might_on_disk = true);
 
 template <any_tnode Parent>
 void compact_(
     UpdateAux &, StateMachine &, Parent &, unsigned index, Node::SharedPtr,
-    chunk_offset_t node_offset, bool copy_node_for_fast_or_slow);
+    chunk_offset_t node_offset, bool copy_node_for_fast_or_slow,
+    timeline_id tid);
 
 void expire_(
     UpdateAux &, StateMachine &, UpdateExpireBase &parent, unsigned branch,
     unsigned index, Node::SharedPtr node, chunk_offset_t node_offset,
-    bool cache_node);
+    bool cache_node, timeline_id tid);
 
 void try_fillin_parent_with_rewritten_node(
-    UpdateAux &, CompactTNode::unique_ptr_type);
+    UpdateAux &, CompactTNode::unique_ptr_type, timeline_id tid);
 
 void try_fillin_parent_after_expiration(
-    UpdateAux &, StateMachine &, ExpireTNode::unique_ptr_type);
+    UpdateAux &, StateMachine &, ExpireTNode::unique_ptr_type, timeline_id tid);
 
-void propagate_upward(UpdateAux &, StateMachine &, TNodeBase *);
+void propagate_upward(
+    UpdateAux &, StateMachine &, TNodeBase *, timeline_id tid);
 
 void fillin_parent_after_expiration(
     UpdateAux &, Node::SharedPtr, UpdateExpireBase *const, uint8_t index,
-    uint8_t branch, bool cache_node);
+    uint8_t branch, bool cache_node, timeline_id tid);
 
 struct async_write_node_result
 {
@@ -115,7 +119,8 @@ struct async_write_node_result
 
 // invoke at the end of each block upsert
 void flush_buffered_writes(UpdateAux &);
-chunk_offset_t write_new_root_node(UpdateAux &, Node &, uint64_t);
+
+// write_new_root_node declared in trie.hpp
 
 void erase_child_from_parent(UpdateTNode &parent, ChildData &entry)
 {
@@ -138,7 +143,8 @@ template <std::derived_from<UpdateExpireBase> Parent>
 void maybe_expire_or_compact_child(
     UpdateAux &aux, StateMachine &sm, Parent &tnode, unsigned index,
     unsigned branch, Node::SharedPtr &child_ptr, chunk_offset_t child_offset,
-    int64_t subtrie_min_version, compact_offset_pair min_offsets)
+    int64_t subtrie_min_version, compact_offset_pair min_offsets,
+    timeline_id const tid)
 {
     if constexpr (std::same_as<Parent, UpdateTNode>) {
         if (!aux.is_on_disk()) {
@@ -147,8 +153,7 @@ void maybe_expire_or_compact_child(
         }
     }
     if (sm.auto_expire() &&
-        subtrie_min_version <
-            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version) {
+        subtrie_min_version < aux.tl(tid).curr_upsert_auto_expire_version) {
         bool const cache = child_ptr != nullptr;
         expire_(
             aux,
@@ -158,11 +163,11 @@ void maybe_expire_or_compact_child(
             index,
             std::move(child_ptr),
             child_offset,
-            cache);
+            cache,
+            tid);
         return;
     }
-    if (sm.compact() &&
-        min_offsets.any_below(aux.tl(timeline_id::primary).compact_offsets)) {
+    if (sm.compact() && min_offsets.any_below(aux.tl(tid).compact_offsets)) {
         compact_(
             aux,
             sm,
@@ -170,8 +175,8 @@ void maybe_expire_or_compact_child(
             index,
             std::move(child_ptr),
             child_offset,
-            min_offsets.fast_below(
-                aux.tl(timeline_id::primary).compact_offsets));
+            min_offsets.fast_below(aux.tl(tid).compact_offsets),
+            tid);
     }
     else {
         tnode.child_done();
@@ -180,7 +185,8 @@ void maybe_expire_or_compact_child(
 
 Node::SharedPtr upsert(
     UpdateAux &aux, uint64_t const version, StateMachine &sm,
-    Node::SharedPtr old, UpdateList &&updates, bool const write_root)
+    Node::SharedPtr old, UpdateList &&updates, bool const write_root,
+    timeline_id const tid)
 {
     aux.reset_stats();
     auto sentinel = make_tnode(1 /*mask*/);
@@ -206,7 +212,8 @@ Node::SharedPtr upsert(
                 old_path_nibbles_len,
                 old_path,
                 old_node.opt_value(),
-                old_node.version);
+                old_node.version,
+                tid);
             sm.up(old_path_nibbles_len);
         }
         else {
@@ -217,7 +224,8 @@ Node::SharedPtr upsert(
                 entry,
                 std::move(old),
                 INVALID_OFFSET,
-                std::move(updates));
+                std::move(updates),
+                tid);
         }
         if (sentinel->npending) {
             aux.io->flush();
@@ -225,13 +233,14 @@ Node::SharedPtr upsert(
         }
     }
     else {
-        create_new_trie_(aux, sm, sentinel->version, entry, std::move(updates));
+        create_new_trie_(
+            aux, sm, sentinel->version, entry, std::move(updates), tid);
         sentinel->child_done();
     }
     auto root = entry.ptr;
     if (aux.is_on_disk() && root) {
         if (write_root) {
-            write_new_root_node(aux, *root, version);
+            write_new_root_node(aux, *root, version, tid);
         }
         else {
             flush_buffered_writes(aux);
@@ -341,7 +350,8 @@ size_t load_all(UpdateAux &aux, StateMachine &sm, NodeCursor const &root)
 
 // Upward update until a unfinished parent node. For each tnode, create the
 // trie Node when all its children are created
-void upward_update(UpdateAux &aux, StateMachine &sm, UpdateTNode *tnode)
+void upward_update(
+    UpdateAux &aux, StateMachine &sm, UpdateTNode *tnode, timeline_id const tid)
 {
     while (!tnode->npending && tnode->parent()) {
         MONAD_ASSERT(tnode->children.size()); // not a leaf
@@ -351,7 +361,7 @@ void upward_update(UpdateAux &aux, StateMachine &sm, UpdateTNode *tnode)
         size_t const level_up =
             tnode->path.nibble_size() + !parent->is_sentinel();
         create_node_compute_data_possibly_async(
-            aux, sm, *parent, entry, tnode_unique_ptr{tnode});
+            aux, sm, *parent, entry, tnode_unique_ptr{tnode}, tid);
         sm.up(level_up);
         tnode = parent;
     }
@@ -396,7 +406,8 @@ public:
 /////////////////////////////////////////////////////
 
 std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
-    UpdateAux &aux, StateMachine &sm, ExpireTNode::unique_ptr_type tnode)
+    UpdateAux &aux, StateMachine &sm, ExpireTNode::unique_ptr_type tnode,
+    timeline_id const tid)
 {
     MONAD_ASSERT(tnode->node);
     // no recomputation of data
@@ -418,7 +429,8 @@ std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
                 [aux = &aux,
                  sm = sm.clone(),
                  tnode = std::move(tnode),
-                 child_branch](Node::SharedPtr read_node) {
+                 child_branch,
+                 tid](Node::SharedPtr read_node) {
                     auto new_node = make_node(
                         *read_node,
                         concat(
@@ -433,8 +445,9 @@ std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
                         tnode->parent(),
                         tnode->index,
                         tnode->branch,
-                        tnode->cache_node);
-                    propagate_upward(*aux, *sm, tnode->parent());
+                        tnode->cache_node,
+                        tid);
+                    propagate_upward(*aux, *sm, tnode->parent(), tid);
                 },
                 orig->fnext(child_index)};
             async_read(aux, std::move(recv));
@@ -509,9 +522,7 @@ std::pair<bool, Node::SharedPtr> create_node_with_expired_branches(
         node_fast[j] = orig_fast[orig_j];
         node_slow[j] = orig_slow[orig_j];
         auto const ver = orig_ver[orig_j];
-        MONAD_ASSERT(
-            ver >=
-            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
+        MONAD_ASSERT(ver >= aux.tl(tid).curr_upsert_auto_expire_version);
         node_ver[j] = ver;
         if (tnode->cache_mask & (1u << orig_j)) {
             node_ptrs[j] = std::exchange(orig_ptrs[orig_j], Node::SharedPtr{});
@@ -525,7 +536,7 @@ Node::SharedPtr create_node_from_children_if_any(
     UpdateAux &aux, StateMachine &sm, uint16_t const orig_mask,
     uint16_t const mask, std::span<ChildData> const children,
     NibblesView const path, std::optional<byte_string_view> const leaf_data,
-    int64_t const version)
+    int64_t const version, timeline_id const tid)
 {
     aux.collect_number_nodes_created_stats();
     // handle non child and single child cases
@@ -570,10 +581,9 @@ Node::SharedPtr create_node_from_children_if_any(
                 MONAD_ASSERT(child_virtual_offset != INVALID_VIRTUAL_OFFSET);
                 child.min_offsets =
                     calc_min_offsets(*child.ptr, child_virtual_offset);
-                MONAD_ASSERT(
-                    !(sm.compact() &&
-                      child.min_offsets.any_below(
-                          aux.tl(timeline_id::primary).compact_offsets)));
+                MONAD_ASSERT(!(
+                    sm.compact() &&
+                    child.min_offsets.any_below(aux.tl(tid).compact_offsets)));
             }
             // apply cache based on state machine state, always cache node that
             // is a single child
@@ -588,7 +598,7 @@ Node::SharedPtr create_node_from_children_if_any(
 
 void create_node_compute_data_possibly_async(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
-    tnode_unique_ptr tnode, bool const might_on_disk)
+    tnode_unique_ptr tnode, timeline_id const tid, bool const might_on_disk)
 {
     if (might_on_disk && tnode->number_of_children() == 1) {
         auto const &child = tnode->children[bitmask_index(
@@ -611,7 +621,7 @@ void create_node_compute_data_possibly_async(
                                                 .offset()));
             }
             node_receiver_t recv{
-                [aux = &aux, sm = sm.clone(), tnode = std::move(tnode)](
+                [aux = &aux, sm = sm.clone(), tnode = std::move(tnode), tid](
                     Node::SharedPtr read_node) mutable {
                     auto *parent = tnode->parent();
                     MONAD_ASSERT(parent);
@@ -623,9 +633,15 @@ void create_node_compute_data_possibly_async(
                     child.ptr = std::move(read_node);
                     auto const path_size = tnode->path.nibble_size();
                     create_node_compute_data_possibly_async(
-                        *aux, *sm, *parent, entry, std::move(tnode), false);
+                        *aux,
+                        *sm,
+                        *parent,
+                        entry,
+                        std::move(tnode),
+                        tid,
+                        false);
                     sm->up(path_size + !parent->is_sentinel());
-                    upward_update(*aux, *sm, parent);
+                    upward_update(*aux, *sm, parent, tid);
                 },
                 child.offset};
             async_read(aux, std::move(recv));
@@ -641,7 +657,8 @@ void create_node_compute_data_possibly_async(
         tnode->children,
         tnode->path,
         tnode->opt_leaf_data,
-        tnode->version);
+        tnode->version,
+        tid);
     MONAD_ASSERT(entry.branch < 16);
     if (node) {
         parent.version = std::max(parent.version, node->version);
@@ -649,7 +666,7 @@ void create_node_compute_data_possibly_async(
         if (sm.auto_expire()) {
             MONAD_ASSERT(
                 entry.subtrie_min_version >=
-                aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
+                aux.tl(tid).curr_upsert_auto_expire_version);
         }
         parent.child_done();
     }
@@ -660,7 +677,8 @@ void create_node_compute_data_possibly_async(
 
 void update_value_and_subtrie_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
-    Node::SharedPtr old, NibblesView const path, Update &update)
+    Node::SharedPtr old, NibblesView const path, Update &update,
+    timeline_id const tid)
 {
     if (update.is_deletion()) {
         erase_child_from_parent(parent, entry);
@@ -681,7 +699,8 @@ void update_value_and_subtrie_(
             path,
             0,
             update.value,
-            update.version);
+            update.version,
+            tid);
         parent.child_done();
     }
     else {
@@ -698,7 +717,8 @@ void update_value_and_subtrie_(
             0,
             path,
             opt_leaf,
-            update.version);
+            update.version,
+            tid);
     }
     return;
 }
@@ -708,7 +728,7 @@ void update_value_and_subtrie_(
 /////////////////////////////////////////////////////
 void create_new_trie_(
     UpdateAux &aux, StateMachine &sm, int64_t &parent_version, ChildData &entry,
-    UpdateList &&updates, unsigned prefix_index)
+    UpdateList &&updates, timeline_id const tid, unsigned prefix_index)
 {
     if (updates.empty()) {
         return;
@@ -737,7 +757,8 @@ void create_new_trie_(
             path,
             0,
             update.value,
-            update.version);
+            update.version,
+            tid);
 
         if (path.nibble_size()) {
             sm.up(path.nibble_size());
@@ -776,7 +797,8 @@ void create_new_trie_(
             prefix_index_start, prefix_index - prefix_index_start),
         prefix_index,
         requests.opt_leaf.and_then(&Update::value),
-        requests.opt_leaf.has_value() ? requests.opt_leaf.value().version : 0);
+        requests.opt_leaf.has_value() ? requests.opt_leaf.value().version : 0,
+        tid);
     if (prefix_index_start != prefix_index) {
         sm.up(prefix_index - prefix_index_start);
     }
@@ -785,7 +807,8 @@ void create_new_trie_(
 void create_new_trie_from_requests_(
     UpdateAux &aux, StateMachine &sm, int64_t &parent_version, ChildData &entry,
     Requests &requests, NibblesView const path, unsigned const prefix_index,
-    std::optional<byte_string_view> const opt_leaf_data, int64_t version)
+    std::optional<byte_string_view> const opt_leaf_data, int64_t version,
+    timeline_id const tid)
 {
     // version will be updated bottom up
     uint16_t const mask = requests.mask;
@@ -799,19 +822,20 @@ void create_new_trie_from_requests_(
             version,
             children[index],
             std::move(requests[branch]),
+            tid,
             prefix_index + 1);
         sm.up(1);
     }
     // can have empty children
     auto node = create_node_from_children_if_any(
-        aux, sm, mask, mask, children, path, opt_leaf_data, version);
+        aux, sm, mask, mask, children, path, opt_leaf_data, version, tid);
     MONAD_ASSERT(node);
     parent_version = std::max(parent_version, node->version);
     entry.finalize(std::move(node), sm.get_compute(), sm.cache());
     if (sm.auto_expire()) {
         MONAD_ASSERT(
             entry.subtrie_min_version >=
-            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
+            aux.tl(tid).curr_upsert_auto_expire_version);
     }
 }
 
@@ -822,7 +846,7 @@ void create_new_trie_from_requests_(
 void upsert_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
     Node::SharedPtr old, chunk_offset_t const old_offset, UpdateList &&updates,
-    unsigned prefix_index, unsigned old_prefix_index)
+    timeline_id const tid, unsigned prefix_index, unsigned old_prefix_index)
 {
     MONAD_ASSERT(!updates.empty());
     // Variable-length tables support only a one-time insert; no deletions or
@@ -838,6 +862,7 @@ void upsert_(
              prefix_index = prefix_index,
              sm = sm.clone(),
              parent = &parent,
+             tid,
              updates = std::move(updates)](Node::SharedPtr read_node) mutable {
                 // continue recurse down the trie starting from `old`
                 upsert_(
@@ -848,9 +873,10 @@ void upsert_(
                     std::move(read_node),
                     INVALID_OFFSET,
                     std::move(updates),
+                    tid,
                     prefix_index);
                 sm->up(1);
-                upward_update(*aux, *sm, parent);
+                upward_update(*aux, *sm, parent, tid);
             },
             old_offset};
         async_read(aux, std::move(recv));
@@ -869,7 +895,7 @@ void upsert_(
             MONAD_ASSERT(old->path_nibbles_len() == old_prefix_index);
             MONAD_ASSERT(old->has_value());
             update_value_and_subtrie_(
-                aux, sm, parent, entry, std::move(old), path, update);
+                aux, sm, parent, entry, std::move(old), path, update, tid);
             break;
         }
         unsigned const number_of_sublists =
@@ -892,7 +918,8 @@ void upsert_(
                 prefix_index,
                 path,
                 opt_leaf_data,
-                version);
+                version,
+                tid);
             break;
         }
         if (auto const old_nibble =
@@ -916,7 +943,8 @@ void upsert_(
             requests,
             path,
             old_prefix_index,
-            prefix_index);
+            prefix_index,
+            tid);
         break;
     }
     if (prefix_index_start != prefix_index) {
@@ -926,14 +954,14 @@ void upsert_(
 
 void fillin_entry(
     UpdateAux &aux, StateMachine &sm, tnode_unique_ptr tnode,
-    UpdateTNode &parent, ChildData &entry)
+    UpdateTNode &parent, ChildData &entry, timeline_id const tid)
 {
     if (tnode->npending) {
         (void)tnode.release();
     }
     else {
         create_node_compute_data_possibly_async(
-            aux, sm, parent, entry, std::move(tnode));
+            aux, sm, parent, entry, std::move(tnode), tid);
     }
 } // NOLINT(clang-analyzer-unix.Malloc)
   // this is related to the `tnode.release()` call above
@@ -944,7 +972,8 @@ void dispatch_updates_impl_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
     Node::SharedPtr const old_ptr, Requests &requests,
     unsigned const prefix_index, NibblesView const path,
-    std::optional<byte_string_view> const opt_leaf_data, int64_t const version)
+    std::optional<byte_string_view> const opt_leaf_data, int64_t const version,
+    timeline_id const tid)
 {
     Node *old = old_ptr.get();
     uint16_t const orig_mask = old->mask | requests.mask;
@@ -973,6 +1002,7 @@ void dispatch_updates_impl_(
                     old->move_next(old->to_child_index(branch)),
                     old->fnext(old->to_child_index(branch)),
                     std::move(requests[branch]),
+                    tid,
                     prefix_index + 1);
                 sm.up(1);
             }
@@ -983,6 +1013,7 @@ void dispatch_updates_impl_(
                     tnode->version,
                     children[index],
                     std::move(requests[branch]),
+                    tid,
                     prefix_index + 1);
                 tnode->child_done();
                 sm.up(1);
@@ -1000,10 +1031,11 @@ void dispatch_updates_impl_(
                 child.ptr,
                 child.offset,
                 child.subtrie_min_version,
-                child.min_offsets);
+                child.min_offsets,
+                tid);
         }
     }
-    fillin_entry(aux, sm, std::move(tnode), parent, entry);
+    fillin_entry(aux, sm, std::move(tnode), parent, entry, tid);
 }
 
 // Split `old` at old_prefix_index, `updates` are already splitted at
@@ -1011,7 +1043,8 @@ void dispatch_updates_impl_(
 void mismatch_handler_(
     UpdateAux &aux, StateMachine &sm, UpdateTNode &parent, ChildData &entry,
     Node::SharedPtr const old_ptr, Requests &requests, NibblesView const path,
-    unsigned const old_prefix_index, unsigned const prefix_index)
+    unsigned const old_prefix_index, unsigned const prefix_index,
+    timeline_id const tid)
 {
     MONAD_ASSERT(old_ptr);
     Node &old = *old_ptr;
@@ -1042,6 +1075,7 @@ void mismatch_handler_(
                     old_ptr,
                     INVALID_OFFSET,
                     std::move(requests[branch]),
+                    tid,
                     prefix_index + 1,
                     old_prefix_index + 1);
             }
@@ -1052,6 +1086,7 @@ void mismatch_handler_(
                     tnode->version,
                     children[index],
                     std::move(requests[branch]),
+                    tid,
                     prefix_index + 1);
                 tnode->child_done();
             }
@@ -1088,21 +1123,23 @@ void mismatch_handler_(
                 child.ptr,
                 INVALID_OFFSET,
                 child.subtrie_min_version,
-                child_min_offsets);
+                child_min_offsets,
+                tid);
         }
     }
-    fillin_entry(aux, sm, std::move(tnode), parent, entry);
+    fillin_entry(aux, sm, std::move(tnode), parent, entry, tid);
 }
 
 void expire_(
     UpdateAux &aux, StateMachine &sm, UpdateExpireBase &parent,
     unsigned const branch, unsigned const index, Node::SharedPtr node,
-    chunk_offset_t const node_offset, bool const cache_node)
+    chunk_offset_t const node_offset, bool const cache_node,
+    timeline_id const tid)
 {
     if (!node) {
         MONAD_ASSERT(node_offset != INVALID_OFFSET);
         node_receiver_t recv{
-            [aux = &aux, sm = sm.clone(), parent = &parent, branch, index](
+            [aux = &aux, sm = sm.clone(), parent = &parent, branch, index, tid](
                 Node::SharedPtr read_node) {
                 expire_(
                     *aux,
@@ -1112,8 +1149,9 @@ void expire_(
                     index,
                     std::move(read_node),
                     INVALID_OFFSET,
-                    false);
-                propagate_upward(*aux, *sm, parent);
+                    false,
+                    tid);
+                propagate_upward(*aux, *sm, parent, tid);
             },
             node_offset};
         aux.collect_expire_stats(true);
@@ -1121,8 +1159,7 @@ void expire_(
         return;
     }
     MONAD_ASSERT(sm.auto_expire() == true && sm.compact() == true);
-    if (node->version <
-        aux.tl(timeline_id::primary).curr_upsert_auto_expire_version) {
+    if (node->version < aux.tl(tid).curr_upsert_auto_expire_version) {
         // entire subtrie is expired, erase from parent
         erase_child_from_parent(
             parent, static_cast<uint8_t>(branch), static_cast<uint8_t>(index));
@@ -1147,14 +1184,16 @@ void expire_(
             child_ptr,
             tnode->node->fnext(ci),
             tnode->node->subtrie_min_version(ci),
-            tnode->node->min_offsets(ci));
+            tnode->node->min_offsets(ci),
+            tid);
     }
-    try_fillin_parent_after_expiration(aux, sm, std::move(tnode));
+    try_fillin_parent_after_expiration(aux, sm, std::move(tnode), tid);
 }
 
 void fillin_parent_after_expiration(
     UpdateAux &aux, Node::SharedPtr new_node, UpdateExpireBase *const parent,
-    uint8_t const index, uint8_t const branch, bool const cache_node)
+    uint8_t const index, uint8_t const branch, bool const cache_node,
+    timeline_id const tid)
 {
     if (new_node == nullptr) {
         // expire this branch from parent
@@ -1173,8 +1212,7 @@ void fillin_parent_after_expiration(
             min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
         auto const min_version = calc_min_version(*new_node);
         MONAD_ASSERT(
-            min_version >=
-            aux.tl(timeline_id::primary).curr_upsert_auto_expire_version);
+            min_version >= aux.tl(tid).curr_upsert_auto_expire_version);
         if (parent->type == tnode_type::update) {
             auto &child = static_cast<UpdateTNode *>(parent)->children[index];
             MONAD_ASSERT(!child.ptr); // been transferred to tnode
@@ -1200,7 +1238,8 @@ void fillin_parent_after_expiration(
 }
 
 void try_fillin_parent_after_expiration(
-    UpdateAux &aux, StateMachine &sm, ExpireTNode::unique_ptr_type tnode)
+    UpdateAux &aux, StateMachine &sm, ExpireTNode::unique_ptr_type tnode,
+    timeline_id const tid)
 {
     if (tnode->npending) {
         (void)tnode.release();
@@ -1213,19 +1252,19 @@ void try_fillin_parent_after_expiration(
     auto const cache_node = tnode->cache_node;
     aux.collect_expire_stats(false);
     auto [done, new_node] =
-        create_node_with_expired_branches(aux, sm, std::move(tnode));
+        create_node_with_expired_branches(aux, sm, std::move(tnode), tid);
     if (!done) {
         return;
     }
     fillin_parent_after_expiration(
-        aux, std::move(new_node), parent, index, branch, cache_node);
+        aux, std::move(new_node), parent, index, branch, cache_node, tid);
 }
 
 template <any_tnode Parent>
 void compact_(
     UpdateAux &aux, StateMachine &sm, Parent &parent, unsigned const index,
     Node::SharedPtr node, chunk_offset_t const node_offset,
-    bool const copy_node_for_fast_or_slow)
+    bool const copy_node_for_fast_or_slow, timeline_id const tid)
 {
     if (!node) {
         MONAD_ASSERT(node_offset != INVALID_OFFSET);
@@ -1235,7 +1274,8 @@ void compact_(
              aux = &aux,
              sm = sm.clone(),
              parent = &parent,
-             index](Node::SharedPtr read_node) {
+             index,
+             tid](Node::SharedPtr read_node) {
                 compact_(
                     *aux,
                     *sm,
@@ -1243,11 +1283,12 @@ void compact_(
                     index,
                     std::move(read_node),
                     node_offset,
-                    copy_node_for_fast_or_slow);
-                propagate_upward(*aux, *sm, parent);
+                    copy_node_for_fast_or_slow,
+                    tid);
+                propagate_upward(*aux, *sm, parent, tid);
             },
             node_offset};
-        aux.collect_compaction_read_stats(node_offset, recv.bytes_to_read);
+        aux.collect_compaction_read_stats(node_offset, recv.bytes_to_read, tid);
         async_read(aux, std::move(recv));
         return;
     }
@@ -1260,10 +1301,9 @@ void compact_(
     if (virtual_node_offset != INVALID_VIRTUAL_OFFSET) {
         compact_virtual_chunk_offset_t const compacted_virtual_offset{
             virtual_node_offset};
-        auto const threshold =
-            virtual_node_offset.in_fast_list()
-                ? aux.tl(timeline_id::primary).compact_offsets.fast
-                : aux.tl(timeline_id::primary).compact_offsets.slow;
+        auto const threshold = virtual_node_offset.in_fast_list()
+                                   ? aux.tl(tid).compact_offsets.fast
+                                   : aux.tl(tid).compact_offsets.slow;
         rewrite_to_fast = compacted_virtual_offset >= threshold;
     }
 
@@ -1275,7 +1315,8 @@ void compact_(
         copy_node_for_fast_or_slow,
         rewrite_to_fast,
         virtual_node_offset,
-        compact_node.get_disk_size());
+        compact_node.get_disk_size(),
+        tid);
 
     unsigned const n = compact_node.number_of_children();
     auto const fnext = compact_node.child_fnext_data();
@@ -1285,8 +1326,8 @@ void compact_(
     for (unsigned j = 0; j < n; ++j) {
         auto child_ptr = std::exchange(ptrs[j], Node::SharedPtr{});
         compact_offset_pair const child_min_offsets{fast[j], slow[j]};
-        if (sm.compact() && child_min_offsets.any_below(
-                                aux.tl(timeline_id::primary).compact_offsets)) {
+        if (sm.compact() &&
+            child_min_offsets.any_below(aux.tl(tid).compact_offsets)) {
             compact_(
                 aux,
                 sm,
@@ -1294,8 +1335,8 @@ void compact_(
                 j,
                 std::move(child_ptr),
                 fnext[j],
-                child_min_offsets.fast_below(
-                    aux.tl(timeline_id::primary).compact_offsets));
+                child_min_offsets.fast_below(aux.tl(tid).compact_offsets),
+                tid);
         }
         else {
             tnode->child_done();
@@ -1303,11 +1344,11 @@ void compact_(
     }
     // Compaction below `node` is completed, rewrite `node` to disk and put
     // offset and min_offset somewhere in parent depends on its type
-    try_fillin_parent_with_rewritten_node(aux, std::move(tnode));
+    try_fillin_parent_with_rewritten_node(aux, std::move(tnode), tid);
 }
 
 void try_fillin_parent_with_rewritten_node(
-    UpdateAux &aux, CompactTNode::unique_ptr_type tnode)
+    UpdateAux &aux, CompactTNode::unique_ptr_type tnode, timeline_id const tid)
 {
     if (tnode->npending) { // there are unfinished async below node
         (void)tnode.release();
@@ -1333,8 +1374,7 @@ void try_fillin_parent_with_rewritten_node(
         min_offsets.slow =
             std::min(min_offsets.slow, truncated_new_virtual_offset);
     }
-    MONAD_ASSERT(
-        !min_offsets.any_below(aux.tl(timeline_id::primary).compact_offsets));
+    MONAD_ASSERT(!min_offsets.any_below(aux.tl(tid).compact_offsets));
     TNodeBase *parent = tnode->parent();
     auto const index = tnode->index;
     if (parent->type == tnode_type::update) {
@@ -1369,11 +1409,12 @@ void try_fillin_parent_with_rewritten_node(
     parent->child_done();
 }
 
-void propagate_upward(UpdateAux &aux, StateMachine &sm, TNodeBase *parent)
+void propagate_upward(
+    UpdateAux &aux, StateMachine &sm, TNodeBase *parent, timeline_id const tid)
 {
     while (!parent->npending) {
         if (parent->type == tnode_type::update) {
-            upward_update(aux, sm, static_cast<UpdateTNode *>(parent));
+            upward_update(aux, sm, static_cast<UpdateTNode *>(parent), tid);
             return;
         }
         auto *next_parent = parent->parent();
@@ -1382,7 +1423,8 @@ void propagate_upward(UpdateAux &aux, StateMachine &sm, TNodeBase *parent)
             try_fillin_parent_with_rewritten_node(
                 aux,
                 CompactTNode::unique_ptr_type{
-                    static_cast<CompactTNode *>(parent)});
+                    static_cast<CompactTNode *>(parent)},
+                tid);
         }
         else {
             MONAD_ASSERT(parent->type == tnode_type::expire);
@@ -1390,7 +1432,8 @@ void propagate_upward(UpdateAux &aux, StateMachine &sm, TNodeBase *parent)
                 aux,
                 sm,
                 ExpireTNode::unique_ptr_type{
-                    static_cast<ExpireTNode *>(parent)});
+                    static_cast<ExpireTNode *>(parent)},
+                tid);
         }
         parent = next_parent;
     }
@@ -1703,8 +1746,8 @@ void flush_buffered_writes(UpdateAux &aux)
 }
 
 // return root physical offset
-chunk_offset_t
-write_new_root_node(UpdateAux &aux, Node &root, uint64_t const version)
+chunk_offset_t write_new_root_node(
+    UpdateAux &aux, Node &root, uint64_t const version, timeline_id const tid)
 {
     auto const offset_written_to = async_write_node_set_spare(aux, root, true);
     flush_buffered_writes(aux);
@@ -1712,11 +1755,31 @@ write_new_root_node(UpdateAux &aux, Node &root, uint64_t const version)
     aux.metadata_ctx().advance_db_offsets_to(
         aux.node_writer_fast->sender().offset(),
         aux.node_writer_slow->sender().offset());
-    // update root offset
-    auto const max_version_in_db = aux.metadata_ctx().db_history_max_version();
+
+    if (tid == timeline_id::secondary) {
+        // Secondary ring: append-or-overwrite, no history trimming.
+        auto const max_ver = aux.metadata_ctx().db_history_max_version(tid);
+        if (max_ver == INVALID_BLOCK_NUM) {
+            aux.metadata_ctx().fast_forward_next_version(version, tid);
+            aux.metadata_ctx().append_root_offset(offset_written_to, tid);
+        }
+        else if (version <= max_ver) {
+            aux.metadata_ctx().update_root_offset(
+                version, offset_written_to, tid);
+        }
+        else {
+            MONAD_ASSERT(version == max_ver + 1);
+            aux.metadata_ctx().append_root_offset(offset_written_to, tid);
+        }
+        return offset_written_to;
+    }
+
+    // Primary timeline: original logic with history management
+    auto const max_version_in_db =
+        aux.metadata_ctx().db_history_max_version(tid);
     if (MONAD_UNLIKELY(max_version_in_db == INVALID_BLOCK_NUM)) {
-        aux.metadata_ctx().fast_forward_next_version(version);
-        aux.metadata_ctx().append_root_offset(offset_written_to);
+        aux.metadata_ctx().fast_forward_next_version(version, tid);
+        aux.metadata_ctx().append_root_offset(offset_written_to, tid);
         MONAD_ASSERT(
             aux.metadata_ctx().db_history_range_lower_bound() == version);
     }
@@ -1729,7 +1792,7 @@ write_new_root_node(UpdateAux &aux, Node &root, uint64_t const version)
                  : 0));
         auto const prev_lower_bound =
             aux.metadata_ctx().db_history_range_lower_bound();
-        aux.metadata_ctx().update_root_offset(version, offset_written_to);
+        aux.metadata_ctx().update_root_offset(version, offset_written_to, tid);
         MONAD_ASSERT(
             aux.metadata_ctx().db_history_range_lower_bound() ==
             std::min(version, prev_lower_bound));
@@ -1738,16 +1801,16 @@ write_new_root_node(UpdateAux &aux, Node &root, uint64_t const version)
         MONAD_ASSERT(version == max_version_in_db + 1);
         // Erase the earliest valid version if it is going to be outdated after
         // writing a new version, must happen before appending new root offset
-        if (version - aux.metadata_ctx().db_history_min_valid_version() >=
+        if (version - aux.metadata_ctx().db_history_min_valid_version(tid) >=
             aux.metadata_ctx()
                 .version_history_length()) { // if exceed history length
             aux.erase_versions_up_to_and_including(
                 version - aux.metadata_ctx().version_history_length());
             MONAD_ASSERT(
-                version - aux.metadata_ctx().db_history_min_valid_version() <
+                version - aux.metadata_ctx().db_history_min_valid_version(tid) <
                 aux.metadata_ctx().version_history_length());
         }
-        aux.metadata_ctx().append_root_offset(offset_written_to);
+        aux.metadata_ctx().append_root_offset(offset_written_to, tid);
     }
     return offset_written_to;
 }

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -23,6 +23,7 @@
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/collected_stats.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
 #include <category/mpt/state_machine.hpp>
@@ -197,7 +198,8 @@ class UpdateAux
     TODO: Develop a more efficient and scalable mechanism for auto-expiration
     throttling. The goal is to ensure stable database commit times despite
     varying block loads. */
-    int64_t calc_auto_expire_version(uint64_t upsert_version) noexcept;
+    int64_t
+    calc_auto_expire_version(uint64_t upsert_version, timeline_id tid) noexcept;
 
     void update_disk_growth_data();
 
@@ -220,12 +222,6 @@ class UpdateAux
         MIN_COMPACT_VIRTUAL_OFFSET};
     compact_virtual_chunk_offset_t last_block_disk_growth_slow_{
         MIN_COMPACT_VIRTUAL_OFFSET};
-    // compaction range
-    compact_virtual_chunk_offset_t compact_offset_range_fast_{
-        MIN_COMPACT_VIRTUAL_OFFSET};
-    compact_virtual_chunk_offset_t compact_offset_range_slow_{
-        MIN_COMPACT_VIRTUAL_OFFSET};
-
     bool alternate_slow_fast_writer_{false};
     bool can_write_to_fast_{true};
 
@@ -233,9 +229,17 @@ public:
     // Allocate the first cnv chunk for db metadata copies
     static constexpr unsigned cnv_chunks_for_db_metadata = 1;
 
-    int64_t curr_upsert_auto_expire_version{0};
-    compact_offset_pair compact_offsets{
-        MIN_COMPACT_VIRTUAL_OFFSET, MIN_COMPACT_VIRTUAL_OFFSET};
+    timeline_compaction_state timeline_[NUM_TIMELINES];
+
+    timeline_compaction_state &tl(timeline_id id) noexcept
+    {
+        return timeline_[static_cast<unsigned>(id)];
+    }
+
+    timeline_compaction_state const &tl(timeline_id id) const noexcept
+    {
+        return timeline_[static_cast<unsigned>(id)];
+    }
 
     // On disk stuff
     MONAD_ASYNC_NAMESPACE::AsyncIO *io{nullptr};
@@ -354,12 +358,18 @@ public:
                (double)num_chunks(chunk_list::free) / (double)io->chunk_count();
     }
 
-    uint32_t num_chunks(chunk_list list) const noexcept;
+    uint32_t num_chunks(chunk_list const list) const noexcept;
+
+    // Timeline lifecycle. The metadata-header portion of each operation lives
+    // on DbMetadataContext; these methods keep the per-timeline compaction
+    // state (tl()) in sync with the header.
+    void activate_secondary_timeline();
+    void deactivate_secondary_timeline();
+    void promote_secondary_to_primary();
 };
 
-// sizeof changed: db_metadata_[2] replaced by unique_ptr<DbMetadataContext>
 static_assert(
-    sizeof(UpdateAux) == 96 + sizeof(detail::TrieUpdateCollectedStats));
+    sizeof(UpdateAux) == 120 + sizeof(detail::TrieUpdateCollectedStats));
 static_assert(alignof(UpdateAux) == 8);
 
 template <receiver Receiver>

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -167,7 +167,8 @@ public:
 
 chunk_offset_t async_write_node_set_spare(UpdateAux &, Node &, bool is_fast);
 
-chunk_offset_t write_new_root_node(UpdateAux &, Node &root, uint64_t version);
+chunk_offset_t
+write_new_root_node(UpdateAux &, Node &root, uint64_t version, timeline_id tid);
 
 node_writer_unique_ptr_type
 replace_node_writer(UpdateAux &, node_writer_unique_ptr_type const &);
@@ -177,7 +178,7 @@ class UpdateAux
 {
     void reset_node_writers();
 
-    void advance_compact_offsets(Node::SharedPtr prev_root);
+    void advance_compact_offsets(Node::SharedPtr prev_root, timeline_id tid);
 
     void free_compacted_chunks();
 
@@ -267,8 +268,8 @@ public:
 
     Node::SharedPtr do_update(
         Node::SharedPtr prev_root, StateMachine &, UpdateList &&,
-        uint64_t version, bool compaction = false,
-        bool can_write_to_fast = true, bool write_root = true);
+        uint64_t version, bool compaction, bool can_write_to_fast,
+        bool write_root, timeline_id tid);
 
     void adjust_history_length_based_on_disk_usage();
     void move_trie_version_forward(uint64_t src, uint64_t dest);
@@ -278,12 +279,13 @@ public:
     void collect_expire_stats(bool is_read);
     void collect_number_nodes_created_stats();
     void collect_compaction_read_stats(
-        chunk_offset_t node_offset, unsigned bytes_to_read);
+        chunk_offset_t node_offset, unsigned bytes_to_read, timeline_id tid);
     void collect_compacted_nodes_stats(
         bool copy_node_for_fast, bool rewrite_to_fast,
-        virtual_chunk_offset_t node_offset, uint32_t node_disk_size);
+        virtual_chunk_offset_t node_offset, uint32_t node_disk_size,
+        timeline_id tid);
 
-    void print_update_stats(uint64_t version);
+    void print_update_stats(uint64_t version, timeline_id tid);
 
     using chunk_list = DbMetadataContext::chunk_list;
 
@@ -406,17 +408,19 @@ void async_read(UpdateAux &aux, Receiver &&receiver)
 // batch upsert, updates can be nested
 Node::SharedPtr upsert(
     UpdateAux &, uint64_t version, StateMachine &, Node::SharedPtr old,
-    UpdateList &&, bool write_root = true);
+    UpdateList &&, bool write_root, timeline_id tid);
 
 // Performs a deep copy of a subtrie from `src_root` trie at
 // `src_prefix` to the `dest_root` trie at `dest_prefix`.
 // Note that `src_root` may be of a different version than `dest_root`.
 // Any pre-existing trie at `dest_prefix` will be overwritten.
 // The in-memory effect is similar to a move operation.
+// `tid` selects which timeline reads the source nodes (and which
+// timeline's root-offset metadata is updated when `write_root` is true).
 Node::SharedPtr copy_trie_to_dest(
     UpdateAux &, Node::SharedPtr src_root, NibblesView src_prefix,
     Node::SharedPtr dest_root, NibblesView dest_prefix, uint64_t dest_version,
-    bool write_root = true);
+    timeline_id tid, bool write_root = true);
 
 // load all nodes as far as caching policy would allow
 size_t load_all(UpdateAux &, StateMachine &, NodeCursor const &);
@@ -515,8 +519,9 @@ the node through blocking read.
 synchronization is provided, and user code should make sure no other place is
 modifying trie.
 */
-find_cursor_result_type
-find_blocking(UpdateAux const &, NodeCursor, NibblesView key, uint64_t version);
+find_cursor_result_type find_blocking(
+    UpdateAux const &, NodeCursor, NibblesView key, uint64_t version,
+    timeline_id tid);
 
 /* This function reads a node from the specified physical offset `node_offset`,
 where the spare bits indicate the number of pages to read. It returns a valid
@@ -524,7 +529,8 @@ where the spare bits indicate the number of pages to read. It returns a valid
 becomes invalid.
 */
 Node::SharedPtr read_node_blocking(
-    UpdateAux const &, chunk_offset_t node_offset, uint64_t version);
+    UpdateAux const &, chunk_offset_t node_offset, uint64_t version,
+    timeline_id tid);
 
 //////////////////////////////////////////////////////////////////////////////
 // helpers

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -24,6 +24,7 @@
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/collected_stats.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/detail/unsigned_20.hpp>
 #include <category/mpt/state_machine.hpp>
 #include <category/mpt/trie.hpp>
@@ -113,17 +114,17 @@ UpdateAux::chunk_list_and_age(uint32_t const idx) const noexcept
     return ret;
 }
 
-int64_t
-UpdateAux::calc_auto_expire_version(uint64_t const upsert_version) noexcept
+int64_t UpdateAux::calc_auto_expire_version(
+    uint64_t const upsert_version, timeline_id const tid) noexcept
 {
     MONAD_ASSERT(is_on_disk());
-    if (metadata_ctx_->db_history_max_version() == INVALID_BLOCK_NUM) {
+    auto const max_version = metadata_ctx_->db_history_max_version(tid);
+    if (max_version == INVALID_BLOCK_NUM) {
         return static_cast<int64_t>(upsert_version);
     }
     auto const min_valid_version =
-        metadata_ctx_->db_history_min_valid_version();
-    auto const max_version_post_upsert =
-        std::max(metadata_ctx_->db_history_max_version(), upsert_version);
+        metadata_ctx_->db_history_min_valid_version(tid);
+    auto const max_version_post_upsert = std::max(max_version, upsert_version);
     uint64_t min_valid_version_post_upsert = min_valid_version;
     if (max_version_post_upsert - min_valid_version + 1 >
         metadata_ctx_->version_history_length()) {
@@ -132,7 +133,7 @@ UpdateAux::calc_auto_expire_version(uint64_t const upsert_version) noexcept
             1;
     }
     return std::min(
-        metadata_ctx_->get_auto_expire_version_metadata() + 2,
+        metadata_ctx_->get_auto_expire_version_metadata(tid) + 2,
         static_cast<int64_t>(min_valid_version_post_upsert));
 }
 
@@ -233,7 +234,8 @@ void UpdateAux::clear_ondisk_db()
 
     metadata_ctx_->set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
     metadata_ctx_->set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-    metadata_ctx_->set_auto_expire_version_metadata(0);
+    metadata_ctx_->set_auto_expire_version_metadata(timeline_id::primary, 0);
+    metadata_ctx_->set_auto_expire_version_metadata(timeline_id::secondary, 0);
 
     metadata_ctx_->advance_db_offsets_to(
         {metadata_ctx_->main()->fast_list.begin, 0},
@@ -454,7 +456,8 @@ Node::SharedPtr UpdateAux::do_update(
 
     if (prev_root) {
         // previous compaction offset
-        compact_offsets = compact_offset_pair::deserialize(prev_root->value());
+        tl(timeline_id::primary).compact_offsets =
+            compact_offset_pair::deserialize(prev_root->value());
     }
     if (compaction) {
         if (enable_dynamic_history_length_) {
@@ -468,9 +471,11 @@ Node::SharedPtr UpdateAux::do_update(
         }
     }
 
-    curr_upsert_auto_expire_version = calc_auto_expire_version(version);
+    tl(timeline_id::primary).curr_upsert_auto_expire_version =
+        calc_auto_expire_version(version, timeline_id::primary);
     UpdateList root_updates;
-    byte_string const compact_offsets_bytes = compact_offsets.serialize();
+    byte_string const compact_offsets_bytes =
+        tl(timeline_id::primary).compact_offsets.serialize();
     auto root_update = make_update(
         {}, compact_offsets_bytes, false, std::move(updates), version);
     root_updates.push_front(root_update);
@@ -484,7 +489,8 @@ Node::SharedPtr UpdateAux::do_update(
         std::move(root_updates),
         write_root);
     metadata_ctx_->set_auto_expire_version_metadata(
-        curr_upsert_auto_expire_version);
+        timeline_id::primary,
+        tl(timeline_id::primary).curr_upsert_auto_expire_version);
 
     auto const upsert_duration = upsert_timer.elapsed();
     if (compaction) {
@@ -512,8 +518,8 @@ Node::SharedPtr UpdateAux::do_update(
         curr_fast_writer_offset.offset,
         curr_slow_writer_offset.count,
         curr_slow_writer_offset.offset,
-        (uint32_t)compact_offsets.fast,
-        (uint32_t)compact_offsets.slow);
+        (uint32_t)tl(timeline_id::primary).compact_offsets.fast,
+        (uint32_t)tl(timeline_id::primary).compact_offsets.slow);
     return root;
 }
 
@@ -685,10 +691,10 @@ void UpdateAux::move_trie_version_forward(
     metadata_ctx_->append_root_offset(offset);
     MONAD_ASSERT(dest == metadata_ctx_->db_history_max_version());
     MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(dest));
-    if (metadata_ctx_->get_auto_expire_version_metadata() ==
+    if (metadata_ctx_->get_auto_expire_version_metadata(timeline_id::primary) ==
         static_cast<int64_t>(src)) {
         metadata_ctx_->set_auto_expire_version_metadata(
-            static_cast<int64_t>(dest));
+            timeline_id::primary, static_cast<int64_t>(dest));
     }
 }
 
@@ -747,14 +753,14 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     if (prev_root) {
         auto const min_offsets = calc_min_offsets(*prev_root);
         MONAD_ASSERT(
-            !min_offsets.any_below(compact_offsets),
+            !min_offsets.any_below(tl(timeline_id::primary).compact_offsets),
             "Detected referenced offsets below compaction boundary; potential "
             "disk corruption");
         if (min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET) {
-            compact_offsets.fast = min_offsets.fast;
+            tl(timeline_id::primary).compact_offsets.fast = min_offsets.fast;
         }
         if (min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET) {
-            compact_offsets.slow = min_offsets.slow;
+            tl(timeline_id::primary).compact_offsets.slow = min_offsets.slow;
         }
     }
 
@@ -769,13 +775,16 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     }
 
     MONAD_ASSERT(
-        compact_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
-        compact_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+        tl(timeline_id::primary).compact_offsets.fast !=
+            INVALID_COMPACT_VIRTUAL_OFFSET &&
+        tl(timeline_id::primary).compact_offsets.slow !=
+            INVALID_COMPACT_VIRTUAL_OFFSET);
     /* The fast list compaction offset range is determined both by the
     average disk growth over historical blocks, and the fast list offset
     range of the latest version, so that fast-list usage adapts appropriately to
     changes in history length. */
-    compact_offset_range_fast_ = MIN_COMPACT_VIRTUAL_OFFSET;
+    tl(timeline_id::primary).compact_offset_range_fast_ =
+        MIN_COMPACT_VIRTUAL_OFFSET;
 
     uint64_t const min_version = metadata_ctx_->db_history_min_valid_version();
     MONAD_ASSERT(min_version != INVALID_BLOCK_NUM);
@@ -800,7 +809,7 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     // worth of growth, to prevent over-compaction when the history window
     // shrinks.
     uint32_t const latest_block_fast_uncompacted_range =
-        curr_fast_writer_offset - compact_offsets.fast;
+        curr_fast_writer_offset - tl(timeline_id::primary).compact_offsets.fast;
     if (latest_block_fast_uncompacted_range >
         static_cast<uint64_t>(avg_disk_growth_fast) *
             min_versions_of_growth_before_compact_fast_list) {
@@ -813,8 +822,10 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
             avg_disk_growth_fast + min_compaction_progress_buffer);
         to_advance =
             std::min(to_advance, max_compact_offset_range); // Cap at 32MB
-        compact_offset_range_fast_.set_value(to_advance);
-        compact_offsets.fast += compact_offset_range_fast_;
+        tl(timeline_id::primary)
+            .compact_offset_range_fast_.set_value(to_advance);
+        tl(timeline_id::primary).compact_offsets.fast +=
+            tl(timeline_id::primary).compact_offset_range_fast_;
     }
     constexpr double usage_limit_start_compact_slow = 0.6;
     constexpr double slow_usage_limit_start_compact_slow = 0.2;
@@ -829,24 +840,28 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
         // collection ratio of the last block. We use the ratio of compacted
         // bytes to determine how aggressively to advance the compaction head.
         if (stats.compacted_bytes_in_slow != 0 &&
-            compact_offset_range_slow_ != 0) {
+            tl(timeline_id::primary).compact_offset_range_slow_ != 0) {
             uint32_t const gc_efficiency = static_cast<uint32_t>(std::round(
-                double(compact_offset_range_slow_ << 16) /
+                double(
+                    tl(timeline_id::primary).compact_offset_range_slow_ << 16) /
                 stats.compacted_bytes_in_slow));
             // Cap at last block's growth + 1 to avoid advancing too fast
             uint32_t const new_range = std::min(
                 static_cast<uint32_t>(last_block_disk_growth_slow_ + 1),
                 gc_efficiency);
-            compact_offset_range_slow_.set_value(new_range);
+            tl(timeline_id::primary)
+                .compact_offset_range_slow_.set_value(new_range);
         }
         else {
             // No valid data, use minimum progress
-            compact_offset_range_slow_.set_value(1);
+            tl(timeline_id::primary).compact_offset_range_slow_.set_value(1);
         }
-        compact_offsets.slow += compact_offset_range_slow_;
+        tl(timeline_id::primary).compact_offsets.slow +=
+            tl(timeline_id::primary).compact_offset_range_slow_;
     }
     else {
-        compact_offset_range_slow_ = MIN_COMPACT_VIRTUAL_OFFSET;
+        tl(timeline_id::primary).compact_offset_range_slow_ =
+            MIN_COMPACT_VIRTUAL_OFFSET;
     }
 }
 
@@ -956,17 +971,17 @@ void UpdateAux::print_update_stats(uint64_t const version)
         stats.nodes_updated_expire,
         stats.nreads_expire);
 
-    if (compact_offset_range_fast_) {
+    if (tl(timeline_id::primary).compact_offset_range_fast_) {
         std::format_to(
             std::back_inserter(buf),
             "   Fast: total growth ~ {} KB, compact range {} KB, "
             "bytes copied fast to slow {:.2f} KB, active data ratio {:.2f}%\n",
             last_block_disk_growth_fast_ << 6,
-            compact_offset_range_fast_ << 6,
+            tl(timeline_id::primary).compact_offset_range_fast_ << 6,
             stats.compacted_bytes_in_fast / 1024.0,
             100.0 * stats.compacted_bytes_in_fast /
-                (compact_offset_range_fast_ << 16));
-        if (compact_offset_range_slow_) {
+                (tl(timeline_id::primary).compact_offset_range_fast_ << 16));
+        if (tl(timeline_id::primary).compact_offset_range_slow_) {
             // slow list compaction range vs growth
             auto const total_bytes_written_to_slow =
                 stats.compacted_bytes_in_fast + stats.compacted_bytes_in_slow;
@@ -976,10 +991,10 @@ void UpdateAux::print_update_stats(uint64_t const version)
                 "KB, bytes copied slow to slow {:.2f} KB, active data ratio "
                 "{:.2f}%. other bytes copied slow to fast {:.2f} KB.\n",
                 total_bytes_written_to_slow / 1024.0,
-                compact_offset_range_slow_ << 6,
+                tl(timeline_id::primary).compact_offset_range_slow_ << 6,
                 stats.compacted_bytes_in_slow / 1024.0,
                 100.0 * stats.compacted_bytes_in_slow /
-                    (compact_offset_range_slow_ << 16),
+                    (tl(timeline_id::primary).compact_offset_range_slow_ << 16),
                 stats.bytes_copied_slow_to_fast_for_slow / 1024.0);
         }
         else {
@@ -1005,7 +1020,7 @@ void UpdateAux::print_update_stats(uint64_t const version)
                 ? (100.0 * stats.nodes_copied_fast_to_fast_for_fast /
                    nodes_copied_for_slow)
                 : 0);
-        if (compact_offsets.slow) {
+        if (tl(timeline_id::primary).compact_offsets.slow) {
             auto const nodes_copied_for_slow =
                 stats.compacted_nodes_in_slow +
                 stats.nodes_copied_fast_to_fast_for_slow +
@@ -1047,13 +1062,14 @@ void UpdateAux::print_update_stats(uint64_t const version)
                     stats.nreads_after_compact_offset[0]))
                 : 0,
             (double)stats.bytes_read_before_compact_offset[0] / 1024,
-            compact_offset_range_fast_ << 6,
+            tl(timeline_id::primary).compact_offset_range_fast_ << 6,
             stats.bytes_read_before_compact_offset[0]
                 ? (100.0 * stats.bytes_read_before_compact_offset[0] /
-                   compact_offset_range_fast_ / 1024 / 64)
+                   tl(timeline_id::primary).compact_offset_range_fast_ / 1024 /
+                   64)
                 : 0,
             (double)stats.bytes_read_after_compact_offset[0] / 1024);
-        if (compact_offset_range_slow_) {
+        if (tl(timeline_id::primary).compact_offset_range_slow_) {
             std::format_to(
                 std::back_inserter(buf),
                 "   Slow: reads within compaction range {} / "
@@ -1070,10 +1086,11 @@ void UpdateAux::print_update_stats(uint64_t const version)
                         stats.nreads_after_compact_offset[1]))
                     : 0,
                 (double)stats.bytes_read_before_compact_offset[1] / 1024,
-                compact_offset_range_slow_ << 6,
+                tl(timeline_id::primary).compact_offset_range_slow_ << 6,
                 stats.bytes_read_before_compact_offset[1]
                     ? (100.0 * stats.bytes_read_before_compact_offset[1] /
-                       compact_offset_range_slow_ / 1024 / 64)
+                       tl(timeline_id::primary).compact_offset_range_slow_ /
+                       1024 / 64)
                     : 0,
                 (double)stats.bytes_read_after_compact_offset[1] / 1024);
         }
@@ -1102,8 +1119,9 @@ void UpdateAux::collect_compaction_read_stats(
 #if MONAD_MPT_COLLECT_STATS
     auto const node_offset = physical_to_virtual(physical_node_offset);
     if (compact_virtual_chunk_offset_t(node_offset) <
-        (node_offset.in_fast_list() ? compact_offsets.fast
-                                    : compact_offsets.slow)) {
+        (node_offset.in_fast_list()
+             ? tl(timeline_id::primary).compact_offsets.fast
+             : tl(timeline_id::primary).compact_offsets.slow)) {
         // node orig offset in fast list but compact to slow list
         ++stats.nreads_before_compact_offset[!node_offset.in_fast_list()];
         stats.bytes_read_before_compact_offset[!node_offset.in_fast_list()] +=
@@ -1163,7 +1181,7 @@ void UpdateAux::collect_compacted_nodes_stats(
             MONAD_ASSERT(!node_offset.in_fast_list());
             MONAD_ASSERT(
                 compact_virtual_chunk_offset_t{node_offset} <
-                compact_offsets.slow);
+                tl(timeline_id::primary).compact_offsets.slow);
             ++stats.compacted_nodes_in_slow;
             stats.compacted_bytes_in_slow += node_disk_size;
         }
@@ -1172,12 +1190,38 @@ void UpdateAux::collect_compacted_nodes_stats(
     if (!copy_node_for_fast && !rewrite_to_fast) {
         MONAD_ASSERT(!node_offset.in_fast_list());
         MONAD_ASSERT(
-            compact_virtual_chunk_offset_t{node_offset} < compact_offsets.slow);
+            compact_virtual_chunk_offset_t{node_offset} <
+            tl(timeline_id::primary).compact_offsets.slow);
         stats.compacted_bytes_in_slow += node_disk_size;
     }
     (void)copy_node_for_fast;
     (void)rewrite_to_fast;
 #endif
+}
+
+void UpdateAux::activate_secondary_timeline()
+{
+    MONAD_ASSERT(is_on_disk());
+    metadata_ctx_->activate_secondary_header();
+    // The secondary timeline starts completely empty; its compaction state
+    // is initialised on the first secondary upsert from the prev_root's
+    // serialised compact_offsets.
+    tl(timeline_id::secondary) = timeline_compaction_state{};
+}
+
+void UpdateAux::deactivate_secondary_timeline()
+{
+    MONAD_ASSERT(is_on_disk());
+    metadata_ctx_->deactivate_secondary_header();
+    tl(timeline_id::secondary) = timeline_compaction_state{};
+}
+
+void UpdateAux::promote_secondary_to_primary()
+{
+    MONAD_ASSERT(is_on_disk());
+    metadata_ctx_->promote_secondary_to_primary_header();
+    std::swap(tl(timeline_id::primary), tl(timeline_id::secondary));
+    LOG_INFO("Promoted secondary timeline to primary");
 }
 
 MONAD_MPT_NAMESPACE_END

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -148,11 +148,13 @@ void UpdateAux::rewind_to_match_offsets()
         metadata_ctx_->main()->db_offsets.start_of_wip_offset_slow;
     MONAD_ASSERT(metadata_ctx_->main()->at(slow_offset.id)->in_slow_list);
 
-    // fast/slow list offsets should always be greater than last written root
-    // offset.
-    auto const ro = metadata_ctx_->root_offsets();
-    auto const last_root_offset = ro[ro.max_version()];
-    if (last_root_offset != INVALID_OFFSET) {
+    // fast/slow list offsets should always be greater than each timeline's
+    // last written root offset.
+    auto const check_root_past_offsets = [&](chunk_offset_t const
+                                                 last_root_offset) {
+        if (last_root_offset == INVALID_OFFSET) {
+            return;
+        }
         auto const virtual_last_root_offset =
             physical_to_virtual(last_root_offset);
         MONAD_ASSERT(virtual_last_root_offset != INVALID_VIRTUAL_OFFSET);
@@ -190,6 +192,16 @@ void UpdateAux::rewind_to_match_offsets()
             MONAD_ABORT_PRINTF(
                 "Detected corruption. Last root offset is in free list.");
         }
+    };
+    auto const primary_ro = metadata_ctx_->root_offsets();
+    check_root_past_offsets(primary_ro[primary_ro.max_version()]);
+    if (metadata_ctx_->timeline_active(timeline_id::secondary)) {
+        auto const secondary_ro =
+            metadata_ctx_->root_offsets(timeline_id::secondary);
+        auto const sec_max = secondary_ro.max_version();
+        if (sec_max != INVALID_BLOCK_NUM) {
+            check_root_past_offsets(secondary_ro[sec_max]);
+        }
     }
 
     // Free all chunks after fast_offset.id
@@ -223,6 +235,10 @@ void UpdateAux::rewind_to_match_offsets()
 void UpdateAux::clear_ondisk_db()
 {
     MONAD_ASSERT(is_on_disk());
+    // No finalized version means no anchor for either timeline; wipe both.
+    if (metadata_ctx_->timeline_active(timeline_id::secondary)) {
+        deactivate_secondary_timeline();
+    }
     auto do_ = [&](unsigned const which) {
         auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
         metadata_ctx_->root_offsets(which).reset_all(0);
@@ -244,19 +260,64 @@ void UpdateAux::clear_ondisk_db()
     return;
 }
 
+// Post-root fast-list offset for the chunk-trim cutoff. Returns nullopt if
+// the root isn't in the fast list (caller skips it from the cutoff calc).
+static std::optional<chunk_offset_t> post_root_fast_offset_(
+    detail::db_metadata const *const main, chunk_offset_t root_offset)
+{
+    if (root_offset == INVALID_OFFSET) {
+        return std::nullopt;
+    }
+    if (!main->at(root_offset.id)->in_fast_list) {
+        return std::nullopt;
+    }
+    unsigned const bytes_to_read =
+        node_disk_pages_spare_15{root_offset}.to_pages() << DISK_PAGE_BITS;
+    chunk_offset_t post = round_down_align<DISK_PAGE_BITS>(
+        root_offset.add_to_offset(bytes_to_read));
+    if (post.offset >= chunk_offset_t::max_offset) {
+        post.id = main->at(post.id)->next_chunk_id;
+        post.offset = 0;
+    }
+    return post;
+}
+
 void UpdateAux::rewind_to_version(uint64_t const version)
 {
     MONAD_ASSERT(is_on_disk());
     MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(version));
-    if (version == metadata_ctx_->db_history_max_version()) {
+
+    bool const secondary_active =
+        metadata_ctx_->timeline_active(timeline_id::secondary);
+    auto const secondary_max_before =
+        secondary_active
+            ? metadata_ctx_->db_history_max_version(timeline_id::secondary)
+            : INVALID_BLOCK_NUM;
+    bool const secondary_needs_rewind =
+        secondary_active && secondary_max_before != INVALID_BLOCK_NUM &&
+        secondary_max_before > version;
+    bool const primary_needs_rewind =
+        metadata_ctx_->db_history_max_version() > version;
+    if (!primary_needs_rewind && !secondary_needs_rewind) {
         return;
     }
+
+    // Step 1: rewind each ring whose max is past the rewind target.
     auto do_ = [&](unsigned const which) {
         auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
-        metadata_ctx_->root_offsets(which).rewind_to_version(version);
+        if (primary_needs_rewind) {
+            metadata_ctx_->root_offsets(timeline_id::primary, which)
+                .rewind_to_version(version);
+        }
+        if (secondary_needs_rewind) {
+            metadata_ctx_->root_offsets(timeline_id::secondary, which)
+                .rewind_to_version(version);
+        }
     };
     do_(0);
     do_(1);
+
+    // Step 2: consensus metadata.
     if (auto const latest_finalized =
             metadata_ctx_->get_latest_finalized_version();
         latest_finalized != INVALID_BLOCK_NUM && latest_finalized > version) {
@@ -265,28 +326,37 @@ void UpdateAux::rewind_to_version(uint64_t const version)
     metadata_ctx_->set_latest_verified_version(INVALID_BLOCK_NUM);
     metadata_ctx_->set_latest_voted(INVALID_BLOCK_NUM, bytes32_t{});
     metadata_ctx_->set_latest_proposed(INVALID_BLOCK_NUM, bytes32_t{});
-    auto last_written_offset = metadata_ctx_->root_offsets()[version];
-    bool const last_written_offset_is_in_fast_list =
-        metadata_ctx_->main()->at(last_written_offset.id)->in_fast_list;
-    unsigned const bytes_to_read =
-        node_disk_pages_spare_15{last_written_offset}.to_pages()
-        << DISK_PAGE_BITS;
-    if (last_written_offset_is_in_fast_list) {
-        // Form offset after the root node for future appends
-        last_written_offset = round_down_align<DISK_PAGE_BITS>(
-            last_written_offset.add_to_offset(bytes_to_read));
-        if (last_written_offset.offset >= chunk_offset_t::max_offset) {
-            last_written_offset.id = metadata_ctx_->main()
-                                         ->at(last_written_offset.id)
-                                         ->next_chunk_id;
-            last_written_offset.offset = 0;
+
+    // Step 3: cutoff = max of both timelines' post-root fast offsets.
+    auto const *const main = metadata_ctx_->main();
+    std::optional<chunk_offset_t> cutoff_fast;
+    auto consider = [&](std::optional<chunk_offset_t> const candidate) {
+        if (!candidate.has_value()) {
+            return;
         }
-        metadata_ctx_->advance_db_offsets_to(
-            last_written_offset, metadata_ctx_->get_start_of_wip_slow_offset());
+        if (!cutoff_fast.has_value() || physical_to_virtual(*candidate) >
+                                            physical_to_virtual(*cutoff_fast)) {
+            cutoff_fast = candidate;
+        }
+    };
+    consider(
+        post_root_fast_offset_(main, metadata_ctx_->root_offsets()[version]));
+    if (secondary_active) {
+        auto const secondary_ro =
+            metadata_ctx_->root_offsets(timeline_id::secondary);
+        auto const sec_max = secondary_ro.max_version();
+        if (sec_max != INVALID_BLOCK_NUM) {
+            auto const sec_root = secondary_ro[sec_max];
+            MONAD_ASSERT(sec_root != INVALID_OFFSET);
+            consider(post_root_fast_offset_(main, sec_root));
+        }
     }
-    // Discard all chunks no longer in use, and if root is on fast list
-    // replace the now partially written chunk with a fresh one able to be
-    // appended immediately after
+    if (cutoff_fast.has_value()) {
+        metadata_ctx_->advance_db_offsets_to(
+            *cutoff_fast, metadata_ctx_->get_start_of_wip_slow_offset());
+    }
+
+    // Step 4: discard chunks past the cutoff and reset node writers.
     rewind_to_match_offsets();
 }
 
@@ -440,7 +510,7 @@ the middle of a continuous history.
 Node::SharedPtr UpdateAux::do_update(
     Node::SharedPtr prev_root, StateMachine &sm, UpdateList &&updates,
     uint64_t const version, bool const compaction, bool const can_write_to_fast,
-    bool const write_root)
+    bool const write_root, timeline_id const tid)
 {
 
     if (is_in_memory()) {
@@ -449,33 +519,39 @@ Node::SharedPtr UpdateAux::do_update(
             make_update({}, {}, false, std::move(updates), version);
         root_updates.push_front(root_update);
         return upsert(
-            *this, version, sm, std::move(prev_root), std::move(root_updates));
+            *this,
+            version,
+            sm,
+            std::move(prev_root),
+            std::move(root_updates),
+            /*write_root=*/true,
+            timeline_id::primary);
     }
     MONAD_ASSERT(is_on_disk());
     set_can_write_to_fast(can_write_to_fast);
 
     if (prev_root) {
         // previous compaction offset
-        tl(timeline_id::primary).compact_offsets =
+        tl(tid).compact_offsets =
             compact_offset_pair::deserialize(prev_root->value());
     }
     if (compaction) {
-        if (enable_dynamic_history_length_) {
-            // WARNING: this step may remove historical versions and free disk
-            // chunks
+        if (tid == timeline_id::primary && enable_dynamic_history_length_) {
+            // WARNING: this step may remove historical versions and free
+            // disk chunks
             adjust_history_length_based_on_disk_usage();
         }
-        if (!metadata_ctx_->version_is_valid_ondisk(version)) {
+        if (!metadata_ctx_->version_is_valid_ondisk(version, tid)) {
             // only advance compaction progress for non existent version
-            advance_compact_offsets(prev_root);
+            advance_compact_offsets(prev_root, tid);
         }
     }
 
-    tl(timeline_id::primary).curr_upsert_auto_expire_version =
-        calc_auto_expire_version(version, timeline_id::primary);
+    tl(tid).curr_upsert_auto_expire_version =
+        calc_auto_expire_version(version, tid);
     UpdateList root_updates;
     byte_string const compact_offsets_bytes =
-        tl(timeline_id::primary).compact_offsets.serialize();
+        tl(tid).compact_offsets.serialize();
     auto root_update = make_update(
         {}, compact_offsets_bytes, false, std::move(updates), version);
     root_updates.push_front(root_update);
@@ -487,28 +563,29 @@ Node::SharedPtr UpdateAux::do_update(
         sm,
         std::move(prev_root),
         std::move(root_updates),
-        write_root);
+        write_root,
+        tid);
     metadata_ctx_->set_auto_expire_version_metadata(
-        timeline_id::primary,
-        tl(timeline_id::primary).curr_upsert_auto_expire_version);
+        tid, tl(tid).curr_upsert_auto_expire_version);
 
     auto const upsert_duration = upsert_timer.elapsed();
     if (compaction) {
         update_disk_growth_data();
         // log stats
-        print_update_stats(version);
+        print_update_stats(version, tid);
     }
     [[maybe_unused]] auto const curr_fast_writer_offset =
         physical_to_virtual(node_writer_fast->sender().offset());
     [[maybe_unused]] auto const curr_slow_writer_offset =
         physical_to_virtual(node_writer_slow->sender().offset());
     LOG_INFO_CFORMAT(
-        "Finish upserting version %lu. Min valid version %lu. Time elapsed: "
-        "%ld us. Disk usage: %.4f. Chunks: %u fast, %u slow, %u free. Writer "
-        "offsets: fast={%u,%u}, slow={%u,%u}. Compaction head offset fast=%u, "
-        "slow=%u",
+        "Finish upserting version %lu (timeline %u). Min valid version %lu. "
+        "Time elapsed: %ld us. Disk usage: %.4f. Chunks: %u fast, %u slow, %u "
+        "free. Writer offsets: fast={%u,%u}, slow={%u,%u}. Compaction head "
+        "offset fast=%u, slow=%u",
         version,
-        metadata_ctx_->db_history_min_valid_version(),
+        static_cast<unsigned>(tid),
+        metadata_ctx_->db_history_min_valid_version(tid),
         upsert_duration.count(),
         disk_usage(),
         num_chunks(chunk_list::fast),
@@ -518,40 +595,71 @@ Node::SharedPtr UpdateAux::do_update(
         curr_fast_writer_offset.offset,
         curr_slow_writer_offset.count,
         curr_slow_writer_offset.offset,
-        (uint32_t)tl(timeline_id::primary).compact_offsets.fast,
-        (uint32_t)tl(timeline_id::primary).compact_offsets.slow);
+        (uint32_t)tl(tid).compact_offsets.fast,
+        (uint32_t)tl(tid).compact_offsets.slow);
     return root;
 }
 
 void UpdateAux::release_unreferenced_chunks()
 {
-    auto const min_valid_version =
-        metadata_ctx_->db_history_min_valid_version();
-    if (min_valid_version == INVALID_BLOCK_NUM) {
+    // Compute the combined GC boundary across all active timelines.
+    // A chunk is safe to free only if its insertion_count is below the
+    // component-wise minimum of all active timelines' oldest roots'
+    // compact_offset_pair.
+    compact_offset_pair combined_min{
+        INVALID_COMPACT_VIRTUAL_OFFSET, INVALID_COMPACT_VIRTUAL_OFFSET};
+    [[maybe_unused]] uint64_t primary_min_ver = INVALID_BLOCK_NUM;
+
+    for (auto const tid : {timeline_id::primary, timeline_id::secondary}) {
+        if (!metadata_ctx_->timeline_active(tid)) {
+            continue;
+        }
+        auto const min_ver = metadata_ctx_->db_history_min_valid_version(tid);
+        if (min_ver == INVALID_BLOCK_NUM) {
+            continue;
+        }
+        auto const root_offset =
+            metadata_ctx_->get_root_offset_at_version(min_ver, tid);
+        if (root_offset == INVALID_OFFSET) {
+            // Primary's min-valid-version must always resolve; an
+            // INVALID_OFFSET would mean corrupt metadata and silently
+            // disable GC. Only the secondary ring may legitimately miss.
+            MONAD_ASSERT(tid != timeline_id::primary);
+            continue;
+        }
+        auto const root = read_node_blocking(*this, root_offset, min_ver, tid);
+        MONAD_ASSERT(root && root->has_value());
+        auto const offsets = compact_offset_pair::deserialize(root->value());
+        if (offsets.fast < combined_min.fast) {
+            combined_min.fast = offsets.fast;
+        }
+        if (offsets.slow < combined_min.slow) {
+            combined_min.slow = offsets.slow;
+        }
+        if (tid == timeline_id::primary) {
+            primary_min_ver = min_ver;
+        }
+    }
+
+    if (combined_min.fast == INVALID_COMPACT_VIRTUAL_OFFSET) {
         return;
     }
-    auto const min_valid_root = read_node_blocking(
-        *this,
-        metadata_ctx_->get_root_offset_at_version(min_valid_version),
-        min_valid_version);
-    auto const min_offsets =
-        compact_offset_pair::deserialize(min_valid_root->value());
     MONAD_ASSERT(
-        min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
-        min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
-    chunks_to_remove_before_count_fast_ = min_offsets.fast.get_count();
-    chunks_to_remove_before_count_slow_ = min_offsets.slow.get_count();
+        combined_min.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
+        combined_min.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
+    chunks_to_remove_before_count_fast_ = combined_min.fast.get_count();
+    chunks_to_remove_before_count_slow_ = combined_min.slow.get_count();
     LOG_INFO_CFORMAT(
-        "Min valid version %lu compaction offset fast=%u, slow=%u. Remove "
+        "Combined GC boundary: compaction offset fast=%u, slow=%u. Remove "
         "chunks before count fast=%u, slow=%u",
-        min_valid_version,
-        (uint32_t)min_offsets.fast,
-        (uint32_t)min_offsets.slow,
+        (uint32_t)combined_min.fast,
+        (uint32_t)combined_min.slow,
         chunks_to_remove_before_count_fast_,
         chunks_to_remove_before_count_slow_);
     MONAD_ASSERT(
+        primary_min_ver == INVALID_BLOCK_NUM ||
         metadata_ctx_->main()->root_offsets.version_lower_bound_ >=
-        min_valid_version);
+            primary_min_ver);
     free_compacted_chunks();
 }
 
@@ -577,7 +685,8 @@ double UpdateAux::calculate_disk_usage_if_erased_up_to_and_including(
     auto const min_valid_root_post_erase = read_node_blocking(
         *this,
         metadata_ctx_->get_root_offset_at_version(min_version_post_erase),
-        min_version_post_erase);
+        min_version_post_erase,
+        timeline_id::primary);
     auto const min_offsets =
         compact_offset_pair::deserialize(min_valid_root_post_erase->value());
     MONAD_ASSERT(
@@ -667,7 +776,8 @@ void UpdateAux::clear_root_offsets_up_to_and_including(uint64_t const version)
     for (uint64_t v = metadata_ctx_->db_history_range_lower_bound();
          v != INVALID_BLOCK_NUM && v <= version;
          v = metadata_ctx_->db_history_range_lower_bound()) {
-        metadata_ctx_->update_root_offset(v, INVALID_OFFSET);
+        metadata_ctx_->update_root_offset(
+            v, INVALID_OFFSET, timeline_id::primary);
     }
 }
 
@@ -681,14 +791,15 @@ void UpdateAux::move_trie_version_forward(
         dest > src && dest != INVALID_BLOCK_NUM &&
         dest >= metadata_ctx_->db_history_max_version());
     auto const offset = metadata_ctx_->get_root_offset_at_version(src);
-    metadata_ctx_->update_root_offset(src, INVALID_OFFSET);
+    metadata_ctx_->update_root_offset(
+        src, INVALID_OFFSET, timeline_id::primary);
     // Must erase versions that will fall out of history range first
     if (dest >= metadata_ctx_->version_history_length()) {
         erase_versions_up_to_and_including(
             dest - metadata_ctx_->version_history_length());
     }
-    metadata_ctx_->fast_forward_next_version(dest);
-    metadata_ctx_->append_root_offset(offset);
+    metadata_ctx_->fast_forward_next_version(dest, timeline_id::primary);
+    metadata_ctx_->append_root_offset(offset, timeline_id::primary);
     MONAD_ASSERT(dest == metadata_ctx_->db_history_max_version());
     MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(dest));
     if (metadata_ctx_->get_auto_expire_version_metadata(timeline_id::primary) ==
@@ -712,7 +823,8 @@ void UpdateAux::update_disk_growth_data()
     last_block_end_offset_slow_ = curr_slow_writer_offset;
 }
 
-void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
+void UpdateAux::advance_compact_offsets(
+    Node::SharedPtr const prev_root, timeline_id const tid)
 {
     /* Note on ring based compaction:
     Fast list compaction is steady pace based on disk growth over recent blocks,
@@ -753,20 +865,20 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     if (prev_root) {
         auto const min_offsets = calc_min_offsets(*prev_root);
         MONAD_ASSERT(
-            !min_offsets.any_below(tl(timeline_id::primary).compact_offsets),
+            !min_offsets.any_below(tl(tid).compact_offsets),
             "Detected referenced offsets below compaction boundary; potential "
             "disk corruption");
         if (min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET) {
-            tl(timeline_id::primary).compact_offsets.fast = min_offsets.fast;
+            tl(tid).compact_offsets.fast = min_offsets.fast;
         }
         if (min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET) {
-            tl(timeline_id::primary).compact_offsets.slow = min_offsets.slow;
+            tl(tid).compact_offsets.slow = min_offsets.slow;
         }
     }
 
     auto const fast_disk_usage =
         num_chunks(chunk_list::fast) / (double)io->chunk_count();
-    uint64_t const max_version = metadata_ctx_->db_history_max_version();
+    uint64_t const max_version = metadata_ctx_->db_history_max_version(tid);
     if ((fast_disk_usage < fast_usage_limit_start_compaction &&
          num_chunks(chunk_list::fast) <
              fast_chunk_count_limit_start_compaction) ||
@@ -775,18 +887,16 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     }
 
     MONAD_ASSERT(
-        tl(timeline_id::primary).compact_offsets.fast !=
-            INVALID_COMPACT_VIRTUAL_OFFSET &&
-        tl(timeline_id::primary).compact_offsets.slow !=
-            INVALID_COMPACT_VIRTUAL_OFFSET);
+        tl(tid).compact_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
+        tl(tid).compact_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
     /* The fast list compaction offset range is determined both by the
     average disk growth over historical blocks, and the fast list offset
     range of the latest version, so that fast-list usage adapts appropriately to
     changes in history length. */
-    tl(timeline_id::primary).compact_offset_range_fast_ =
-        MIN_COMPACT_VIRTUAL_OFFSET;
+    tl(tid).compact_offset_range_fast_ = MIN_COMPACT_VIRTUAL_OFFSET;
 
-    uint64_t const min_version = metadata_ctx_->db_history_min_valid_version();
+    uint64_t const min_version =
+        metadata_ctx_->db_history_min_valid_version(tid);
     MONAD_ASSERT(min_version != INVALID_BLOCK_NUM);
     compact_virtual_chunk_offset_t const curr_fast_writer_offset{
         physical_to_virtual(node_writer_fast->sender().offset())};
@@ -796,7 +906,7 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     // slow list).
     uint32_t avg_disk_growth_fast = last_block_disk_growth_fast_;
     auto const min_version_root_virtual_offset = physical_to_virtual(
-        metadata_ctx_->get_root_offset_at_version(min_version));
+        metadata_ctx_->get_root_offset_at_version(min_version, tid));
     if (min_version_root_virtual_offset.in_fast_list() &&
         max_version > min_version) {
         avg_disk_growth_fast = divide_and_round(
@@ -809,7 +919,7 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
     // worth of growth, to prevent over-compaction when the history window
     // shrinks.
     uint32_t const latest_block_fast_uncompacted_range =
-        curr_fast_writer_offset - tl(timeline_id::primary).compact_offsets.fast;
+        curr_fast_writer_offset - tl(tid).compact_offsets.fast;
     if (latest_block_fast_uncompacted_range >
         static_cast<uint64_t>(avg_disk_growth_fast) *
             min_versions_of_growth_before_compact_fast_list) {
@@ -822,10 +932,8 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
             avg_disk_growth_fast + min_compaction_progress_buffer);
         to_advance =
             std::min(to_advance, max_compact_offset_range); // Cap at 32MB
-        tl(timeline_id::primary)
-            .compact_offset_range_fast_.set_value(to_advance);
-        tl(timeline_id::primary).compact_offsets.fast +=
-            tl(timeline_id::primary).compact_offset_range_fast_;
+        tl(tid).compact_offset_range_fast_.set_value(to_advance);
+        tl(tid).compact_offsets.fast += tl(tid).compact_offset_range_fast_;
     }
     constexpr double usage_limit_start_compact_slow = 0.6;
     constexpr double slow_usage_limit_start_compact_slow = 0.2;
@@ -840,28 +948,24 @@ void UpdateAux::advance_compact_offsets(Node::SharedPtr const prev_root)
         // collection ratio of the last block. We use the ratio of compacted
         // bytes to determine how aggressively to advance the compaction head.
         if (stats.compacted_bytes_in_slow != 0 &&
-            tl(timeline_id::primary).compact_offset_range_slow_ != 0) {
+            tl(tid).compact_offset_range_slow_ != 0) {
             uint32_t const gc_efficiency = static_cast<uint32_t>(std::round(
-                double(
-                    tl(timeline_id::primary).compact_offset_range_slow_ << 16) /
+                double(tl(tid).compact_offset_range_slow_ << 16) /
                 stats.compacted_bytes_in_slow));
             // Cap at last block's growth + 1 to avoid advancing too fast
             uint32_t const new_range = std::min(
                 static_cast<uint32_t>(last_block_disk_growth_slow_ + 1),
                 gc_efficiency);
-            tl(timeline_id::primary)
-                .compact_offset_range_slow_.set_value(new_range);
+            tl(tid).compact_offset_range_slow_.set_value(new_range);
         }
         else {
             // No valid data, use minimum progress
-            tl(timeline_id::primary).compact_offset_range_slow_.set_value(1);
+            tl(tid).compact_offset_range_slow_.set_value(1);
         }
-        tl(timeline_id::primary).compact_offsets.slow +=
-            tl(timeline_id::primary).compact_offset_range_slow_;
+        tl(tid).compact_offsets.slow += tl(tid).compact_offset_range_slow_;
     }
     else {
-        tl(timeline_id::primary).compact_offset_range_slow_ =
-            MIN_COMPACT_VIRTUAL_OFFSET;
+        tl(tid).compact_offset_range_slow_ = MIN_COMPACT_VIRTUAL_OFFSET;
     }
 }
 
@@ -951,7 +1055,8 @@ uint32_t UpdateAux::num_chunks(chunk_list const list) const noexcept
     return 0;
 }
 
-void UpdateAux::print_update_stats(uint64_t const version)
+void UpdateAux::print_update_stats(
+    uint64_t const version, timeline_id const tid)
 {
 #if MONAD_MPT_COLLECT_STATS
     if (stats.nodes_updated_expire > 50'000) {
@@ -971,17 +1076,17 @@ void UpdateAux::print_update_stats(uint64_t const version)
         stats.nodes_updated_expire,
         stats.nreads_expire);
 
-    if (tl(timeline_id::primary).compact_offset_range_fast_) {
+    if (tl(tid).compact_offset_range_fast_) {
         std::format_to(
             std::back_inserter(buf),
             "   Fast: total growth ~ {} KB, compact range {} KB, "
             "bytes copied fast to slow {:.2f} KB, active data ratio {:.2f}%\n",
             last_block_disk_growth_fast_ << 6,
-            tl(timeline_id::primary).compact_offset_range_fast_ << 6,
+            tl(tid).compact_offset_range_fast_ << 6,
             stats.compacted_bytes_in_fast / 1024.0,
             100.0 * stats.compacted_bytes_in_fast /
-                (tl(timeline_id::primary).compact_offset_range_fast_ << 16));
-        if (tl(timeline_id::primary).compact_offset_range_slow_) {
+                (tl(tid).compact_offset_range_fast_ << 16));
+        if (tl(tid).compact_offset_range_slow_) {
             // slow list compaction range vs growth
             auto const total_bytes_written_to_slow =
                 stats.compacted_bytes_in_fast + stats.compacted_bytes_in_slow;
@@ -991,10 +1096,10 @@ void UpdateAux::print_update_stats(uint64_t const version)
                 "KB, bytes copied slow to slow {:.2f} KB, active data ratio "
                 "{:.2f}%. other bytes copied slow to fast {:.2f} KB.\n",
                 total_bytes_written_to_slow / 1024.0,
-                tl(timeline_id::primary).compact_offset_range_slow_ << 6,
+                tl(tid).compact_offset_range_slow_ << 6,
                 stats.compacted_bytes_in_slow / 1024.0,
                 100.0 * stats.compacted_bytes_in_slow /
-                    (tl(timeline_id::primary).compact_offset_range_slow_ << 16),
+                    (tl(tid).compact_offset_range_slow_ << 16),
                 stats.bytes_copied_slow_to_fast_for_slow / 1024.0);
         }
         else {
@@ -1020,7 +1125,7 @@ void UpdateAux::print_update_stats(uint64_t const version)
                 ? (100.0 * stats.nodes_copied_fast_to_fast_for_fast /
                    nodes_copied_for_slow)
                 : 0);
-        if (tl(timeline_id::primary).compact_offsets.slow) {
+        if (tl(tid).compact_offsets.slow) {
             auto const nodes_copied_for_slow =
                 stats.compacted_nodes_in_slow +
                 stats.nodes_copied_fast_to_fast_for_slow +
@@ -1062,14 +1167,13 @@ void UpdateAux::print_update_stats(uint64_t const version)
                     stats.nreads_after_compact_offset[0]))
                 : 0,
             (double)stats.bytes_read_before_compact_offset[0] / 1024,
-            tl(timeline_id::primary).compact_offset_range_fast_ << 6,
+            tl(tid).compact_offset_range_fast_ << 6,
             stats.bytes_read_before_compact_offset[0]
                 ? (100.0 * stats.bytes_read_before_compact_offset[0] /
-                   tl(timeline_id::primary).compact_offset_range_fast_ / 1024 /
-                   64)
+                   tl(tid).compact_offset_range_fast_ / 1024 / 64)
                 : 0,
             (double)stats.bytes_read_after_compact_offset[0] / 1024);
-        if (tl(timeline_id::primary).compact_offset_range_slow_) {
+        if (tl(tid).compact_offset_range_slow_) {
             std::format_to(
                 std::back_inserter(buf),
                 "   Slow: reads within compaction range {} / "
@@ -1086,11 +1190,10 @@ void UpdateAux::print_update_stats(uint64_t const version)
                         stats.nreads_after_compact_offset[1]))
                     : 0,
                 (double)stats.bytes_read_before_compact_offset[1] / 1024,
-                tl(timeline_id::primary).compact_offset_range_slow_ << 6,
+                tl(tid).compact_offset_range_slow_ << 6,
                 stats.bytes_read_before_compact_offset[1]
                     ? (100.0 * stats.bytes_read_before_compact_offset[1] /
-                       tl(timeline_id::primary).compact_offset_range_slow_ /
-                       1024 / 64)
+                       tl(tid).compact_offset_range_slow_ / 1024 / 64)
                     : 0,
                 (double)stats.bytes_read_after_compact_offset[1] / 1024);
         }
@@ -1114,14 +1217,14 @@ void UpdateAux::collect_number_nodes_created_stats()
 }
 
 void UpdateAux::collect_compaction_read_stats(
-    chunk_offset_t const physical_node_offset, unsigned const bytes_to_read)
+    chunk_offset_t const physical_node_offset, unsigned const bytes_to_read,
+    timeline_id const tid)
 {
 #if MONAD_MPT_COLLECT_STATS
     auto const node_offset = physical_to_virtual(physical_node_offset);
     if (compact_virtual_chunk_offset_t(node_offset) <
-        (node_offset.in_fast_list()
-             ? tl(timeline_id::primary).compact_offsets.fast
-             : tl(timeline_id::primary).compact_offsets.slow)) {
+        (node_offset.in_fast_list() ? tl(tid).compact_offsets.fast
+                                    : tl(tid).compact_offsets.slow)) {
         // node orig offset in fast list but compact to slow list
         ++stats.nreads_before_compact_offset[!node_offset.in_fast_list()];
         stats.bytes_read_before_compact_offset[!node_offset.in_fast_list()] +=
@@ -1155,7 +1258,8 @@ void UpdateAux::collect_expire_stats(bool const is_read)
 
 void UpdateAux::collect_compacted_nodes_stats(
     bool const copy_node_for_fast, bool const rewrite_to_fast,
-    virtual_chunk_offset_t const node_offset, uint32_t const node_disk_size)
+    virtual_chunk_offset_t const node_offset, uint32_t const node_disk_size,
+    timeline_id const tid)
 {
 #if MONAD_MPT_COLLECT_STATS
     if (copy_node_for_fast) {
@@ -1181,7 +1285,7 @@ void UpdateAux::collect_compacted_nodes_stats(
             MONAD_ASSERT(!node_offset.in_fast_list());
             MONAD_ASSERT(
                 compact_virtual_chunk_offset_t{node_offset} <
-                tl(timeline_id::primary).compact_offsets.slow);
+                tl(tid).compact_offsets.slow);
             ++stats.compacted_nodes_in_slow;
             stats.compacted_bytes_in_slow += node_disk_size;
         }
@@ -1191,7 +1295,7 @@ void UpdateAux::collect_compacted_nodes_stats(
         MONAD_ASSERT(!node_offset.in_fast_list());
         MONAD_ASSERT(
             compact_virtual_chunk_offset_t{node_offset} <
-            tl(timeline_id::primary).compact_offsets.slow);
+            tl(tid).compact_offsets.slow);
         stats.compacted_bytes_in_slow += node_disk_size;
     }
     (void)copy_node_for_fast;

--- a/docs/dual_timeline_metadata.md
+++ b/docs/dual_timeline_metadata.md
@@ -1,0 +1,315 @@
+# Dual-timeline metadata
+
+## Purpose
+
+During a chain fork, execution must serve both the pre-fork canonical
+chain and the forked branch from the same on-disk state. The dual-
+timeline design gives `UpdateAux` two physical root-offset rings and
+three lifecycle primitives — `activate_secondary`, `promote`, and
+`deactivate_secondary` — to orchestrate the transition without taking
+the DB offline and without duplicating the full node-index.
+
+This document covers the metadata layer only: how the two rings live
+inside the existing `db_metadata`, how promote flips the "which ring
+is primary" label atomically, how shrink/grow redistributes cnv
+chunks between the rings while preserving crash safety, and how the
+constructor recovers from a crash that lands mid-operation.
+
+## Layout
+
+The two rings, `ring_a` and `ring_b`, share one header type
+(`root_offsets_ring_t`) and each has its own cnv-chunks-backed
+storage. Both live inside `db_metadata`:
+
+```
+db_metadata {
+    // existing fields (magic, chunk counts, db_offsets, consensus
+    // versions) ...
+    root_offsets_ring_t root_offsets;        // ring_a
+    root_offsets_ring_t secondary_timeline;  // ring_b
+    uint8_t primary_ring_idx;                // 0 = ring_a, 1 = ring_b
+    uint8_t secondary_timeline_active_;      // 1 if non-primary ring is live
+    uint64_t shrink_grow_seq_;               // seqlock (see below)
+    pending_shrink_grow_t pending_shrink_grow;  // intent log (see below)
+    uint8_t future_variables_unused[...];
+    // chunk lists ...
+}
+```
+
+The fixed header is still 4480 bytes; new fields were carved out of
+`future_variables_unused`, which `init_new_pool` zero-fills (matching
+the MONAD007→008 migration), so pre-existing MONAD008 pools see the
+new fields as their idle state on first reopen.
+
+`root_offsets_ring_t::SIZE_` dropped 65536 → 32. The original
+cnv_chunks[] array was vastly over-provisioned for the real chunk
+counts used by the pool.
+
+## Physical vs logical ring
+
+At pool init, `primary_ring_idx = 0` and all cnv ring chunks go to
+`ring_a`. `ring_b` starts with `cnv_chunks_len = 0`. The "primary"
+role is a label: which physical ring a query routes to depends on
+`primary_ring_idx`, not on the struct field name.
+
+`promote_secondary_to_primary_header` is therefore a single atomic
+byte flip of `primary_ring_idx` on both metadata copies. Header
+fields don't move and in-memory spans don't swap — the role change
+is observed at query time via `root_offsets(timeline_id)`.
+
+Both copies hold their `is_dirty` bit across both flips
+simultaneously. If a crash lands between the two flips, dirty-bit
+recovery on reopen propagates the clean copy over the dirty one,
+yielding either "both flipped" or "neither flipped" — never "the two
+copies disagree on which ring is primary." Since the physical ring
+carrying the role keeps its own header and data across a promote,
+the DB remains consistent either way.
+
+## Shrink/grow (activate/deactivate)
+
+`activate_secondary_header(fork_version)` atomically shrinks the
+primary ring by half and hands the freed cnv chunks to the other
+ring, which becomes the secondary role's backing store initialised at
+`fork_version`. `deactivate_secondary_header` reverses the transfer.
+
+Both require the primary's cnv_chunks_len to be a power of two;
+ring-position computation uses `v & (cap − 1)`.
+
+### VA stability
+
+The ring span pointers (`ring_a_span`, `ring_b_span`) are stable
+across shrink/grow. Each ring reserves its max-size virtual address
+range at startup; `MAP_FIXED` installs individual cnv chunks into
+their slots on activate/deactivate. A slot outside the currently-
+occupied prefix remains `PROT_NONE` anonymous.
+
+### The crash-corruption window
+
+Ring data (primary/secondary spans) and the metadata page live in
+*different* backing files from the kernel pagecache's perspective:
+the metadata is mmap'd on cnv chunk 0, and each ring slot is mmap'd
+on a cnv chunk 1..N. Kernel writeback of these pages is independent
+and unordered.
+
+A naïve shrink would touch the ring pages (in-place copy of entries
+from the discarded half into the retained half) and then update
+`cnv_chunks_len` on the metadata page. If the kernel flushes the
+ring pages before the metadata page and a crash occurs in that
+window, on reopen the metadata still shows the old capacity but the
+ring has overwritten low-index slots. Readers index under the old
+capacity mask, land on slots that now carry data for different
+versions, and get silently wrong answers.
+
+The existing dual-copy + `is_dirty` recovery can't detect this:
+`is_dirty` lives in the metadata page that wasn't flushed, so
+recovery sees both copies clean. And `db_copy` only propagates
+metadata — it doesn't touch ring data.
+
+### The intent-log protocol
+
+`pending_shrink_grow` is a stamp on the metadata page that records
+the in-flight operation:
+
+```
+struct pending_shrink_grow_t {
+    uint32_t op_kind;                  // NONE | ACTIVATE | DEACTIVATE
+    uint32_t target_primary_chunks;    // post-op primary cnv_chunks_len
+    uint64_t fork_version;             // meaningful for ACTIVATE
+}
+```
+
+The public API wraps each operation in six steps:
+
+```
+1. set_pending_shrink_grow_ (stamp flag, bump seq to odd) under
+   hold_dirty, per copy
+2. sync_metadata_to_disk_   (msync + fsync cnv chunk 0)
+3. do_*_secondary_body_     (idempotent ring copy + commit)
+4. sync_ring_data_to_disk_  (msync ring pages + fsync each backing
+                              cnv chunk)
+5. sync_metadata_to_disk_
+6. clear_pending_shrink_grow_ (unstamp flag, bump seq to even) under
+   hold_dirty, per copy
+7. sync_metadata_to_disk_
+```
+
+On any crash, the constructor's `replay_pending_shrink_grow_` fires
+if either copy has `op_kind != NONE` (see Recovery below) and runs
+the body to completion.
+
+### Body idempotency
+
+Every step in `do_activate_secondary_body_` and
+`do_deactivate_secondary_body_` is safe to re-run against any partial
+state the body itself could have produced:
+
+- **`version_lower_bound_` bump.** `std::max(cur_lb, ...)` is a fixed
+  point under repeated application.
+- **Ring-copy loop.** Sources are in `[new_cap, old_cap)` (for
+  activate; symmetric for deactivate); destinations are in
+  `[0, new_cap)`. Ranges are disjoint, and the loop never writes to
+  a source slot. Re-running the loop with the same source contents
+  produces the same destination state.
+- **`MAP_FIXED` installs.** Happen *before* the `cnv_chunks[]` swap.
+  If an install fails, the cnv_chunks state is still whole, so
+  recovery remains unambiguous. Each install is idempotent (it
+  replaces any existing mapping) and the source chunk id is derived
+  from either `sstore.cnv_chunks[k]` (already moved in a prior
+  partial run) or `pstore.cnv_chunks[new_chunks + k]` (not yet
+  moved).
+- **`cnv_chunks[]` move.** Guarded on the destination slot's current
+  id: if `sstore.cnv_chunks[k].cnv_chunk_id != uint32_t(-1)`, the
+  move has already run for this k — skip.
+- **Secondary ring init (memset + version fields).** Safe to re-run
+  because replay executes in the constructor before any client
+  thread can observe the DB, and the live-path public API is
+  synchronous — no push can have touched the post-activate state
+  until the API call returns (after the flag-clear msync).
+- **`cnv_chunks_len` commit and `secondary_timeline_active_` flip.**
+  Plain stores of the target value; re-running sets the same value.
+
+`map_ring_a_storage` / `map_ring_b_storage` tolerate
+`cnv_chunks[k].cnv_chunk_id == uint32_t(-1)` so a crash mid-swap
+doesn't prevent the constructor from reaching the replay path.
+
+## Concurrent readers
+
+Readers use a seqlock, `shrink_grow_seq_`, to retry if a shrink/grow
+commits or replay runs while they're reading:
+
+```
+do {
+    seq = shrink_grow_seq_acquire();  // copy 0
+    if (seq & 1u) { yield; continue; }
+    ... read ring snapshot ...
+} while (seq != shrink_grow_seq_acquire());
+```
+
+The seq is bumped under the same `hold_dirty` as the intent-log
+stamp/clear, so a durable odd seq is always accompanied by a non-
+`NONE` op_kind — replay on reopen always restores even parity before
+any reader observes the DB.
+
+### Parity alignment after partial-stamp crash
+
+The set/clear scopes run per copy with the `hold_dirty` scope closed
+between them. If a crash lands between the two scopes — copy 0
+stamped and clean, copy 1 unstamped and clean — neither is dirty and
+the dirty-bit path does nothing. Replay fires because copy 0 has
+`op_kind != NONE`, runs the body, then calls `clear_pending_shrink_
+grow_`.
+
+A blind `fetch_add(1)` on each copy's seq in the clear path would
+leave copy 0 even but copy 1 odd. If copy 0 were later healed from
+copy 1 via `db_copy`, readers of copy 0 would spin on the seqlock.
+
+Instead, clear stores `(cur + 2) & ~1ULL` — the smallest even value
+strictly greater than `cur`. Set stores `(cur + 1) | 1ULL` — the
+smallest odd value strictly greater than `cur`. Both copies end at
+the correct parity regardless of their starting state, and each
+copy's generation counter strictly advances.
+
+## Constructor recovery
+
+The constructor runs, in order:
+
+1. Magic validation (restore corrupted copy 0 from copy 1 via
+   `db_copy` if needed).
+2. MONAD007 → MONAD008 migration (see section below).
+3. Version-mismatch check.
+4. Dirty-bit recovery (`is_dirty` on one copy → `db_copy` from the
+   other).
+5. `map_ring_a_storage` / `map_ring_b_storage` (tolerant of
+   `uint32_t(-1)` cnv_chunk_ids from a partial swap).
+6. `replay_pending_shrink_grow_`:
+   - If both copies have non-NONE `op_kind`, assert byte-wise
+     equality of the pending records (defends against protocol
+     regression / out-of-band corruption).
+   - Use whichever copy has `op_kind != NONE` (single-side case
+     arises when the crash fell in the gap between set/clear scopes).
+   - Run the appropriate `do_*_body_` with the stamped params.
+   - `sync_ring_data_to_disk_`, `sync_metadata_to_disk_`.
+   - `clear_pending_shrink_grow_`, `sync_metadata_to_disk_`.
+
+Readers only observe the DB after the constructor returns, so the
+replay runs without concurrency.
+
+## MONAD007 → MONAD008 layout-shift migration
+
+MONAD008 dropped `root_offsets_ring_t::SIZE_` from 65536 to 32, which
+took `sizeof(db_metadata)` from 528512 bytes to 4480. The flexible
+`chunk_info[]` array therefore moved from file offset 528512 to 4480,
+and several fields that lived at the end of the old header moved too:
+
+| Field                                          | MONAD007 offset | MONAD008 offset |
+|------------------------------------------------|-----------------|-----------------|
+| `db_offsets` + consensus block (128 bytes)     | 524328          | 296             |
+| free/fast/slow list triple (24 bytes)          | 528488          | 4456            |
+| `chunk_info[]` (flexible)                      | 528512          | 4480            |
+
+The first 24 bytes (magic, `chunk_info_count` bitfield,
+`capacity_in_free_list`) sit at the same offsets in both layouts, and
+so do `root_offsets.version_lower_bound_` / `next_version_` / the
+`storage_` header. The first 31 `cnv_chunks[]` entries (the max a
+MONAD008 pool can hold) also survive in place; MONAD007 pools that
+somehow populated `cnv_chunks[31..65534]` cannot be migrated and the
+ctor aborts.
+
+**mmap sizing.** To read from offset 528512+ on a MONAD007 pool, the
+ctor maps the full half-capacity of cnv chunk 0 (we guarantee metadata
+never spans multiple chunks, so the half-chunk always covers any past
+or future fixed-header layout). `db_map_size_` tracks the small
+logical metadata region — used for `msync`, `db_copy`, and similar
+ops — while `metadata_mmap_size_` tracks the VA reservation used for
+mmap/munmap.
+
+**Migration steps** (per copy, under `hold_dirty`):
+
+1. Assert `root_offsets.storage_.cnv_chunks_len < SIZE_` — the live
+   chunks list must fit under MONAD008's cap.
+2. `memmove` `chunk_info[]` from file offset 528512 to 4480
+   (`chunk_count × sizeof(chunk_info_t)` bytes; ranges are disjoint
+   for any realistic `chunk_count`).
+3. `memcpy` the list triple from offset 528488 to 4456.
+4. `memcpy` the `db_offsets` + consensus block (128 bytes) from 524328
+   to 296.
+5. Zero the region `[&secondary_timeline, &free_list)` so every
+   new-in-MONAD008 field starts at its idle value (secondary inactive,
+   `shrink_grow_seq_` even, `pending_shrink_grow.op_kind == NONE`).
+   Without this, MONAD007's `0xff` padding would make the secondary
+   look active, stick the seqlock at odd, and set `op_kind` to an
+   unknown value that replay would reject.
+6. Bump the magic to MONAD008.
+
+After both copies finish, `sync_metadata_to_disk_` commits the
+relocated layout before downstream ctor code reads through the new
+offsets.
+
+**Crash safety.** Each copy is migrated under `hold_dirty`, so a
+crash mid-copy leaves `is_dirty = 1` and the magic-validation heal on
+the next open copies the already-migrated sibling over the stragglier
+(the heal's `db_copy` is layout-agnostic since the on-disk MONAD008
+bytes form a valid image). Crashes between copies are covered by the
+per-copy loop restarting on MONAD007-magic copies. The individual
+`memmove`/`memcpy`/`memset` operations don't overwrite their sources,
+so even a fully-restarted migration on a mid-migrated pool is
+idempotent.
+
+## CLI restore
+
+`do_restore_database` in `cli_tool_impl.cpp` copies these fields from
+the archive's `db_metadata`:
+
+- `root_offsets` (header + storage)
+- `secondary_timeline` (header + storage)
+- `primary_ring_idx`, `secondary_timeline_active_`
+- consensus versions and block IDs
+
+Explicitly **not** copied (left at init zero):
+
+- `shrink_grow_seq_`
+- `pending_shrink_grow`
+
+Starting the restored DB from a quiescent state avoids replaying an
+archive-era in-flight op against freshly-restored ring data whose
+layout assumptions may differ.

--- a/docs/monad_mpt_upgrade.md
+++ b/docs/monad_mpt_upgrade.md
@@ -1,0 +1,59 @@
+# monad-mpt --upgrade
+
+## When to run
+
+Run `monad-mpt --upgrade` once on each monad node after upgrading the
+monad apt package to a release that advances the on-disk metadata
+version. Today that means: any upgrade that crosses from a pre-MONAD008
+package to a MONAD008-or-later package.
+
+If the package notes do not mention a metadata version bump, `--upgrade`
+is still safe to run (it is a no-op on an already-current pool, ending
+in a metadata flush), but it is not required.
+
+## Runbook
+
+1. Stop all monad services that access the DB (monad-node, any
+   supporting services). Confirm with `systemctl status` or
+   equivalent.
+2. `apt install monad=<new-version>` (or the equivalent for your
+   package manager).
+3. Run the upgrade, pointing at the same storage sources your services
+   use:
+   ```
+   monad-mpt --upgrade --storage /dev/<device1> [--storage /dev/<device2> ...]
+   ```
+   The command exits 0 on success. Typical runtime is sub-second: the
+   tool only touches the cnv metadata chunk, not seq data.
+4. Start services.
+
+## Reading the output
+
+- `Migrated DB metadata from MONAD007 to MONAD008.` — an on-disk
+  migration happened.
+- `DB is on version MONAD008; flushing metadata...` — the tool
+  confirms the final state and flushes the metadata to disk for
+  durability. Printed both when the DB was already MONAD008 and when
+  the ctor just migrated it from MONAD007 (the `Migrated DB metadata`
+  line above distinguishes the two).
+- `WARNING: --upgrade found no existing DB metadata; a fresh MONAD008
+  pool was created.` — the storage device had no prior DB. You probably
+  meant to run `--create` on a fresh device; the resulting pool is
+  well-formed but empty.
+- `Success.` — exit 0 on the final line.
+
+## If a service fails to start with "DB is on older format"
+
+A service binary observed `PREVIOUS_MAGIC` on the DB and refused to
+auto-migrate. This is by design: services never run migrations. Stop
+all services, run `monad-mpt --upgrade`, then start services again.
+
+## Safety
+
+`monad-mpt --upgrade` is safe to re-run. It is idempotent on
+already-current pools, and the migration itself is crash-safe (each
+metadata copy is migrated under a dirty guard; a crash mid-migration
+heals on the next writable open that has `allow_migration = true`).
+
+Running `monad-mpt --upgrade` while a monad service is accessing the DB
+is not supported. Follow the runbook and stop services first.


### PR DESCRIPTION
## Summary

- Adds `monad-mpt --upgrade`: the operator-facing step that brings an on-disk MPT pool up to the current metadata version (MONAD008) and flushes it durably to disk before monad services start.
- Closes the migration race that #2228 leaves open: removes automatic ctor-level migration from the normal open path and gates it behind a new `allow_migration` flag on `storage_pool::creation_flags`. Services now abort on `PREVIOUS_MAGIC` with a clear "run `monad-mpt --upgrade`" message; only `monad-mpt --upgrade` sets the flag.
- Operator runbook at `docs/monad_mpt_upgrade.md`.

Stacked on #2228 (`max/dual-timeline`).

## Shape

- `storage_pool::creation_flags::allow_migration` + `is_migration_allowed()` accessor (default false).
- `DbMetadataContext` ctor consults `is_migration_allowed()` before entering the MONAD007→MONAD008 block. Without the opt-in: `MONAD_ABORT_PRINTF` with the runbook message. The preexisting `can_write_to_map_` gate is preserved.
- Public `DbMetadataContext::sync_metadata_to_disk()` forwarder. The tool calls it after the ctor returns — idempotent on already-current pools, also covers the case where a prior run msync'd but the box was power-cycled before the kernel flushed.
- `--upgrade` joins the existing `cli_ops_group` in `cli_tool_impl.cpp` (mutually exclusive with `--create`, `--truncate`, `--create-empty`, `--rewind-to`, `--reset-history-length` via the existing `require_option(0, 1)`).

## Tests

New:
- `cli_tool.upgrade_idempotent_on_current_pool` — `--create` then `--upgrade` → exits 0, stdout contains `"already on version MONAD008"`.
- `cli_tool.upgrade_rejects_combined_mutation` — `--upgrade --create` → CLI11 parse error.
- `cli_tool.upgrade_migrates_monad007_pool` — end-to-end: fabricates a MONAD007 layout over a `--create`'d file via the pool's own chunk API (correct offsets, real chunk count), runs `--upgrade`, reopens read-only, verifies MONAD008 magic and that `history_length` survived at its new offset.
- `cli_tool.upgrade_requires_storage` — `--upgrade` without `--storage` rejected.
- `update_aux_death_test.aborts_on_monad007_without_allow_migration` — service-path abort with the `"monad-mpt --upgrade"` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)