### PR TITLE
Make mpt::Db own std::unique_ptr<StateMachine>

### DIFF
--- a/category/execution/ethereum/block_hash_buffer_test.cpp
+++ b/category/execution/ethereum/block_hash_buffer_test.cpp
@@ -210,9 +210,9 @@ TEST(BlockHashBufferTest, init_from_db)
         return dbname;
     }();
 
-    OnDiskMachine machine;
     mpt::Db db{
-        machine, mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
+        std::make_unique<OnDiskMachine>(),
+        mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
     TrieDb tdb{db};
 
     BlockHashBufferFinalized expected;

--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -50,7 +50,6 @@ namespace
 
     struct BlockHistoryFixture : public ::testing::Test
     {
-        InMemoryMachine machine;
         mpt::Db db;
         TrieDb tdb;
         vm::VM vm;
@@ -61,7 +60,7 @@ namespace
             0x00000000000000000000000000000000000123_address;
 
         BlockHistoryFixture()
-            : db{machine}
+            : db{std::make_unique<InMemoryMachine>()}
             , tdb{db}
             , block_state{tdb, vm}
             , state{block_state, Incarnation{0, 0}}

--- a/category/execution/ethereum/block_reward_test.cpp
+++ b/category/execution/ethereum/block_reward_test.cpp
@@ -44,8 +44,7 @@ constexpr auto c{0xa5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5_address};
 
 TYPED_TEST(TraitsTest, apply_block_reward)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     commit_sequential(

--- a/category/execution/ethereum/core/contract/test_storage.cpp
+++ b/category/execution/ethereum/core/contract/test_storage.cpp
@@ -44,9 +44,8 @@ struct Storage : public ::testing::Test
 {
     static constexpr auto ADDRESS{
         0x36928500bc1dcd7af6a2b4008875cc336b927d57_address};
-    OnDiskMachine machine;
     vm::VM vm;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<OnDiskMachine>()};
     TrieDb tdb{db};
     BlockState bs{tdb, vm};
     State state{bs, Incarnation{0, 0}};

--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -34,7 +34,6 @@
 struct monad_db_snapshot_loader
 {
     uint64_t block;
-    monad::OnDiskMachine machine;
     monad::mpt::Db db;
     monad::mpt::Node::SharedPtr root;
     std::array<monad::byte_string, 256> eth_headers;
@@ -52,7 +51,7 @@ struct monad_db_snapshot_loader
         uint64_t const block, char const *const *const dbname_paths,
         size_t const len, unsigned const sq_thread_cpu)
         : block{block}
-        , db{machine,
+        , db{std::make_unique<monad::OnDiskMachine>(),
              monad::mpt::OnDiskDbConfig{
                  .append = true,
                  .compaction = false,

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -71,8 +71,7 @@ namespace
     {
         static constexpr bool on_disk = false;
 
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         vm::VM vm;
     };
 
@@ -80,8 +79,7 @@ namespace
     {
         static constexpr bool on_disk = true;
 
-        OnDiskMachine machine;
-        mpt::Db db{machine, mpt::OnDiskDbConfig{}};
+        mpt::Db db{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
         vm::VM vm;
     };
 
@@ -191,8 +189,9 @@ TEST(DBTest, read_only)
         (::testing::UnitTest::GetInstance()->current_test_info()->name() +
          std::to_string(rand()));
     {
-        OnDiskMachine machine;
-        mpt::Db db{machine, mpt::OnDiskDbConfig{.dbname_paths = {name}}};
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            mpt::OnDiskDbConfig{.dbname_paths = {name}}};
         TrieDb rw(db);
 
         Account const acct1{.nonce = 1};
@@ -732,9 +731,10 @@ TYPED_TEST(DBTest, to_json)
     auto db = [&] {
         if (this->on_disk) {
             return mpt::Db{
-                this->machine, mpt::OnDiskDbConfig{.dbname_paths = {dbname}}};
+                std::make_unique<OnDiskMachine>(),
+                mpt::OnDiskDbConfig{.dbname_paths = {dbname}}};
         }
-        return mpt::Db{this->machine};
+        return mpt::Db{std::make_unique<InMemoryMachine>()};
     }();
     TrieDb tdb{db};
     load_db(tdb, 0);

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -86,8 +86,7 @@ namespace
 
 TYPED_TEST(TraitsTest, create_with_insufficient)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -146,8 +145,7 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
 // do not bump nonce prior to MONAD_FIVE but do bump it after
 TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -230,8 +228,7 @@ TYPED_TEST(TraitsTest, create_revert_preserves_access_list_trace)
         GTEST_SKIP() << "access-list tracing requires EIP-2929 access tracking";
     }
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -315,8 +312,7 @@ TYPED_TEST(TraitsTest, create_revert_preserves_access_list_trace)
 
 TYPED_TEST(TraitsTest, eip684_existing_code)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -379,8 +375,7 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
 
 TYPED_TEST(TraitsTest, create_nonce_out_of_range)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -444,8 +439,7 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
 
 TYPED_TEST(TraitsTest, static_precompile_execution)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -514,8 +508,7 @@ TYPED_TEST(TraitsTest, static_precompile_execution)
 
 TYPED_TEST(TraitsTest, out_of_gas_static_precompile_execution)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -591,8 +584,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
     static constexpr auto from{
         0x5353535353535353535353535353535353535353_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
 
@@ -712,8 +704,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
     static constexpr auto from{
         0x5353535353535353535353535353535353535353_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
 
@@ -830,8 +821,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_not_enough_of_gas)
 
     static constexpr auto a{0xbebebebebebebebebebebebebebebebebebebebe_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     commit_sequential(
@@ -876,8 +866,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_max_code_size)
 
     static constexpr auto a{0xbebebebebebebebebebebebebebebebebebebebe_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     commit_sequential(
@@ -910,8 +899,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_validation)
 {
     static constexpr auto a{0xbebebebebebebebebebebebebebebebebebebebe_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     commit_sequential(
@@ -944,8 +932,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_validation)
 
 TYPED_TEST(TraitsTest, create_inside_delegated_call)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -1049,8 +1036,7 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
 
 TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -1180,8 +1166,7 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
 
 TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -1290,8 +1275,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
 {
     static_assert(TestFixture::Trait::evm_rev() > EVMC_HOMESTEAD);
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -1393,8 +1377,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
 
 TYPED_TEST(TraitsTest, defensive_delegation_check)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};

--- a/category/execution/ethereum/evmc_host_test.cpp
+++ b/category/execution/ethereum/evmc_host_test.cpp
@@ -133,8 +133,7 @@ TYPED_TEST(TraitsTest, emit_log)
     static constexpr evmc::bytes32 topics[] = {topic0, topic1};
     static byte_string const data = {0x00, 0x01, 0x02, 0x03, 0x04};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -170,8 +169,7 @@ TYPED_TEST(TraitsTest, emit_log)
 
 TYPED_TEST(TraitsTest, access_precompile)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -170,8 +170,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
     static constexpr auto ca{
         0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
 
     vm::VM vm;
@@ -340,8 +339,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
     static constexpr auto to{
         0xbbbf5374fce5edbc8e2a8697c15331677e6ebf0b_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
 
     vm::VM vm;
@@ -481,8 +479,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
     static constexpr auto ca{
         0x095e7baea6a6c7c4c2dfeb977efac326af552d87_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
 
     vm::VM vm;

--- a/category/execution/ethereum/execute_transaction_test.cpp
+++ b/category/execution/ethereum/execute_transaction_test.cpp
@@ -67,8 +67,7 @@ TYPED_TEST(TraitsTest, irrevocable_gas_and_refund_new_contract)
     static constexpr auto gas_limit = actual_gas_cost + 2'000;
     static constexpr auto max_fee_per_gas = 10;
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -172,8 +171,7 @@ TYPED_TEST(TraitsTest, TopLevelCreate)
     static constexpr auto bene{
         0x5353535353535353535353535353535353535353_address};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -321,8 +319,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
         }
     }();
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -480,8 +477,7 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
     static constexpr auto slot = bytes32_t{};
     auto const initial_value = store_be_as<bytes32_t>(uint256_t{1});
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -630,9 +626,7 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
 TYPED_TEST(TraitsTest, static_validate_transaction_failure)
 {
     static_assert(TestFixture::Trait::evm_rev() > EVMC_TANGERINE_WHISTLE);
-
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     db_t tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};

--- a/category/execution/ethereum/precompiles_test.cpp
+++ b/category/execution/ethereum/precompiles_test.cpp
@@ -296,8 +296,7 @@ namespace
         char const *suite_name, std::span<test_case const> test_cases,
         monad::Address const &code_address)
     {
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         TrieDb tdb{db};
         vm::VM vm;
         BlockState bs{tdb, vm};

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -93,17 +93,15 @@ namespace
 
     struct InMemoryStateTestBase
     {
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         TrieDb tdb{db};
         vm::VM vm;
     };
 
     struct OnDiskStateTest : public ::testing::Test
     {
-        OnDiskMachine machine;
-        mpt::Db db{machine, mpt::OnDiskDbConfig{}};
-        TrieDb tdb;
+        mpt::Db db{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
+        TrieDb tdb{db};
         vm::VM vm;
 
         explicit OnDiskStateTest(bool const cache = false)
@@ -135,9 +133,12 @@ namespace
 
     struct TwoOnDisk : public ::testing::Test
     {
-        OnDiskMachine machine;
-        mpt::Db db1{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
-        mpt::Db db2{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
+        mpt::Db db1{
+            std::make_unique<OnDiskMachine>(),
+            mpt::OnDiskDbConfig{.file_size_db = 8}};
+        mpt::Db db2{
+            std::make_unique<OnDiskMachine>(),
+            mpt::OnDiskDbConfig{.file_size_db = 8}};
         // baseline noncaching db for tdb1
         TrieDb tdb1{db1};
         TrieDb tdb2{db2, /*enable_multiblock_cache=*/true};

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -127,8 +127,7 @@ TEST(CallTrace, enter_and_exit)
 
 TYPED_TEST(TraitsTest, execute_success)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -212,8 +211,7 @@ TYPED_TEST(TraitsTest, execute_success)
 
 TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -297,8 +295,7 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
 
 TYPED_TEST(TraitsTest, create_call_trace)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -398,8 +395,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
 
 TYPED_TEST(TraitsTest, selfdestruct_logs)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -508,8 +504,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
 
 TYPED_TEST(TraitsTest, selfdestruct_logs_value)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -608,8 +603,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
 //
 TYPED_TEST(TraitsTest, selfdestruct_depth)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -698,8 +692,7 @@ TYPED_TEST(TraitsTest, selfdestruct_depth)
 
 TYPED_TEST(TraitsTest, simulate_v1_trace)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -797,8 +790,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace)
 
 TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -902,8 +894,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
 
 TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -991,8 +982,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
 
 TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1210,8 +1200,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
 // contract.
 TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1374,8 +1363,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
     // be a self-transfer)
     // * DELEGATECALL: no event emission
     // * STATICCALL: no event emission
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -95,8 +95,9 @@ TEST(DbBinarySnapshot, Basic)
     Code code_delta;
     BlockHeader last_header;
     {
-        OnDiskMachine machine;
-        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db.path}}};
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.dbname_paths = {src_db.path}}};
         Node::SharedPtr root{};
         for (uint64_t i = 0; i < 100; ++i) {
             root = load_header(std::move(root), db, BlockHeader{.number = i});
@@ -159,9 +160,9 @@ TEST(DbBinarySnapshot, Basic)
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
 
         {
-            OnDiskMachine machine;
             mpt::Db dest_init{
-                machine, OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
         }
         char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(
@@ -208,8 +209,9 @@ TEST(DbBinarySnapshot, MultipleShards)
     Code code_delta;
     BlockHeader last_header;
     {
-        OnDiskMachine machine;
-        mpt::Db db{machine, OnDiskDbConfig{.dbname_paths = {src_db.path}}};
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.dbname_paths = {src_db.path}}};
         Node::SharedPtr root{};
         for (uint64_t i = 0; i < 100; ++i) {
             root = load_header(std::move(root), db, BlockHeader{.number = i});
@@ -310,9 +312,9 @@ TEST(DbBinarySnapshot, MultipleShards)
 
         EXPECT_EQ(total_shards_copied, 256u);
         {
-            OnDiskMachine machine;
             mpt::Db dest_init{
-                machine, OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
         }
         char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -62,8 +62,7 @@ TYPED_TEST(MonadTraitsTest, compute_gas_refund)
 TYPED_TEST(TraitsTest, Genesis)
 {
     {
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         TrieDb tdb{db};
         MonadTestnet const chain;
         load_genesis_state(chain.get_genesis_state(), tdb);
@@ -87,8 +86,7 @@ TYPED_TEST(TraitsTest, Genesis)
     }
 
     {
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         TrieDb tdb{db};
         MonadDevnet const chain;
         load_genesis_state(chain.get_genesis_state(), tdb);
@@ -110,8 +108,7 @@ TYPED_TEST(TraitsTest, Genesis)
         }
     }
     {
-        InMemoryMachine machine;
-        mpt::Db db{machine};
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
         TrieDb tdb{db};
         MonadMainnet const chain;
         load_genesis_state(chain.get_genesis_state(), tdb);
@@ -158,8 +155,7 @@ void run_revert_transaction_test(
 {
     static constexpr uint256_t BASE_FEE_PER_GAS = 10;
     static constexpr Address SENDER{1};
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -362,8 +358,7 @@ TYPED_TEST(
         return uint256_t{mon} * 1000000000000000000ULL;
     };
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -438,8 +433,7 @@ TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
         return uint256_t{mon} * staking::MON;
     };
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -564,8 +558,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
         return uint256_t{mon} * 1000000000000000000ULL;
     };
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -643,8 +636,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
         return uint256_t{mon} * 1000000000000000000ULL;
     };
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -714,8 +706,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
         return uint256_t{mon} * 1000000000000000000ULL;
     };
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -789,8 +780,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
 
 TYPED_TEST(MonadTraitsTest, system_transaction_sender_is_authority)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};

--- a/category/execution/ethereum/test/test_traits_state.hpp
+++ b/category/execution/ethereum/test/test_traits_state.hpp
@@ -28,8 +28,7 @@ MONAD_NAMESPACE_BEGIN
 
 struct InMemoryStateTestBase
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState block_state{tdb, vm};

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -97,8 +97,7 @@ TEST(PrestateTracer, pre_state_to_json)
     prestate.emplace(ADDR_A, as);
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -137,8 +136,7 @@ TEST(PrestateTracer, zero_nonce)
     prestate.emplace(ADDR_A, as);
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -164,8 +162,7 @@ TEST(PrestateTracer, state_deltas_to_json)
 {
     Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -211,8 +208,7 @@ TEST(PrestateTracer, statediff_account_creation)
 {
     Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -251,8 +247,7 @@ TEST(PrestateTracer, statediff_balance_nonce_update)
     b.nonce += 1;
     b.balance -= 100;
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -296,8 +291,7 @@ TEST(PrestateTracer, statediff_delete_storage)
     b.nonce += 1;
     b.balance -= 100;
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -352,8 +346,7 @@ TEST(PrestateTracer, statediff_multiple_fields_update)
     Account a{.balance = 500, .code_hash = A_CODE_HASH, .nonce = 1};
     Account b{.balance = 42, .code_hash = B_CODE_HASH, .nonce = 2};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -411,8 +404,7 @@ TEST(PrestateTracer, statediff_account_deletion)
 {
     Account a{.balance = 32, .code_hash = NULL_HASH, .nonce = 1};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -478,8 +470,7 @@ TEST(PrestateTracer, geth_example_prestate)
     prestate.emplace(addr4, as);
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -531,8 +522,7 @@ TEST(PrestateTracer, geth_example_statediff)
     };
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -565,8 +555,7 @@ TEST(PrestateTracer, prestate_empty)
     trace::Map<Address, OriginalAccountState> prestate{};
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -586,8 +575,7 @@ TEST(PrestateTracer, statediff_empty)
     StateDeltas state_deltas{};
 
     // The State setup is only used to get code
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -612,8 +600,7 @@ TYPED_TEST(TraitsTest, access_list_empty)
 {
     StateDeltas state_deltas{};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -632,8 +619,7 @@ TYPED_TEST(TraitsTest, access_list_empty)
 
 TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -658,8 +644,7 @@ TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
 
 TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -696,8 +681,7 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
 
 TYPED_TEST(TraitsTest, access_list_records_rejected_frame_regular_account)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -734,8 +718,7 @@ TYPED_TEST(TraitsTest, access_list_write)
 {
     StateDeltas state_deltas{};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -781,8 +764,7 @@ TYPED_TEST(TraitsTest, access_list_write)
 
 TYPED_TEST(TraitsTest, access_list_regular_account)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -851,8 +833,7 @@ TYPED_TEST(TraitsTest, access_list_regular_account)
 
 TYPED_TEST(TraitsTest, access_list_sender)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -910,8 +891,7 @@ TYPED_TEST(TraitsTest, access_list_sender)
 
 TYPED_TEST(TraitsTest, access_list_beneficiary)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -969,8 +949,7 @@ TYPED_TEST(TraitsTest, access_list_beneficiary)
 
 TYPED_TEST(TraitsTest, access_list_recipient)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1028,8 +1007,7 @@ TYPED_TEST(TraitsTest, access_list_recipient)
 
 TYPED_TEST(TraitsTest, access_list_authorities)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1100,8 +1078,7 @@ TYPED_TEST(TraitsTest, access_list_authorities)
 
 TYPED_TEST(TraitsTest, access_list_precompiles)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1153,8 +1130,7 @@ TYPED_TEST(TraitsTest, access_list_precompiles)
 TEST(PrestateTracer, prestate_access_storage)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1225,8 +1201,7 @@ TEST(PrestateTracer, prestate_access_storage)
 TEST(PrestateTracer, prestate_retain_beneficiary_set_storage)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1294,8 +1269,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_set_storage)
 TEST(PrestateTracer, prestate_retain_beneficiary_modified_storage)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1372,8 +1346,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_storage)
 TEST(PrestateTracer, prestate_retain_beneficiary_modified_balance)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1443,8 +1416,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_balance)
 TEST(PrestateTracer, prestate_retain_beneficiary_modified_nonce)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1510,8 +1482,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_nonce)
 TEST(PrestateTracer, prestate_retain_beneficiary_modified_code_hash)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1580,8 +1551,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_code_hash)
 TEST(PrestateTracer, prestate_retain_beneficiary_access_storage)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1652,8 +1622,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_access_storage)
 TEST(PrestateTracer, prestate_omit_beneficiary)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -1706,8 +1675,7 @@ TEST(PrestateTracer, prestate_omit_beneficiary)
 TEST(PrestateTracer, prestate_empty_block_no_reward)
 {
     // Setup matter
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 

--- a/category/execution/monad/execute_system_transaction_test.cpp
+++ b/category/execution/monad/execute_system_transaction_test.cpp
@@ -48,8 +48,7 @@ using namespace monad::test;
 
 TEST(SystemTransaction, prestate_trace_staking_epoch_change)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -162,8 +161,7 @@ TEST(SystemTransaction, prestate_trace_staking_epoch_change)
 
 TEST(SystemTransaction, statediff_trace_staking_epoch_change)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -288,8 +286,7 @@ TEST(SystemTransaction, statediff_trace_staking_epoch_change)
 
 TEST(SystemTransaction, static_validate_system_transaction_failure)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 
@@ -327,8 +324,7 @@ TEST(SystemTransaction, static_validate_system_transaction_failure)
 
 TEST(SystemTransaction, static_validate_transaction_failure)
 {
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
 

--- a/category/execution/monad/monad_block_hash_history_test.cpp
+++ b/category/execution/monad/monad_block_hash_history_test.cpp
@@ -31,8 +31,7 @@ class MonadBlockHashHistoryFixture : public MonadTraitsTest<MonadRevisionT>
 protected:
     using Trait = MonadTraitsTest<MonadRevisionT>::Trait;
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState block_state{tdb, vm};

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -85,9 +85,8 @@ struct ReserveBalanceTest : public ::testing::Test
     static constexpr auto account_b = Address{0xcafebabe};
     static constexpr auto account_c = Address{0xabbaabba};
 
-    OnDiskMachine machine;
     vm::VM vm;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<OnDiskMachine>()};
     TrieDb tdb{db};
     BlockState bs{tdb, vm};
     State state{bs, Incarnation{0, 0}};
@@ -253,8 +252,7 @@ void run_dipped_into_reserve_test(
     static constexpr Address EOA{0xaaaaaaaa};
     static constexpr Address SCW{0xcccccccc};
 
-    InMemoryMachine machine;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
     BlockState bs{tdb, vm};
@@ -588,9 +586,8 @@ struct MonadPrecompileTest : public ::MonadTraitsTest<MonadRevisionT>
 {
     static constexpr auto account_a = Address{0xdeadbeef};
 
-    OnDiskMachine machine;
     vm::VM vm;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<OnDiskMachine>()};
     TrieDb tdb{db};
     BlockState bs{tdb, vm};
     State state{bs, Incarnation{0, 0}};

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.hpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.hpp
@@ -27,8 +27,7 @@ namespace monad::staking::test
     class StakingContractModel
     {
         vm::VM vm_;
-        OnDiskMachine mpt_machine_;
-        mpt::Db mpt_db_{mpt_machine_};
+        mpt::Db mpt_db_{std::make_unique<OnDiskMachine>()};
         TrieDb trie_db_{mpt_db_};
         BlockState block_state_{trie_db_, vm_};
         State state_{block_state_, Incarnation{0, 0}};

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -88,10 +88,10 @@ protected:
     void SetUp() override
     {
         {
-            OnDiskMachine machine;
             vm::VM vm;
             mpt::Db db{
-                machine, mpt::OnDiskDbConfig{.dbname_paths = {db_file.path}}};
+                std::make_unique<OnDiskMachine>(),
+                mpt::OnDiskDbConfig{.dbname_paths = {db_file.path}}};
             TrieDb tdb{db};
             BlockState bs{tdb, vm};
             State state{bs, Incarnation{0, 0}};

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -85,9 +85,8 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
 {
     using Trait = MonadTraitsTest<MonadRevisionT>::Trait;
 
-    OnDiskMachine machine;
     vm::VM vm;
-    mpt::Db db{machine};
+    mpt::Db db{std::make_unique<OnDiskMachine>()};
     TrieDb tdb{db};
     BlockState bs{tdb, vm};
     State state{bs, Incarnation{0, 0}};

--- a/category/mpt/bench/async_read_bench.cpp
+++ b/category/mpt/bench/async_read_bench.cpp
@@ -234,12 +234,11 @@ int main(int const argc, char *const argv[])
                 << std::endl;
 
             // construct RWDb
-            StateMachineAlwaysMerkle machine{};
             auto const config = OnDiskDbConfig{
                 .append = true,
                 .compaction = true,
                 .dbname_paths = {dbname_paths}};
-            Db rw_db{machine, config};
+            Db rw_db{std::make_unique<StateMachineAlwaysMerkle>(), config};
             auto rw_root =
                 rw_db.load_root_for_version(rw_db.get_latest_version());
 

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -248,13 +248,14 @@ public:
 class Db::InMemory final : public Db::Impl
 {
     UpdateAux aux_;
-    StateMachine &machine_;
+    std::unique_ptr<StateMachine> machine_;
 
 public:
-    explicit InMemory(StateMachine &machine)
+    explicit InMemory(std::unique_ptr<StateMachine> machine)
         : aux_{}
-        , machine_{machine}
+        , machine_{std::move(machine)}
     {
+        MONAD_ASSERT(machine_);
     }
 
     virtual UpdateAux &aux() override
@@ -267,7 +268,7 @@ public:
         bool, bool) override
     {
         return aux_.do_update(
-            std::move(root), machine_, std::move(list), version, false);
+            std::move(root), *machine_, std::move(list), version, false);
     }
 
     virtual Node::SharedPtr copy_trie_fiber_blocking(
@@ -675,21 +676,23 @@ public:
 class Db::RWOnDisk final : public Impl
 {
     std::shared_ptr<OnDiskDbServiceThread> worker_thread_;
-    StateMachine &machine_;
+    // instantiated at construction and never changed, so safe to read without
+    // synchronization after constructor finishes
+    std::unique_ptr<StateMachine> machine_;
     bool const compaction_;
-
     uint64_t unflushed_version_{INVALID_BLOCK_NUM};
 
 public:
     RWOnDisk(
         std::shared_ptr<OnDiskDbServiceThread> worker_thread,
-        StateMachine &machine, bool compaction)
+        std::unique_ptr<StateMachine> machine, bool compaction)
         : worker_thread_(std::move(worker_thread))
-        , machine_{machine}
-        , compaction_(compaction)
+        , machine_{std::move(machine)}
+        , compaction_{compaction}
         , unflushed_version_{INVALID_BLOCK_NUM}
     {
         MONAD_ASSERT(worker_thread_ != nullptr);
+        MONAD_ASSERT(machine_);
     }
 
     virtual UpdateAux &aux() override
@@ -737,7 +740,7 @@ public:
         worker_thread_->submit(OnDiskDbServiceThread::FiberUpsertRequest{
             .promise = std::move(promise),
             .prev_root = std::move(root),
-            .sm = machine_,
+            .sm = *machine_,
             .updates = std::move(updates),
             .version = version,
             .enable_compaction = enable_compaction && compaction_,
@@ -765,7 +768,7 @@ public:
             OnDiskDbServiceThread::FiberLoadAllFromBlockRequest{
                 .promise = std::move(promise),
                 .root = NodeCursor{root},
-                .sm = machine_});
+                .sm = *machine_});
         return fut.get();
     }
 
@@ -972,14 +975,14 @@ bool RODb::traverse(
         cursor.node, machine, block_id, concurrency_limit);
 }
 
-Db::Db(StateMachine &machine)
-    : impl_{std::make_unique<InMemory>(machine)}
+Db::Db(std::unique_ptr<StateMachine> machine)
+    : impl_{std::make_unique<InMemory>(std::move(machine))}
 {
 }
 
-Db::Db(StateMachine &machine, OnDiskDbConfig const &config)
+Db::Db(std::unique_ptr<StateMachine> machine, OnDiskDbConfig const &config)
     : impl_{std::make_unique<RWOnDisk>(
-          std::make_shared<OnDiskDbServiceThread>(config), machine,
+          std::make_shared<OnDiskDbServiceThread>(config), std::move(machine),
           config.compaction)}
 {
     MONAD_ASSERT(impl_->aux().is_on_disk());

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -98,8 +98,8 @@ private:
     std::unique_ptr<Impl> impl_;
 
 public:
-    explicit Db(StateMachine &); // In-memory mode
-    Db(StateMachine &, OnDiskDbConfig const &);
+    explicit Db(std::unique_ptr<StateMachine>); // In-memory mode
+    Db(std::unique_ptr<StateMachine>, OnDiskDbConfig const &);
     explicit Db(AsyncIOContext &);
 
     Db(Db const &) = delete;

--- a/category/mpt/ondisk_db_config.hpp
+++ b/category/mpt/ondisk_db_config.hpp
@@ -36,7 +36,6 @@ struct OnDiskDbConfig
     unsigned wr_buffers{4};
     unsigned uring_entries{512};
     std::optional<unsigned> sq_thread_cpu{0};
-    std::optional<uint64_t> start_block_id{std::nullopt};
     std::vector<std::filesystem::path> dbname_paths{};
     int64_t file_size_db{512}; // truncate files to this size
     unsigned concurrent_read_io_limit{1024};

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -135,16 +135,14 @@ namespace
 
     struct InMemoryDbFixture : public ::testing::Test
     {
-        StateMachineAlwaysMerkle machine;
-        Db db{machine};
+        Db db{std::make_unique<StateMachineAlwaysMerkle>()};
         Node::SharedPtr root;
     };
 
     struct OnDiskDbFixture : public ::testing::Test
     {
-        StateMachineAlwaysMerkle machine;
         Db db{
-            machine,
+            std::make_unique<StateMachineAlwaysMerkle>(),
             OnDiskDbConfig{.fixed_history_length = MPT_TEST_HISTORY_LENGTH}};
         Node::SharedPtr root;
     };
@@ -840,12 +838,11 @@ TEST_F(OnDiskDbWithFileFixture, upsert_but_not_write_root)
 TEST(DbTest, history_length_adjustment_never_under_min)
 {
     auto const dbname = create_temp_file(4);
-    StateMachineAlwaysEmpty machine{};
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname}};
-    Db db{machine, config};
+    Db db{std::make_unique<StateMachineAlwaysEmpty>(), config};
     Node::SharedPtr root{};
 
     constexpr unsigned nkeys = 100;
@@ -1172,13 +1169,12 @@ TEST(DbTest, out_of_order_upserts_to_nonexist_earlier_version)
     auto const dbname = create_temp_file(2); // 2Gb db
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlwaysEmpty machine{};
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname},
         .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
-    Db db{machine, config};
+    Db db{std::make_unique<StateMachineAlwaysEmpty>(), config};
 
     AsyncIOContext io_ctx{ReadOnlyOnDiskDbConfig{.dbname_paths = {dbname}}};
     Db rodb{io_ctx};
@@ -1234,13 +1230,12 @@ TEST(DbTest, out_of_order_upserts_with_compaction)
     auto const dbname = create_temp_file(3); // 3Gb db
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlwaysMerkle machine{};
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname},
         .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
-    Db db{machine, config};
+    Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
     AsyncIOContext io_ctx{ReadOnlyOnDiskDbConfig{.dbname_paths = {dbname}}};
     Db rodb{io_ctx};
 
@@ -1678,8 +1673,7 @@ TYPED_TEST(DbTraverseTest, trimmed_traverse)
 
 TEST(RangedGetTest, path_exceeds_min_prefix)
 {
-    StateMachineAlwaysVarLen machine;
-    Db db{machine};
+    Db db{std::make_unique<StateMachineAlwaysVarLen>()};
     Node::SharedPtr root;
 
     Nibbles const min{0x0124_bytes};
@@ -1731,8 +1725,7 @@ TEST(RangedGetTest, path_exceeds_min_prefix)
 
 TEST(RangedGetTest, path_longer_than_min_and_max)
 {
-    StateMachineAlwaysVarLen machine;
-    Db db{machine};
+    Db db{std::make_unique<StateMachineAlwaysVarLen>()};
     Node::SharedPtr root;
 
     // Very short bounds: all keys will have paths longer than both min and max.
@@ -1835,17 +1828,16 @@ TEST(DbTest, auto_expire_large_set)
     auto const dbname = create_temp_file(8);
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlways<
+    using ExpireMachine = StateMachineAlways<
         EmptyCompute,
-        StateMachineConfig{.expire = true, .cache_depth = 3}>
-        machine{};
+        StateMachineConfig{.expire = true, .cache_depth = 3}>;
     constexpr auto history_len = 20;
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname},
         .fixed_history_length = history_len};
-    Db db{machine, config};
+    Db db{std::make_unique<ExpireMachine>(), config};
     Node::SharedPtr root;
 
     auto const prefix = 0x00_bytes;
@@ -1909,16 +1901,15 @@ TEST(DbTest, auto_expire)
     auto const dbname = create_temp_file(8);
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlways<
+    using ExpireMachine = StateMachineAlways<
         EmptyCompute,
-        StateMachineConfig{.expire = true, .cache_depth = 3}>
-        machine{};
+        StateMachineConfig{.expire = true, .cache_depth = 3}>;
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname},
         .fixed_history_length = 5};
-    Db db{machine, config};
+    Db db{std::make_unique<ExpireMachine>(), config};
     Node::SharedPtr root;
 
     auto const prefix = 0x00_bytes;
@@ -2236,12 +2227,11 @@ TEST(DbTest, move_trie_version_forward_history_ring_wrap_around)
     auto const dbname = create_temp_file(2);
     auto const undb = monad::make_scope_exit(
         [&]() noexcept { std::filesystem::remove(dbname); });
-    StateMachineAlwaysEmpty machine{};
     OnDiskDbConfig const config{
         .compaction = true,
         .sq_thread_cpu{std::nullopt},
         .dbname_paths = {dbname}};
-    Db db{machine, config};
+    Db db{std::make_unique<StateMachineAlwaysEmpty>(), config};
     Node::SharedPtr root;
 
     uint64_t const root_offsets_ring_capacity =
@@ -2563,7 +2553,7 @@ TEST_F(
     auto new_config = this->config;
     new_config.fixed_history_length = 65536;
     new_config.append = true;
-    new (&db) Db(machine, new_config);
+    new (&db) Db(std::make_unique<StateMachineAlwaysMerkle>(), new_config);
     EXPECT_EQ(ro_db.get_latest_version(), dest_block_id);
     EXPECT_EQ(ro_db.get_earliest_version(), earliest_block_id);
 }
@@ -2632,7 +2622,7 @@ TEST_F(OnDiskDbWithFileFixture, reset_history_length_concurrent)
     config.append = true;
     while (config.fixed_history_length > end_history_length) {
         config.fixed_history_length = *config.fixed_history_length - 1;
-        Db const new_db{machine, config};
+        Db const new_db{std::make_unique<StateMachineAlwaysMerkle>(), config};
         EXPECT_EQ(new_db.get_history_length(), config.fixed_history_length);
         EXPECT_EQ(new_db.get_latest_version(), MPT_TEST_HISTORY_LENGTH - 1);
     }
@@ -2689,7 +2679,7 @@ TEST_F(OnDiskDbWithFileFixture, rwdb_reset_history_length)
     config.fixed_history_length = MPT_TEST_HISTORY_LENGTH / 2;
     config.append = true;
     {
-        Db const new_rw{machine, config};
+        Db const new_rw{std::make_unique<StateMachineAlwaysMerkle>(), config};
         EXPECT_EQ(new_rw.get_history_length(), config.fixed_history_length);
         EXPECT_EQ(new_rw.get_latest_version(), max_block_id);
     }
@@ -2708,7 +2698,7 @@ TEST_F(OnDiskDbWithFileFixture, rwdb_reset_history_length)
 
     // Reopen rwdb with a longer history length
     config.fixed_history_length = MPT_TEST_HISTORY_LENGTH;
-    Db const new_rw{machine, config};
+    Db const new_rw{std::make_unique<StateMachineAlwaysMerkle>(), config};
     EXPECT_EQ(new_rw.get_history_length(), config.fixed_history_length);
     EXPECT_EQ(new_rw.get_earliest_version(), min_block_num_after);
     EXPECT_EQ(ro_db.get_history_length(), config.fixed_history_length);

--- a/category/mpt/test/read_only_db_stress_test.cpp
+++ b/category/mpt/test/read_only_db_stress_test.cpp
@@ -173,15 +173,13 @@ int main(int const argc, char *const argv[])
             }
 
             // construct RWDb
-            StateMachineAlwaysMerkle machine{};
-
             auto const config =
                 overwrite_keys_mode
                     ? OnDiskDbConfig{.compaction = true, .dbname_paths = {dbname_paths}, .file_size_db = 4, .fixed_history_length = 40}
                     : OnDiskDbConfig{
                           .compaction = enable_compaction,
                           .dbname_paths = {dbname_paths}};
-            Db rw_db{machine, config};
+            Db rw_db{std::make_unique<StateMachineAlwaysMerkle>(), config};
             Node::SharedPtr rw_root = nullptr;
 
             auto upsert_new_version_overwrite_keys =

--- a/category/mpt/test/test_fixtures_gtest.hpp
+++ b/category/mpt/test/test_fixtures_gtest.hpp
@@ -68,20 +68,18 @@ namespace monad::test
     struct OnDiskDbWithFileFixtureBase : public ::testing::Test
     {
         std::filesystem::path const dbname;
-        StateMachineType machine;
         monad::mpt::OnDiskDbConfig config;
         monad::mpt::Db db;
         Node::SharedPtr root;
 
         OnDiskDbWithFileFixtureBase()
             : dbname{create_temp_file(8)}
-            , machine{StateMachineType{}}
             , config{OnDiskDbConfig{
                   .compaction = true,
                   .sq_thread_cpu = std::nullopt,
                   .dbname_paths = {dbname},
                   .fixed_history_length = MPT_TEST_HISTORY_LENGTH}}
-            , db{machine, config}
+            , db{std::make_unique<StateMachineType>(), config}
             , root{}
         {
         }

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -127,7 +127,6 @@ namespace
     struct EthCallFixture : public ::testing::Test
     {
         std::filesystem::path dbname;
-        OnDiskMachine machine;
         mpt::Db db;
         TrieDb tdb;
         vm::VM vm;
@@ -146,7 +145,7 @@ namespace
                 ::close(fd);
                 return dbname;
             }()}
-            , db{machine,
+            , db{std::make_unique<OnDiskMachine>(),
                  mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}}
             , tdb{db}
         {

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -34,7 +34,7 @@ monad_statesync_client_context::monad_statesync_client_context(
     monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
-    : db{machine,
+    : db{std::make_unique<OnDiskMachine>(),
          mpt::OnDiskDbConfig{
              .append = true,
              .compaction = false,

--- a/category/statesync/statesync_client_context.hpp
+++ b/category/statesync/statesync_client_context.hpp
@@ -45,7 +45,6 @@ struct monad_statesync_client_context
 
     using StateDelta = std::pair<monad::Account, StorageDeltas>;
 
-    monad::OnDiskMachine machine;
     monad::mpt::Db db;
     monad::TrieDb tdb;
     std::vector<std::pair<uint64_t, uint64_t>> progress;

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -249,9 +249,8 @@ namespace
             ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
         ::close(fd);
         char const *const path = dbname.c_str();
-        OnDiskMachine machine;
         mpt::Db const db{
-            machine,
+            std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
         return dbname;
     }
@@ -280,9 +279,9 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
             &client,
             &statesync_send_request);
     std::filesystem::path sdbname{tmp_dbname()};
-    OnDiskMachine machine;
     mpt::Db sdb{
-        machine, OnDiskDbConfig{.append = true, .dbname_paths = {sdbname}}};
+        std::make_unique<OnDiskMachine>(),
+        OnDiskDbConfig{.append = true, .dbname_paths = {sdbname}}};
     TrieDb stdb{sdb};
     std::unique_ptr<monad_statesync_server_context> sctx =
         std::make_unique<monad_statesync_server_context>(stdb);

--- a/category/statesync/test/test_network_shutdown.cpp
+++ b/category/statesync/test/test_network_shutdown.cpp
@@ -66,11 +66,10 @@ namespace
             MONAD_ASSERT(
                 -1 !=
                 ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
-            monad::OnDiskMachine machine;
             // Initialize the on-disk DB format; the Db object is not needed
             // after this point.
             (void)monad::mpt::Db{
-                machine,
+                std::make_unique<monad::OnDiskMachine>(),
                 monad::mpt::OnDiskDbConfig{
                     .append = false, .dbname_paths = {path}}};
         }

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -75,9 +75,8 @@ namespace
             ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
         ::close(fd);
         char const *const path = dbname.c_str();
-        OnDiskMachine machine;
         mpt::Db const db{
-            machine,
+            std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
         return dbname;
     }
@@ -144,7 +143,6 @@ namespace
         monad_statesync_client client;
         monad_statesync_client_context *cctx;
         std::filesystem::path sdbname;
-        OnDiskMachine machine;
         mpt::Db sdb;
         TrieDb stdb;
         monad_statesync_server_context sctx;
@@ -157,7 +155,7 @@ namespace
             : cdbname{tmp_dbname()}
             , cctx{nullptr}
             , sdbname{tmp_dbname()}
-            , sdb{machine,
+            , sdb{std::make_unique<OnDiskMachine>(),
                   OnDiskDbConfig{.append = true, .dbname_paths = {sdbname}}}
             , stdb{sdb}
             , sctx{stdb}
@@ -210,9 +208,9 @@ TEST_F(StateSyncFixture, sync_from_latest)
     constexpr auto N = 1'000'000;
     bytes32_t parent_hash{NULL_HASH};
     {
-        OnDiskMachine machine;
         mpt::Db db{
-            machine, OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
         uint64_t const block_number = N - 257;
         load_header(
@@ -277,9 +275,8 @@ TEST_F(StateSyncFixture, sync_from_empty)
     EXPECT_TRUE(monad_statesync_client_has_reached_target(cctx));
     EXPECT_TRUE(monad_statesync_client_finalize(cctx));
 
-    OnDiskMachine machine;
     mpt::Db cdb{
-        machine,
+        std::make_unique<OnDiskMachine>(),
         mpt::OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
     TrieDb ctdb{cdb};
     ctdb.set_block_and_prefix(cdb.get_latest_finalized_version());
@@ -312,9 +309,9 @@ TEST_F(StateSyncFixture, sync_from_empty)
 TEST_F(StateSyncFixture, sync_from_some)
 {
     {
-        OnDiskMachine machine;
         mpt::Db db{
-            machine, OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
         load_genesis_state(GENESIS_STATE, tdb);
         // commit some proposal to client db
@@ -510,9 +507,9 @@ TEST_F(StateSyncFixture, sync_from_some)
 TEST_F(StateSyncFixture, deletion_proposal)
 {
     {
-        OnDiskMachine machine;
         mpt::Db db{
-            machine, OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
         load_genesis_state(GENESIS_STATE, tdb);
         load_genesis_state(GENESIS_STATE, stdb);
@@ -634,9 +631,9 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
 {
     {
         // init client DB
-        OnDiskMachine machine;
         mpt::Db db{
-            machine, OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
         tdb.reset_root(load_header({}, db, BlockHeader{.number = 0}), 0);
         for (uint64_t n = 1; n <= 249; ++n) {

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -265,12 +265,10 @@ try {
     if (!statesync.empty()) {
         net.emplace(statesync.c_str());
     }
-    std::unique_ptr<mpt::StateMachine> machine;
     mpt::Db raw_db = [&] {
         if (!db_in_memory) {
-            machine = std::make_unique<OnDiskMachine>();
             return mpt::Db{
-                *machine,
+                std::make_unique<OnDiskMachine>(),
                 mpt::OnDiskDbConfig{
                     .append = true,
                     .compaction = !no_compaction,
@@ -281,8 +279,7 @@ try {
                     .sq_thread_cpu = sq_thread_cpu,
                     .dbname_paths = dbname_paths}};
         }
-        machine = std::make_unique<InMemoryMachine>();
-        return mpt::Db{*machine};
+        return mpt::Db{std::make_unique<InMemoryMachine>()};
     }();
 
     auto chain = [chain_config] -> std::unique_ptr<Chain> {

--- a/test/utils/test_state.hpp
+++ b/test/utils/test_state.hpp
@@ -25,12 +25,11 @@ MONAD_TEST_NAMESPACE_BEGIN
 
 struct TestState
 {
-    monad::InMemoryMachine machine;
     monad::mpt::Db db;
     monad::TrieDb trie_db;
 
     TestState()
-        : db{machine}
+        : db{std::make_unique<monad::InMemoryMachine>()}
         , trie_db{db}
     {
     }


### PR DESCRIPTION
Core changes are in db.hpp / db.cpp
Remaining changes update call sites for the new constructor API

This is necessary for supporting replay Monad once we change the commitment scheme in writing to database.