### PR TITLE
[execution]: Automatically distribute priority fees to stakers

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -260,6 +260,8 @@ add_library(
   "monad/staking/config.hpp"
   "monad/staking/execute_block_prelude.cpp"
   "monad/staking/execute_block_prelude.hpp"
+  "monad/staking/priority_fee.cpp"
+  "monad/staking/priority_fee.hpp"
   "monad/staking/fuzzer/staking_contract_machine.cpp"
   "monad/staking/fuzzer/staking_contract_machine.hpp"
   "monad/staking/fuzzer/staking_contract_model.cpp"

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -46,6 +46,7 @@
 #include <category/execution/ethereum/trace/event_trace.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/staking/priority_fee.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -320,6 +321,11 @@ Result<std::vector<Receipt>> execute_block(
     }
 
     apply_block_reward<traits>(state, block);
+
+    // TODO: move to execute_monad_block
+    if constexpr (traits::mip_11_active()) {
+        staking::distribute_priority_fees(state);
+    }
 
     state.destruct_touched_dead();
 

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -38,6 +38,7 @@
 #include <category/execution/ethereum/tx_context.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
+#include <category/execution/monad/staking/priority_fee.hpp>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/switch_traits.hpp>
@@ -391,9 +392,14 @@ Receipt ExecuteTransaction<traits>::execute_final(
         }
     }
 
-    auto const reward = calculate_txn_award<traits>(
+    uint256_t const reward = calculate_txn_award<traits>(
         tx_, header_.base_fee_per_gas.value_or(0), gas_used);
-    state.add_to_balance(header_.beneficiary, reward);
+    if constexpr (traits::mip_11_active()) {
+        staking::collect_priority_fee(state, reward);
+    }
+    else {
+        state.add_to_balance(header_.beneficiary, reward);
+    }
 
     // finalize state, Eqn. 77-79
     state.destruct_suicides<traits>();

--- a/category/execution/monad/staking/priority_fee.cpp
+++ b/category/execution/monad/staking/priority_fee.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/monad/staking/priority_fee.hpp>
+#include <category/execution/monad/staking/staking_contract.hpp>
+
+MONAD_STAKING_NAMESPACE_BEGIN
+
+void collect_priority_fee(State &state, uint256_t const &fee)
+{
+    state.add_to_balance(PRIORITY_FEE_DIST_ADDRESS, fee);
+}
+
+void distribute_priority_fees(State &state)
+{
+    uint256_t const fees = state.get_balance(PRIORITY_FEE_DIST_ADDRESS);
+    if (fees == 0) {
+        return;
+    }
+
+    // Drain unconditionally: the subtract is outside the push/pop, so a
+    // failed distribution burns the fees rather than leaving them in the
+    // dist address.
+    state.subtract_from_balance(PRIORITY_FEE_DIST_ADDRESS, fees);
+
+    state.push();
+    state.add_to_balance(STAKING_CA, fees);
+    NoopCallTracer call_tracer;
+    StakingContract contract(state, call_tracer);
+    auto const res = contract.distribute_priority_fees(fees);
+    if (res.has_error()) {
+        state.pop_reject();
+    }
+    else {
+        state.pop_accept();
+    }
+}
+
+MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/staking/priority_fee.cpp
+++ b/category/execution/monad/staking/priority_fee.cpp
@@ -14,10 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/int.hpp>
+#include <category/core/log.hpp>
+#include <category/core/monad_exception.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/monad/staking/priority_fee.hpp>
 #include <category/execution/monad/staking/staking_contract.hpp>
+#include <category/execution/monad/staking/util/staking_error.hpp>
 
 MONAD_STAKING_NAMESPACE_BEGIN
 
@@ -44,6 +47,16 @@ void distribute_priority_fees(State &state)
     StakingContract contract(state, call_tracer);
     auto const res = contract.distribute_priority_fees(fees);
     if (res.has_error()) {
+        LOG_ERROR(
+            "staking: distribute priority fee reverted: {}",
+            res.error().message());
+        // At the start of block execution, the proposer id is always cleared to
+        // 0 and is set by the reward syscall. If the reward syscall was not
+        // included, `UnknownValidator` will be returned, and that is the only
+        // state we permit.
+        MONAD_ASSERT_THROW(
+            res.error() == StakingError::UnknownValidator,
+            "fee distribution error");
         state.pop_reject();
     }
     else {

--- a/category/execution/monad/staking/priority_fee.hpp
+++ b/category/execution/monad/staking/priority_fee.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/execution/monad/staking/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+class State;
+
+MONAD_NAMESPACE_END
+
+MONAD_STAKING_NAMESPACE_BEGIN
+
+void collect_priority_fee(State &, uint256_t const &);
+
+void distribute_priority_fees(State &);
+
+MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/staking/priority_fee_routing_test.cpp
+++ b/category/execution/monad/staking/priority_fee_routing_test.cpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/execute_transaction.hpp>
+#include <category/execution/ethereum/metrics/block_metrics.hpp>
+#include <category/execution/ethereum/state2/block_state.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/staking/util/constants.hpp>
+#include <category/vm/vm.hpp>
+#include <monad/test/traits_test.hpp>
+
+#include <boost/fiber/future/promise.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+
+TYPED_TEST(MonadTraitsTest, mip11_fork)
+{
+    using Trait = TestFixture::Trait;
+
+    static constexpr Address from{
+        0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address};
+    static constexpr Address beneficiary{0xb0b0_address};
+    static constexpr Address recipient{0xa1ce_address};
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+    BlockMetrics metrics;
+
+    {
+        State state{bs, Incarnation{0, 0}};
+        state.add_to_balance(from, 1'000'000'000'000'000'000);
+        bs.merge(state);
+    }
+
+    static constexpr uint64_t gas_limit = 21'000;
+    static constexpr uint256_t max_fee_per_gas = 10;
+    static constexpr uint256_t expected_priority_fee =
+        gas_limit * max_fee_per_gas;
+    Transaction const tx{
+        .sc = {.r = 1, .s = 2, .y_parity = 0},
+        .nonce = 0,
+        .max_fee_per_gas = max_fee_per_gas,
+        .gas_limit = gas_limit,
+        .to = recipient,
+    };
+
+    BlockHeader const header{.beneficiary = beneficiary};
+    BlockHashBufferFinalized const block_hash_buffer;
+
+    boost::fibers::promise<void> prev{};
+    prev.set_value();
+
+    NoopCallTracer call_tracer;
+    trace::StateTracer state_tracer = std::monostate{};
+    auto const chain_ctx = ChainContext<Trait>::debug_empty();
+
+    MonadDevnet const chain;
+    auto const receipt = ExecuteTransaction<Trait>(
+        chain,
+        0, /* txn index */
+        tx,
+        from,
+        {},
+        header,
+        block_hash_buffer,
+        bs,
+        metrics,
+        prev,
+        call_tracer,
+        state_tracer,
+        chain_ctx)();
+
+    ASSERT_FALSE(receipt.has_error());
+    EXPECT_EQ(receipt.value().status, 1u);
+
+    State state{bs, Incarnation{0, 0}};
+    if constexpr (Trait::mip_11_active()) {
+        EXPECT_EQ(state.get_balance(beneficiary), 0);
+        EXPECT_EQ(
+            state.get_balance(staking::PRIORITY_FEE_DIST_ADDRESS),
+            expected_priority_fee);
+    }
+    else {
+        EXPECT_EQ(state.get_balance(beneficiary), expected_priority_fee);
+        EXPECT_EQ(state.get_balance(staking::PRIORITY_FEE_DIST_ADDRESS), 0);
+    }
+}

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -358,6 +358,15 @@ Result<void> function_not_payable(uint256_be_t const &value)
     return outcome::success();
 }
 
+Result<std::pair<uint256_t, uint256_t>>
+split_commission(uint256_t const &reward, uint256_t const &commission_rate)
+{
+    BOOST_OUTCOME_TRY(
+        auto const commission, checked_mul_div(reward, commission_rate, MON));
+    BOOST_OUTCOME_TRY(auto const del_reward, checked_sub(reward, commission));
+    return std::pair{commission, del_reward};
+}
+
 MONAD_STAKING_ANONYMOUS_NAMESPACE_END
 
 MONAD_STAKING_NAMESPACE_BEGIN
@@ -1698,14 +1707,12 @@ Result<void> StakingContract::syscall_reward(
 
     mint_tokens(raw_reward);
 
-    // 3. subtract commission
+    // 3. Split off commission and credit it to the auth delegator.
     uint256_t const commission_rate =
         consensus_view.commission().load().native();
     BOOST_OUTCOME_TRY(
-        auto const commission,
-        checked_mul_div(raw_reward, commission_rate, MON));
-
-    // 4. Send commission to the auth address
+        auto const split, split_commission(raw_reward, commission_rate));
+    auto const &[commission, del_reward] = split;
     auto val_execution = vars.val_execution(val_id.value());
     auto auth = vars.delegator(val_id.value(), val_execution.auth_address());
     BOOST_OUTCOME_TRY(
@@ -1713,13 +1720,11 @@ Result<void> StakingContract::syscall_reward(
         checked_add(auth.rewards().load().native(), commission));
     auth.rewards().store(auth_reward);
 
-    BOOST_OUTCOME_TRY(
-        auto const del_reward, checked_sub(raw_reward, commission));
-    // 5. update accumulator and unclaimed rewards for this validator pool
+    // 4. update accumulator and unclaimed rewards for this validator pool
     BOOST_OUTCOME_TRY(
         apply_reward(val_id.value(), SYSTEM_SENDER, del_reward, active_stake));
 
-    // 6. Store the proposer validator id for other contracts to query.
+    // 5. Store the proposer validator id for other contracts to query.
     if constexpr (traits::monad_rev() >= MONAD_FIVE) {
         vars.proposer_val_id.store(val_id.value());
     }
@@ -1833,6 +1838,48 @@ Result<void> StakingContract::syscall_snapshot(
     }
 
     vars.in_epoch_delay_period.store(true);
+
+    return outcome::success();
+}
+
+Result<void> StakingContract::distribute_priority_fees(uint256_t const &fees)
+{
+    // 1. Validate the proposer is in the consensus set.
+    u64_be const val_id = vars.proposer_val_id.load();
+    auto val_execution = vars.val_execution(val_id);
+    if (MONAD_UNLIKELY(!val_execution.exists())) {
+        return StakingError::UnknownValidator;
+    }
+    auto consensus_view = vars.this_epoch_view(val_id);
+    uint256_t const active_stake = consensus_view.stake().load().native();
+    if (MONAD_UNLIKELY(active_stake == 0)) {
+        return StakingError::NotInValidatorSet;
+    }
+
+    // 2. Split commission off the raw fees and credit it to the auth
+    // delegator.
+    uint256_t const commission_rate =
+        consensus_view.commission().load().native();
+    BOOST_OUTCOME_TRY(
+        auto const split, split_commission(fees, commission_rate));
+    auto const &[commission, del_reward] = split;
+
+    auto auth = vars.delegator(val_id, val_execution.auth_address());
+    BOOST_OUTCOME_TRY(
+        auto const auth_reward,
+        checked_add(auth.rewards().load().native(), commission));
+    auth.rewards().store(auth_reward);
+
+    // 3. Distribute the remainder to delegators pro-rata, or burn if dust.
+    //
+    // NOTE: no upper bound — in-protocol distribution is uncapped.
+    if (del_reward < limits::min_external_reward()) {
+        state_.subtract_from_balance(STAKING_CA, del_reward);
+    }
+    else {
+        BOOST_OUTCOME_TRY(apply_reward(
+            val_id, PRIORITY_FEE_DIST_ADDRESS, del_reward, active_stake));
+    }
 
     return outcome::success();
 }

--- a/category/execution/monad/staking/staking_contract.hpp
+++ b/category/execution/monad/staking/staking_contract.hpp
@@ -620,6 +620,11 @@ public:
     Result<void> syscall_on_epoch_change(byte_string_view, uint256_t const &);
 
     Result<void> syscall_snapshot(byte_string_view, uint256_t const &);
+
+    /////////////////////////////////
+    //  In-protocol functionality  //
+    /////////////////////////////////
+    Result<void> distribute_priority_fees(uint256_t const &fees);
 };
 
 MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -2162,6 +2162,30 @@ TEST_F(StakeLatest, priority_fee_distribution_no_reward_txn_burns)
         0);
 }
 
+TEST_F(StakeLatest, priority_fee_distribution_throw)
+{
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res = add_validator(auth_address, ACTIVE_VALIDATOR_STAKE);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    EXPECT_FALSE(
+        syscall_reward(val.sign_address, 0 /* isolate priority-fee path */)
+            .has_error());
+
+    // force an accumulator error. viz. any error that is not unknown validator
+    auto proposer =
+        contract.vars.val_execution(contract.vars.proposer_val_id.load());
+    proposer.accumulated_reward_per_token().store(
+        std::numeric_limits<uint256_t>::max());
+
+    // no eligible validator is the only error we handle gracefully
+    constexpr uint256_t fees = 10 * MON;
+    collect_priority_fee(state, fees);
+    EXPECT_THROW(distribute_priority_fees(state), MonadException);
+}
+
 TEST_F(StakeLatest, priority_fee_distribution_one_hundred_percent_commission)
 {
     constexpr uint256_t commission_rate = MON; // 100%

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -36,6 +36,7 @@
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/monad/staking/priority_fee.hpp>
 #include <category/execution/monad/staking/staking_contract.hpp>
 #include <category/execution/monad/staking/test/input_generation.hpp>
 #include <category/execution/monad/staking/util/constants.hpp>
@@ -2053,6 +2054,211 @@ TEST_F(StakeLatest, validator_external_rewards_uniform_reward_pool)
         EXPECT_EQ(
             contract.vars.delegator(val.id, d).rewards().load().native(),
             4 * MON);
+    }
+}
+
+/////////////////////
+// priority fee tests
+/////////////////////
+
+TEST_F(StakeLatest, priority_fee_distribution_empty_block)
+{
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+    distribute_priority_fees(state);
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before);
+}
+
+TEST_F(StakeLatest, priority_fee_distribution_e2e)
+{
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res = add_validator(auth_address, ACTIVE_VALIDATOR_STAKE);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+
+    // Reward txn runs first in the block; this is what sets proposer_val_id.
+    EXPECT_FALSE(syscall_reward(val.sign_address).has_error());
+
+    // User txns accumulate priority fees via the per-tx entry point.
+    constexpr uint256_t tx_fee = 5 * MON;
+    constexpr uint64_t num_txs = 4;
+    for (uint64_t i = 0; i < num_txs; ++i) {
+        collect_priority_fee(state, tx_fee);
+    }
+    uint256_t const total_fees = num_txs * tx_fee;
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), total_fees);
+
+    distribute_priority_fees(state);
+
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before + REWARD + total_fees);
+
+    // The sole delegator claims the block reward and the full priority-fee
+    // distribution. If STAKING_CA weren't credited during distribution,
+    // send_tokens would underflow here.
+    EXPECT_EQ(get_balance(auth_address), 0);
+    EXPECT_FALSE(claim_rewards(val.id, auth_address).has_error());
+    EXPECT_EQ(get_balance(auth_address), REWARD + total_fees);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before);
+}
+
+// Distribution path has no per-call cap on fees; a single block can credit
+// arbitrarily large totals to the validator pool.
+TEST_F(StakeLatest, priority_fee_distribution_above_max_external_reward)
+{
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res = add_validator(auth_address, ACTIVE_VALIDATOR_STAKE);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    EXPECT_FALSE(
+        syscall_reward(val.sign_address, 0 /* isolate priority-fee path */)
+            .has_error());
+
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+
+    uint256_t const huge_fees = MAX_EXTERNAL_REWARD + MON;
+    collect_priority_fee(state, huge_fees);
+    distribute_priority_fees(state);
+
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before + huge_fees);
+    pull_delegator_up_to_date(val.id, auth_address);
+    EXPECT_EQ(
+        contract.vars.delegator(val.id, auth_address).rewards().load().native(),
+        huge_fees);
+}
+
+TEST_F(StakeLatest, priority_fee_distribution_no_reward_txn_burns)
+{
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res = add_validator(auth_address, ACTIVE_VALIDATOR_STAKE);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    // Deliberately skip syscall_reward — proposer_val_id stays at its
+    // default of 0. val_id 0 is never assigned (first validator id is 1),
+    // so apply_external_reward returns UnknownValidator and the
+    // accumulator update reverts.
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+    constexpr uint256_t total_fees = 10 * MON;
+    collect_priority_fee(state, total_fees);
+
+    distribute_priority_fees(state);
+
+    // apply_external_reward returns UnknownValidator, so the credit to
+    // STAKING_CA and the accumulator update both revert. The dist-address
+    // subtract is outside the push, so fees are removed from total supply.
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before);
+    pull_delegator_up_to_date(val.id, auth_address);
+    EXPECT_EQ(
+        contract.vars.delegator(val.id, auth_address).rewards().load().native(),
+        0);
+}
+
+TEST_F(StakeLatest, priority_fee_distribution_one_hundred_percent_commission)
+{
+    constexpr uint256_t commission_rate = MON; // 100%
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res =
+        add_validator(auth_address, ACTIVE_VALIDATOR_STAKE, commission_rate);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    EXPECT_FALSE(
+        syscall_reward(val.sign_address, 0 /* isolate priority-fee path */)
+            .has_error());
+
+    constexpr uint256_t fees = 10 * MON;
+
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+    collect_priority_fee(state, fees);
+    distribute_priority_fees(state);
+
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before + fees);
+    pull_delegator_up_to_date(val.id, auth_address);
+    EXPECT_EQ(
+        contract.vars.delegator(val.id, auth_address).rewards().load().native(),
+        fees);
+}
+
+TEST_F(StakeLatest, priority_fee_distribution_when_delegator_share_is_dust)
+{
+    constexpr uint256_t commission_rate = MON / 5; // 20%
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res =
+        add_validator(auth_address, ACTIVE_VALIDATOR_STAKE, commission_rate);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+    skip_to_next_epoch();
+
+    EXPECT_FALSE(
+        syscall_reward(val.sign_address, 0 /* isolate priority-fee path */)
+            .has_error());
+
+    constexpr uint256_t fees = 1'200'000'000;
+    constexpr uint256_t del_share = fees - fees * commission_rate / MON;
+    constexpr uint256_t auth_share = fees - del_share;
+    static_assert(fees >= MIN_EXTERNAL_REWARD);
+    static_assert(del_share < MIN_EXTERNAL_REWARD);
+
+    uint256_t const staking_ca_before = get_balance(STAKING_CA);
+    collect_priority_fee(state, fees);
+    distribute_priority_fees(state);
+
+    EXPECT_EQ(get_balance(PRIORITY_FEE_DIST_ADDRESS), 0);
+    EXPECT_EQ(get_balance(STAKING_CA), staking_ca_before + auth_share);
+    pull_delegator_up_to_date(val.id, auth_address);
+    EXPECT_EQ(
+        contract.vars.delegator(val.id, auth_address).rewards().load().native(),
+        auth_share);
+}
+
+TEST_F(StakeLatest, priority_fee_distribution_uniform_pool)
+{
+    constexpr uint256_t commission_rate = MON / 10; // 10%
+    auto const auth_address = 0xdeadbeef_address;
+    auto const val_res =
+        add_validator(auth_address, ACTIVE_VALIDATOR_STAKE, commission_rate);
+    ASSERT_FALSE(val_res.has_error());
+    auto const val = val_res.value();
+
+    std::array<Address, 3> const delegators = {
+        auth_address, 0xaaaa_address, 0xbbbb_address};
+    for (auto const &d : delegators) {
+        if (d != auth_address) {
+            EXPECT_FALSE(
+                delegate(val.id, d, ACTIVE_VALIDATOR_STAKE).has_error());
+        }
+    }
+    skip_to_next_epoch();
+
+    EXPECT_FALSE(
+        syscall_reward(val.sign_address, 0 /* isolate priority-fee path */)
+            .has_error());
+
+    // 10 MON total fees, 10% commission → 1 MON to auth, 9 MON to the pool.
+    // 3 equal-stake delegators split the 9 MON pool evenly (3 MON each).
+    // Auth ends up with 1 MON commission + 3 MON pool share = 4 MON.
+    constexpr uint256_t total_fees = 10 * MON;
+    collect_priority_fee(state, total_fees);
+
+    distribute_priority_fees(state);
+
+    for (auto const &d : delegators) {
+        pull_delegator_up_to_date(val.id, d);
+        uint256_t const expected = (d == auth_address) ? 4 * MON : 3 * MON;
+        EXPECT_EQ(
+            contract.vars.delegator(val.id, d).rewards().load().native(),
+            expected);
     }
 }
 

--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -34,6 +34,9 @@ using namespace monad::literals;
 // staking contract address
 inline constexpr Address STAKING_CA{0x1000};
 
+inline constexpr Address PRIORITY_FEE_DIST_ADDRESS{
+    0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5_address};
+
 // 1e18 constant
 inline constexpr uint256_t MON{1000000000000000000_u256};
 

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -1937,6 +1937,9 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                     "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                         "balance": "0x1",
                         "nonce": 1
+                    },
+                    "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                        "balance": "0x0"
                     }
                 },
                 "txHash": "0x659b50d5b5c543fb681ace210eb175938d5b829297bcf579bc186ac0ea0874dd"
@@ -1950,6 +1953,9 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                     "0xc48513273d60b70ee2f25d5c4256612a91573e1e": {
                         "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                         "nonce": 2
+                    },
+                    "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                        "balance": "0x0"
                     }
                 },
                 "txHash": "0x0b391cd83e5ebd2a5d5c0223c4258eaa364737cc6cb9f88c83eced5eb2543e8b"
@@ -2175,6 +2181,9 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                 "balance": "0x1",
                 "nonce": 1
+            },
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x0"
             }
         })";
 
@@ -2217,6 +2226,9 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
                 "balance":
                 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce": 2
+            },
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x0"
             }
         })";
         EXPECT_EQ(
@@ -2733,6 +2745,9 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
             "0xbedcab535cc48a9bd659ac448f092d02ba23a05a": {
                 "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce":1
+            },
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x0"
             }
         })";
         EXPECT_EQ(
@@ -2796,6 +2811,9 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                 "balance": "0x1",
                 "nonce":1
+            },
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x0"
             }
         })";
 
@@ -4186,9 +4204,8 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "balance": "0x1",
                 "nonce": 1
             },
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
-                "balance": "0x0",
-                "nonce": 1
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x0"
             }
         })";
 
@@ -4227,14 +4244,13 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "balance": "0xabbb",
                 "nonce": 1
             },
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
-                "balance": "0x1b7740",
-                "nonce": 1
-            },
             "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                 "balance":
                 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce": 2
+            },
+            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "balance": "0x1b7740"
             }
         })";
         EXPECT_EQ(
@@ -4280,7 +4296,7 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0xabbb"
                 },
-                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
                     "balance": "0x1b7740"
                 }
             },
@@ -4292,10 +4308,6 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 },
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0x1",
-                    "nonce": 1
-                },
-                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
-                    "balance": "0x0",
                     "nonce": 1
                 }
             }
@@ -4336,13 +4348,13 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0x15775"
                 },
-                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
-                    "balance": "0x36ee80"
-                },
                 "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                     "balance":
                     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0cfc5",
                     "nonce": 3
+                },
+                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                    "balance": "0x36ee80"
                 }
             },
             "pre": {
@@ -4350,14 +4362,13 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                     "balance": "0xabbb",
                     "nonce": 1
                 },
-                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
-                    "balance": "0x1b7740",
-                    "nonce": 1
-                },
                 "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                     "balance":
                     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                     "nonce": 2
+                },
+                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                    "balance": "0x1b7740"
                 }
             }
         })";

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -70,6 +70,7 @@ namespace monad
         { T::eip_7951_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
         { T::mip_8_active() } -> std::same_as<bool>;
+        { T::mip_11_active() } -> std::same_as<bool>;
         { T::can_create_inside_delegated() } -> std::same_as<bool>;
 
         // Constants
@@ -142,6 +143,11 @@ namespace monad
         }
 
         static consteval bool mip_3_active() noexcept
+        {
+            return false;
+        }
+
+        static consteval bool mip_11_active() noexcept
         {
             return false;
         }
@@ -268,6 +274,11 @@ namespace monad
                 return true;
             }
             return false;
+        }
+
+        static consteval bool mip_11_active() noexcept
+        {
+            return Rev >= MONAD_NEXT;
         }
 
         static consteval bool can_create_inside_delegated() noexcept


### PR DESCRIPTION
The staking contract already keeps state of the current proposer. This was the larger piece of work, and this PR strings together existing functionality in the staking contract.

At the end of each transaction, instead of transferring fees to the beneficary, is collected in a special staging address. MIP-11 refers to this as the "distribution account", which is the constant `PRIORITY_FEE_DIST_ADDRESS` introduced in this PR.

At the end of each block, the balance in distribution account balance is transferred to the block proposers validator pool using an internal version of the externalRewards() precompile. If the fees are less than the dust, no balance is transferred.

https://github.com/monad-crypto/MIPs/blob/main/MIPs/MIP-11.md