### PR TITLE
[rust/event] Fix `cargo check` warnings wrt `state`.

### DIFF
--- a/rust/crates/monad-exec-events/src/block_builder/executed/mod.rs
+++ b/rust/crates/monad-exec-events/src/block_builder/executed/mod.rs
@@ -150,7 +150,7 @@ impl ExecutedBlockBuilder {
                 None
             }
             ExecEvent::BlockReject(_) => {
-                let state = self.state.as_mut()?;
+                let _state = self.state.as_mut()?;
 
                 self.reset();
 
@@ -339,7 +339,7 @@ impl ExecutedBlockBuilder {
                 None
             }
             ExecEvent::TxnReject { .. } => {
-                let state = self.state.as_mut()?;
+                let _state = self.state.as_mut()?;
 
                 self.reset();
 
@@ -465,7 +465,7 @@ impl ExecutedBlockBuilder {
             }
             ExecEvent::TxnEnd => None,
             ExecEvent::EvmError(monad_exec_evm_error) => {
-                let state = self.state.as_mut()?;
+                let _state = self.state.as_mut()?;
 
                 unimplemented!("EvmError {monad_exec_evm_error:#?}");
             }


### PR DESCRIPTION
This patch fixes three warnings emitted by `cargo check` (when invoked in the `rust/` directory). Thus, reducing the amount of noise generated when compiling the Rust code. Before this patch you would see:
```
warning: monad-event-ring@0.1.0: monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c: In function 'monad_event_iterator_sync_wait__extern':
warning: monad-event-ring@0.1.0: monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c:13:136: warning: passing argument 1 of 'monad_event_iterator_sync_wait' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: monad-event-ring@0.1.0:    13 | uint64_t monad_event_iterator_sync_wait__extern(const struct monad_event_iterator *const iter) { return monad_event_iterator_sync_wait(iter); }
warning: monad-event-ring@0.1.0:       |                                                                                                                                        ^~~~
warning: monad-event-ring@0.1.0: In file included from ../../../category/core/event/event_iterator.h:90,
warning: monad-event-ring@0.1.0:                  from monad/rust/crates/monad-event-ring/wrapper.h:16,
warning: monad-event-ring@0.1.0:                  from monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c:1:
warning: monad-event-ring@0.1.0: ../../../category/core/event/event_iterator_inline.h:42:67: note: expected 'struct monad_event_iterator * const' but argument is of type 'const struct monad_event_iterator *'
warning: monad-event-ring@0.1.0:    42 | monad_event_iterator_sync_wait(struct monad_event_iterator *const iter)
warning: monad-event-ring@0.1.0:       |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
warning: unused variable: `state`
   --> crates/monad-exec-events/src/block_builder/executed/mod.rs:153:21
    |
153 |                 let state = self.state.as_mut()?;
    |                     ^^^^^ help: if this is intentional, prefix it with an underscore: `_state`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `state`
   --> crates/monad-exec-events/src/block_builder/executed/mod.rs:342:21
    |
342 |                 let state = self.state.as_mut()?;
    |                     ^^^^^ help: if this is intentional, prefix it with an underscore: `_state`

warning: unused variable: `state`
   --> crates/monad-exec-events/src/block_builder/executed/mod.rs:468:21
    |
468 |                 let state = self.state.as_mut()?;
    |                     ^^^^^ help: if this is intentional, prefix it with an underscore: `_state`
```

While after this patch you will see:
```
warning: monad-event-ring@0.1.0: monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c: In function 'monad_event_iterator_sync_wait__extern':
warning: monad-event-ring@0.1.0: monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c:13:136: warning: passing argument 1 of 'monad_event_iterator_sync_wait' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: monad-event-ring@0.1.0:    13 | uint64_t monad_event_iterator_sync_wait__extern(const struct monad_event_iterator *const iter) { return monad_event_iterator_sync_wait(iter); }
warning: monad-event-ring@0.1.0:       |                                                                                                                                        ^~~~
warning: monad-event-ring@0.1.0: In file included from ../../../category/core/event/event_iterator.h:90,
warning: monad-event-ring@0.1.0:                  from monad/rust/crates/monad-event-ring/wrapper.h:16,
warning: monad-event-ring@0.1.0:                  from monad/rust/target/debug/build/monad-event-ring-85598692ef5237a8/out/monad_event__wrap_static_fns.c:1:
warning: monad-event-ring@0.1.0: ../../../category/core/event/event_iterator_inline.h:42:67: note: expected 'struct monad_event_iterator * const' but argument is of type 'const struct monad_event_iterator *'
warning: monad-event-ring@0.1.0:    42 | monad_event_iterator_sync_wait(struct monad_event_iterator *const iter)
warning: monad-event-ring@0.1.0:       |
```

The remaining "noise" seems to be related to the Rust <-> C bindings generated by `bindgen` -- we should fix these too, but I will leave that for a subsequent patch.

This patch introduces no functional changes. It simply implements the syntactic fix suggested by `cargo`, i.e. renaming `state` => `_state`.