### PR TITLE
build libhugetlbfs as external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ function(monad_compile_options target)
   target_compile_definitions(${target} PUBLIC "JSON_HAS_RANGES=0")
 endfunction()
 
+include(ExternalProject)
+
 find_package(Boost REQUIRED COMPONENTS context filesystem json CONFIG)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
@@ -175,6 +177,30 @@ endif()
 # komihash
 add_library(komihash INTERFACE)
 target_include_directories(komihash INTERFACE "third_party/komihash")
+
+# libhugetlbfs
+set(LIBHUGETLBFS_INSTALL_DIR ${CMAKE_BINARY_DIR}/libhugetlbfs-install)
+ExternalProject_Add(
+  libhugetlbfs_ext
+  GIT_REPOSITORY https://github.com/libhugetlbfs/libhugetlbfs.git
+  GIT_TAG 1322884fb0d55dc55f53563c1aa6328d118997e7
+  PREFIX ${CMAKE_BINARY_DIR}/libhugetlbfs
+  INSTALL_DIR ${LIBHUGETLBFS_INSTALL_DIR}
+  CONFIGURE_COMMAND COMMAND /bin/sh autogen.sh
+                   COMMAND env CC=${CMAKE_C_COMPILER} ./configure --prefix=${LIBHUGETLBFS_INSTALL_DIR}
+  BUILD_COMMAND make -C <SOURCE_DIR> libs CC=${CMAKE_C_COMPILER} PREFIX=${LIBHUGETLBFS_INSTALL_DIR}
+               BUILDTYPE=NATIVEONLY
+  INSTALL_COMMAND make -C <SOURCE_DIR> install-libs CC=${CMAKE_C_COMPILER} PREFIX=${LIBHUGETLBFS_INSTALL_DIR}
+                  BUILDTYPE=NATIVEONLY
+  BUILD_IN_SOURCE 1
+  BUILD_BYPRODUCTS ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.so)
+add_library(libhugetlbfs SHARED IMPORTED GLOBAL)
+add_dependencies(libhugetlbfs libhugetlbfs_ext)
+file(MAKE_DIRECTORY ${LIBHUGETLBFS_INSTALL_DIR}/include)
+set_target_properties(
+  libhugetlbfs
+  PROPERTIES IMPORTED_LOCATION ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.so
+             INTERFACE_INCLUDE_DIRECTORIES ${LIBHUGETLBFS_INSTALL_DIR}/include)
 
 # magic_enum
 add_subdirectory("third_party/magic_enum")

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -224,7 +224,7 @@ target_link_libraries(monad_core PUBLIC quill)
 target_link_libraries(monad_core PUBLIC unordered_dense)
 target_link_libraries(monad_core PUBLIC PkgConfig::zstd)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_link_libraries(monad_core PUBLIC hugetlbfs uring)
+  target_link_libraries(monad_core PUBLIC libhugetlbfs uring)
 endif()
 
 add_library(

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -88,11 +88,10 @@ target_compile_options(monad_event PRIVATE -Wall -Wextra -Wconversion -Werror)
 target_link_libraries(monad_event PRIVATE ${libzstd_file})
 
 if(MONAD_EVENT_USE_LIBHUGETLBFS)
-  find_library(libhugetlbfs NAMES hugetlbfs REQUIRED)
   target_sources(monad_event PRIVATE
     "../core/mem/hugetlb_path.c"
     "../core/mem/hugetlb_path.h")
-  target_link_libraries(monad_event PRIVATE hugetlbfs)
+  target_link_libraries(monad_event PRIVATE libhugetlbfs)
 else()
   target_compile_definitions(monad_event PRIVATE MONAD_EVENT_DISABLE_LIBHUGETLBFS)
 endif()

--- a/scripts/ubuntu-build/install-deps.sh
+++ b/scripts/ubuntu-build/install-deps.sh
@@ -12,7 +12,6 @@ packages=(
   libgmock-dev
   libgmp-dev
   libgtest-dev
-  libhugetlbfs-dev
   libtbb-dev
   liburing-dev
   libzstd-dev

--- a/scripts/ubuntu-build/install-tools.sh
+++ b/scripts/ubuntu-build/install-tools.sh
@@ -2,6 +2,8 @@
 
 packages=(
   apt-utils
+  autoconf
+  automake
   ca-certificates
   clang-19
   clang-tools-19
@@ -16,7 +18,6 @@ packages=(
   gnupg
   libclang-common-19-dev
   libclang-rt-19-dev
-  libhugetlbfs-bin
   llvm-19-dev
   make
   ninja-build


### PR DESCRIPTION
some linux distributions no longer include libhugetlbfs library

since glibc removed morecore support, the library no longer functions as an LD_PRELOAD to back regular allocations by huge pages

also many have accepted transparent huge pages as the solution to this

however, there is still value in using this library so we should just build it ourselves

the library is still being maintained to an extent