### PR TITLE
[execution/ethereum] Generalize EIP-7685 request hashing

### DIFF
--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -342,7 +342,7 @@ Result<std::vector<Receipt>> execute_block(
         process_withdrawal(state, block.withdrawals);
     }
 
-    if constexpr (traits::eip_7002_active()) {
+    if constexpr (traits::eip_7685_active()) {
         BOOST_OUTCOME_TRY(
             auto const computed_requests_hash,
             process_requests<traits>(

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -224,7 +224,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
     block_rlp = rlp::encode_block(block.value());
     ASSERT_TRUE(!block.has_error());
 
-    if constexpr (TestFixture::Trait::eip_7002_active()) {
+    if constexpr (TestFixture::Trait::eip_7685_active()) {
         block.value().header.requests_hash = EMPTY_REQUESTS_HASH;
     }
 
@@ -388,7 +388,7 @@ TYPED_TEST(TraitsTest, assertion_exception)
     block_rlp = rlp::encode_block(block.value());
     ASSERT_TRUE(!block.has_error());
 
-    if constexpr (TestFixture::Trait::eip_7002_active()) {
+    if constexpr (TestFixture::Trait::eip_7685_active()) {
         block.value().header.requests_hash = EMPTY_REQUESTS_HASH;
     }
 
@@ -542,7 +542,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
     block_rlp = rlp::encode_block(block.value());
     ASSERT_TRUE(!block.has_error());
 
-    if constexpr (TestFixture::Trait::eip_7002_active()) {
+    if constexpr (TestFixture::Trait::eip_7685_active()) {
         block.value().header.requests_hash = EMPTY_REQUESTS_HASH;
     }
 

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -32,9 +32,17 @@
 #include <boost/outcome/try.hpp>
 #include <intx/intx.hpp>
 
+#include <array>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
 using BOOST_OUTCOME_V2_NAMESPACE::success;
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+constexpr uint8_t WITHDRAWAL_REQUEST_TYPE = 0x01;
+constexpr uint8_t CONSOLIDATION_REQUEST_TYPE = 0x02;
 
 template <Traits traits>
 Result<byte_string> system_call(
@@ -125,42 +133,38 @@ Result<byte_string> system_call(
         result.output_data, result.output_data + result.output_size);
 }
 
-bytes32_t compute_requests_hash(
-    byte_string const &withdrawal_output,
-    byte_string const &consolidation_output)
-{
-    // at most 3 types * 32 bytes
-    uint8_t inner_hashes_buf[96];
-    size_t inner_hashes_len = 0;
-
-    auto const hash_request = [&](uint8_t type, byte_string const &data) {
-        // EIP-7685 flat requests encoding: empty request types are excluded
-        // from the hash.
-        if (data.empty()) {
-            return;
-        }
-        byte_string buf;
-        buf.reserve(1 + data.size());
-        buf.push_back(type);
-        buf.insert(buf.end(), data.begin(), data.end());
-        silkpre_sha256(
-            inner_hashes_buf + inner_hashes_len, buf.data(), buf.size(), true);
-        inner_hashes_len += 32;
-    };
-
-    // TODO: EIP-6110 deposits
-    hash_request(0x00, {});
-    hash_request(0x01, withdrawal_output);
-    hash_request(0x02, consolidation_output);
-
-    bytes32_t outer_hash;
-    silkpre_sha256(outer_hash.bytes, inner_hashes_buf, inner_hashes_len, true);
-    return outer_hash;
-}
-
 MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
+
+bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
+{
+    std::vector<uint8_t> inner_hashes;
+    inner_hashes.reserve(32 * requests.size());
+
+    for (auto const &req : requests) {
+        // EIP-7685 flat requests encoding: empty request data are excluded from
+        // the hash.
+        if (req.data.empty()) {
+            continue;
+        }
+
+        bytes32_t inner;
+        byte_string buf;
+        buf.reserve(1 + req.data.size());
+        buf.push_back(req.type);
+        buf.append_range(req.data);
+        silkpre_sha256(inner.bytes, buf.data(), buf.size(), true);
+        inner_hashes.append_range(inner.bytes);
+    }
+
+    static constexpr uint8_t EMPTY_SHA256_INPUT = 0;
+    bytes32_t outer_hash;
+    uint8_t const *outer_input =
+        inner_hashes.empty() ? &EMPTY_SHA256_INPUT : inner_hashes.data();
+    silkpre_sha256(outer_hash.bytes, outer_input, inner_hashes.size(), true);
+    return outer_hash;
+}
 
 template <Traits traits>
 Result<bytes32_t> process_requests(
@@ -171,7 +175,7 @@ Result<bytes32_t> process_requests(
     constexpr auto WITHDRAWAL_REQUEST_ADDRESS =
         0x00000961ef480eb55e80d19ad83579a64c007002_address;
     BOOST_OUTCOME_TRY(
-        auto const withdrawal_output,
+        auto withdrawal_output,
         system_call<traits>(
             chain,
             state,
@@ -184,7 +188,7 @@ Result<bytes32_t> process_requests(
     constexpr auto CONSOLIDATION_REQUEST_ADDRESS =
         0x0000bbddc7ce488642fb579f8b00f3a590007251_address;
     BOOST_OUTCOME_TRY(
-        auto const consolidation_output,
+        auto consolidation_output,
         system_call<traits>(
             chain,
             state,
@@ -193,7 +197,12 @@ Result<bytes32_t> process_requests(
             CONSOLIDATION_REQUEST_ADDRESS,
             chain_ctx));
 
-    return compute_requests_hash(withdrawal_output, consolidation_output);
+    // TODO: EIP-6110 deposits. Deposit requests are type 0x00 and must be
+    // placed before withdrawal and consolidation requests.
+    return compute_requests_hash(std::array<BlockRequest, 2>{{
+        {WITHDRAWAL_REQUEST_TYPE, std::move(withdrawal_output)},
+        {CONSOLIDATION_REQUEST_TYPE, std::move(consolidation_output)},
+    }});
 }
 
 EXPLICIT_EVM_TRAITS(process_requests);

--- a/category/execution/ethereum/process_requests.hpp
+++ b/category/execution/ethereum/process_requests.hpp
@@ -21,11 +21,24 @@
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/vm/evm/traits.hpp>
 
+#include <cstdint>
+#include <span>
+
 MONAD_NAMESPACE_BEGIN
 
 class BlockHashBuffer;
 class State;
 struct BlockHeader;
+
+struct BlockRequest
+{
+    uint8_t type;
+    byte_string data;
+};
+
+// EIP-7685: Canonical callers must supply requests ordered by ascending request
+// type.  The hash function preserves the supplied order.
+bytes32_t compute_requests_hash(std::span<BlockRequest const> requests);
 
 template <Traits traits>
 Result<bytes32_t> process_requests(

--- a/category/execution/ethereum/process_requests_test.cpp
+++ b/category/execution/ethereum/process_requests_test.cpp
@@ -1,0 +1,127 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/process_requests.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+using namespace monad;
+
+namespace
+{
+    using monad::literals::operator""_bytes;
+
+    // EIP-7685 requests_hash test vectors:
+    // sha256(concat(sha256(request_type || request_data).digest())).
+    // Expected values were generated independently with Python hashlib.sha256
+    // for: [], [(0x01, aabbcc)], [(0x02, aabbcc)], [(0x01, 00..7f)],
+    // [(0x01, 1122), (0x02, 3344)], and the reversed order.
+    constexpr auto EMPTY_REQUESTS_HASH =
+        0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_bytes32;
+    constexpr auto WITHDRAWAL_AABBCC_REQUESTS_HASH =
+        0x8053cefe887c01df53ed249a88f280c4a550f84faf7363d29acaad6b57b0c4eb_bytes32;
+    constexpr auto CONSOLIDATION_AABBCC_REQUESTS_HASH =
+        0xce00379bd99b3739955f6375984912eb0f18027bf935a056cc03167161007e2d_bytes32;
+    constexpr auto LARGE_0X01_REQUESTS_HASH =
+        0xb371760f13b3feadb186aaf03d8723138b3316bb1ce1d18d6ce1385cde8f3828_bytes32;
+    constexpr auto ORDERED_0X01_0X02_REQUESTS_HASH =
+        0x1bfdf42ee5c7c1cf68be7759dc298f49ff824ceea15be154dedd2d40822de069_bytes32;
+    constexpr auto REVERSED_0X02_0X01_REQUESTS_HASH =
+        0x00a28f3139e5ac6a7c8aa970bce5488f9669e3f5db94205291b6bf9772478bf0_bytes32;
+}
+
+TEST(ProcessRequests, EmptyRequestListHash)
+{
+    EXPECT_EQ(
+        compute_requests_hash(std::span<BlockRequest const>{}),
+        EMPTY_REQUESTS_HASH);
+}
+
+TEST(ProcessRequests, EmptyRequestDataIsSkipped)
+{
+    auto const withdrawal_data = 0xaabbcc_bytes;
+    std::array<BlockRequest, 2> const requests{{
+        {0x00, {}},
+        {0x01, withdrawal_data},
+    }};
+
+    EXPECT_EQ(compute_requests_hash(requests), WITHDRAWAL_AABBCC_REQUESTS_HASH);
+}
+
+TEST(ProcessRequests, RequestTypeParticipatesInHash)
+{
+    auto const data = 0xaabbcc_bytes;
+    std::array<BlockRequest, 1> const withdrawal_requests{{
+        {0x01, data},
+    }};
+    std::array<BlockRequest, 1> const consolidation_requests{{
+        {0x02, data},
+    }};
+
+    EXPECT_EQ(
+        compute_requests_hash(withdrawal_requests),
+        WITHDRAWAL_AABBCC_REQUESTS_HASH);
+    EXPECT_EQ(
+        compute_requests_hash(consolidation_requests),
+        CONSOLIDATION_AABBCC_REQUESTS_HASH);
+    EXPECT_NE(
+        compute_requests_hash(withdrawal_requests),
+        compute_requests_hash(consolidation_requests));
+}
+
+TEST(ProcessRequests, HashesFullRequestPayload)
+{
+    byte_string large_data(128, uint8_t{0});
+    for (std::size_t i = 0; i < large_data.size(); ++i) {
+        large_data[i] = static_cast<uint8_t>(i);
+    }
+
+    std::array<BlockRequest, 1> const requests{{
+        {0x01, large_data},
+    }};
+
+    EXPECT_EQ(compute_requests_hash(requests), LARGE_0X01_REQUESTS_HASH);
+}
+
+TEST(ProcessRequests, NoncanonicalRequestOrderIsPreserved)
+{
+    auto const withdrawal_data = 0x1122_bytes;
+    auto const consolidation_data = 0x3344_bytes;
+    std::array<BlockRequest, 2> const ordered_requests{{
+        {0x01, withdrawal_data},
+        {0x02, consolidation_data},
+    }};
+    std::array<BlockRequest, 2> const reversed_requests{{
+        {0x02, consolidation_data},
+        {0x01, withdrawal_data},
+    }};
+
+    // Canonical block request lists are ordered by ascending request type, but
+    // the hash helper does not sort or normalize caller input.
+    EXPECT_EQ(
+        compute_requests_hash(ordered_requests),
+        ORDERED_0X01_0X02_REQUESTS_HASH);
+    EXPECT_EQ(
+        compute_requests_hash(reversed_requests),
+        REVERSED_0X02_0X01_REQUESTS_HASH);
+    EXPECT_NE(
+        compute_requests_hash(ordered_requests),
+        compute_requests_hash(reversed_requests));
+}

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -51,7 +51,7 @@ namespace monad
         { T::eip_2565_active() } -> std::same_as<bool>;
         { T::eip_2929_active() } -> std::same_as<bool>;
         { T::eip_4844_active() } -> std::same_as<bool>;
-        { T::eip_7002_active() } -> std::same_as<bool>;
+        { T::eip_7685_active() } -> std::same_as<bool>;
         { T::eip_7823_active() } -> std::same_as<bool>;
         { T::eip_7883_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
@@ -96,7 +96,7 @@ namespace monad
             return Rev >= EVMC_CANCUN;
         }
 
-        static consteval bool eip_7002_active() noexcept
+        static consteval bool eip_7685_active() noexcept
         {
             return Rev >= EVMC_PRAGUE;
         }
@@ -202,7 +202,7 @@ namespace monad
             return false;
         }
 
-        static consteval bool eip_7002_active() noexcept
+        static consteval bool eip_7685_active() noexcept
         {
             return false;
         }


### PR DESCRIPTION
Rename the request-processing trait gate from eip_7002_active to eip_7685_active so block-level request hash handling is tied to the EIP that defines requests_hash rather than to a specific request type.

Expose BlockRequest and make compute_requests_hash operate on a typed request list.

Add focused unit tests for EIP-7685 request hash semantics.