### PR TITLE
[execution]: Memory Bound LRU Cache

### DIFF
--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -25,9 +25,11 @@
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
+#include <category/vm/utils/lru_weight_cache.hpp>
 
 #include <cstdint>
 #include <cstring>
+#include <format>
 #include <memory>
 #include <optional>
 #include <string>
@@ -62,11 +64,13 @@ class DbCache final
     using StorageKeyHashCompare = BytesHashCompare<StorageKey>;
     using AccountsCache =
         LruCache<Address, std::optional<Account>, AddressHashCompare>;
-    using StorageCache =
-        LruCache<StorageKey, byte_string, StorageKeyHashCompare>;
+    using StorageCache = vm::utils::LruWeightCache<
+        StorageKey, byte_string, StorageKeyHashCompare>;
+
+    static constexpr uint32_t STORAGE_CACHE_MAX_BYTES = 256u * 1024 * 1024;
 
     AccountsCache accounts_{10'000'000};
-    StorageCache storage_{10'000'000};
+    StorageCache storage_{STORAGE_CACHE_MAX_BYTES};
     Proposals proposals_;
 
 public:
@@ -89,6 +93,10 @@ public:
         return false;
     }
 
+    // TODO: switch to a templated `F&& on_found` callback that takes a
+    // byte_string_view (pinned into the cache / proposal state) once
+    // ProposalPostState holds encoded pages — both sources will then expose
+    // pinned byte_strings and the extra copy here becomes unnecessary.
     bool try_read_storage(
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, byte_string &result)
@@ -131,7 +139,9 @@ public:
             insert_in_lru_caches(ps->state());
         }
         else {
-            // Finalizing a truncated proposal. Clear LRU caches.
+            // Finalizing a truncated proposal. Clear LRU caches.  This is an
+            // expensive operation. However, with 100 unfinalized propoals,
+            // cache speed is the least of our problems.
             accounts_.clear();
             storage_.clear();
         }
@@ -144,7 +154,8 @@ public:
 
     std::string storage_stats()
     {
-        return storage_.print_stats();
+        return std::format(
+            "{:8} / {:10}", storage_.size(), storage_.approx_weight());
     }
 
 private:
@@ -158,10 +169,12 @@ private:
             if (account.has_value()) {
                 for (auto const &[key, storage_delta] : storage) {
                     auto const incarnation = account->incarnation;
+                    byte_string const v{
+                        compact_storage_view(storage_delta.second)};
                     storage_.insert(
                         StorageKey(address, incarnation, key),
-                        byte_string{
-                            compact_storage_view(storage_delta.second)});
+                        v,
+                        static_cast<uint32_t>(v.size()));
                 }
             }
         }

--- a/category/vm/utils/lru_weight_cache.hpp
+++ b/category/vm/utils/lru_weight_cache.hpp
@@ -99,6 +99,14 @@ namespace monad::vm::utils
             return is_new_key;
         }
 
+        // Not thread-safe with other cache operations.
+        void clear()
+        {
+            hmap_.clear();
+            lru_.clear();
+            weight_.store(0, std::memory_order_release);
+        }
+
         /// Like insert, but does not overwrite an existing value in the cache.
         /// Instead if a value already exists under `key` then it will
         /// overwrite the `value` argument with the existing value.
@@ -234,6 +242,12 @@ namespace monad::vm::utils
         public:
             explicit LruList(int64_t const lru_update_period)
                 : lru_update_period_{lru_update_period}
+            {
+                clear();
+            }
+
+            // Not thread-safe with other LruList operations.
+            void clear()
             {
                 base_.second.next_ = &base_;
                 base_.second.prev_ = &base_;

--- a/test/vm/unit/lru_weight_cache_tests.cpp
+++ b/test/vm/unit/lru_weight_cache_tests.cpp
@@ -251,6 +251,25 @@ TEST_F(LruWeightCacheTest, reread_evict)
     ASSERT_FALSE(weight_cache_find(base_key).has_value());
 }
 
+TEST_F(LruWeightCacheTest, clear)
+{
+    uint32_t total_weight = 0;
+    for (size_t i = 0; i < 3; ++i) {
+        Value const v = default_values(elems[i]);
+        weight_cache_.insert(elems[i], v, v);
+        total_weight += v;
+    }
+    ASSERT_EQ(weight_cache_.size(), 3u);
+    ASSERT_EQ(weight_cache_.approx_weight(), total_weight);
+
+    weight_cache_.clear();
+    ASSERT_EQ(weight_cache_.size(), 0u);
+    ASSERT_EQ(weight_cache_.approx_weight(), 0u);
+    for (size_t i = 0; i < 3; ++i) {
+        ASSERT_FALSE(weight_cache_find(elems[i]).has_value());
+    }
+}
+
 TEST_F(LruWeightCacheTest, is_consistent)
 {
     for (uint32_t i = 0; i < 20; ++i) {


### PR DESCRIPTION
[execution]: Memory Bound LRU Cache
Introduces a memory bound LRU cache for variable length storage slots.
Under page storage, the cache will hold encoded pages, which have different
sizes.

LruWeightCache does exactly what we need.  I experimented with several
slab allocator of fixed sized pool approaches. Rolling one by hand has
marginal improvements: around 10ns on insert time. Perhaps real world
data could inform the slab class sizes. For now, this simpler solution
is preferred.