### PR TITLE
change DbCache StorageCache value to byte_string

### DIFF
--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -16,11 +16,13 @@
 #pragma once
 
 #include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/bytes_hash_compare.hpp>
 #include <category/core/config.hpp>
 #include <category/core/lru/lru_cache.hpp>
 #include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
 
@@ -60,7 +62,8 @@ class DbCache final
     using StorageKeyHashCompare = BytesHashCompare<StorageKey>;
     using AccountsCache =
         LruCache<Address, std::optional<Account>, AddressHashCompare>;
-    using StorageCache = LruCache<StorageKey, bytes32_t, StorageKeyHashCompare>;
+    using StorageCache =
+        LruCache<StorageKey, byte_string, StorageKeyHashCompare>;
 
     AccountsCache accounts_{10'000'000};
     StorageCache storage_{10'000'000};
@@ -88,7 +91,7 @@ public:
 
     bool try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result)
+        bytes32_t const &key, byte_string &result)
     {
         auto const res =
             proposals_.try_read_storage(address, incarnation, key, result);
@@ -157,7 +160,8 @@ private:
                     auto const incarnation = account->incarnation;
                     storage_.insert(
                         StorageKey(address, incarnation, key),
-                        storage_delta.second);
+                        byte_string{
+                            compact_storage_view(storage_delta.second)});
                 }
             }
         }

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -121,9 +121,9 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
 bytes32_t TrieDb::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
-    bytes32_t result{};
-    if (cache_ && cache_->try_read_storage(addr, incarnation, key, result)) {
-        return result;
+    byte_string cached;
+    if (cache_ && cache_->try_read_storage(addr, incarnation, key, cached)) {
+        return to_bytes(cached);
     }
     auto const res = db_.find(
         curr_root_,

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -666,11 +666,19 @@ Result<Account> decode_account_db_ignore_address(byte_string_view &enc)
     return decode_account_db_helper(res.second);
 }
 
+byte_string_view compact_storage_view(bytes32_t const &val)
+{
+    return rlp::zeroless_view(to_byte_string_view(val.bytes));
+}
+
 byte_string encode_storage_db(bytes32_t const &key, bytes32_t const &val)
 {
     byte_string encoded_storage;
     encoded_storage += rlp::encode_bytes32_compact(key);
-    encoded_storage += rlp::encode_bytes32_compact(val);
+    // Equivalent to `rlp::encode_bytes32_compact(val)`, but written this way
+    // to make the storage-value representation (zeroless big-endian) explicit
+    // at the encode site.
+    encoded_storage += rlp::encode_string2(compact_storage_view(val));
     return rlp::encode_list2(encoded_storage);
 }
 

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -136,6 +136,13 @@ inline constexpr unsigned char FINALIZED_NIBBLE = 1;
 inline mpt::Nibbles const proposal_nibbles = mpt::concat(PROPOSAL_NIBBLE);
 inline mpt::Nibbles const finalized_nibbles = mpt::concat(FINALIZED_NIBBLE);
 
+// Returns the zeroless big-endian representation of a storage slot value.
+// This is the canonical on-disk and in-cache form of a storage value, matching
+// the second element of the pair returned by `decode_storage_db_raw()`. The
+// returned view aliases the input, so the `bytes32_t` argument must outlive
+// the view.
+byte_string_view compact_storage_view(bytes32_t const &);
+
 byte_string encode_account_db(Address const &, Account const &);
 byte_string encode_storage_db(bytes32_t const &, bytes32_t const &);
 

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -16,10 +16,12 @@
 #pragma once
 
 #include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/log.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/fmt/int_fmt.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/vm/vm.hpp>
 
@@ -69,7 +71,7 @@ public:
 
     bool try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result) const
+        bytes32_t const &key, byte_string &result) const
     {
         StateDeltas::const_accessor it{};
         if (!state_->find(it, address)) {
@@ -83,7 +85,7 @@ public:
         auto const &storage = it->second.storage;
         StorageDeltas::const_accessor it2{};
         if (storage.find(it2, key)) {
-            result = it2->second.second;
+            result = compact_storage_view(it2->second.second);
             return true;
         }
         return false;
@@ -135,7 +137,7 @@ public:
 
     TryReadResult try_read_storage(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result) const
+        bytes32_t const &key, byte_string &result) const
     {
         auto const fn =
             [&address, incarnation, &key, &result](ProposalState const &ps) {


### PR DESCRIPTION
Storage values in DbCache are now held as the zeroless big-endian byte_string (the canonical on-disk form, matching the second field of decode_storage_db_raw). This is prep work for page-encoded storage where the cache value will be encode_storage_page output rather than a full storage page, both of which fit naturally in byte_string.

Add compact_storage_view(bytes32_t) helper so the storage-value representation is named at every call site; route encode_storage_db through it so the encode side stays in sync.

Follow up: now the value in LruCache is variable length, need to make the LruCache bound by data size as well.