### PR TITLE
[rpc] Hoist `LazyBlockHash` into its own TU

### DIFF
--- a/category/rpc/CMakeLists.txt
+++ b/category/rpc/CMakeLists.txt
@@ -23,8 +23,14 @@ add_library(
   monad_rpc
   OBJECT
   # rpc
-  "monad_executor.cpp" "monad_executor.h"
-  "overrides.cpp" "overrides.h" "overrides.hpp")
+  "lazy_block_hash.cpp" 
+  "lazy_block_hash.hpp"
+  "monad_executor.cpp" 
+  "monad_executor.h"
+  "overrides.cpp" 
+  "overrides.h" 
+  "overrides.hpp"
+  )
 
 target_include_directories(monad_rpc PUBLIC ${CATEGORY_MAIN_DIR})
 

--- a/category/rpc/lazy_block_hash.cpp
+++ b/category/rpc/lazy_block_hash.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/lru/static_lru_cache.hpp>
+#include <category/core/monad_exception.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/nibbles_view.hpp>
+#include <category/rpc/lazy_block_hash.hpp>
+
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+LazyBlockHash::LazyBlockHash(mpt::RODb const &db, uint64_t const n)
+    : db_{db}
+    , n_{n}
+    , blockhash_cache_{N}
+{
+}
+
+uint64_t LazyBlockHash::n() const
+{
+    return n_;
+}
+
+bytes32_t const &LazyBlockHash::get(uint64_t const n) const
+{
+    MONAD_ASSERT_PRINTF(n < n_ && n + N >= n_, "n_=%lu, n=%lu", n_, n);
+    if (Cache::ConstAccessor acc; blockhash_cache_.find(acc, n)) {
+        return acc->second->val;
+    }
+
+    auto const cursor_res = db_.find(
+        mpt::concat(FINALIZED_NIBBLE, mpt::NibblesView{block_header_nibbles}),
+        n);
+    MONAD_ASSERT_THROW(!cursor_res.has_error(), "blockhash: error querying DB");
+    bytes32_t const blockhash =
+        to_bytes(keccak256(cursor_res.value().node->value()));
+    auto const res = blockhash_cache_.insert(n, blockhash);
+    return res.first->second->val;
+}
+
+MONAD_NAMESPACE_END

--- a/category/rpc/lazy_block_hash.hpp
+++ b/category/rpc/lazy_block_hash.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/lru/static_lru_cache.hpp>
+#include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/mpt/db.hpp>
+
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+// eth call on latest uses eip-2935. historical eth calls use this class,
+// which lazily loads the block header from the DB and computes BLOCKHASH.
+// historical can always query from the finalized prefix.
+//
+// A thread-safe LRU is not needed. Each submitted call to the executor pool
+// creates its own LazyBlockHash instance.
+class LazyBlockHash : public BlockHashBuffer
+{
+    using BlockHashBuffer::N;
+
+    mpt::RODb const &db_;
+    uint64_t const n_;
+    using Cache = static_lru_cache<uint64_t, bytes32_t>;
+    mutable Cache blockhash_cache_;
+
+public:
+    LazyBlockHash(mpt::RODb const &db, uint64_t const n);
+    ~LazyBlockHash() override = default;
+
+    uint64_t n() const override;
+    bytes32_t const &get(uint64_t const n) const override;
+};
+
+MONAD_NAMESPACE_END

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -27,7 +27,6 @@
 #include <category/core/keccak.hpp>
 #include <category/core/likely.h>
 #include <category/core/log.hpp>
-#include <category/core/lru/static_lru_cache.hpp>
 #include <category/core/monad_exception.hpp>
 #include <category/core/result.hpp>
 #include <category/core/runtime/uint256.hpp>
@@ -64,8 +63,8 @@
 #include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/mpt/db.hpp>
-#include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/rpc/lazy_block_hash.hpp>
 #include <category/vm/evm/switch_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
@@ -102,56 +101,6 @@ using namespace monad::vm;
 
 namespace
 {
-    // eth call on latest uses eip-2935. historical eth calls use this class,
-    // which lazily loads the block header from the DB and computes BLOCKHASH.
-    // historical can always query from the finalized prefix.
-    //
-    // A thread-safe LRU is not needed. Each submitted call to the executor pool
-    // creates its own LazyBlockHash instance.
-    class LazyBlockHash : public BlockHashBuffer
-    {
-        using BlockHashBuffer::N;
-
-        mpt::RODb const &db_;
-        uint64_t const n_;
-        using Cache = static_lru_cache<uint64_t, bytes32_t>;
-        mutable Cache blockhash_cache_;
-
-    public:
-        LazyBlockHash(mpt::RODb const &db, uint64_t const n)
-            : db_{db}
-            , n_{n}
-            , blockhash_cache_{N}
-        {
-        }
-
-        ~LazyBlockHash() override = default;
-
-        uint64_t n() const override
-        {
-            return n_;
-        }
-
-        bytes32_t const &get(uint64_t const n) const override
-        {
-            MONAD_ASSERT_PRINTF(n < n_ && n + N >= n_, "n_=%lu, n=%lu", n_, n);
-            if (Cache::ConstAccessor acc; blockhash_cache_.find(acc, n)) {
-                return acc->second->val;
-            }
-
-            auto const cursor_res = db_.find(
-                mpt::concat(
-                    FINALIZED_NIBBLE, mpt::NibblesView{block_header_nibbles}),
-                n);
-            MONAD_ASSERT_THROW(
-                !cursor_res.has_error(), "blockhash: error querying DB");
-            bytes32_t const blockhash =
-                to_bytes(keccak256(cursor_res.value().node->value()));
-            auto const res = blockhash_cache_.insert(n, blockhash);
-            return res.first->second->val;
-        }
-    };
-
     char const *const UNEXPECTED_EXCEPTION_ERR_MSG = "unexpected error";
     char const *const EXCEED_QUEUE_SIZE_ERR_MSG =
         "failure to submit eth_call to thread pool: queue size exceeded";


### PR DESCRIPTION
This patch hoists the `LazyBlockHash` abstraction into its translation unit. In addition the abstraction is moved into the `monad` namespace.