### PR TITLE
[execution/monad]: MIP-8 gas schedule

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -188,6 +188,7 @@ add_library(
   "ethereum/state3/account_state.cpp"
   "ethereum/state3/account_state.hpp"
   "ethereum/state3/account_substate.hpp"
+  "ethereum/state3/page_tracker.hpp"
   "ethereum/state3/state.cpp"
   "ethereum/state3/state.hpp"
   "ethereum/state3/version_stack.hpp"

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -195,18 +195,6 @@ void EvmcHostBase::emit_log(
     stack_unwind();
 }
 
-evmc_access_status EvmcHostBase::access_storage(
-    evmc::address const &address, evmc::bytes32 const &key) noexcept
-{
-    try {
-        return state_.access_storage(address, key);
-    }
-    catch (...) {
-        capture_current_exception();
-    }
-    stack_unwind();
-}
-
 evmc::bytes32 EvmcHostBase::get_transient_storage(
     evmc::address const &address, evmc::bytes32 const &key) const noexcept
 {
@@ -225,6 +213,19 @@ void EvmcHostBase::set_transient_storage(
 {
     try {
         return state_.set_transient_storage(address, key, value);
+    }
+    catch (...) {
+        capture_current_exception();
+    }
+    stack_unwind();
+}
+
+EvmcHostBase::PageStorageStatus EvmcHostBase::update_page(
+    evmc::address const &address, evmc::bytes32 const &page_key,
+    evmc_storage_status const status) noexcept
+{
+    try {
+        return state_.update_page(address, page_key, status);
     }
     catch (...) {
         capture_current_exception();

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -93,9 +93,6 @@ public:
         evmc::address const &, uint8_t const *data, size_t data_size,
         evmc::bytes32 const topics[], size_t num_topics) noexcept override;
 
-    virtual evmc_access_status access_storage(
-        evmc::address const &, evmc::bytes32 const &key) noexcept override;
-
     virtual evmc::bytes32 get_transient_storage(
         evmc::address const &,
         evmc::bytes32 const &key) const noexcept override;
@@ -103,6 +100,10 @@ public:
     virtual void set_transient_storage(
         evmc::address const &, evmc::bytes32 const &key,
         evmc::bytes32 const &value) noexcept override;
+
+    virtual PageStorageStatus update_page(
+        evmc::address const &, evmc::bytes32 const &page_key,
+        evmc_storage_status) noexcept override;
 };
 
 static_assert(sizeof(EvmcHostBase) == 72);
@@ -202,6 +203,19 @@ struct EvmcHost final : public EvmcHostBase
                 return EVMC_ACCESS_WARM;
             }
             return state_.access_account(address);
+        }
+        catch (...) {
+            capture_current_exception();
+        }
+        stack_unwind();
+    }
+
+    virtual evmc_access_status access_storage(
+        evmc::address const &address,
+        evmc::bytes32 const &key) noexcept override
+    {
+        try {
+            return state_.access_storage<traits>(address, key);
         }
         catch (...) {
             capture_current_exception();

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -262,7 +262,7 @@ evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
     for (auto const &ae : tx_.access_list) {
         state.access_account(ae.a);
         for (auto const &keys : ae.keys) {
-            state.access_storage(ae.a, keys);
+            state.access_storage<traits>(ae.a, keys);
         }
     }
     if (MONAD_LIKELY(tx_.to)) {

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -960,19 +960,21 @@ TYPED_TEST(InMemoryStateTraitsTest, destruct_touched_dead)
 }
 
 // Storage
-TEST_F(InMemoryStateTest, access_storage)
+TYPED_TEST(InMemoryStateTraitsTest, access_storage)
 {
+    using Trait = typename TestFixture::Trait;
+
     BlockState bs{this->tdb, this->vm};
 
     State s{bs, Incarnation{1, 1}};
-    EXPECT_EQ(s.access_storage(a, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(a, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(b, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(b, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(a, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(a, key2), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(b, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(b, key2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(a, key1), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(a, key1), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(b, key1), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(b, key1), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(a, key2), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(a, key2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(b, key2), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(b, key2), EVMC_ACCESS_WARM);
 }
 
 TEST_F(InMemoryStateTest, get_storage)

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -22,6 +22,7 @@
 #include <category/core/likely.h>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/state3/account_substate.hpp>
+#include <category/execution/ethereum/state3/page_tracker.hpp>
 
 #include <evmc/evmc.h>
 
@@ -68,6 +69,7 @@ private:
 public:
     StorageMap storage_{};
     StorageMap transient_storage_{};
+    PageTracker page_tracker_{};
 
     evmc_storage_status zero_out_key(
         bytes32_t const &key, bytes32_t const &original_value,
@@ -153,7 +155,7 @@ public:
     }
 };
 
-static_assert(sizeof(AccountState) == 144);
+static_assert(sizeof(AccountState) == 160);
 
 // RELAXED MERGE
 // track the min original balance needed at start of transaction and if the

--- a/category/execution/ethereum/state3/page_tracker.hpp
+++ b/category/execution/ethereum/state3/page_tracker.hpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/vm/host.hpp>
+
+#include <evmc/evmc.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include <immer/map.hpp>
+#pragma GCC diagnostic pop
+
+MONAD_NAMESPACE_BEGIN
+
+// This is temp. Will be removed after the storage_page PR is merged.
+namespace detail
+{
+    inline bytes32_t compute_page_key(bytes32_t const &storage_key)
+    {
+        constexpr size_t PAGE_KEY_SHIFT = 7;
+        return store_be_as<bytes32_t>(
+            load_be<uint256_t>(storage_key) >> PAGE_KEY_SHIFT);
+    }
+}
+
+class PageTracker
+{
+    struct PageState
+    {
+        bool accessed{false}; // read
+        bool dirty{false}; // write
+        int16_t peak_growth{0};
+        int16_t current_growth{0};
+    };
+
+    using PageMap = immer::map<
+        bytes32_t, PageState, ankerl::unordered_dense::hash<monad::bytes32_t>>;
+
+    PageMap pages_{};
+
+    PageState lookup_page_state(bytes32_t const &page_key) const
+    {
+        auto const *cur = pages_.find(page_key);
+        return cur ? *cur : PageState{};
+    }
+
+public:
+    evmc_access_status access_page(bytes32_t const &key)
+    {
+        auto const pkey = detail::compute_page_key(key);
+        PageState s = lookup_page_state(pkey);
+        if (s.accessed) {
+            return EVMC_ACCESS_WARM;
+        }
+        s.accessed = true;
+        pages_ = pages_.set(pkey, s);
+        return EVMC_ACCESS_COLD;
+    }
+
+    vm::Host::PageStorageStatus
+    update_page(bytes32_t const &key, evmc_storage_status status)
+    {
+        auto const pkey = detail::compute_page_key(key);
+        PageState ps = lookup_page_state(pkey);
+
+        bool const value_changed = (status != EVMC_STORAGE_ASSIGNED);
+        bool first_page_write = false;
+        if (!ps.dirty) {
+            first_page_write = value_changed;
+            ps.dirty = value_changed;
+        }
+
+        switch (status) {
+        case EVMC_STORAGE_ADDED:
+        case EVMC_STORAGE_DELETED_ADDED:
+        case EVMC_STORAGE_DELETED_RESTORED:
+            ++ps.current_growth;
+            break;
+        case EVMC_STORAGE_DELETED:
+        case EVMC_STORAGE_MODIFIED_DELETED:
+        case EVMC_STORAGE_ADDED_DELETED:
+            --ps.current_growth;
+            break;
+        default:
+            break;
+        }
+
+        bool const grew_state = ps.current_growth > ps.peak_growth;
+        if (grew_state) {
+            ps.peak_growth = ps.current_growth;
+        }
+        if (value_changed) {
+            pages_ = pages_.set(pkey, ps);
+        }
+
+        return {first_page_write, grew_state};
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state3/page_tracker_test.cpp
+++ b/category/execution/ethereum/state3/page_tracker_test.cpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/state3/page_tracker.hpp>
+
+#include <evmc/evmc.h>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+
+namespace
+{
+    constexpr bytes32_t SLOT_A{0x1ea0};
+    constexpr bytes32_t SLOT_A2{0x1eaf};
+    constexpr bytes32_t SLOT_B{0xdeadbeef};
+}
+
+TEST(PageTracker, cold_write)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).first_page_write);
+    EXPECT_FALSE(
+        pt.update_page(SLOT_A2, EVMC_STORAGE_MODIFIED).first_page_write);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED).first_page_write);
+}
+
+TEST(PageTracker, state_growth)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_MODIFIED).grew_state);
+}
+
+TEST(PageTracker, intra_txn_free)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_ADDED).grew_state);
+}
+
+TEST(PageTracker, distinct_pages)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).first_page_write);
+    EXPECT_FALSE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).first_page_write);
+
+    auto const r = pt.update_page(SLOT_B, EVMC_STORAGE_ADDED);
+    EXPECT_TRUE(r.first_page_write);
+    EXPECT_TRUE(r.grew_state);
+}
+
+TEST(PageTracker, cold_read_then_warm_read)
+{
+    PageTracker pt;
+
+    EXPECT_EQ(pt.access_page(SLOT_A), EVMC_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_A2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_WARM);
+}
+
+TEST(PageTracker, deleted_then_readded_returns_to_baseline)
+{
+    PageTracker pt;
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED);
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_ADDED);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+}
+
+TEST(PageTracker, deleted_then_restored_returns_to_baseline)
+{
+    PageTracker pt;
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED);
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_RESTORED);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+}

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -412,11 +412,26 @@ evmc_access_status State::access_account(Address const &address)
     return account_state.access();
 }
 
+template <Traits traits>
 evmc_access_status
 State::access_storage(Address const &address, bytes32_t const &key)
 {
     auto &account_state = current_account_state(address);
-    return account_state.access_storage(key);
+    auto const slot_status = account_state.access_storage(key);
+    if constexpr (traits::mip_8_active()) {
+        return account_state.page_tracker_.access_page(key);
+    }
+    return slot_status;
+}
+
+EXPLICIT_TRAITS_MEMBER(State::access_storage);
+
+vm::Host::PageStorageStatus State::update_page(
+    Address const &address, bytes32_t const &key,
+    evmc_storage_status const status)
+{
+    auto &account_state = current_account_state(address);
+    return account_state.page_tracker_.update_page(key, status);
 }
 
 template <Traits traits>

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -167,7 +167,11 @@ public:
 
     evmc_access_status access_account(Address const &);
 
+    template <Traits traits>
     evmc_access_status access_storage(Address const &, bytes32_t const &key);
+
+    vm::Host::PageStorageStatus update_page(
+        Address const &, bytes32_t const &key, evmc_storage_status status);
 
     ////////////////////////////////////////
 

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -643,7 +643,7 @@ TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
     State s(bs, Incarnation{0, 0});
 
     s.push();
-    s.access_storage(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
     s.pop_reject();
 
     nlohmann::json storage;
@@ -673,7 +673,7 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
         AccessListTracer{storage, addr1, addr2, std::nullopt, authorities};
 
     s.push();
-    s.access_storage(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
     on_frame_reject(tracer, s);
     s.pop_reject();
 
@@ -745,9 +745,9 @@ TYPED_TEST(TraitsTest, access_list_write)
     s.create_account_no_rollback(addr2);
     s.create_account_no_rollback(addr3);
 
-    s.access_storage(addr2, key1);
-    s.access_storage(addr2, key2);
-    s.access_storage(addr3, key3);
+    s.access_storage<typename TestFixture::Trait>(addr2, key1);
+    s.access_storage<typename TestFixture::Trait>(addr2, key2);
+    s.access_storage<typename TestFixture::Trait>(addr3, key3);
 
     nlohmann::json storage;
     auto const authorities = std::vector<std::optional<Address>>{};
@@ -822,7 +822,7 @@ TYPED_TEST(TraitsTest, access_list_regular_account)
         s.create_account_no_rollback(addr3);
         s.create_account_no_rollback(addr4);
 
-        s.access_storage(addr4, key1);
+        s.access_storage<typename TestFixture::Trait>(addr4, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -880,7 +880,7 @@ TYPED_TEST(TraitsTest, access_list_sender)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr1, key1);
+        s.access_storage<typename TestFixture::Trait>(addr1, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -938,7 +938,7 @@ TYPED_TEST(TraitsTest, access_list_beneficiary)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr2, key1);
+        s.access_storage<typename TestFixture::Trait>(addr2, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -996,7 +996,7 @@ TYPED_TEST(TraitsTest, access_list_recipient)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr3, key1);
+        s.access_storage<typename TestFixture::Trait>(addr3, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -1059,8 +1059,8 @@ TYPED_TEST(TraitsTest, access_list_authorities)
         s.create_account_no_rollback(addr4);
         s.create_account_no_rollback(addr5);
 
-        s.access_storage(addr4, key1);
-        s.access_storage(addr5, key2);
+        s.access_storage<typename TestFixture::Trait>(addr4, key1);
+        s.access_storage<typename TestFixture::Trait>(addr5, key2);
 
         nlohmann::json storage;
         auto const authorities =

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -1093,7 +1093,7 @@ TEST_F(EthCallFixture, from_contract_account)
     EXPECT_EQ(ctx.result->output_data_len, 0);
     EXPECT_EQ(ctx.result->encoded_trace_len, 0);
     EXPECT_EQ(ctx.result->gas_refund, 0);
-    EXPECT_EQ(ctx.result->gas_used, 62094);
+    EXPECT_EQ(ctx.result->gas_used, 29594);
 
     monad_state_override_destroy(state_override);
     monad_executor_destroy(executor);
@@ -1178,7 +1178,7 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
         EXPECT_EQ(ctx->result->output_data_len, 0);
         EXPECT_EQ(ctx->result->encoded_trace_len, 0);
         EXPECT_EQ(ctx->result->gas_refund, 0);
-        EXPECT_EQ(ctx->result->gas_used, 62094);
+        EXPECT_EQ(ctx->result->gas_used, 29594);
 
         monad_state_override_destroy(state_override);
     }

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -737,7 +737,9 @@ namespace monad::vm::compiler
     consteval std::array<OpCodeInfo, 256>
     make_opcode_table<MonadTraits<MONAD_NEXT>>()
     {
-        return make_opcode_table<MonadTraits<MONAD_NEXT>::evm_base>();
+        auto table = make_opcode_table<MonadTraits<MONAD_NEXT>::evm_base>();
+        table[SSTORE].min_gas = MonadTraits<MONAD_NEXT>::base_sstore_cost();
+        return table;
     }
 
     /**

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -58,6 +58,7 @@ namespace monad
         { T::eip_7883_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
+        { T::mip_8_active() } -> std::same_as<bool>;
         { T::can_create_inside_delegated() } -> std::same_as<bool>;
 
         // Constants
@@ -122,6 +123,11 @@ namespace monad
         static consteval bool eip_7951_active() noexcept
         {
             return Rev >= MONAD_ETH_OSAKA;
+        }
+
+        static consteval bool mip_8_active() noexcept
+        {
+            return false;
         }
 
         static consteval bool mip_3_active() noexcept
@@ -252,6 +258,11 @@ namespace monad
             return false;
         }
 
+        static consteval bool mip_8_active() noexcept
+        {
+            return Rev >= MONAD_NEXT;
+        }
+
         // Pricing version 1 activates the changes in:
         // Monad specification §4: Opcode Gas Costs and Gas Refunds
         static consteval uint8_t monad_pricing_version() noexcept
@@ -261,6 +272,26 @@ namespace monad
             }
 
             return 0;
+        }
+
+        static consteval int64_t base_sload_cost() noexcept
+        {
+            return 100;
+        }
+
+        static consteval int64_t base_sstore_cost() noexcept
+        {
+            return 100;
+        }
+
+        static consteval int64_t page_write_cost() noexcept
+        {
+            return 2800;
+        }
+
+        static consteval int64_t page_growth_cost() noexcept
+        {
+            return 17000;
         }
 
         static consteval size_t max_code_size() noexcept

--- a/category/vm/host.hpp
+++ b/category/vm/host.hpp
@@ -30,6 +30,16 @@ namespace monad::vm
         friend class VM;
 
     public:
+        struct PageStorageStatus
+        {
+            bool first_page_write;
+            bool grew_state;
+        };
+
+        virtual PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept = 0;
+
         /// Capture `std::current_exception()`.
         /// IMPORTANT: Make sure to call this from inside a `catch` block.
         void capture_current_exception() const noexcept

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -20,11 +20,13 @@
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/revision.h>
 #include <category/vm/evm/traits.hpp>
+#include <category/vm/host.hpp>
 #include <category/vm/runtime/storage.hpp>
 #include <category/vm/runtime/storage_costs.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
 
 #include <cstdint>
 
@@ -75,28 +77,51 @@ namespace monad::vm::runtime
         auto key = store_be_as<bytes32_t>(*key_ptr);
         auto value = store_be_as<bytes32_t>(*value_ptr);
 
-        auto access_status = EVMC_ACCESS_COLD;
-        if constexpr (traits::eip_2929_active()) {
-            access_status = ctx->host->access_storage(
+        if constexpr (traits::mip_8_active()) {
+            auto const access_status = ctx->host->access_storage(
                 ctx->context, &ctx->env.recipient, &key);
             if (access_status == EVMC_ACCESS_COLD) {
-                ctx->deduct_gas(traits::cold_storage_cost() + min_gas);
+                ctx->deduct_gas(traits::cold_storage_cost());
             }
+
+            auto const storage_status = ctx->host->set_storage(
+                ctx->context, &ctx->env.recipient, &key, &value);
+
+            auto *monad_host = evmc::Host::from_context<vm::Host>(ctx->context);
+            auto const [first_page_write, grew_state] = monad_host->update_page(
+                ctx->env.recipient, key, storage_status);
+
+            int64_t gas_used = traits::base_sstore_cost();
+            if (first_page_write) {
+                gas_used += traits::page_write_cost();
+            }
+            if (grew_state) {
+                gas_used += traits::page_growth_cost();
+            }
+
+            gas_used -= min_gas;
+            ctx->deduct_gas(gas_used);
         }
+        else {
+            auto access_status = EVMC_ACCESS_COLD;
+            if constexpr (traits::eip_2929_active()) {
+                access_status = ctx->host->access_storage(
+                    ctx->context, &ctx->env.recipient, &key);
+                if (access_status == EVMC_ACCESS_COLD) {
+                    ctx->deduct_gas(traits::cold_storage_cost() + min_gas);
+                }
+            }
 
-        auto const storage_status = ctx->host->set_storage(
-            ctx->context, &ctx->env.recipient, &key, &value);
+            auto const storage_status = ctx->host->set_storage(
+                ctx->context, &ctx->env.recipient, &key, &value);
 
-        auto [gas_used, gas_refund] = store_cost<traits>(storage_status);
+            auto [gas_used, gas_refund] = store_cost<traits>(storage_status);
 
-        // The code generator has taken care of accounting for the minimum base
-        // gas cost of this SSTORE already, but to keep the table of costs
-        // readable it encodes the total gas usage of each combination, rather
-        // than the amount relative to the minimum gas.
-        gas_used -= min_gas;
+            gas_used -= min_gas;
 
-        ctx->gas_refund += gas_refund;
-        ctx->deduct_gas(gas_used);
+            ctx->gas_refund += gas_refund;
+            ctx->deduct_gas(gas_used);
+        }
     }
 
     EXPLICIT_TRAITS(sstore);

--- a/test/vm/unit/monad_vm_interface_tests.cpp
+++ b/test/vm/unit/monad_vm_interface_tests.cpp
@@ -201,6 +201,13 @@ namespace
             evmc::bytes32 const &) noexcept override
         {
         }
+
+        PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept override
+        {
+            return {};
+        }
     };
 }
 

--- a/test/vm/unit/runtime/fixture.cpp
+++ b/test/vm/unit/runtime/fixture.cpp
@@ -42,10 +42,10 @@ namespace monad::vm::compiler::test
 {
     namespace
     {
-        evmc::MockedHost init_host(std::array<evmc_bytes32, 2> &blob_hashes_)
+        void init_host(
+            monad::vm::test::MockedHost &host,
+            std::array<evmc_bytes32, 2> &blob_hashes_)
         {
-            auto host = evmc::MockedHost{};
-
             host.tx_context = evmc_tx_context{
                 .tx_gas_price = store_be_as<bytes32_t>(uint256_t{56762}),
                 .tx_origin = 0x000000000000000000000000000000005CA1AB1E_address,
@@ -66,14 +66,12 @@ namespace monad::vm::compiler::test
 
             host.block_hash = store_be_as<bytes32_t>(
                 0x105DF6064F84551C4100A368056B8AF0E491077245DAB1536D2CFA6AB78421CE_u256);
-
-            return host;
         }
     }
 
     RuntimeTestBase::RuntimeTestBase()
         : blob_hashes_{store_be_as<bytes32_t>(uint256_t{1}), store_be_as<bytes32_t>(uint256_t{2})}
-        , host_{init_host(blob_hashes_)}
+        , host_{}
         , test_ctx_{[&](auto &x) {
             x.host = &host_.get_interface(), x.context = host_.to_context(),
             x.gas_remaining = std::numeric_limits<std::int64_t>::max(),
@@ -96,6 +94,7 @@ namespace monad::vm::compiler::test
         }}
         , ctx_{*test_ctx_}
     {
+        init_host(host_, blob_hashes_);
         std::iota(code_.rbegin(), code_.rend(), 0);
         std::iota(call_data_.begin(), call_data_.end(), 0);
         std::iota(call_return_data_.begin(), call_return_data_.end(), 0);

--- a/test/vm/unit/runtime/fixture.hpp
+++ b/test/vm/unit/runtime/fixture.hpp
@@ -20,12 +20,12 @@
 #include <category/vm/runtime/detail.hpp>
 #include <category/vm/runtime/types.hpp>
 #include <monad/test/traits_test.hpp>
+#include <test/vm/unit/runtime/mocked_host.hpp>
 #include <test/vm/utils/test_context.hpp>
 
 #include <gtest/gtest.h>
 
 #include <evmc/evmc.hpp>
-#include <evmc/mocked_host.hpp>
 
 #include <limits>
 
@@ -46,7 +46,7 @@ namespace monad::vm::compiler::test
         std::array<std::uint8_t, 128> call_return_data_;
 
         std::array<evmc_bytes32, 2> blob_hashes_;
-        evmc::MockedHost host_;
+        monad::vm::test::MockedHost host_;
         monad::vm::test::TestContext test_ctx_;
         vm::runtime::Context &ctx_;
 

--- a/test/vm/unit/runtime/memory_tests.cpp
+++ b/test/vm/unit/runtime/memory_tests.cpp
@@ -36,10 +36,10 @@ namespace
     {
         vm::test::TestMemory init_memory_;
         Context *prev_rt_ctx_;
-        evmc::MockedHost &host_;
+        monad::vm::test::MockedHost &host_;
 
     public:
-        MemoryTestMachine(evmc::MockedHost &host)
+        MemoryTestMachine(monad::vm::test::MockedHost &host)
             : prev_rt_ctx_{}
             , host_{host}
         {
@@ -175,7 +175,7 @@ namespace
 
     template <Traits traits>
     void run_memory_test_machine(
-        evmc::MockedHost &host, MemoryTestMachineConfig config)
+        monad::vm::test::MockedHost &host, MemoryTestMachineConfig config)
     {
         MemoryTestMachine<traits> machine{host};
         machine.call([&](auto &ctx) {

--- a/test/vm/unit/runtime/mocked_host.hpp
+++ b/test/vm/unit/runtime/mocked_host.hpp
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/int.hpp>
+#include <category/vm/host.hpp>
+
+#include <evmc/evmc.hpp>
+#include <evmc/mocked_host.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <utility>
+
+namespace monad::vm::test
+{
+    class MockedHost : public Host
+    {
+        evmc::MockedHost inner_;
+
+        static constexpr size_t PAGE_KEY_SHIFT = 7;
+
+        struct PageGrowth
+        {
+            int current_state_growth{0};
+            int net_state_growth{0};
+        };
+
+        using PageKey = std::pair<evmc::address, evmc::bytes32>;
+
+        std::set<PageKey> read_accessed_pages_;
+        std::set<PageKey> write_accessed_pages_;
+        std::map<PageKey, PageGrowth> growth_;
+        PageStorageStatus last_write_page_status_{};
+
+        static evmc::bytes32
+        compute_page_key(evmc::bytes32 const &slot_key) noexcept
+        {
+            return store_be_as<evmc::bytes32>(
+                load_be<uint256_t>(slot_key) >> PAGE_KEY_SHIFT);
+        }
+
+    public:
+        decltype(inner_.accounts) &accounts = inner_.accounts;
+        decltype(inner_.recorded_calls) &recorded_calls = inner_.recorded_calls;
+        decltype(inner_.recorded_logs) &recorded_logs = inner_.recorded_logs;
+        decltype(inner_.recorded_selfdestructs) &recorded_selfdestructs =
+            inner_.recorded_selfdestructs;
+        decltype(inner_.recorded_account_accesses) &recorded_account_accesses =
+            inner_.recorded_account_accesses;
+        decltype(inner_.recorded_blockhashes) &recorded_blockhashes =
+            inner_.recorded_blockhashes;
+        decltype(inner_.tx_context) &tx_context = inner_.tx_context;
+        decltype(inner_.block_hash) &block_hash = inner_.block_hash;
+        decltype(inner_.call_result) &call_result = inner_.call_result;
+
+        bool account_exists(evmc::address const &addr) const noexcept override
+        {
+            return inner_.account_exists(addr);
+        }
+
+        evmc::bytes32 get_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) const noexcept override
+        {
+            return inner_.get_storage(addr, key);
+        }
+
+        evmc_storage_status set_storage(
+            evmc::address const &addr, evmc::bytes32 const &key,
+            evmc::bytes32 const &v_new) noexcept override
+        {
+            auto const v_current = inner_.get_storage(addr, key);
+            auto const p = PageKey{addr, compute_page_key(key)};
+
+            bool first_page_write = false;
+            if (v_current != v_new) {
+                auto const [it, inserted] = write_accessed_pages_.insert(p);
+                if (inserted) {
+                    first_page_write = true;
+                    growth_[p] = PageGrowth{};
+                }
+            }
+
+            auto const zero = evmc::bytes32{};
+            if (v_current == zero && v_new != zero) {
+                growth_[p].current_state_growth += 1;
+            }
+            else if (v_current != zero && v_new == zero) {
+                growth_[p].current_state_growth -= 1;
+            }
+
+            bool grew_state = false;
+            if (growth_[p].current_state_growth > growth_[p].net_state_growth) {
+                growth_[p].net_state_growth = growth_[p].current_state_growth;
+                grew_state = true;
+            }
+
+            last_write_page_status_ = {first_page_write, grew_state};
+
+            return inner_.set_storage(addr, key, v_new);
+        }
+
+        evmc::uint256be
+        get_balance(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_balance(addr);
+        }
+
+        size_t get_code_size(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_code_size(addr);
+        }
+
+        evmc::bytes32
+        get_code_hash(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_code_hash(addr);
+        }
+
+        size_t copy_code(
+            evmc::address const &addr, size_t code_offset, uint8_t *buffer_data,
+            size_t buffer_size) const noexcept override
+        {
+            return inner_.copy_code(
+                addr, code_offset, buffer_data, buffer_size);
+        }
+
+        bool selfdestruct(
+            evmc::address const &addr,
+            evmc::address const &beneficiary) noexcept override
+        {
+            return inner_.selfdestruct(addr, beneficiary);
+        }
+
+        evmc::Result call(evmc_message const &msg) noexcept override
+        {
+            return inner_.call(msg);
+        }
+
+        evmc_tx_context const *get_tx_context() const noexcept override
+        {
+            return inner_.get_tx_context();
+        }
+
+        evmc::bytes32
+        get_block_hash(int64_t block_number) const noexcept override
+        {
+            return inner_.get_block_hash(block_number);
+        }
+
+        void emit_log(
+            evmc::address const &addr, uint8_t const *data, size_t data_size,
+            evmc::bytes32 const topics[], size_t topics_count) noexcept override
+        {
+            inner_.emit_log(addr, data, data_size, topics, topics_count);
+        }
+
+        evmc_access_status
+        access_account(evmc::address const &addr) noexcept override
+        {
+            return inner_.access_account(addr);
+        }
+
+        evmc_access_status access_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) noexcept override
+        {
+            inner_.access_storage(addr, key);
+            auto const p = PageKey{addr, compute_page_key(key)};
+            auto const [it, inserted] = read_accessed_pages_.insert(p);
+            return inserted ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
+        }
+
+        evmc::bytes32 get_transient_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) const noexcept override
+        {
+            return inner_.get_transient_storage(addr, key);
+        }
+
+        void set_transient_storage(
+            evmc::address const &addr, evmc::bytes32 const &key,
+            evmc::bytes32 const &value) noexcept override
+        {
+            inner_.set_transient_storage(addr, key, value);
+        }
+
+        PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept override
+        {
+            return last_write_page_status_;
+        }
+    };
+}

--- a/test/vm/unit/runtime/storage_tests.cpp
+++ b/test/vm/unit/runtime/storage_tests.cpp
@@ -132,6 +132,9 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalEmpty)
     };
 
     if constexpr (is_monad_trait_v<traits>) {
+        if constexpr (traits::mip_8_active()) {
+            return do_test(27800, 0);
+        }
         if constexpr (traits::monad_rev() >= MONAD_SEVEN) {
             return do_test(28000, 19900);
         }
@@ -182,7 +185,10 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
         store(key, 0);
         ASSERT_EQ(ctx_.result.status, StatusCode::Success);
         ASSERT_EQ(ctx_.gas_remaining, 2301);
-        if constexpr (traits::evm_rev() <= MONAD_ETH_BERLIN) {
+        if constexpr (traits::mip_8_active()) {
+            ASSERT_EQ(ctx_.gas_refund, 0);
+        }
+        else if constexpr (traits::evm_rev() <= MONAD_ETH_BERLIN) {
             ASSERT_EQ(ctx_.gas_refund, 15000);
         }
         else {
@@ -193,6 +199,9 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
     };
 
     if constexpr (is_monad_trait_v<traits>) {
+        if constexpr (traits::mip_8_active()) {
+            return do_test(100, 2800);
+        }
         if constexpr (traits::monad_rev() >= MONAD_SEVEN) {
             return do_test(0, 2800);
         }
@@ -202,5 +211,43 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
     }
     else {
         do_test(6000, 2800);
+    }
+}
+
+TYPED_TEST(RuntimeTraitsTest, StorageLoadDifferentSlotsSamePage)
+{
+    using traits = TestFixture::Trait;
+    if constexpr (!traits::mip_8_active()) {
+        GTEST_SKIP();
+    }
+    else {
+        auto load = TestFixture::wrap(sload<traits>);
+
+        this->ctx_.gas_remaining = traits::cold_storage_cost();
+        ASSERT_EQ(load(0), 0);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+
+        this->ctx_.gas_remaining = 0;
+        ASSERT_EQ(load(1), 0);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+    }
+}
+
+TYPED_TEST(RuntimeTraitsTest, StorageColdAddChargesSpecTotal)
+{
+    using traits = TestFixture::Trait;
+    if constexpr (!traits::mip_8_active()) {
+        GTEST_SKIP();
+    }
+    else {
+        auto store = TestFixture::wrap(sstore<traits>);
+
+        this->ctx_.gas_remaining = 27800;
+        store(key, val);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+        static_assert(
+            traits::cold_storage_cost() + traits::page_write_cost() +
+                traits::page_growth_cost() ==
+            27800);
     }
 }


### PR DESCRIPTION
Adds the following data structures
    
  * PageTracker: Runtime tracking of page accesses, modifications, and
       the high watermark of slots changed, all within a transaction. Lives
       inside of account state and used by evm layer to charge sload/sstore.
  * Extended EvmcHost interface to return page status for sload costs.
    
Extended the MockHost object provided by evmc to include a reference to `update_page()`, otherwise any test for MONAD_NEXT segfaults.