### PR TITLE
[zkVM] Add a custom iterator to TraverseMachine

### DIFF
--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1208,6 +1208,12 @@ UpdateAux const &Db::aux() const
     return impl_->aux();
 }
 
+UpdateAux &Db::aux()
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux();
+}
+
 uint64_t Db::get_history_length() const
 {
     return is_on_disk() ? impl_->aux().metadata_ctx().version_history_length()

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -151,6 +151,21 @@ public:
     // Blocking traverse never wait on a fiber future.
     bool
     traverse_blocking(NodeCursor const &, TraverseMachine &, uint64_t block_id);
+
+    // Variant that lets the caller supply a `children_of(mask) -> range`
+    // factory controlling the order in which a node's children are visited.
+    // The factory is invoked once per node; its returned range must own its
+    // storage so the recursive descent below cannot clobber it.
+    template <class ChildrenVisitRange>
+    bool traverse_blocking(
+        NodeCursor const &cursor, TraverseMachine &machine,
+        uint64_t const block_id, ChildrenVisitRange children_of)
+    {
+        MONAD_ASSERT(cursor.is_valid());
+        return preorder_traverse_blocking(
+            aux(), *cursor.node, machine, block_id, std::move(children_of));
+    }
+
     uint64_t get_latest_version() const;
     uint64_t get_earliest_version() const;
     uint64_t get_history_length() const;
@@ -170,6 +185,7 @@ public:
 private:
     friend struct test::DbAccessor;
     UpdateAux const &aux() const;
+    UpdateAux &aux();
 };
 
 // The following are not threadsafe. Please use async get from the RODb owning

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -1671,6 +1671,90 @@ TYPED_TEST(DbTraverseTest, trimmed_traverse)
     }
 }
 
+TYPED_TEST(DbTraverseTest, traverse_blocking_custom_children_iterator)
+{
+    // Recording machine: collects the sequence of branches passed to down().
+    struct RecordingTraverse : public TraverseMachine
+    {
+        std::vector<unsigned char> &branches;
+
+        explicit RecordingTraverse(std::vector<unsigned char> &branches)
+            : branches(branches)
+        {
+        }
+
+        virtual bool down(unsigned char const branch, Node const &) override
+        {
+            if (branch != INVALID_BRANCH) {
+                branches.push_back(branch);
+            }
+            return true;
+        }
+
+        virtual void up(unsigned char const, Node const &) override {}
+
+        virtual std::unique_ptr<TraverseMachine> clone() const override
+        {
+            return std::make_unique<RecordingTraverse>(*this);
+        }
+    };
+
+    // Custom factory: returns the node's children in descending branch order,
+    // i.e. the reverse of the default NodeChildrenRange traversal.
+    struct ReverseChildrenRange
+    {
+        std::vector<std::pair<uint8_t, unsigned char>>
+        operator()(uint16_t const mask) const
+        {
+            std::vector<std::pair<uint8_t, unsigned char>> children;
+            for (auto const &p : NodeChildrenRange(mask)) {
+                children.push_back(p);
+            }
+            std::reverse(children.begin(), children.end());
+            return children;
+        }
+    };
+
+    /*
+        Fixture tree (see DbTraverseFixture):
+
+                root (branch 0)
+                 |
+                 12  (branch 1)
+               /    \
+             34      445678  (branches 3, 4)
+            / \
+         5678  6678          (branches 5, 6)
+
+        Default child iteration visits branches in ascending order, so the
+        sequence reaching down() is {0, 1, 3, 5, 6, 4}. With the reverse
+        iterator, sibling pairs (3,4) and (5,6) flip, giving
+        {0, 1, 4, 3, 6, 5}.
+    */
+
+    // Default iterator: ascending branch order.
+    {
+        std::vector<unsigned char> branches;
+        RecordingTraverse traverse{branches};
+        ASSERT_TRUE(
+            this->db.traverse_blocking(this->root, traverse, this->block_id));
+
+        std::vector<unsigned char> const expected{0, 1, 3, 5, 6, 4};
+        EXPECT_EQ(branches, expected);
+    }
+
+    // Custom iterator: descending branch order.
+    {
+        std::vector<unsigned char> branches;
+        RecordingTraverse traverse{branches};
+        ASSERT_TRUE(this->db.traverse_blocking(
+            this->root, traverse, this->block_id, ReverseChildrenRange{}));
+
+        std::vector<unsigned char> const expected{0, 1, 4, 3, 6, 5};
+        EXPECT_EQ(branches, expected);
+    }
+}
+
 TEST(RangedGetTest, path_exceeds_min_prefix)
 {
     Db db{std::make_unique<StateMachineAlwaysVarLen>()};

--- a/category/mpt/traverse.hpp
+++ b/category/mpt/traverse.hpp
@@ -64,22 +64,38 @@ namespace detail
         async::erased_connected_operation *traverse_state, Node const &node,
         TraverseMachine &machine, unsigned char branch);
 
+    struct DefaultChildrenVisitRange
+    {
+        auto operator()(uint16_t const mask) const
+        {
+            return NodeChildrenRange(mask);
+        }
+    };
+
     // current implementation does not contaminate triedb node caching
+    template <class ChildrenVisitRange>
     inline bool preorder_traverse_blocking_impl(
         UpdateAux &aux, unsigned char const branch, Node const &node,
-        TraverseMachine &traverse, uint64_t const version)
+        TraverseMachine &traverse, uint64_t const version,
+        ChildrenVisitRange &children_of)
     {
         ++traverse.level;
         if (!traverse.down(branch, node)) {
             --traverse.level;
             return true;
         }
-        for (auto const [idx, next_branch] : NodeChildrenRange(node.mask)) {
+        auto const range = children_of(node.mask);
+        for (auto const &[idx, next_branch] : range) {
             if (traverse.should_visit(node, next_branch)) {
                 if (Node::SharedPtr const &next = node.next(idx);
                     next != nullptr) {
                     if (!preorder_traverse_blocking_impl(
-                            aux, next_branch, *next, traverse, version)) {
+                            aux,
+                            next_branch,
+                            *next,
+                            traverse,
+                            version,
+                            children_of)) {
                         --traverse.level;
                         traverse.up(branch, node);
                         return false;
@@ -94,7 +110,8 @@ namespace detail
                                              next_branch,
                                              *next_node_ondisk,
                                              traverse,
-                                             version)) {
+                                             version,
+                                             children_of)) {
                     --traverse.level;
                     traverse.up(branch, node);
                     return false;
@@ -374,12 +391,13 @@ namespace detail
 }
 
 // return value indicates if we have done the full traversal or not
+template <class ChildrenVisitRange = detail::DefaultChildrenVisitRange>
 inline bool preorder_traverse_blocking(
     UpdateAux &aux, Node const &node, TraverseMachine &traverse,
-    uint64_t const version)
+    uint64_t const version, ChildrenVisitRange children_of = {})
 {
     auto const ret = detail::preorder_traverse_blocking_impl(
-        aux, INVALID_BRANCH, node, traverse, version);
+        aux, INVALID_BRANCH, node, traverse, version, children_of);
     MONAD_ASSERT(traverse.level == 0);
     return ret;
 }


### PR DESCRIPTION
## Why

The witness generator on `sam/witness_gen` needs to control the order in which a `TraverseMachine` descends into a node's children. Specifically, `WitnessEmitMachine` must visit branches that lie on a deletion path (SSTORE-zero / SELFDESTRUCT) **before** their siblings, so the emitter knows whether a sibling is a compression-survivor before deciding to emit it — without this, `trie_delete` on the rebuilt trie may hit a`HashStub` when the witness is replayed.

The existing traversal hard-codes `NodeChildrenRange(node.mask)`, which walks children in nibble order with no way for the `TraverseMachine` to influence the order.