### PR TITLE
Db::read_storage() return byte_string

### DIFF
--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -41,7 +41,9 @@ struct Db
 {
     virtual std::optional<Account> read_account(Address const &) = 0;
 
-    virtual bytes32_t
+    // Returns the zeroless big-endian representation of the slot value,
+    // equivalent to `compact_storage_view(slot_value)` (see db/util.hpp).
+    virtual byte_string
     read_storage(Address const &, Incarnation, bytes32_t const &key) = 0;
 
     virtual vm::SharedIntercode read_code(bytes32_t const &) = 0;

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -22,6 +22,7 @@
 #include <category/core/lru/lru_cache.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
@@ -64,7 +65,8 @@ class DbCache final : public Db
     using StorageKeyHashCompare = BytesHashCompare<StorageKey>;
     using AccountsCache =
         LruCache<Address, std::optional<Account>, AddressHashCompare>;
-    using StorageCache = LruCache<StorageKey, bytes32_t, StorageKeyHashCompare>;
+    using StorageCache =
+        LruCache<StorageKey, byte_string, StorageKeyHashCompare>;
 
     AccountsCache accounts_{10'000'000};
     StorageCache storage_{10'000'000};
@@ -92,11 +94,11 @@ public:
         return db_.read_account(address);
     }
 
-    virtual bytes32_t read_storage(
+    virtual byte_string read_storage(
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key) override
     {
-        bytes32_t result;
+        byte_string result;
         auto const res =
             proposals_.try_read_storage(address, incarnation, key, result);
         if (res.found) {
@@ -233,7 +235,8 @@ private:
                     auto const incarnation = account->incarnation;
                     storage_.insert(
                         StorageKey(address, incarnation, key),
-                        storage_delta.second);
+                        byte_string{
+                            compact_storage_view(storage_delta.second)});
                 }
             }
         }

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -386,7 +386,7 @@ std::optional<Account> PartialTrieDb::read_account(Address const &)
     return std::nullopt;
 }
 
-bytes32_t
+byte_string
 PartialTrieDb::read_storage(Address const &, Incarnation, bytes32_t const &)
 {
     return {};

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -168,7 +168,7 @@ public:
 
     std::optional<Account> read_account(Address const &) override;
 
-    bytes32_t
+    byte_string
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
 
     vm::SharedIntercode read_code(bytes32_t const &code_hash) override;

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -257,7 +257,8 @@ TYPED_TEST(DBTest, read_storage)
         BlockHeader{});
 
     // Existing storage
-    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key1), value1);
+    EXPECT_EQ(
+        to_bytes(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key1)), value1);
     EXPECT_EQ(
         read_storage_and_slot(
             tdb.get_root(), this->db, tdb.get_block_number(), ADDR_A, key1)
@@ -265,7 +266,9 @@ TYPED_TEST(DBTest, read_storage)
         key1);
 
     // Non-existing key
-    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key2), bytes32_t{});
+    EXPECT_EQ(
+        to_bytes(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key2)),
+        bytes32_t{});
     EXPECT_EQ(
         read_storage_and_slot(
             tdb.get_root(), this->db, tdb.get_block_number(), ADDR_A, key2)
@@ -274,7 +277,7 @@ TYPED_TEST(DBTest, read_storage)
 
     // Non-existing account
     EXPECT_FALSE(tdb.read_account(ADDR_B).has_value());
-    EXPECT_EQ(tdb.read_storage(ADDR_B, Incarnation{0, 0}, key1), bytes32_t{});
+    EXPECT_EQ(tdb.read_storage(ADDR_B, Incarnation{0, 0}, key1), byte_string{});
     EXPECT_EQ(
         read_storage_and_slot(
             tdb.get_root(), this->db, tdb.get_block_number(), ADDR_B, key1)
@@ -431,7 +434,7 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
         BlockHeader{.number = 1});
 
     EXPECT_EQ(tdb.read_account(ADDR_A), std::nullopt);
-    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key1), bytes32_t{});
+    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, key1), byte_string{});
     EXPECT_EQ(tdb.state_root(), NULL_ROOT);
 }
 

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -115,7 +115,7 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
     return acct.value();
 }
 
-bytes32_t
+byte_string
 TrieDb::read_storage(Address const &addr, Incarnation, bytes32_t const &key)
 {
     auto const res = db_.find(
@@ -134,7 +134,7 @@ TrieDb::read_storage(Address const &addr, Incarnation, bytes32_t const &key)
     auto encoded_storage = res.value().node->value();
     auto const storage = decode_storage_db_ignore_slot(encoded_storage);
     MONAD_ASSERT(!storage.has_error());
-    return to_bytes(storage.value());
+    return byte_string{storage.value()};
 };
 
 vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -59,7 +59,7 @@ public:
     ::monad::mpt::Node::SharedPtr const &get_root() const;
 
     virtual std::optional<Account> read_account(Address const &) override;
-    virtual bytes32_t
+    virtual byte_string
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
     virtual vm::SharedIntercode read_code(bytes32_t const &) override;
     virtual void set_block_and_prefix(

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -89,7 +89,7 @@ public:
         return acct.value();
     }
 
-    virtual bytes32_t read_storage(
+    virtual byte_string read_storage(
         Address const &addr, Incarnation, bytes32_t const &key) override
     {
         auto storage_leaf_res = db_.find(
@@ -109,7 +109,7 @@ public:
         auto encoded_storage = storage_leaf_res.value().node->value();
         auto const storage = decode_storage_db_ignore_slot(encoded_storage);
         MONAD_ASSERT(!storage.has_error());
-        return to_bytes(storage.value());
+        return byte_string{storage.value()};
     }
 
     virtual vm::SharedIntercode read_code(bytes32_t const &code_hash) override

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -666,11 +666,19 @@ Result<Account> decode_account_db_ignore_address(byte_string_view &enc)
     return decode_account_db_helper(res.second);
 }
 
+byte_string_view compact_storage_view(bytes32_t const &val)
+{
+    return rlp::zeroless_view(to_byte_string_view(val.bytes));
+}
+
 byte_string encode_storage_db(bytes32_t const &key, bytes32_t const &val)
 {
     byte_string encoded_storage;
     encoded_storage += rlp::encode_bytes32_compact(key);
-    encoded_storage += rlp::encode_bytes32_compact(val);
+    // Equivalent to `rlp::encode_bytes32_compact(val)`, but written this way
+    // to make the storage-value representation (zeroless big-endian) explicit
+    // at the encode site.
+    encoded_storage += rlp::encode_string2(compact_storage_view(val));
     return rlp::encode_list2(encoded_storage);
 }
 

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -136,6 +136,13 @@ inline constexpr unsigned char FINALIZED_NIBBLE = 1;
 inline mpt::Nibbles const proposal_nibbles = mpt::concat(PROPOSAL_NIBBLE);
 inline mpt::Nibbles const finalized_nibbles = mpt::concat(FINALIZED_NIBBLE);
 
+// Returns the zeroless big-endian representation of a storage slot value.
+// This is the canonical on-disk and in-cache form of a storage value, matching
+// return of `Db::read_storage()`, and the second element of the pair returned
+// by `decode_storage_db_raw()`. The returned view aliases the input, so the
+// `bytes32_t` argument must outlive the view.
+byte_string_view compact_storage_view(bytes32_t const &);
+
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);
 

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -101,9 +101,9 @@ bytes32_t BlockState::read_storage(
     }
     // database
     {
-        auto const result = read_storage
-                                ? db_.read_storage(address, incarnation, key)
-                                : bytes32_t{};
+        auto const result =
+            read_storage ? to_bytes(db_.read_storage(address, incarnation, key))
+                         : bytes32_t{};
         StateDeltas::accessor it{};
         MONAD_ASSERT(state_->find(it, address));
         auto const &account = it->second.account.second;

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -599,7 +599,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
         this->tdb.finalize(1, bytes32_t{1});
         this->tdb.set_block_and_prefix(1);
         EXPECT_EQ(
-            this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
+            this->tdb.read_storage(a, Incarnation{1, 2}, key1), byte_string{});
     }
 }
 
@@ -653,18 +653,25 @@ TYPED_TEST(
             std::nullopt);
         this->tdb.finalize(1, bytes32_t{1});
         this->tdb.set_block_and_prefix(1);
-        EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key1), value1);
-        EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value2);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key1)),
+            value1);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key2)),
+            value2);
         if constexpr (TestFixture::Trait::evm_rev() >= EVMC_CANCUN) {
             EXPECT_EQ(
-                this->tdb.read_storage(a, Incarnation{1, 2}, key3), value3);
+                to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key3)),
+                value3);
 
             EXPECT_EQ(
                 this->tdb.state_root(),
                 0x425AE06EDEDEC27A17412E8A2BC2F148A4AF94EE510FFB7AEA81E1ABF5450768_bytes32);
         }
         else {
-            EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key3), null);
+            EXPECT_EQ(
+                to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key3)),
+                null);
             EXPECT_EQ(
                 this->tdb.state_root(),
                 0x5B853ED6066181BF0E0D405DA0926FD7707446BCBE670DE13C9EDA7A84F6A401_bytes32);
@@ -714,8 +721,11 @@ TYPED_TEST(
         this->tdb.finalize(0, NULL_HASH_BLAKE3);
         this->tdb.set_block_and_prefix(0);
         EXPECT_EQ(
-            this->tdb.read_storage(a, Incarnation{1, 2}, key1), bytes32_t{});
-        EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key2), value3);
+            to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key1)),
+            bytes32_t{});
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(a, Incarnation{1, 2}, key2)),
+            value3);
     }
 }
 
@@ -1288,7 +1298,8 @@ TEST_F(InMemoryStateTest, commit_storage_and_account_together_regression)
 
     EXPECT_TRUE(this->tdb.read_account(a).has_value());
     EXPECT_EQ(this->tdb.read_account(a).value().balance, 1u);
-    EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 1}, key1), value1);
+    EXPECT_EQ(
+        to_bytes(this->tdb.read_storage(a, Incarnation{1, 1}, key1)), value1);
 }
 
 TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
@@ -1316,7 +1327,8 @@ TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
         std::nullopt);
 
     EXPECT_EQ(
-        this->tdb.read_storage(a, Incarnation{1, 1}, key1), monad::bytes32_t{});
+        to_bytes(this->tdb.read_storage(a, Incarnation{1, 1}, key1)),
+        monad::bytes32_t{});
 }
 
 TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
@@ -1370,8 +1382,12 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
             BlockHeader{.number = 10});
         this->tdb.finalize(10, bytes32_t{10});
 
-        EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
-        EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value2);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key1)),
+            value2);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key2)),
+            value2);
 
         this->tdb.set_block_and_prefix(10, bytes32_t{10});
     }
@@ -1396,15 +1412,16 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
             bytes32_t{11},
             BlockHeader{.number = 11});
         EXPECT_EQ(
-            this->tdb.read_storage(c, Incarnation{2, 1}, key1),
+            to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key1)),
             monad::bytes32_t{});
         if constexpr (TestFixture::Trait::evm_rev() >= EVMC_CANCUN) {
             EXPECT_EQ(
-                this->tdb.read_storage(c, Incarnation{2, 1}, key2), value1);
+                to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key2)),
+                value1);
         }
         else {
             EXPECT_EQ(
-                this->tdb.read_storage(c, Incarnation{2, 1}, key2),
+                to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key2)),
                 monad::bytes32_t{});
         }
 
@@ -1412,15 +1429,16 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         this->tdb.finalize(11, bytes32_t{11});
         this->tdb.set_block_and_prefix(11);
         EXPECT_EQ(
-            this->tdb.read_storage(c, Incarnation{2, 1}, key1),
+            to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key1)),
             monad::bytes32_t{});
         if constexpr (TestFixture::Trait::evm_rev() >= EVMC_CANCUN) {
             EXPECT_EQ(
-                this->tdb.read_storage(c, Incarnation{2, 1}, key2), value1);
+                to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key2)),
+                value1);
         }
         else {
             EXPECT_EQ(
-                this->tdb.read_storage(c, Incarnation{2, 1}, key2),
+                to_bytes(this->tdb.read_storage(c, Incarnation{2, 1}, key2)),
                 monad::bytes32_t{});
         }
     }
@@ -1479,9 +1497,12 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
             BlockHeader{.number = 11});
 
         EXPECT_EQ(this->tdb.read_account(b).value().balance, 82'000);
-        EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
         EXPECT_EQ(
-            this->tdb.read_storage(b, Incarnation{1, 1}, key2), bytes32_t{});
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key1)),
+            value2);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key2)),
+            bytes32_t{});
     }
     auto const state_root_round8 = this->tdb.state_root();
 
@@ -1508,9 +1529,11 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
 
         EXPECT_EQ(this->tdb.read_account(b).value().balance, 84'000);
         EXPECT_EQ(
-            this->tdb.read_storage(b, Incarnation{1, 1}, key1), bytes32_t{});
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key1)),
+            bytes32_t{});
         EXPECT_EQ(
-            this->tdb.read_storage(b, Incarnation{1, 1}, key2), bytes32_t{});
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key2)),
+            bytes32_t{});
     }
 
     auto const state_root_round6 = this->tdb.state_root();
@@ -1537,8 +1560,12 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
             BlockHeader{.number = 11});
 
         EXPECT_EQ(this->tdb.read_account(b).value().balance, 72'000);
-        EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key1), value2);
-        EXPECT_EQ(this->tdb.read_storage(b, Incarnation{1, 1}, key2), value3);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key1)),
+            value2);
+        EXPECT_EQ(
+            to_bytes(this->tdb.read_storage(b, Incarnation{1, 1}, key2)),
+            value3);
     }
     auto const state_root_round7 = this->tdb.state_root();
     this->tdb.finalize(11, bytes32_t{117});
@@ -1656,10 +1683,14 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
     EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{20'000});
     EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{30'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), value2);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key1)), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key2)), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key1)), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key2)), value2);
 
     LOG_INFO("block 11 round 111 on block 10 round 100");
     db_cache.set_block_and_prefix(10, bytes32_t{10});
@@ -1690,10 +1721,15 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
     EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{60'000});
     EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{30'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key1)), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key2)),
+        bytes32_t{});
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key1)), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key2)), value2);
 
     LOG_INFO("block 12 round 121 on block 11 round 111");
     db_cache.set_block_and_prefix(11, bytes32_t{111});
@@ -1722,10 +1758,15 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
     EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{60'000});
     EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{40'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key1)), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key2)),
+        bytes32_t{});
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key1)), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key2)), value1);
 
     LOG_INFO("block 11 round 112 on block 10 round 100");
     db_cache.set_block_and_prefix(10, bytes32_t{10});
@@ -1833,10 +1874,13 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
     EXPECT_EQ(db_cache.read_account(b).value().balance, 80'000);
     EXPECT_EQ(db_cache.read_account(c).value().balance, 40'000);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), bytes32_t{});
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key1)), value2);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(b, Incarnation{0, 0}, key2)), value1);
+    EXPECT_EQ(
+        to_bytes(db_cache.read_storage(c, Incarnation{0, 0}, key1)), value2);
+    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), byte_string{});
 
     // check state root of previous rounds
     db_cache.set_block_and_prefix(11, bytes32_t{111});
@@ -2206,9 +2250,9 @@ namespace
                     for (uint8_t const j : KEYS) {
                         bytes32_t const key(j);
                         auto const val1 =
-                            db1_.read_storage(addr, incarnation, key);
+                            to_bytes(db1_.read_storage(addr, incarnation, key));
                         auto const val2 =
-                            db2_.read_storage(addr, incarnation, key);
+                            to_bytes(db2_.read_storage(addr, incarnation, key));
                         if (val1 != bytes32_t{0}) {
                             LOG_INFO(
                                 "Check_storage_ a_{}          k_{} {}",

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/log.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/vm/vm.hpp>
 
@@ -67,7 +69,7 @@ public:
 
     bool try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result) const
+        bytes32_t const &key, byte_string &result) const
     {
         StateDeltas::const_accessor it{};
         if (!state_->find(it, address)) {
@@ -81,7 +83,7 @@ public:
         auto const &storage = it->second.storage;
         StorageDeltas::const_accessor it2{};
         if (storage.find(it2, key)) {
-            result = it2->second.second;
+            result = compact_storage_view(it2->second.second);
             return true;
         }
         return false;
@@ -133,7 +135,7 @@ public:
 
     TryReadResult try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result) const
+        bytes32_t const &key, byte_string &result) const
     {
         auto const fn =
             [&address, incarnation, &key, &result](ProposalState const &ps) {

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -3287,10 +3287,10 @@ TEST_F(EthCallFixture, prestate_override_state)
     commit_sequential(
         tdb, deltas, {{code_hash, compiled_code}}, BlockHeader{.number = 0});
 
-    auto const storage = tdb.read_storage(
+    auto const storage = to_bytes(tdb.read_storage(
         CONTRACT_ADDR,
         Incarnation{0, 0},
-        to_bytes(to_big_endian(uint256_t{0})));
+        to_bytes(to_big_endian(uint256_t{0}))));
     ASSERT_EQ(storage, to_bytes(to_big_endian(uint256_t{uint64_t{64}})));
 
     for (uint64_t i = 1; i < 256; ++i) {

--- a/category/statesync/statesync_protocol.cpp
+++ b/category/statesync/statesync_protocol.cpp
@@ -33,7 +33,7 @@ bytes32_t read_storage(
     monad_statesync_client_context &ctx, Address const &addr,
     bytes32_t const &key)
 {
-    return ctx.tdb.read_storage(addr, Incarnation{0, 0}, key);
+    return to_bytes(ctx.tdb.read_storage(addr, Incarnation{0, 0}, key));
 }
 
 void account_update(

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -225,7 +225,7 @@ monad_statesync_server_context::read_account(Address const &addr)
     return rw.read_account(addr);
 }
 
-bytes32_t monad_statesync_server_context::read_storage(
+byte_string monad_statesync_server_context::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
     return rw.read_storage(addr, incarnation, key);

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -101,7 +101,7 @@ struct monad_statesync_server_context final : public monad::Db
     virtual std::optional<monad::Account>
     read_account(monad::Address const &addr) override;
 
-    virtual monad::bytes32_t read_storage(
+    virtual monad::byte_string read_storage(
         monad::Address const &addr, monad::Incarnation,
         monad::bytes32_t const &key) override;
 

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -210,7 +210,8 @@ namespace
         MONAD_ASSERT(begin != end);
         bytes32_t const key{erase ? begin : n % (end - begin) + begin};
         bytes32_t const value{erase ? 0 : n};
-        auto const sorig = db.read_storage(addr, orig->incarnation, key);
+        auto const sorig =
+            to_bytes(db.read_storage(addr, orig->incarnation, key));
         bool const success = deltas.emplace(
             addr,
             StateDelta{


### PR DESCRIPTION
## Summary

Change the execution `Db::read_storage()` API to return `byte_string` instead of `bytes32_t`. The returned bytes are the zeroless view of the slot value, equivalent to `zeroless_view(to_byte_string_view(slot_value.bytes))`.

In TrieDb, this is just propagating the result of `decode_storage_db_ignore_slot()` directly: 
```
    auto const storage = decode_storage_db_ignore_slot(encoded_storage);
    MONAD_ASSERT(!storage.has_error());
    return byte_string{storage.value()};
```
## Motivation                                                                                                                          

Prep work for pagified storage. The on-disk encoding of a storage page will be:                                                     
                  
 ```
rlp_encode_list([encode_bytes32_compact(key), encode_string(encode_storage_page(page))])                                            
```
                  
`Db::read_storage()` will need to return the second list element with the RLP string wrap stripped, which is naturally a              
variable-length byte string rather than a fixed bytes32_t. Switching the API now lets later page-format work plug in without churning every caller again.  

## Future Work
Make the LRU in DbCache both size and memory bound.

