### PR TITLE
[zkVM] CodeTracer for witness generation

### DIFF
--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -277,6 +277,7 @@ evmc::Result execute_create_message(
                 host->base_fee_per_gas_.value_or(0),
                 host->i_,
                 state,
+                host->state_tracer_,
                 host->chain_ctx_)) {
             result.status_code = EVMC_MONAD_RESERVE_BALANCE_VIOLATION;
         }
@@ -325,6 +326,7 @@ evmc::Result execute_call_message(
     else {
         auto const hash = state.get_code_hash(msg.code_address);
         auto const code = state.read_code(hash);
+        trace::on_read_code(host->state_tracer_, hash, code->intercode());
         result = state.vm().execute<traits>(*host, &msg, hash, code);
     }
 
@@ -335,6 +337,7 @@ evmc::Result execute_call_message(
                 host->base_fee_per_gas_.value_or(0),
                 host->i_,
                 state,
+                host->state_tracer_,
                 host->chain_ctx_)) {
             result.status_code = EVMC_MONAD_RESERVE_BALANCE_VIOLATION;
             result.gas_refund = 0;

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -79,6 +79,7 @@ namespace
                 host.tx_,
                 host.base_fee_per_gas_,
                 host.i_,
+                host.state_tracer_,
                 host.chain_ctx_);
         }
     }

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -18,6 +18,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
+#include <category/core/likely.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_history.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
@@ -35,14 +36,15 @@
 MONAD_NAMESPACE_BEGIN
 
 EvmcHostBase::EvmcHostBase(
-    CallTracerBase &call_tracer, evmc_tx_context const &tx_context,
-    BlockHashBuffer const &block_hash_buffer, State &state,
-    bool const log_native_transfers) noexcept
+    CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+    evmc_tx_context const &tx_context, BlockHashBuffer const &block_hash_buffer,
+    State &state, bool const log_native_transfers) noexcept
     : block_hash_buffer_{block_hash_buffer}
     , tx_context_{tx_context}
     , state_{state}
     , call_tracer_{call_tracer}
     , log_native_transfers_{log_native_transfers}
+    , state_tracer_{state_tracer}
 {
 }
 
@@ -86,6 +88,17 @@ EvmcHostBase::get_balance(evmc::address const &address) const noexcept
 size_t EvmcHostBase::get_code_size(evmc::address const &address) const noexcept
 {
     try {
+        if (MONAD_UNLIKELY(
+                std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
+            bytes32_t const hash = state_.get_code_hash(address);
+            if (hash == NULL_HASH) {
+                return 0;
+            }
+            auto const vcode = state_.read_code(hash);
+            MONAD_ASSERT(vcode);
+            trace::on_read_code(state_tracer_, hash, vcode->intercode());
+            return vcode->intercode()->size();
+        }
         return state_.get_code_size(address);
     }
     catch (...) {
@@ -114,6 +127,17 @@ size_t EvmcHostBase::copy_code(
     size_t const size) const noexcept
 {
     try {
+        if (MONAD_UNLIKELY(
+                std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
+            bytes32_t const hash = state_.get_code_hash(address);
+            if (hash != NULL_HASH) {
+                auto const vcode = state_.read_code(hash);
+                MONAD_ASSERT(vcode);
+                trace::on_read_code(state_tracer_, hash, vcode->intercode());
+                return vcode->intercode()->copy_code(offset, data, size);
+            }
+            return 0;
+        }
         return state_.copy_code(address, offset, data, size);
     }
     catch (...) {

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -57,9 +57,11 @@ protected:
     bool const log_native_transfers_;
 
 public:
+    trace::StateTracer &state_tracer_;
+
     EvmcHostBase(
-        CallTracerBase &, evmc_tx_context const &, BlockHashBuffer const &,
-        State &, bool log_native_transfers) noexcept;
+        CallTracerBase &, trace::StateTracer &, evmc_tx_context const &,
+        BlockHashBuffer const &, State &, bool log_native_transfers) noexcept;
 
     virtual ~EvmcHostBase() noexcept = default;
 
@@ -103,7 +105,7 @@ public:
         evmc::bytes32 const &value) noexcept override;
 };
 
-static_assert(sizeof(EvmcHostBase) == 64);
+static_assert(sizeof(EvmcHostBase) == 72);
 static_assert(alignof(EvmcHostBase) == 8);
 
 template <Traits traits>
@@ -113,7 +115,6 @@ struct EvmcHost final : public EvmcHostBase
     std::optional<uint256_t> base_fee_per_gas_;
     uint64_t i_;
     ChainContext<traits> const &chain_ctx_;
-    trace::StateTracer &state_tracer_;
 
     EvmcHost(
         CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
@@ -122,12 +123,11 @@ struct EvmcHost final : public EvmcHostBase
         Transaction const &tx, std::optional<uint256_t> const base_fee_per_gas,
         uint64_t const i, ChainContext<traits> const &chain_ctx,
         bool const log_native_transfers = false) noexcept
-        : EvmcHostBase{call_tracer, tx_context, block_hash_buffer, state, log_native_transfers}
+        : EvmcHostBase{call_tracer, state_tracer, tx_context, block_hash_buffer, state, log_native_transfers}
         , tx_{tx}
         , base_fee_per_gas_{base_fee_per_gas}
         , i_{i}
         , chain_ctx_{chain_ctx}
-        , state_tracer_{state_tracer}
     {
     }
 

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -309,6 +309,7 @@ Result<std::vector<Receipt>> execute_block(
     fiber::FiberGroup &priority_pool, BlockMetrics &block_metrics,
     std::span<std::unique_ptr<CallTracerBase>> const call_tracers,
     std::span<std::unique_ptr<trace::StateTracer>> const state_tracers,
+    trace::StateTracer &system_call_state_tracer,
     ChainContext<traits> const &chain_ctx, bool const trace_transfers)
 {
     static_assert(traits::evm_rev() > EVMC_TANGERINE_WHISTLE);
@@ -353,6 +354,7 @@ Result<std::vector<Receipt>> execute_block(
                 state,
                 block_hash_buffer,
                 block.header,
+                system_call_state_tracer,
                 chain_ctx,
                 retvals));
         MONAD_ASSERT(block.header.requests_hash.has_value());

--- a/category/execution/ethereum/execute_block.hpp
+++ b/category/execution/ethereum/execute_block.hpp
@@ -66,6 +66,7 @@ Result<std::vector<Receipt>> execute_block(
     BlockState &, BlockHashBuffer const &, fiber::FiberGroup &, BlockMetrics &,
     std::span<std::unique_ptr<CallTracerBase>>,
     std::span<std::unique_ptr<trace::StateTracer>> state_tracers,
+    trace::StateTracer &system_call_state_tracer,
     ChainContext<traits> const &chain_ctx, bool trace_transfers = false);
 
 std::vector<std::optional<Address>>

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -250,6 +250,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
         block.value().transactions.size());
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers;
     std::vector<std::unique_ptr<trace::StateTracer>> state_tracers;
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (size_t i = 0; i < block.value().transactions.size(); ++i) {
         call_tracers.emplace_back(std::make_unique<CallTracer>(
             block.value().transactions[i], call_frames[i]));
@@ -291,6 +292,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
             metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_ctx);
     };
 
@@ -414,6 +416,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
         block.value().transactions.size());
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers;
     std::vector<std::unique_ptr<trace::StateTracer>> state_tracers;
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (size_t i = 0; i < block.value().transactions.size(); ++i) {
         call_tracers.emplace_back(std::make_unique<CallTracer>(
             block.value().transactions[i], call_frames[i]));
@@ -455,6 +458,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
             metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_ctx);
     };
 
@@ -568,6 +572,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
         block.value().transactions.size());
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers;
     std::vector<std::unique_ptr<trace::StateTracer>> state_tracers;
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (size_t i = 0; i < block.value().transactions.size(); ++i) {
         call_tracers.emplace_back(std::make_unique<CallTracer>(
             block.value().transactions[i], call_frames[i]));
@@ -609,6 +614,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
             metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_ctx);
     };
 

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -142,7 +142,9 @@ uint64_t ExecuteTransactionNoValidation<traits>::process_authorizations(
         state.access_account(*authority);
 
         // 5. Verify the code of authority is empty or already delegated.
-        auto const icode = state.get_code(*authority)->intercode();
+        auto const code_hash = state.get_code_hash(*authority);
+        auto const icode = state.read_code(code_hash)->intercode();
+        trace::on_read_code(host.state_tracer_, code_hash, icode);
         auto const code = std::span{icode->code(), *icode->code_size()};
         if (!(code.empty() || vm::evm::is_delegated(code))) {
             continue;
@@ -235,6 +237,7 @@ evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
             tx_,
             header_.base_fee_per_gas,
             host.i_,
+            host.state_tracer_,
             host.chain_ctx_);
     }
 
@@ -327,7 +330,8 @@ Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
             sender_,
             state,
             header_.base_fee_per_gas.value_or(0),
-            authorities_);
+            authorities_,
+            state_tracer_);
         if (!result) {
             // RELAXED MERGE
             // if `validate_transaction` fails using current values, require

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -53,7 +53,7 @@ template <Traits traits>
 Result<byte_string> system_call(
     Chain const &chain, State &state, BlockHashBuffer const &block_hash_buffer,
     BlockHeader const &header, Address const &contract_address,
-    ChainContext<traits> const &chain_ctx)
+    trace::StateTracer &state_tracer, ChainContext<traits> const &chain_ctx)
 {
     constexpr auto SYSTEM_ADDRESS =
         0xfffffffffffffffffffffffffffffffffffffffe_address;
@@ -65,6 +65,7 @@ Result<byte_string> system_call(
         return BlockError::SystemCallMissingCode;
     }
     auto const code = state.read_code(hash);
+    trace::on_read_code(state_tracer, hash, code->intercode());
 
     evmc_tx_context const tx_context = {
         .tx_gas_price = {},
@@ -109,11 +110,10 @@ Result<byte_string> system_call(
     state.access_account(contract_address);
 
     NoopCallTracer noop_tracer;
-    trace::StateTracer noop_state_tracer = std::monostate{};
     Transaction const empty_tx{};
     EvmcHost<traits> host{
         noop_tracer,
-        noop_state_tracer,
+        state_tracer,
         tx_context,
         block_hash_buffer,
         state,
@@ -253,7 +253,8 @@ bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
 template <Traits traits>
 Result<bytes32_t> process_requests(
     Chain const &chain, State &state, BlockHashBuffer const &block_hash_buffer,
-    BlockHeader const &header, ChainContext<traits> const &chain_ctx,
+    BlockHeader const &header, trace::StateTracer &state_tracer,
+    ChainContext<traits> const &chain_ctx,
     std::span<Receipt const> const receipts)
 {
     BOOST_OUTCOME_TRY(auto deposit_output, extract_deposit_requests(receipts));
@@ -269,6 +270,7 @@ Result<bytes32_t> process_requests(
             block_hash_buffer,
             header,
             WITHDRAWAL_REQUEST_ADDRESS,
+            state_tracer,
             chain_ctx));
 
     // EIP-7251
@@ -282,6 +284,7 @@ Result<bytes32_t> process_requests(
             block_hash_buffer,
             header,
             CONSOLIDATION_REQUEST_ADDRESS,
+            state_tracer,
             chain_ctx));
 
     return compute_requests_hash(std::array<BlockRequest, 3>{{

--- a/category/execution/ethereum/process_requests.hpp
+++ b/category/execution/ethereum/process_requests.hpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/traits.hpp>
 
 #include <cstdint>
@@ -47,6 +48,7 @@ Result<byte_string> extract_deposit_requests(std::span<Receipt const> receipts);
 template <Traits traits>
 Result<bytes32_t> process_requests(
     Chain const &, State &, BlockHashBuffer const &, BlockHeader const &,
-    ChainContext<traits> const &, std::span<Receipt const>);
+    trace::StateTracer &, ChainContext<traits> const &,
+    std::span<Receipt const>);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/reserve_balance.cpp
+++ b/category/execution/ethereum/reserve_balance.cpp
@@ -22,7 +22,7 @@ MONAD_NAMESPACE_BEGIN
 template <Traits traits>
 bool revert_transaction(
     Address const &, Transaction const &, uint256_t const &, uint64_t const,
-    State &, ChainContext<traits> const &)
+    State &, trace::StateTracer &, ChainContext<traits> const &)
 {
     return false;
 }

--- a/category/execution/ethereum/reserve_balance.hpp
+++ b/category/execution/ethereum/reserve_balance.hpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/traits.hpp>
 
 #include <evmc/evmc.h>
@@ -35,7 +36,7 @@ template <Traits traits>
 bool revert_transaction(
     Address const &sender, Transaction const &,
     uint256_t const &base_fee_per_gas, uint64_t i, State &,
-    ChainContext<traits> const &);
+    trace::StateTracer &state_tracer, ChainContext<traits> const &);
 
 template <Traits traits>
 bool revert_transaction_cached(State &);
@@ -45,6 +46,6 @@ template <Traits traits>
 void init_reserve_balance_context(
     State &state, Address const &sender, Transaction const &tx,
     std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
-    ChainContext<traits> const &ctx);
+    trace::StateTracer &state_tracer, ChainContext<traits> const &ctx);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -544,26 +544,9 @@ size_t State::copy_code(
     if (MONAD_UNLIKELY(!account.has_value())) {
         return 0;
     }
-    bytes32_t const &code_hash = account.value().code_hash;
-    vm::SharedVarcode vcode{};
-    {
-        auto const it = code_.find(code_hash);
-        if (it != code_.end()) {
-            vcode = it->second;
-        }
-        else {
-            vcode = block_state_.read_code(code_hash);
-        }
-    }
+    vm::SharedVarcode const vcode = read_code(account.value().code_hash);
     MONAD_ASSERT(vcode);
-    auto const &icode = vcode->intercode();
-    auto const code_size = icode->size();
-    if (offset > code_size) {
-        return 0;
-    }
-    auto const n = std::min(code_size - offset, buffer_size);
-    std::copy_n(icode->code() + offset, n, buffer);
-    return n;
+    return vcode->intercode()->copy_code(offset, buffer, buffer_size);
 }
 
 void State::set_code(Address const &address, byte_string_view const code)

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -77,7 +77,7 @@ class State
         requires is_monad_trait_v<traits>
     friend void init_reserve_balance_context(
         State &, Address const &, Transaction const &,
-        std::optional<uint256_t> const &, uint64_t,
+        std::optional<uint256_t> const &, uint64_t, trace::StateTracer &,
         ChainContext<traits> const &);
 
 public:

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -239,8 +239,15 @@ void run_revert_transaction_test(
 
     {
         State state{bs, Incarnation{1, 1}};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         init_reserve_balance_context<traits>(
-            state, SENDER, tx, BASE_FEE_PER_GAS, 1, chain_context);
+            state,
+            SENDER,
+            tx,
+            BASE_FEE_PER_GAS,
+            1,
+            noop_state_tracer,
+            chain_context);
         state.subtract_from_balance(SENDER, gas_fee);
         uint256_t const value = uint256_t{value_mon} * 1000000000000000000ULL;
         state.subtract_from_balance(SENDER, value);
@@ -250,6 +257,7 @@ void run_revert_transaction_test(
             BASE_FEE_PER_GAS,
             1, // transaction index
             state,
+            noop_state_tracer,
             chain_context);
         bool should_revert_cached = revert_transaction_cached<traits>(state);
 
@@ -402,12 +410,13 @@ TYPED_TEST(
     };
 
     State state{bs, Incarnation{1, 1}};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     init_reserve_balance_context<traits>(
-        state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+        state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
     state.subtract_from_balance(SENDER, sender_gas_fee);
 
     EXPECT_TRUE(revert_transaction<traits>(
-        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context));
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context));
     EXPECT_TRUE(revert_transaction_cached<traits>(state));
 
     uint256_t const sender_balance = state.get_balance(SENDER);
@@ -415,7 +424,7 @@ TYPED_TEST(
         SENDER, std::numeric_limits<uint256_t>::max() - sender_balance);
 
     EXPECT_TRUE(revert_transaction<traits>(
-        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context));
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context));
     EXPECT_TRUE(revert_transaction_cached<traits>(state));
 }
 
@@ -468,13 +477,26 @@ TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
     };
 
     State state{bs, Incarnation{1, 1}};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     init_reserve_balance_context<traits>(
-        state, sender, tx, base_fee_per_gas, 0, chain_context);
+        state,
+        sender,
+        tx,
+        base_fee_per_gas,
+        0,
+        noop_state_tracer,
+        chain_context);
     state.subtract_from_balance(sender, sender_gas_fee);
     state.subtract_from_balance(staking::STAKING_CA, to_wei(1));
 
     EXPECT_FALSE(revert_transaction<traits>(
-        sender, tx, base_fee_per_gas, 0, state, chain_context));
+        sender,
+        tx,
+        base_fee_per_gas,
+        0,
+        state,
+        noop_state_tracer,
+        chain_context));
     EXPECT_FALSE(revert_transaction_cached<traits>(state));
 }
 
@@ -596,9 +618,10 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
         .senders = senders,
         .authorities = authorities};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const prepare_state = [&](State &state) {
         init_reserve_balance_context<traits>(
-            state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+            state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
         state.subtract_from_balance(SENDER, gas_cost);
         state.subtract_from_balance(NEW_CONTRACT, to_wei(3));
         byte_string const contract_code{0x60, 0x00};
@@ -609,7 +632,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
     prepare_state(state);
 
     bool const should_revert = revert_transaction<traits>(
-        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context);
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context);
     bool const should_revert_cached = revert_transaction_cached<traits>(state);
 
     if constexpr (traits::monad_rev() < MONAD_FOUR) {
@@ -675,14 +698,15 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
         .authorities = authorities};
 
     State state{bs, Incarnation{1, 1}};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     init_reserve_balance_context<traits>(
-        state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+        state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
     state.subtract_from_balance(SENDER, gas_cost);
     state.subtract_from_balance(NEW_CONTRACT, to_wei(3));
     state.set_code(NEW_CONTRACT, {});
 
     bool const should_revert = revert_transaction<traits>(
-        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context);
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context);
     bool const should_revert_cached = revert_transaction_cached<traits>(state);
 
     if constexpr (traits::monad_rev() < MONAD_FOUR) {
@@ -745,8 +769,9 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
         .authorities = authorities};
 
     State state{bs, Incarnation{1, 1}};
+    trace::StateTracer noop_state_tracer = std::monostate{};
     init_reserve_balance_context<traits>(
-        state, SENDER, tx, BASE_FEE_PER_GAS, 0, context);
+        state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
     state.subtract_from_balance(SENDER, gas_cost);
 
     // Model constructor-time SELFDESTRUCT at a pre-funded address:
@@ -761,7 +786,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
     EXPECT_EQ(state.get_balance(BENEFICIARY), to_wei(3));
 
     bool const should_revert = revert_transaction<traits>(
-        SENDER, tx, BASE_FEE_PER_GAS, 0, state, context);
+        SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context);
     bool const should_revert_cached = revert_transaction_cached<traits>(state);
 
     if constexpr (traits::monad_rev() < MONAD_FOUR) {
@@ -787,8 +812,9 @@ TYPED_TEST(MonadTraitsTest, system_transaction_sender_is_authority)
     State state{bs, Incarnation{0, 0}};
     std::vector<std::optional<Address>> const authorities = {SYSTEM_SENDER};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const res = validate_transaction<typename TestFixture::Trait>(
-        {}, {}, state, 0, authorities);
+        {}, {}, state, 0, authorities, noop_state_tracer);
     if constexpr (TestFixture::Trait::monad_rev() < MONAD_FOUR) {
         EXPECT_TRUE(res.has_value());
     }

--- a/category/execution/ethereum/test/test_validation.cpp
+++ b/category/execution/ethereum/test/test_validation.cpp
@@ -118,9 +118,10 @@ TYPED_TEST(InMemoryStateTraitsTest, validate_deployed_code)
     this->state.set_code(sender, 0x00_bytes);
     Transaction const tx{.gas_limit = 60'500};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), TransactionError::SenderNotEoa);
 }
@@ -133,9 +134,10 @@ TYPED_TEST(InMemoryStateTraitsTest, validate_deployed_code_delegated)
         sender, 0xEF01001122334455112233445511223344551122334455_bytes);
     Transaction const tx{.gas_limit = 60'500};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     if constexpr (TestFixture::Trait::evm_rev() >= EVMC_PRAGUE) {
         EXPECT_TRUE(result.has_value());
     }
@@ -155,9 +157,10 @@ TYPED_TEST(InMemoryStateTraitsTest, validate_nonce)
         .gas_limit = 60'500,
         .value = 55'939'568'773'815'811};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), TransactionError::BadNonce);
 }
@@ -172,9 +175,10 @@ TYPED_TEST(InMemoryStateTraitsTest, validate_nonce_optimistically)
         .gas_limit = 60'500,
         .value = 55'939'568'773'815'811};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), TransactionError::BadNonce);
 }
@@ -190,9 +194,10 @@ TYPED_TEST(InMemoryStateTraitsTest, validate_enough_balance)
         .max_priority_fee_per_gas = 100'000'000,
     };
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), TransactionError::InsufficientBalance);
 }
@@ -214,9 +219,10 @@ TYPED_TEST(InMemoryStateTraitsTest, successful_validation)
             tx, 0, std::nullopt, 1);
     EXPECT_TRUE(result1.has_value());
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result2 =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     EXPECT_TRUE(result2.has_value());
 }
 
@@ -282,9 +288,10 @@ TYPED_TEST(InMemoryStateTraitsTest, insufficent_balance_overflow)
         .value = 0,
         .to = to};
 
+    trace::StateTracer noop_state_tracer = std::monostate{};
     auto const result =
         validate_ethereum_transaction<typename TestFixture::Trait>(
-            tx, sender, this->state);
+            tx, sender, this->state, noop_state_tracer);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), TransactionError::InsufficientBalance);
 }

--- a/category/execution/ethereum/trace/state_tracer.cpp
+++ b/category/execution/ethereum/trace/state_tracer.cpp
@@ -332,7 +332,8 @@ namespace trace
                 },
                 [&state](AccessListTracer &access_list) {
                     access_list.encode<traits>(state);
-                }},
+                },
+                [](CodeTracer &) {}},
             tracer);
     }
 

--- a/category/execution/ethereum/trace/state_tracer.hpp
+++ b/category/execution/ethereum/trace/state_tracer.hpp
@@ -25,6 +25,7 @@
 #include <immer/map.hpp>
 #include <nlohmann/json.hpp>
 
+#include <memory>
 #include <span>
 #include <variant>
 
@@ -121,8 +122,31 @@ namespace trace
         bool should_exclude_address(Address const &) const;
     };
 
+    /// Records every code preimage read during execution, keyed by
+    /// code_hash. Used by witness generation to assemble the codes section
+    /// of the post-block witness. Insertions happen from the EVM host's
+    /// code-read entry points; production execution uses `std::monostate`
+    /// instead, so the recording path has zero cost. A CodeTracer is only
+    /// ever accessed from a single thread, so a plain (non-concurrent) map
+    /// suffices.
+    struct CodeTracer
+    {
+        Map<bytes32_t, vm::SharedIntercode> codes{};
+    };
+
     using StateTracer = std::variant<
-        std::monostate, PrestateTracer, StateDiffTracer, AccessListTracer>;
+        std::monostate, PrestateTracer, StateDiffTracer, AccessListTracer,
+        CodeTracer>;
+
+    inline void on_read_code(
+        StateTracer &tracer, bytes32_t const &code_hash,
+        vm::SharedIntercode const &intercode)
+    {
+        if (auto *t = std::get_if<CodeTracer>(&tracer);
+            t && code_hash != NULL_HASH) {
+            t->codes.emplace(code_hash, intercode);
+        }
+    }
 
     // State-tracer lifecycle hook for a failed frame. Call immediately before
     // State::pop_reject(), while rejected-frame access metadata is still

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -13,12 +13,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_reward.hpp>
+#include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/evm.hpp>
+#include <category/execution/ethereum/evmc_host.hpp>
+#include <category/execution/ethereum/execute_transaction.hpp>
+#include <category/execution/ethereum/process_requests.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/account_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
+#include <category/execution/ethereum/tx_context.hpp>
+#include <category/execution/ethereum/validate_transaction.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/execution/monad/reserve_balance.hpp>
 #include <monad/test/traits_test.hpp>
 
 #include <category/core/address.hpp>
@@ -35,11 +47,13 @@
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 
+#include <ankerl/unordered_dense.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
 #include <test_resource_data.h>
 
+#include <bit>
 #include <optional>
 #include <vector>
 
@@ -1718,4 +1732,495 @@ TEST(PrestateTracer, prestate_empty_block_no_reward)
 
         EXPECT_EQ(trace, nlohmann::json::parse(json_str));
     }
+}
+
+// CodeTracer coverage.
+//
+// Each test below constructs `StateTracer{CodeTracer{}}`, exercises exactly
+// one of the `on_read_code` recording sites in the execution layer, and
+// asserts that the recorded codes map contains the (code_hash, intercode)
+// pair that the site is responsible for. The sites are:
+//
+//   1. EvmcHostBase::get_code_size  (EXTCODESIZE host hook)
+//   2. EvmcHostBase::copy_code       (EXTCODECOPY host hook)
+//   3. execute_call_message          (called contract code, per CALL)
+//   4. system_call (via process_requests, EIP-7002/7251)
+//   5. validate_ethereum_transaction (EIP-7702 sender code check)
+//   6. process_authorizations        (EIP-7702 authority code check)
+//   7. dipped_into_reserve + is_delegated (Monad reserve-balance revert path)
+//
+// Without these, future changes to any site can silently drop a code preimage
+// from the witness without CI catching it.
+
+namespace
+{
+    // EIP-7002/7251 predeploy addresses + a trivial system contract stub
+    // (single STOP opcode) used by the process_requests test below.
+    constexpr auto WITHDRAWAL_REQUEST_ADDRESS =
+        0x00000961ef480eb55e80d19ad83579a64c007002_address;
+    constexpr auto CONSOLIDATION_REQUEST_ADDRESS =
+        0x0000bbddc7ce488642fb579f8b00f3a590007251_address;
+    inline auto const SYSTEM_STUB_CODE = monad::from_hex("00").value();
+    inline auto const SYSTEM_STUB_CODE_HASH =
+        to_bytes(monad::keccak256(SYSTEM_STUB_CODE));
+    inline auto const SYSTEM_STUB_ICODE =
+        monad::vm::make_shared_intercode(SYSTEM_STUB_CODE);
+}
+
+// Site 1: EvmcHostBase::get_code_size
+TYPED_TEST(TraitsTest, code_tracer_records_extcodesize)
+{
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(
+        tdb,
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.code_hash = A_CODE_HASH}}}}}),
+        Code{{A_CODE_HASH, A_ICODE}},
+        BlockHeader{.number = 0});
+
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+
+    NoopCallTracer call_tracer;
+    BlockHashBufferFinalized const block_hash_buffer;
+    Transaction const tx{};
+    auto const chain_ctx =
+        ChainContext<typename TestFixture::Trait>::debug_empty();
+    uint256_t const base_fee{0};
+    trace::StateTracer state_tracer = trace::CodeTracer{};
+    EvmcHost<typename TestFixture::Trait> host{
+        call_tracer,
+        state_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        state,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
+
+    EXPECT_EQ(host.get_code_size(ADDR_A), A_ICODE->size());
+
+    auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+    EXPECT_EQ(codes.size(), 1u);
+    auto const it = codes.find(A_CODE_HASH);
+    ASSERT_TRUE(it != codes.end());
+    EXPECT_EQ(
+        byte_string_view(it->second->code(), it->second->size()),
+        byte_string_view(A_ICODE->code(), A_ICODE->size()));
+}
+
+// Site 2: EvmcHostBase::copy_code
+TYPED_TEST(TraitsTest, code_tracer_records_extcodecopy)
+{
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(
+        tdb,
+        sd(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.code_hash = A_CODE_HASH}}}}}),
+        Code{{A_CODE_HASH, A_ICODE}},
+        BlockHeader{.number = 0});
+
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+
+    NoopCallTracer call_tracer;
+    BlockHashBufferFinalized const block_hash_buffer;
+    Transaction const tx{};
+    auto const chain_ctx =
+        ChainContext<typename TestFixture::Trait>::debug_empty();
+    uint256_t const base_fee{0};
+    trace::StateTracer state_tracer = trace::CodeTracer{};
+    EvmcHost<typename TestFixture::Trait> host{
+        call_tracer,
+        state_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        state,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
+
+    std::vector<uint8_t> buf(A_ICODE->size(), 0);
+    auto const n = host.copy_code(ADDR_A, 0, buf.data(), buf.size());
+    EXPECT_EQ(n, A_ICODE->size());
+    EXPECT_TRUE(std::equal(
+        buf.begin(),
+        buf.begin() + static_cast<std::ptrdiff_t>(n),
+        A_ICODE->code()));
+
+    auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+    EXPECT_EQ(codes.size(), 1u);
+    auto const it = codes.find(A_CODE_HASH);
+    ASSERT_TRUE(it != codes.end());
+    EXPECT_EQ(
+        byte_string_view(it->second->code(), it->second->size()),
+        byte_string_view(A_ICODE->code(), A_ICODE->size()));
+}
+
+// Site 3: execute_call_message records called-contract code
+TYPED_TEST(TraitsTest, code_tracer_records_called_contract_code)
+{
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(
+        tdb,
+        sd({{ADDR_A,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.balance = 10'000'000'000}}}},
+            {ADDR_B,
+             StateDelta{
+                 .account =
+                     {std::nullopt, Account{.code_hash = B_CODE_HASH}}}}}),
+        Code{{B_CODE_HASH, B_ICODE}},
+        BlockHeader{.number = 0});
+
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+
+    NoopCallTracer call_tracer;
+    BlockHashBufferFinalized const block_hash_buffer;
+    Transaction const tx{};
+    auto const chain_ctx =
+        ChainContext<typename TestFixture::Trait>::debug_empty();
+    uint256_t const base_fee{0};
+    trace::StateTracer state_tracer = trace::CodeTracer{};
+    EvmcHost<typename TestFixture::Trait> host{
+        call_tracer,
+        state_tracer,
+        EMPTY_TX_CONTEXT,
+        block_hash_buffer,
+        state,
+        tx,
+        base_fee,
+        0,
+        chain_ctx};
+
+    // depth = 1 to bypass the depth-0 reserve-balance revert path; we want
+    // to isolate execute_call_message's own code-read here.
+    auto msg_memory = vm.message_memory_ref();
+    evmc_message const msg{
+        .kind = EVMC_CALL,
+        .depth = 1,
+        .gas = 1'000'000,
+        .recipient = ADDR_B,
+        .sender = ADDR_A,
+        .code_address = ADDR_B,
+        .memory_handle = msg_memory.get(),
+        .memory = msg_memory.get(),
+        .memory_capacity = vm.message_memory_capacity(),
+    };
+
+    (void)execute_call_message<typename TestFixture::Trait>(&host, state, msg);
+
+    auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+    auto const it = codes.find(B_CODE_HASH);
+    ASSERT_TRUE(it != codes.end())
+        << "called contract code not recorded by execute_call_message";
+    EXPECT_EQ(
+        byte_string_view(it->second->code(), it->second->size()),
+        byte_string_view(B_ICODE->code(), B_ICODE->size()));
+}
+
+// Site 4: system_call (via process_requests) records system-contract code
+TYPED_TEST(TraitsTest, code_tracer_records_system_contract_code)
+{
+    if constexpr (!TestFixture::Trait::eip_7685_active()) {
+        GTEST_SKIP() << "process_requests requires EIP-7685";
+    }
+    else {
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
+        TrieDb tdb{db};
+        vm::VM vm;
+
+        commit_sequential(
+            tdb,
+            sd({{WITHDRAWAL_REQUEST_ADDRESS,
+                 StateDelta{
+                     .account =
+                         {std::nullopt,
+                          Account{.code_hash = SYSTEM_STUB_CODE_HASH}}}},
+                {CONSOLIDATION_REQUEST_ADDRESS,
+                 StateDelta{
+                     .account =
+                         {std::nullopt,
+                          Account{.code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
+            Code{{SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
+            BlockHeader{.number = 0});
+
+        BlockState bs{tdb, vm};
+        State state{bs, Incarnation{0, 0}};
+
+        BlockHashBufferFinalized const block_hash_buffer;
+        BlockHeader const header{};
+        EthereumMainnet const chain;
+        auto const chain_ctx =
+            ChainContext<typename TestFixture::Trait>::debug_empty();
+        trace::StateTracer state_tracer = trace::CodeTracer{};
+
+        auto const result = process_requests<typename TestFixture::Trait>(
+            chain,
+            state,
+            block_hash_buffer,
+            header,
+            state_tracer,
+            chain_ctx,
+            std::span<Receipt const>{});
+        ASSERT_TRUE(result.has_value());
+
+        auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+        auto const it = codes.find(SYSTEM_STUB_CODE_HASH);
+        ASSERT_TRUE(it != codes.end())
+            << "system contract code not recorded by system_call";
+        EXPECT_EQ(
+            byte_string_view(it->second->code(), it->second->size()),
+            byte_string_view(
+                SYSTEM_STUB_ICODE->code(), SYSTEM_STUB_ICODE->size()));
+    }
+}
+
+// Site 5: validate_ethereum_transaction records sender code on EIP-7702 check
+TYPED_TEST(TraitsTest, code_tracer_records_sender_code_in_validate)
+{
+    if constexpr (TestFixture::Trait::evm_rev() < EVMC_PRAGUE) {
+        GTEST_SKIP() << "EIP-7702 sender code read requires Prague+";
+    }
+    else {
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
+        TrieDb tdb{db};
+        vm::VM vm;
+
+        // Sender has non-empty code so the Prague+ branch reads it. The code
+        // is not a delegation indicator, so validate returns SenderNotEoa,
+        // but the read site still records --- which is the property under test.
+        commit_sequential(
+            tdb,
+            sd(
+                {{ADDR_A,
+                  StateDelta{
+                      .account =
+                          {std::nullopt,
+                           Account{
+                               .balance = 100'000'000'000'000'000,
+                               .code_hash = C_CODE_HASH}}}}}),
+            Code{{C_CODE_HASH, C_ICODE}},
+            BlockHeader{.number = 0});
+
+        BlockState bs{tdb, vm};
+        State state{bs, Incarnation{0, 0}};
+
+        Transaction const tx{.gas_limit = 60'500};
+        trace::StateTracer state_tracer = trace::CodeTracer{};
+        (void)validate_ethereum_transaction<typename TestFixture::Trait>(
+            tx, ADDR_A, state, state_tracer);
+
+        auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+        auto const it = codes.find(C_CODE_HASH);
+        ASSERT_TRUE(it != codes.end())
+            << "sender code not recorded by validate_ethereum_transaction";
+        EXPECT_EQ(
+            byte_string_view(it->second->code(), it->second->size()),
+            byte_string_view(C_ICODE->code(), C_ICODE->size()));
+    }
+}
+
+// Site 6: process_authorizations records authority code
+//
+// Goes through ExecuteTransactionNoValidation because process_authorizations
+// is a private member. The authority's code (B_CODE) is neither empty nor a
+// delegation indicator, so the entry is rejected after the read --- but the
+// read site still records, which is what we assert.
+//
+// Restricted to Ethereum Prague+ to avoid having to construct a sized
+// Monad-specific ChainContext for init_reserve_balance_context, which runs
+// at the top of operator() for monad traits. The Monad MONAD_FOUR+ exercise
+// of process_authorizations is structurally identical and is indirectly
+// covered by the witness-generation integration tests.
+TYPED_TEST(EvmTraitsTest, code_tracer_records_authorization_code)
+{
+    if constexpr (TestFixture::Trait::evm_rev() < EVMC_PRAGUE) {
+        GTEST_SKIP() << "EIP-7702 authority code read requires Prague+";
+    }
+    else {
+        mpt::Db db{std::make_unique<InMemoryMachine>()};
+        TrieDb tdb{db};
+        vm::VM vm;
+
+        commit_sequential(
+            tdb,
+            sd({{ADDR_A,
+                 StateDelta{
+                     .account =
+                         {std::nullopt,
+                          Account{
+                              .balance = 100'000'000'000'000'000,
+                              .nonce = 0}}}},
+                {ADDR_B,
+                 StateDelta{
+                     .account =
+                         {std::nullopt, Account{.code_hash = B_CODE_HASH}}}}}),
+            Code{{B_CODE_HASH, B_ICODE}},
+            BlockHeader{.number = 0});
+
+        BlockState bs{tdb, vm};
+        State state{bs, Incarnation{0, 0}};
+
+        // One authorization entry whose authority is ADDR_B. The authorities
+        // span shadows recovered addresses; we set it to ADDR_B directly,
+        // sidestepping signature recovery.
+        AuthorizationEntry auth{};
+        auth.sc.chain_id = 0; // 0 always matches host_chain_id in step 1
+        auth.nonce = 0;
+        auth.address = ADDR_B;
+        Transaction tx{
+            .max_fee_per_gas = 1,
+            .gas_limit = 100'000,
+            .to = ADDR_B,
+            .type = TransactionType::eip7702,
+        };
+        tx.authorization_list.push_back(auth);
+
+        std::vector<std::optional<Address>> const authorities = {ADDR_B};
+
+        NoopCallTracer call_tracer;
+        BlockHashBufferFinalized const block_hash_buffer;
+        auto const chain_ctx =
+            ChainContext<typename TestFixture::Trait>::debug_empty();
+        uint256_t const base_fee{0};
+        trace::StateTracer state_tracer = trace::CodeTracer{};
+        EvmcHost<typename TestFixture::Trait> host{
+            call_tracer,
+            state_tracer,
+            EMPTY_TX_CONTEXT,
+            block_hash_buffer,
+            state,
+            tx,
+            base_fee,
+            0,
+            chain_ctx};
+
+        (void)ExecuteTransactionNoValidation<typename TestFixture::Trait>{
+            EthereumMainnet{}, tx, ADDR_A, authorities, BlockHeader{}}(
+            state, host);
+
+        auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+        auto const it = codes.find(B_CODE_HASH);
+        ASSERT_TRUE(it != codes.end())
+            << "authority code not recorded by process_authorizations";
+        EXPECT_EQ(
+            byte_string_view(it->second->code(), it->second->size()),
+            byte_string_view(B_ICODE->code(), B_ICODE->size()));
+    }
+}
+
+// Sites 7+8: dipped_into_reserve and is_delegated (Monad MONAD_FOUR+).
+//
+// init_reserve_balance_context calls is_delegated for the sender, which
+// reads and records the sender's code when sender_code_hash != NULL_HASH.
+// revert_transaction -> dipped_into_reserve iterates state.current() and
+// records each non-empty code there (the read happens before the
+// is_delegated short-circuit, so non-delegated accounts are still recorded).
+//
+// We engineer the setup so each hash is attributable to exactly one site:
+//   - A_CODE_HASH: only recorded via is_delegated (sender is NOT in current())
+//   - B_CODE_HASH: only recorded via dipped_into_reserve (ADDR_B is in
+//                  current() but is not the sender, so the is_delegated call
+//                  above does not touch it).
+TYPED_TEST(MonadTraitsTest, code_tracer_records_reserve_balance_code)
+{
+    using Trait = typename TestFixture::Trait;
+    if (TestFixture::REV < MONAD_FOUR) {
+        GTEST_SKIP() << "reserve-balance code reads are MONAD_FOUR+ only";
+    }
+
+    constexpr auto SENDER = 0x5353535353535353535353535353535353535353_address;
+
+    mpt::Db db{std::make_unique<InMemoryMachine>()};
+    TrieDb tdb{db};
+    vm::VM vm;
+
+    commit_sequential(
+        tdb,
+        sd({{SENDER,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 100'000'000'000'000'000,
+                          .code_hash = A_CODE_HASH}}}},
+            {ADDR_B,
+             StateDelta{
+                 .account =
+                     {std::nullopt,
+                      Account{
+                          .balance = 100'000, .code_hash = B_CODE_HASH}}}}}),
+        Code{{A_CODE_HASH, A_ICODE}, {B_CODE_HASH, B_ICODE}},
+        BlockHeader{.number = 0});
+
+    BlockState bs{tdb, vm};
+    State state{bs, Incarnation{0, 0}};
+
+    // Bring ADDR_B into state.current() so dipped_into_reserve iterates it.
+    // Sender is intentionally NOT accessed: init_reserve_balance_context's
+    // is_delegated reads via state.get_code_hash / original_account_state,
+    // neither of which inserts into current_.
+    state.access_account(ADDR_B);
+
+    ankerl::unordered_dense::segmented_set<Address> const empty_neighbours;
+    std::vector<Address> const senders = {SENDER};
+    std::vector<std::vector<std::optional<Address>>> const authorities = {{}};
+    ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
+    senders_and_authorities.insert(SENDER);
+    ChainContext<Trait> const ctx{
+        .grandparent_senders_and_authorities = empty_neighbours,
+        .parent_senders_and_authorities = empty_neighbours,
+        .senders_and_authorities = senders_and_authorities,
+        .senders = senders,
+        .authorities = authorities};
+
+    Transaction const tx{.max_fee_per_gas = 1, .gas_limit = 21'000};
+    trace::StateTracer state_tracer = trace::CodeTracer{};
+
+    init_reserve_balance_context<Trait>(
+        state,
+        SENDER,
+        tx,
+        std::optional<uint256_t>{0},
+        /*i=*/0,
+        state_tracer,
+        ctx);
+
+    (void)revert_transaction<Trait>(
+        SENDER, tx, /*base_fee_per_gas=*/0, /*i=*/0, state, state_tracer, ctx);
+
+    auto const &codes = std::get<trace::CodeTracer>(state_tracer).codes;
+    auto const it_a = codes.find(A_CODE_HASH);
+    ASSERT_TRUE(it_a != codes.end())
+        << "sender code not recorded by is_delegated";
+    EXPECT_EQ(
+        byte_string_view(it_a->second->code(), it_a->second->size()),
+        byte_string_view(A_ICODE->code(), A_ICODE->size()));
+    auto const it_b = codes.find(B_CODE_HASH);
+    ASSERT_TRUE(it_b != codes.end())
+        << "current()-iterated account code not recorded by "
+           "dipped_into_reserve";
+    EXPECT_EQ(
+        byte_string_view(it_b->second->code(), it_b->second->size()),
+        byte_string_view(B_ICODE->code(), B_ICODE->size()));
 }

--- a/category/execution/ethereum/validate_transaction.cpp
+++ b/category/execution/ethereum/validate_transaction.cpp
@@ -200,10 +200,12 @@ template <Traits traits>
 Result<void> validate_transaction(
     Transaction const &tx, Address const &sender, State &state,
     uint256_t const & /*base_fee_per_gas*/,
-    std::span<std::optional<Address> const> const /*authorities*/)
+    std::span<std::optional<Address> const> const /*authorities*/,
+    trace::StateTracer &state_tracer)
 {
     static_assert(is_evm_trait_v<traits>);
-    return validate_ethereum_transaction<traits>(tx, sender, state);
+    return validate_ethereum_transaction<traits>(
+        tx, sender, state, state_tracer);
 }
 
 EXPLICIT_EVM_TRAITS(validate_transaction);

--- a/category/execution/ethereum/validate_transaction.hpp
+++ b/category/execution/ethereum/validate_transaction.hpp
@@ -22,6 +22,7 @@
 #include <category/execution/ethereum/core/contract/checked_math.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/execution/ethereum/validate_transaction_error.hpp>
 #include <category/vm/code.hpp>
@@ -51,11 +52,13 @@ template <Traits traits>
 Result<void> validate_transaction(
     Transaction const &tx, Address const &sender, State &state,
     uint256_t const &base_fee_per_gas,
-    std::span<std::optional<Address> const> const authorities);
+    std::span<std::optional<Address> const> const authorities,
+    trace::StateTracer &state_tracer);
 
 template <Traits traits>
 [[gnu::always_inline]] inline Result<void> validate_ethereum_transaction(
-    Transaction const &tx, Address const &sender, State &state)
+    Transaction const &tx, Address const &sender, State &state,
+    trace::StateTracer &state_tracer)
 {
     using BOOST_OUTCOME_V2_NAMESPACE::success;
 
@@ -94,10 +97,12 @@ template <Traits traits>
     }
 
     // YP (71)
-    bool sender_is_eoa = state.get_code_hash(sender) == NULL_HASH;
+    auto const code_hash = state.get_code_hash(sender);
+    bool sender_is_eoa = code_hash == NULL_HASH;
     if constexpr (traits::evm_rev() >= EVMC_PRAGUE) {
         // EIP-7702
-        auto const icode = state.get_code(sender)->intercode();
+        auto const icode = state.read_code(code_hash)->intercode();
+        trace::on_read_code(state_tracer, code_hash, icode);
         sender_is_eoa = sender_is_eoa ||
                         vm::evm::is_delegated({icode->code(), icode->size()});
     }

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -53,7 +53,8 @@ template <Traits traits>
 bool dipped_into_reserve(
     Address const &sender, Transaction const &tx,
     uint256_t const &base_fee_per_gas, uint64_t const i,
-    ChainContext<traits> const &ctx, State &state)
+    trace::StateTracer &state_tracer, ChainContext<traits> const &ctx,
+    State &state)
 {
     MONAD_ASSERT(i < ctx.senders.size());
     MONAD_ASSERT(i < ctx.authorities.size());
@@ -85,6 +86,7 @@ bool dipped_into_reserve(
         if (effective_code_hash != NULL_HASH) {
             vm::SharedIntercode const intercode =
                 state.read_code(effective_code_hash)->intercode();
+            trace::on_read_code(state_tracer, effective_code_hash, intercode);
             effective_is_delegated = monad::vm::evm::is_delegated(
                 {intercode->code(), intercode->size()});
             if (!effective_is_delegated) {
@@ -134,7 +136,8 @@ bool dipped_into_reserve(
     return false;
 }
 
-bool is_delegated(State &state, bytes32_t const &code_hash)
+bool is_delegated(
+    State &state, bytes32_t const &code_hash, trace::StateTracer &state_tracer)
 {
     if (MONAD_UNLIKELY(code_hash == NULL_HASH)) {
         return false;
@@ -143,6 +146,7 @@ bool is_delegated(State &state, bytes32_t const &code_hash)
     auto const vcode = state.read_code(code_hash);
     MONAD_ASSERT(vcode);
     auto const &icode = vcode->intercode();
+    trace::on_read_code(state_tracer, code_hash, icode);
     return vm::evm::is_delegated({icode->code(), icode->size()});
 }
 
@@ -197,7 +201,8 @@ bool ReserveBalance::subject_account(Address const &address)
     if (effective_code_hash == NULL_HASH) {
         return true;
     }
-    return is_delegated(*state_, effective_code_hash);
+    MONAD_ASSERT(state_tracer_ != nullptr);
+    return is_delegated(*state_, effective_code_hash, *state_tracer_);
 }
 
 uint256_t ReserveBalance::pretx_reserve(Address const &address)
@@ -318,8 +323,10 @@ template <Traits traits>
 void ReserveBalance::init_from_tx(
     Address const &sender, Transaction const &tx,
     std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
-    ChainContext<traits> const &ctx)
+    trace::StateTracer &state_tracer, ChainContext<traits> const &ctx)
 {
+    state_tracer_ = &state_tracer;
+
     constexpr bool tracking_disabled = []() {
         if constexpr (!is_monad_trait_v<traits>) {
             return true;
@@ -351,7 +358,7 @@ void ReserveBalance::init_from_tx(
             ? state_->get_code_hash(sender)
             : state_->original_account_state(sender).get_code_hash();
     bool const sender_can_dip = can_sender_dip_into_reserve<traits>(
-        sender, i, is_delegated(*state_, sender_code_hash), ctx);
+        sender, i, is_delegated(*state_, sender_code_hash, state_tracer), ctx);
     tracking_enabled_ = true;
     sender_ = sender;
     sender_gas_fees_ = uint256_t{tx.gas_limit} *
@@ -371,9 +378,10 @@ template <Traits traits>
 void init_reserve_balance_context(
     State &state, Address const &sender, Transaction const &tx,
     std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
-    ChainContext<traits> const &ctx)
+    trace::StateTracer &state_tracer, ChainContext<traits> const &ctx)
 {
-    state.rb_.init_from_tx<traits>(sender, tx, base_fee_per_gas, i, ctx);
+    state.rb_.init_from_tx<traits>(
+        sender, tx, base_fee_per_gas, i, state_tracer, ctx);
 }
 
 EXPLICIT_MONAD_TRAITS(init_reserve_balance_context);
@@ -382,11 +390,11 @@ template <Traits traits>
 bool revert_transaction(
     Address const &sender, Transaction const &tx,
     uint256_t const &base_fee_per_gas, uint64_t const i, State &state,
-    ChainContext<traits> const &ctx)
+    trace::StateTracer &state_tracer, ChainContext<traits> const &ctx)
 {
     if constexpr (traits::monad_rev() >= MONAD_FOUR) {
         return dipped_into_reserve<traits>(
-            sender, tx, base_fee_per_gas, i, ctx, state);
+            sender, tx, base_fee_per_gas, i, state_tracer, ctx, state);
     }
     else if constexpr (traits::monad_rev() >= MONAD_ZERO) {
         return false;

--- a/category/execution/monad/reserve_balance.hpp
+++ b/category/execution/monad/reserve_balance.hpp
@@ -20,6 +20,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/monad/revision.h>
 #include <category/vm/evm/traits.hpp>
 
@@ -45,6 +46,10 @@ class ReserveBalance
         Address, std::optional<uint256_t>>;
 
     State *state_;
+    // Tracer for code reads triggered by reserve-balance checks. Always
+    // non-null after `init_from_tx` returns (callers thread a noop monostate
+    // when not recording).
+    trace::StateTracer *state_tracer_{nullptr};
     bool tracking_enabled_{false};
     bool use_recent_code_hash_{false};
     bool allow_init_selfdestruct_exemption_{false};
@@ -79,7 +84,7 @@ public:
     void init_from_tx(
         Address const &sender, Transaction const &tx,
         std::optional<uint256_t> const &base_fee_per_gas, uint64_t i,
-        ChainContext<traits> const &ctx);
+        trace::StateTracer &state_tracer, ChainContext<traits> const &ctx);
 };
 
 template <Traits traits>

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -349,6 +349,7 @@ void run_dipped_into_reserve_test(
             tx,
             host.base_fee_per_gas_,
             host.i_,
+            host.state_tracer_,
             host.chain_ctx_);
 
         auto const &code_hash =
@@ -397,6 +398,7 @@ TEST_F(ReserveBalanceEvm, precompile_fallback)
             empty_tx,
             h.base_fee_per_gas_,
             h.i_,
+            h.state_tracer_,
             h.chain_ctx_);
 
         auto const result = h.call(m);
@@ -429,6 +431,7 @@ TEST_F(ReserveBalanceEvm, precompile_fallback)
             empty_tx,
             h.base_fee_per_gas_,
             h.i_,
+            h.state_tracer_,
             h.chain_ctx_);
 
         auto const result = h.call(m);
@@ -460,6 +463,7 @@ TEST_F(ReserveBalanceEvm, precompile_dipped_into_reserve_present)
         empty_tx,
         h.base_fee_per_gas_,
         h.i_,
+        h.state_tracer_,
         h.chain_ctx_);
 
     auto const result = h.call(m);
@@ -490,6 +494,7 @@ TEST_F(ReserveBalanceEvm, precompile_dipped_into_reserve_oog)
         empty_tx,
         h.base_fee_per_gas_,
         h.i_,
+        h.state_tracer_,
         h.chain_ctx_);
 
     auto const result = h.call(m);
@@ -520,6 +525,7 @@ TEST_F(ReserveBalanceEvm, precompile_dipped_into_reserve_with_argument)
         empty_tx,
         h.base_fee_per_gas_,
         h.i_,
+        h.state_tracer_,
         h.chain_ctx_);
 
     auto const result = h.call(m);
@@ -839,6 +845,7 @@ TYPED_TEST(
             this->empty_tx,
             this->h.base_fee_per_gas_,
             this->h.i_,
+            this->h.state_tracer_,
             this->h.chain_ctx_);
 
         std::array<uint8_t, 32> expected_message{};

--- a/category/execution/monad/validate_monad_transaction.cpp
+++ b/category/execution/monad/validate_monad_transaction.cpp
@@ -33,9 +33,11 @@ template <Traits traits>
 Result<void> validate_transaction(
     Transaction const &tx, Address const &sender, State &state,
     uint256_t const &base_fee_per_gas,
-    std::span<std::optional<Address> const> const authorities)
+    std::span<std::optional<Address> const> const authorities,
+    trace::StateTracer &state_tracer)
 {
-    auto res = validate_ethereum_transaction<traits>(tx, sender, state);
+    auto res =
+        validate_ethereum_transaction<traits>(tx, sender, state, state_tracer);
     if constexpr (traits::monad_rev() >= MONAD_FOUR) {
         if (res.has_error() &&
             res.error() != TransactionError::InsufficientBalance) {

--- a/category/execution/monad/validate_monad_transaction.hpp
+++ b/category/execution/monad/validate_monad_transaction.hpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/core/result.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/monad/revision.h>
 
 #include <evmc/evmc.h>
@@ -53,7 +54,8 @@ template <Traits traits>
 Result<void> validate_transaction(
     Transaction const &, Address const &sender, State &,
     uint256_t const &base_fee_per_gas,
-    std::span<std::optional<Address> const> authorities);
+    std::span<std::optional<Address> const> authorities,
+    trace::StateTracer &state_tracer);
 
 MONAD_NAMESPACE_END
 

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -244,7 +244,7 @@ namespace
             // be EOA for validation
             state.set_code(sender, {});
             BOOST_OUTCOME_TRY(validate_ethereum_transaction<traits>(
-                enriched_txn, sender, state));
+                enriched_txn, sender, state, state_tracer));
         }
 
         auto const senders = std::vector{sender};
@@ -377,7 +377,6 @@ namespace
         execute_block_header<traits>(block_state, header);
         BlockMetrics metrics{};
 
-        // Prepare state tracers and auxiliary noop call tracers.
         std::vector<std::unique_ptr<trace::StateTracer>> state_tracers{};
         state_tracers.reserve(transactions_size);
 
@@ -840,6 +839,7 @@ namespace
                     std::vector<std::unique_ptr<CallTracerBase>>{};
                 auto state_tracers =
                     std::vector<std::unique_ptr<trace::StateTracer>>{};
+                trace::StateTracer system_call_state_tracer{std::monostate{}};
 
                 static std::vector<Address> empty_senders{};
                 static std::vector<std::vector<std::optional<Address>>>
@@ -861,6 +861,7 @@ namespace
                         block_metrics,
                         call_tracers,
                         state_tracers,
+                        system_call_state_tracer,
                         chain_context,
                         emit_native_transfer_logs));
 
@@ -947,6 +948,7 @@ namespace
             auto state_tracers =
                 std::vector<std::unique_ptr<trace::StateTracer>>{};
             state_tracers.reserve(calls[block_idx].size());
+            trace::StateTracer system_call_state_tracer{std::monostate{}};
 
             for (Transaction const &tx : calls[block_idx]) {
                 call_frames.emplace_back();
@@ -979,6 +981,7 @@ namespace
                     block_metrics,
                     call_tracers,
                     state_tracers,
+                    system_call_state_tracer,
                     chain_context,
                     emit_native_transfer_logs));
 

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -92,6 +92,7 @@
 #include <stdlib.h>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <unistd.h>
@@ -2493,8 +2494,15 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
         BlockState block_state{tdb, vm};
         State state{
             block_state, Incarnation{header.number - 1, Incarnation::LAST_TX}};
+        trace::StateTracer noop_state_tracer = std::monostate{};
         init_reserve_balance_context<monad::MonadTraits<MONAD_NEXT>>(
-            state, sender, tx, header.base_fee_per_gas, 0, chain_context);
+            state,
+            sender,
+            tx,
+            header.base_fee_per_gas,
+            0,
+            noop_state_tracer,
+            chain_context);
         state.subtract_from_balance(sender, gas_fee);
         state.subtract_from_balance(sender, value);
         EXPECT_TRUE(block_state.can_merge(state));
@@ -2505,6 +2513,7 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
                 BASE_FEE_PER_GAS,
                 0, // transaction index
                 state,
+                noop_state_tracer,
                 chain_context);
         EXPECT_TRUE(should_revert);
     }

--- a/category/vm/interpreter/intercode.hpp
+++ b/category/vm/interpreter/intercode.hpp
@@ -17,6 +17,7 @@
 
 #include <category/vm/runtime/bin.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -73,6 +74,20 @@ namespace monad::vm::interpreter
         bool is_jumpdest(size_t const pc) const noexcept
         {
             return pc < *code_size_ && jumpdest_map_[pc];
+        }
+
+        [[gnu::always_inline]]
+        size_t copy_code(
+            size_t const offset, uint8_t *const buffer,
+            size_t const buffer_size) const
+        {
+            auto const code_size = size();
+            if (offset > code_size) {
+                return 0;
+            }
+            auto const n = std::min(code_size - offset, buffer_size);
+            std::copy_n(code() + offset, n, buffer);
+            return n;
         }
 
     private:

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -134,8 +134,9 @@ Result<void> process_ethereum_block(
     std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
         block.transactions.size()};
-    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers{
-        block.transactions.size()};
+    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers(
+        block.transactions.size());
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
         call_tracers[i] =
             enable_tracing
@@ -143,8 +144,8 @@ Result<void> process_ethereum_block(
                       block.transactions[i], call_frames[i])}
                 : std::unique_ptr<CallTracerBase>{
                       std::make_unique<NoopCallTracer>()};
-        state_tracers[i] = std::unique_ptr<trace::StateTracer>{
-            std::make_unique<trace::StateTracer>(std::monostate{})};
+        state_tracers[i] =
+            std::make_unique<trace::StateTracer>(std::monostate{});
     }
 
     // Core execution: transaction-level EVM execution that tracks state
@@ -168,6 +169,7 @@ Result<void> process_ethereum_block(
             block_metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_ctx));
     record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -228,8 +228,9 @@ Result<BlockExecOutput> propose_block(
     std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
         block.transactions.size()};
-    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers{
-        block.transactions.size()};
+    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers(
+        block.transactions.size());
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
         call_tracers[i] =
             enable_tracing
@@ -237,8 +238,8 @@ Result<BlockExecOutput> propose_block(
                       block.transactions[i], call_frames[i])}
                 : std::unique_ptr<CallTracerBase>{
                       std::make_unique<NoopCallTracer>()};
-        state_tracers[i] = std::unique_ptr<trace::StateTracer>{
-            std::make_unique<trace::StateTracer>(std::monostate{})};
+        state_tracers[i] =
+            std::make_unique<trace::StateTracer>(std::monostate{});
     }
 
     auto const
@@ -299,6 +300,7 @@ Result<BlockExecOutput> propose_block(
             block_metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_context));
     record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -178,8 +178,9 @@ Result<void> process_monad_block(
     std::vector<std::vector<CallFrame>> call_frames{block.transactions.size()};
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
         block.transactions.size()};
-    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers{
-        block.transactions.size()};
+    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers(
+        block.transactions.size());
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
         call_tracers[i] =
             enable_tracing
@@ -187,8 +188,8 @@ Result<void> process_monad_block(
                       block.transactions[i], call_frames[i])}
                 : std::unique_ptr<CallTracerBase>{
                       std::make_unique<NoopCallTracer>()};
-        state_tracers[i] = std::unique_ptr<trace::StateTracer>{
-            std::make_unique<trace::StateTracer>(std::monostate{})};
+        state_tracers[i] =
+            std::make_unique<trace::StateTracer>(std::monostate{});
     }
 
     senders_and_authorities_out = senders_and_authorities;
@@ -223,6 +224,7 @@ Result<void> process_monad_block(
             block_metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_context));
     record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -252,8 +252,9 @@ Result<BlockExecOutput> execute(
     std::vector<std::unique_ptr<CallTracerBase>> call_tracers{
         block.transactions.size()};
     call_frames.resize(block.transactions.size());
-    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers{
-        block.transactions.size()};
+    std::vector<std::unique_ptr<trace::StateTracer>> state_tracers(
+        block.transactions.size());
+    trace::StateTracer system_call_state_tracer{std::monostate{}};
     for (unsigned i = 0; i < block.transactions.size(); ++i) {
         call_tracers[i] =
             enable_tracing
@@ -261,8 +262,8 @@ Result<BlockExecOutput> execute(
                       block.transactions[i], call_frames[i])}
                 : std::unique_ptr<CallTracerBase>{
                       std::make_unique<NoopCallTracer>()};
-        state_tracers[i] = std::unique_ptr<trace::StateTracer>{
-            std::make_unique<trace::StateTracer>(std::monostate{})};
+        state_tracers[i] =
+            std::make_unique<trace::StateTracer>(std::monostate{});
     }
 
     senders_and_authorities_map[block.header.number] =
@@ -301,6 +302,7 @@ Result<BlockExecOutput> execute(
             metrics,
             call_tracers,
             state_tracers,
+            system_call_state_tracer,
             chain_context));
 
     block_state.log_debug();


### PR DESCRIPTION
### Summary
  Adds a `CodeTracer` variant to the `StateTracer` so witness generation can record every code preimage read during block execution.

### Changes
  - **`trace::CodeTracer`** (new `StateTracer` alternative): holds a `Code` map of `code_hash → SharedIntercode`.
  `trace::on_read_code` inserts when the active tracer is `CodeTracer`, no-op otherwise.
  - **EVM host code reads**: `EvmcHostBase::get_code_size` / `copy_code` now resolve the code hash and call `on_read_code` when the `StateTracer` is a `CodeTracer`. `state_tracer_` has been promoted from `EvmcHost<traits>` to `EvmcHostBase` (`sizeof` 64 → 72) so the base class can hook these paths.
  - **Reserve-balance code reads**: threads `trace::StateTracer&` through `revert_transaction`, `init_reserve_balance_context`, `ReserveBalance::init_from_tx`, `dipped_into_reserve`, and `is_delegated`, recording the delegated-code lookups that happen.
  - **System-call tracing**: `process_requests` (EIP-7002 / EIP-7251 system calls) now also takes a `StateTracer&` and records code reads against it. To accommodate this, `state_tracers` is sized `senders.size() + 1`: index `0` is the block-level tracer used by `process_requests`, and transaction `i` now uses `state_tracers[i + 1]`.