### PR TITLE
[barrett reduction] Clarify proof sketches and tighten generic template constraints

### DIFF
--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -1931,8 +1931,8 @@ namespace monad::vm::runtime
             /**
              * For Barrett reduction, we compute the quotient approximant
              *     q_hat = floor((x*reciprocal_) / 2^SHIFT)
-             * Under some conditions we can pre-divide x by 2^SHIFT to narrow
-             * the multiplications involved. The quantity computed is
+             * Under some conditions we can pre-divide x by 2^PRE_PRODUCT_SHIFT
+             * to narrow the multiplications involved. The quantity computed is
              *     q_hat = floor(
              *         floor(x/2^PRE_PRODUCT_SHIFT)*reciprocal_
              *         / 2^POST_PRODUCT_SHIFT
@@ -1941,11 +1941,12 @@ namespace monad::vm::runtime
              */
             static constexpr size_t PRE_PRODUCT_SHIFT = []() -> size_t {
                 if (MULTIPLIER_BITS) {
-                    // If there is a multiplier, then we cannot pre-shift the
-                    // input as this would mean we're discarding too many bits.
-                    // This is because (x - lowest_n_bits_x) / 1^n differs from
-                    // x / 1^n by at most 1, but ((x-lowest_n_bits_x)*y)/1^n
-                    // doesn't.
+                    // If there is a multiplier, then we cannot pre-shift x
+                    // uniformly. Dropping the low n bits omits
+                    // lowest_n_bits_x * y from the numerator, so the discarded
+                    // contribution is not bounded by one.
+                    // Without a multiplier, the discarded contribution is
+                    // lowest_n_bits_x / 2^n < 1.
                     // We could in principle calculate the number of bits that
                     // can be dropped by looking at the multiplier, but it would
                     // lead to a combinatorial explosion of parameters for
@@ -1963,7 +1964,7 @@ namespace monad::vm::runtime
                 //   2. (SHIFT - k) == 0 mod 64
                 //     * This ensures that the pre-product shift does not add
                 //       any extra shr steps
-                size_t max_pre_product_shift = bit_width(MIN_DENOMINATOR) - 1;
+                size_t max_pre_product_shift = MIN_DENOMINATOR_BITS - 1;
                 size_t const max_pre_product_shift_64 =
                     max_pre_product_shift % 64;
                 size_t const shift_64 = BIT_SHIFT;
@@ -2030,8 +2031,10 @@ namespace monad::vm::runtime
             /**
              * Maximum number of words needed to hold the approximate remainder.
              * In all cases, we are underestimating the quotient by at most 2.
-             * Therefore, we are overestimating the remainder by at most
-             * 2*denominator_ which fits in MAX_DENOMINATOR_BITS + 2 bits
+             * Therefore, the approximate remainder can contain the true
+             * remainder plus up to two denominator copies that were not
+             * subtracted. This is bounded by three times the denominator and
+             * fits in MAX_DENOMINATOR_BITS + 2 bits.
              */
             static constexpr size_t MAX_R_HAT_BITS = std::min(
                 INPUT_BITS + MULTIPLIER_BITS, MAX_DENOMINATOR_BITS + 2UL);
@@ -2040,10 +2043,13 @@ namespace monad::vm::runtime
             /**
              * Maximum number of words to hold the relevant part of the
              * quotient.
-             * Since we only care about the remainder (except for udivrem)
-             * and we know that the initial approximant and subsequent
-             * refinements will fit in MAX_R_HAT_WORDS, we only need
-             * to compute the quotient estimate up to RELEVANT_QUOTIENT_BITS
+             *
+             * Since we only care about the remainder (except for udivrem), the
+             * relevant quotient bits are those that can affect the truncated
+             * product with denominator_. That product is kept only up to
+             * MAX_R_HAT_BITS, so higher quotient bits cannot affect the
+             * approximate remainder.
+             *
              * The quotient that we obtain from Barrett reduction is only
              * correct when RELEVANT_QUOTIENT_WORDS == MAX_QUOTIENT_WORDS
              */
@@ -2071,10 +2077,10 @@ namespace monad::vm::runtime
              *         floor(x / 2^PRE_PRODUCT_SHIFT) * reciprocal_
              *         / 2^POST_PRODUCT_SHIFT
              *     )
-             * If PRE_PRODUCT_SHIFT == 0, then q_hat underapproximates q by at
-             * most 1
-             * If PRE_PRODUCT_SHIFT != 0, then q_hat underapproximates q by at
-             * most 2
+             * If PRE_PRODUCT_SHIFT == 0, then q_hat underapproximates the true
+             * quotient by at most 1
+             * If PRE_PRODUCT_SHIFT != 0, then q_hat underapproximates the true
+             * quotient by at most 2
              *
              * If need_quotient is false, then the quotient is only computed
              * up to RELEVANT_QUOTIENT_WORDS, which is sufficient to compute
@@ -2106,27 +2112,45 @@ namespace monad::vm::runtime
                     quot,
                 std::span<uint64_t, uint256_t::num_words> rem) const noexcept
             {
-                // Let B = PRE_PRODUCT_SHIFT
+                // Let S = SHIFT = INPUT_BITS, B = PRE_PRODUCT_SHIFT, and
+                // d = denominator_.
+                //
                 // We are approximating the shifted product
                 //     floor(r * x / 2^S)
                 // by the shifted product
-                //     floor(r * floor(x/2^B) / 2^(S - B))
-                // As seen in the definition of PRE_PRODUCT_SHIFT, B is chosen
-                // so that d > 2^B
+                //     floor(r * floor(x / 2^B) / 2^(S - B)).
+                //
+                // As seen in the definition of PRE_PRODUCT_SHIFT, B is
+                // chosen so that 2^B <= d.
+                //
                 // To see why this is sound, let
                 //     q = floor(x / d)
-                //     x = x_1 * 2^(S-B) + x_0
-                //           where x_1 is (256-S) bits and x_0 is S bits
-                //     q1 = floor(x_1 * 2^(256-S) / d)
-                //     q1_hat = floor(r * x_1 / 2^B)
-                //            = floor((r * x_1*2^B)/2^(S-B))
-                // By the correctness proof of the reciprocal above, we know
-                //     q1 - 1 <= q1_hat <= q1
-                // However, since u_0 < v, we also know q1 <= q <= q1+1 and
-                // therefore
-                //     q - 2 <= q1_hat <= q
+                //     x = x_1 * 2^B + x_0
+                //         where x_1 = floor(x / 2^B)
+                //         and x_0 = x mod 2^B.
+                //
+                // Then x_0 < 2^B <= d.
+                //
+                // Let
+                //     q1 = floor((x_1 * 2^B) / d)
+                //     q_hat = floor(r * x_1 / 2^(S - B))
+                //           = floor((r * x_1 * 2^B) / 2^S).
+                //
+                // By the correctness proof of the reciprocal above, applied
+                // to x_1 * 2^B, we know
+                //     q1 - 1 <= q_hat <= q1.
+                //
+                // Since x and x_1 * 2^B differ by x_0, and x_0 < d, we also
+                // know
+                //     q1 <= q <= q1 + 1.
+                //
+                // Therefore
+                //     q - 2 <= q_hat <= q.
+                //
+                // If a constant multiplier is stored in the reciprocal, then
+                // B is zero and the true numerator is x * multiplier_.
                 // This optimization is similar to the version of Barrett
-                // reduction described in Modern Computer Arithithmetic.
+                // reduction described in Modern Computer Arithmetic.
                 auto const q_hat = estimate_q<need_quotient>(x);
 
                 // The bit width of q_hat is often of the form 64*k+1. In
@@ -2136,8 +2160,10 @@ namespace monad::vm::runtime
                 words_t<MAX_R_HAT_WORDS> const qv =
                     truncating_mul<MAX_R_HAT_WORDS>(q_hat, denominator_);
 
-                // We may have underestimated the quotient by up to 2, so the
-                // remainder may need one extra word to fit.
+                // If the quotient estimate is too small, r_hat keeps the true
+                // remainder plus the denominator copies that were not
+                // subtracted. MAX_R_HAT_WORDS provides room for that
+                // overestimate.
                 words_t<MAX_R_HAT_WORDS> r_hat;
                 if constexpr (MULTIPLIER_BITS) {
                     auto const xy =
@@ -2382,10 +2408,10 @@ namespace monad::vm::runtime
             barrett::reciprocal<Params> const &rec) noexcept
             requires(Params.input_bits >= 257)
         {
-            auto const &d = rec.denominator_;
-            // When d >= 2^192 and x, y < d we could implement the same
-            // optimization as we do for division-based addmod, but the Barrett
-            // version is fast enough that branch mispredictions dominate.
+            // When denominator_ >= 2^192 and x, y < denominator_, we could
+            // implement the same optimization as we do for division-based
+            // addmod, but the Barrett version is fast enough that branch
+            // mispredictions dominate.
             auto const [sum_base, sum_carry] = addc(x, y);
             words_t<5> const sum{
                 sum_base[0], sum_base[1], sum_base[2], sum_base[3], sum_carry};

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -1819,6 +1819,14 @@ namespace monad::vm::runtime
                 return MIN_DENOMINATOR <= d && d <= MAX_DENOMINATOR;
             }
 
+            [[gnu::always_inline]]
+            static inline constexpr bool
+            valid_multiplier(uint256_t const &y) noexcept
+                requires(MULTIPLIER_WORDS > 0)
+            {
+                return bit_width(y.as_words()) <= MULTIPLIER_BITS;
+            }
+
             /**
              * Compute an underapproximation of the reciprocal for use in
              * Barrett reduction for udivrem, addmod and mulmod when all
@@ -1909,6 +1917,11 @@ namespace monad::vm::runtime
                 , multiplier_{}
             {
                 MONAD_VM_DEBUG_ASSERT(valid_denominator(d));
+                static_assert(
+                    MULTIPLIER_BITS <= uint256_t::num_bits,
+                    "Barrett multiplier reciprocals accept only uint256_t "
+                    "multipliers");
+                MONAD_VM_ASSERT(valid_multiplier(y));
                 auto quot = udivrem(numerator(y.as_words()), d.as_words()).quot;
                 std::memcpy(&reciprocal_, &quot, sizeof(reciprocal_));
                 for (size_t i = RECIPROCAL_WORDS;
@@ -2112,6 +2125,13 @@ namespace monad::vm::runtime
                     quot,
                 std::span<uint64_t, uint256_t::num_words> rem) const noexcept
             {
+                if constexpr (!need_quotient) {
+                    static_assert(
+                        POST_PRODUCT_BIT_SHIFT == 0,
+                        "Barrett reduce<false> requires a word-aligned "
+                        "post-product shift");
+                }
+
                 // Let S = SHIFT = INPUT_BITS, B = PRE_PRODUCT_SHIFT, and
                 // d = denominator_.
                 //

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -734,6 +734,20 @@ namespace monad::vm::runtime
         return 0;
     }
 
+    template <size_t N>
+    [[gnu::always_inline]]
+    inline constexpr size_t bit_width(std::array<uint64_t, N> const &x) noexcept
+    {
+        auto const significant_words = count_significant_words(x);
+        if (significant_words == 0) {
+            return 0;
+        }
+
+        auto const leading_word = x[significant_words - 1];
+        return 64 * static_cast<size_t>(significant_words - 1) +
+               static_cast<size_t>(64 - std::countl_zero(leading_word));
+    }
+
     [[gnu::always_inline]]
     inline constexpr uint32_t
     count_significant_bytes(uint256_t const &x) noexcept
@@ -1725,14 +1739,14 @@ namespace monad::vm::runtime
 
             static constexpr size_t NUMERATOR_WORDS = []() -> size_t {
                 if constexpr (MULTIPLIER_WORDS) {
-                    // Numerator will be y * (1 ^ INPUT_BITS)
+                    // Numerator will represent y << SHIFT
                     size_t const multiplier_bits = 64 * MULTIPLIER_WORDS;
                     size_t const shifted_multiplier_bits =
-                        multiplier_bits + INPUT_BITS;
+                        multiplier_bits + SHIFT;
                     return min_words(shifted_multiplier_bits);
                 }
                 else {
-                    // Numerator is 1 ^ INPUT_BITS
+                    // Numerator will represent 1 << SHIFT
                     return 1 + WORD_SHIFT;
                 }
             }();
@@ -1742,7 +1756,7 @@ namespace monad::vm::runtime
                 requires(MULTIPLIER_WORDS == 0)
             {
                 words_t<NUMERATOR_WORDS> num{0};
-                num[WORD_SHIFT] = 1 << BIT_SHIFT;
+                num[WORD_SHIFT] = uint64_t{1} << BIT_SHIFT;
                 return num;
             }
 
@@ -1761,10 +1775,11 @@ namespace monad::vm::runtime
                 else {
                     // Currently unused, provided here for completeness
                     num[WORD_SHIFT] = y[0] << BIT_SHIFT;
-                    for (size_t i = 0; i < MULTIPLIER_WORDS; i++) {
-                        num[i + 1 + WORD_SHIFT] =
-                            shld(y[i + 1], y[i], BIT_SHIFT);
+                    for (size_t i = 1; i < MULTIPLIER_WORDS; i++) {
+                        num[i + WORD_SHIFT] = shld(y[i], y[i - 1], BIT_SHIFT);
                     }
+                    num[MULTIPLIER_WORDS + WORD_SHIFT] =
+                        y[MULTIPLIER_WORDS - 1] >> 1 >> (63 - BIT_SHIFT);
                 }
                 return num;
             }
@@ -1791,17 +1806,7 @@ namespace monad::vm::runtime
                     max_q =
                         udivrem(numerator(), MIN_DENOMINATOR.as_words()).quot;
                 }
-                size_t significant_bits = 0;
-                for (size_t i = 0; i < NUMERATOR_WORDS; i++) {
-                    size_t const ix = NUMERATOR_WORDS - 1 - i;
-                    size_t const bits =
-                        static_cast<size_t>(64 - std::countl_zero(max_q[ix]));
-                    if (bits) {
-                        significant_bits = 64 * ix + bits;
-                        break;
-                    }
-                }
-                return significant_bits;
+                return bit_width(max_q);
             }();
 
             static constexpr size_t RECIPROCAL_WORDS =
@@ -1822,7 +1827,7 @@ namespace monad::vm::runtime
              *
              * Soundness property:
              *     For all inputs x such that 0 <= x < 2^input_bits,
-             *         let q = x / denominator_
+             *         let q = floor(x / denominator_)
              *         let q_hat = floor((x * reciprocal_) / 2^SHIFT)
              *         then q - 1 <= q_hat <= q
              * Auxiliary definitions:
@@ -1839,7 +1844,7 @@ namespace monad::vm::runtime
              *   3. (x/d) - (x/2^S) < r*x/2^S <= x/d (dividing by 2^S)
              * But x has at most S bits, therefore x/2^S < 1, hence:
              *   4. x/d - 1 < r*x/2^S <= x/d
-             * Let q = x/d, q_hat = floor(r*x/2^S). Then:
+             * Let q = floor(x/d), q_hat = floor(r*x/2^S). Then:
              *   5. q_hat <= r*x/2^S < q_hat + 1 (by def. of floor)
              *   6. q - 1 < q_hat + 1 (by 4 and 5)
              *   7. q_hat <= q        (by 4 and 5)
@@ -1852,10 +1857,7 @@ namespace monad::vm::runtime
                 , multiplier_{}
             {
                 MONAD_VM_DEBUG_ASSERT(valid_denominator(d));
-                // numerator = 1 << floor(log2(d)) + 1
-                words_t<NUMERATOR_WORDS> numerator{0};
-                numerator[WORD_SHIFT] = 1 << BIT_SHIFT;
-                auto quot = udivrem(numerator, d.as_words()).quot;
+                auto quot = udivrem(numerator(), d.as_words()).quot;
                 std::memcpy(&reciprocal_, &quot, sizeof(reciprocal_));
                 for (size_t i = RECIPROCAL_WORDS;
                      i < std::tuple_size_v<decltype(quot)>;
@@ -1876,7 +1878,7 @@ namespace monad::vm::runtime
              *
              * Soundness property:
              *     For all inputs x such that 0 <= x < 2^input_bits,
-             *         let q = x * y / denominator_
+             *         let q = floor(x * y / denominator_)
              *         let q_hat = floor((x * reciprocal_) / 2^SHIFT)
              *         then q - 1 <= q_hat <= q
              * Auxiliary definitions:
@@ -1893,7 +1895,7 @@ namespace monad::vm::runtime
              *   3. (xy/d) - (x/2^S) < r*x/2^S <= xy/d (dividing by 2^S)
              * But x has at most S bits, therefore x/2^S < 1, hence:
              *   4. xy/d - 1 < r*x/2^S <= xy/d
-             * Let q = xy/d, q_hat = floor(r*x/2^S). Then:
+             * Let q = floor(xy/d), q_hat = floor(r*x/2^S). Then:
              *   5. q_hat <= r*x/2^S < q_hat + 1 (by def. of floor)
              *   6. q - 1 < q_hat + 1 (by 4 and 5)
              *   7. q_hat <= q        (by 4 and 5)


### PR DESCRIPTION
This PR revises proof sketches and tightens generic template constraints based on findings from [the Rocq model and correctness proofs branch](https://github.com/category-labs/monad/tree/cmcl/barrett-rocq-model).   Code changes are either semantics-preserving replacements or along dormant paths that are not exercised by the exported Barrett aliases, i.e. there is no change to exported Barrett behaviour