### PR TITLE
core: extract logger helpers and MONAD_LOG_LOGGABLE macro

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -96,6 +96,8 @@ add_library(
   "keccak.h"
   "keccak.hpp"
   "likely.h"
+  "log.cpp"
+  "log.hpp"
   "log_ffi.cpp"
   "log_ffi.h"
   "math.hpp"

--- a/category/core/log.cpp
+++ b/category/core/log.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/core/log.hpp>
+
+#include <filesystem>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+constexpr char default_pattern[] =
+    "%(time) [%(thread_id)] %(file_name):%(line_number) "
+    "LOG_%(log_level)\t%(message)";
+constexpr char default_time_format[] = "%Y-%m-%d %H:%M:%S.%Qns";
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
+
+void init_root_logger(quill::LogLevel const level)
+{
+    auto const stdout_handler = quill::stdout_handler();
+    stdout_handler->set_pattern(
+        default_pattern, default_time_format, quill::Timezone::GmtTime);
+    quill::Config cfg;
+    cfg.default_handlers.emplace_back(stdout_handler);
+    quill::configure(cfg);
+    quill::start(true);
+    quill::get_root_logger()->set_log_level(level);
+}
+
+void start_logger_minimal()
+{
+    quill::start(true);
+}
+
+void flush_logger()
+{
+    quill::flush();
+}
+
+quill::Logger *create_event_tracer(std::filesystem::path const &trace_log)
+{
+    quill::FileHandlerConfig handler_cfg;
+    handler_cfg.set_pattern("%(message)", "");
+    return quill::create_logger(
+        "event_trace", quill::file_handler(trace_log, handler_cfg));
+}
+
+MONAD_NAMESPACE_END

--- a/category/core/log.hpp
+++ b/category/core/log.hpp
@@ -34,6 +34,52 @@
 // `quill::get_root_logger()` shim live, so call sites don't need to change
 // again.
 
+#include <category/core/config.hpp>
+
 #include <quill/Quill.h>
 
+#include <filesystem>
+#include <type_traits>
+
 namespace fmt = fmtquill;
+
+// Registers `T` with quill's logging-by-copy machinery. The current
+// implementation specializes `quill::copy_loggable<T>`; the upcoming v11
+// upgrade replaces that with `quill::Codec<T> : DirectFormatCodec<T>`, so
+// every site that uses this macro picks up the new shape with no edit.
+//
+// Use the manual specialization form for templated types (e.g.
+// `intx::uint<N>`, `monad::Delta<T>`) and for the rare non-true_type case
+// (`NibblesView`) — the macro only handles the common
+// `template <> struct quill::copy_loggable<T> : std::true_type {};` shape.
+#define MONAD_LOG_LOGGABLE(T)                                                  \
+    template <>                                                                \
+    struct quill::copy_loggable<T> : std::true_type                            \
+    {                                                                          \
+    }
+
+MONAD_NAMESPACE_BEGIN
+
+// Configures the root quill logger with the project's default pattern
+// (timestamp, thread id, source location, level, message), starts the
+// backend with the system signal handler installed, and sets the root
+// log level. Call once near the top of main(). Not thread-safe and
+// intended to only run once per process.
+void init_root_logger(quill::LogLevel level);
+
+// Starts the quill backend with the signal handler but does NOT
+// configure a stdout handler. For tools and tests that don't need
+// their own log output but still expect the queue to be drained.
+void start_logger_minimal();
+
+// Flushes any buffered log messages to their handlers.
+void flush_logger();
+
+// Creates a quill logger named "event_trace" backed by the given file
+// with a bare "%(message)" pattern, suitable for the ENABLE_EVENT_TRACING
+// path. Returns the new logger so callers can store it in
+// ::monad::event_tracer (declared in
+// category/execution/ethereum/trace/event_trace.hpp).
+quill::Logger *create_event_tracer(std::filesystem::path const &trace_log);
+
+MONAD_NAMESPACE_END

--- a/category/core/log_ffi.cpp
+++ b/category/core/log_ffi.cpp
@@ -13,9 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/core/log_ffi.h>
-
 #include <category/core/log.hpp>
+#include <category/core/log_ffi.h>
 
 #include <cerrno>
 #include <chrono>

--- a/category/core/log_ffi_test.cpp
+++ b/category/core/log_ffi_test.cpp
@@ -13,9 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/core/log_ffi.h>
-
 #include <category/core/log.hpp>
+#include <category/core/log_ffi.h>
 
 #include <bit>
 #include <chrono>

--- a/category/execution/ethereum/core/fmt/account_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/account_fmt.hpp
@@ -21,10 +21,7 @@
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
 #include <category/execution/ethereum/types/fmt/incarnation_fmt.hpp>
 
-template <>
-struct quill::copy_loggable<monad::Account> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Account);
 
 template <>
 struct fmt::formatter<monad::Account> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/address_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/address_fmt.hpp
@@ -19,10 +19,7 @@
 #include <category/core/basic_formatter.hpp>
 #include <category/core/log.hpp>
 
-template <>
-struct quill::copy_loggable<monad::Address> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Address);
 
 template <>
 struct fmt::formatter<monad::Address> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/block_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/block_fmt.hpp
@@ -24,10 +24,7 @@
 #include <category/core/fmt/transaction_fmt.hpp>
 #include <category/core/log.hpp>
 
-template <>
-struct quill::copy_loggable<monad::BlockHeader> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::BlockHeader);
 
 template <>
 struct fmt::formatter<monad::BlockHeader> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/bytes_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/bytes_fmt.hpp
@@ -19,10 +19,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/log.hpp>
 
-template <>
-struct quill::copy_loggable<monad::bytes32_t> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::bytes32_t);
 
 template <>
 struct fmt::formatter<monad::bytes32_t> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/receipt_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/receipt_fmt.hpp
@@ -21,15 +21,9 @@
 #include <category/execution/ethereum/core/fmt/transaction_fmt.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 
-template <>
-struct quill::copy_loggable<monad::Receipt::Log> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Receipt::Log);
 
-template <>
-struct quill::copy_loggable<monad::Receipt> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Receipt);
 
 template <>
 struct fmt::formatter<monad::Receipt::Log> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/signature_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/signature_fmt.hpp
@@ -20,10 +20,7 @@
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
 #include <category/execution/ethereum/core/signature.hpp>
 
-template <>
-struct quill::copy_loggable<monad::SignatureAndChain> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::SignatureAndChain);
 
 template <>
 struct fmt::formatter<monad::SignatureAndChain> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/transaction_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/transaction_fmt.hpp
@@ -22,25 +22,13 @@
 #include <category/execution/ethereum/core/fmt/signature_fmt.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 
-template <>
-struct quill::copy_loggable<monad::TransactionType> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::TransactionType);
 
-template <>
-struct quill::copy_loggable<monad::AccessEntry> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::AccessEntry);
 
-template <>
-struct quill::copy_loggable<monad::AccessList> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::AccessList);
 
-template <>
-struct quill::copy_loggable<monad::Transaction> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Transaction);
 
 template <>
 struct fmt::formatter<monad::TransactionType> : public monad::BasicFormatter

--- a/category/execution/ethereum/core/fmt/withdrawal_fmt.hpp
+++ b/category/execution/ethereum/core/fmt/withdrawal_fmt.hpp
@@ -18,10 +18,7 @@
 #include <category/core/basic_formatter.hpp>
 #include <category/core/withdrawal.hpp>
 
-template <>
-struct quill::copy_loggable<monad::Withdrawal> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Withdrawal);
 
 template <>
 struct fmt::formatter<monad::Withdrawal> : public monad::BasicFormatter

--- a/category/execution/ethereum/fmt/event_trace_fmt.hpp
+++ b/category/execution/ethereum/fmt/event_trace_fmt.hpp
@@ -19,10 +19,7 @@
 
 #include <category/core/log.hpp>
 
-template <>
-struct quill::copy_loggable<monad::TraceEvent> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::TraceEvent);
 
 template <>
 struct fmt::formatter<monad::TraceEvent> : public fmt::ostream_formatter

--- a/category/execution/ethereum/state2/fmt/state_deltas_fmt.hpp
+++ b/category/execution/ethereum/state2/fmt/state_deltas_fmt.hpp
@@ -28,20 +28,11 @@ struct quill::copy_loggable<monad::Delta<T>>
 {
 };
 
-template <>
-struct quill::copy_loggable<monad::StateDelta> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::StateDelta);
 
-template <>
-struct quill::copy_loggable<monad::StateDeltas> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::StateDeltas);
 
-template <>
-struct quill::copy_loggable<monad::Code> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Code);
 
 template <>
 struct fmt::formatter<monad::StateDelta> : public monad::BasicFormatter

--- a/category/execution/ethereum/types/fmt/incarnation_fmt.hpp
+++ b/category/execution/ethereum/types/fmt/incarnation_fmt.hpp
@@ -21,10 +21,7 @@
 
 #include <type_traits>
 
-template <>
-struct quill::copy_loggable<monad::Incarnation> : std::true_type
-{
-};
+MONAD_LOG_LOGGABLE(monad::Incarnation);
 
 template <>
 struct fmt::formatter<monad::Incarnation> : public monad::BasicFormatter

--- a/category/mpt/bench/async_read_bench.cpp
+++ b/category/mpt/bench/async_read_bench.cpp
@@ -181,7 +181,7 @@ int main(int const argc, char *const argv[])
             std::cout << "  update_delay: " << update_delay_ms << " ms"
                       << std::endl;
 
-            quill::start(true);
+            monad::start_logger_minimal();
 
             struct sigaction sig;
             sig.sa_handler = &on_signal;

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -1495,7 +1495,7 @@ opened.
                 cli.parse(std::move(rargs));
             }
 
-            quill::start(true);
+            monad::start_logger_minimal();
 
             auto mode =
                 MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -397,7 +397,7 @@ int main(int const argc, char *argv[])
                 csv_writer << "\"Keys written\",\"Per second\"\n";
             }
 
-            quill::start(true);
+            monad::start_logger_minimal();
 
             /* This does a good job of emptying the CPU's data caches and
             data TLB. It does not empty instruction caches nor instruction TLB,

--- a/category/mpt/test/read_only_db_stress_test.cpp
+++ b/category/mpt/test/read_only_db_stress_test.cpp
@@ -156,7 +156,7 @@ int main(int const argc, char *const argv[])
 
             cli.parse(argc, argv);
 
-            quill::start(true);
+            monad::start_logger_minimal();
 
             struct sigaction sig;
             sig.sa_handler = &on_signal;

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -364,7 +364,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
             monad_statesync_server_run_once(server);
         }
     }
-    quill::flush();
+    flush_logger();
     MONAD_ASSERT(monad_statesync_client_has_reached_target(cctx));
     MONAD_ASSERT(monad_statesync_client_finalize(cctx));
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -1059,7 +1059,7 @@ TEST_F(StateSyncFixture, benchmark)
     handle_target(cctx, hdr);
     run();
     EXPECT_TRUE(monad_statesync_client_finalize(cctx));
-    quill::flush();
+    flush_logger();
 }
 
 TEST(Deletions, history_length)

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -231,17 +231,7 @@ try {
         return cli.exit(e);
     }
 
-    auto stdout_handler = quill::stdout_handler();
-    stdout_handler->set_pattern(
-        "%(time) [%(thread_id)] %(file_name):%(line_number) LOG_%(log_level)\t"
-        "%(message)",
-        "%Y-%m-%d %H:%M:%S.%Qns",
-        quill::Timezone::GmtTime);
-    quill::Config cfg;
-    cfg.default_handlers.emplace_back(stdout_handler);
-    quill::configure(cfg);
-    quill::start(true);
-    quill::get_root_logger()->set_log_level(log_level);
+    init_root_logger(log_level);
     LOG_INFO("running with commit '{}'", GIT_COMMIT_HASH);
 
     // Initialize the event system if --exec-event-ring is specified
@@ -263,10 +253,7 @@ try {
     }
 
 #ifdef ENABLE_EVENT_TRACING
-    quill::FileHandlerConfig handler_cfg;
-    handler_cfg.set_pattern("%(message)", "");
-    event_tracer = quill::create_logger(
-        "event_trace", quill::file_handler(trace_log, handler_cfg));
+    event_tracer = create_event_tracer(trace_log);
 #endif
 
     MONAD_ASSERT(init_trusted_setup());

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -863,19 +863,9 @@ int main(int const argc, char *argv[])
         return cli.exit(e);
     }
 
-    auto stdout_handler = quill::stdout_handler();
-    stdout_handler->set_pattern(
-        "%(time) [%(thread_id)] %(file_name):%(line_number) LOG_%(log_level)\t"
-        "%(message)",
-        "%Y-%m-%d %H:%M:%S.%Qns",
-        quill::Timezone::GmtTime);
-    quill::Config cfg;
-    cfg.default_handlers.emplace_back(stdout_handler);
-    quill::configure(cfg);
-    quill::start(true);
-    quill::get_root_logger()->set_log_level(log_level);
+    init_root_logger(log_level);
     LOG_INFO("running with commit '{}'", GIT_COMMIT_HASH);
-    quill::flush();
+    flush_logger();
 
     {
         fmt::println("Opening read only database {}.", dbname_paths);

--- a/cmd/vm/mce/mce.cpp
+++ b/cmd/vm/mce/mce.cpp
@@ -123,7 +123,7 @@ static arguments parse_args(int const argc, char **const argv)
         std::exit(app.exit(e));
     }
 
-    quill::start(true);
+    monad::start_logger_minimal();
 
     return args;
 }
@@ -208,7 +208,7 @@ int mce_main(arguments const &args)
     }();
     if (!ir) {
         LOG_ERROR("Parsing failed.");
-        quill::flush();
+        monad::flush_logger();
         abort();
     }
 

--- a/cmd/vm/mce/src/instrumentable_compiler.hpp
+++ b/cmd/vm/mce/src/instrumentable_compiler.hpp
@@ -97,7 +97,7 @@ public:
                 rt_, ir, config_);
         if (!nc->entrypoint()) {
             LOG_ERROR("Compilation failed.");
-            quill::flush();
+            monad::flush_logger();
             abort();
         }
 


### PR DESCRIPTION
## Summary

Stacked on top of #2235. Two more chokepoint moves to shrink the eventual quill v11 migration's per-file edit surface. Both work fully under the current quill — no behavior change.

### 1. Logger init helpers (`category/core/log.{hpp,cpp}`)

The `stdout_handler → set_pattern → Config → configure → start → set_log_level` block was duplicated verbatim in `cmd/monad/main.cpp` and `cmd/monad_cli.cpp`; `quill::start(true)` was repeated bare across 5 mpt tools/tests; `quill::flush()` was sprinkled across 3 sites; the `event_trace` logger setup was inline in `main.cpp`. Extract:

- `monad::init_root_logger(quill::LogLevel)` — full stdout-handler + pattern setup
- `monad::start_logger_minimal()` — bare `quill::start(true)`
- `monad::flush_logger()` — wraps `quill::flush()`
- `monad::create_event_tracer(path)` — file-backed `event_trace` logger

The fuzz_statesync test still calls `quill::start(false)` directly because it deliberately disables the signal handler — doesn't fit the helper shape.

**Migration impact**: rewrite one `.cpp` (`category/core/log.cpp`) for the v11 Frontend/Backend/Sink API instead of porting 7 init sites.

### 2. `MONAD_LOG_LOGGABLE(T)` macro (`category/core/log.hpp`)

17 of the 20 `quill::copy_loggable<T>` specializations are textually identical:

```cpp
template <>
struct quill::copy_loggable<T> : std::true_type
{
};
```

Hide that behind `MONAD_LOG_LOGGABLE(T);`. The 3 non-uniform cases — templated `intx::uint<N>` / `monad::Delta<T>` and the lone `std::false_type` for `NibblesView` — keep manual specializations (the macro doc calls this out).

**Migration impact**: rewriting the macro body (`copy_loggable<T> : std::true_type` → `Codec<T> : DirectFormatCodec<T>`) propagates to all 17 sites; only the 3 manual specializations still need per-site edits.

## Test plan

- [x] `cmake --build build` clean (clang-19, Debug, MONAD_COMPILER_TESTING, MONAD_COMPILER_BENCHMARKS, UTILS_CLANG_TIDY_AUTO_CONST)
- [x] `scripts/apply-clang-format.sh` clean
- [x] `scripts/check-clang-tidy.sh -p build` clean (zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)