### PR TITLE
[execution]: Make DbCache a member of TrieDb

### DIFF
--- a/category/execution/ethereum/block_hash_buffer_test.cpp
+++ b/category/execution/ethereum/block_hash_buffer_test.cpp
@@ -217,7 +217,7 @@ TEST(BlockHashBufferTest, init_from_db)
 
     BlockHashBufferFinalized expected;
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
         expected.set(
             i,
             to_bytes(

--- a/category/execution/ethereum/block_reward_test.cpp
+++ b/category/execution/ethereum/block_reward_test.cpp
@@ -52,7 +52,7 @@ TYPED_TEST(TraitsTest, apply_block_reward)
     vm::VM vm;
     commit_sequential(
         tdb,
-        StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -97,7 +97,11 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         builder.add_withdrawals({});
     }
     db.commit(
-        NULL_HASH_BLAKE3, builder, genesis.header, deltas, [&](BlockHeader &h) {
+        NULL_HASH_BLAKE3,
+        builder,
+        genesis.header,
+        std::make_unique<StateDeltas>(std::move(deltas)),
+        [&](BlockHeader &h) {
             h.receipts_root = db.receipts_root();
             h.state_root = db.state_root();
             h.withdrawals_root = db.withdrawals_root();

--- a/category/execution/ethereum/core/contract/test_storage.cpp
+++ b/category/execution/ethereum/core/contract/test_storage.cpp
@@ -48,11 +48,11 @@ struct Storage : public ::testing::Test
     {
         commit_sequential(
             tdb,
-            StateDeltas{
-                {ADDRESS,
-                 StateDelta{
-                     .account =
-                         {std::nullopt, Account{.balance = 1, .nonce = 1}}}}},
+            sd(
+                {{ADDRESS,
+                  StateDelta{
+                      .account =
+                          {std::nullopt, Account{.balance = 1, .nonce = 1}}}}}),
             Code{},
             BlockHeader{});
         state.touch(ADDRESS);

--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -67,7 +67,7 @@ struct Db
     // two-stage commit
     virtual void commit(
         bytes32_t const &block_id, CommitBuilder &builder,
-        BlockHeader const &header, StateDeltas const &state_deltas,
+        BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
         std::function<void(BlockHeader &)> populate_header_fn) = 0;
 
     virtual std::string print_stats()

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -21,23 +21,19 @@
 #include <category/core/config.hpp>
 #include <category/core/lru/lru_cache.hpp>
 #include <category/execution/ethereum/core/account.hpp>
-#include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
-#include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
-#include <category/vm/vm.hpp>
 
-#include <evmc/evmc.hpp>
-
+#include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
+#include <string>
 
 MONAD_NAMESPACE_BEGIN
 
-class DbCache final : public Db
+class DbCache final
 {
-    Db &db_;
-
     struct StorageKey
     {
         static constexpr size_t k_bytes =
@@ -71,62 +67,60 @@ class DbCache final : public Db
     Proposals proposals_;
 
 public:
-    DbCache(Db &db)
-        : db_{db}
-    {
-    }
+    DbCache() = default;
 
-    virtual std::optional<Account> read_account(Address const &address) override
+    bool
+    try_read_account(Address const &address, std::optional<Account> &result)
     {
-        std::optional<Account> result;
         auto const res = proposals_.try_read_account(address, result);
         if (res.found) {
-            return result;
+            return true;
         }
         if (!res.truncated) {
             AccountsCache::ConstAccessor acc{};
             if (accounts_.find(acc, address)) {
-                return acc->second.value_;
+                result = acc->second.value_;
+                return true;
             }
         }
-        return db_.read_account(address);
+        return false;
     }
 
-    virtual bytes32_t read_storage(
+    bool try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key) override
+        bytes32_t const &key, bytes32_t &result)
     {
-        bytes32_t result;
         auto const res =
             proposals_.try_read_storage(address, incarnation, key, result);
         if (res.found) {
-            return result;
+            return true;
         }
         if (!res.truncated) {
             StorageKey const skey{address, incarnation, key};
             StorageCache::ConstAccessor acc{};
             if (storage_.find(acc, skey)) {
-                return acc->second.value_;
+                result = acc->second.value_;
+                return true;
             }
         }
-        return db_.read_storage(address, incarnation, key);
+        return false;
     }
 
-    virtual vm::SharedIntercode read_code(bytes32_t const &code_hash) override
-    {
-        return db_.read_code(code_hash);
-    }
-
-    virtual void set_block_and_prefix(
-        uint64_t const block_number,
-        bytes32_t const &block_id = bytes32_t{}) override
+    void
+    set_block_and_prefix(uint64_t const block_number, bytes32_t const &block_id)
     {
         proposals_.set_block_and_prefix(block_number, block_id);
-        db_.set_block_and_prefix(block_number, block_id);
     }
 
-    virtual void
-    finalize(uint64_t const block_number, bytes32_t const &block_id) override
+    void update_proposal_state(
+        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
+        bytes32_t const &block_id)
+    {
+        MONAD_ASSERT(state_deltas);
+        proposals_.commit(std::move(state_deltas), block_number, block_id);
+    }
+
+    void on_finalize(uint64_t const block_number, bytes32_t const &block_id)
     {
         std::unique_ptr<ProposalState> const ps =
             proposals_.finalize(block_number, block_id);
@@ -138,82 +132,16 @@ public:
             accounts_.clear();
             storage_.clear();
         }
-        db_.finalize(block_number, block_id);
-        proposals_.set_block_and_prefix(block_number, block_id);
     }
 
-    virtual void update_verified_block(uint64_t const block_number) override
+    std::string accounts_stats()
     {
-        db_.update_verified_block(block_number);
+        return accounts_.print_stats();
     }
 
-    virtual void update_voted_metadata(
-        uint64_t const block_number, bytes32_t const &block_id) override
+    std::string storage_stats()
     {
-        db_.update_voted_metadata(block_number, block_id);
-    }
-
-    virtual void update_proposed_metadata(
-        uint64_t const block_number, bytes32_t const &block_id) override
-    {
-        db_.update_proposed_metadata(block_number, block_id);
-    }
-
-    virtual void commit(
-        bytes32_t const &block_id, CommitBuilder &builder,
-        BlockHeader const &header, StateDeltas const &state_deltas,
-        std::function<void(BlockHeader &)> populate_header_fn) override
-    {
-        db_.commit(
-            block_id,
-            builder,
-            header,
-            state_deltas,
-            std::move(populate_header_fn));
-    }
-
-    void update_proposal_state(
-        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
-        bytes32_t const &block_id)
-    {
-        MONAD_ASSERT(state_deltas);
-        proposals_.commit(std::move(state_deltas), block_number, block_id);
-    }
-
-    virtual BlockHeader read_eth_header() override
-    {
-        return db_.read_eth_header();
-    }
-
-    virtual bytes32_t state_root() override
-    {
-        return db_.state_root();
-    }
-
-    virtual bytes32_t receipts_root() override
-    {
-        return db_.receipts_root();
-    }
-
-    virtual bytes32_t transactions_root() override
-    {
-        return db_.transactions_root();
-    }
-
-    virtual std::optional<bytes32_t> withdrawals_root() override
-    {
-        return db_.withdrawals_root();
-    }
-
-    virtual std::string print_stats() override
-    {
-        return db_.print_stats() + ",ac=" + accounts_.print_stats() +
-               ",sc=" + storage_.print_stats();
-    }
-
-    virtual uint64_t get_block_number() const override
-    {
-        return db_.get_block_number();
+        return storage_.print_stats();
     }
 
 private:

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -147,17 +147,13 @@ public:
 private:
     void insert_in_lru_caches(StateDeltas const &state_deltas)
     {
-        for (auto it = state_deltas.cbegin(); it != state_deltas.cend(); ++it) {
-            auto const &address = it->first;
-            auto const &account_delta = it->second.account;
+        for (auto const &[address, delta] : state_deltas) {
+            auto const &account_delta = delta.account;
             accounts_.insert(address, account_delta.second);
-            auto const &storage = it->second.storage;
+            auto const &storage = delta.storage;
             auto const &account = account_delta.second;
             if (account.has_value()) {
-                for (auto it2 = storage.cbegin(); it2 != storage.cend();
-                     ++it2) {
-                    auto const &key = it2->first;
-                    auto const &storage_delta = it2->second;
+                for (auto const &[key, storage_delta] : storage) {
                     auto const incarnation = account->incarnation;
                     storage_.insert(
                         StorageKey(address, incarnation, key),

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -447,7 +447,7 @@ void PartialTrieDb::set_block_and_prefix(
 
 void PartialTrieDb::commit(
     bytes32_t const &, CommitBuilder &, BlockHeader const &,
-    StateDeltas const &, std::function<void(BlockHeader &)>)
+    std::unique_ptr<StateDeltas>, std::function<void(BlockHeader &)>)
 {
 }
 

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -188,7 +188,8 @@ public:
 
     void commit(
         bytes32_t const &block_id, CommitBuilder &, BlockHeader const &,
-        StateDeltas const &, std::function<void(BlockHeader &)>) override;
+        std::unique_ptr<StateDeltas>,
+        std::function<void(BlockHeader &)>) override;
 
     // No-op overrides for operations that are irrelevant in the witness
     // context.

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -15,10 +15,12 @@
 
 #pragma once
 
+#include <category/core/assert.h>
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
 
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -27,8 +29,13 @@ MONAD_NAMESPACE_BEGIN
 namespace test
 {
 
+    inline auto sd(StateDeltas v = {})
+    {
+        return std::make_unique<StateDeltas>(std::move(v));
+    }
+
     inline void commit_simple(
-        ::monad::Db &db, StateDeltas const &deltas, Code const &code,
+        ::monad::Db &db, std::unique_ptr<StateDeltas> deltas, Code const &code,
         bytes32_t const &block_id, BlockHeader const &header,
         std::vector<Receipt> const &receipts = {},
         std::vector<std::vector<CallFrame>> const &call_frames = {},
@@ -39,7 +46,7 @@ namespace test
             std::nullopt)
     {
         CommitBuilder builder(header.number);
-        builder.add_state_deltas(deltas)
+        builder.add_state_deltas(*deltas)
             .add_code(code)
             .add_receipts(receipts)
             .add_transactions(txns, senders)
@@ -48,18 +55,19 @@ namespace test
         if (withdrawals.has_value()) {
             builder.add_withdrawals(withdrawals.value());
         }
-        db.commit(block_id, builder, header, deltas, [&](BlockHeader &h) {
-            // eth pre-byzantium receipts root is invalid
-            if (h.receipts_root == NULL_ROOT) {
-                h.receipts_root = db.receipts_root();
-            }
-            h.state_root = db.state_root();
-            h.withdrawals_root = db.withdrawals_root();
-            h.transactions_root = db.transactions_root();
-            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-            h.logs_bloom = compute_bloom(receipts);
-            h.ommers_hash = compute_ommers_hash(ommers);
-        });
+        db.commit(
+            block_id, builder, header, std::move(deltas), [&](BlockHeader &h) {
+                // eth pre-byzantium receipts root is invalid
+                if (h.receipts_root == NULL_ROOT) {
+                    h.receipts_root = db.receipts_root();
+                }
+                h.state_root = db.state_root();
+                h.withdrawals_root = db.withdrawals_root();
+                h.transactions_root = db.transactions_root();
+                h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+                h.logs_bloom = compute_bloom(receipts);
+                h.ommers_hash = compute_ommers_hash(ommers);
+            });
     }
 
 } // namespace test

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -198,16 +198,18 @@ TEST(DBTest, read_only)
         Account const acct1{.nonce = 1};
         commit_sequential(
             rw,
-            StateDeltas{
-                {ADDR_A,
-                 StateDelta{.account = {std::nullopt, acct1}, .storage = {}}}},
+            sd(
+                {{ADDR_A,
+                  StateDelta{
+                      .account = {std::nullopt, acct1}, .storage = {}}}}),
             Code{},
             BlockHeader{.number = 0});
         Account const acct2{.nonce = 2};
         commit_sequential(
             rw,
-            StateDeltas{
-                {ADDR_A, StateDelta{.account = {acct1, acct2}, .storage = {}}}},
+            sd(
+                {{ADDR_A,
+                  StateDelta{.account = {acct1, acct2}, .storage = {}}}}),
             Code{},
             BlockHeader{.number = 1});
 
@@ -223,8 +225,9 @@ TEST(DBTest, read_only)
         Account const acct3{.nonce = 3};
         commit_sequential(
             rw,
-            StateDeltas{
-                {ADDR_A, StateDelta{.account = {acct2, acct3}, .storage = {}}}},
+            sd(
+                {{ADDR_A,
+                  StateDelta{.account = {acct2, acct3}, .storage = {}}}}),
             Code{},
             BlockHeader{.number = 2});
         // Read block 0
@@ -248,11 +251,11 @@ TYPED_TEST(DBTest, read_storage)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, acct},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, acct},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -288,7 +291,7 @@ TYPED_TEST(DBTest, read_code)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{{ADDR_A, StateDelta{.account = {std::nullopt, acct_a}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, acct_a}}}}),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -298,7 +301,7 @@ TYPED_TEST(DBTest, read_code)
     Account acct_b{.balance = 0, .code_hash = B_CODE_HASH, .nonce = 1};
     commit_sequential(
         tdb,
-        StateDeltas{{ADDR_B, StateDelta{.account = {std::nullopt, acct_b}}}},
+        sd({{ADDR_B, StateDelta{.account = {std::nullopt, acct_b}}}}),
         Code{{B_CODE_HASH, B_ICODE}},
         BlockHeader{.number = 1});
 
@@ -315,7 +318,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
 
     tdb.set_block_and_prefix(8);
     auto const round9_block_id =
-        commit_sequential(tdb, StateDeltas{}, Code{}, BlockHeader{.number = 9});
+        commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 9});
     EXPECT_EQ(db.get_latest_finalized_version(), 9);
     {
         auto const proposals = get_proposal_block_ids(db, 9);
@@ -328,7 +331,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header0{.number = 10};
     bytes32_t const block_id0{header0.number};
     block_ids.emplace(block_id0);
-    commit_simple(tdb, StateDeltas{}, Code{}, block_id0, header0);
+    commit_simple(tdb, sd({}), Code{}, block_id0, header0);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -337,7 +340,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header1{.number = 10};
     bytes32_t const block_id1{header1.number};
     block_ids.emplace(block_id1);
-    commit_simple(tdb, StateDeltas{}, Code{}, block_id1, header1);
+    commit_simple(tdb, sd({}), Code{}, block_id1, header1);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -347,7 +350,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header2{.number = 10};
     bytes32_t const block_id2{header2.number};
     block_ids.emplace(block_id2);
-    commit_simple(tdb, StateDeltas{}, Code{}, block_id2, header2);
+    commit_simple(tdb, sd({}), Code{}, block_id2, header2);
 
     tdb.finalize(10, block_id0);
     EXPECT_EQ(db.get_latest_finalized_version(), 10);
@@ -363,24 +366,24 @@ TYPED_TEST(DBTest, ModifyStorageOfAccount)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, acct},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, acct},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{.number = 0});
 
     acct = tdb.read_account(ADDR_A).value();
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {acct, acct},
-                 .storage = {{key2, {value2, value1}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {acct, acct},
+                  .storage = {{key2, {value2, value1}}}}}}),
         Code{},
         BlockHeader{.number = 1});
 
@@ -394,8 +397,7 @@ TYPED_TEST(DBTest, touch_without_modify_regression)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, std::nullopt}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, std::nullopt}}}}),
         Code{},
         BlockHeader{});
 
@@ -409,24 +411,24 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, acct},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, acct},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{.number = 0});
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {acct, std::nullopt},
-                 .storage =
-                     {{key1, {value1, value2}}, {key2, {value2, value1}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {acct, std::nullopt},
+                  .storage =
+                      {{key1, {value1, value2}}, {key2, {value2, value1}}}}}}),
         Code{},
         BlockHeader{.number = 1});
 
@@ -442,24 +444,24 @@ TYPED_TEST(DBTest, storage_deletion)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, acct},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, acct},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{.number = 0});
 
     acct = tdb.read_account(ADDR_A).value();
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {acct, acct},
-                 .storage = {{key1, {value1, bytes32_t{}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {acct, acct},
+                  .storage = {{key1, {value1, bytes32_t{}}}}}}}),
         Code{},
         BlockHeader{.number = 1});
 
@@ -475,7 +477,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
 
     TrieDb tdb{this->db};
     // empty receipts
-    commit_sequential(tdb, StateDeltas{}, Code{}, BlockHeader{});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{});
     EXPECT_EQ(tdb.receipts_root(), NULL_ROOT);
 
     std::vector<Receipt> receipts;
@@ -535,7 +537,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
     std::vector<Address> senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        StateDeltas{},
+        sd({}),
         Code{},
         BlockHeader{.number = first_block},
         receipts,
@@ -626,7 +628,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
     senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        StateDeltas{},
+        sd({}),
         Code{},
         BlockHeader{.number = second_block},
         receipts,
@@ -686,7 +688,7 @@ TEST_F(OnDiskTrieDbWithFileFixture, get_transactions)
     std::vector<Address> senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        StateDeltas{},
+        sd({}),
         Code{},
         BlockHeader{.number = block_number},
         receipts,
@@ -910,7 +912,7 @@ TYPED_TEST(DBTest, commit_call_frames)
     std::vector<Address> const senders{call_frames.size()};
     commit_sequential(
         tdb,
-        StateDeltas{},
+        sd({}),
         Code{},
         BlockHeader{},
         receipts,

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -73,12 +73,13 @@ MONAD_NAMESPACE_BEGIN
 
 using namespace monad::mpt;
 
-TrieDb::TrieDb(mpt::Db &db)
+TrieDb::TrieDb(mpt::Db &db, bool const enable_multiblock_cache)
     : db_{db}
     , block_number_{db.get_latest_finalized_version()}
     , proposal_block_id_{bytes32_t{}}
     , prefix_{finalized_nibbles}
     , curr_root_{db.load_root_for_version(block_number_)}
+    , cache_{enable_multiblock_cache ? std::make_unique<DbCache>() : nullptr}
 {
 }
 
@@ -97,6 +98,10 @@ Node::SharedPtr const &TrieDb::get_root() const
 
 std::optional<Account> TrieDb::read_account(Address const &addr)
 {
+    std::optional<Account> result;
+    if (cache_ && cache_->try_read_account(addr, result)) {
+        return result;
+    }
     auto const res = db_.find(
         curr_root_,
         concat(
@@ -109,15 +114,17 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
         return std::nullopt;
     }
     stats_account_value();
-
     auto encoded_account = res.value().node->value();
-    auto const acct = decode_account_db_ignore_address(encoded_account);
-    return acct.value();
+    return decode_account_db_ignore_address(encoded_account).value();
 }
 
-bytes32_t
-TrieDb::read_storage(Address const &addr, Incarnation, bytes32_t const &key)
+bytes32_t TrieDb::read_storage(
+    Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
+    bytes32_t result{};
+    if (cache_ && cache_->try_read_storage(addr, incarnation, key, result)) {
+        return result;
+    }
     auto const res = db_.find(
         curr_root_,
         concat(
@@ -135,7 +142,7 @@ TrieDb::read_storage(Address const &addr, Incarnation, bytes32_t const &key)
     auto const storage = decode_storage_db_ignore_slot(encoded_storage);
     MONAD_ASSERT(!storage.has_error());
     return to_bytes(storage.value());
-};
+}
 
 vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
 {
@@ -155,11 +162,12 @@ vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
 
 void TrieDb::commit(
     bytes32_t const &block_id, CommitBuilder &builder,
-    BlockHeader const &header, StateDeltas const &,
+    BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
     std::function<void(BlockHeader &)> const populate_header_fn)
 {
     auto const block_number = header.number;
     MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());
+    MONAD_ASSERT(state_deltas);
 
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk() && block_id != proposal_block_id_) {
@@ -194,11 +202,19 @@ void TrieDb::commit(
     builder.add_block_header(complete_header);
     curr_root_ = db_.upsert(
         std::move(curr_root_), builder.build(prefix_), block_number_, false);
+
+    if (cache_) {
+        cache_->update_proposal_state(
+            std::move(state_deltas), header.number, block_id);
+    }
 }
 
 void TrieDb::set_block_and_prefix(
     uint64_t const block_number, bytes32_t const &block_id)
 {
+    if (cache_) {
+        cache_->set_block_and_prefix(block_number, block_id);
+    }
     // set read state
     if (!db_.is_on_disk()) {
         MONAD_ASSERT(proposal_block_id_ == bytes32_t{});
@@ -243,6 +259,9 @@ void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
     }
     block_number_ = block_number;
     db_.update_finalized_version(block_number);
+    if (cache_) {
+        cache_->on_finalize(block_number, block_id);
+    }
 }
 
 void TrieDb::update_verified_block(uint64_t const block_number)
@@ -338,6 +357,10 @@ std::string TrieDb::print_stats()
     n_account_value_.store(0, std::memory_order_release);
     n_storage_no_value_.store(0, std::memory_order_release);
     n_storage_value_.store(0, std::memory_order_release);
+    if (cache_) {
+        ret += ",ac=" + cache_->accounts_stats() +
+               ",sc=" + cache_->storage_stats();
+    }
     return ret;
 }
 

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -23,6 +23,7 @@
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/mpt/compute.hpp>
@@ -50,9 +51,13 @@ class TrieDb final : public ::monad::Db
     bytes32_t proposal_block_id_;
     ::monad::mpt::Nibbles prefix_;
     ::monad::mpt::Node::SharedPtr curr_root_;
+    // DbCache default constructor initializes two massive mempools.
+    // We only want to pay that price when the cache is enabled, hence
+    // the need for unique_ptr.
+    std::unique_ptr<DbCache> cache_;
 
 public:
-    explicit TrieDb(mpt::Db &);
+    explicit TrieDb(mpt::Db &, bool enable_multiblock_cache = false);
     ~TrieDb();
 
     void reset_root(::monad::mpt::Node::SharedPtr root, uint64_t block_number);
@@ -68,7 +73,7 @@ public:
 
     virtual void commit(
         bytes32_t const &block_id, CommitBuilder &builder,
-        BlockHeader const &header, StateDeltas const &state_deltas,
+        BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
         std::function<void(BlockHeader &)> populate_header_fn) override;
 
     virtual void

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -133,7 +133,8 @@ public:
 
     virtual void commit(
         bytes32_t const &, CommitBuilder &, BlockHeader const &,
-        StateDeltas const &, std::function<void(BlockHeader &)>) override
+        std::unique_ptr<StateDeltas>,
+        std::function<void(BlockHeader &)>) override
     {
         MONAD_ABORT();
     }

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -90,11 +90,11 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt, Account{.balance = 10'000'000'000}}}}},
+        sd(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 10'000'000'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -151,14 +151,14 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .nonce = initial_nonce}}}}},
+        sd(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .nonce = initial_nonce}}}}}),
         Code{},
         BlockHeader{});
 
@@ -235,12 +235,12 @@ TYPED_TEST(TraitsTest, create_revert_preserves_access_list_trace)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 10'000'000'000, .nonce = nonce}}}}},
+        sd(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 10'000'000'000, .nonce = nonce}}}}}),
         Code{},
         BlockHeader{});
 
@@ -323,15 +323,14 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{.balance = 10'000'000'000, .nonce = 7}}}},
             {to,
              StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = code_hash}}}}},
+                 .account = {std::nullopt, Account{.code_hash = code_hash}}}}}),
         Code{},
         BlockHeader{});
 
@@ -404,14 +403,14 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .nonce = std::numeric_limits<uint64_t>::max()}}}}},
+        sd(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .nonce = std::numeric_limits<uint64_t>::max()}}}}}),
         Code{},
         BlockHeader{});
 
@@ -469,12 +468,11 @@ TYPED_TEST(TraitsTest, static_precompile_execution)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {code_address,
+        sd({{code_address,
              StateDelta{.account = {std::nullopt, Account{.nonce = 4}}}},
             {from,
              StateDelta{
-                 .account = {std::nullopt, Account{.balance = 15'000}}}}},
+                 .account = {std::nullopt, Account{.balance = 15'000}}}}}),
         Code{},
         BlockHeader{});
     init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
@@ -540,12 +538,11 @@ TYPED_TEST(TraitsTest, out_of_gas_static_precompile_execution)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {code_address,
+        sd({{code_address,
              StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}},
             {from,
              StateDelta{
-                 .account = {std::nullopt, Account{.balance = 15'000}}}}},
+                 .account = {std::nullopt, Account{.balance = 15'000}}}}}),
         Code{},
         BlockHeader{});
     init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
@@ -605,7 +602,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {good_code_address,
              StateDelta{
                  .account =
@@ -622,7 +619,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
                           .balance = 0xba1a9ce0ba1a9ce,
                           .code_hash = bad_code_hash,
                       }}}},
-        },
+        }),
         Code{
             {good_code_hash, good_icode},
             {bad_code_hash, bad_icode},
@@ -730,7 +727,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {good_code_address,
              StateDelta{
                  .account =
@@ -747,7 +744,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
                           .balance = 0xba1a9ce0ba1a9ce,
                           .code_hash = bad_code_hash,
                       }}}},
-        },
+        }),
         Code{
             {good_code_hash, good_icode},
             {bad_code_hash, bad_icode},
@@ -831,7 +828,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_not_enough_of_gas)
     vm::VM vm;
     commit_sequential(
         tdb,
-        StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -875,7 +872,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_max_code_size)
     vm::VM vm;
     commit_sequential(
         tdb,
-        StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -913,7 +910,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_validation)
     vm::VM vm;
     commit_sequential(
         tdb,
-        StateDeltas{{a, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -969,8 +966,7 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {eoa,
+        sd({{eoa,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -992,7 +988,7 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
                       Account{
                           .balance = 10'000'000'000,
                           .code_hash = delegated_code_hash,
-                      }}}}},
+                      }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {delegated_code_hash, delegated_icode},
@@ -1092,8 +1088,7 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {eoa,
+        sd({{eoa,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1123,7 +1118,7 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
                       Account{
                           .balance = 10'000'000'000,
                           .code_hash = creator_code_hash,
-                      }}}}},
+                      }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {delegated_code_hash, delegated_icode},
@@ -1217,8 +1212,7 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {eoa,
+        sd({{eoa,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1240,7 +1234,7 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
                       Account{
                           .balance = 10'000'000'000,
                           .code_hash = contract_code_hash,
-                      }}}}},
+                      }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {contract_code_hash, contract_icode},
@@ -1311,8 +1305,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1325,7 +1318,7 @@ TYPED_TEST(TraitsTest, cold_account_access)
                      {std::nullopt,
                       Account{
                           .code_hash = code_hash,
-                      }}}}},
+                      }}}}}),
         Code{
             {code_hash, icode},
         },
@@ -1436,8 +1429,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {falsely_delegated_1,
+        sd({{falsely_delegated_1,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1468,7 +1460,7 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
                       Account{
                           .balance = 10'000'000'000,
                           .code_hash = good_code_hash,
-                      }}}}},
+                      }}}}}),
         Code{
             {bad_code_hash, bad_icode},
             {bad_code_hash2, bad_icode2},

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -143,8 +143,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -175,7 +174,8 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}}},
+                          .balance = 0,
+                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -278,7 +278,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
     auto [state, code] = std::move(bs).release();
     commit_simple(
         tdb,
-        *state,
+        std::move(state),
         code,
         block_id,
         header,
@@ -314,8 +314,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -341,7 +340,8 @@ TYPED_TEST(TraitsTest, assertion_exception)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}}},
+                          .balance = 0,
+                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -456,8 +456,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -497,7 +496,8 @@ TYPED_TEST(TraitsTest, call_frames_refund)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}}},
+                          .balance = 0,
+                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {REFUND_TEST_CODE_HASH, REFUND_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -600,7 +600,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
     auto [state, code] = std::move(bs).release();
     commit_simple(
         tdb,
-        *state,
+        std::move(state),
         code,
         block_id,
         header,

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -26,7 +26,6 @@
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
 #include <category/execution/ethereum/db/db.hpp>
-#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
@@ -105,8 +104,21 @@ namespace
     {
         OnDiskMachine machine;
         mpt::Db db{machine, mpt::OnDiskDbConfig{}};
-        TrieDb tdb{db};
+        TrieDb tdb;
         vm::VM vm;
+
+        explicit OnDiskStateTest(bool const cache = false)
+            : tdb{db, cache}
+        {
+        }
+    };
+
+    struct OnDiskStateTestCached : public OnDiskStateTest
+    {
+        OnDiskStateTestCached()
+            : OnDiskStateTest(/*cache=*/true)
+        {
+        }
     };
 
     struct InMemoryStateTest
@@ -127,8 +139,9 @@ namespace
         OnDiskMachine machine;
         mpt::Db db1{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
         mpt::Db db2{machine, mpt::OnDiskDbConfig{.file_size_db = 8}};
+        // baseline noncaching db for tdb1
         TrieDb tdb1{db1};
-        TrieDb tdb2{db2};
+        TrieDb tdb2{db2, /*enable_multiblock_cache=*/true};
         vm::VM vm;
     };
 }
@@ -140,10 +153,10 @@ TEST_F(InMemoryStateTest, access_account)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 10'000}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 10'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -160,10 +173,10 @@ TEST_F(InMemoryStateTest, account_exists)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 10'000}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 10'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -194,10 +207,10 @@ TEST_F(InMemoryStateTest, get_balance)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 10'000}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 10'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -213,8 +226,7 @@ TEST_F(InMemoryStateTest, add_to_balance)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a, StateDelta{.account = {std::nullopt, Account{.balance = 1}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{.balance = 1}}}}}),
         Code{},
         BlockHeader{});
 
@@ -231,8 +243,7 @@ TEST_F(InMemoryStateTest, get_nonce)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a, StateDelta{.account = {std::nullopt, Account{.nonce = 2}}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, Account{.nonce = 2}}}}}),
         Code{},
         BlockHeader{});
 
@@ -258,10 +269,10 @@ TEST_F(InMemoryStateTest, get_code_hash)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = hash1}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.code_hash = hash1}}}}}),
         Code{},
         BlockHeader{});
 
@@ -288,12 +299,11 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{.account = {std::nullopt, Account{.balance = 18'000}}}},
             {c,
              StateDelta{
-                 .account = {std::nullopt, Account{.balance = 38'000}}}}},
+                 .account = {std::nullopt, Account{.balance = 38'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -334,8 +344,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_separate_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -348,7 +357,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_separate_tx)
                      {std::nullopt,
                       Account{
                           .balance = 38'000,
-                          .incarnation = Incarnation{1, 1}}}}}},
+                          .incarnation = Incarnation{1, 1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -377,8 +386,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_same_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -391,7 +399,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_same_tx)
                      {std::nullopt,
                       Account{
                           .balance = 38'000,
-                          .incarnation = Incarnation{1, 1}}}}}},
+                          .incarnation = Incarnation{1, 1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -415,10 +423,10 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_self_separate_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 18'000}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -450,14 +458,14 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_self_same_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 18'000,
-                          .incarnation = Incarnation{1, 1}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 18'000,
+                           .incarnation = Incarnation{1, 1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -478,11 +486,11 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 18'000}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
     {
@@ -512,11 +520,11 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_create_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 18'000}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
     {
@@ -561,11 +569,11 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 18'000}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
     {
@@ -586,7 +594,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{1},
             BlockHeader{.number = 1},
@@ -609,13 +617,13 @@ TYPED_TEST(
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value2}},
-                      {key3, {bytes32_t{}, value3}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value2}},
+                       {key3, {bytes32_t{}, value3}}}}}}),
         Code{},
         BlockHeader{});
     {
@@ -641,7 +649,7 @@ TYPED_TEST(
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{1},
             BlockHeader{.number = 1},
@@ -701,7 +709,7 @@ TYPED_TEST(
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             NULL_HASH_BLAKE3,
             BlockHeader{.number = 0},
@@ -724,11 +732,11 @@ TEST_F(InMemoryStateTest, create_conflict_address_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 18'000}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -746,10 +754,9 @@ TYPED_TEST(InMemoryStateTraitsTest, destruct_touched_dead)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{.account = {std::nullopt, Account{.balance = 10'000}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}},
+            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -806,8 +813,7 @@ TEST_F(InMemoryStateTest, get_storage)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage =
@@ -816,7 +822,7 @@ TEST_F(InMemoryStateTest, get_storage)
             {b,
              StateDelta{
                  .account = {std::nullopt, Account{}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+                 .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -836,12 +842,11 @@ TEST_F(InMemoryStateTest, set_storage_modified)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}},
+            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -857,11 +862,11 @@ TEST_F(InMemoryStateTest, set_storage_deleted)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -880,7 +885,7 @@ TEST_F(InMemoryStateTest, set_storage_added)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -899,12 +904,11 @@ TEST_F(InMemoryStateTest, set_storage_different_assigned)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}},
+            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -921,12 +925,11 @@ TEST_F(InMemoryStateTest, set_storage_unchanged_assigned)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{
                  .account = {std::nullopt, Account{}},
                  .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}},
+            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -941,7 +944,7 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -958,7 +961,7 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted_null)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{{b, StateDelta{.account = {std::nullopt, Account{}}}}},
+        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -975,11 +978,11 @@ TEST_F(InMemoryStateTest, set_storage_modify_delete)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -996,11 +999,11 @@ TEST_F(InMemoryStateTest, set_storage_delete_restored)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1017,11 +1020,11 @@ TEST_F(InMemoryStateTest, set_storage_modified_restored)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}}},
+        sd(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1040,7 +1043,7 @@ TEST_F(InMemoryStateTest, get_code_size)
     Account acct{.code_hash = code_hash1};
     commit_sequential(
         this->tdb,
-        StateDeltas{{a, StateDelta{.account = {std::nullopt, acct}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, acct}}}}),
         Code{{code_hash1, icode1}},
         BlockHeader{});
 
@@ -1056,9 +1059,8 @@ TEST_F(InMemoryStateTest, copy_code)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a, StateDelta{.account = {std::nullopt, acct_a}}},
-            {b, StateDelta{.account = {std::nullopt, acct_b}}}},
+        sd({{a, StateDelta{.account = {std::nullopt, acct_a}}},
+            {b, StateDelta{.account = {std::nullopt, acct_b}}}}),
         Code{{code_hash1, icode1}, {code_hash2, icode2}},
         BlockHeader{});
 
@@ -1108,10 +1110,11 @@ TEST_F(InMemoryStateTest, get_code)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = code_hash1}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.code_hash = code_hash1}}}}}),
         Code{{code_hash1, vm::make_shared_intercode(contract)}},
         BlockHeader{});
 
@@ -1151,8 +1154,7 @@ TEST_F(InMemoryStateTest, can_merge_same_account_different_storage)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
+        sd({{b,
              StateDelta{
                  .account = {std::nullopt, Account{.balance = 40'000}},
                  .storage =
@@ -1163,7 +1165,7 @@ TEST_F(InMemoryStateTest, can_merge_same_account_different_storage)
                  .account = {std::nullopt, Account{.balance = 50'000}},
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+                      {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1186,11 +1188,11 @@ TEST_F(InMemoryStateTest, cant_merge_colliding_storage)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 40'000}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 40'000}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1222,8 +1224,7 @@ TYPED_TEST(InMemoryStateTraitsTest, merge_txn0_and_txn1)
 
     commit_sequential(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
             {b,
              StateDelta{
@@ -1236,7 +1237,7 @@ TYPED_TEST(InMemoryStateTraitsTest, merge_txn0_and_txn1)
                  .account = {std::nullopt, Account{.balance = 50'000}},
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+                      {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1273,7 +1274,7 @@ TEST_F(InMemoryStateTest, commit_storage_and_account_together_regression)
     auto [released_state, released_code] = std::move(bs).release();
     commit_simple(
         this->tdb,
-        *released_state,
+        std::move(released_state),
         released_code,
         NULL_HASH_BLAKE3,
         BlockHeader{.number = 0},
@@ -1304,7 +1305,7 @@ TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
     auto [released_state, released_code] = std::move(bs).release();
     commit_simple(
         this->tdb,
-        *released_state,
+        std::move(released_state),
         released_code,
         NULL_HASH_BLAKE3,
         {},
@@ -1328,8 +1329,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
     this->tdb.set_block_and_prefix(8);
     commit_simple(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
             {b,
              StateDelta{
@@ -1342,7 +1342,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
                  .account = {std::nullopt, Account{.balance = 50'000}},
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+                      {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         bytes32_t{9},
         BlockHeader{.number = 9});
@@ -1364,7 +1364,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{10},
             BlockHeader{.number = 10});
@@ -1391,7 +1391,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{11},
             BlockHeader{.number = 11});
@@ -1434,8 +1434,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
     this->tdb.set_block_and_prefix(9);
     commit_simple(
         this->tdb,
-        StateDeltas{
-            {a,
+        sd({{a,
              StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
             {b,
              StateDelta{
@@ -1448,7 +1447,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
                  .account = {std::nullopt, Account{.balance = 50'000}},
                  .storage =
                      {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}},
+                      {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         bytes32_t{10},
         BlockHeader{.number = 10},
@@ -1473,7 +1472,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{118},
             BlockHeader{.number = 11});
@@ -1501,7 +1500,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{116},
             BlockHeader{.number = 11});
@@ -1531,7 +1530,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            *released_state,
+            std::move(released_state),
             released_code,
             bytes32_t{117},
             BlockHeader{.number = 11});
@@ -1553,67 +1552,62 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
     EXPECT_EQ(state_root_round8, this->tdb.state_root());
 }
 
-TEST_F(OnDiskStateTest, proposal_basics)
+TEST_F(OnDiskStateTestCached, proposal_basics)
 {
     this->tdb.reset_root(
         load_header({}, this->db, BlockHeader{.number = 9}), 9);
     Db &db = this->tdb;
     commit_simple(
         db,
-        StateDeltas{
-            {a,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 30'000}}}}},
+        sd(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 30'000}}}}}),
         Code{},
         bytes32_t{10},
         BlockHeader{.number = 10});
     db.set_block_and_prefix(10, bytes32_t{10});
     EXPECT_EQ(db.read_account(a).value().balance, 30'000);
 
-    DbCache db_cache(db);
-    db_cache.set_block_and_prefix(10, bytes32_t{10});
-    BlockState bs1(db_cache, this->vm);
+    db.set_block_and_prefix(10, bytes32_t{10});
+    BlockState bs1(db, this->vm);
     EXPECT_EQ(bs1.read_account(a).value().balance, 30'000);
     auto [released_state1, released_code1] = std::move(bs1).release();
     commit_simple(
-        db_cache,
-        *released_state1,
+        db,
+        std::move(released_state1),
         released_code1,
         bytes32_t{11},
         BlockHeader{.number = 11});
-    db_cache.update_proposal_state(
-        std::move(released_state1), 11, bytes32_t{11});
-    db_cache.finalize(11, bytes32_t{11});
+    db.finalize(11, bytes32_t{11});
 
-    db_cache.set_block_and_prefix(11, bytes32_t{11});
-    BlockState bs2(db_cache, this->vm);
+    db.set_block_and_prefix(11, bytes32_t{11});
+    BlockState bs2(db, this->vm);
     State as{bs2, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(a));
     as.add_to_balance(a, 10'000);
     EXPECT_TRUE(bs2.can_merge(as));
     bs2.merge(as);
-    EXPECT_EQ(db_cache.read_account(a).value().balance, 30'000);
+    EXPECT_EQ(db.read_account(a).value().balance, 30'000);
     auto [released_state2, released_code2] = std::move(bs2).release();
     commit_simple(
-        db_cache,
-        *released_state2,
+        db,
+        std::move(released_state2),
         released_code2,
         bytes32_t{12},
         BlockHeader{.number = 12});
-    db_cache.update_proposal_state(
-        std::move(released_state2), 12, bytes32_t{12});
-    EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
-    db_cache.finalize(12, bytes32_t{12});
-    EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
+    EXPECT_EQ(db.read_account(a).value().balance, 40'000);
+    db.finalize(12, bytes32_t{12});
+    EXPECT_EQ(db.read_account(a).value().balance, 40'000);
     // read an older block's state
-    db_cache.set_block_and_prefix(11); // set to block 11 finalized
-    EXPECT_EQ(db_cache.read_account(a).value().balance, 30'000);
+    db.set_block_and_prefix(11); // set to block 11 finalized
+    EXPECT_EQ(db.read_account(a).value().balance, 30'000);
 }
 
-TEST_F(OnDiskStateTest, undecided_proposals)
+TEST_F(OnDiskStateTestCached, undecided_proposals)
 {
     load_header({}, this->db, BlockHeader{.number = 9});
-    DbCache db_cache(this->tdb);
+    Db &db = this->tdb;
 
     // b10 r100        a 10   b 20 v1 v2   c 30 v1 v2
     // b11 r111 r100           +40 v2 --
@@ -1641,29 +1635,28 @@ TEST_F(OnDiskStateTest, undecided_proposals)
              .storage = {
                  {key1, {bytes32_t{}, value1}},
                  {key2, {bytes32_t{}, value2}}}}}}};
-    db_cache.set_block_and_prefix(9);
+    db.set_block_and_prefix(9);
     commit_simple(
-        db_cache,
-        *state_deltas,
+        db,
+        std::move(state_deltas),
         Code{},
         bytes32_t{10},
         BlockHeader{.number = 10});
-    db_cache.update_proposal_state(std::move(state_deltas), 10, bytes32_t{10});
-    db_cache.finalize(10, bytes32_t{10});
-    EXPECT_TRUE(db_cache.read_account(a).has_value());
-    EXPECT_TRUE(db_cache.read_account(b).has_value());
-    EXPECT_TRUE(db_cache.read_account(c).has_value());
-    EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
-    EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{20'000});
-    EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{30'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), value2);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value2);
+    db.finalize(10, bytes32_t{10});
+    EXPECT_TRUE(db.read_account(a).has_value());
+    EXPECT_TRUE(db.read_account(b).has_value());
+    EXPECT_TRUE(db.read_account(c).has_value());
+    EXPECT_EQ(db.read_account(a).value().balance, uint256_t{10'000});
+    EXPECT_EQ(db.read_account(b).value().balance, uint256_t{20'000});
+    EXPECT_EQ(db.read_account(c).value().balance, uint256_t{30'000});
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key1), value1);
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key2), value2);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key1), value1);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key2), value2);
 
     LOG_INFO("block 11 round 111 on block 10 round 100");
-    db_cache.set_block_and_prefix(10, bytes32_t{10});
-    BlockState bs_111(db_cache, this->vm);
+    db.set_block_and_prefix(10, bytes32_t{10});
+    BlockState bs_111(db, this->vm);
     // b11 r111 r100           +40 v2 --
     {
         State as{bs_111, Incarnation{11, 1}};
@@ -1675,29 +1668,27 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_111, released_code_111] = std::move(bs_111).release();
     commit_simple(
-        db_cache,
-        *released_state_111,
+        db,
+        std::move(released_state_111),
         released_code_111,
         bytes32_t{111},
         BlockHeader{.number = 11});
-    db_cache.update_proposal_state(
-        std::move(released_state_111), 11, bytes32_t{111});
-    auto const state_root_round_111 = db_cache.state_root();
-    db_cache.set_block_and_prefix(11, bytes32_t{111});
-    EXPECT_TRUE(db_cache.read_account(a).has_value());
-    EXPECT_TRUE(db_cache.read_account(b).has_value());
-    EXPECT_TRUE(db_cache.read_account(c).has_value());
-    EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
-    EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{60'000});
-    EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{30'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value2);
+    auto const state_root_round_111 = db.state_root();
+    db.set_block_and_prefix(11, bytes32_t{111});
+    EXPECT_TRUE(db.read_account(a).has_value());
+    EXPECT_TRUE(db.read_account(b).has_value());
+    EXPECT_TRUE(db.read_account(c).has_value());
+    EXPECT_EQ(db.read_account(a).value().balance, uint256_t{10'000});
+    EXPECT_EQ(db.read_account(b).value().balance, uint256_t{60'000});
+    EXPECT_EQ(db.read_account(c).value().balance, uint256_t{30'000});
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key1), value2);
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key1), value1);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key2), value2);
 
     LOG_INFO("block 12 round 121 on block 11 round 111");
-    db_cache.set_block_and_prefix(11, bytes32_t{111});
-    BlockState bs_121(db_cache, this->vm);
+    db.set_block_and_prefix(11, bytes32_t{111});
+    BlockState bs_121(db, this->vm);
     // b12 r121 r111                        +10    v1
     {
         State as{bs_121, Incarnation{12, 1}};
@@ -1708,28 +1699,26 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_121, released_code_121] = std::move(bs_121).release();
     commit_simple(
-        db_cache,
-        *released_state_121,
+        db,
+        std::move(released_state_121),
         released_code_121,
         bytes32_t{121},
         BlockHeader{.number = 12});
-    db_cache.update_proposal_state(
-        std::move(released_state_121), 12, bytes32_t{121});
-    db_cache.set_block_and_prefix(12, bytes32_t{121});
-    EXPECT_TRUE(db_cache.read_account(a).has_value());
-    EXPECT_TRUE(db_cache.read_account(b).has_value());
-    EXPECT_TRUE(db_cache.read_account(c).has_value());
-    EXPECT_EQ(db_cache.read_account(a).value().balance, uint256_t{10'000});
-    EXPECT_EQ(db_cache.read_account(b).value().balance, uint256_t{60'000});
-    EXPECT_EQ(db_cache.read_account(c).value().balance, uint256_t{40'000});
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), value1);
+    db.set_block_and_prefix(12, bytes32_t{121});
+    EXPECT_TRUE(db.read_account(a).has_value());
+    EXPECT_TRUE(db.read_account(b).has_value());
+    EXPECT_TRUE(db.read_account(c).has_value());
+    EXPECT_EQ(db.read_account(a).value().balance, uint256_t{10'000});
+    EXPECT_EQ(db.read_account(b).value().balance, uint256_t{60'000});
+    EXPECT_EQ(db.read_account(c).value().balance, uint256_t{40'000});
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key1), value2);
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key2), bytes32_t{});
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key1), value1);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key2), value1);
 
     LOG_INFO("block 11 round 112 on block 10 round 100");
-    db_cache.set_block_and_prefix(10, bytes32_t{10});
-    BlockState bs_112(db_cache, this->vm);
+    db.set_block_and_prefix(10, bytes32_t{10});
+    BlockState bs_112(db, this->vm);
     // b11 r112 r100    +20        --           --
     {
         State as{bs_112, Incarnation{11, 1}};
@@ -1741,17 +1730,15 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_112, released_code_112] = std::move(bs_112).release();
     commit_simple(
-        db_cache,
-        *released_state_112,
+        db,
+        std::move(released_state_112),
         released_code_112,
         bytes32_t{112},
         BlockHeader{.number = 11});
-    db_cache.update_proposal_state(
-        std::move(released_state_112), 11, bytes32_t{112});
 
     LOG_INFO("block 12 round 122 on block 11 round 112");
-    db_cache.set_block_and_prefix(11, bytes32_t{112});
-    BlockState bs_122(db_cache, this->vm);
+    db.set_block_and_prefix(11, bytes32_t{112});
+    BlockState bs_122(db, this->vm);
     //  b12 r122 r112           +20 v3              v1
     {
         State as{bs_122, Incarnation{12, 1}};
@@ -1762,17 +1749,15 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_122, released_code_122] = std::move(bs_122).release();
     commit_simple(
-        db_cache,
-        *released_state_122,
+        db,
+        std::move(released_state_122),
         released_code_122,
         bytes32_t{122},
         BlockHeader{.number = 12});
-    db_cache.update_proposal_state(
-        std::move(released_state_122), 12, bytes32_t{122});
 
     LOG_INFO("block 13 round 131 on block 12 round 121");
-    db_cache.set_block_and_prefix(12, bytes32_t{121});
-    BlockState bs_131(db_cache, this->vm);
+    db.set_block_and_prefix(12, bytes32_t{121});
+    BlockState bs_131(db, this->vm);
     //  b13 r131 r121    +30    +20    v1        v2 __
     {
         State as{bs_131, Incarnation{13, 1}};
@@ -1786,18 +1771,16 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_131, released_code_131] = std::move(bs_131).release();
     commit_simple(
-        db_cache,
-        *released_state_131,
+        db,
+        std::move(released_state_131),
         released_code_131,
         bytes32_t{131},
         BlockHeader{.number = 13});
-    db_cache.update_proposal_state(
-        std::move(released_state_131), 13, bytes32_t{131});
-    auto const state_root_round_131 = db_cache.state_root();
+    auto const state_root_round_131 = db.state_root();
 
     LOG_INFO("block 13 round 132 on block 12 round 122");
-    db_cache.set_block_and_prefix(12, bytes32_t{122});
-    BlockState bs_132(db_cache, this->vm);
+    db.set_block_and_prefix(12, bytes32_t{122});
+    BlockState bs_132(db, this->vm);
     // b13 r132 r122                  --        v3
     {
         State as{bs_132, Incarnation{13, 1}};
@@ -1808,13 +1791,11 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     }
     auto [released_state_132, released_code_132] = std::move(bs_132).release();
     commit_simple(
-        db_cache,
-        *released_state_132,
+        db,
+        std::move(released_state_132),
         released_code_132,
         bytes32_t{132},
         BlockHeader{.number = 13});
-    db_cache.update_proposal_state(
-        std::move(released_state_132), 13, bytes32_t{132});
 
     //  b10 r100        a 10   b 20 v1 v2   c 30 v1 v2
     //  b11 r111 r100           +40 v2 --
@@ -1822,28 +1803,28 @@ TEST_F(OnDiskStateTest, undecided_proposals)
     //  b13 r131 r121    +30    +20    v1        v2 --
     //                  a 40   b 80 v2 v1   c 40 v2 --
     //  finalize r111 r121 r131
-    db_cache.finalize(11, bytes32_t{111});
-    db_cache.finalize(12, bytes32_t{121});
-    db_cache.finalize(13, bytes32_t{131});
+    db.finalize(11, bytes32_t{111});
+    db.finalize(12, bytes32_t{121});
+    db.finalize(13, bytes32_t{131});
 
-    db_cache.set_block_and_prefix(13, bytes32_t{131});
-    EXPECT_TRUE(db_cache.read_account(a).has_value());
-    EXPECT_TRUE(db_cache.read_account(b).has_value());
-    EXPECT_TRUE(db_cache.read_account(c).has_value());
-    EXPECT_EQ(db_cache.read_account(a).value().balance, 40'000);
-    EXPECT_EQ(db_cache.read_account(b).value().balance, 80'000);
-    EXPECT_EQ(db_cache.read_account(c).value().balance, 40'000);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(b, Incarnation{0, 0}, key2), value1);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key1), value2);
-    EXPECT_EQ(db_cache.read_storage(c, Incarnation{0, 0}, key2), bytes32_t{});
+    db.set_block_and_prefix(13, bytes32_t{131});
+    EXPECT_TRUE(db.read_account(a).has_value());
+    EXPECT_TRUE(db.read_account(b).has_value());
+    EXPECT_TRUE(db.read_account(c).has_value());
+    EXPECT_EQ(db.read_account(a).value().balance, 40'000);
+    EXPECT_EQ(db.read_account(b).value().balance, 80'000);
+    EXPECT_EQ(db.read_account(c).value().balance, 40'000);
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key1), value2);
+    EXPECT_EQ(db.read_storage(b, Incarnation{0, 0}, key2), value1);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key1), value2);
+    EXPECT_EQ(db.read_storage(c, Incarnation{0, 0}, key2), bytes32_t{});
 
     // check state root of previous rounds
-    db_cache.set_block_and_prefix(11, bytes32_t{111});
-    EXPECT_EQ(state_root_round_111, db_cache.state_root());
+    db.set_block_and_prefix(11, bytes32_t{111});
+    EXPECT_EQ(state_root_round_111, db.state_root());
 
-    db_cache.set_block_and_prefix(13, bytes32_t{131});
-    EXPECT_EQ(state_root_round_131, db_cache.state_root());
+    db.set_block_and_prefix(13, bytes32_t{131});
+    EXPECT_EQ(state_root_round_131, db.state_root());
 }
 
 namespace
@@ -1862,7 +1843,7 @@ namespace
 
         std::mt19937_64 rng_;
         Db &db1_;
-        DbCache &db2_;
+        Db &db2_;
         vm::VM &vm_;
         uint64_t finalized_block_{0};
         uint64_t finalized_proposal_seed_{0};
@@ -1884,7 +1865,7 @@ namespace
 
     public:
         RandomProposalGenerator(
-            uint64_t const seed, Db &db1, DbCache &db2, vm::VM &vm)
+            uint64_t const seed, Db &db1, Db &db2, vm::VM &vm)
             : rng_(seed)
             , db1_(db1)
             , db2_(db2)
@@ -2100,7 +2081,7 @@ namespace
                 auto [state1, code1] = std::move(bs1).release();
                 commit_simple(
                     db1_,
-                    *state1,
+                    std::move(state1),
                     code1,
                     get_dummy_block_id(proposal_seed),
                     BlockHeader{.number = block});
@@ -2109,14 +2090,10 @@ namespace
                 auto [state2, code2] = std::move(bs2).release();
                 commit_simple(
                     db2_,
-                    *state2,
+                    std::move(state2),
                     code2,
                     get_dummy_block_id(proposal_seed),
                     BlockHeader{.number = block});
-                db2_.update_proposal_state(
-                    std::move(state2),
-                    block,
-                    get_dummy_block_id(proposal_seed));
             }
         }
 
@@ -2237,8 +2214,8 @@ TEST_F(TwoOnDisk, random_proposals)
         load_header({}, this->db1, BlockHeader{.number = 0}), 0);
     this->tdb2.reset_root(
         load_header({}, this->db2, BlockHeader{.number = 0}), 0);
-    TrieDb &db1 = this->tdb1;
-    DbCache db2(this->tdb2);
+    Db &db1 = this->tdb1;
+    Db &db2 = this->tdb2;
 
     uint64_t const seed = [] {
         char const *str = std::getenv("MONAD_RANDOM_PROPOSALS_SEED");

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -122,8 +122,7 @@ TYPED_TEST(TraitsTest, execute_success)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -135,7 +134,7 @@ TYPED_TEST(TraitsTest, execute_success)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                      Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{});
 
@@ -208,8 +207,7 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -221,7 +219,7 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                      Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{});
 
@@ -299,8 +297,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -310,7 +307,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = code_hash}}}}},
+                      Account{.balance = 0, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -423,8 +420,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -434,7 +430,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -513,8 +509,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_C,
+        sd({{ADDR_C,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -524,7 +519,7 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -617,13 +612,14 @@ TYPED_TEST(TraitsTest, selfdestruct_depth)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance =
+                               std::numeric_limits<uint256_t>::max()}}}}}),
         Code{},
         BlockHeader{});
 
@@ -697,15 +693,14 @@ TYPED_TEST(TraitsTest, simulate_v1_trace)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max()}}}},
             {ADDR_B,
-             StateDelta{.account = {std::nullopt, Account{.balance = 0}}}}},
+             StateDelta{.account = {std::nullopt, Account{.balance = 0}}}}}),
         Code{},
         BlockHeader{});
 
@@ -803,8 +798,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_C,
+        sd({{ADDR_C,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -814,7 +808,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}},
+                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -909,8 +903,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_C,
+        sd({{ADDR_C,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -920,7 +913,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0u, .code_hash = code_hash}}}}},
+                      Account{.balance = 0u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -1047,8 +1040,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {TX_SENDER_ADDR,
+        sd({{TX_SENDER_ADDR,
              StateDelta{
                  .account =
                      {std::nullopt, Account{.balance = 1'000'000'000'000u}}}},
@@ -1065,9 +1057,9 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000,
-                          .code_hash = selfdestruct_code_hash}}}}}
+                          .code_hash = selfdestruct_code_hash}}}}})
 
-        ,
+            ,
         Code{
             {intermediary_code_hash, intermediary_contract},
             {selfdestruct_code_hash, selfdestruct_contract},
@@ -1273,8 +1265,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {TX_SENDER_ADDR,
+        sd({{TX_SENDER_ADDR,
              StateDelta{
                  .account =
                      {std::nullopt, Account{.balance = 1'000'000'000'000UL}}}},
@@ -1284,9 +1275,9 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
                      {std::nullopt,
                       Account{
                           .balance = 1'000'000UL,
-                          .code_hash = selfdestruct_code_hash}}}}}
+                          .code_hash = selfdestruct_code_hash}}}}})
 
-        ,
+            ,
         Code{
             {selfdestruct_code_hash, selfdestruct_contract},
         },
@@ -1432,8 +1423,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1441,9 +1431,9 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
                           .balance = 1'000'000'000'000UL,
                           .code_hash = a_code_hash}}}},
             {ADDR_B,
-             StateDelta{.account = {std::nullopt, Account{.balance = 1UL}}}}}
+             StateDelta{.account = {std::nullopt, Account{.balance = 1UL}}}}})
 
-        ,
+            ,
         Code{{a_code_hash, a_contract}},
         BlockHeader{});
 

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -131,7 +131,7 @@ TEST(DbBinarySnapshot, Basic)
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
         monad::test::commit_simple(
             tdb,
-            deltas,
+            monad::test::sd(std::move(deltas)),
             code_delta,
             bytes32_t{100},
             BlockHeader{.number = 100});
@@ -244,7 +244,7 @@ TEST(DbBinarySnapshot, MultipleShards)
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
         monad::test::commit_simple(
             tdb,
-            deltas,
+            monad::test::sd(std::move(deltas)),
             code_delta,
             bytes32_t{100},
             BlockHeader{.number = 100});

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -89,10 +89,7 @@ TEST(PrestateTracer, pre_state_to_json)
     vm::VM vm;
 
     commit_sequential(
-        tdb,
-        StateDeltas{},
-        Code{{A_CODE_HASH, A_ICODE}},
-        BlockHeader{.number = 0});
+        tdb, sd({}), Code{{A_CODE_HASH, A_ICODE}}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -131,7 +128,7 @@ TEST(PrestateTracer, zero_nonce)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, StateDeltas{}, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -169,7 +166,7 @@ TEST(PrestateTracer, state_deltas_to_json)
 
     commit_sequential(
         tdb,
-        state_deltas,
+        sd(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -210,7 +207,7 @@ TEST(PrestateTracer, statediff_account_creation)
 
     commit_sequential(
         tdb,
-        state_deltas,
+        sd(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -250,7 +247,7 @@ TEST(PrestateTracer, statediff_balance_nonce_update)
 
     commit_sequential(
         tdb,
-        state_deltas,
+        sd(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -302,11 +299,11 @@ TEST(PrestateTracer, statediff_delete_storage)
 
     commit_sequential(
         tdb,
-        state_deltas1,
+        sd(state_deltas1),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
-    commit_sequential(tdb, state_deltas2, Code{}, BlockHeader{.number = 1});
+    commit_sequential(tdb, sd(state_deltas2), Code{}, BlockHeader{.number = 1});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -359,7 +356,7 @@ TEST(PrestateTracer, statediff_multiple_fields_update)
 
     commit_sequential(
         tdb,
-        state_deltas,
+        sd(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}, {B_CODE_HASH, B_ICODE}},
         BlockHeader{.number = 0});
 
@@ -409,13 +406,13 @@ TEST(PrestateTracer, statediff_account_deletion)
         {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}},
     };
 
-    commit_sequential(tdb, state_deltas1, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd(state_deltas1), Code{}, BlockHeader{.number = 0});
 
     StateDeltas state_deltas2{
         {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}},
     };
 
-    commit_sequential(tdb, state_deltas2, Code{}, BlockHeader{.number = 1});
+    commit_sequential(tdb, sd(state_deltas2), Code{}, BlockHeader{.number = 1});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -473,10 +470,7 @@ TEST(PrestateTracer, geth_example_prestate)
     vm::VM vm;
 
     commit_sequential(
-        tdb,
-        StateDeltas{},
-        Code{{A_CODE_HASH, A_ICODE}},
-        BlockHeader{.number = 0});
+        tdb, sd({}), Code{{A_CODE_HASH, A_ICODE}}, BlockHeader{.number = 0});
 
     BlockState bs0(tdb, vm);
     State s(bs0, Incarnation{0, 0});
@@ -528,7 +522,7 @@ TEST(PrestateTracer, geth_example_statediff)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs0(tdb, vm);
     State s(bs0, Incarnation{0, 0});
@@ -562,7 +556,7 @@ TEST(PrestateTracer, prestate_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, {}, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -583,7 +577,7 @@ TEST(PrestateTracer, statediff_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -609,7 +603,7 @@ TYPED_TEST(TraitsTest, access_list_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -624,14 +618,12 @@ TYPED_TEST(TraitsTest, access_list_empty)
 
 TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -652,14 +644,12 @@ TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
 
 TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -692,14 +682,12 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
 
 TYPED_TEST(TraitsTest, access_list_records_rejected_frame_regular_account)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -737,7 +725,7 @@ TYPED_TEST(TraitsTest, access_list_write)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -779,14 +767,12 @@ TYPED_TEST(TraitsTest, access_list_write)
 
 TYPED_TEST(TraitsTest, access_list_regular_account)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -851,14 +837,12 @@ TYPED_TEST(TraitsTest, access_list_regular_account)
 
 TYPED_TEST(TraitsTest, access_list_sender)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -912,14 +896,12 @@ TYPED_TEST(TraitsTest, access_list_sender)
 
 TYPED_TEST(TraitsTest, access_list_beneficiary)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -973,14 +955,12 @@ TYPED_TEST(TraitsTest, access_list_beneficiary)
 
 TYPED_TEST(TraitsTest, access_list_recipient)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1034,14 +1014,12 @@ TYPED_TEST(TraitsTest, access_list_recipient)
 
 TYPED_TEST(TraitsTest, access_list_authorities)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1108,14 +1086,12 @@ TYPED_TEST(TraitsTest, access_list_authorities)
 
 TYPED_TEST(TraitsTest, access_list_precompiles)
 {
-    StateDeltas state_deltas{};
-
     InMemoryMachine machine;
     mpt::Db db{machine};
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, state_deltas, Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1173,13 +1149,13 @@ TEST(PrestateTracer, prestate_access_storage)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, a},
-                 .storage = {StorageDeltas{
-                     {key1, {bytes32_t{}, value1}},
-                     {key2, {bytes32_t{}, value2}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, a},
+                  .storage = {StorageDeltas{
+                      {key1, {bytes32_t{}, value1}},
+                      {key2, {bytes32_t{}, value2}}}}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1245,8 +1221,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_set_storage)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1315,11 +1290,11 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_storage)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, a},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, a},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1393,8 +1368,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_balance)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1465,8 +1439,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_nonce)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1533,8 +1506,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_code_hash)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -1604,13 +1576,13 @@ TEST(PrestateTracer, prestate_retain_beneficiary_access_storage)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, a},
-                 .storage = {StorageDeltas{
-                     {key1, {bytes32_t{}, value1}},
-                     {key2, {bytes32_t{}, value2}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, a},
+                  .storage = {StorageDeltas{
+                      {key1, {bytes32_t{}, value1}},
+                      {key2, {bytes32_t{}, value2}}}}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1676,8 +1648,7 @@ TEST(PrestateTracer, prestate_omit_beneficiary)
     // Block 0
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1730,7 +1701,7 @@ TEST(PrestateTracer, prestate_empty_block_no_reward)
     Block const block{header, {}, {}};
 
     // Block 0
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -49,11 +49,11 @@ namespace monad::staking::test
     {
         commit_simple(
             trie_db_,
-            StateDeltas{
-                {STAKING_CA,
-                 StateDelta{
-                     .account =
-                         {std::nullopt, Account{.balance = 0, .nonce = 1}}}}},
+            sd(
+                {{STAKING_CA,
+                  StateDelta{
+                      .account =
+                          {std::nullopt, Account{.balance = 0, .nonce = 1}}}}}),
             Code{},
             NULL_HASH_BLAKE3,
             BlockHeader{},

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -112,7 +112,7 @@ protected:
             auto [state_deltas, code] = std::move(bs).release();
             test::commit_simple(
                 tdb,
-                *state_deltas,
+                std::move(state_deltas),
                 code,
                 NULL_HASH_BLAKE3,
                 BlockHeader{.number = TEST_BLOCK_NUM});

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -106,11 +106,11 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
     {
         commit_sequential(
             tdb,
-            StateDeltas{
-                {STAKING_CA,
-                 StateDelta{
-                     .account =
-                         {std::nullopt, Account{.balance = 0, .nonce = 1}}}}},
+            sd(
+                {{STAKING_CA,
+                  StateDelta{
+                      .account =
+                          {std::nullopt, Account{.balance = 0, .nonce = 1}}}}}),
             Code{},
             BlockHeader{});
         state.add_to_balance(STAKING_CA, 0); // create account like a txn would

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -18,6 +18,8 @@
 #include <category/core/address.hpp>
 #include <category/core/config.hpp>
 #include <category/core/log.hpp>
+#include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/core/fmt/int_fmt.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/vm/vm.hpp>
 

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -183,15 +183,14 @@ namespace
     void EthCallFixture::test_transfer_call_with_trace(bool const gas_specified)
     {
         for (uint64_t i = 0; i < 256; ++i) {
-            commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+            commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
         }
 
         BlockHeader const header{.number = 256};
 
         commit_sequential(
             tdb,
-            StateDeltas{
-                {ADDR_A,
+            sd({{ADDR_A,
                  StateDelta{
                      .account =
                          {std::nullopt,
@@ -203,7 +202,7 @@ namespace
                  StateDelta{
                      .account =
                          {std::nullopt,
-                          Account{.balance = 0, .code_hash = NULL_HASH}}}}},
+                          Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
             Code{},
             header);
 
@@ -288,7 +287,7 @@ namespace
 TEST_F(EthCallFixture, simple_success_call)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -300,7 +299,7 @@ TEST_F(EthCallFixture, simple_success_call)
         .gas_limit = 100000u, .to = to, .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -344,7 +343,7 @@ TEST_F(EthCallFixture, simple_success_call)
 TEST_F(EthCallFixture, insufficient_balance)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -359,7 +358,7 @@ TEST_F(EthCallFixture, insufficient_balance)
         .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -404,7 +403,7 @@ TEST_F(EthCallFixture, insufficient_balance)
 TEST_F(EthCallFixture, on_proposed_block)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -416,7 +415,7 @@ TEST_F(EthCallFixture, on_proposed_block)
         .gas_limit = 100000u, .to = to, .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_simple(tdb, {}, {}, bytes32_t{256}, header);
+    commit_simple(tdb, sd({}), {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
@@ -464,7 +463,7 @@ TEST_F(EthCallFixture, blockhash_before_fork)
 
     // The behavior in evmc is that, if eip-2935 is
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -494,7 +493,7 @@ TEST_F(EthCallFixture, blockhash_before_fork)
         .data = byte_string{bytecode.data(), bytecode.size()}};
     BlockHeader const header{.number = 256};
 
-    commit_simple(tdb, {}, {}, bytes32_t{256}, header);
+    commit_simple(tdb, sd({}), {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
@@ -552,7 +551,7 @@ TEST_F(EthCallFixture, failed_to_read)
     // missing 256 previous blocks
     tdb.reset_root(load_header(nullptr, db, BlockHeader{.number = 1199}), 1199);
     for (uint64_t i = 1200; i < 1256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -572,7 +571,7 @@ TEST_F(EthCallFixture, failed_to_read)
         .data = byte_string{bytecode.data(), bytecode.size()}};
     BlockHeader const header{.number = 1256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -617,7 +616,7 @@ TEST_F(EthCallFixture, failed_to_read)
 TEST_F(EthCallFixture, contract_deployment_success)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -628,7 +627,7 @@ TEST_F(EthCallFixture, contract_deployment_success)
     Transaction const tx{.gas_limit = 200000u, .data = tx_data};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -688,8 +687,7 @@ TEST_F(EthCallFixture, assertion_exception_depth1)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {from,
+        sd({{from,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -700,7 +698,7 @@ TEST_F(EthCallFixture, assertion_exception_depth1)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}}},
+                          .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{.number = 0});
 
@@ -779,8 +777,7 @@ TEST_F(EthCallFixture, assertion_exception_depth2)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {addr1,
+        sd({{addr1,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -796,7 +793,7 @@ TEST_F(EthCallFixture, assertion_exception_depth2)
                      {std::nullopt,
                       Account{
                           .balance = std::numeric_limits<uint256_t>::max() - 1,
-                          .code_hash = NULL_HASH}}}}},
+                          .code_hash = NULL_HASH}}}}}),
         Code{{hash2, icode2}},
         BlockHeader{.number = 0});
 
@@ -860,12 +857,12 @@ TEST_F(EthCallFixture, loop_out_of_gas)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ca,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+        sd(
+            {{ca,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0x1b58, .code_hash = code_hash}}}}}),
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -979,12 +976,12 @@ TEST_F(EthCallFixture, expensive_read_out_of_gas)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ca,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+        sd(
+            {{ca,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0x1b58, .code_hash = code_hash}}}}}),
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -1046,12 +1043,12 @@ TEST_F(EthCallFixture, from_contract_account)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ca,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = code_hash}}}}},
+        sd(
+            {{ca,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0x1b58, .code_hash = code_hash}}}}}),
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
@@ -1114,19 +1111,19 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
 
             commit_sequential(
                 tdb,
-                StateDeltas{
-                    {ca,
-                     StateDelta{
-                         .account =
-                             {std::nullopt,
-                              Account{
-                                  .balance = 0x1b58,
-                                  .code_hash = code_hash}}}}},
+                sd(
+                    {{ca,
+                      StateDelta{
+                          .account =
+                              {std::nullopt,
+                               Account{
+                                   .balance = 0x1b58,
+                                   .code_hash = code_hash}}}}}),
                 Code{{code_hash, icode}},
                 BlockHeader{.number = i});
         }
         else {
-            commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+            commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
         }
     }
 
@@ -1238,8 +1235,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1265,7 +1261,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = d_code_hash}}}}},
+                      Account{.balance = 0, .code_hash = d_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -1436,15 +1432,14 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
     byte_string_view const data = to_byte_string_view(s);
 
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     BlockHeader const header{.number = 256};
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A,
+        sd({{ADDR_A,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -1453,7 +1448,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
                           .code_hash = NULL_HASH,
                           .nonce = 0x0}}}},
             {precompile_address,
-             StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}}},
+             StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}}}),
         Code{},
         header);
 
@@ -1536,7 +1531,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
 TEST_F(EthCallFixture, transfer_success_with_state_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     BlockHeader const header{.number = 256};
@@ -1551,9 +1546,8 @@ TEST_F(EthCallFixture, transfer_success_with_state_trace)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, acct_from}}},
-            {ADDR_B, StateDelta{.account = {std::nullopt, acct_to}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, acct_from}}},
+            {ADDR_B, StateDelta{.account = {std::nullopt, acct_to}}}}),
         Code{},
         header);
 
@@ -1686,7 +1680,7 @@ TEST_F(EthCallFixture, transfer_success_with_state_trace)
 TEST_F(EthCallFixture, contract_deployment_success_with_state_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -1697,7 +1691,7 @@ TEST_F(EthCallFixture, contract_deployment_success_with_state_trace)
     Transaction const tx{.gas_limit = 200000u, .data = tx_data};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -1819,7 +1813,7 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
         0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_address;
     {
         // Initial state.
-        StateDeltas const deltas{
+        StateDeltas deltas{
             {ADDR_A,
              StateDelta{
                  .account =
@@ -1828,12 +1822,13 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                           .balance = uint256_t{uint64_t{0x01}}, .nonce = 1}}}},
         };
 
-        commit_sequential(tdb, deltas, {}, BlockHeader{.number = 0});
+        commit_sequential(
+            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -1872,7 +1867,8 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                         .balance = std::numeric_limits<uint256_t>::max(),
                         .nonce = transaction.nonce}}});
     }
-    commit_sequential(tdb, senders_state, {}, BlockHeader{.number = 255});
+    commit_sequential(
+        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{.number = 256};
@@ -1889,7 +1885,7 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
 
     commit_sequential(
         tdb,
-        {},
+        sd({}),
         {},
         BlockHeader{.number = 256},
         receipts,
@@ -2055,7 +2051,7 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
         0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_address;
     {
         // Initial state.
-        StateDeltas const deltas{
+        StateDeltas deltas{
             {ADDR_A,
              StateDelta{
                  .account =
@@ -2064,12 +2060,13 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
                           .balance = uint256_t{uint64_t{0x01}}, .nonce = 1}}}},
         };
 
-        commit_sequential(tdb, deltas, {}, BlockHeader{.number = 0});
+        commit_sequential(
+            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -2108,7 +2105,8 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
                         .balance = std::numeric_limits<uint256_t>::max(),
                         .nonce = transaction.nonce}}});
     }
-    commit_sequential(tdb, senders_state, {}, BlockHeader{.number = 255});
+    commit_sequential(
+        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{.number = 256};
@@ -2125,7 +2123,7 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
 
     commit_sequential(
         tdb,
-        {},
+        sd({}),
         {},
         BlockHeader{.number = 256},
         receipts,
@@ -2382,19 +2380,20 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
         .nonce = 1};
     {
         // Initial state.
-        StateDeltas const deltas{
+        StateDeltas deltas{
             {
                 sender,
                 StateDelta{.account = {std::nullopt, sender_acc}},
             },
         };
 
-        commit_sequential(tdb, deltas, {}, BlockHeader{.number = 0});
+        commit_sequential(
+            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 255
     for (uint64_t i = 1; i < 254; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     // Setup parent block transactions.
@@ -2427,12 +2426,12 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
 
         commit_sequential(
             tdb,
-            StateDeltas{
+            sd({
                 {
                     sender,
                     StateDelta{.account = {sender_acc, sender_acc2}},
                 },
-            },
+            }),
             {},
             header,
             receipts,
@@ -2457,12 +2456,12 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {
                 sender,
                 StateDelta{.account = {sender_acc2, sender_acc3}},
             },
-        },
+        }),
         {},
         header,
         receipts,
@@ -2602,7 +2601,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
 
     {
         // Initial state.
-        StateDeltas const deltas{
+        StateDeltas deltas{
             {ADDR_A,
              StateDelta{
                  .account =
@@ -2625,7 +2624,8 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
                              uint256_t{std::numeric_limits<uint64_t>::max()},
                          .nonce = block2_tx.nonce}}}}};
 
-        commit_sequential(tdb, deltas, {}, BlockHeader{.number = 0});
+        commit_sequential(
+            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Genesis block
@@ -2680,7 +2680,14 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
         auto const rlp_header = to_vec(rlp::encode_block_header(header));
 
         commit_sequential(
-            tdb, {}, {}, header, receipts, call_frames, senders, transactions);
+            tdb,
+            sd({}),
+            {},
+            header,
+            receipts,
+            call_frames,
+            senders,
+            transactions);
 
         boost::fibers::future<void> f =
             block1_prestate_ctx.promise.get_future();
@@ -2736,7 +2743,14 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
         auto const rlp_header = to_vec(rlp::encode_block_header(header));
 
         commit_sequential(
-            tdb, {}, {}, header, receipts, call_frames, senders, transactions);
+            tdb,
+            sd({}),
+            {},
+            header,
+            receipts,
+            call_frames,
+            senders,
+            transactions);
 
         boost::fibers::future<void> f =
             block2_prestate_ctx.promise.get_future();
@@ -2787,7 +2801,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
 TEST_F(EthCallFixture, access_list_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -2804,8 +2818,7 @@ TEST_F(EthCallFixture, access_list_trace)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -2817,7 +2830,7 @@ TEST_F(EthCallFixture, access_list_trace)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}},
+                          .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -2889,7 +2902,7 @@ TEST_F(EthCallFixture, access_list_trace)
 TEST_F(EthCallFixture, access_list_trace_reverted_call)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -2906,8 +2919,7 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -2919,7 +2931,7 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}},
+                          .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -2995,7 +3007,7 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
 TEST_F(EthCallFixture, access_list_trace_empty)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3012,8 +3024,7 @@ TEST_F(EthCallFixture, access_list_trace_empty)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -3025,7 +3036,7 @@ TEST_F(EthCallFixture, access_list_trace_empty)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}},
+                          .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -3101,8 +3112,7 @@ TEST_F(EthCallFixture, access_list_trace_nested)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -3118,7 +3128,7 @@ TEST_F(EthCallFixture, access_list_trace_nested)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}}},
+                      Account{.balance = 0, .code_hash = b_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -3216,8 +3226,7 @@ TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
 
     commit_sequential(
         tdb,
-        StateDeltas{
-            {sender,
+        sd({{sender,
              StateDelta{
                  .account =
                      {std::nullopt,
@@ -3233,7 +3242,7 @@ TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}}},
+                      Account{.balance = 0, .code_hash = b_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -3314,7 +3323,7 @@ TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
 TEST_F(EthCallFixture, prestate_state_overrides)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -3328,7 +3337,7 @@ TEST_F(EthCallFixture, prestate_state_overrides)
         .gas_limit = 200000u, .data = from_hex(tx_data).value()};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -3493,7 +3502,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     bytes32_t const untouched_storage_value =
         to_bytes(to_big_endian(uint256_t{256}));
 
-    StateDeltas const deltas{
+    StateDeltas deltas{
         {CONTRACT_ADDR,
          StateDelta{
              .account =
@@ -3508,7 +3517,10 @@ TEST_F(EthCallFixture, prestate_override_state)
                  StorageDeltas{{storage_key, {bytes32_t{}, storage_value}}}}}};
 
     commit_sequential(
-        tdb, deltas, {{code_hash, compiled_code}}, BlockHeader{.number = 0});
+        tdb,
+        sd(std::move(deltas)),
+        {{code_hash, compiled_code}},
+        BlockHeader{.number = 0});
 
     auto const storage = tdb.read_storage(
         CONTRACT_ADDR,
@@ -3517,7 +3529,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     ASSERT_EQ(storage, to_bytes(to_big_endian(uint256_t{uint64_t{64}})));
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -3525,7 +3537,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     Transaction const tx{.gas_limit = 200000u, .to = CONTRACT_ADDR};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, {}, {}, header);
+    commit_sequential(tdb, sd({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -3709,7 +3721,7 @@ TEST_F(EthCallFixture, prestate_override_state)
 TEST_F(EthCallFixture, eth_call_reserve_balance)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     // Scenario:
@@ -3757,7 +3769,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {sender,
              StateDelta{
                  .account =
@@ -3788,7 +3800,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                      {std::nullopt,
                       Account{
                           .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
-        },
+        }),
         Code{
             {contract_code_hash, contract_icode},
             {delegated_eoa_code_hash, delegated_eoa_icode},
@@ -3844,7 +3856,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
 TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3857,7 +3869,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {sender,
              StateDelta{
                  .account =
@@ -3872,7 +3884,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
                      {std::nullopt,
                       Account{
                           .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
-        },
+        }),
         Code{},
         header);
 
@@ -3923,7 +3935,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3957,7 +3969,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
 
     commit_sequential(
         tdb,
-        StateDeltas{
+        sd({
             {sender,
              StateDelta{
                  .account =
@@ -3980,7 +3992,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
                      {std::nullopt,
                       Account{
                           .balance = 0, .code_hash = NULL_HASH, .nonce = 0}}}},
-        },
+        }),
         Code{
             {delegated_eoa_code_hash, delegated_eoa_icode},
             {contract_code_hash, contract_icode},
@@ -4043,7 +4055,7 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
 
     {
         // Initial state.
-        StateDeltas const deltas{
+        StateDeltas deltas{
             {ADDR_A,
              StateDelta{
                  .account =
@@ -4058,12 +4070,13 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                           .balance = uint256_t{uint64_t{0x0}}, .nonce = 1}}}},
         };
 
-        commit_sequential(tdb, deltas, {}, BlockHeader{.number = 0});
+        commit_sequential(
+            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -4103,7 +4116,8 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                         .balance = std::numeric_limits<uint256_t>::max(),
                         .nonce = transaction.nonce}}});
     }
-    commit_sequential(tdb, senders_state, {}, BlockHeader{.number = 255});
+    commit_sequential(
+        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{
@@ -4120,7 +4134,7 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
     auto const rlp_grandparent_id = to_vec(rlp::encode_bytes32(bytes32_t{254}));
 
     commit_sequential(
-        tdb, {}, {}, header, receipts, call_frames, senders, transactions);
+        tdb, sd({}), {}, header, receipts, call_frames, senders, transactions);
 
     auto *executor = create_executor(dbname.string());
 

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -89,6 +89,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <unistd.h>

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -295,12 +295,17 @@ void monad_statesync_server_context::update_proposed_metadata(
 
 void monad_statesync_server_context::commit(
     bytes32_t const &block_id, CommitBuilder &builder,
-    BlockHeader const &header, StateDeltas const &state_deltas,
+    BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
     std::function<void(BlockHeader &)> populate_header_fn)
 {
-    on_commit(*this, state_deltas, header.number, block_id);
+    MONAD_ASSERT(state_deltas);
+    on_commit(*this, *state_deltas, header.number, block_id);
     rw.commit(
-        block_id, builder, header, state_deltas, std::move(populate_header_fn));
+        block_id,
+        builder,
+        header,
+        std::move(state_deltas),
+        std::move(populate_header_fn));
 }
 
 uint64_t monad_statesync_server_context::get_block_number() const

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -131,7 +131,7 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual void commit(
         monad::bytes32_t const &, monad::CommitBuilder &,
-        monad::BlockHeader const &, monad::StateDeltas const &,
+        monad::BlockHeader const &, std::unique_ptr<monad::StateDeltas>,
         std::function<void(monad::BlockHeader &)>) override;
 
     virtual uint64_t get_block_number() const override;

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -311,7 +311,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     // write the genesis block
     {
         monad::test::commit_simple(
-            *sctx, StateDeltas{}, Code{}, NULL_HASH_BLAKE3, hdr);
+            *sctx, monad::test::sd({}), Code{}, NULL_HASH_BLAKE3, hdr);
         sctx->finalize(0, NULL_HASH_BLAKE3);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));
@@ -353,7 +353,8 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
         hdr.parent_hash = parent_hash;
         bytes32_t const curr_block_id = bytes32_t{hdr.number};
         sctx->set_block_and_prefix(hdr.number - 1);
-        monad::test::commit_simple(*sctx, deltas, {}, curr_block_id, hdr);
+        monad::test::commit_simple(
+            *sctx, monad::test::sd(std::move(deltas)), {}, curr_block_id, hdr);
         sctx->finalize(hdr.number, curr_block_id);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -222,7 +222,7 @@ TEST_F(StateSyncFixture, sync_from_latest)
         for (size_t i = N - 256; i < N; ++i) {
             BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
             tdb.set_block_and_prefix(i - 1);
-            commit_sequential(tdb, {}, {}, hdr);
+            commit_sequential(tdb, sd({}), {}, hdr);
             parent_hash = to_bytes(
                 keccak256(rlp::encode_block_header(tdb.read_eth_header())));
         }
@@ -230,7 +230,7 @@ TEST_F(StateSyncFixture, sync_from_latest)
         // commit some proposal to client db
         tdb.set_block_and_prefix(N);
         commit_simple(
-            tdb, {}, {}, bytes32_t{N + 1}, BlockHeader{.number = N + 1});
+            tdb, sd({}), {}, bytes32_t{N + 1}, BlockHeader{.number = N + 1});
         init();
     }
     handle_target(
@@ -258,7 +258,7 @@ TEST_F(StateSyncFixture, sync_from_empty)
             stdb.set_block_and_prefix(i - 1);
             commit_sequential(
                 stdb,
-                {},
+                sd({}),
                 {},
                 BlockHeader{.parent_hash = parent_hash, .number = i});
             parent_hash = to_bytes(
@@ -318,7 +318,8 @@ TEST_F(StateSyncFixture, sync_from_some)
         TrieDb tdb{db};
         load_genesis_state(GENESIS_STATE, tdb);
         // commit some proposal to client db
-        commit_simple(tdb, {}, {}, NULL_HASH_BLAKE3, BlockHeader{.number = 1});
+        commit_simple(
+            tdb, sd({}), {}, NULL_HASH_BLAKE3, BlockHeader{.number = 1});
         load_genesis_state(GENESIS_STATE, stdb);
         init();
     }
@@ -339,7 +340,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         commit_sequential(
             sctx,
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
+            sd({{ADDR1, {.account = {acct, std::nullopt}}}}),
             Code{},
             hdr1);
         EXPECT_EQ(stdb.read_eth_header(), hdr1);
@@ -356,13 +357,13 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const acct = stdb.read_account(ADDR1);
         commit_sequential(
             sctx,
-            StateDeltas{
-                {ADDR1,
-                 {.account = {acct, acct},
-                  .storage =
-                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                        {{},
-                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
+            sd(
+                {{ADDR1,
+                  {.account = {acct, acct},
+                   .storage =
+                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                         {{},
+                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
             Code{},
             hdr2);
         EXPECT_EQ(stdb.read_eth_header(), hdr2);
@@ -385,21 +386,21 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const icode = vm::make_shared_intercode(code);
         commit_sequential(
             sctx,
-            StateDeltas{
-                {ADDR1,
-                 {.account =
-                      {std::nullopt,
-                       Account{
-                           .balance = 1337,
-                           .code_hash = code_hash,
-                           .nonce = 1,
-                           .incarnation = Incarnation{3, 0}}},
-                  .storage =
-                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                        {{},
-                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
+            sd(
+                {{ADDR1,
+                  {.account =
+                       {std::nullopt,
+                        Account{
+                            .balance = 1337,
+                            .code_hash = code_hash,
+                            .nonce = 1,
+                            .incarnation = Incarnation{3, 0}}},
+                   .storage =
+                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                         {{},
+                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
 
-            },
+                }),
             Code{{code_hash, icode}},
             hdr3);
         EXPECT_EQ(stdb.read_eth_header(), hdr3);
@@ -416,13 +417,13 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const acct = stdb.read_account(ADDR1);
         commit_sequential(
             sctx,
-            StateDeltas{
-                {ADDR1,
-                 {.account = {acct, acct},
-                  .storage =
-                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                        {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
-                         {}}}}}}},
+            sd(
+                {{ADDR1,
+                  {.account = {acct, acct},
+                   .storage =
+                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                         {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
+                          {}}}}}}}),
             Code{},
             hdr4);
         EXPECT_EQ(stdb.read_eth_header(), hdr4);
@@ -441,13 +442,13 @@ TEST_F(StateSyncFixture, sync_from_some)
         acct->incarnation = Incarnation{5, 0};
         commit_sequential(
             sctx,
-            StateDeltas{
-                {ADDR1,
-                 {.account = {old, acct},
-                  .storage =
-                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                        {{},
-                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
+            sd(
+                {{ADDR1,
+                  {.account = {old, acct},
+                   .storage =
+                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                         {{},
+                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
             Code{},
             hdr5);
         EXPECT_EQ(stdb.read_eth_header(), hdr5);
@@ -465,7 +466,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         commit_sequential(
             sctx,
-            StateDeltas{{ADDR1, {.account = {acct, std::nullopt}}}},
+            sd({{ADDR1, {.account = {acct, std::nullopt}}}}),
             Code{},
             hdr6);
         EXPECT_EQ(stdb.read_eth_header(), hdr6);
@@ -530,7 +531,11 @@ TEST_F(StateSyncFixture, deletion_proposal)
         StateDeltas deltas{{ADDR1, {.account = {acct, std::nullopt}}}};
         sctx.set_block_and_prefix(0);
         commit_simple(
-            sctx, deltas, Code{}, bytes32_t{1}, BlockHeader{.number = 1});
+            sctx,
+            sd(std::move(deltas)),
+            Code{},
+            bytes32_t{1},
+            BlockHeader{.number = 1});
     }
     // delete ADDR2 on another
     {
@@ -541,7 +546,11 @@ TEST_F(StateSyncFixture, deletion_proposal)
         StateDeltas deltas{{ADDR2, {.account = {acct, std::nullopt}}}};
         sctx.set_block_and_prefix(0);
         commit_simple(
-            sctx, deltas, Code{}, bytes32_t{2}, BlockHeader{.number = 1});
+            sctx,
+            sd(std::move(deltas)),
+            Code{},
+            bytes32_t{2},
+            BlockHeader{.number = 1});
     }
     sctx.finalize(1, bytes32_t{2});
 
@@ -569,17 +578,20 @@ TEST_F(StateSyncFixture, sync_one_account)
     for (size_t i = N - 256; i < N; ++i) {
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
     commit_sequential(
         stdb,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 100}},
-                 .storage = {}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 100}},
+                  .storage = {}}}}),
         Code{},
         BlockHeader{.number = N});
     init();
@@ -604,12 +616,14 @@ TEST_F(StateSyncFixture, sync_empty)
     for (size_t i = N - 256; i < N; ++i) {
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
-    commit_sequential(
-        stdb, StateDeltas{}, Code{}, BlockHeader{.number = 1'000'000});
+    commit_sequential(stdb, sd({}), Code{}, BlockHeader{.number = 1'000'000});
     init();
     handle_target(cctx, BlockHeader{.parent_hash = parent_hash, .number = N});
     run();
@@ -626,7 +640,8 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
         TrieDb tdb{db};
         tdb.reset_root(load_header({}, db, BlockHeader{.number = 0}), 0);
         for (uint64_t n = 1; n <= 249; ++n) {
-            commit_simple(tdb, {}, {}, bytes32_t{n}, BlockHeader{.number = n});
+            commit_simple(
+                tdb, sd({}), {}, bytes32_t{n}, BlockHeader{.number = n});
         }
     }
 
@@ -641,7 +656,7 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
         for (size_t i = N - 256; i < N; ++i) {
             BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
             stdb.set_block_and_prefix(i - 1);
-            commit_sequential(stdb, {}, {}, hdr);
+            commit_sequential(stdb, sd({}), {}, hdr);
             parent_hash = to_bytes(
                 keccak256(rlp::encode_block_header(stdb.read_eth_header())));
         }
@@ -664,39 +679,39 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
     bytes32_t parent_hash{NULL_HASH};
     for (size_t i = 0; i < 100; ++i) {
         BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
-        commit_sequential(stdb, {}, {}, hdr);
+        commit_sequential(stdb, sd({}), {}, hdr);
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
     BlockHeader hdr{.parent_hash = parent_hash, .number = 100};
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 100}},
-                 .storage =
-                     {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                       {bytes32_t{},
-                        0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 100}},
+                  .storage =
+                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                        {bytes32_t{},
+                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
         Code{},
         hdr);
     parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr = BlockHeader{.parent_hash = parent_hash, .number = 101};
-    commit_sequential(sctx, {}, {}, hdr);
+    commit_sequential(sctx, sd({}), {}, hdr);
     parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr = BlockHeader{.parent_hash = parent_hash, .number = 102};
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {Account{.balance = 100}, Account{.balance = 200}},
-                 .storage = {}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {Account{.balance = 100}, Account{.balance = 200}},
+                  .storage = {}}}}),
         Code{},
         hdr);
     init();
@@ -711,39 +726,39 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
     bytes32_t parent_hash{NULL_HASH};
     for (size_t i = 0; i < 100; ++i) {
         BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
-        commit_sequential(stdb, {}, {}, hdr);
+        commit_sequential(stdb, sd({}), {}, hdr);
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
     BlockHeader hdr{.parent_hash = parent_hash, .number = 100};
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 100}},
-                 .storage =
-                     {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                       {bytes32_t{},
-                        0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 100}},
+                  .storage =
+                      {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                        {bytes32_t{},
+                         0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
         Code{},
         hdr);
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr.number = 101;
-    commit_sequential(sctx, {}, {}, hdr);
+    commit_sequential(sctx, sd({}), {}, hdr);
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr.number = 102;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {Account{.balance = 100}, std::nullopt},
-                 .storage = {}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {Account{.balance = 100}, std::nullopt},
+                  .storage = {}}}}),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), NULL_ROOT);
@@ -756,7 +771,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
 {
     init();
     BlockHeader hdr{.parent_hash = NULL_HASH};
-    commit_sequential(sctx, StateDeltas{}, Code{}, hdr);
+    commit_sequential(sctx, sd({}), Code{}, hdr);
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     hdr.number = 1;
@@ -764,11 +779,11 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
         0x7537c605448f37499129a14743eb442cd09e5b2ec50ef7e73a5e715ee82d0453_bytes32;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 100}},
-                 .storage = {}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 100}},
+                  .storage = {}}}}),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -781,11 +796,11 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
     hdr.state_root = NULL_ROOT;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {Account{.balance = 100}, std::nullopt},
-                 .storage = {}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {Account{.balance = 100}, std::nullopt},
+                  .storage = {}}}}),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -796,7 +811,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     hdr.number = 3;
     hdr.state_root = NULL_ROOT;
-    commit_sequential(sctx, StateDeltas{}, Code{}, hdr);
+    commit_sequential(sctx, sd({}), Code{}, hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
     handle_target(cctx, hdr);
     run();
@@ -807,7 +822,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
 {
     init();
     BlockHeader hdr{.parent_hash = NULL_HASH};
-    commit_sequential(sctx, StateDeltas{}, Code{}, hdr);
+    commit_sequential(sctx, sd({}), Code{}, hdr);
 
     Account const a{.balance = 100, .incarnation = Incarnation{1, 0}};
 
@@ -818,8 +833,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 1;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         Code{},
         hdr);
     handle_target(cctx, hdr);
@@ -832,11 +846,11 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 2;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {a, a},
-                 .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {a, a},
+                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}}),
         Code{},
         hdr);
     handle_target(cctx, hdr);
@@ -851,8 +865,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 3;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
         Code{},
         hdr);
     handle_target(cctx, hdr);
@@ -875,7 +888,10 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     for (size_t i = 1'000'000 - 256; i < 1'000'000; ++i) {
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -887,13 +903,13 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
         .number = 1'000'000};
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, a},
-                 .storage =
-                     {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}},
-                      {bytes32_t{1}, {bytes32_t{}, bytes32_t{64}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, a},
+                  .storage =
+                      {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}},
+                       {bytes32_t{1}, {bytes32_t{}, bytes32_t{64}}}}}}}),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -905,8 +921,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'001;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}},
+        sd({{ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
         Code{},
         hdr);
     hdr.parent_hash =
@@ -914,11 +929,11 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'002;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {std::nullopt, a},
-                 .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {std::nullopt, a},
+                  .storage = {{bytes32_t{}, {bytes32_t{}, bytes32_t{64}}}}}}}),
         Code{},
         hdr);
     hdr.parent_hash =
@@ -928,11 +943,11 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'003;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR_A,
-             StateDelta{
-                 .account = {a, a},
-                 .storage = {{bytes32_t{}, {bytes32_t{64}, bytes32_t{}}}}}}},
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account = {a, a},
+                  .storage = {{bytes32_t{}, {bytes32_t{64}, bytes32_t{}}}}}}}),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -946,7 +961,7 @@ TEST_F(StateSyncFixture, update_contract_twice)
     init();
 
     BlockHeader hdr{.parent_hash = NULL_HASH, .number = 0};
-    commit_sequential(sctx, StateDeltas{}, Code{}, hdr);
+    commit_sequential(sctx, sd({}), Code{}, hdr);
 
     constexpr auto ADDR1 = 0x5353535353535353535353535353535353535353_address;
     hdr.parent_hash =
@@ -971,15 +986,15 @@ TEST_F(StateSyncFixture, update_contract_twice)
     hdr.number = 1;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR1,
-             {.account = {std::nullopt, a},
-              .storage =
-                  {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                    {{},
-                     0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
+        sd(
+            {{ADDR1,
+              {.account = {std::nullopt, a},
+               .storage =
+                   {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                     {{},
+                      0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
 
-        },
+            }),
         Code{{code_hash, icode}},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -993,15 +1008,15 @@ TEST_F(StateSyncFixture, update_contract_twice)
     hdr.number = 2;
     commit_sequential(
         sctx,
-        StateDeltas{
-            {ADDR1,
-             {.account = {a, a},
-              .storage =
-                  {{0x0000000000000000000000000000000000000000000000000000000011110000_bytes32,
-                    {{},
-                     0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
+        sd(
+            {{ADDR1,
+              {.account = {a, a},
+               .storage =
+                   {{0x0000000000000000000000000000000000000000000000000000000011110000_bytes32,
+                     {{},
+                      0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
 
-        },
+            }),
         Code{},
         hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
@@ -1043,7 +1058,10 @@ TEST_F(StateSyncFixture, benchmark)
     for (size_t i = 1'000'000 - 256; i < 1'000'000; ++i) {
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -1054,7 +1072,7 @@ TEST_F(StateSyncFixture, benchmark)
             0x50510e4f9ecc40a8cc5819bdc589a0e09c172ed268490d5f755dba939f7e8997_bytes32,
         .number = N};
     StateDeltas deltas{v.begin(), v.end()};
-    commit_sequential(stdb, deltas, Code{}, hdr);
+    commit_sequential(stdb, sd(std::move(deltas)), Code{}, hdr);
     init();
     handle_target(cctx, hdr);
     run();
@@ -1226,7 +1244,10 @@ TEST_F(StateSyncFixture, validation_prefix_bytes_too_large)
             stdb.set_block_and_prefix(i - 1);
         }
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -1254,7 +1275,10 @@ TEST_F(StateSyncFixture, validation_target_invalid)
             stdb.set_block_and_prefix(i - 1);
         }
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -1281,7 +1305,10 @@ TEST_F(StateSyncFixture, validation_from_greater_than_until)
             stdb.set_block_and_prefix(i - 1);
         }
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -1308,7 +1335,10 @@ TEST_F(StateSyncFixture, validation_until_greater_than_target)
             stdb.set_block_and_prefix(i - 1);
         }
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
@@ -1335,7 +1365,10 @@ TEST_F(StateSyncFixture, validation_old_target_greater_than_target)
             stdb.set_block_and_prefix(i - 1);
         }
         commit_sequential(
-            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+            stdb,
+            sd({}),
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -98,9 +98,10 @@ inline auto const H_CODE_HASH = to_bytes(keccak256(H_CODE));
 inline auto const H_ICODE = vm::make_shared_intercode(H_CODE);
 
 using monad::test::commit_simple;
+using monad::test::sd;
 
 inline bytes32_t commit_sequential(
-    monad::Db &db, StateDeltas const &deltas, Code const &code,
+    monad::Db &db, std::unique_ptr<StateDeltas> deltas, Code const &code,
     BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
     std::vector<std::vector<CallFrame>> const &call_frames = {},
     std::vector<Address> const &senders = {},
@@ -111,7 +112,7 @@ inline bytes32_t commit_sequential(
     bytes32_t const block_id =
         eth_header.number ? bytes32_t{eth_header.number} : NULL_HASH_BLAKE3;
 
-    commit_simple(db, deltas, code, block_id, eth_header,
+    commit_simple(db, std::move(deltas), code, block_id, eth_header,
         receipts, call_frames, senders, txns, ommers, withdrawals);
 
     db.finalize(eth_header.number, block_id);
@@ -125,7 +126,7 @@ inline void load_db(TrieDb &db, uint64_t const n)
 {
     commit_sequential(
         db,
-        StateDeltas{
+        monad::test::sd({
             {ADDR_A,
              StateDelta{
                  .account =
@@ -179,7 +180,7 @@ inline void load_db(TrieDb &db, uint64_t const n)
                      {std::nullopt,
                       Account{
                           .balance = 0xba1a9ce0ba1a9cf,
-                          .code_hash = H_CODE_HASH}}}}},
+                          .code_hash = H_CODE_HASH}}}}}),
         Code{
             {A_CODE_HASH, A_ICODE},
             {B_CODE_HASH, B_ICODE},

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -35,7 +35,6 @@
 #include <category/execution/ethereum/core/log_level_map.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
-#include <category/execution/ethereum/db/db_cache.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/precompiles.hpp>
@@ -267,7 +266,7 @@ try {
         net.emplace(statesync.c_str());
     }
     std::unique_ptr<mpt::StateMachine> machine;
-    mpt::Db db = [&] {
+    mpt::Db raw_db = [&] {
         if (!db_in_memory) {
             machine = std::make_unique<OnDiskMachine>();
             return mpt::Db{
@@ -302,7 +301,10 @@ try {
         MONAD_ASSERT(false);
     }();
 
-    TrieDb triedb{db}; // init block number to latest finalized block
+    TrieDb triedb{
+        raw_db,
+        /*enable_multiblock_cache=*/true}; // init block number to latest
+                                           // finalized block
     // Note: in memory db block number is always zero
     uint64_t const init_block_num = [&] {
         if (!snapshot.empty()) {
@@ -314,13 +316,13 @@ try {
             std::ifstream accounts(snapshot / "accounts");
             std::ifstream code(snapshot / "code");
             auto const n = std::stoul(snapshot.stem());
-            auto root = load_from_binary(db, accounts, code, n);
+            auto root = load_from_binary(raw_db, accounts, code, n);
             // load the eth header for snapshot
             BlockDb block_db{block_db_path};
             Block block;
             MONAD_ASSERT_PRINTF(
                 block_db.get(n, block), "FATAL: Could not load block %lu", n);
-            root = load_header(std::move(root), db, block.header);
+            root = load_header(std::move(root), raw_db, block.header);
             triedb.reset_root(std::move(root), n);
         }
         else if (triedb.get_root() == nullptr) {
@@ -346,8 +348,8 @@ try {
         "last verified block = {}, state root = {}, time elapsed "
         "= {}",
         init_block_num,
-        db.get_latest_finalized_version(),
-        db.get_latest_verified_version(),
+        raw_db.get_latest_finalized_version(),
+        raw_db.get_latest_verified_version(),
         triedb.state_root(),
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - load_start_time));
@@ -402,15 +404,15 @@ try {
     // codes that are required to serve RPC responses that include call traces.
     vm::VM vm{trace_calls ? vm::VM::InterpreterOnly : vm::VM::Dual};
 
-    DbCache db_cache =
-        sync_server ? DbCache{*sync_server->ctx} : DbCache{triedb};
+    Db &db = sync_server ? static_cast<Db &>(*sync_server->ctx)
+                         : static_cast<Db &>(triedb);
     auto const result = [&] {
         switch (chain_config) {
         case CHAIN_CONFIG_ETHEREUM_MAINNET:
             return runloop_ethereum(
                 *chain,
                 block_db_path,
-                db_cache,
+                db,
                 vm,
                 block_hash_buffer,
                 priority_pool,
@@ -422,7 +424,7 @@ try {
             return runloop_ethereum(
                 *chain,
                 block_db_path,
-                db_cache,
+                db,
                 vm,
                 block_hash_buffer,
                 priority_pool,
@@ -438,7 +440,7 @@ try {
                 return runloop_monad_ethblocks(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
-                    db_cache,
+                    db,
                     vm,
                     block_hash_buffer,
                     priority_pool,
@@ -452,8 +454,8 @@ try {
                 return runloop_monad(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
+                    raw_db,
                     db,
-                    db_cache,
                     vm,
                     block_hash_buffer,
                     priority_pool,

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -29,7 +29,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
-#include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
 #include <category/execution/ethereum/event/record_block_events.hpp>
@@ -86,7 +86,7 @@ void log_tps(
 // Process a single historical Ethereum block
 template <Traits traits>
 Result<void> process_ethereum_block(
-    Chain const &chain, DbCache &db, vm::VM &vm,
+    Chain const &chain, Db &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing)
@@ -184,24 +184,24 @@ Result<void> process_ethereum_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
-        // second stage: populate block header
-        if constexpr (traits::evm_rev() <= EVMC_BYZANTIUM) {
-            // TrieDb receipts root is not valid pre-Byzantium; use the
-            // block's original receipts root.
-            h.receipts_root = block.header.receipts_root;
-        }
-        else {
-            h.receipts_root = db.receipts_root();
-        }
-        h.state_root = db.state_root();
-        h.withdrawals_root = db.withdrawals_root();
-        h.transactions_root = db.transactions_root();
-        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-        h.logs_bloom = compute_bloom(receipts);
-        h.ommers_hash = compute_ommers_hash(block.ommers);
-    });
-    db.update_proposal_state(std::move(state), block.header.number, block_id);
+    db.commit(
+        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
+            // second stage: populate block header
+            if constexpr (traits::evm_rev() <= EVMC_BYZANTIUM) {
+                // TrieDb receipts root is not valid pre-Byzantium; use the
+                // block's original receipts root.
+                h.receipts_root = block.header.receipts_root;
+            }
+            else {
+                h.receipts_root = db.receipts_root();
+            }
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+            h.logs_bloom = compute_bloom(receipts);
+            h.ommers_hash = compute_ommers_hash(block.ommers);
+        });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
@@ -269,7 +269,7 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &chain, std::filesystem::path const &ledger_dir, DbCache &db,
+    Chain const &chain, std::filesystem::path const &ledger_dir, Db &db,
     vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,

--- a/cmd/monad/runloop_ethereum.hpp
+++ b/cmd/monad/runloop_ethereum.hpp
@@ -28,7 +28,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct Chain;
-class DbCache;
+struct Db;
 class BlockHashBufferFinalized;
 
 namespace fiber
@@ -37,7 +37,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
-    Chain const &, std::filesystem::path const &, DbCache &, vm::VM &,
+    Chain const &, std::filesystem::path const &, Db &, vm::VM &,
     BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
     sig_atomic_t const volatile &, bool enable_tracing,
     std::filesystem::path const &rlp_path = {});

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -30,7 +30,7 @@
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
-#include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
@@ -177,7 +177,7 @@ template <Traits traits, class MonadConsensusBlockHeader>
 Result<BlockExecOutput> propose_block(
     bytes32_t const &block_id,
     MonadConsensusBlockHeader const &consensus_header, Block block,
-    BlockHashChain &block_hash_chain, MonadChain const &chain, DbCache &db,
+    BlockHashChain &block_hash_chain, MonadChain const &chain, Db &db,
     vm::VM &vm, fiber::PriorityPool &priority_pool, bool const is_first_block,
     bool const enable_tracing, BlockCache &block_cache)
 {
@@ -306,6 +306,7 @@ Result<BlockExecOutput> propose_block(
     block_state.log_debug();
     auto const commit_begin = std::chrono::steady_clock::now();
     auto [state, code] = std::move(block_state).release();
+    MONAD_ASSERT(state);
 
     CommitBuilder builder(block.header.number);
     builder.add_state_deltas(*state)
@@ -317,17 +318,17 @@ Result<BlockExecOutput> propose_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
-        // second stage: populate block header
-        h.receipts_root = db.receipts_root();
-        h.state_root = db.state_root();
-        h.withdrawals_root = db.withdrawals_root();
-        h.transactions_root = db.transactions_root();
-        h.gas_used = results.empty() ? 0 : results.back().gas_used;
-        h.logs_bloom = compute_bloom(results);
-        h.ommers_hash = compute_ommers_hash(block.ommers);
-    });
-    db.update_proposal_state(std::move(state), block.header.number, block_id);
+    db.commit(
+        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
+            // second stage: populate block header
+            h.receipts_root = db.receipts_root();
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = results.empty() ? 0 : results.back().gas_used;
+            h.logs_bloom = compute_bloom(results);
+            h.ommers_hash = compute_ommers_hash(block.ommers);
+        });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
@@ -472,7 +473,7 @@ MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &chain, std::filesystem::path const &ledger_dir,
-    mpt::Db &raw_db, DbCache &db, vm::VM &vm,
+    mpt::Db &raw_db, Db &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,

--- a/cmd/monad/runloop_monad.hpp
+++ b/cmd/monad/runloop_monad.hpp
@@ -28,7 +28,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct MonadChain;
-class DbCache;
+struct Db;
 class BlockHashBufferFinalized;
 
 namespace mpt
@@ -42,7 +42,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
-    MonadChain const &, std::filesystem::path const &, mpt::Db &, DbCache &,
+    MonadChain const &, std::filesystem::path const &, mpt::Db &, Db &,
     vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
     uint64_t, sig_atomic_t const volatile &, bool enable_tracing);
 

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -28,7 +28,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
-#include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
 #include <category/execution/ethereum/event/record_block_events.hpp>
@@ -116,7 +116,7 @@ void get_block_with_retry(
 template <Traits traits>
     requires is_monad_trait_v<traits>
 Result<void> process_monad_block(
-    MonadChain const &chain, DbCache &db, vm::VM &vm,
+    MonadChain const &chain, Db &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing,
@@ -241,17 +241,17 @@ Result<void> process_monad_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
-        // second stage: populate block header
-        h.receipts_root = db.receipts_root();
-        h.state_root = db.state_root();
-        h.withdrawals_root = db.withdrawals_root();
-        h.transactions_root = db.transactions_root();
-        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-        h.logs_bloom = compute_bloom(receipts);
-        h.ommers_hash = compute_ommers_hash(block.ommers);
-    });
-    db.update_proposal_state(std::move(state), block.header.number, block_id);
+    db.commit(
+        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
+            // second stage: populate block header
+            h.receipts_root = db.receipts_root();
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+            h.logs_bloom = compute_bloom(receipts);
+            h.ommers_hash = compute_ommers_hash(block.ommers);
+        });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
@@ -319,8 +319,8 @@ MONAD_ANONYMOUS_NAMESPACE_END
 MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
-    MonadChain const &chain, std::filesystem::path const &ledger_dir,
-    DbCache &db, vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
+    MonadChain const &chain, std::filesystem::path const &ledger_dir, Db &db,
+    vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &finalized_block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
     bool const enable_tracing, std::chrono::seconds const block_db_timeout)

--- a/cmd/monad/runloop_monad_ethblocks.hpp
+++ b/cmd/monad/runloop_monad_ethblocks.hpp
@@ -30,7 +30,7 @@
 MONAD_NAMESPACE_BEGIN
 
 struct MonadChain;
-class DbCache;
+struct Db;
 class BlockHashBufferFinalized;
 
 namespace fiber
@@ -39,7 +39,7 @@ namespace fiber
 }
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
-    MonadChain const &, std::filesystem::path const &, DbCache &, vm::VM &,
+    MonadChain const &, std::filesystem::path const &, Db &, vm::VM &,
     BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
     sig_atomic_t const volatile &, bool enable_tracing,
     std::chrono::seconds block_db_timeout);

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -310,7 +310,7 @@ Result<BlockExecOutput> execute(
         bytes32_t{block.header.number},
         builder,
         block.header,
-        *state,
+        std::move(state),
         [&](BlockHeader &h) {
             if constexpr (traits::evm_rev() <= EVMC_BYZANTIUM) {
                 // TrieDb receipts root is not valid pre-Byzantium; use the

--- a/test/utils/json_state.cpp
+++ b/test/utils/json_state.cpp
@@ -43,7 +43,7 @@ TestStateRef JsonState::make_test_state() const
     auto [released_state, released_code] = std::move(bs).release();
     commit_simple(
         test_state->trie_db,
-        *released_state,
+        std::move(released_state),
         released_code,
         NULL_HASH_BLAKE3,
         header,


### PR DESCRIPTION
This is in preparation for MIP-8. The idea is for the DbCache to cache pages, not slots. DbCache will hold the pages in their own disk representation. The minor compression of zero slots will is ideal, since the DbCache will evict by bytes used as opposed to entries.

This compressed form has a dynamic length and the type must be bytes. However, we don't want this detail of the DbCache to leak into the Db interface. That is the motivation for this work.

The DbCache is slimmed out. `try_read_account()` and `try_read_storage()` are called directly from the TrieDb methods. The logic is equivalent to the old DbCache behavior. But instead of falling through to the lower level Db, the logic is inlined in TrieDb.