### PR TITLE
Reject non-canonical RLP encoded strings/lists

### DIFF
--- a/category/execution/ethereum/rlp/decode.hpp
+++ b/category/execution/ethereum/rlp/decode.hpp
@@ -130,6 +130,14 @@ namespace detail
         {
             length = enc[0] - 0x80;
             ++i;
+            if (length == 1) {
+                if (MONAD_UNLIKELY(enc.size() < 2)) {
+                    return DecodeError::InputTooShort;
+                }
+                if (MONAD_UNLIKELY(enc[1] < 0x80)) {
+                    return DecodeError::TypeUnexpected;
+                }
+            }
         }
         else // [0xb8, 0xbf] - long string, N+1 bytes for length, then
              // payload
@@ -141,6 +149,9 @@ namespace detail
             }
             BOOST_OUTCOME_TRY(
                 length, decode_length(enc.substr(i, length_of_length)));
+            if (MONAD_UNLIKELY(length < 56)) {
+                return DecodeError::TypeUnexpected;
+            }
             i += length_of_length;
         }
         return extract_payload<RlpType::String, Options...>(enc, i, length);
@@ -170,6 +181,9 @@ namespace detail
             }
             BOOST_OUTCOME_TRY(
                 length, decode_length(enc.substr(i, length_of_length)));
+            if (MONAD_UNLIKELY(length < 56)) {
+                return DecodeError::TypeUnexpected;
+            }
             i += length_of_length;
         }
         return extract_payload<RlpType::List, Options...>(enc, i, length);

--- a/category/execution/ethereum/rlp/test/test_decode.cpp
+++ b/category/execution/ethereum/rlp/test/test_decode.cpp
@@ -132,6 +132,64 @@ TEST(Rlp, ParseMetadata)
         EXPECT_EQ(enc.size(), 0);
     }
 
+    // Empty string, encoded as 0x80
+    {
+        byte_string const encoding{0x80};
+        byte_string_view enc{encoding};
+
+        auto const result = parse_metadata(enc);
+        ASSERT_FALSE(result.has_error());
+        EXPECT_EQ(result.value().first, RlpType::String);
+        EXPECT_EQ(result.value().second, byte_string_view{});
+        EXPECT_EQ(enc.size(), 0);
+    }
+
+    // Single byte 0x80 encoded as a short string, i.e. 0x81 0x80
+    // (canonical: 0x80 is not < 0x80, so it cannot be encoded as itself)
+    {
+        byte_string const encoding{0x81, 0x80};
+        byte_string_view enc{encoding};
+
+        auto const result = parse_metadata(enc);
+        ASSERT_FALSE(result.has_error());
+        EXPECT_EQ(result.value().first, RlpType::String);
+        EXPECT_EQ(result.value().second, byte_string_view(encoding).substr(1));
+        EXPECT_EQ(enc.size(), 0);
+    }
+
+    // Single byte `b` in the range 0x00-0x7f encoded as
+    // 0x81, <b> -> TypeUnexpected
+    {
+        byte_string const encoding{0x81, 0x01};
+        byte_string_view enc{encoding};
+
+        auto const result = parse_metadata(enc);
+        ASSERT_TRUE(result.has_error());
+        EXPECT_EQ(result.error(), DecodeError::TypeUnexpected);
+    }
+
+    // Long string form when payload length < 56 bytes, e.g. 0xb8 0x01 0x01 ->
+    // TypeUnexpected
+    {
+        byte_string const encoding{0xb8, 0x01, 0x01};
+        byte_string_view enc{encoding};
+
+        auto const result = parse_metadata(enc);
+        ASSERT_TRUE(result.has_error());
+        EXPECT_EQ(result.error(), DecodeError::TypeUnexpected);
+    }
+
+    // Long list form when payload length < 56 bytes, e.g. 0xf8 0x01 0xc0 ->
+    // TypeUnexpected
+    {
+        byte_string const encoding{0xf8, 0x01, 0xc0};
+        byte_string_view enc{encoding};
+
+        auto const result = parse_metadata(enc);
+        ASSERT_TRUE(result.has_error());
+        EXPECT_EQ(result.error(), DecodeError::TypeUnexpected);
+    }
+
     // parse_string_metadata on a list-prefix input -> TypeUnexpected
     {
         auto encoding = encode_list2(

--- a/test/ethereum_test/exclude/berlin.cmake
+++ b/test/ethereum_test/exclude/berlin.cmake
@@ -60,6 +60,4 @@ set(berlin_excluded_tests
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json" # Difficulty (Pre-merge)
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/byzantium.cmake
+++ b/test/ethereum_test/exclude/byzantium.cmake
@@ -1,4 +1,2 @@
 set(byzantium_excluded_tests
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/constantinoplefix.cmake
+++ b/test/ethereum_test/exclude/constantinoplefix.cmake
@@ -1,4 +1,2 @@
 set(constantinoplefix_excluded_tests
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/eip150.cmake
+++ b/test/ethereum_test/exclude/eip150.cmake
@@ -1,4 +1,2 @@
 set(eip150_excluded_tests
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/eip158.cmake
+++ b/test/ethereum_test/exclude/eip158.cmake
@@ -1,4 +1,2 @@
 set(eip158_excluded_tests
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/istanbul.cmake
+++ b/test/ethereum_test/exclude/istanbul.cmake
@@ -60,6 +60,4 @@ set(istanbul_excluded_tests
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json" # Difficulty (Pre-merge)
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 )

--- a/test/ethereum_test/exclude/london.cmake
+++ b/test/ethereum_test/exclude/london.cmake
@@ -65,8 +65,6 @@ set(london_excluded_tests
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json" # Difficulty (Pre-merge)
     "BlockchainTests.ValidBlocks/bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json" # Difficulty (Pre-merge)
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 
     # Stricter validation of base fee
     "BlockchainTests.london/validation/test_invalid_header.json"

--- a/test/ethereum_test/exclude/paris.cmake
+++ b/test/ethereum_test/exclude/paris.cmake
@@ -15,8 +15,6 @@ set(paris_excluded_tests
     "BlockchainTests.InvalidBlocks/bcInvalidHeaderTest/wrongTimestamp.json" # ParentHeader
     "BlockchainTests.InvalidBlocks/bcInvalidHeaderTest/wrongTransactionsTrie.json" # Trie
     "BlockchainTests.InvalidBlocks/bcMultiChainTest/UncleFromSideChain.json" # Uncle
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 
     # Stricter validation of base fee
     "BlockchainTests.london/validation/test_invalid_header.json"

--- a/test/ethereum_test/exclude/shanghai.cmake
+++ b/test/ethereum_test/exclude/shanghai.cmake
@@ -16,8 +16,6 @@ set(shanghai_excluded_tests
     "BlockchainTests.InvalidBlocks/bcInvalidHeaderTest/wrongTimestamp.json" # ParentHeader
     "BlockchainTests.InvalidBlocks/bcInvalidHeaderTest/wrongTransactionsTrie.json" # Trie
     "BlockchainTests.InvalidBlocks/bcMultiChainTest/UncleFromSideChain.json" # Uncle
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding01.json"
-    "TransactionTests.ttWrongRLP/RLPIncorrectByteEncoding127.json"
 
     # Stricter validation of base fee
     "BlockchainTests.london/validation/test_invalid_header.json"


### PR DESCRIPTION
ethereum rlp decoders should reject:
- short string form for a single byte < 0x80, e.g. 0x81 0x01
- long string form when payload length < 56, e.g. 0xb8 0x01 0x01
- long list form when payload length < 56, e.g. 0xf8 0x01 0xc0