### PR TITLE
core: copy silkpre's sha256 and rmd160 into third_party

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,9 @@ target_compile_options(
   ff
   PRIVATE -Wno-unused-parameter -Wno-unused-const-variable -Wno-uninitialized)
 
+# silkpre_vendor (vendored sha256 + rmd160)
+add_subdirectory("third_party/silkpre_vendor")
+
 # tbb
 find_package(TBB REQUIRED)
 

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -308,6 +308,7 @@ target_link_libraries(
   PRIVATE Boost::fiber
   PRIVATE Boost::json
   PUBLIC c-kzg-4844
+  PRIVATE monad_crypto
   PRIVATE PkgConfig::brotli
   PRIVATE PkgConfig::crypto++
   PUBLIC ethash::keccak

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -36,13 +36,15 @@
 
 #include <evmc/evmc.h>
 
+#include <silkpre_vendor/rmd160.h>
+#include <silkpre_vendor/sha256.h>
+
 #include <setup/settings.h>
 #include <setup/setup.h>
 
 #include <stdio.h>
 
 #include <silkpre/precompile.h>
-#include <silkpre/sha256.h>
 
 #include <cstdint>
 #include <cstdlib>
@@ -58,8 +60,7 @@ namespace
     {
         constexpr uint8_t VERSION_HASH_VERSION_KZG = 1;
         monad::bytes32_t h;
-        // TODO: remove silkpre
-        silkpre_sha256(
+        monad_sha256(
             h.bytes,
             commitment.bytes,
             sizeof(KZGCommitment),
@@ -114,6 +115,15 @@ static inline PrecompileResult silkpre_execute(byte_string_view const input)
     return {EVMC_SUCCESS, output, output_size};
 }
 
+// Substitute a pointer to the empty string when `input.data()` is null.
+// monad_sha256 / monad_rmd160 invoke undefined behaviour on a null input
+// pointer even when the length is zero.
+static inline uint8_t const *nonnull_input_data(byte_string_view const input)
+{
+    return input.data() != nullptr ? input.data()
+                                   : reinterpret_cast<uint8_t const *>("");
+}
+
 PrecompileResult ecrecover_execute(byte_string_view const input)
 {
     auto const clamped_input = input.substr(0, 128);
@@ -122,20 +132,29 @@ PrecompileResult ecrecover_execute(byte_string_view const input)
 
 PrecompileResult sha256_execute(byte_string_view const input)
 {
-    if (MONAD_UNLIKELY(input.data() == nullptr)) {
-        // Passing a null pointer to the Silkpre sha256 implementation invokes
-        // undefined behaviour. We sidestep the UB here by passing a pointer to
-        // the empty string instead.
-        byte_string_view const nonnull{
-            reinterpret_cast<unsigned char const *>(""), 0UL};
-        return silkpre_execute<silkpre_sha256_run>(nonnull);
-    }
-    return silkpre_execute<silkpre_sha256_run>(input);
+    auto *const output = static_cast<uint8_t *>(std::malloc(32));
+    MONAD_ASSERT(output != nullptr);
+
+    monad_sha256(
+        output,
+        nonnull_input_data(input),
+        input.size(),
+        /*use_cpu_extensions=*/true);
+
+    return {EVMC_SUCCESS, output, 32};
 }
 
 PrecompileResult ripemd160_execute(byte_string_view const input)
 {
-    return silkpre_execute<silkpre_rip160_run>(input);
+    auto *const output = static_cast<uint8_t *>(std::malloc(32));
+    MONAD_ASSERT(output != nullptr);
+
+    // Ethereum's RIPEMD-160 precompile returns the 20-byte digest left-padded
+    // with 12 zero bytes to a 32-byte ABI word.
+    std::memset(output, 0, 12);
+    monad_rmd160(output + 12, nonnull_input_data(input), input.size());
+
+    return {EVMC_SUCCESS, output, 32};
 }
 
 PrecompileResult ecadd_execute(byte_string_view const input)

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -31,7 +31,7 @@
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
-#include <silkpre/sha256.h>
+#include <silkpre_vendor/sha256.h>
 
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
@@ -239,7 +239,7 @@ bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
         buf.reserve(1 + req.data.size());
         buf.push_back(req.type);
         buf.append_range(req.data);
-        silkpre_sha256(inner.bytes, buf.data(), buf.size(), true);
+        monad_sha256(inner.bytes, buf.data(), buf.size(), true);
         inner_hashes.append_range(inner.bytes);
     }
 
@@ -247,7 +247,7 @@ bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
     bytes32_t outer_hash;
     uint8_t const *outer_input =
         inner_hashes.empty() ? &EMPTY_SHA256_INPUT : inner_hashes.data();
-    silkpre_sha256(outer_hash.bytes, outer_input, inner_hashes.size(), true);
+    monad_sha256(outer_hash.bytes, outer_input, inner_hashes.size(), true);
     return outer_hash;
 }
 

--- a/third_party/silkpre_vendor/CMakeLists.txt
+++ b/third_party/silkpre_vendor/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# SHA-256 and RIPEMD-160 implementations vendored from silkpre.
+# See NOTICE and LICENSE.
+
+add_library(monad_crypto STATIC)
+
+monad_compile_options(monad_crypto)
+
+target_sources(monad_crypto PRIVATE
+  "src/silkpre_vendor/rmd160.c"
+  "src/silkpre_vendor/rmd160.h"
+  "src/silkpre_vendor/sha256.c"
+  "src/silkpre_vendor/sha256.h"
+)
+
+# Consumers include the headers via `<silkpre_vendor/sha256.h>` etc.
+target_include_directories(monad_crypto PUBLIC src/)
+
+# Silence the warnings these vendored sources legitimately trip on; the
+# upstream silkpre build doesn't enforce them.
+target_compile_options(monad_crypto PRIVATE
+  -Wno-conversion -Wno-sign-conversion)

--- a/third_party/silkpre_vendor/LICENSE
+++ b/third_party/silkpre_vendor/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/silkpre_vendor/NOTICE
+++ b/third_party/silkpre_vendor/NOTICE
@@ -1,0 +1,16 @@
+This directory contains code vendored from the Silkpre project
+(https://github.com/category-labs/silkpre), licensed under the Apache
+License v2.0. See LICENSE for the full license text.
+
+sha256.c / sha256.h are derived from public-domain implementations
+by Alain Mosnier (amosnier/sha-2), Jeffrey Walton
+(noloader/SHA-Intrinsics), and Alexander Yee (Mysticial/FeatureDetector),
+wrapped under the Silkpre Apache-2.0 copyright.
+
+rmd160.c / rmd160.h carry their own MIT-style permissive license,
+originally Copyright (c) 1996 Katholieke Universiteit Leuven
+(Antoon Bosselaers); the full notice is preserved in the file headers.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
@@ -1,0 +1,387 @@
+/********************************************************************\
+ *
+ *      FILE:     rmd160.c
+ *
+ *      CONTENTS: A sample C-implementation of the RIPEMD-160
+ *                hash-function.
+ *      TARGET:   any computer with an ANSI C compiler
+ *
+ *      AUTHOR:   Antoon Bosselaers, ESAT-COSIC
+ *      DATE:     1 March 1996
+ *      MODIFIED: 2020-2022 by Andrew Ashikhmin
+ *
+ *      Copyright (c) 1996 Katholieke Universiteit Leuven
+ *
+ *      Permission is hereby granted, free of charge, to any person
+ *      obtaining a copy of this software and associated documentation
+ *      files (the "Software"), to deal in the Software without restriction,
+ *      including without limitation the rights to use, copy, modify, merge,
+ *      publish, distribute, sublicense, and/or sell copies of the Software,
+ *      and to permit persons to whom the Software is furnished to do so,
+ *      subject to the following conditions:
+ *
+ *      The above copyright notice and this permission notice shall be
+ *      included in all copies or substantial portions of the Software.
+ *
+ *      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+\********************************************************************/
+
+/*  header files */
+#include "rmd160.h"
+
+#include <string.h>
+
+/********************************************************************/
+
+/* macro definitions */
+
+/* ROL(x, n) cyclically rotates x over n bits to the left */
+/* x must be of an unsigned 32 bits type and 0 <= n < 32. */
+#define ROL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+/* the five basic functions F(), G() and H() */
+#define F(x, y, z) ((x) ^ (y) ^ (z))
+#define G(x, y, z) (((x) & (y)) | (~(x) & (z)))
+#define H(x, y, z) (((x) | ~(y)) ^ (z))
+#define I(x, y, z) (((x) & (z)) | ((y) & ~(z)))
+#define J(x, y, z) ((x) ^ ((y) | ~(z)))
+
+/* the ten basic operations FF() through III() */
+#define FF(a, b, c, d, e, x, s)        \
+    {                                  \
+        (a) += F((b), (c), (d)) + (x); \
+        (a) = ROL((a), (s)) + (e);     \
+        (c) = ROL((c), 10);            \
+    }
+#define GG(a, b, c, d, e, x, s)                       \
+    {                                                 \
+        (a) += G((b), (c), (d)) + (x) + 0x5a827999UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define HH(a, b, c, d, e, x, s)                       \
+    {                                                 \
+        (a) += H((b), (c), (d)) + (x) + 0x6ed9eba1UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define II(a, b, c, d, e, x, s)                       \
+    {                                                 \
+        (a) += I((b), (c), (d)) + (x) + 0x8f1bbcdcUL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define JJ(a, b, c, d, e, x, s)                       \
+    {                                                 \
+        (a) += J((b), (c), (d)) + (x) + 0xa953fd4eUL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define FFF(a, b, c, d, e, x, s)       \
+    {                                  \
+        (a) += F((b), (c), (d)) + (x); \
+        (a) = ROL((a), (s)) + (e);     \
+        (c) = ROL((c), 10);            \
+    }
+#define GGG(a, b, c, d, e, x, s)                      \
+    {                                                 \
+        (a) += G((b), (c), (d)) + (x) + 0x7a6d76e9UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define HHH(a, b, c, d, e, x, s)                      \
+    {                                                 \
+        (a) += H((b), (c), (d)) + (x) + 0x6d703ef3UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define III(a, b, c, d, e, x, s)                      \
+    {                                                 \
+        (a) += I((b), (c), (d)) + (x) + 0x5c4dd124UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+#define JJJ(a, b, c, d, e, x, s)                      \
+    {                                                 \
+        (a) += J((b), (c), (d)) + (x) + 0x50a28be6UL; \
+        (a) = ROL((a), (s)) + (e);                    \
+        (c) = ROL((c), 10);                           \
+    }
+
+/*
+ *  initializes MDbuffer to "magic constants"
+ */
+static inline void rmd160_init(uint32_t* MDbuf) {
+    MDbuf[0] = 0x67452301UL;
+    MDbuf[1] = 0xefcdab89UL;
+    MDbuf[2] = 0x98badcfeUL;
+    MDbuf[3] = 0x10325476UL;
+    MDbuf[4] = 0xc3d2e1f0UL;
+}
+
+/*
+ *  the compression function.
+ *  transforms MDbuf using message bytes X[0] through X[15]
+ */
+static inline void rmd160_compress(uint32_t* MDbuf, const uint32_t* X) {
+    uint32_t aa = MDbuf[0], bb = MDbuf[1], cc = MDbuf[2], dd = MDbuf[3], ee = MDbuf[4];
+    uint32_t aaa = MDbuf[0], bbb = MDbuf[1], ccc = MDbuf[2], ddd = MDbuf[3], eee = MDbuf[4];
+
+    /* round 1 */
+    FF(aa, bb, cc, dd, ee, X[0], 11);
+    FF(ee, aa, bb, cc, dd, X[1], 14);
+    FF(dd, ee, aa, bb, cc, X[2], 15);
+    FF(cc, dd, ee, aa, bb, X[3], 12);
+    FF(bb, cc, dd, ee, aa, X[4], 5);
+    FF(aa, bb, cc, dd, ee, X[5], 8);
+    FF(ee, aa, bb, cc, dd, X[6], 7);
+    FF(dd, ee, aa, bb, cc, X[7], 9);
+    FF(cc, dd, ee, aa, bb, X[8], 11);
+    FF(bb, cc, dd, ee, aa, X[9], 13);
+    FF(aa, bb, cc, dd, ee, X[10], 14);
+    FF(ee, aa, bb, cc, dd, X[11], 15);
+    FF(dd, ee, aa, bb, cc, X[12], 6);
+    FF(cc, dd, ee, aa, bb, X[13], 7);
+    FF(bb, cc, dd, ee, aa, X[14], 9);
+    FF(aa, bb, cc, dd, ee, X[15], 8);
+
+    /* round 2 */
+    GG(ee, aa, bb, cc, dd, X[7], 7);
+    GG(dd, ee, aa, bb, cc, X[4], 6);
+    GG(cc, dd, ee, aa, bb, X[13], 8);
+    GG(bb, cc, dd, ee, aa, X[1], 13);
+    GG(aa, bb, cc, dd, ee, X[10], 11);
+    GG(ee, aa, bb, cc, dd, X[6], 9);
+    GG(dd, ee, aa, bb, cc, X[15], 7);
+    GG(cc, dd, ee, aa, bb, X[3], 15);
+    GG(bb, cc, dd, ee, aa, X[12], 7);
+    GG(aa, bb, cc, dd, ee, X[0], 12);
+    GG(ee, aa, bb, cc, dd, X[9], 15);
+    GG(dd, ee, aa, bb, cc, X[5], 9);
+    GG(cc, dd, ee, aa, bb, X[2], 11);
+    GG(bb, cc, dd, ee, aa, X[14], 7);
+    GG(aa, bb, cc, dd, ee, X[11], 13);
+    GG(ee, aa, bb, cc, dd, X[8], 12);
+
+    /* round 3 */
+    HH(dd, ee, aa, bb, cc, X[3], 11);
+    HH(cc, dd, ee, aa, bb, X[10], 13);
+    HH(bb, cc, dd, ee, aa, X[14], 6);
+    HH(aa, bb, cc, dd, ee, X[4], 7);
+    HH(ee, aa, bb, cc, dd, X[9], 14);
+    HH(dd, ee, aa, bb, cc, X[15], 9);
+    HH(cc, dd, ee, aa, bb, X[8], 13);
+    HH(bb, cc, dd, ee, aa, X[1], 15);
+    HH(aa, bb, cc, dd, ee, X[2], 14);
+    HH(ee, aa, bb, cc, dd, X[7], 8);
+    HH(dd, ee, aa, bb, cc, X[0], 13);
+    HH(cc, dd, ee, aa, bb, X[6], 6);
+    HH(bb, cc, dd, ee, aa, X[13], 5);
+    HH(aa, bb, cc, dd, ee, X[11], 12);
+    HH(ee, aa, bb, cc, dd, X[5], 7);
+    HH(dd, ee, aa, bb, cc, X[12], 5);
+
+    /* round 4 */
+    II(cc, dd, ee, aa, bb, X[1], 11);
+    II(bb, cc, dd, ee, aa, X[9], 12);
+    II(aa, bb, cc, dd, ee, X[11], 14);
+    II(ee, aa, bb, cc, dd, X[10], 15);
+    II(dd, ee, aa, bb, cc, X[0], 14);
+    II(cc, dd, ee, aa, bb, X[8], 15);
+    II(bb, cc, dd, ee, aa, X[12], 9);
+    II(aa, bb, cc, dd, ee, X[4], 8);
+    II(ee, aa, bb, cc, dd, X[13], 9);
+    II(dd, ee, aa, bb, cc, X[3], 14);
+    II(cc, dd, ee, aa, bb, X[7], 5);
+    II(bb, cc, dd, ee, aa, X[15], 6);
+    II(aa, bb, cc, dd, ee, X[14], 8);
+    II(ee, aa, bb, cc, dd, X[5], 6);
+    II(dd, ee, aa, bb, cc, X[6], 5);
+    II(cc, dd, ee, aa, bb, X[2], 12);
+
+    /* round 5 */
+    JJ(bb, cc, dd, ee, aa, X[4], 9);
+    JJ(aa, bb, cc, dd, ee, X[0], 15);
+    JJ(ee, aa, bb, cc, dd, X[5], 5);
+    JJ(dd, ee, aa, bb, cc, X[9], 11);
+    JJ(cc, dd, ee, aa, bb, X[7], 6);
+    JJ(bb, cc, dd, ee, aa, X[12], 8);
+    JJ(aa, bb, cc, dd, ee, X[2], 13);
+    JJ(ee, aa, bb, cc, dd, X[10], 12);
+    JJ(dd, ee, aa, bb, cc, X[14], 5);
+    JJ(cc, dd, ee, aa, bb, X[1], 12);
+    JJ(bb, cc, dd, ee, aa, X[3], 13);
+    JJ(aa, bb, cc, dd, ee, X[8], 14);
+    JJ(ee, aa, bb, cc, dd, X[11], 11);
+    JJ(dd, ee, aa, bb, cc, X[6], 8);
+    JJ(cc, dd, ee, aa, bb, X[15], 5);
+    JJ(bb, cc, dd, ee, aa, X[13], 6);
+
+    /* parallel round 1 */
+    JJJ(aaa, bbb, ccc, ddd, eee, X[5], 8);
+    JJJ(eee, aaa, bbb, ccc, ddd, X[14], 9);
+    JJJ(ddd, eee, aaa, bbb, ccc, X[7], 9);
+    JJJ(ccc, ddd, eee, aaa, bbb, X[0], 11);
+    JJJ(bbb, ccc, ddd, eee, aaa, X[9], 13);
+    JJJ(aaa, bbb, ccc, ddd, eee, X[2], 15);
+    JJJ(eee, aaa, bbb, ccc, ddd, X[11], 15);
+    JJJ(ddd, eee, aaa, bbb, ccc, X[4], 5);
+    JJJ(ccc, ddd, eee, aaa, bbb, X[13], 7);
+    JJJ(bbb, ccc, ddd, eee, aaa, X[6], 7);
+    JJJ(aaa, bbb, ccc, ddd, eee, X[15], 8);
+    JJJ(eee, aaa, bbb, ccc, ddd, X[8], 11);
+    JJJ(ddd, eee, aaa, bbb, ccc, X[1], 14);
+    JJJ(ccc, ddd, eee, aaa, bbb, X[10], 14);
+    JJJ(bbb, ccc, ddd, eee, aaa, X[3], 12);
+    JJJ(aaa, bbb, ccc, ddd, eee, X[12], 6);
+
+    /* parallel round 2 */
+    III(eee, aaa, bbb, ccc, ddd, X[6], 9);
+    III(ddd, eee, aaa, bbb, ccc, X[11], 13);
+    III(ccc, ddd, eee, aaa, bbb, X[3], 15);
+    III(bbb, ccc, ddd, eee, aaa, X[7], 7);
+    III(aaa, bbb, ccc, ddd, eee, X[0], 12);
+    III(eee, aaa, bbb, ccc, ddd, X[13], 8);
+    III(ddd, eee, aaa, bbb, ccc, X[5], 9);
+    III(ccc, ddd, eee, aaa, bbb, X[10], 11);
+    III(bbb, ccc, ddd, eee, aaa, X[14], 7);
+    III(aaa, bbb, ccc, ddd, eee, X[15], 7);
+    III(eee, aaa, bbb, ccc, ddd, X[8], 12);
+    III(ddd, eee, aaa, bbb, ccc, X[12], 7);
+    III(ccc, ddd, eee, aaa, bbb, X[4], 6);
+    III(bbb, ccc, ddd, eee, aaa, X[9], 15);
+    III(aaa, bbb, ccc, ddd, eee, X[1], 13);
+    III(eee, aaa, bbb, ccc, ddd, X[2], 11);
+
+    /* parallel round 3 */
+    HHH(ddd, eee, aaa, bbb, ccc, X[15], 9);
+    HHH(ccc, ddd, eee, aaa, bbb, X[5], 7);
+    HHH(bbb, ccc, ddd, eee, aaa, X[1], 15);
+    HHH(aaa, bbb, ccc, ddd, eee, X[3], 11);
+    HHH(eee, aaa, bbb, ccc, ddd, X[7], 8);
+    HHH(ddd, eee, aaa, bbb, ccc, X[14], 6);
+    HHH(ccc, ddd, eee, aaa, bbb, X[6], 6);
+    HHH(bbb, ccc, ddd, eee, aaa, X[9], 14);
+    HHH(aaa, bbb, ccc, ddd, eee, X[11], 12);
+    HHH(eee, aaa, bbb, ccc, ddd, X[8], 13);
+    HHH(ddd, eee, aaa, bbb, ccc, X[12], 5);
+    HHH(ccc, ddd, eee, aaa, bbb, X[2], 14);
+    HHH(bbb, ccc, ddd, eee, aaa, X[10], 13);
+    HHH(aaa, bbb, ccc, ddd, eee, X[0], 13);
+    HHH(eee, aaa, bbb, ccc, ddd, X[4], 7);
+    HHH(ddd, eee, aaa, bbb, ccc, X[13], 5);
+
+    /* parallel round 4 */
+    GGG(ccc, ddd, eee, aaa, bbb, X[8], 15);
+    GGG(bbb, ccc, ddd, eee, aaa, X[6], 5);
+    GGG(aaa, bbb, ccc, ddd, eee, X[4], 8);
+    GGG(eee, aaa, bbb, ccc, ddd, X[1], 11);
+    GGG(ddd, eee, aaa, bbb, ccc, X[3], 14);
+    GGG(ccc, ddd, eee, aaa, bbb, X[11], 14);
+    GGG(bbb, ccc, ddd, eee, aaa, X[15], 6);
+    GGG(aaa, bbb, ccc, ddd, eee, X[0], 14);
+    GGG(eee, aaa, bbb, ccc, ddd, X[5], 6);
+    GGG(ddd, eee, aaa, bbb, ccc, X[12], 9);
+    GGG(ccc, ddd, eee, aaa, bbb, X[2], 12);
+    GGG(bbb, ccc, ddd, eee, aaa, X[13], 9);
+    GGG(aaa, bbb, ccc, ddd, eee, X[9], 12);
+    GGG(eee, aaa, bbb, ccc, ddd, X[7], 5);
+    GGG(ddd, eee, aaa, bbb, ccc, X[10], 15);
+    GGG(ccc, ddd, eee, aaa, bbb, X[14], 8);
+
+    /* parallel round 5 */
+    FFF(bbb, ccc, ddd, eee, aaa, X[12], 8);
+    FFF(aaa, bbb, ccc, ddd, eee, X[15], 5);
+    FFF(eee, aaa, bbb, ccc, ddd, X[10], 12);
+    FFF(ddd, eee, aaa, bbb, ccc, X[4], 9);
+    FFF(ccc, ddd, eee, aaa, bbb, X[1], 12);
+    FFF(bbb, ccc, ddd, eee, aaa, X[5], 5);
+    FFF(aaa, bbb, ccc, ddd, eee, X[8], 14);
+    FFF(eee, aaa, bbb, ccc, ddd, X[7], 6);
+    FFF(ddd, eee, aaa, bbb, ccc, X[6], 8);
+    FFF(ccc, ddd, eee, aaa, bbb, X[2], 13);
+    FFF(bbb, ccc, ddd, eee, aaa, X[13], 6);
+    FFF(aaa, bbb, ccc, ddd, eee, X[14], 5);
+    FFF(eee, aaa, bbb, ccc, ddd, X[0], 15);
+    FFF(ddd, eee, aaa, bbb, ccc, X[3], 13);
+    FFF(ccc, ddd, eee, aaa, bbb, X[9], 11);
+    FFF(bbb, ccc, ddd, eee, aaa, X[11], 11);
+
+    /* combine results */
+    ddd += cc + MDbuf[1]; /* final result for MDbuf[0] */
+    MDbuf[1] = MDbuf[2] + dd + eee;
+    MDbuf[2] = MDbuf[3] + ee + aaa;
+    MDbuf[3] = MDbuf[4] + aa + bbb;
+    MDbuf[4] = MDbuf[0] + bb + ccc;
+    MDbuf[0] = ddd;
+}
+
+/*
+ *  puts bytes from strptr into X and pad out; appends length
+ *  and finally, compresses the last block(s)
+ *  note: length in bits == 8 * lswlen.
+ *  note: there are (lswlen mod 64) bytes left in strptr.
+ */
+static inline void rmd160_finish(uint32_t* MDbuf, uint8_t const* strptr, uint32_t lswlen) {
+    unsigned int i; /* counter       */
+    uint32_t X[16]; /* message words */
+
+    memset(X, 0, 16 * sizeof(uint32_t));
+
+    /* put bytes from strptr into X */
+    for (i = 0; i < (lswlen & 63); i++) {
+        /* byte i goes into word X[i div 4] at pos.  8*(i mod 4)  */
+        X[i >> 2] ^= (uint32_t)*strptr++ << (8 * (i & 3));
+    }
+
+    /* append the bit m_n == 1 */
+    X[(lswlen >> 2) & 15] ^= (uint32_t)1 << (8 * (lswlen & 3) + 7);
+
+    if ((lswlen & 63) > 55) {
+        /* length goes to next block */
+        rmd160_compress(MDbuf, X);
+        memset(X, 0, 16 * sizeof(uint32_t));
+    }
+
+    /* append length in bits*/
+    X[14] = lswlen << 3;
+    X[15] = lswlen >> 29;
+    rmd160_compress(MDbuf, X);
+}
+
+static inline uint32_t load32(const void* src) {
+    uint32_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+}
+
+void silkpre_rmd160(uint8_t out[20], const uint8_t* ptr, size_t len) {
+    uint32_t buf[160 / 32];
+
+    rmd160_init(buf);
+
+    uint32_t current[16];
+    for (size_t remaining = len; remaining >= 64; remaining -= 64) {
+        for (unsigned i = 0; i < 16; ++i) {
+            current[i] = load32(ptr);
+            ptr += 4;
+        }
+        rmd160_compress(buf, current);
+    }
+
+    rmd160_finish(buf, ptr, len);
+
+    for (unsigned i = 0; i < 20; i += 4) {
+        out[i] = buf[i >> 2];
+        out[i + 1] = buf[i >> 2] >> 8;
+        out[i + 2] = buf[i >> 2] >> 16;
+        out[i + 3] = buf[i >> 2] >> 24;
+    }
+}

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
@@ -31,10 +31,12 @@
  *      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  *      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
+ *      Modified 2026 by Category Labs: renamed silkpre_rmd160 to monad_rmd160.
+ *
 \********************************************************************/
 
 /*  header files */
-#include "rmd160.h"
+#include <silkpre_vendor/rmd160.h>
 
 #include <string.h>
 
@@ -362,7 +364,7 @@ static inline uint32_t load32(const void* src) {
     return w;
 }
 
-void silkpre_rmd160(uint8_t out[20], const uint8_t* ptr, size_t len) {
+void monad_rmd160(uint8_t out[20], const uint8_t* ptr, size_t len) {
     uint32_t buf[160 / 32];
 
     rmd160_init(buf);

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
@@ -1,0 +1,54 @@
+/********************************************************************\
+ *
+ *      FILE:     rmd160.h
+ *
+ *      CONTENTS: Header file for a sample C-implementation of the
+ *                RIPEMD-160 hash-function.
+ *      TARGET:   any computer with an ANSI C compiler
+ *
+ *      AUTHOR:   Antoon Bosselaers, ESAT-COSIC
+ *      DATE:     1 March 1996
+ *      MODIFIED: 2020-2022 by Andrew Ashikhmin
+ *
+ *      Copyright (c) 1996 Katholieke Universiteit Leuven
+ *
+ *      Permission is hereby granted, free of charge, to any person
+ *      obtaining a copy of this software and associated documentation
+ *      files (the "Software"), to deal in the Software without restriction,
+ *      including without limitation the rights to use, copy, modify, merge,
+ *      publish, distribute, sublicense, and/or sell copies of the Software,
+ *      and to permit persons to whom the Software is furnished to do so,
+ *      subject to the following conditions:
+ *
+ *      The above copyright notice and this permission notice shall be
+ *      included in all copies or substantial portions of the Software.
+ *
+ *      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *      Modified 2022 for Silkpre by Andrew Ashikhmin.
+ *
+\********************************************************************/
+
+#ifndef SILKPRE_RMD160_H_
+#define SILKPRE_RMD160_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+void silkpre_rmd160(uint8_t out[20], const uint8_t* input, size_t len);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // SILKPRE_RMD160_H_

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
@@ -33,10 +33,12 @@
  *
  *      Modified 2022 for Silkpre by Andrew Ashikhmin.
  *
+ *      Modified 2026 by Category Labs: renamed silkpre_rmd160 to monad_rmd160.
+ *
 \********************************************************************/
 
-#ifndef SILKPRE_RMD160_H_
-#define SILKPRE_RMD160_H_
+#ifndef MONAD_RMD160_H_
+#define MONAD_RMD160_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -45,10 +47,10 @@
 extern "C" {
 #endif
 
-void silkpre_rmd160(uint8_t out[20], const uint8_t* input, size_t len);
+void monad_rmd160(uint8_t out[20], const uint8_t* input, size_t len);
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif  // SILKPRE_RMD160_H_
+#endif  // MONAD_RMD160_H_

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
@@ -1,0 +1,703 @@
+/*
+   Copyright 2022 The Silkpre Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Based on several bits of code released to public domain:
+// https://github.com/amosnier/sha-2 (Author: Alain Mosnier)
+// https://github.com/noloader/SHA-Intrinsics (Author: Jeffrey Walton)
+// https://github.com/Mysticial/FeatureDetector (Author: Alexander Yee)
+
+#include "sha256.h"
+
+#include <string.h>
+
+#if defined(__x86_64__)
+
+#include <cpuid.h>
+#include <x86intrin.h>
+
+#elif defined(__aarch64__) && defined(__APPLE__)
+
+#include <arm_neon.h>
+
+#if defined(__linux__)
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif  // defined(__linux__), defined(__APPLE__)
+
+#endif  // defined(__x86_64__), defined(__aarch64__)
+
+#if _MSC_VER
+#define ALWAYS_INLINE __forceinline
+#elif __has_attribute(always_inline)
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+#define CHUNK_SIZE 64
+#define TOTAL_LEN_LEN 8
+
+/*
+ * Comments from pseudo-code at https://en.wikipedia.org/wiki/SHA-2 are reproduced here.
+ * When useful for clarification, portions of the pseudo-code are reproduced here too.
+ */
+
+/*
+ * Initialize array of round constants:
+ * (first 32 bits of the fractional parts of the cube roots of the first 64 primes 2..311):
+ */
+static const uint32_t k[] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+struct buffer_state {
+    const uint8_t* p;
+    size_t len;
+    size_t total_len;
+    bool single_one_delivered;
+    bool total_len_delivered;
+};
+
+static inline uint32_t right_rot(uint32_t value, unsigned int count) {
+    /*
+     * Defined behaviour in standard C for all count where 0 < count < 32,
+     * which is what we need here.
+     */
+    return value >> count | value << (32 - count);
+}
+
+static void init_buf_state(struct buffer_state* state, const void* input, size_t len) {
+    state->p = input;
+    state->len = len;
+    state->total_len = len;
+    state->single_one_delivered = false;
+    state->total_len_delivered = false;
+}
+
+static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state* state) {
+    if (state->total_len_delivered) {
+        return false;
+    }
+
+    if (state->len >= CHUNK_SIZE) {
+        memcpy(chunk, state->p, CHUNK_SIZE);
+        state->p += CHUNK_SIZE;
+        state->len -= CHUNK_SIZE;
+        return true;
+    }
+
+    memcpy(chunk, state->p, state->len);
+    chunk += state->len;
+    size_t space_in_chunk = CHUNK_SIZE - state->len;
+    if (state->len) {  // avoid adding 0 to nullptr
+        state->p += state->len;
+    }
+    state->len = 0;
+
+    /* If we are here, space_in_chunk is one at minimum. */
+    if (!state->single_one_delivered) {
+        *chunk++ = 0x80;
+        space_in_chunk -= 1;
+        state->single_one_delivered = true;
+    }
+
+    /*
+     * Now:
+     * - either there is enough space left for the total length, and we can conclude,
+     * - or there is too little space left, and we have to pad the rest of this chunk with zeroes.
+     * In the latter case, we will conclude at the next invocation of this function.
+     */
+    if (space_in_chunk >= TOTAL_LEN_LEN) {
+        const size_t left = space_in_chunk - TOTAL_LEN_LEN;
+        size_t len = state->total_len;
+        int i;
+        memset(chunk, 0x00, left);
+        chunk += left;
+
+        /* Storing of len * 8 as a big endian 64-bit without overflow. */
+        chunk[7] = (uint8_t)(len << 3);
+        len >>= 5;
+        for (i = 6; i >= 0; i--) {
+            chunk[i] = (uint8_t)len;
+            len >>= 8;
+        }
+        state->total_len_delivered = true;
+    } else {
+        memset(chunk, 0x00, space_in_chunk);
+    }
+
+    return true;
+}
+
+static inline ALWAYS_INLINE void sha_256_implementation(uint32_t h[8], const void* input, size_t len) {
+    /*
+     * Note 1: All integers (expect indexes) are 32-bit unsigned integers and addition is calculated modulo 2^32.
+     *
+     * Note 2: For each round, there is one round constant k[i] and one entry in the message schedule array w[i],
+     * 0 = i = 63
+     *
+     * Note 3: The compression function uses 8 working variables, a through h
+     *
+     * Note 4: Big-endian convention is used when expressing the constants in this pseudocode,
+     *     and when parsing message block data from bytes to words, for example,
+     *     the first word of the input message "abc" after padding is 0x61626380
+     */
+
+    struct buffer_state state;
+    init_buf_state(&state, input, len);
+
+    /* 512-bit chunks is what we will operate on. */
+    uint8_t chunk[CHUNK_SIZE];
+
+    while (calc_chunk(chunk, &state)) {
+        unsigned i, j;
+
+        uint32_t ah[8];
+        /* Initialize working variables to current hash value: */
+        for (i = 0; i < 8; i++) {
+            ah[i] = h[i];
+        }
+
+        const uint8_t* p = chunk;
+
+        /*
+         * The w-array is really w[64], but since we only need
+         * 16 of them at a time, we save stack by calculating
+         * 16 at a time.
+         *
+         * This optimization was not there initially and the
+         * rest of the comments about w[64] are kept in their
+         * initial state.
+         */
+
+        /*
+         * create a 64-entry message schedule array w[0..63] of 32-bit words
+         * (The initial values in w[0..63] don't matter, so many implementations zero them here)
+         * copy chunk into first 16 words w[0..15] of the message schedule array
+         */
+        uint32_t w[16];
+
+        /* Compression function main loop: */
+        for (i = 0; i < 4; i++) {
+            for (j = 0; j < 16; j++) {
+                if (i == 0) {
+                    w[j] = (uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 | (uint32_t)p[2] << 8 | (uint32_t)p[3];
+                    p += 4;
+                } else {
+                    /* Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array: */
+                    const uint32_t s0 =
+                        right_rot(w[(j + 1) & 0xf], 7) ^ right_rot(w[(j + 1) & 0xf], 18) ^ (w[(j + 1) & 0xf] >> 3);
+                    const uint32_t s1 =
+                        right_rot(w[(j + 14) & 0xf], 17) ^ right_rot(w[(j + 14) & 0xf], 19) ^ (w[(j + 14) & 0xf] >> 10);
+                    w[j] = w[j] + s0 + w[(j + 9) & 0xf] + s1;
+                }
+                const uint32_t s1 = right_rot(ah[4], 6) ^ right_rot(ah[4], 11) ^ right_rot(ah[4], 25);
+                const uint32_t ch = (ah[4] & ah[5]) ^ (~ah[4] & ah[6]);
+                const uint32_t temp1 = ah[7] + s1 + ch + k[i << 4 | j] + w[j];
+                const uint32_t s0 = right_rot(ah[0], 2) ^ right_rot(ah[0], 13) ^ right_rot(ah[0], 22);
+                const uint32_t maj = (ah[0] & ah[1]) ^ (ah[0] & ah[2]) ^ (ah[1] & ah[2]);
+                const uint32_t temp2 = s0 + maj;
+
+                ah[7] = ah[6];
+                ah[6] = ah[5];
+                ah[5] = ah[4];
+                ah[4] = ah[3] + temp1;
+                ah[3] = ah[2];
+                ah[2] = ah[1];
+                ah[1] = ah[0];
+                ah[0] = temp1 + temp2;
+            }
+        }
+
+        /* Add the compressed chunk to the current hash value: */
+        for (i = 0; i < 8; i++) {
+            h[i] += ah[i];
+        }
+    }
+}
+
+static void sha_256_generic(uint32_t h[8], const void* input, size_t len) { sha_256_implementation(h, input, len); }
+
+static void (*sha_256_best)(uint32_t h[8], const void* input, size_t len) = sha_256_generic;
+
+#if defined(__x86_64__)
+
+__attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(uint32_t h[8], const void* input, size_t len) {
+    sha_256_implementation(h, input, len);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+
+// The following function was adapted from https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-x86.c
+/*   Intel SHA extensions using C intrinsics               */
+/*   Written and place in public domain by Jeffrey Walton  */
+/*   Based on code from Intel, and by Sean Gulley for      */
+/*   the miTLS project.                                    */
+__attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8], const void* input, size_t len) {
+    __m128i STATE0, STATE1;
+    __m128i MSG, TMP;
+    __m128i MSG0, MSG1, MSG2, MSG3;
+    __m128i ABEF_SAVE, CDGH_SAVE;
+    const __m128i MASK = _mm_set_epi64x(0x0c0d0e0f08090a0bULL, 0x0405060700010203ULL);
+
+    /* Load initial values */
+    TMP = _mm_loadu_si128((const __m128i*)&h[0]);
+    STATE1 = _mm_loadu_si128((const __m128i*)&h[4]);
+
+    TMP = _mm_shuffle_epi32(TMP, 0xB1);          /* CDAB */
+    STATE1 = _mm_shuffle_epi32(STATE1, 0x1B);    /* EFGH */
+    STATE0 = _mm_alignr_epi8(TMP, STATE1, 8);    /* ABEF */
+    STATE1 = _mm_blend_epi16(STATE1, TMP, 0xF0); /* CDGH */
+
+    struct buffer_state state;
+    init_buf_state(&state, input, len);
+
+    /* 512-bit chunks is what we will operate on. */
+    uint8_t chunk[CHUNK_SIZE];
+
+    while (calc_chunk(chunk, &state)) {
+        /* Save current state */
+        ABEF_SAVE = STATE0;
+        CDGH_SAVE = STATE1;
+
+        /* Rounds 0-3 */
+        MSG = _mm_loadu_si128((const __m128i*)(chunk + 0));
+        MSG0 = _mm_shuffle_epi8(MSG, MASK);
+        MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCFULL, 0x71374491428A2F98ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+        /* Rounds 4-7 */
+        MSG1 = _mm_loadu_si128((const __m128i*)(chunk + 16));
+        MSG1 = _mm_shuffle_epi8(MSG1, MASK);
+        MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0xAB1C5ED5923F82A4ULL, 0x59F111F13956C25BULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+        /* Rounds 8-11 */
+        MSG2 = _mm_loadu_si128((const __m128i*)(chunk + 32));
+        MSG2 = _mm_shuffle_epi8(MSG2, MASK);
+        MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0x550C7DC3243185BEULL, 0x12835B01D807AA98ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+        /* Rounds 12-15 */
+        MSG3 = _mm_loadu_si128((const __m128i*)(chunk + 48));
+        MSG3 = _mm_shuffle_epi8(MSG3, MASK);
+        MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0xC19BF1749BDC06A7ULL, 0x80DEB1FE72BE5D74ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+        MSG0 = _mm_add_epi32(MSG0, TMP);
+        MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+        /* Rounds 16-19 */
+        MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x240CA1CC0FC19DC6ULL, 0xEFBE4786E49B69C1ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+        MSG1 = _mm_add_epi32(MSG1, TMP);
+        MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+        /* Rounds 20-23 */
+        MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x76F988DA5CB0A9DCULL, 0x4A7484AA2DE92C6FULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+        MSG2 = _mm_add_epi32(MSG2, TMP);
+        MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+        /* Rounds 24-27 */
+        MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0xBF597FC7B00327C8ULL, 0xA831C66D983E5152ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+        MSG3 = _mm_add_epi32(MSG3, TMP);
+        MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+        /* Rounds 28-31 */
+        MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0x1429296706CA6351ULL, 0xD5A79147C6E00BF3ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+        MSG0 = _mm_add_epi32(MSG0, TMP);
+        MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+        /* Rounds 32-35 */
+        MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x53380D134D2C6DFCULL, 0x2E1B213827B70A85ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+        MSG1 = _mm_add_epi32(MSG1, TMP);
+        MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+        /* Rounds 36-39 */
+        MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x92722C8581C2C92EULL, 0x766A0ABB650A7354ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+        MSG2 = _mm_add_epi32(MSG2, TMP);
+        MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+        /* Rounds 40-43 */
+        MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0xC76C51A3C24B8B70ULL, 0xA81A664BA2BFE8A1ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+        MSG3 = _mm_add_epi32(MSG3, TMP);
+        MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+        /* Rounds 44-47 */
+        MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0x106AA070F40E3585ULL, 0xD6990624D192E819ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+        MSG0 = _mm_add_epi32(MSG0, TMP);
+        MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+        /* Rounds 48-51 */
+        MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x34B0BCB52748774CULL, 0x1E376C0819A4C116ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+        MSG1 = _mm_add_epi32(MSG1, TMP);
+        MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+        MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+        /* Rounds 52-55 */
+        MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x682E6FF35B9CCA4FULL, 0x4ED8AA4A391C0CB3ULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+        MSG2 = _mm_add_epi32(MSG2, TMP);
+        MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+        /* Rounds 56-59 */
+        MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0x8CC7020884C87814ULL, 0x78A5636F748F82EEULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+        MSG3 = _mm_add_epi32(MSG3, TMP);
+        MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+        /* Rounds 60-63 */
+        MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0xC67178F2BEF9A3F7ULL, 0xA4506CEB90BEFFFAULL));
+        STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+        MSG = _mm_shuffle_epi32(MSG, 0x0E);
+        STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+        /* Combine state  */
+        STATE0 = _mm_add_epi32(STATE0, ABEF_SAVE);
+        STATE1 = _mm_add_epi32(STATE1, CDGH_SAVE);
+    }
+
+    TMP = _mm_shuffle_epi32(STATE0, 0x1B);       /* FEBA */
+    STATE1 = _mm_shuffle_epi32(STATE1, 0xB1);    /* DCHG */
+    STATE0 = _mm_blend_epi16(TMP, STATE1, 0xF0); /* DCBA */
+    STATE1 = _mm_alignr_epi8(STATE1, TMP, 8);    /* ABEF */
+
+    /* Save state */
+    _mm_storeu_si128((__m128i*)&h[0], STATE0);
+    _mm_storeu_si128((__m128i*)&h[4], STATE1);
+}
+
+#pragma GCC diagnostic pop
+
+// https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
+void cpuid(int info[4], int InfoType) { __cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]); }
+
+__attribute__((constructor)) static void select_sha256_implementation() {
+    int info[4];
+    cpuid(info, 0);
+    int nIds = info[0];
+
+    bool hw_sse41 = false;
+    bool hw_bmi1 = false;
+    bool hw_bmi2 = false;
+    bool hw_sha = false;
+
+    if (nIds >= 0x00000001) {
+        cpuid(info, 0x00000001);
+        hw_sse41 = (info[2] & ((int)1 << 19)) != 0;
+    }
+    if (nIds >= 0x00000007) {
+        cpuid(info, 0x00000007);
+        hw_bmi1 = (info[1] & ((int)1 << 3)) != 0;
+        hw_bmi2 = (info[1] & ((int)1 << 8)) != 0;
+        hw_sha = (info[1] & ((int)1 << 29)) != 0;
+    }
+
+    if (hw_sse41 && hw_sha) {
+        sha_256_best = sha_256_x86_sha;
+    } else if (hw_bmi1 && hw_bmi2) {
+        sha_256_best = sha_256_x86_bmi;
+    }
+}
+
+#elif defined(__aarch64__) && defined(__APPLE__)
+
+// The following function was adapted from https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-arm.c
+/* sha256-arm.c - ARMv8 SHA extensions using C intrinsics     */
+/*   Written and placed in public domain by Jeffrey Walton    */
+/*   Based on code from ARM, and by Johannes Schneiders, Skip */
+/*   Hovsmith and Barry O'Rourke for the mbedTLS project.     */
+static void sha_256_arm_v8(uint32_t h[8], const void* input, size_t len) {
+    uint32x4_t STATE0, STATE1, ABEF_SAVE, CDGH_SAVE;
+    uint32x4_t MSG0, MSG1, MSG2, MSG3;
+    uint32x4_t TMP0, TMP1, TMP2;
+
+    /* Load state */
+    STATE0 = vld1q_u32(&h[0]);
+    STATE1 = vld1q_u32(&h[4]);
+
+    struct buffer_state state;
+    init_buf_state(&state, input, len);
+
+    /* 512-bit chunks is what we will operate on. */
+    uint8_t chunk[CHUNK_SIZE];
+
+    while (calc_chunk(chunk, &state)) {
+        /* Save state */
+        ABEF_SAVE = STATE0;
+        CDGH_SAVE = STATE1;
+
+        /* Load message */
+        MSG0 = vld1q_u32((const uint32_t*)(chunk + 0));
+        MSG1 = vld1q_u32((const uint32_t*)(chunk + 16));
+        MSG2 = vld1q_u32((const uint32_t*)(chunk + 32));
+        MSG3 = vld1q_u32((const uint32_t*)(chunk + 48));
+
+        /* Reverse for little endian */
+        MSG0 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSG0)));
+        MSG1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSG1)));
+        MSG2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSG2)));
+        MSG3 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSG3)));
+
+        TMP0 = vaddq_u32(MSG0, vld1q_u32(&k[0x00]));
+
+        /* Rounds 0-3 */
+        MSG0 = vsha256su0q_u32(MSG0, MSG1);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG1, vld1q_u32(&k[0x04]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG0 = vsha256su1q_u32(MSG0, MSG2, MSG3);
+
+        /* Rounds 4-7 */
+        MSG1 = vsha256su0q_u32(MSG1, MSG2);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG2, vld1q_u32(&k[0x08]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG1 = vsha256su1q_u32(MSG1, MSG3, MSG0);
+
+        /* Rounds 8-11 */
+        MSG2 = vsha256su0q_u32(MSG2, MSG3);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG3, vld1q_u32(&k[0x0c]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG2 = vsha256su1q_u32(MSG2, MSG0, MSG1);
+
+        /* Rounds 12-15 */
+        MSG3 = vsha256su0q_u32(MSG3, MSG0);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG0, vld1q_u32(&k[0x10]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG3 = vsha256su1q_u32(MSG3, MSG1, MSG2);
+
+        /* Rounds 16-19 */
+        MSG0 = vsha256su0q_u32(MSG0, MSG1);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG1, vld1q_u32(&k[0x14]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG0 = vsha256su1q_u32(MSG0, MSG2, MSG3);
+
+        /* Rounds 20-23 */
+        MSG1 = vsha256su0q_u32(MSG1, MSG2);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG2, vld1q_u32(&k[0x18]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG1 = vsha256su1q_u32(MSG1, MSG3, MSG0);
+
+        /* Rounds 24-27 */
+        MSG2 = vsha256su0q_u32(MSG2, MSG3);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG3, vld1q_u32(&k[0x1c]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG2 = vsha256su1q_u32(MSG2, MSG0, MSG1);
+
+        /* Rounds 28-31 */
+        MSG3 = vsha256su0q_u32(MSG3, MSG0);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG0, vld1q_u32(&k[0x20]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG3 = vsha256su1q_u32(MSG3, MSG1, MSG2);
+
+        /* Rounds 32-35 */
+        MSG0 = vsha256su0q_u32(MSG0, MSG1);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG1, vld1q_u32(&k[0x24]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG0 = vsha256su1q_u32(MSG0, MSG2, MSG3);
+
+        /* Rounds 36-39 */
+        MSG1 = vsha256su0q_u32(MSG1, MSG2);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG2, vld1q_u32(&k[0x28]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG1 = vsha256su1q_u32(MSG1, MSG3, MSG0);
+
+        /* Rounds 40-43 */
+        MSG2 = vsha256su0q_u32(MSG2, MSG3);
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG3, vld1q_u32(&k[0x2c]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+        MSG2 = vsha256su1q_u32(MSG2, MSG0, MSG1);
+
+        /* Rounds 44-47 */
+        MSG3 = vsha256su0q_u32(MSG3, MSG0);
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG0, vld1q_u32(&k[0x30]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+        MSG3 = vsha256su1q_u32(MSG3, MSG1, MSG2);
+
+        /* Rounds 48-51 */
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG1, vld1q_u32(&k[0x34]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+
+        /* Rounds 52-55 */
+        TMP2 = STATE0;
+        TMP0 = vaddq_u32(MSG2, vld1q_u32(&k[0x38]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+
+        /* Rounds 56-59 */
+        TMP2 = STATE0;
+        TMP1 = vaddq_u32(MSG3, vld1q_u32(&k[0x3c]));
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP0);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP0);
+
+        /* Rounds 60-63 */
+        TMP2 = STATE0;
+        STATE0 = vsha256hq_u32(STATE0, STATE1, TMP1);
+        STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
+
+        /* Combine state */
+        STATE0 = vaddq_u32(STATE0, ABEF_SAVE);
+        STATE1 = vaddq_u32(STATE1, CDGH_SAVE);
+    }
+
+    /* Save state */
+    vst1q_u32(&h[0], STATE0);
+    vst1q_u32(&h[4], STATE1);
+}
+
+__attribute__((constructor)) static void select_sha256_implementation() {
+#if defined(__linux__)
+    if ((getauxval(AT_HWCAP) & HWCAP_SHA2) != 0) {
+        sha_256_best = sha_256_arm_v8;
+    }
+#elif defined(__APPLE__)
+    int64_t hw_cap = 0;
+    size_t size = sizeof(hw_cap);
+
+    if (sysctlbyname("hw.optional.armv8_2_sha3", &hw_cap, &size, NULL, 0) == 0) {
+        // Use SHA3 as proxy for SHA2 (sysctl hw doesn't list SHA2 for Apple M1)
+        if (hw_cap == 1) {
+            sha_256_best = sha_256_arm_v8;
+        }
+    }
+#endif  // defined(__linux__), defined(__APPLE__)
+}
+
+#endif  // defined(__x86_64__), defined(__aarch64__)
+
+/*
+ * Limitations:
+ * - Since input is a pointer in RAM, the data to hash should be in RAM, which could be a problem
+ *   for large data sizes.
+ * - SHA algorithms theoretically operate on bit strings. However, this implementation has no support
+ *   for bit string lengths that are not multiples of eight, and it really operates on arrays of bytes.
+ *   In particular, the len parameter is a number of bytes.
+ */
+void silkpre_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions) {
+    /*
+     * Initialize hash values:
+     * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
+     */
+    uint32_t h[] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+    if (use_cpu_extensions) {
+        sha_256_best(h, input, len);
+    } else {
+        sha_256_generic(h, input, len);
+    }
+
+    /* Produce the final hash value (big-endian): */
+    for (unsigned i = 0, j = 0; i < 8; i++) {
+        hash[j++] = (uint8_t)(h[i] >> 24);
+        hash[j++] = (uint8_t)(h[i] >> 16);
+        hash[j++] = (uint8_t)(h[i] >> 8);
+        hash[j++] = (uint8_t)h[i];
+    }
+}

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
@@ -14,12 +14,17 @@
    limitations under the License.
 */
 
+// Modified 2026 by Category Labs:
+//   - renamed silkpre_sha256 to monad_sha256
+//   - made internal helper `cpuid` static to avoid colliding with silkpre's
+//     copy at link time
+
 // Based on several bits of code released to public domain:
 // https://github.com/amosnier/sha-2 (Author: Alain Mosnier)
 // https://github.com/noloader/SHA-Intrinsics (Author: Jeffrey Walton)
 // https://github.com/Mysticial/FeatureDetector (Author: Alexander Yee)
 
-#include "sha256.h"
+#include <silkpre_vendor/sha256.h>
 
 #include <string.h>
 
@@ -452,7 +457,7 @@ __attribute__((target("sha,sse4.1"))) static void sha_256_x86_sha(uint32_t h[8],
 #pragma GCC diagnostic pop
 
 // https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
-void cpuid(int info[4], int InfoType) { __cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]); }
+static void cpuid(int info[4], int InfoType) { __cpuid_count(InfoType, 0, info[0], info[1], info[2], info[3]); }
 
 __attribute__((constructor)) static void select_sha256_implementation() {
     int info[4];
@@ -680,7 +685,7 @@ __attribute__((constructor)) static void select_sha256_implementation() {
  *   for bit string lengths that are not multiples of eight, and it really operates on arrays of bytes.
  *   In particular, the len parameter is a number of bytes.
  */
-void silkpre_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions) {
+void monad_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions) {
     /*
      * Initialize hash values:
      * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
@@ -1,0 +1,34 @@
+/*
+   Copyright 2022 The Silkpre Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKPRE_SHA256_H_
+#define SILKPRE_SHA256_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+void silkpre_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // SILKPRE_SHA256_H_

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
@@ -14,8 +14,10 @@
    limitations under the License.
 */
 
-#ifndef SILKPRE_SHA256_H_
-#define SILKPRE_SHA256_H_
+// Modified 2026 by Category Labs: renamed silkpre_sha256 to monad_sha256.
+
+#ifndef MONAD_SHA256_H_
+#define MONAD_SHA256_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -25,10 +27,10 @@
 extern "C" {
 #endif
 
-void silkpre_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions);
+void monad_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions);
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif  // SILKPRE_SHA256_H_
+#endif  // MONAD_SHA256_H_


### PR DESCRIPTION
Vendors two silkpre crypto sources into `category/core/crypto/` so monad's call sites no longer go through the silkpre wrappers. Two commits, one per primitive.

### sha256 (7c1cb9820)

Copies `silkpre/lib/silkpre/sha256.{c,h}` verbatim apart from:
  - renaming `silkpre_sha256` to `monad_sha256` (and the matching header guard) so the new symbol can coexist with silkpre's during the migration
  - making the internal helper `cpuid` static — it was non-static in silkpre upstream, which only worked because there was a single copy of the file in the link

`NOTICE` + `SILKPRE-LICENSE.txt` are dropped alongside, mirroring the pattern in `utils/clang-tidy-auto-const/`. Sources are added to `monad_core` with per-file `-Wno-conversion` / `-Wno-sign-conversion` to keep `-Werror` honest without modifying the vendored code, and a `.clang-format` / `.clang-tidy` pair in the directory excludes the vendored files from the project lint/format scripts.

In-tree direct callers are switched to `monad_sha256`:
  - `sha256_execute` (precompiles_impl.cpp) is rewritten to malloc its output buffer and call `monad_sha256` directly, matching the ownership pattern used by `identity_execute` / `point_evaluation_execute`
  - `kzg_to_version_hashed` (precompiles_impl.cpp) and the two call sites in `compute_requests_hash` (process_requests.cpp) just swap the symbol name

### rmd160 (f370b1eee)

Mirror of the sha256 vendor: copies `silkpre/lib/silkpre/rmd160.{c,h}` verbatim apart from renaming `silkpre_rmd160` to `monad_rmd160` (and the matching header guard). The vendored file exports a single symbol, so no static-helper fixups were needed.

The KU Leuven 1996 MIT-style notice already in the file headers is self-contained, so no separate LICENSE drop is required; `NOTICE` is extended to describe the rmd160 provenance, and the per-file `-Wno-conversion` / `-Wno-sign-conversion` treatment is reused.

`ripemd160_execute` (precompiles_impl.cpp) is rewritten to malloc its 32-byte output, zero the top 12 bytes, and write the 20-byte digest at offset 12 — matching `silkpre_rip160_run`'s behaviour exactly.

### Notes

`silkpre_sha256_run` and the ripemd160 silkpre wrapper, used by silkpre internally, still call silkpre's own implementations, but neither is reached from monad code. Dropping the AArch64 path from the vendored sha256.c is a follow-up.