### PR TITLE
[zkVM] Expose rlp encoding functions for MPT nodes

### DIFF
--- a/category/core/rlp/encode.hpp
+++ b/category/core/rlp/encode.hpp
@@ -129,36 +129,32 @@ constexpr size_t list_length(size_t const concatenated_size)
 }
 
 constexpr std::span<unsigned char>
-encode_list(std::span<unsigned char> d, byte_string_view const s)
+encode_list_prefix(std::span<unsigned char> d, size_t const payload_size)
 {
-    if (s.size() <= 55) {
-        d[0] = 0xC0 + static_cast<unsigned char>(s.size());
-        d = d.subspan(1);
-        if (d.size() < s.size()) {
-#ifdef NDEBUG
-            __builtin_unreachable();
-#else
-            abort();
-#endif
-        }
-        std::copy(s.begin(), s.end(), d.data());
-        d = d.subspan(s.size());
+    if (payload_size <= 55) {
+        d[0] = 0xC0 + static_cast<unsigned char>(payload_size);
+        return d.subspan(1);
     }
     else {
-        d[0] = 0xF7 + static_cast<unsigned char>(impl::length_length(s.size()));
-        d = d.subspan(1);
-        d = impl::encode_length(d, s.size());
-        if (d.size() < s.size()) {
-#ifdef NDEBUG
-            __builtin_unreachable();
-#else
-            abort();
-#endif
-        }
-        std::copy(s.begin(), s.end(), d.data());
-        d = d.subspan(s.size());
+        d[0] = 0xF7 +
+               static_cast<unsigned char>(impl::length_length(payload_size));
+        return impl::encode_length(d.subspan(1), payload_size);
     }
-    return d;
+}
+
+constexpr std::span<unsigned char>
+encode_list(std::span<unsigned char> d, byte_string_view const s)
+{
+    d = encode_list_prefix(d, s.size());
+    if (d.size() < s.size()) {
+#ifdef NDEBUG
+        __builtin_unreachable();
+#else
+        abort();
+#endif
+    }
+    std::copy(s.begin(), s.end(), d.data());
+    return d.subspan(s.size());
 }
 
 MONAD_RLP_NAMESPACE_END

--- a/category/execution/ethereum/db/test/test_account_leaf_processor.cpp
+++ b/category/execution/ethereum/db/test/test_account_leaf_processor.cpp
@@ -1,0 +1,135 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/mpt/node.hpp>
+
+#include <evmc/evmc.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <span>
+
+using namespace monad;
+using namespace monad::literals;
+
+TEST(AccountLeafProcessor, RoundtripNoChildren)
+{
+    // A leaf with no children represents an account whose storage trie is
+    // empty: AccountLeafProcessor::process must emit RLP with
+    // storage_root == NULL_ROOT regardless of the node's data field.
+    Account const original{
+        .balance = uint256_t{24'000'000},
+        .code_hash =
+            0x6b8cebdc2590b486457bbb286e96011bdd50ccc1d8580c1ffb3c89e828462283_bytes32,
+        .nonce = 7,
+        .incarnation = Incarnation{0, 0}};
+    Address const address = 0x00000000000000000000000000000000deadbeef_address;
+
+    byte_string const db_encoded = encode_account_db(address, original);
+
+    mpt::Node::SharedPtr const node = mpt::make_node(
+        /*mask=*/0,
+        /*children=*/{},
+        /*path=*/mpt::NibblesView{},
+        /*value=*/byte_string_view{db_encoded},
+        /*data=*/byte_string_view{},
+        /*version=*/0);
+
+    byte_string const encoded = AccountLeafProcessor::process(*node);
+
+    byte_string_view encoded_view{encoded};
+    bytes32_t decoded_storage_root{};
+    auto const decoded =
+        rlp::decode_account(decoded_storage_root, encoded_view);
+    ASSERT_FALSE(decoded.has_error());
+    EXPECT_EQ(encoded_view.size(), 0);
+
+    EXPECT_EQ(decoded_storage_root, NULL_ROOT);
+    EXPECT_EQ(decoded.value().balance, original.balance);
+    EXPECT_EQ(decoded.value().nonce, original.nonce);
+    EXPECT_EQ(decoded.value().code_hash, original.code_hash);
+}
+
+TEST(AccountLeafProcessor, RoundtripWithChildren)
+{
+    // An account leaf with children carries the storage trie root in
+    // node.data(). AccountLeafProcessor::process must surface that root in
+    // the emitted RLP rather than falling through to NULL_ROOT.
+    Account const original{
+        .balance = uint256_t{42},
+        .code_hash =
+            0x6b8cebdc2590b486457bbb286e96011bdd50ccc1d8580c1ffb3c89e828462283_bytes32,
+        .nonce = 1,
+        .incarnation = Incarnation{0, 0}};
+    Address const address = 0x00000000000000000000000000000000deadbeef_address;
+    bytes32_t const storage_root =
+        0xbea34dd04b09ad3b6014251ee24578074087ee60fda8c391cf466dfe5d687d7b_bytes32;
+
+    byte_string const db_encoded = encode_account_db(address, original);
+
+    mpt::ChildData child{};
+    child.len = 1;
+    child.data[0] = 0xa;
+    child.branch = 0x5;
+    child.ptr = mpt::make_node(
+        0, {}, mpt::NibblesView{}, byte_string_view{}, byte_string_view{}, 0);
+    std::array<mpt::ChildData, 1> children{child};
+
+    mpt::Node::SharedPtr const node = mpt::make_node(
+        /*mask=*/static_cast<uint16_t>(1u << 0x5),
+        /*children=*/std::span<mpt::ChildData>{children},
+        /*path=*/mpt::NibblesView{},
+        /*value=*/byte_string_view{db_encoded},
+        /*data=*/
+        byte_string_view{storage_root.bytes, sizeof(storage_root.bytes)},
+        /*version=*/0);
+
+    byte_string const encoded = AccountLeafProcessor::process(*node);
+
+    byte_string_view encoded_view{encoded};
+    bytes32_t decoded_storage_root{};
+    auto const decoded =
+        rlp::decode_account(decoded_storage_root, encoded_view);
+    ASSERT_FALSE(decoded.has_error());
+    EXPECT_EQ(encoded_view.size(), 0);
+
+    EXPECT_EQ(decoded_storage_root, storage_root);
+    EXPECT_EQ(decoded.value().balance, original.balance);
+    EXPECT_EQ(decoded.value().nonce, original.nonce);
+    EXPECT_EQ(decoded.value().code_hash, original.code_hash);
+}
+
+TEST(AccountLeafProcessor, EmptyValueReturnsEmpty)
+{
+    // A leaf carrying an empty value is the block-number leaf: process must
+    // short-circuit and emit no bytes, regardless of any data field.
+    mpt::Node::SharedPtr const node = mpt::make_node(
+        /*mask=*/0,
+        /*children=*/{},
+        /*path=*/mpt::NibblesView{},
+        /*value=*/byte_string_view{},
+        /*data=*/byte_string_view{},
+        /*version=*/0);
+
+    EXPECT_EQ(AccountLeafProcessor::process(*node), byte_string{});
+}

--- a/category/execution/ethereum/db/test/test_storage_leaf_processor.cpp
+++ b/category/execution/ethereum/db/test/test_storage_leaf_processor.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/mpt/node.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+using namespace monad::literals;
+
+TEST(StorageLeafProcessor, Roundtrip)
+{
+    // A storage leaf's value is encode_storage_db(slot, val). The processor
+    // strips the slot and re-emits just the value as an RLP-encoded compact
+    // (leading-zero-stripped) bytes32. Decoding the result must yield the
+    // original value, regardless of the slot.
+    bytes32_t const slot =
+        0x0000000000000000000000000000000000000000000000000000000000000042_bytes32;
+    bytes32_t const value =
+        0x00000000000000000000000000000000000000000000000000000000deadbeef_bytes32;
+
+    byte_string const db_encoded = encode_storage_db(slot, value);
+
+    mpt::Node::SharedPtr const node = mpt::make_node(
+        /*mask=*/0,
+        /*children=*/{},
+        /*path=*/mpt::NibblesView{},
+        /*value=*/byte_string_view{db_encoded},
+        /*data=*/byte_string_view{},
+        /*version=*/0);
+
+    byte_string const encoded = StorageLeafProcessor::process(*node);
+
+    byte_string_view encoded_view{encoded};
+    auto const decoded = rlp::decode_bytes32_compact(encoded_view);
+    ASSERT_FALSE(decoded.has_error());
+    EXPECT_EQ(encoded_view.size(), 0);
+    EXPECT_EQ(decoded.value(), value);
+}

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -340,43 +340,6 @@ namespace
         }
     };
 
-    struct AccountLeafProcessor
-    {
-        static byte_string process(mpt::Node const &node)
-        {
-            MONAD_ASSERT(node.has_value());
-
-            // this is the block number leaf
-            if (MONAD_UNLIKELY(node.value().empty())) {
-                return {};
-            }
-
-            auto encoded_account = node.value();
-            auto const acct = decode_account_db_ignore_address(encoded_account);
-            MONAD_ASSERT(!acct.has_error());
-            MONAD_ASSERT(encoded_account.empty());
-            bytes32_t storage_root = NULL_ROOT;
-            if (node.number_of_children()) {
-                MONAD_ASSERT(node.data().size() == sizeof(bytes32_t));
-                std::copy_n(
-                    node.data().data(), sizeof(bytes32_t), storage_root.bytes);
-            }
-            return rlp::encode_account(acct.value(), storage_root);
-        }
-    };
-
-    struct StorageLeafProcessor
-    {
-        static byte_string process(mpt::Node const &node)
-        {
-            MONAD_ASSERT(node.has_value());
-            auto encoded_storage = node.value();
-            auto const storage = decode_storage_db_ignore_slot(encoded_storage);
-            MONAD_ASSERT(!storage.has_error());
-            return rlp::encode_string2(storage.value());
-        }
-    };
-
     Result<byte_string_view>
     parse_encoded_receipt_ignore_log_index(byte_string_view &enc)
     {
@@ -424,7 +387,7 @@ namespace
         compute(unsigned char *const buffer, Node const &node) override
         {
             MONAD_ASSERT(node.has_value());
-            return encode_two_pieces(
+            return encode_two_pieces_reference(
                 buffer,
                 node.path_nibble_view(),
                 AccountLeafProcessor::process(node),
@@ -700,6 +663,36 @@ Result<byte_string_view> decode_storage_db_ignore_slot(byte_string_view &enc)
     }
     return res.second;
 };
+
+byte_string AccountLeafProcessor::process(mpt::Node const &node)
+{
+    MONAD_ASSERT(node.has_value());
+
+    // this is the block number leaf
+    if (MONAD_UNLIKELY(node.value().empty())) {
+        return {};
+    }
+
+    auto encoded_account = node.value();
+    auto const acct = decode_account_db_ignore_address(encoded_account);
+    MONAD_ASSERT(!acct.has_error());
+    MONAD_ASSERT(encoded_account.empty());
+    bytes32_t storage_root = NULL_ROOT;
+    if (node.number_of_children()) {
+        MONAD_ASSERT(node.data().size() == sizeof(bytes32_t));
+        std::copy_n(node.data().data(), sizeof(bytes32_t), storage_root.bytes);
+    }
+    return rlp::encode_account(acct.value(), storage_root);
+}
+
+byte_string StorageLeafProcessor::process(mpt::Node const &node)
+{
+    MONAD_ASSERT(node.has_value());
+    auto encoded_storage = node.value();
+    auto const storage = decode_storage_db_ignore_slot(encoded_storage);
+    MONAD_ASSERT(!storage.has_error());
+    return rlp::encode_string2(storage.value());
+}
 
 void write_to_file(
     nlohmann::json const &j, std::filesystem::path const &root_path,

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -149,6 +149,16 @@ decode_storage_db_raw(byte_string_view &);
 Result<std::pair<bytes32_t, bytes32_t>> decode_storage_db(byte_string_view &);
 Result<byte_string_view> decode_storage_db_ignore_slot(byte_string_view &);
 
+struct AccountLeafProcessor
+{
+    static byte_string process(mpt::Node const &node);
+};
+
+struct StorageLeafProcessor
+{
+    static byte_string process(mpt::Node const &node);
+};
+
 Result<std::pair<Receipt, size_t>> decode_receipt_db(byte_string_view &);
 Result<std::pair<Transaction, Address>>
 decode_transaction_db(byte_string_view &);

--- a/category/execution/ethereum/rlp/decode.hpp
+++ b/category/execution/ethereum/rlp/decode.hpp
@@ -70,11 +70,16 @@ namespace detail
     enum class ParseMetadataOptions
     {
         ReturnRlpType,
+        KeepRlpHeader,
     };
 
     template <ParseMetadataOptions... Options>
     inline constexpr bool should_return_rlp_type =
         ((Options == ParseMetadataOptions::ReturnRlpType) || ...);
+
+    template <ParseMetadataOptions... Options>
+    inline constexpr bool should_keep_rlp_header =
+        ((Options == ParseMetadataOptions::KeepRlpHeader) || ...);
 
     // We want two return versions of the functions below. One which simply
     // returns a byte_string_view when we are parsing/expecting a specific type,
@@ -99,7 +104,14 @@ namespace detail
             return DecodeError::InputTooShort;
         }
 
-        auto const payload = enc.substr(i, length);
+        auto const payload = [&] {
+            if constexpr (should_keep_rlp_header<Options...>) {
+                return enc.substr(0, end);
+            }
+            else {
+                return enc.substr(i, length);
+            }
+        }();
         enc = enc.substr(end);
 
         if constexpr (should_return_rlp_type<Options...>) {
@@ -226,6 +238,24 @@ inline Result<byte_string_view> parse_list_metadata(byte_string_view &enc)
     }
 
     return detail::parse_list_metadata(enc);
+}
+
+// Like parse_list_metadata, but the returned view spans the full list
+// encoding including the RLP list header — i.e. the header byte(s) plus the
+// payload — rather than just the payload. `enc` is still advanced past the
+// end of the list. Useful when the caller needs to re-emit or hash the list
+// in its original wire form.
+inline Result<byte_string_view> parse_list_metadata_raw(byte_string_view &enc)
+{
+    if (MONAD_UNLIKELY(enc.empty())) {
+        return DecodeError::InputTooShort;
+    }
+    if (MONAD_UNLIKELY(enc[0] < 0xc0)) {
+        return DecodeError::TypeUnexpected;
+    }
+
+    return detail::parse_list_metadata<
+        detail::ParseMetadataOptions::KeepRlpHeader>(enc);
 }
 
 inline Result<byte_string_view> decode_string(byte_string_view &enc)

--- a/category/execution/ethereum/rlp/test/test_decode.cpp
+++ b/category/execution/ethereum/rlp/test/test_decode.cpp
@@ -211,4 +211,18 @@ TEST(Rlp, ParseMetadata)
         ASSERT_TRUE(result.has_error());
         EXPECT_EQ(result.error(), DecodeError::TypeUnexpected);
     }
+
+    // parse_list_metadata_raw returns the full list encoding, header
+    // included (unlike parse_list_metadata which strips it).
+    {
+        auto encoding = encode_list2(
+            encode_string2(to_byte_string_view("cat")),
+            encode_string2(to_byte_string_view("dog")));
+        byte_string_view enc{encoding};
+
+        auto const result = parse_list_metadata_raw(enc);
+        ASSERT_FALSE(result.has_error());
+        EXPECT_EQ(result.value(), byte_string_view{encoding});
+        EXPECT_EQ(enc.size(), 0);
+    }
 }

--- a/category/mpt/compute.cpp
+++ b/category/mpt/compute.cpp
@@ -21,7 +21,6 @@
 #include <category/core/rlp/encode.hpp>
 #include <category/mpt/config.hpp>
 #include <category/mpt/merkle/compact_encode.hpp>
-#include <category/mpt/merkle/node_reference.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 
@@ -31,9 +30,8 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-unsigned encode_two_pieces(
-    unsigned char *const dest, NibblesView const path,
-    byte_string_view const second, bool const has_value)
+byte_string encode_two_pieces(
+    NibblesView const path, byte_string_view const second, bool const has_value)
 {
     constexpr size_t max_compact_encode_size = KECCAK256_SIZE + 1;
 
@@ -60,9 +58,7 @@ unsigned encode_two_pieces(
 
     byte_string rlp(rlp::list_length(concat_len), 0);
     rlp::encode_list(rlp, {concat_rlp.data(), concat_rlp.size()});
-    auto const ret = to_node_reference({rlp.data(), rlp.size()}, dest);
-    // free any long array allocated on heap
-    return ret;
+    return rlp;
 }
 
 std::span<unsigned char>

--- a/category/mpt/compute.hpp
+++ b/category/mpt/compute.hpp
@@ -47,6 +47,13 @@ namespace detail
             }
         }
     };
+
+    constexpr unsigned calc_branch_rlp_max_size(unsigned const leaf_data_size)
+    {
+        return static_cast<unsigned>(rlp::list_length(
+            rlp::list_length(KECCAK256_SIZE) * 16 +
+            rlp::list_length(leaf_data_size)));
+    }
 }
 
 std::span<unsigned char> encode_empty_string(std::span<unsigned char> result);
@@ -57,9 +64,16 @@ encode_16_children(std::span<ChildData>, std::span<unsigned char> result);
 std::span<unsigned char>
 encode_16_children(Node const &, std::span<unsigned char> result);
 
-unsigned encode_two_pieces(
-    unsigned char *dest, NibblesView path, byte_string_view second,
-    bool has_value = false);
+byte_string encode_two_pieces(
+    NibblesView path, byte_string_view second, bool has_value = false);
+
+[[gnu::always_inline]] inline unsigned encode_two_pieces_reference(
+    unsigned char *const dest, NibblesView const path,
+    byte_string_view const second, bool const has_value = false)
+{
+    auto const rlp = encode_two_pieces(path, second, has_value);
+    return to_node_reference({rlp.data(), rlp.size()}, dest);
+}
 
 struct Compute
 {
@@ -183,7 +197,7 @@ struct MerkleComputeBase : Compute
     compute(unsigned char *const buffer, Node const &node) override
     {
         if (node.has_value()) {
-            return encode_two_pieces(
+            return encode_two_pieces_reference(
                 buffer,
                 node.path_nibble_view(),
                 LeafValueProcessor::process(node), // processed leaf data
@@ -193,7 +207,7 @@ struct MerkleComputeBase : Compute
         if (node.has_path()) {
             unsigned char reference[KECCAK256_SIZE];
             unsigned const len = compute_branch_reference_(reference, node);
-            return encode_two_pieces(
+            return encode_two_pieces_reference(
                 buffer, node.path_nibble_view(), {reference, len}, false);
         }
         return compute_branch_reference_(buffer, node);
@@ -207,7 +221,7 @@ private:
         Node *const node = single_child.ptr.get();
         MONAD_ASSERT(node);
 
-        return state.len = encode_two_pieces(
+        return state.len = encode_two_pieces_reference(
                 state.buffer,
                 concat(single_child.branch, node->path_nibble_view()),
                 (node->has_value()
@@ -260,15 +274,25 @@ struct NoopProcessor
 };
 
 template <leaf_processor LeafValueProcessor = NoopProcessor>
+byte_string encode_branch(Node const &node)
+{
+    MONAD_ASSERT(node.number_of_children());
+    byte_string branch_str_rlp(
+        detail::calc_branch_rlp_max_size(node.value_len), 0);
+    auto result = encode_16_children(node, branch_str_rlp);
+    result = (node.has_value() && node.value_len)
+                 ? rlp::encode_string(result, LeafValueProcessor::process(node))
+                 : encode_empty_string(result);
+    auto const concat_len =
+        static_cast<size_t>(result.data() - branch_str_rlp.data());
+    byte_string branch_rlp(rlp::list_length(concat_len), 0);
+    rlp::encode_list(branch_rlp, {branch_str_rlp.data(), concat_len});
+    return branch_rlp;
+}
+
+template <leaf_processor LeafValueProcessor = NoopProcessor>
 struct VarLenMerkleCompute : Compute
 {
-    static constexpr auto calc_rlp_max_size =
-        [](unsigned const leaf_data_size) -> unsigned {
-        return static_cast<unsigned>(rlp::list_length(
-            rlp::list_length(KECCAK256_SIZE) * 16 +
-            rlp::list_length(leaf_data_size)));
-    };
-
     // Compute the intermediate branch data to the internal state.
     // For variable length merkle trie, we store branch node data inline in
     // nodes that have at least one child and non-empty path.
@@ -308,7 +332,7 @@ struct VarLenMerkleCompute : Compute
         // Ethereum leaf: leaf node hash without child
         if (node.number_of_children() == 0) {
             MONAD_ASSERT(node.has_value());
-            return encode_two_pieces(
+            return encode_two_pieces_reference(
                 buffer,
                 node.path_nibble_view(),
                 LeafValueProcessor::process(node),
@@ -318,7 +342,7 @@ struct VarLenMerkleCompute : Compute
         // rlp(encoded path, inline branch hash)
         if (node.has_path()) { // extension node, rlp encode with path too
             MONAD_ASSERT(node.bitpacked.data_len);
-            return encode_two_pieces(
+            return encode_two_pieces_reference(
                 buffer, node.path_nibble_view(), node.data(), node.has_value());
         }
         // Ethereum branch
@@ -333,7 +357,7 @@ protected:
         std::optional<byte_string_view> const value)
     {
         // compute branch node data to internal state
-        unsigned const branch_str_max_len = calc_rlp_max_size(
+        unsigned const branch_str_max_len = detail::calc_branch_rlp_max_size(
             (unsigned)value.transform(&byte_string_view::size).value_or(0));
 
         byte_string branch_str_rlp(branch_str_max_len, 0);
@@ -356,21 +380,8 @@ protected:
     unsigned
     compute_branch_reference_(unsigned char *const buffer, Node const &node)
     {
-        MONAD_ASSERT(node.number_of_children());
-        // compute branch node hash
-        byte_string branch_str_rlp(calc_rlp_max_size(node.value_len), 0);
-        auto result = encode_16_children(node, branch_str_rlp);
-        // encode vt
-        result =
-            (node.has_value() && node.value_len)
-                ? rlp::encode_string(result, LeafValueProcessor::process(node))
-                : encode_empty_string(result);
-        auto const concat_len =
-            static_cast<size_t>(result.data() - branch_str_rlp.data());
-        byte_string branch_rlp(rlp::list_length(concat_len), 0);
-        rlp::encode_list(branch_rlp, {branch_str_rlp.data(), concat_len});
-        return to_node_reference(
-            {branch_rlp.data(), branch_rlp.size()}, buffer);
+        auto const rlp = encode_branch<LeafValueProcessor>(node);
+        return to_node_reference({rlp.data(), rlp.size()}, buffer);
     }
 };
 
@@ -419,7 +430,7 @@ private:
         Node *const node = single_child.ptr.get();
         MONAD_ASSERT(node != nullptr);
 
-        return state.len = encode_two_pieces(
+        return state.len = encode_two_pieces_reference(
                    state.buffer,
                    concat(single_child.branch, node->path_nibble_view()),
                    /* second: branch hash or leaf value */

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -30,6 +30,9 @@ add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")
 add_trie_test(TARGET update_aux_test SOURCES "update_aux_test.cpp")
 add_trie_test(TARGET db_test SOURCES "db_test.cpp")
+add_trie_test(TARGET encode_branch_test SOURCES "encode_branch_test.cpp")
+add_trie_test(TARGET encode_two_pieces_test SOURCES
+              "encode_two_pieces_test.cpp")
 add_trie_test(TARGET load_all_test SOURCES "load_all_test.cpp")
 add_trie_test(TARGET many_nested_updates SOURCES "many_nested_updates.cpp"
               LINK_LIBRARIES Boost::json)

--- a/category/mpt/test/encode_branch_test.cpp
+++ b/category/mpt/test/encode_branch_test.cpp
@@ -1,0 +1,130 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/mpt/compute.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/mpt/node.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+
+using namespace monad;
+using namespace monad::mpt;
+
+TEST(EncodeBranch, NoValueInlineChildren)
+{
+    // Branch with two sub-KECCAK256_SIZE child refs at slots 3 and 8 and no
+    // value. encode_16_children memcpys inline child data verbatim; empty
+    // slots and the missing value each emit 0x80. Expected layout:
+    //   [child slot 0: 0x80, ..., slot 3: 0x11, ..., slot 8: 0x22, ...,
+    //    slot 15: 0x80, value: 0x80]
+    // Payload is 17 bytes; the RLP list header is 0xc0 + 17 = 0xd1.
+    ChildData c0{};
+    c0.len = 1;
+    c0.data[0] = 0x11;
+    c0.branch = 0x3;
+    c0.ptr = make_node(
+        0, {}, NibblesView{}, byte_string_view{}, byte_string_view{}, 0);
+
+    ChildData c1{};
+    c1.len = 1;
+    c1.data[0] = 0x22;
+    c1.branch = 0x8;
+    c1.ptr = make_node(
+        0, {}, NibblesView{}, byte_string_view{}, byte_string_view{}, 0);
+
+    std::array<ChildData, 2> children{c0, c1};
+
+    Node::SharedPtr const node = make_node(
+        /*mask=*/static_cast<uint16_t>((1u << 0x3) | (1u << 0x8)),
+        /*children=*/std::span<ChildData>{children},
+        /*path=*/NibblesView{},
+        /*value=*/std::nullopt,
+        /*data=*/byte_string_view{},
+        /*version=*/0);
+
+    byte_string const encoded = encode_branch(*node);
+
+    byte_string const expected = {
+        0xd1,
+        0x80,
+        0x80,
+        0x80,
+        0x11,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x22,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80};
+    EXPECT_EQ(encoded, expected);
+}
+
+TEST(EncodeBranch, HashedChildAndValue)
+{
+    // Branch with a single KECCAK256_SIZE-sized child reference at slot 0
+    // and a non-empty value. encode_16_children RLP-string-wraps the 32-byte
+    // child (header 0xa0 = 0x80 + 32), the other 15 slots are 0x80, and the
+    // value is RLP-string-wrapped by NoopProcessor.
+    std::array<unsigned char, 32> child_hash{};
+    child_hash.fill(0xaa);
+
+    ChildData c0{};
+    c0.len = 32;
+    std::copy_n(child_hash.data(), 32, c0.data);
+    c0.branch = 0x0;
+    c0.ptr = make_node(
+        0, {}, NibblesView{}, byte_string_view{}, byte_string_view{}, 0);
+
+    std::array<ChildData, 1> children{c0};
+
+    byte_string const value = {'h', 'e', 'l', 'l', 'o'};
+    Node::SharedPtr const node = make_node(
+        /*mask=*/static_cast<uint16_t>(1u << 0x0),
+        /*children=*/std::span<ChildData>{children},
+        /*path=*/NibblesView{},
+        /*value=*/byte_string_view{value},
+        /*data=*/byte_string_view{},
+        /*version=*/0);
+
+    byte_string const encoded = encode_branch(*node);
+
+    // Payload: 33 (0xa0 + 32 hash bytes) + 15 (empty slots) + 6 (0x85 +
+    // "hello") = 54 bytes. List header is 0xc0 + 54 = 0xf6.
+    byte_string expected;
+    expected.push_back(0xf6);
+    expected.push_back(0xa0);
+    expected.append(child_hash.begin(), child_hash.end());
+    for (int i = 0; i < 15; ++i) {
+        expected.push_back(0x80);
+    }
+    expected.push_back(0x85);
+    expected.append(value.begin(), value.end());
+
+    EXPECT_EQ(encoded, expected);
+}

--- a/category/mpt/test/encode_two_pieces_test.cpp
+++ b/category/mpt/test/encode_two_pieces_test.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/byte_string.hpp>
+#include <category/mpt/compute.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+using namespace monad::mpt;
+
+TEST(EncodeTwoPieces, Leaf)
+{
+    // Path {1, 2, 3} as a terminating (leaf) compact encoding:
+    //   prefix byte 0x31 = terminating (0x20) | odd-length (0x10) | first
+    //   nibble 0x1; remaining nibbles {2, 3} pack into 0x23.
+    // RLP-encoded compact path: 0x82 0x31 0x23 (string of length 2).
+    // RLP-encoded value "hello": 0x85 'h' 'e' 'l' 'l' 'o'.
+    // Wrapped in an RLP list of payload length 9: header 0xc9.
+    Nibbles path{3};
+    path.set(0, 0x1);
+    path.set(1, 0x2);
+    path.set(2, 0x3);
+
+    byte_string const value = {'h', 'e', 'l', 'l', 'o'};
+    auto const encoded = encode_two_pieces(
+        NibblesView{path}, byte_string_view{value}, /*has_value=*/true);
+
+    byte_string const expected = {
+        0xc9, 0x82, 0x31, 0x23, 0x85, 'h', 'e', 'l', 'l', 'o'};
+    EXPECT_EQ(encoded, expected);
+}
+
+TEST(EncodeTwoPieces, ExtensionShortChildRef)
+{
+    // Extension with a sub-KECCAK256_SIZE child reference: the second piece
+    // is already RLP and is concatenated raw rather than re-encoded as an RLP
+    // string. Path {0xa, 0xb} as an even-length extension compact-encodes to
+    // [0x00, 0xab]; RLP-encoded that's 0x82 0x00 0xab. The 4-byte second
+    // piece is appended verbatim. Payload length 7, list header 0xc7.
+    Nibbles path{2};
+    path.set(0, 0xa);
+    path.set(1, 0xb);
+
+    byte_string const second = {0xc3, 0x01, 0x02, 0x03};
+    auto const encoded = encode_two_pieces(
+        NibblesView{path}, byte_string_view{second}, /*has_value=*/false);
+
+    byte_string const expected = {
+        0xc7, 0x82, 0x00, 0xab, 0xc3, 0x01, 0x02, 0x03};
+    EXPECT_EQ(encoded, expected);
+}


### PR DESCRIPTION
This PR is mostly just re-organising soem helper RLP encoding functions, and publicly exposing RLP encoders for canonical Ethereum MPT nodes. These are needed to serialise a partial TrieDb snapshot as RLP encoded MPT nodes in the witness.