### PR TITLE
fix(execution): preserve access lists for reverted frames

### DIFF
--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -94,8 +94,10 @@ namespace
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
             call_tracer,
+            noop_state_tracer,
             tx_context,
             block_hash_buffer,
             state,
@@ -251,8 +253,17 @@ TEST_F(BlockHistoryFixture, read_from_block_hash_history_contract)
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
-            call_tracer, tx_context, buffer, state, tx, base_fee, 0, chain_ctx};
+            call_tracer,
+            noop_state_tracer,
+            tx_context,
+            buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
 
         bytes32_t const calldata = enc(block_number);
         auto msg_memory = state.vm().message_memory_ref();
@@ -319,8 +330,17 @@ TEST_F(BlockHistoryFixture, read_write_block_hash_history_contract)
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
-            call_tracer, tx_context, buffer, state, tx, base_fee, 0, chain_ctx};
+            call_tracer,
+            noop_state_tracer,
+            tx_context,
+            buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
 
         auto msg_memory = state.vm().message_memory_ref();
         evmc_message const msg{
@@ -358,8 +378,17 @@ TEST_F(BlockHistoryFixture, read_write_block_hash_history_contract)
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
-            call_tracer, tx_context, buffer, state, tx, base_fee, 0, chain_ctx};
+            call_tracer,
+            noop_state_tracer,
+            tx_context,
+            buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
 
         bytes32_t const calldata = enc(block_number);
         auto msg_memory = state.vm().message_memory_ref();
@@ -448,8 +477,17 @@ TEST_F(BlockHistoryFixture, unauthorized_set)
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
-            call_tracer, tx_context, buffer, state, tx, base_fee, 0, chain_ctx};
+            call_tracer,
+            noop_state_tracer,
+            tx_context,
+            buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
 
         auto msg_memory = state.vm().message_memory_ref();
         evmc_message const msg{
@@ -492,8 +530,17 @@ TEST_F(BlockHistoryFixture, unauthorized_set)
 
         ChainContext<Prague> chain_ctx{};
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<Prague> host{
-            call_tracer, tx_context, buffer, state, tx, base_fee, 0, chain_ctx};
+            call_tracer,
+            noop_state_tracer,
+            tx_context,
+            buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
 
         bytes32_t const calldata = enc(block_number);
         auto msg_memory = state.vm().message_memory_ref();

--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -117,6 +117,8 @@ pre_call(EvmcHost<traits> &host, evmc_message const &msg, State &state)
 
     if (msg.kind != EVMC_DELEGATECALL) {
         if (MONAD_UNLIKELY(!sender_has_balance(state, msg))) {
+            // The pushed frame exits before bytecode, account access, or
+            // storage access, so there is no access-list metadata to capture.
             state.pop_reject();
             return evmc::Result{EVMC_INSUFFICIENT_BALANCE, msg.gas};
         }
@@ -139,7 +141,24 @@ pre_call(EvmcHost<traits> &host, evmc_message const &msg, State &state)
     return std::nullopt;
 }
 
-void post_call(State &state, evmc::Result const &result)
+template <Traits traits>
+void reject_frame(EvmcHost<traits> &host, State &state)
+{
+    // Successful frames remain in State and are captured when the state tracer
+    // is encoded. Failed frames are about to be rolled back, so the state
+    // tracer lifecycle hook runs before pop_reject().
+    trace::on_frame_reject(host.state_tracer_, state);
+
+    bool const ripemd_touched = state.is_touched(ripemd_address);
+    state.pop_reject();
+    if (MONAD_UNLIKELY(ripemd_touched)) {
+        // YP K.1. Deletion of an Account Despite Out-of-gas.
+        state.touch(ripemd_address);
+    }
+}
+
+template <Traits traits>
+void post_call(EvmcHost<traits> &host, State &state, evmc::Result const &result)
 {
     MONAD_ASSERT(result.status_code == EVMC_SUCCESS || result.gas_refund == 0);
     MONAD_ASSERT(
@@ -152,12 +171,7 @@ void post_call(State &state, evmc::Result const &result)
         state.pop_accept();
     }
     else {
-        bool const ripemd_touched = state.is_touched(ripemd_address);
-        state.pop_reject();
-        if (MONAD_UNLIKELY(ripemd_touched)) {
-            // YP K.1. Deletion of an Account Despite Out-of-gas.
-            state.touch(ripemd_address);
-        }
+        reject_frame(host, state);
     }
 }
 
@@ -279,12 +293,7 @@ evmc::Result execute_create_message(
         if (result.status_code != EVMC_REVERT) {
             result.gas_left = 0;
         }
-        bool const ripemd_touched = state.is_touched(ripemd_address);
-        state.pop_reject();
-        if (MONAD_UNLIKELY(ripemd_touched)) {
-            // YP K.1. Deletion of an Account Despite Out-of-gas.
-            state.touch(ripemd_address);
-        }
+        reject_frame(*host, state);
     }
 
     call_tracer.on_exit(result);
@@ -335,7 +344,7 @@ evmc::Result execute_call_message(
         }
     }
 
-    post_call(state, result);
+    post_call(*host, state, result);
     call_tracer.on_exit(result);
     return result;
 }

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -20,12 +20,14 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/create_contract_address.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/evm.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/tx_context.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
@@ -37,6 +39,7 @@
 #include <evmc/evmc.hpp>
 
 #include <intx/intx.hpp>
+#include <nlohmann/json.hpp>
 
 #include <gtest/gtest.h>
 
@@ -44,7 +47,9 @@
 #include <cstring>
 #include <limits>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 using namespace monad;
 using namespace monad::test;
@@ -111,8 +116,10 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -174,8 +181,10 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -205,6 +214,95 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
         // sufficient to pay for the gas + value
         EXPECT_EQ(final_nonce, initial_nonce);
     }
+}
+
+TYPED_TEST(TraitsTest, create_revert_preserves_access_list_trace)
+{
+    if constexpr (!TestFixture::Trait::eip_2929_active()) {
+        GTEST_SKIP() << "access-list tracing requires EIP-2929 access tracking";
+    }
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    db_t tdb{db};
+    vm::VM vm;
+    BlockState bs{tdb, vm};
+    State s{bs, Incarnation{0, 0}};
+
+    static constexpr auto from =
+        0x5353535353535353535353535353535353535353_address;
+    static constexpr uint64_t nonce = 7;
+
+    commit_sequential(
+        tdb,
+        StateDeltas{
+            {from,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 10'000'000'000, .nonce = nonce}}}}},
+        Code{},
+        BlockHeader{});
+
+    static constexpr auto storage_key =
+        0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+
+    // PUSH1 0x01; SLOAD; PUSH1 0x00; PUSH1 0x00; REVERT.
+    // The CREATE frame touches storage, then fails and is rolled back.
+    using monad::literals::operator""_bytes;
+    auto const initcode = 0x60015460006000fd_bytes;
+
+    nlohmann::json trace_storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    trace::StateTracer state_tracer = trace::AccessListTracer{
+        trace_storage, from, Address{}, std::nullopt, authorities};
+
+    BlockHashBufferFinalized const block_hash_buffer;
+    NoopCallTracer call_tracer;
+    Transaction tx{};
+    auto const chain_ctx =
+        ChainContext<typename TestFixture::Trait>::debug_empty();
+    uint256_t base_fee{0};
+    EvmcHost<typename TestFixture::Trait> h{
+        call_tracer,
+        state_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
+    init_rb_for_test<typename TestFixture::Trait>(s, h, from);
+
+    auto msg_memory = vm.message_memory_ref();
+    evmc_message m{
+        .kind = EVMC_CREATE,
+        .depth = 1,
+        .gas = 1'000'000,
+        .sender = from,
+        .input_data = initcode.data(),
+        .input_size = initcode.size(),
+        .memory_handle = msg_memory.get(),
+        .memory = msg_memory.get(),
+        .memory_capacity = vm.message_memory_capacity(),
+    };
+
+    auto const contract_address = create_contract_address(from, nonce);
+    auto const result =
+        execute_create_message<typename TestFixture::Trait>(&h, s, m);
+    ASSERT_EQ(result.status_code, EVMC_REVERT);
+    EXPECT_FALSE(s.account_exists(contract_address));
+
+    trace::run_tracer<typename TestFixture::Trait>(state_tracer, s);
+
+    auto const expected = nlohmann::json::array({nlohmann::json::object({
+        {"address", std::string{"0x"} + to_hex(contract_address)},
+        {"storageKeys",
+         nlohmann::json::array({std::string{"0x"} + to_hex(storage_key)})},
+    })});
+
+    EXPECT_EQ(trace_storage, expected);
 }
 
 TYPED_TEST(TraitsTest, eip684_existing_code)
@@ -255,8 +353,10 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -290,8 +390,10 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -353,8 +455,10 @@ TYPED_TEST(TraitsTest, static_precompile_execution)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -422,8 +526,10 @@ TYPED_TEST(TraitsTest, out_of_gas_static_precompile_execution)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -533,8 +639,10 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -656,8 +764,10 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -908,8 +1018,10 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -1038,8 +1150,10 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -1153,8 +1267,10 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
         auto const chain_ctx =
             ChainContext<typename TestFixture::Trait>::debug_empty();
         uint256_t base_fee{0};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         EvmcHost<typename TestFixture::Trait> h{
             call_tracer,
+            noop_state_tracer,
             EMPTY_TX_CONTEXT,
             block_hash_buffer,
             s,
@@ -1235,8 +1351,10 @@ TYPED_TEST(TraitsTest, cold_account_access)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,
@@ -1362,8 +1480,10 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         s,

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -26,6 +26,7 @@
 #include <category/execution/ethereum/reserve_balance.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/traits.hpp>
@@ -114,9 +115,11 @@ struct EvmcHost final : public EvmcHostBase
     std::optional<uint256_t> base_fee_per_gas_;
     uint64_t i_;
     ChainContext<traits> const &chain_ctx_;
+    trace::StateTracer &state_tracer_;
 
     EvmcHost(
-        CallTracerBase &call_tracer, evmc_tx_context const &tx_context,
+        CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+        evmc_tx_context const &tx_context,
         BlockHashBuffer const &block_hash_buffer, State &state,
         Transaction const &tx, std::optional<uint256_t> const base_fee_per_gas,
         uint64_t const i, ChainContext<traits> const &chain_ctx,
@@ -126,6 +129,7 @@ struct EvmcHost final : public EvmcHostBase
         , base_fee_per_gas_{base_fee_per_gas}
         , i_{i}
         , chain_ctx_{chain_ctx}
+        , state_tracer_{state_tracer}
     {
     }
 
@@ -240,9 +244,9 @@ struct EvmcHost final : public EvmcHostBase
     }
 };
 
-static_assert(sizeof(EvmcHost<EvmTraits<EVMC_LATEST_STABLE_REVISION>>) == 128);
+static_assert(sizeof(EvmcHost<EvmTraits<EVMC_LATEST_STABLE_REVISION>>) == 136);
 static_assert(alignof(EvmcHost<EvmTraits<EVMC_LATEST_STABLE_REVISION>>) == 8);
-static_assert(sizeof(EvmcHost<MonadTraits<MONAD_NEXT>>) == 128);
+static_assert(sizeof(EvmcHost<MonadTraits<MONAD_NEXT>>) == 136);
 static_assert(alignof(EvmcHost<MonadTraits<MONAD_NEXT>>) == 8);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/evmc_host_test.cpp
+++ b/category/execution/ethereum/evmc_host_test.cpp
@@ -144,8 +144,10 @@ TYPED_TEST(TraitsTest, emit_log)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,
@@ -179,8 +181,10 @@ TYPED_TEST(TraitsTest, access_precompile)
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -330,6 +330,7 @@ Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
         get_tx_context<traits>(tx_, sender_, header_, chain_.get_chain_id());
     EvmcHost<traits> host{
         call_tracer_,
+        state_tracer_,
         tx_context,
         block_hash_buffer_,
         state,
@@ -425,6 +426,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();
+        trace::reset(state_tracer_);
 
         auto result = execute_impl2(state);
 
@@ -449,6 +451,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
 
         call_tracer_.reset();
+        trace::reset(state_tracer_);
 
         auto result = execute_impl2(state);
 

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -95,9 +95,11 @@ Result<byte_string> system_call(
     state.access_account(contract_address);
 
     NoopCallTracer noop_tracer;
+    trace::StateTracer noop_state_tracer = std::monostate{};
     Transaction const empty_tx{};
     EvmcHost<traits> host{
         noop_tracer,
+        noop_state_tracer,
         tx_context,
         block_hash_buffer,
         state,

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -119,6 +119,14 @@ State::Map<bytes32_t, vm::SharedVarcode> const &State::code() const
     return code_;
 }
 
+State::Set<Address> const &State::current_frame_dirty_accounts() const
+{
+    MONAD_ASSERT(version_);
+    MONAD_ASSERT(dirty_.size() == version_);
+
+    return dirty_.back();
+}
+
 void State::push()
 {
     MONAD_ASSERT(dirty_.size() == version_);

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -39,7 +39,6 @@
 #include <cstdint>
 #include <deque>
 #include <optional>
-#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -112,6 +111,12 @@ public:
     void pop_accept();
 
     void pop_reject();
+
+    // Return addresses marked dirty (including touched/accessed accounts) in
+    // the currently pushed frame. Intended for observers that must inspect
+    // frame-local metadata immediately before pop_accept() or pop_reject();
+    // callers must not retain references beyond the frame pop.
+    Set<Address> const &current_frame_dirty_accounts() const;
 
     ////////////////////////////////////////
 

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -161,8 +161,17 @@ TYPED_TEST(TraitsTest, execute_success)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -238,8 +247,17 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -320,8 +338,17 @@ TYPED_TEST(TraitsTest, create_call_trace)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -436,8 +463,17 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -516,8 +552,17 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -605,8 +650,17 @@ TYPED_TEST(TraitsTest, selfdestruct_depth)
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
     uint256_t base_fee{0};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<typename TestFixture::Trait> host{
-        call_tracer, tx_context, buffer, s, tx, base_fee, 0, chain_ctx};
+        call_tracer,
+        noop_state_tracer,
+        tx_context,
+        buffer,
+        s,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
 
     auto const result =
         ExecuteTransactionNoValidation<typename TestFixture::Trait>(
@@ -675,12 +729,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace)
     CallTracer call_tracer{tx, call_frames};
 
     uint256_t base_fee{0};
+
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
 
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         tx_context,
         buffer,
         s,
@@ -783,12 +840,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
     CallTracer call_tracer{tx, call_frames};
 
     uint256_t base_fee{0};
+
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
 
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         tx_context,
         buffer,
         s,
@@ -886,12 +946,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
     CallTracer call_tracer{tx, call_frames};
 
     uint256_t base_fee{0};
+
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
 
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         tx_context,
         buffer,
         s,
@@ -1028,12 +1091,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
     CallTracer call_tracer{tx, call_frames};
 
     uint256_t base_fee{0};
+
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
 
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         tx_context,
         buffer,
         s,
@@ -1242,12 +1308,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
     CallTracer call_tracer{tx, call_frames};
 
     uint256_t base_fee{0};
+
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const chain_ctx =
         ChainContext<typename TestFixture::Trait>::debug_empty();
     constexpr std::span<std::optional<Address> const> authorities_empty{};
 
     EvmcHost<typename TestFixture::Trait> host{
         call_tracer,
+        noop_state_tracer,
         tx_context,
         buffer,
         s,
@@ -1405,12 +1474,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
         CallTracer call_tracer{tx, call_frames};
 
         uint256_t base_fee{0};
+
+        trace::StateTracer noop_state_tracer = std::monostate{};
         auto const chain_ctx =
             ChainContext<typename TestFixture::Trait>::debug_empty();
         constexpr std::span<std::optional<Address> const> authorities_empty{};
 
         EvmcHost<typename TestFixture::Trait> host{
             call_tracer,
+            noop_state_tracer,
             tx_context,
             buffer,
             s,

--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -31,8 +31,10 @@
 #include <ankerl/unordered_dense.h>
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <format>
 #include <optional>
+#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -200,30 +202,82 @@ namespace trace
         }
     }
 
+    void AccessListTracer::capture_accesses(
+        Address const &address, AccountState const &account_state)
+    {
+        auto &storage_keys = accesses_[address];
+        for (auto const &key : account_state.get_accessed_storage()) {
+            storage_keys.insert(key);
+        }
+    }
+
+    void AccessListTracer::capture_accesses(State const &state)
+    {
+        for (auto const &[address, current_stack] : state.current()) {
+            capture_accesses(address, current_stack.recent());
+        }
+    }
+
+    void AccessListTracer::capture_rejected_frame_accesses(State const &state)
+    {
+        auto const &current = state.current();
+        for (auto const &address : state.current_frame_dirty_accounts()) {
+            auto const it = current.find(address);
+            MONAD_ASSERT(it != current.end());
+            capture_accesses(address, it->second.recent());
+        }
+    }
+
+    void AccessListTracer::reset()
+    {
+        accesses_.clear();
+    }
+
     template <Traits traits>
     void AccessListTracer::encode(State &state)
     {
-        auto access_list = json::array();
-        for (auto const &[address, current_stack] : state.current()) {
-            auto keys = json::array();
-            auto const &current_account_state = current_stack.recent();
-            for (auto const &key :
-                 current_account_state.get_accessed_storage()) {
-                keys.push_back(bytes_to_hex(key.bytes));
-            }
+        // Merge accepted-frame accesses still visible in State with any
+        // failed-frame accesses captured before rollback.
+        capture_accesses(state);
 
+        struct AccessListEntry
+        {
+            Address address;
+            std::vector<bytes32_t> storage_keys;
+        };
+
+        std::vector<AccessListEntry> entries;
+        entries.reserve(accesses_.size());
+        for (auto const &[address, storage_keys] : accesses_) {
+            auto &entry = entries.emplace_back();
+            entry.address = address;
+            entry.storage_keys.assign(storage_keys.begin(), storage_keys.end());
+            // Match go-ethereum's access-list tracer output order: storage
+            // keys are sorted within each address, then entries are sorted by
+            // address below.
+            std::ranges::sort(entry.storage_keys);
+        }
+        std::ranges::sort(entries, {}, &AccessListEntry::address);
+
+        auto access_list = json::array();
+        for (auto const &[address, storage_keys] : entries) {
             // If an address is excluded because it's always considered warm, we
             // still want to include it in the access list if it's had storage
             // keys set by this transaction.
-            auto const exclude =
-                keys.empty() && should_exclude_address<traits>(address);
-
-            if (!exclude) {
-                access_list.push_back(json::object({
-                    {"address", bytes_to_hex(address.bytes)},
-                    {"storageKeys", std::move(keys)},
-                }));
+            if (storage_keys.empty() &&
+                should_exclude_address<traits>(address)) {
+                continue;
             }
+
+            auto keys = json::array();
+            for (auto const &key : storage_keys) {
+                keys.push_back(bytes_to_hex(key.bytes));
+            }
+
+            access_list.push_back(json::object({
+                {"address", bytes_to_hex(address.bytes)},
+                {"storageKeys", std::move(keys)},
+            }));
         }
 
         storage_ = std::move(access_list);
@@ -239,6 +293,20 @@ namespace trace
     }
 
     EXPLICIT_TRAITS_MEMBER(AccessListTracer::should_exclude_address);
+
+    void on_frame_reject(StateTracer &tracer, State &state)
+    {
+        if (auto *access_list = std::get_if<AccessListTracer>(&tracer)) {
+            access_list->capture_rejected_frame_accesses(state);
+        }
+    }
+
+    void reset(StateTracer &tracer)
+    {
+        if (auto *access_list = std::get_if<AccessListTracer>(&tracer)) {
+            access_list->reset();
+        }
+    }
 
     template <Traits traits>
     void run_tracer(StateTracer &tracer, State &state)

--- a/category/execution/ethereum/trace/state_tracer.hpp
+++ b/category/execution/ethereum/trace/state_tracer.hpp
@@ -98,9 +98,24 @@ namespace trace
         template <Traits traits>
         void encode(State &);
 
+        void reset();
+
+        // Capture rollback-sensitive accesses from the frame that is about to
+        // be rejected. Must be called while that State frame is still pushed.
+        void capture_rejected_frame_accesses(State const &);
+
     private:
+        // Merge one account's access metadata into tracer-owned storage.
+        void
+        capture_accesses(Address const &, AccountState const &account_state);
+
+        // Capture accepted-frame accesses that are still visible in State at
+        // final encoding time.
+        void capture_accesses(State const &);
+
         nlohmann::json &storage_;
         Set<Address> excluded_addresses_{};
+        Map<Address, Set<bytes32_t>> accesses_{};
 
         template <Traits traits>
         bool should_exclude_address(Address const &) const;
@@ -109,6 +124,16 @@ namespace trace
     using StateTracer = std::variant<
         std::monostate, PrestateTracer, StateDiffTracer, AccessListTracer>;
 
+    // State-tracer lifecycle hook for a failed frame. Call immediately before
+    // State::pop_reject(), while rejected-frame access metadata is still
+    // visible through State.
+    void on_frame_reject(StateTracer &, State &);
+
+    // Clear execution-attempt-local tracer state before speculative execution.
+    void reset(StateTracer &);
+
+    // Finalise and serialise tracer output after transaction execution, once
+    // accepted-frame state has been merged into the visible State view.
     template <Traits traits>
     void run_tracer(StateTracer &tracer, State &state);
 

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -622,6 +622,112 @@ TYPED_TEST(TraitsTest, access_list_empty)
     EXPECT_EQ(storage, nlohmann::json::parse("[]"));
 }
 
+TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
+{
+    StateDeltas state_deltas{};
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.push();
+    s.access_storage(addr4, key4);
+    s.pop_reject();
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    AccessListTracer tracer{storage, addr1, addr2, std::nullopt, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    // Rejected frames must not leak accessed storage back into State. RPC
+    // access-list observability needs to be handled by tracer-specific capture.
+    EXPECT_EQ(storage, nlohmann::json::parse("[]"));
+}
+
+TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
+{
+    StateDeltas state_deltas{};
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    StateTracer tracer =
+        AccessListTracer{storage, addr1, addr2, std::nullopt, authorities};
+
+    s.push();
+    s.access_storage(addr4, key4);
+    on_frame_reject(tracer, s);
+    s.pop_reject();
+
+    run_tracer<typename TestFixture::Trait>(tracer, s);
+
+    auto const json_str = R"(
+        [
+            {
+                "address" : "0xc8ba32cab1757528daf49033e3673fae77dcf05d",
+                "storageKeys": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ]
+            }
+        ]
+    )";
+
+    EXPECT_EQ(storage, nlohmann::json::parse(json_str));
+}
+
+TYPED_TEST(TraitsTest, access_list_records_rejected_frame_regular_account)
+{
+    StateDeltas state_deltas{};
+
+    InMemoryMachine machine;
+    mpt::Db db{machine};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    StateTracer tracer =
+        AccessListTracer{storage, addr1, addr2, std::nullopt, authorities};
+
+    s.push();
+    s.access_account(addr4);
+    on_frame_reject(tracer, s);
+    s.pop_reject();
+
+    run_tracer<typename TestFixture::Trait>(tracer, s);
+
+    auto const json_str = R"(
+        [
+            {
+                "address" : "0xc8ba32cab1757528daf49033e3673fae77dcf05d",
+                "storageKeys": []
+            }
+        ]
+    )";
+
+    EXPECT_EQ(storage, nlohmann::json::parse(json_str));
+}
+
 TYPED_TEST(TraitsTest, access_list_write)
 {
     StateDeltas state_deltas{};

--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -111,6 +111,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();
+        trace::reset(state_tracer_);
 
         auto result = execute(state);
 
@@ -135,6 +136,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
 
         call_tracer_.reset();
+        trace::reset(state_tracer_);
 
         auto result = execute(state);
 

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -107,8 +107,10 @@ struct ReserveBalanceEvm : public ReserveBalanceTest
         senders,
         authorities};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<MonadTraits<MONAD_NEXT>> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,
@@ -315,9 +317,11 @@ void run_dipped_into_reserve_test(
 
     {
         State state{bs, Incarnation{1, 1}};
+        trace::StateTracer noop_state_tracer = std::monostate{};
 
         EvmcHost<traits> host{
             call_tracer,
+            noop_state_tracer,
             tx_context,
             block_hash_buffer,
             state,
@@ -602,8 +606,10 @@ struct MonadPrecompileTest : public ::MonadTraitsTest<MonadRevisionT>
         senders,
         authorities};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     EvmcHost<MonadTraits<MONAD_NEXT>> h{
         call_tracer,
+        noop_state_tracer,
         EMPTY_TX_CONTEXT,
         block_hash_buffer,
         state,

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -322,6 +322,7 @@ namespace
 
         EvmcHost<traits> host{
             call_tracer,
+            state_tracer,
             tx_context,
             buffer,
             state,

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -2886,6 +2886,112 @@ TEST_F(EthCallFixture, access_list_trace)
     monad_executor_destroy(executor);
 }
 
+TEST_F(EthCallFixture, access_list_trace_reverted_call)
+{
+    for (uint64_t i = 0; i < 256; ++i) {
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+    }
+
+    static constexpr auto sender =
+        0x00000000000000000000000000000000deadbeef_address;
+
+    static constexpr auto contract_address =
+        0x00000000000000000000000000000000aaaaaaaa_address;
+    // CALLDATALOAD(0); SLOAD; REVERT(0, 0)
+    auto const contract_code = 0x6000355460006000fd_bytes;
+    auto const contract_code_hash = to_bytes(keccak256(contract_code));
+    auto const contract_icode = monad::vm::make_shared_intercode(contract_code);
+
+    auto const header = BlockHeader{.number = 256};
+
+    commit_sequential(
+        tdb,
+        StateDeltas{
+            {sender,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = std::numeric_limits<uint256_t>::max(),
+                          .code_hash = NULL_HASH}}}},
+            {contract_address,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 0, .code_hash = contract_code_hash}}}}},
+        Code{
+            {contract_code_hash, contract_icode},
+        },
+        header);
+
+    Transaction const tx{
+        .max_fee_per_gas = 1,
+        .gas_limit = 1'000'000,
+        .value = 0,
+        .to = contract_address,
+        .data =
+            0x7300000000000000000000000000000000000000000000000000000000000000_bytes,
+    };
+
+    auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
+    auto const rlp_header = to_vec(rlp::encode_block_header(header));
+    auto const rlp_sender =
+        to_vec(rlp::encode_address(std::make_optional(sender)));
+    auto const rlp_block_id = to_vec(rlp_finalized_id);
+
+    auto *executor = create_executor(dbname.string());
+    auto *state_override = monad_state_override_create();
+
+    struct callback_context ctx;
+
+    {
+        boost::fibers::future<void> f = ctx.promise.get_future();
+        monad_executor_eth_call_submit(
+            executor,
+            CHAIN_CONFIG_MONAD_DEVNET,
+            rlp_tx.data(),
+            rlp_tx.size(),
+            rlp_header.data(),
+            rlp_header.size(),
+            rlp_sender.data(),
+            rlp_sender.size(),
+            header.number,
+            rlp_block_id.data(),
+            rlp_block_id.size(),
+            state_override,
+            complete_callback,
+            (void *)&ctx,
+            ACCESS_LIST_TRACER,
+            true);
+        f.get();
+
+        ASSERT_TRUE(ctx.result->status_code == EVMC_REVERT);
+        ASSERT_NE(ctx.result->encoded_trace, nullptr);
+        ASSERT_GT(ctx.result->encoded_trace_len, 0);
+
+        std::vector<uint8_t> const encoded_trace(
+            ctx.result->encoded_trace,
+            ctx.result->encoded_trace + ctx.result->encoded_trace_len);
+
+        auto const *const expected = R"([
+            {
+                "address" : "0x00000000000000000000000000000000aaaaaaaa",
+                "storageKeys" : [
+                    "0x7300000000000000000000000000000000000000000000000000000000000000"
+                ]
+            }
+        ])";
+
+        EXPECT_EQ(
+            nlohmann::json::parse(expected),
+            nlohmann::json::from_cbor(encoded_trace));
+    }
+
+    monad_state_override_destroy(state_override);
+    monad_executor_destroy(executor);
+}
+
 TEST_F(EthCallFixture, access_list_trace_empty)
 {
     for (uint64_t i = 0; i < 256; ++i) {
@@ -2978,17 +3084,17 @@ TEST_F(EthCallFixture, access_list_trace_nested)
     static constexpr auto sender =
         0x00000000000000000000000000000000deadbeef_address;
 
-    // SSTORE(0, 2); CALL(b)
     static constexpr auto a_address =
         0x00000000000000000000000000000000aaaaaaaa_address;
+    // SSTORE(0, 2); CALL(b)
     auto const a_code =
         0x60025f555f5f5f5f5f7300000000000000000000000000000000bbbbbbbb5af1_bytes;
     auto const a_code_hash = to_bytes(keccak256(a_code));
     auto const a_icode = monad::vm::make_shared_intercode(a_code);
 
-    // SSTORE(1, 1)
     static constexpr auto b_address =
         0x00000000000000000000000000000000bbbbbbbb_address;
+    // SSTORE(1, 1)
     auto const b_code = 0x6001600155_bytes;
     auto const b_code_hash = to_bytes(keccak256(b_code));
     auto const b_icode = monad::vm::make_shared_intercode(b_code);
@@ -3076,6 +3182,123 @@ TEST_F(EthCallFixture, access_list_trace_nested)
             "address" : "0x00000000000000000000000000000000bbbbbbbb",
             "storageKeys" : [
                 "0x0000000000000000000000000000000000000000000000000000000000000001"
+            ]
+        }
+    ])";
+
+    EXPECT_EQ(
+        nlohmann::json::parse(expected),
+        nlohmann::json::from_cbor(encoded_trace));
+
+    monad_state_override_destroy(state_override);
+    monad_executor_destroy(executor);
+}
+
+TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
+{
+    static constexpr auto sender =
+        0x00000000000000000000000000000000deadbeef_address;
+
+    static constexpr auto a_address =
+        0x00000000000000000000000000000000aaaaaaaa_address;
+    // SSTORE(0, 2); CALL(b)
+    auto const a_code =
+        0x60025f555f5f5f5f5f7300000000000000000000000000000000bbbbbbbb5af1_bytes;
+    auto const a_code_hash = to_bytes(keccak256(a_code));
+    auto const a_icode = monad::vm::make_shared_intercode(a_code);
+
+    static constexpr auto b_address =
+        0x00000000000000000000000000000000bbbbbbbb_address;
+    // SLOAD(2); REVERT(0, 0)
+    auto const b_code = 0x60025460006000fd_bytes;
+    auto const b_code_hash = to_bytes(keccak256(b_code));
+    auto const b_icode = monad::vm::make_shared_intercode(b_code);
+
+    commit_sequential(
+        tdb,
+        StateDeltas{
+            {sender,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = std::numeric_limits<uint256_t>::max(),
+                          .code_hash = NULL_HASH}}}},
+            {a_address,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 0, .code_hash = a_code_hash}}}},
+            {b_address,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{.balance = 0, .code_hash = b_code_hash}}}}},
+        Code{
+            {a_code_hash, a_icode},
+            {b_code_hash, b_icode},
+        },
+        BlockHeader{.number = 0});
+    BlockHeader const header{.number = 0};
+
+    Transaction const tx{
+        .max_fee_per_gas = 1,
+        .gas_limit = 1'000'000,
+        .value = 0,
+        .to = a_address,
+        .data = byte_string{},
+    };
+
+    auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
+    auto const rlp_header = to_vec(rlp::encode_block_header(header));
+    auto const rlp_sender =
+        to_vec(rlp::encode_address(std::make_optional(sender)));
+    auto const rlp_block_id = to_vec(rlp_finalized_id);
+
+    auto *executor = create_executor(dbname.string());
+    auto *state_override = monad_state_override_create();
+
+    struct callback_context ctx;
+    boost::fibers::future<void> f = ctx.promise.get_future();
+
+    monad_executor_eth_call_submit(
+        executor,
+        CHAIN_CONFIG_MONAD_DEVNET,
+        rlp_tx.data(),
+        rlp_tx.size(),
+        rlp_header.data(),
+        rlp_header.size(),
+        rlp_sender.data(),
+        rlp_sender.size(),
+        header.number,
+        rlp_block_id.data(),
+        rlp_block_id.size(),
+        state_override,
+        complete_callback,
+        (void *)&ctx,
+        ACCESS_LIST_TRACER,
+        true);
+    f.get();
+
+    EXPECT_TRUE(ctx.result->status_code == EVMC_SUCCESS);
+    ASSERT_NE(ctx.result->encoded_trace, nullptr);
+    ASSERT_GT(ctx.result->encoded_trace_len, 0);
+
+    std::vector<uint8_t> const encoded_trace(
+        ctx.result->encoded_trace,
+        ctx.result->encoded_trace + ctx.result->encoded_trace_len);
+
+    auto const *const expected = R"([
+        {
+            "address" : "0x00000000000000000000000000000000aaaaaaaa",
+            "storageKeys" : [
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            ]
+        },
+        {
+            "address" : "0x00000000000000000000000000000000bbbbbbbb",
+            "storageKeys" : [
+                "0x0000000000000000000000000000000000000000000000000000000000000002"
             ]
         }
     ])";

--- a/test/vm/utils/test_host.hpp
+++ b/test/vm/utils/test_host.hpp
@@ -42,6 +42,7 @@ namespace monad::test
         ankerl::unordered_dense::segmented_set<Address>
             chain_context_senders_and_authorities_;
         ChainContext<traits> chain_context_;
+        trace::StateTracer noop_state_tracer_;
         EvmcHost<traits> host_;
 
         ChainContext<traits> make_chain_context()
@@ -82,8 +83,10 @@ namespace monad::test
             , chain_context_senders_and_authorities_{combine_senders_and_authorities(
                   chain_context_senders_, chain_context_authorities_)}
             , chain_context_{make_chain_context()}
+            , noop_state_tracer_{std::monostate{}}
             , host_{
                   noop_call_tracer_,
+                  noop_state_tracer_,
                   tx_context_,
                   block_hash_buffer,
                   state,


### PR DESCRIPTION
# Preserve access-list traces for reverted frames

Context: this was discovered while working on https://github.com/category-labs/monad-bft/issues/2684. After fixing the RPC layer so `eth_createAccessList` could return execution failures inside the result object, the test still failed because the returned access list was empty. Further debugging showed that the execution tracer was losing reverted-frame storage accesses before RPC could encode them.

## Problem

`eth_createAccessList` should still return the access list collected during simulation when the simulated call reverts. The revert should be reported inside the JSON-RPC result, not by discarding the access-list result as a top-level RPC error.

This was not happening on Monad testnet. A contract that reads storage and then
reverts returned a top-level JSON-RPC error:

```bash
curl --request POST \
  --url https://testnet-rpc.monad.xyz/ \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/12.5.0' \
  --data '{
        "params": [{
                "to": "0x25Db08EdD8ffC4FF026fECa9F38c0f635d563132",
                "data": "0x7300000000000000000000000000000000000000000000000000000000000000"
        }
        ],
        "method": "eth_createAccessList",
        "jsonrpc": "2.0",
        "id": 73
}'
```

Observed Monad response:

```json
{"jsonrpc":"2.0","error":{"code":-32603,"message":"execution reverted"},"id":73}
```

The equivalent behavior on Sepolia returns a normal JSON-RPC result containing both the access list and the execution error:

```bash
curl --request POST \
  --url https://sepolia.drpc.org/ \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/12.5.0' \
  --data '{
        "params": [{
                "to": "0xCBBD82B84BE1C5975bd6928858143eE2fDd46122",
                "data": "0x7300000000000000000000000000000000000000000000000000000000000000"
        }
        ],
        "method": "eth_createAccessList",
        "jsonrpc": "2.0",
        "id": 73
}'
```

Observed Sepolia response:

```json
{
  "id": 73,
  "jsonrpc": "2.0",
  "result": {
    "accessList": [
      {
        "address": "0xcbbd82b84be1c5975bd6928858143ee2fdd46122",
        "storageKeys": [
          "0x7300000000000000000000000000000000000000000000000000000000000000"
        ]
      }
    ],
    "error": "execution reverted",
    "gasUsed": "0x63d0"
  }
}
```

The important behavior is that the access list survives the revert. The caller can still see which account and storage key were touched before execution failed.

## Reproduction Contract

The contract used to isolate the problem is intentionally small: it reads a storage slot selected by calldata, then immediately reverts.

Runtime bytecode:

```text
6000355460006000fd
```

Disassembly:

```text
60 00    PUSH1 0x00      ; calldata offset
35       CALLDATALOAD    ; read the 32-byte storage slot from calldata
54       SLOAD           ; access that slot so it appears in the access list
60 00    PUSH1 0x00      ; revert data offset
60 00    PUSH1 0x00      ; revert data length
fd       REVERT          ; fail after the storage read
```

Initcode from the original walkthrough:

```text
6009600c60003960096000f36000355460006000fd
```

Disassembly:

```text
60 09    PUSH1 0x09      ; runtime length
60 0c    PUSH1 0x0c      ; runtime offset in this initcode
60 00    PUSH1 0x00      ; destination memory offset
39       CODECOPY        ; copy runtime into memory
60 09    PUSH1 0x09      ; runtime length
60 00    PUSH1 0x00      ; source memory offset
f3       RETURN          ; return runtime as deployed code
```

The high-signal property is that the contract can only produce the expected access list if the execution layer preserves the `SLOAD` access across the subsequent `REVERT`.

## Root Cause

The state rollback behavior was correct. Reverted frames should be rejected, and their frame-local state should not leak into the accepted parent state.

The bug was in the access-list tracing path. `eth_call_impl` ran `trace::run_tracer` after execution returned. For a reverted call, the execution path had already rejected the frame:

```text
execute_call_message
  -> VM executes contract
     -> SLOAD records accessed storage in the current State frame
     -> REVERT
  -> post_call(state, result)
     -> state.pop_reject()
  -> return to eth_call_impl
  -> trace::run_tracer(state_tracer, state)
     -> AccessListTracer reads state.current()
     -> reverted-frame storage access is already gone
```

So `AccessListTracer` was reading rollback-sensitive access metadata too late. Changing `State::pop_reject()` would have been the wrong fix because consensus rollback semantics should remain independent from RPC observability.

## Solution

The fix keeps rollback semantics unchanged and treats frame rejection as a state-tracer lifecycle event. State tracers that care about rejected-frame metadata can observe the frame immediately before it is popped, while tracers that do not care about this event remain no-ops.

Execution code receives the same tracing dependencies used elsewhere in the client: a `CallTracerBase&` for call tracing and a `trace::StateTracer&` for state tracing. `EvmcHost` stores both references, and the shared `reject_frame` helper calls `trace::on_frame_reject` directly while the failed frame is still visible in `State`.

`trace::on_frame_reject(StateTracer&, State&)` mirrors `trace::run_tracer`: it dispatches on the state-tracer variant. `std::monostate`, `PrestateTracer`, and `StateDiffTracer` do nothing for this event. `AccessListTracer` captures access metadata from the frame that is about to be rejected.

`AccessListTracer` owns an accumulated map of observed accesses. The frame-reject hook copies access-list metadata from the currently pushed frame into tracer-owned storage while that frame is still visible in `State`. The capture is scoped to the current frame's dirty accounts, so it preserves rollback-sensitive accesses without re-recording unrelated accepted state.

Failed `CALL` and `CREATE` paths go through a shared `reject_frame` helper. That helper notifies the state tracer, then calls `State::pop_reject()`, preserving the existing rollback behavior including the RIPEMD touched-account rule.

The final encode step still observes the accepted state through `trace::run_tracer` before producing the JSON result. That gives the tracer both categories of data:

- accepted-frame accesses still visible in `State`
- rejected-frame accesses that were captured before rollback

`trace::reset` clears access-list accumulation before each transaction execution attempt, so speculative retries do not leak observation state from an abandoned attempt.

## Tests

This PR adds focused coverage for the behavior that was missing:

- `EthCallFixture.access_list_trace_reverted_call`
  - runs the tiny `CALLDATALOAD; SLOAD; REVERT` contract through
    `monad_executor_eth_call_submit`
  - asserts the execution status is `EVMC_REVERT`
  - asserts an encoded access-list trace exists
  - asserts the trace contains the touched storage key
- `EthCallFixture.access_list_trace_nested_reverted_call`
  - verifies access-list tracing also preserves storage touched inside a nested
    reverted call
- `TraitsTest.create_revert_preserves_access_list_trace`
  - verifies rejected `CREATE` frames snapshot access-list metadata before the
    created account is rolled back
- `access_list_state_view_excludes_rejected_frame`
  - documents that rejected frame accesses must not leak back through `State`
  - reinforces that this is tracer-specific capture, not a rollback change
- `access_list_records_rejected_frame_storage`
  - verifies the state-tracer lifecycle hook preserves rejected-frame storage
    accesses
- `access_list_records_rejected_frame_regular_account`
  - verifies the same hook preserves rejected-frame account accesses without
    storage keys

Verified locally:

```text
cmake --build cmake-build-debug --target state_tracer_test monad_executor_test
./cmake-build-debug/category/execution/state_tracer_test
./cmake-build-debug/category/rpc/monad_executor_test --gtest_filter='EthCallFixture.access_list_trace:EthCallFixture.access_list_trace_reverted_call:EthCallFixture.access_list_trace_empty:EthCallFixture.access_list_trace_nested:EthCallFixture.access_list_trace_nested_reverted_call'
```

**Note**: this is my first PR in the repo, any tips on how to better test these changes are very welcome!

