### PR TITLE
Quill: prepare for breaking API changes by hiding log code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,7 @@
     - key:          bugprone-string-constructor.StringNames
       value:        ::std::basic_string;::std::basic_string_view;::absl::string_view
     - key:          misc-include-cleaner.IgnoreHeaders
-      value:        gtest/.*|gmock/.*|sys/.*|CLI/.*|boost/.*|llvm/.*|quill/.*|bits/.*
+      value:        gtest/.*|gmock/.*|sys/.*|CLI/.*|boost/.*|llvm/.*|quill/.*|bits/.*|category/core/log\.hpp
     - key:          modernize-use-default-member-init.UseAssignment
       value:        1
     - key:          modernize-use-transparent-functors.SafeMode

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -21,6 +21,7 @@
 #include <category/core/assert.h>
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/hash.hpp>
+#include <category/core/log.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -40,8 +41,6 @@
 #include <vector>
 
 #include <stdlib.h>
-
-#include <quill/Quill.h>
 
 #include <asm-generic/ioctl.h>
 #include <fcntl.h>

--- a/category/core/basic_formatter.hpp
+++ b/category/core/basic_formatter.hpp
@@ -16,10 +16,7 @@
 #pragma once
 
 #include <category/core/config.hpp>
-
-#include <quill/Fmt.h>
-
-namespace fmt = fmtquill::v10;
+#include <category/core/log.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/core/log.hpp
+++ b/category/core/log.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// Project-internal logging header — the single chokepoint for everything
+// the codebase pulls from quill. Files that emit log messages, hold a
+// `quill::Logger *`, specialize `quill::copy_loggable`, or use the `fmt::`
+// formatter should include this instead of reaching directly into
+// `<quill/...>` headers.
+//
+// Today this re-exports `<quill/Quill.h>`, which transitively provides
+// every quill name our code uses (LogLevel, Logger, Handler, FileHandler,
+// the bundled `fmtquill` formatter, etc.). The `fmt` alias points at
+// `fmtquill` rather than `fmtquill::v10` so it survives the inline-namespace
+// tag bump (v10 → v12) in the upcoming quill v11 upgrade — call sites that
+// say `fmt::format(...)` keep working without source changes.
+//
+// The upcoming quill v11 upgrade splits the umbrella across
+// Backend/Frontend/LogMacros and removes the QUILL_ROOT_LOGGER_ONLY mode;
+// at that point this file becomes where the wrapper macros and
+// `quill::get_root_logger()` shim live, so call sites don't need to change
+// again.
+
+#include <quill/Quill.h>
+
+namespace fmt = fmtquill;

--- a/category/core/log_ffi.cpp
+++ b/category/core/log_ffi.cpp
@@ -15,6 +15,8 @@
 
 #include <category/core/log_ffi.h>
 
+#include <category/core/log.hpp>
+
 #include <cerrno>
 #include <chrono>
 #include <cstddef>
@@ -25,10 +27,6 @@
 #include <memory>
 #include <span>
 #include <utility>
-
-#include <quill/LogLevel.h>
-#include <quill/Quill.h>
-#include <quill/handlers/Handler.h>
 
 static thread_local char error_buf[1024];
 

--- a/category/core/log_ffi_test.cpp
+++ b/category/core/log_ffi_test.cpp
@@ -15,6 +15,8 @@
 
 #include <category/core/log_ffi.h>
 
+#include <category/core/log.hpp>
+
 #include <bit>
 #include <chrono>
 #include <cstdint>
@@ -26,7 +28,6 @@
 #include <string.h>
 
 #include <gtest/gtest.h>
-#include <quill/Quill.h>
 
 static void capture_log(monad_log const *const input_log, uintptr_t const ptr)
 {

--- a/category/execution/ethereum/block_hash_buffer.cpp
+++ b/category/execution/ethereum/block_hash_buffer.cpp
@@ -18,14 +18,13 @@
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/nibbles_view.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/category/execution/ethereum/core/fmt/address_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/address_fmt.hpp
@@ -17,9 +17,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/basic_formatter.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
+#include <category/core/log.hpp>
 
 template <>
 struct quill::copy_loggable<monad::Address> : std::true_type

--- a/category/execution/ethereum/core/fmt/block_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/block_fmt.hpp
@@ -22,9 +22,7 @@
 #include <category/core/fmt/int_fmt.hpp>
 #include <category/core/fmt/receipt_fmt.hpp>
 #include <category/core/fmt/transaction_fmt.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
+#include <category/core/log.hpp>
 
 template <>
 struct quill::copy_loggable<monad::BlockHeader> : std::true_type

--- a/category/execution/ethereum/core/fmt/bytes_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/bytes_fmt.hpp
@@ -17,9 +17,7 @@
 
 #include <category/core/basic_formatter.hpp>
 #include <category/core/bytes.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
+#include <category/core/log.hpp>
 
 template <>
 struct quill::copy_loggable<monad::bytes32_t> : std::true_type

--- a/category/execution/ethereum/core/fmt/int_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/int_fmt.hpp
@@ -17,9 +17,7 @@
 
 #include <category/core/basic_formatter.hpp>
 #include <category/core/int.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
+#include <category/core/log.hpp>
 
 template <unsigned N>
 struct quill::copy_loggable<intx::uint<N>> : std::true_type

--- a/category/execution/ethereum/core/fmt/signature_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/signature_fmt.hpp
@@ -16,10 +16,9 @@
 #pragma once
 
 #include <category/core/basic_formatter.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
 #include <category/execution/ethereum/core/signature.hpp>
-
-#include <quill/Quill.h>
 
 template <>
 struct quill::copy_loggable<monad::SignatureAndChain> : std::true_type

--- a/category/execution/ethereum/core/log_level_map.hpp
+++ b/category/execution/ethereum/core/log_level_map.hpp
@@ -16,8 +16,7 @@
 #pragma once
 
 #include <category/core/config.hpp>
-
-#include <quill/LogLevel.h>
+#include <category/core/log.hpp>
 
 #include <string>
 #include <unordered_map>

--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -17,6 +17,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/endian.hpp> // little endian
+#include <category/core/log.hpp>
 #include <category/core/nibble.h>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
@@ -26,7 +27,6 @@
 #include <category/mpt/ondisk_db_config.hpp>
 
 #include <ankerl/unordered_dense.h>
-#include <quill/Quill.h>
 
 #include <deque>
 #include <limits>

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -21,6 +21,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/keccak.h>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/fmt/address_fmt.hpp> // NOLINT
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp> // NOLINT
@@ -53,9 +54,6 @@
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-
-#include <quill/bundled/fmt/core.h>
-#include <quill/bundled/fmt/format.h>
 
 #include <algorithm>
 #include <atomic>

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/core/result.hpp>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/account.hpp>
@@ -51,9 +52,6 @@
 #include <boost/outcome/try.hpp>
 
 #include <nlohmann/json_fwd.hpp>
-
-#include <quill/Quill.h> // NOLINT
-#include <quill/detail/LogMacros.h>
 
 #include <algorithm>
 #include <chrono>

--- a/category/execution/ethereum/fmt/event_trace_fmt.hpp
+++ b/category/execution/ethereum/fmt/event_trace_fmt.hpp
@@ -17,10 +17,7 @@
 
 #include <category/execution/ethereum/trace/event_trace.hpp>
 
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
-
-namespace fmt = fmtquill::v10;
+#include <category/core/log.hpp>
 
 template <>
 struct quill::copy_loggable<monad::TraceEvent> : std::true_type

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -18,6 +18,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp> // NOLINT
@@ -36,9 +37,6 @@
 #include <category/vm/vm.hpp>
 
 #include <ankerl/unordered_dense.h>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
 
 #include <memory>
 #include <optional>

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -21,6 +21,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
@@ -44,8 +45,6 @@
 #include <evmc/evmc.hpp>
 
 #include <gtest/gtest.h>
-
-#include <quill/Quill.h>
 
 #include <cstdint>
 #include <cstdlib>

--- a/category/execution/ethereum/trace/event_trace.cpp
+++ b/category/execution/ethereum/trace/event_trace.cpp
@@ -15,11 +15,9 @@
 
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/fmt/event_trace_fmt.hpp> // NOLINT
 #include <category/execution/ethereum/trace/event_trace.hpp>
-
-#include <quill/Quill.h> // NOLINT
-#include <quill/detail/LogMacros.h>
 
 #include <chrono>
 #include <cstdint>

--- a/category/execution/ethereum/trace/event_trace.hpp
+++ b/category/execution/ethereum/trace/event_trace.hpp
@@ -16,8 +16,7 @@
 #pragma once
 
 #include <category/core/config.hpp>
-
-#include <quill/Quill.h>
+#include <category/core/log.hpp>
 
 #include <chrono>
 #include <cstdint>

--- a/category/execution/ethereum/types/fmt/incarnation_fmt.hpp
+++ b/category/execution/ethereum/types/fmt/incarnation_fmt.hpp
@@ -16,10 +16,8 @@
 #pragma once
 
 #include <category/core/basic_formatter.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
 
 #include <type_traits>
 

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -17,6 +17,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/core/monad_exception.hpp>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/contract/abi_decode.hpp>
@@ -37,8 +38,6 @@
 
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <cstring>

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -17,12 +17,11 @@
 
 #include <category/core/address.hpp>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/vm/vm.hpp>
 
 #include <category/core/hex.hpp>
-
-#include <quill/Quill.h>
 
 #include <map>
 #include <memory>

--- a/category/mpt/bench/async_read_bench.cpp
+++ b/category/mpt/bench/async_read_bench.cpp
@@ -21,6 +21,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/keccak.h>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/small_prng.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/nibbles_view.hpp>
@@ -32,8 +33,6 @@
 #include <category/mpt/util.hpp>
 
 #include <CLI/CLI.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <atomic>

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -25,13 +25,12 @@
 #include <category/core/hex.hpp>
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>
+#include <category/core/log.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/kbhit.hpp>
 #include <category/mpt/detail/unsigned_20.hpp>
 #include <category/mpt/trie.hpp>
-
-#include <quill/Quill.h>
 
 #include <CLI/CLI.hpp>
 

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -28,6 +28,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>
+#include <category/core/log.hpp>
 #include <category/core/result.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_error.hpp>
@@ -46,8 +47,6 @@
 
 #include <boost/container/deque.hpp>
 #include <boost/fiber/operations.hpp>
-
-#include <quill/Quill.h>
 
 #include <atomic>
 #include <cerrno>

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -20,13 +20,12 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
+#include <category/core/log.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <atomic>

--- a/category/mpt/nibbles_view_fmt.hpp
+++ b/category/mpt/nibbles_view_fmt.hpp
@@ -16,10 +16,8 @@
 #pragma once
 
 #include <category/core/basic_formatter.hpp>
+#include <category/core/log.hpp>
 #include <category/mpt/nibbles_view.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
 
 template <>
 struct quill::copy_loggable<monad::mpt::NibblesView> : std::false_type

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -28,6 +28,7 @@
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>
 #include <category/core/keccak.h>
+#include <category/core/log.hpp>
 #include <category/core/small_prng.hpp>
 #include <category/mpt/detail/boost_fiber_workarounds.hpp>
 #include <category/mpt/find_request_sender.hpp>
@@ -42,8 +43,6 @@
 #include <boost/fiber/operations.hpp>
 
 #include <ankerl/unordered_dense.h>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <array>

--- a/category/mpt/test/read_only_db_stress_test.cpp
+++ b/category/mpt/test/read_only_db_stress_test.cpp
@@ -22,6 +22,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/keccak.h>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/small_prng.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/nibbles_view.hpp>
@@ -33,8 +34,6 @@
 #include <category/mpt/util.hpp>
 
 #include <CLI/CLI.hpp>
-
-#include <quill/Quill.h>
 
 #include <atomic>
 #include <cmath>

--- a/category/mpt/trie.cpp
+++ b/category/mpt/trie.cpp
@@ -22,6 +22,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/deserialize_node_from_receiver_result.hpp>
 #include <category/mpt/nibbles_view.hpp>
@@ -32,8 +33,6 @@
 #include <category/mpt/update.hpp>
 #include <category/mpt/upward_tnode.hpp>
 #include <category/mpt/util.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <bit>

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -18,6 +18,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/log.hpp>
 #include <category/core/util/stopwatch.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/db_metadata_context.hpp>
@@ -28,8 +29,6 @@
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
 #include <category/mpt/util.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <atomic>

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -27,6 +27,7 @@
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/core/lru/static_lru_cache.hpp>
 #include <category/core/monad_exception.hpp>
 #include <category/core/result.hpp>
@@ -96,7 +97,6 @@
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 #include <nlohmann/json_fwd.hpp>
-#include <quill/Quill.h>
 
 using namespace monad;
 using namespace monad::vm;

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -19,6 +19,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
@@ -26,9 +27,6 @@
 #include <category/mpt/traverse.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
-
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/format.h>
 
 #include <chrono>
 #include <fcntl.h>

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -17,14 +17,13 @@
 #include <category/core/basic_formatter.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/fmt/address_fmt.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/mpt/db.hpp>
 #include <category/statesync/statesync_server_context.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/category/statesync/statesync_server_network.hpp
+++ b/category/statesync/statesync_server_network.hpp
@@ -17,9 +17,8 @@
 
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/statesync/statesync_messages.h>
-
-#include <quill/Quill.h>
 
 #include <array>
 #include <chrono>
@@ -231,10 +230,10 @@ inline void statesync_server_send_upsert(
     LOG_DEBUG(
         "sending upsert type={} {} ns={}",
         std::to_underlying(type),
-        fmtquill::format(
+        fmt::format(
             "v1=0x{:02x} v2=0x{:02x}",
-            fmtquill::join(std::as_bytes(std::span(v1, size1)), ""),
-            fmtquill::join(std::as_bytes(std::span(v2, size2)), "")),
+            fmt::join(std::as_bytes(std::span(v1, size1)), ""),
+            fmt::join(std::as_bytes(std::span(v2, size2)), "")),
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::steady_clock::now() - start));
 }

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -17,6 +17,7 @@
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
@@ -30,7 +31,6 @@
 #include <category/statesync/statesync_version.h>
 
 #include <ankerl/unordered_dense.h>
-#include <quill/Quill.h>
 
 #include <cstdint>
 #include <deque>

--- a/category/vm/compiler/ir/x86.cpp
+++ b/category/vm/compiler/ir/x86.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/instruction.hpp>
 #include <category/vm/compiler/ir/x86.hpp>
@@ -27,8 +28,6 @@
 #include <category/vm/runtime/types.hpp>
 
 #include <asmjit/core/jitruntime.h>
-
-#include <quill/Quill.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/category/vm/vm.cpp
+++ b/category/vm/vm.cpp
@@ -16,6 +16,7 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/compiler/ir/x86.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
@@ -28,8 +29,6 @@
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
-
-#include <quill/Quill.h>
 
 #include <cstdint>
 #include <memory>

--- a/cmd/monad/event.cpp
+++ b/cmd/monad/event.cpp
@@ -20,6 +20,7 @@
 #include <category/core/config.hpp>
 #include <category/core/event/event_ring.h>
 #include <category/core/event/event_ring_util.h>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
 
@@ -45,9 +46,6 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-#include <quill/LogLevel.h>
-#include <quill/Quill.h>
 
 namespace fs = std::filesystem;
 

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -23,6 +23,7 @@
 #include <category/core/config.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/likely.h>
+#include <category/core/log.hpp>
 #include <category/core/monad_exception.hpp>
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
@@ -50,10 +51,6 @@
 #include <category/vm/vm.hpp>
 
 #include <CLI/CLI.hpp>
-
-#include <quill/LogLevel.h>
-#include <quill/Quill.h>
-#include <quill/handlers/FileHandler.h>
 
 #include <boost/outcome/try.hpp>
 

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -20,6 +20,7 @@
 #include <category/core/config.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
@@ -44,7 +45,6 @@
 #include <category/vm/evm/traits.hpp>
 
 #include <boost/outcome/try.hpp>
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <chrono>

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -23,6 +23,7 @@
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -54,8 +55,6 @@
 
 #include <ankerl/unordered_dense.h>
 #include <boost/outcome/try.hpp>
-#include <quill/Quill.h>
-#include <quill/detail/LogMacros.h>
 
 #include <chrono>
 #include <deque>

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -20,6 +20,7 @@
 #include <category/core/config.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -48,7 +49,6 @@
 #include <ankerl/unordered_dense.h>
 
 #include <boost/outcome/try.hpp>
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <chrono>

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -21,6 +21,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/keccak.h>
 #include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/fmt/account_fmt.hpp> // NOLINT
@@ -43,9 +44,6 @@
 
 #include <CLI/CLI.hpp>
 #include <evmc/evmc.hpp>
-#include <quill/Quill.h>
-#include <quill/bundled/fmt/core.h>
-#include <quill/bundled/fmt/format.h>
 
 #include <algorithm>
 #include <cctype>

--- a/cmd/vm/mce/mce.cpp
+++ b/cmd/vm/mce/mce.cpp
@@ -20,6 +20,7 @@
 #include <instrumentation_device.hpp>
 #include <stopwatch.hpp>
 
+#include <category/core/log.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
@@ -35,8 +36,6 @@
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-
-#include <quill/Quill.h>
 
 #include <algorithm>
 #include <cctype>

--- a/cmd/vm/mce/src/instrumentable_compiler.hpp
+++ b/cmd/vm/mce/src/instrumentable_compiler.hpp
@@ -19,13 +19,13 @@
 #include <stopwatch.hpp>
 
 #include <category/core/assert.h>
+#include <category/core/log.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86.hpp>
 #include <category/vm/evm/traits.hpp>
 
 #include <asmjit/x86.h>
 #include <evmc/evmc.h>
-#include <quill/Quill.h>
 #include <valgrind/cachegrind.h>
 
 #include <cstdint>

--- a/cmd/vm/mce/src/instrumentable_vm.hpp
+++ b/cmd/vm/mce/src/instrumentable_vm.hpp
@@ -17,6 +17,7 @@
 #include <stopwatch.hpp>
 
 #include <category/core/assert.h>
+#include <category/core/log.hpp>
 #include <category/vm/compiler/ir/x86.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/memory_pool.hpp>
@@ -28,7 +29,6 @@
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 #include <evmone/evmone.h>
-#include <quill/Quill.h>
 #include <valgrind/cachegrind.h>
 
 #include "host.hpp"

--- a/rust/crates/monad-triedb/triedb-driver/src/triedb.cpp
+++ b/rust/crates/monad-triedb/triedb-driver/src/triedb.cpp
@@ -16,6 +16,7 @@
 #include "triedb.h"
 
 #include <category/core/byte_string.hpp>
+#include <category/core/log.hpp>
 #include <category/core/nibble.h>
 #include <category/execution/monad/staking/read_valset.hpp>
 #include <category/mpt/db.hpp>
@@ -31,8 +32,6 @@
 #include <optional>
 #include <utility>
 #include <vector>
-
-#include <quill/Quill.h>
 
 // Convert a nibble path into a packed byte array.
 void nibbles_to_bytes(

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <blockchain_test.hpp>
+#include <category/core/log.hpp>
 #include <event.hpp>
 #include <revision_map.hpp>
 
@@ -70,10 +71,6 @@
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-
-#include <quill/bundled/fmt/core.h>
-#include <quill/bundled/fmt/format.h>
-#include <quill/detail/LogMacros.h>
 
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>

--- a/test/ethereum_test/src/main.cpp
+++ b/test/ethereum_test/src/main.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/core/log_level_map.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/event_trace.hpp>
@@ -28,10 +29,6 @@
 #include <evmc/evmc.h>
 
 #include <CLI/CLI.hpp>
-
-#include <quill/LogLevel.h>
-#include <quill/Quill.h>
-#include <quill/detail/LogMacros.h>
 
 #include <gtest/gtest.h>
 

--- a/test/ethereum_test/src/transaction_test.cpp
+++ b/test/ethereum_test/src/transaction_test.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/log.hpp>
 #include <revision_map.hpp>
 #include <transaction_test.hpp>
 
@@ -34,9 +35,6 @@
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-
-#include <quill/bundled/fmt/core.h>
-#include <quill/detail/LogMacros.h>
 
 #include <gtest/gtest.h>
 

--- a/test/unit/common/include/monad/test/environment.hpp
+++ b/test/unit/common/include/monad/test/environment.hpp
@@ -19,10 +19,9 @@
 
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/execution/ethereum/trace/event_trace.hpp>
 #include <monad/test/config.hpp>
-
-#include <quill/Quill.h>
 
 MONAD_NAMESPACE_BEGIN
 


### PR DESCRIPTION
## Summary

Prep for the upcoming quill v3.9.0 → v11.1.0 upgrade. Two no-op refactors that work under the current quill, split out so the migration PR can focus on genuine API porting (Handler→Sink, Config→BackendOptions, copy_loggable→Codec/DirectFormatCodec) without mechanical churn drowning the diff.

1. **Add `category/core/log.hpp` as the project's quill chokepoint.** Every file that emits log messages, holds a `quill::Logger *`, specializes `quill::copy_loggable`, or uses the bundled `fmt::` formatter now goes through this single header instead of reaching into `<quill/...>` directly. Today it re-exports `<quill/Quill.h>`, which transitively provides every quill name our code uses (LogLevel, Logger, Handler, FileHandler, fmtquill, etc.) — verified via a standalone `clang -fsyntax-only` smoke test. In the v11 migration the shim's contents become `Backend.h` + `Frontend.h` + `LogMacros.h` plus wrapper macros for the removed `QUILL_ROOT_LOGGER_ONLY` mode and a `quill::get_root_logger()` lookup; call sites don't move.

   This sweep also drops 30 redundant granular `<quill/...>` includes (`LogLevel.h`, `handlers/Handler.h`, `handlers/FileHandler.h`, `Fmt.h`, `bundled/fmt/...`, `detail/LogMacros.h`) — they're all covered by the umbrella the shim re-exports. `category/core/log\.hpp` is added to `misc-include-cleaner.IgnoreHeaders` alongside `quill/.*` so the deliberate facade isn't flagged as "unused."

2. **Replace `namespace fmt = fmtquill::v10` with `namespace fmt = fmtquill`.** The bundled fmt's inline-namespace tag bumps from `v10` to `v12` between quill v3 and v11, so the version-pinned alias breaks under the upgrade. `fmtquill::format` is reachable via the unqualified `fmtquill` namespace because of the inline-namespace declaration, so the alias works under both fmt 10 and 12. Moved into `log.hpp` so the chokepoint owns it; removed from `basic_formatter.hpp` and `event_trace_fmt.hpp`. **Every `fmt::` call site is byte-identical to main** — no rename churn.

54 files changed (+97/-126). The bulk is `<quill/Quill.h>` → `<category/core/log.hpp>` swaps and granular-include cleanup; everything else is the new shim header itself, the `fmt::` alias relocation, and the `.clang-tidy` ignore-list entry.

## Test plan

- [x] `cmake --build build` clean (clang-19, Debug, `MONAD_COMPILER_TESTING`, `MONAD_COMPILER_BENCHMARKS`, `UTILS_CLANG_TIDY_AUTO_CONST`)
- [x] `scripts/apply-clang-format.sh` clean
- [x] `scripts/check-clang-tidy.sh -p build` clean (after adding `log.hpp` to `IgnoreHeaders`)
- [x] `scripts/check-trait-instantiations.py` clean (excluding stray `.claude/worktrees/` copies — script doesn't filter those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)