### PR TITLE
Prevent iterator overrun on odd input length

### DIFF
--- a/category/vm/utils/load_program.hpp
+++ b/category/vm/utils/load_program.hpp
@@ -35,9 +35,11 @@ namespace monad::vm::utils
         auto program = std::vector<uint8_t>(static_cast<size_t>(hex_size / 2));
 
         auto output_it = program.begin();
-        auto out_end = program.end();
+        // Round down to a whole number of hex pairs so that `input_it` does
+        // not advance one past `end` for odd-length inputs.
+        auto pairs_end = begin + (hex_size / 2) * 2;
 
-        for (auto input_it = begin; input_it != end && output_it != out_end;
+        for (auto input_it = begin; input_it != pairs_end;
              input_it += 2, output_it++) {
             auto *begin_char = &*input_it;
             auto *end_char = begin_char + 2;


### PR DESCRIPTION
Fixes a low severity audit finding.

Technically, the condition output_it != out_end should prevent the overrun already, but this change should make it clearer that input_it doesn't advance past the end of the iterator.