### PR TITLE
mpt: make auto_expire_large_set test reject duplicate random keys

### DIFF
--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -68,6 +68,7 @@
 #include <optional>
 #include <thread>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -1855,14 +1856,22 @@ TEST(DbTest, auto_expire_large_set)
     constexpr uint64_t blocks = 1000;
     keys.reserve(blocks * keys_per_block);
 
-    // randomize keys
+    // randomize keys; reject duplicates so an expired key cannot reappear in a
+    // later block and spuriously pass a lookup that should fail
     auto const seed = static_cast<uint32_t>(time(nullptr));
     std::cout << "seed to reproduce: " << seed << std::endl;
     monad::small_prng rand(seed);
+    std::unordered_set<uint64_t> seen;
+    seen.reserve(blocks * keys_per_block);
     for (uint64_t block_id = 0; block_id < blocks; ++block_id) {
         for (unsigned i = 0; i < keys_per_block; ++i) {
             auto &key = keys.emplace_back(32, 0);
-            uint64_t raw = rand();
+            uint64_t raw;
+            do {
+                raw = (static_cast<uint64_t>(rand()) << 32) |
+                      static_cast<uint64_t>(rand());
+            }
+            while (!seen.insert(raw).second);
             keccak256((unsigned char const *)&raw, 8, key.data());
         }
         uint64_t const index = keys_per_block * block_id;


### PR DESCRIPTION
The test seeds small_prng with time(nullptr) and generates 5000 keys from rand() outputs. Two issues caused rare nondeterministic failures:

1. small_prng::operator() returns uint32_t, so the previous `uint64_t raw = rand()` left the upper 4 bytes zero, giving each key only 32 bits of entropy. Birthday probability of a collision among 5000 draws is around 0.29% per run.

2. When the colliding pair straddled the history window, an already-expired key reappeared in a still-live block, so the lookup that the test expected to fail succeeded instead.

Widen `raw` to a full 64 bits and additionally track seen values in an unordered_set, retrying on collision. The set gives a hard uniqueness guarantee rather than relying on probability.