### PR TITLE
eth_createAccessList: deduplicate storage keys by page under MIP-8

### DIFF
--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -29,6 +29,7 @@
 #include <category/execution/ethereum/state3/account_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -261,11 +262,21 @@ namespace trace
         for (auto const &[address, storage_keys] : accesses_) {
             auto &entry = entries.emplace_back();
             entry.address = address;
-            entry.storage_keys.assign(storage_keys.begin(), storage_keys.end());
             // Match go-ethereum's access-list tracer output order: storage
             // keys are sorted within each address, then entries are sorted by
             // address below.
+            entry.storage_keys.assign(storage_keys.begin(), storage_keys.end());
             std::ranges::sort(entry.storage_keys);
+            if constexpr (traits::mip_8_active()) {
+                // Under page-gas (MIP-8), warming one slot warms all 128 slots
+                // on its page, so keep only one representative per page. The
+                // keys are already sorted ascending, so each page's slots are
+                // contiguous and unique() retains the first (= minimum) of
+                // each run -- avoiding charging users for redundant entries.
+                auto const dups = std::ranges::unique(
+                    entry.storage_keys, {}, compute_page_key);
+                entry.storage_keys.erase(dups.begin(), dups.end());
+            }
         }
         std::ranges::sort(entries, {}, &AccessListEntry::address);
 

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -53,6 +53,7 @@
 
 #include <test_resource_data.h>
 
+#include <algorithm>
 #include <bit>
 #include <optional>
 #include <vector>
@@ -77,6 +78,10 @@ namespace
         0x8d8ebb65ec00cb973d4fe086a607728fd1b9de14aa48208381eed9592f0dee9a_bytes32;
     constexpr auto key7 =
         0xff896b09014882056009dedb136458f017fcef9a4729467d0d00b4fd413fb1f1_bytes32;
+    constexpr auto page0_slot1 =
+        0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+    constexpr auto page1_slot0 =
+        0x0000000000000000000000000000000000000000000000000000000000000080_bytes32;
     constexpr auto value1 =
         0x0000000000000000000000000000000000000000000000000000000000000003_bytes32;
     constexpr auto value2 =
@@ -2249,4 +2254,341 @@ TYPED_TEST(MonadTraitsTest, code_tracer_records_reserve_balance_code)
     EXPECT_EQ(
         byte_string_view(it_b->second->code(), it_b->second->size()),
         byte_string_view(B_ICODE->code(), B_ICODE->size()));
+}
+
+// Under MIP-8 (mip_8_active), eth_createAccessList deduplicates storage keys
+// to one minimum-slot representative per page.
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_same_page)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // key4 (0x...00) and page0_slot1 (0x...01) are on the same page (both <
+    // 128)
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, page0_slot1);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    auto const json_str = R"([
+        {
+            "address": "0xc8ba32cab1757528daf49033e3673fae77dcf05d",
+            "storageKeys": [
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            ]
+        }
+    ])";
+
+    EXPECT_EQ(storage, nlohmann::json::parse(json_str));
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_same_page_three_slots)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // Slots 0, 1, 2 are all on page 0; only slot 0 should survive.
+    constexpr auto page0_slot2 =
+        0x0000000000000000000000000000000000000000000000000000000000000002_bytes32;
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, page0_slot1);
+    s.access_storage<typename TestFixture::Trait>(addr4, page0_slot2);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    auto const json_str = R"([
+        {
+            "address": "0xc8ba32cab1757528daf49033e3673fae77dcf05d",
+            "storageKeys": [
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            ]
+        }
+    ])";
+
+    EXPECT_EQ(storage, nlohmann::json::parse(json_str));
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_mip8_passthrough_two_addresses)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+    s.create_account_no_rollback(addr5);
+
+    // Two addresses each with one slot in page-gas mode; both must appear in
+    // the output unchanged (no dedup occurs because each address sees only one
+    // slot).
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr5, page1_slot0);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    // Sort outer array by address for deterministic comparison
+    std::sort(storage.begin(), storage.end(), [](auto const &a, auto const &b) {
+        return a["address"] < b["address"];
+    });
+
+    auto const json_str = R"([
+        {
+            "address": "0xc8ba32cab1757528daf49033e3673fae77dcf05d",
+            "storageKeys": [
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            ]
+        },
+        {
+            "address": "0xe02ad958162c9acb9c3eb90f67b02db21b10d3e0",
+            "storageKeys": [
+                "0x0000000000000000000000000000000000000000000000000000000000000080"
+            ]
+        }
+    ])";
+
+    EXPECT_EQ(storage, nlohmann::json::parse(json_str));
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_one_addr_two_pages)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // key4 (0x...00, page 0) and page1_slot0 (0x...80 = 128, page 1) are on
+    // different pages under the same address — both representatives must
+    // survive
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, page1_slot0);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    ASSERT_EQ(storage.size(), 1U);
+    EXPECT_EQ(
+        storage[0]["address"], "0xc8ba32cab1757528daf49033e3673fae77dcf05d");
+    auto two_page_keys = storage[0]["storageKeys"];
+    std::sort(two_page_keys.begin(), two_page_keys.end());
+    ASSERT_EQ(two_page_keys.size(), 2U);
+    EXPECT_EQ(
+        two_page_keys[0],
+        "0x0000000000000000000000000000000000000000000000000000000000000000");
+    EXPECT_EQ(
+        two_page_keys[1],
+        "0x0000000000000000000000000000000000000000000000000000000000000080");
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_old_revision)
+{
+    if constexpr (TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP()
+            << "old-revision behaviour only tested before mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // Same page, but old revisions return all accessed slots unchanged
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, page0_slot1);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    ASSERT_EQ(storage.size(), 1U);
+    EXPECT_EQ(
+        storage[0]["address"], "0xc8ba32cab1757528daf49033e3673fae77dcf05d");
+    auto old_keys = storage[0]["storageKeys"];
+    std::sort(old_keys.begin(), old_keys.end());
+    ASSERT_EQ(old_keys.size(), 2U);
+    EXPECT_EQ(
+        old_keys[0],
+        "0x0000000000000000000000000000000000000000000000000000000000000000");
+    EXPECT_EQ(
+        old_keys[1],
+        "0x0000000000000000000000000000000000000000000000000000000000000001");
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_page_boundary)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // 0x7f (127) is the last slot on page 0; 0x80 (128) is the first slot on
+    // page 1. Both must survive deduplication since they are on different
+    // pages.
+    constexpr auto page0_last =
+        0x000000000000000000000000000000000000000000000000000000000000007f_bytes32;
+    s.access_storage<typename TestFixture::Trait>(addr4, page0_last);
+    s.access_storage<typename TestFixture::Trait>(addr4, page1_slot0);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    ASSERT_EQ(storage.size(), 1U);
+    EXPECT_EQ(
+        storage[0]["address"], "0xc8ba32cab1757528daf49033e3673fae77dcf05d");
+    auto boundary_keys = storage[0]["storageKeys"];
+    std::sort(boundary_keys.begin(), boundary_keys.end());
+    ASSERT_EQ(boundary_keys.size(), 2U);
+    EXPECT_EQ(
+        boundary_keys[0],
+        "0x000000000000000000000000000000000000000000000000000000000000007f");
+    EXPECT_EQ(
+        boundary_keys[1],
+        "0x0000000000000000000000000000000000000000000000000000000000000080");
+}
+
+TYPED_TEST(MonadTraitsTest, access_list_page_dedup_multi_byte_page_boundary)
+{
+    if constexpr (!TestFixture::Trait::mip_8_active()) {
+        GTEST_SKIP() << "page-gas dedup only active when mip_8_active";
+    }
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
+
+    BlockState bs(tdb, vm);
+    State s(bs, Incarnation{0, 0});
+
+    s.create_account_no_rollback(addr1);
+    s.create_account_no_rollback(addr2);
+    s.create_account_no_rollback(addr3);
+    s.create_account_no_rollback(addr4);
+
+    // 0x00ff is the last slot on page 1; 0x0100 is the first slot on page 2.
+    // key.bytes[30] == 0x01 for slot 0x0100, so the carry term
+    // (key.bytes[i-1] << 1) is non-zero — exercising cross-byte shifting.
+    // Both slots must survive deduplication since they are on different pages.
+    constexpr auto page1_last =
+        0x00000000000000000000000000000000000000000000000000000000000000ff_bytes32;
+    constexpr auto page2_first =
+        0x0000000000000000000000000000000000000000000000000000000000000100_bytes32;
+    s.access_storage<typename TestFixture::Trait>(addr4, page1_last);
+    s.access_storage<typename TestFixture::Trait>(addr4, page2_first);
+
+    nlohmann::json storage;
+    auto const authorities = std::vector<std::optional<Address>>{};
+    auto const to = std::optional<Address>{addr3};
+    AccessListTracer tracer{storage, addr1, addr2, to, authorities};
+    tracer.encode<typename TestFixture::Trait>(s);
+
+    ASSERT_EQ(storage.size(), 1U);
+    EXPECT_EQ(
+        storage[0]["address"], "0xc8ba32cab1757528daf49033e3673fae77dcf05d");
+    auto boundary_keys = storage[0]["storageKeys"];
+    std::sort(boundary_keys.begin(), boundary_keys.end());
+    ASSERT_EQ(boundary_keys.size(), 2U);
+    EXPECT_EQ(
+        boundary_keys[0],
+        "0x00000000000000000000000000000000000000000000000000000000000000ff");
+    EXPECT_EQ(
+        boundary_keys[1],
+        "0x0000000000000000000000000000000000000000000000000000000000000100");
 }

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -3046,6 +3046,113 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
     monad_executor_destroy(executor);
 }
 
+// Requires CHAIN_CONFIG_MONAD_DEVNET (MONAD_NEXT), which activates
+// mip_8_active().
+TEST_F(EthCallFixture, access_list_trace_page_dedup)
+{
+    for (uint64_t i = 0; i < 256; ++i) {
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
+    }
+
+    static constexpr auto sender =
+        0x00000000000000000000000000000000deadbeef_address;
+
+    // SSTORE(0, 1); SSTORE(1, 1) — both slots on page 0 (page_shift=7, 128-slot
+    // pages)
+    static constexpr auto contract_address =
+        0x00000000000000000000000000000000aaaaaaaa_address;
+    auto const contract_code = 0x60016000556001600155_bytes;
+    auto const contract_code_hash = to_bytes(keccak256(contract_code));
+    auto const contract_icode = vm::make_shared_intercode(contract_code);
+
+    auto const header = BlockHeader{.number = 256};
+
+    commit_sequential(
+        tdb,
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {contract_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = contract_code_hash}}}}}),
+        Code{
+            {contract_code_hash, contract_icode},
+        },
+        header);
+
+    Transaction const tx{
+        .max_fee_per_gas = 1,
+        .gas_limit = 1'000'000,
+        .value = 0,
+        .to = contract_address,
+    };
+
+    auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
+    auto const rlp_header = to_vec(rlp::encode_block_header(header));
+    auto const rlp_sender =
+        to_vec(rlp::encode_address(std::make_optional(sender)));
+    auto const rlp_block_id = to_vec(rlp_finalized_id);
+
+    auto *executor = create_executor(dbname.string());
+    auto *state_override = monad_state_override_create();
+
+    struct callback_context ctx;
+
+    {
+        boost::fibers::future<void> f = ctx.promise.get_future();
+        monad_executor_eth_call_submit(
+            executor,
+            CHAIN_CONFIG_MONAD_DEVNET,
+            rlp_tx.data(),
+            rlp_tx.size(),
+            rlp_header.data(),
+            rlp_header.size(),
+            rlp_sender.data(),
+            rlp_sender.size(),
+            header.number,
+            rlp_block_id.data(),
+            rlp_block_id.size(),
+            state_override,
+            complete_callback,
+            (void *)&ctx,
+            ACCESS_LIST_TRACER,
+            true);
+        f.get();
+
+        ASSERT_TRUE(ctx.result->status_code == EVMC_SUCCESS);
+
+        std::vector<uint8_t> const encoded_trace(
+            ctx.result->encoded_trace,
+            ctx.result->encoded_trace + ctx.result->encoded_trace_len);
+
+        // Under page_gas, only the minimum slot per page is returned.
+        // Slots 0x00 and 0x01 share page 0; only 0x00 survives dedup.
+        auto const *const expected = R"([
+            {
+                "address" : "0x00000000000000000000000000000000aaaaaaaa",
+                "storageKeys" : [
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ]
+            }
+        ])";
+
+        EXPECT_EQ(
+            nlohmann::json::parse(expected),
+            nlohmann::json::from_cbor(encoded_trace));
+    }
+
+    monad_state_override_destroy(state_override);
+    monad_executor_destroy(executor);
+}
+
 TEST_F(EthCallFixture, access_list_trace_empty)
 {
     for (uint64_t i = 0; i < 256; ++i) {


### PR DESCRIPTION
Under page-gas (monad_pricing_version >= 2 / MONAD_NEXT), the EVM warms an entire 128-slot page when any slot on that page is accessed. Including multiple slots from the same page in the access list wastes users' gas (1,900 per entry) with no benefit.

AccessListTracer::encode now keeps only the minimum slot per page when page_gas_active(), reducing the returned access list to the cheapest set that achieves the same warming effect.

Adds monad_pricing_version 2 and page_gas_active()/storage_page_shift() to MonadTraits (concept + defaults + MonadRevision), and five MonadTraitsTest cases covering same-page deduplication (2-slot and 3-slot), different-page retention, one-address two-pages, and pre-MONAD_NEXT unchanged behaviour.