### PR TITLE
[test] Fix `cli_tool` test regressions on Ubuntu 26.04

### DIFF
--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -52,7 +52,11 @@ TEST(cli_tool, no_args_prints_fatal_and_help)
     int const retcode = main_impl(cout, cerr, args);
     ASSERT_EQ(retcode, 1);
     EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
-    EXPECT_NE(std::string::npos, cerr.str().find("Options:"));
+    {
+        std::string out = cerr.str();
+        std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+        EXPECT_NE(std::string::npos, out.find("options:"));
+    }
 }
 
 TEST(cli_tool, help_prints_help)

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -28,6 +28,8 @@
 #include <category/mpt/node_cursor.hpp>
 #include <category/mpt/trie.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <future>
 #include <iostream>
@@ -60,7 +62,11 @@ TEST(cli_tool, help_prints_help)
     std::string_view args[] = {"monad-mpt", "--help"};
     int const retcode = main_impl(cout, cerr, args);
     ASSERT_EQ(retcode, 0);
-    EXPECT_NE(std::string::npos, cout.str().find("Options:"));
+    {
+        std::string out = cout.str();
+        std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+        EXPECT_NE(std::string::npos, out.find("options:"));
+    }
 }
 
 TEST(cli_tool, create)


### PR DESCRIPTION
It appears to be the case that the `CLI11` package provided by Ubuntu 26.04 LTS has changed the output formatting of `CLI11::help()` such that it now prints `OPTIONS:` rather than `Options:`. Consequently, two tests are failing on the platform. This PR includes fixes for the two test regressions by normalizing the output before comparison.