### PR TITLE
[execution/ethereum] Add EIP-6110 deposit requests

### DIFF
--- a/category/execution/ethereum/core/contract/abi_decode.hpp
+++ b/category/execution/ethereum/core/contract/abi_decode.hpp
@@ -56,17 +56,16 @@ Result<T> abi_decode_fixed(byte_string_view &enc)
     return output;
 }
 
-// Dynamic sized data goes in the "tail". Note that for precompiles, we always
-// know the size of the bytes we are reading in, which is why we return a fixed
-// size byte string.
+// Dynamic sized data goes in the "tail". Note that for precompiles and
+// protocol payloads, we often know the size of the bytes we are reading in,
+// which is why we return a fixed size byte string.
 //
 // The expectation for using this API is to simply skip over the user provided
 // offsets in the head, look for bytes of an expected length in the tail.
 template <size_t N>
-Result<byte_string_fixed<N>> abi_decode_bytes_tail(byte_string_view &enc)
+Result<byte_string_fixed<N>>
+abi_decode_dynamic_bytes_tail(byte_string_view &enc)
 {
-    static_assert(N > 32, "bytesN (N<=32) belongs in head");
-
     BOOST_OUTCOME_TRY(auto const length, abi_decode_fixed<u256_be>(enc));
     if (MONAD_UNLIKELY(length.native() != N)) {
         return AbiDecodeError::LengthMismatch;
@@ -81,6 +80,16 @@ Result<byte_string_fixed<N>> abi_decode_bytes_tail(byte_string_view &enc)
     std::memcpy(output.data(), enc.data(), N);
     enc.remove_prefix(padded);
     return output;
+}
+
+// Prefer abi_decode_dynamic_bytes_tail for Solidity `bytes`. This helper keeps
+// the original precompile-focused restriction for existing callers.
+template <size_t N>
+Result<byte_string_fixed<N>> abi_decode_bytes_tail(byte_string_view &enc)
+{
+    static_assert(N > 32, "bytesN (N<=32) belongs in head");
+
+    return abi_decode_dynamic_bytes_tail<N>(enc);
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/core/contract/test_abi_decode.cpp
+++ b/category/execution/ethereum/core/contract/test_abi_decode.cpp
@@ -154,6 +154,64 @@ TEST(AbiDecode, bytes_in_tail_length_mismatch)
     EXPECT_EQ(decode_res.assume_error(), AbiDecodeError::LengthMismatch);
 }
 
+TEST(AbiDecode, dynamic_bytes_tail_decodes_less_than_word)
+{
+    byte_string_fixed<8> bytes{};
+    bytes.fill(0xAB);
+    byte_string const encoded = abi_encode_bytes(to_byte_string_view(bytes));
+    byte_string_view input{encoded};
+    auto const decode_res = abi_decode_dynamic_bytes_tail<8>(input);
+    ASSERT_FALSE(decode_res.has_error());
+    EXPECT_TRUE(input.empty());
+    EXPECT_EQ(decode_res.value(), bytes);
+}
+
+TEST(AbiDecode, dynamic_bytes_tail_decodes_exactly_word)
+{
+    byte_string_fixed<32> bytes{};
+    bytes.fill(0xAB);
+    byte_string const encoded = abi_encode_bytes(to_byte_string_view(bytes));
+    byte_string_view input{encoded};
+    auto const decode_res = abi_decode_dynamic_bytes_tail<32>(input);
+    ASSERT_FALSE(decode_res.has_error());
+    EXPECT_TRUE(input.empty());
+    EXPECT_EQ(decode_res.value(), bytes);
+}
+
+TEST(AbiDecode, dynamic_bytes_tail_decodes_more_than_word)
+{
+    byte_string_fixed<48> bytes{};
+    bytes.fill(0xAB);
+    byte_string const encoded = abi_encode_bytes(to_byte_string_view(bytes));
+    byte_string_view input{encoded};
+    auto const decode_res = abi_decode_dynamic_bytes_tail<48>(input);
+    ASSERT_FALSE(decode_res.has_error());
+    EXPECT_TRUE(input.empty());
+    EXPECT_EQ(decode_res.value(), bytes);
+}
+
+TEST(AbiDecode, dynamic_bytes_tail_input_too_short)
+{
+    byte_string_fixed<8> bytes{};
+    bytes.fill(0xAB);
+    byte_string const encoded = abi_encode_bytes(to_byte_string_view(bytes));
+    byte_string_view input = byte_string_view{encoded}.substr(0, 32 + 4);
+    auto const decode_res = abi_decode_dynamic_bytes_tail<8>(input);
+    ASSERT_TRUE(decode_res.has_error());
+    EXPECT_EQ(decode_res.assume_error(), AbiDecodeError::InputTooShort);
+}
+
+TEST(AbiDecode, dynamic_bytes_tail_length_mismatch)
+{
+    byte_string_fixed<8> bytes{};
+    bytes.fill(0xAB);
+    byte_string const encoded = abi_encode_bytes(to_byte_string_view(bytes));
+    byte_string_view input{encoded};
+    auto const decode_res = abi_decode_dynamic_bytes_tail<32>(input);
+    ASSERT_TRUE(decode_res.has_error());
+    EXPECT_EQ(decode_res.assume_error(), AbiDecodeError::LengthMismatch);
+}
+
 TEST(AbiDecode, complex_decode)
 {
     // encode with both a head and tail. Note that we only decode known types,

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -349,7 +349,12 @@ Result<std::vector<Receipt>> execute_block(
         BOOST_OUTCOME_TRY(
             auto const computed_requests_hash,
             process_requests<traits>(
-                chain, state, block_hash_buffer, block.header, chain_ctx));
+                chain,
+                state,
+                block_hash_buffer,
+                block.header,
+                chain_ctx,
+                retvals));
         MONAD_ASSERT(block.header.requests_hash.has_value());
         if (MONAD_UNLIKELY(
                 computed_requests_hash != block.header.requests_hash.value())) {

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -13,9 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/byte_string.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/contract/abi_decode.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/process_requests.hpp>
@@ -41,6 +45,7 @@ using BOOST_OUTCOME_V2_NAMESPACE::success;
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
+constexpr uint8_t DEPOSIT_REQUEST_TYPE = 0x00;
 constexpr uint8_t WITHDRAWAL_REQUEST_TYPE = 0x01;
 constexpr uint8_t CONSOLIDATION_REQUEST_TYPE = 0x02;
 
@@ -133,9 +138,87 @@ Result<byte_string> system_call(
         result.output_data, result.output_data + result.output_size);
 }
 
+Result<void> consume_deposit_event_head(byte_string_view &cursor)
+{
+    auto const check_offset = [&](uint32_t expected) -> Result<void> {
+        auto const actual = abi_decode_fixed<u256_be>(cursor);
+        if (actual.has_error() || actual.value().native() != expected) {
+            return BlockError::InvalidDepositLog;
+        }
+        return success();
+    };
+
+    BOOST_OUTCOME_TRY(check_offset(160));
+    BOOST_OUTCOME_TRY(check_offset(256));
+    BOOST_OUTCOME_TRY(check_offset(320));
+    BOOST_OUTCOME_TRY(check_offset(384));
+    BOOST_OUTCOME_TRY(check_offset(512));
+
+    return success();
+}
+
+template <size_t N>
+Result<void>
+append_deposit_event_field(byte_string &deposits, byte_string_view &cursor)
+{
+    auto const field = abi_decode_dynamic_bytes_tail<N>(cursor);
+    if (field.has_error()) {
+        return BlockError::InvalidDepositLog;
+    }
+    deposits.append_range(field.value());
+    return success();
+}
+
+Result<void>
+append_deposit_request(byte_string &deposits, byte_string_view cursor)
+{
+    // EIP-6110 accepts one canonical 576-byte ABI log-data item emitted by the
+    // deposit contract's DepositEvent(bytes,bytes,bytes,bytes,bytes). The
+    // 5-word head occupies bytes [0, 160); each head word is an ABI offset from
+    // the start of that event data to the corresponding dynamic `bytes` tail:
+    //
+    //   pubkey                  offset 160, size 48
+    //   withdrawal_credentials  offset 256, size 32
+    //   amount                  offset 320, size 8
+    //   signature               offset 384, size 96
+    //   index                   offset 512, size 8
+    if (cursor.length() != 576) {
+        return BlockError::InvalidDepositLog;
+    }
+
+    BOOST_OUTCOME_TRY(consume_deposit_event_head(cursor));
+
+    BOOST_OUTCOME_TRY(append_deposit_event_field<48>(deposits, cursor));
+    BOOST_OUTCOME_TRY(append_deposit_event_field<32>(deposits, cursor));
+    BOOST_OUTCOME_TRY(append_deposit_event_field<8>(deposits, cursor));
+    BOOST_OUTCOME_TRY(append_deposit_event_field<96>(deposits, cursor));
+    BOOST_OUTCOME_TRY(append_deposit_event_field<8>(deposits, cursor));
+    return success();
+}
+
 MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
+
+Result<byte_string>
+extract_deposit_requests(std::span<Receipt const> const receipts)
+{
+    constexpr auto DEPOSIT_CONTRACT_ADDRESS =
+        0x00000000219ab540356cbb839cbe05303d7705fa_address;
+    constexpr auto DEPOSIT_EVENT_SIGNATURE_HASH =
+        0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5_bytes32;
+    byte_string deposits;
+    for (auto const &receipt : receipts) {
+        for (auto const &log : receipt.logs) {
+            if (log.address != DEPOSIT_CONTRACT_ADDRESS || log.topics.empty() ||
+                log.topics[0] != DEPOSIT_EVENT_SIGNATURE_HASH) {
+                continue;
+            }
+            BOOST_OUTCOME_TRY(append_deposit_request(deposits, log.data));
+        }
+    }
+    return deposits;
+}
 
 bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
 {
@@ -169,8 +252,11 @@ bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
 template <Traits traits>
 Result<bytes32_t> process_requests(
     Chain const &chain, State &state, BlockHashBuffer const &block_hash_buffer,
-    BlockHeader const &header, ChainContext<traits> const &chain_ctx)
+    BlockHeader const &header, ChainContext<traits> const &chain_ctx,
+    std::span<Receipt const> const receipts)
 {
+    BOOST_OUTCOME_TRY(auto deposit_output, extract_deposit_requests(receipts));
+
     // EIP-7002
     constexpr auto WITHDRAWAL_REQUEST_ADDRESS =
         0x00000961ef480eb55e80d19ad83579a64c007002_address;
@@ -197,9 +283,8 @@ Result<bytes32_t> process_requests(
             CONSOLIDATION_REQUEST_ADDRESS,
             chain_ctx));
 
-    // TODO: EIP-6110 deposits. Deposit requests are type 0x00 and must be
-    // placed before withdrawal and consolidation requests.
-    return compute_requests_hash(std::array<BlockRequest, 2>{{
+    return compute_requests_hash(std::array<BlockRequest, 3>{{
+        {DEPOSIT_REQUEST_TYPE, std::move(deposit_output)},
         {WITHDRAWAL_REQUEST_TYPE, std::move(withdrawal_output)},
         {CONSOLIDATION_REQUEST_TYPE, std::move(consolidation_output)},
     }});

--- a/category/execution/ethereum/process_requests.hpp
+++ b/category/execution/ethereum/process_requests.hpp
@@ -27,6 +27,7 @@
 MONAD_NAMESPACE_BEGIN
 
 class BlockHashBuffer;
+struct Receipt;
 class State;
 struct BlockHeader;
 
@@ -40,9 +41,12 @@ struct BlockRequest
 // type.  The hash function preserves the supplied order.
 bytes32_t compute_requests_hash(std::span<BlockRequest const> requests);
 
+// EIP-6110: extract concatenated deposit request payloads from receipt logs.
+Result<byte_string> extract_deposit_requests(std::span<Receipt const> receipts);
+
 template <Traits traits>
 Result<bytes32_t> process_requests(
     Chain const &, State &, BlockHashBuffer const &, BlockHeader const &,
-    ChainContext<traits> const &);
+    ChainContext<traits> const &, std::span<Receipt const>);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/process_requests_test.cpp
+++ b/category/execution/ethereum/process_requests_test.cpp
@@ -13,7 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/execution/ethereum/core/contract/abi_encode.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/process_requests.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
 
 #include <gtest/gtest.h>
 
@@ -21,6 +24,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <utility>
+#include <vector>
 
 using namespace monad;
 
@@ -45,6 +50,69 @@ namespace
         0x1bfdf42ee5c7c1cf68be7759dc298f49ff824ceea15be154dedd2d40822de069_bytes32;
     constexpr auto REVERSED_0X02_0X01_REQUESTS_HASH =
         0x00a28f3139e5ac6a7c8aa970bce5488f9669e3f5db94205291b6bf9772478bf0_bytes32;
+
+    constexpr auto DEPOSIT_CONTRACT_ADDRESS =
+        0x00000000219ab540356cbb839cbe05303d7705fa_address;
+    constexpr auto OTHER_ADDRESS =
+        0x0000000000000000000000000000000000000001_address;
+    constexpr auto DEPOSIT_EVENT_SIGNATURE_HASH =
+        0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5_bytes32;
+
+    byte_string make_bytes(std::size_t const size, uint8_t const seed)
+    {
+        byte_string bytes(size, uint8_t{0});
+        for (std::size_t i = 0; i < bytes.size(); ++i) {
+            bytes[i] = static_cast<uint8_t>(seed + i);
+        }
+        return bytes;
+    }
+
+    struct DepositEvent
+    {
+        byte_string log_data;
+        byte_string request_data;
+    };
+
+    DepositEvent make_deposit_event(uint8_t const seed)
+    {
+        byte_string const pubkey = make_bytes(48, seed);
+        byte_string const withdrawal_credentials = make_bytes(32, seed + 0x30);
+        byte_string const amount = make_bytes(8, seed + 0x50);
+        byte_string const signature = make_bytes(96, seed + 0x60);
+        byte_string const index = make_bytes(8, seed + 0xc0);
+
+        AbiEncoder encoder;
+        encoder.add_bytes(pubkey);
+        encoder.add_bytes(withdrawal_credentials);
+        encoder.add_bytes(amount);
+        encoder.add_bytes(signature);
+        encoder.add_bytes(index);
+
+        byte_string request_data;
+        request_data += pubkey;
+        request_data += withdrawal_credentials;
+        request_data += amount;
+        request_data += signature;
+        request_data += index;
+
+        return {
+            .log_data = encoder.encode_final(),
+            .request_data = std::move(request_data)};
+    }
+
+    Receipt::Log make_log(
+        Address const address, std::vector<bytes32_t> topics, byte_string data)
+    {
+        return {
+            .data = std::move(data),
+            .topics = std::move(topics),
+            .address = address};
+    }
+
+    Receipt make_receipt(std::vector<Receipt::Log> logs)
+    {
+        return {.logs = std::move(logs)};
+    }
 }
 
 TEST(ProcessRequests, EmptyRequestListHash)
@@ -124,4 +192,124 @@ TEST(ProcessRequests, NoncanonicalRequestOrderIsPreserved)
     EXPECT_NE(
         compute_requests_hash(ordered_requests),
         compute_requests_hash(reversed_requests));
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsDecodesCanonicalEvent)
+{
+    auto const deposit = make_deposit_event(0x10);
+    std::vector<Receipt> const receipts{make_receipt({make_log(
+        DEPOSIT_CONTRACT_ADDRESS,
+        {DEPOSIT_EVENT_SIGNATURE_HASH},
+        deposit.log_data)})};
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), deposit.request_data);
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsAppendsLogsInReceiptOrder)
+{
+    auto const first = make_deposit_event(0x10);
+    auto const second = make_deposit_event(0x20);
+    std::vector<Receipt> const receipts{
+        make_receipt({make_log(
+            DEPOSIT_CONTRACT_ADDRESS,
+            {DEPOSIT_EVENT_SIGNATURE_HASH},
+            first.log_data)}),
+        make_receipt({make_log(
+            DEPOSIT_CONTRACT_ADDRESS,
+            {DEPOSIT_EVENT_SIGNATURE_HASH},
+            second.log_data)})};
+    byte_string expected = first.request_data;
+    expected += second.request_data;
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), expected);
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsAppendsLogsInSingleReceiptOrder)
+{
+    auto const first = make_deposit_event(0x10);
+    auto const second = make_deposit_event(0x20);
+    std::vector<Receipt> const receipts{make_receipt({
+        make_log(
+            DEPOSIT_CONTRACT_ADDRESS,
+            {DEPOSIT_EVENT_SIGNATURE_HASH},
+            first.log_data),
+        make_log(
+            DEPOSIT_CONTRACT_ADDRESS,
+            {DEPOSIT_EVENT_SIGNATURE_HASH},
+            second.log_data),
+    })};
+    byte_string expected = first.request_data;
+    expected += second.request_data;
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), expected);
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsIgnoresNonDepositLogs)
+{
+    auto const deposit = make_deposit_event(0x10);
+    std::vector<Receipt> const receipts{make_receipt({
+        make_log(
+            OTHER_ADDRESS, {DEPOSIT_EVENT_SIGNATURE_HASH}, deposit.log_data),
+        make_log(DEPOSIT_CONTRACT_ADDRESS, {}, deposit.log_data),
+        make_log(DEPOSIT_CONTRACT_ADDRESS, {bytes32_t{}}, deposit.log_data),
+    })};
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsRejectsBadHeadOffset)
+{
+    auto deposit = make_deposit_event(0x10);
+    deposit.log_data[31] ^= 0x01;
+    std::vector<Receipt> const receipts{make_receipt({make_log(
+        DEPOSIT_CONTRACT_ADDRESS,
+        {DEPOSIT_EVENT_SIGNATURE_HASH},
+        deposit.log_data)})};
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), BlockError::InvalidDepositLog);
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsRejectsBadFieldLength)
+{
+    auto deposit = make_deposit_event(0x10);
+    deposit.log_data[351] = 0x09;
+    std::vector<Receipt> const receipts{make_receipt({make_log(
+        DEPOSIT_CONTRACT_ADDRESS,
+        {DEPOSIT_EVENT_SIGNATURE_HASH},
+        deposit.log_data)})};
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), BlockError::InvalidDepositLog);
+}
+
+TEST(ProcessRequests, ExtractDepositRequestsRejectsTruncatedEvent)
+{
+    auto deposit = make_deposit_event(0x10);
+    deposit.log_data.pop_back();
+    std::vector<Receipt> const receipts{make_receipt({make_log(
+        DEPOSIT_CONTRACT_ADDRESS,
+        {DEPOSIT_EVENT_SIGNATURE_HASH},
+        deposit.log_data)})};
+
+    auto const result = extract_deposit_requests(receipts);
+
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), BlockError::InvalidDepositLog);
 }

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -335,7 +335,8 @@ quick_status_code_from_enum<monad::BlockError>::value_mappings()
          "system call target has no code",
          {}},
         {BlockError::SystemCallFailed, "system call failed", {}},
-        {BlockError::InvalidRequestsHash, "invalid requests hash", {}}};
+        {BlockError::InvalidRequestsHash, "invalid requests hash", {}},
+        {BlockError::InvalidDepositLog, "invalid deposit log", {}}};
 
     return v;
 }

--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -57,7 +57,8 @@ enum class BlockError
     WrongMerkleRoot,
     SystemCallMissingCode,
     SystemCallFailed,
-    InvalidRequestsHash
+    InvalidRequestsHash,
+    InvalidDepositLog
 };
 
 struct Chain;

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -205,6 +205,10 @@ namespace monad
 
         static consteval bool eip_7685_active() noexcept
         {
+            // Monad Prague blocks carry a requests_hash header field, but
+            // monad-bft currently proposes and validates it as zero rather
+            // than as an Ethereum EIP-7685 request-list hash. Keep those
+            // paths paired before enabling real request hash processing.
             return false;
         }
 

--- a/test/ethereum_test/exclude/prague.cmake
+++ b/test/ethereum_test/exclude/prague.cmake
@@ -2,9 +2,6 @@ set(prague_excluded_tests
     # Blobs (EIP-4844)
     "BlockchainTests.cancun/eip4844_blobs/*"
 
-    # Unimplemented Prague EIPs
-    "BlockchainTests.prague/eip6110_deposits/*"
-    "BlockchainTests.prague/eip7685_general_purpose_el_requests/*"
 
     # Long-running tests
     "BlockchainTests.prague/eip2935_historical_block_hashes_from_state/block_hashes/block_hashes_history.json"


### PR DESCRIPTION
Add support for [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) deposit requests.

Extended ABI support for decoding Solidity bytes tail fields whose expected length is 32 bytes or less, which is needed for EIP-6110 amount, index, and withdrawal_credentials fields.

Removed Prague EIP-7685 exclusions.

Depends on:
- https://github.com/category-labs/monad/pull/2273

Base branch will be switched to `main` once the dependency is merged.