### PR TITLE
Introduce MonadTxEnvelope type

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,6 +97,7 @@ checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "k256",
  "serde",
  "thiserror",
 ]
@@ -161,6 +162,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "itoa",
+ "k256",
  "paste",
  "rand 0.9.2",
  "ruint",
@@ -1438,6 +1440,7 @@ dependencies = [
  "futures",
  "hex",
  "monad-cxx",
+ "monad-tx-envelope",
  "serde",
  "tracing",
 ]
@@ -1472,6 +1475,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "monad-event-ring",
+ "monad-tx-envelope",
  "ratatui",
  "serde",
  "serde_json",
@@ -1496,6 +1500,14 @@ dependencies = [
  "futures",
  "monad-cxx",
  "tracing",
+]
+
+[[package]]
+name = "monad-tx-envelope"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ monad-event-ring = { path = "./crates/monad-event-ring" }
 monad-exec-events = { path = "./crates/monad-exec-events" }
 monad-statesync = { path = "./crates/monad-statesync" }
 monad-triedb = { path = "./crates/monad-triedb" }
+monad-tx-envelope = { path = "./crates/monad-tx-envelope" }
 
 alloy-consensus  = { version = "2.0",     default-features = false }
 alloy-eips       = { version = "2.0",     default-features = false }

--- a/rust/crates/monad-ethcall/Cargo.toml
+++ b/rust/crates/monad-ethcall/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 monad-cxx = { workspace = true }
+monad-tx-envelope = { workspace = true }
 
 alloy-consensus = { workspace = true }
 alloy-eips = { workspace = true }

--- a/rust/crates/monad-ethcall/src/lib.rs
+++ b/rust/crates/monad-ethcall/src/lib.rs
@@ -19,12 +19,13 @@ use std::{
     path::Path,
 };
 
-use alloy_consensus::{Header, Transaction as _, TxEnvelope};
+use alloy_consensus::{Header, Transaction as _};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_rlp::Encodable;
 use alloy_sol_types::decode_revert_reason;
 use futures::channel::oneshot::{channel, Sender};
+use monad_tx_envelope::MonadTxEnvelope;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
@@ -208,7 +209,7 @@ pub type StateOverrideSet = HashMap<Address, StateOverrideObject>;
 
 pub struct EthCallRequest<'a> {
     pub chain_id: ChainId,
-    pub transaction: &'a TxEnvelope,
+    pub transaction: &'a MonadTxEnvelope,
     pub block_header: &'a Header,
     pub sender: Address,
     pub block_number: u64,

--- a/rust/crates/monad-exec-events/Cargo.toml
+++ b/rust/crates/monad-exec-events/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 monad-event-ring = { workspace = true }
+monad-tx-envelope = { workspace = true, optional = true }
 
 alloy-consensus = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
@@ -33,7 +34,7 @@ strum = { workspace = true }
 
 [features]
 default = []
-alloy = ["dep:alloy-consensus", "dep:alloy-eips", "dep:alloy-primitives", "dep:alloy-rpc-types"]
+alloy = ["dep:alloy-consensus", "dep:alloy-eips", "dep:alloy-primitives", "dep:alloy-rpc-types", "dep:monad-tx-envelope"]
 
 [[bench]]
 name = "snapshot_exec"

--- a/rust/crates/monad-exec-events/src/block.rs
+++ b/rust/crates/monad-exec-events/src/block.rs
@@ -94,7 +94,10 @@ impl ExecutedBlock {
     }
 
     /// Creates an alloy block with a full transaction list.
-    pub fn to_alloy_rpc(&self) -> alloy_rpc_types::Block {
+    pub fn to_alloy_rpc(
+        &self,
+    ) -> alloy_rpc_types::Block<alloy_rpc_types::Transaction<monad_tx_envelope::MonadTxEnvelope>>
+    {
         let header = self.to_alloy_rpc_header();
 
         let transactions = self
@@ -130,12 +133,15 @@ impl ExecutedBlock {
     /// Iterate over alloy transactions.
     pub fn iter_alloy_tx_envelopes(
         &self,
-    ) -> impl Iterator<Item = alloy_consensus::TxEnvelope> + '_ {
+    ) -> impl Iterator<Item = monad_tx_envelope::MonadTxEnvelope> + '_ {
         self.txns.iter().map(|tx| tx.to_alloy())
     }
 
     /// Iterate over alloy rpc transactions.
-    pub fn iter_alloy_rpc_txs(&self) -> impl Iterator<Item = alloy_rpc_types::Transaction> + '_ {
+    pub fn iter_alloy_rpc_txs(
+        &self,
+    ) -> impl Iterator<Item = alloy_rpc_types::Transaction<monad_tx_envelope::MonadTxEnvelope>> + '_
+    {
         let block_hash = alloy_primitives::FixedBytes::from(self.end.eth_block_hash.bytes);
         let block_number = self.start.eth_block_input.number;
         let block_timestamp = self.start.eth_block_input.timestamp;
@@ -323,7 +329,7 @@ pub struct ExecutedTxn {
 #[cfg(feature = "alloy")]
 impl ExecutedTxn {
     /// Creates an alloy tx envelope.
-    pub fn to_alloy(&self) -> alloy_consensus::TxEnvelope {
+    pub fn to_alloy(&self) -> monad_tx_envelope::MonadTxEnvelope {
         let to = if self.header.is_contract_creation {
             alloy_primitives::TxKind::Create
         } else {
@@ -398,7 +404,7 @@ impl ExecutedTxn {
 
         match self.header.txn_type {
             ffi::MONAD_TXN_LEGACY => {
-                alloy_consensus::TxEnvelope::Legacy(alloy_consensus::Signed::new_unchecked(
+                monad_tx_envelope::MonadTxEnvelope::Legacy(alloy_consensus::Signed::new_unchecked(
                     alloy_consensus::TxLegacy {
                         chain_id: (chain_id != 0).then_some(chain_id),
                         nonce: self.header.nonce,
@@ -413,7 +419,7 @@ impl ExecutedTxn {
                 ))
             }
             ffi::MONAD_TXN_EIP2930 => {
-                alloy_consensus::TxEnvelope::Eip2930(alloy_consensus::Signed::new_unchecked(
+                monad_tx_envelope::MonadTxEnvelope::Eip2930(alloy_consensus::Signed::new_unchecked(
                     alloy_consensus::TxEip2930 {
                         chain_id,
                         nonce: self.header.nonce,
@@ -429,7 +435,7 @@ impl ExecutedTxn {
                 ))
             }
             ffi::MONAD_TXN_EIP1559 => {
-                alloy_consensus::TxEnvelope::Eip1559(alloy_consensus::Signed::new_unchecked(
+                monad_tx_envelope::MonadTxEnvelope::Eip1559(alloy_consensus::Signed::new_unchecked(
                     alloy_consensus::TxEip1559 {
                         chain_id,
                         nonce: self.header.nonce,
@@ -453,7 +459,7 @@ impl ExecutedTxn {
                 unreachable!("ExecutedTxn encountered unsupported EIP4844 tx type");
             }
             ffi::MONAD_TXN_EIP7702 => {
-                alloy_consensus::TxEnvelope::Eip7702(alloy_consensus::Signed::new_unchecked(
+                monad_tx_envelope::MonadTxEnvelope::Eip7702(alloy_consensus::Signed::new_unchecked(
                     alloy_consensus::TxEip7702 {
                         chain_id,
                         nonce: self.header.nonce,
@@ -488,7 +494,7 @@ impl ExecutedTxn {
     /// Creates a recovered alloy tx envelope.
     pub fn to_alloy_recovered(
         &self,
-    ) -> alloy_consensus::transaction::Recovered<alloy_consensus::TxEnvelope> {
+    ) -> alloy_consensus::transaction::Recovered<monad_tx_envelope::MonadTxEnvelope> {
         alloy_consensus::transaction::Recovered::new_unchecked(
             self.to_alloy(),
             alloy_primitives::Address::from(self.sender.bytes),

--- a/rust/crates/monad-tx-envelope/Cargo.toml
+++ b/rust/crates/monad-tx-envelope/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "monad-tx-envelope"
+description = "Monad's EIP-2718 transaction envelope type"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+bench = false
+
+[dependencies]
+alloy-consensus = { workspace = true, features = ["k256", "serde"] }
+alloy-primitives = { workspace = true, features = ["serde"] }

--- a/rust/crates/monad-tx-envelope/src/envelope.rs
+++ b/rust/crates/monad-tx-envelope/src/envelope.rs
@@ -1,0 +1,225 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloy_consensus::{
+    transaction::SignerRecoverable, Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEip7702,
+    TxEnvelope, TxLegacy,
+};
+use alloy_primitives::{Address, Signature, B256};
+
+/// Monad's EIP-2718 transaction envelope. Mirrors `alloy_consensus::TxEnvelope`
+/// minus EIP-4844 (unsupported on Monad), with room to add Monad-specific variants.
+#[derive(Clone, Debug, TransactionEnvelope)]
+#[envelope(tx_type_name = MonadTxType, typed = MonadTypedTransaction)]
+pub enum MonadTxEnvelope {
+    #[envelope(ty = 0)]
+    Legacy(Signed<TxLegacy>),
+    #[envelope(ty = 1)]
+    Eip2930(Signed<TxEip2930>),
+    #[envelope(ty = 2)]
+    Eip1559(Signed<TxEip1559>),
+    #[envelope(ty = 4)]
+    Eip7702(Signed<TxEip7702>),
+}
+
+impl MonadTxEnvelope {
+    /// Calculate the signing hash for the transaction.
+    pub fn signature_hash(&self) -> B256 {
+        match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+        }
+    }
+
+    /// Return the reference to signature.
+    pub const fn signature(&self) -> &Signature {
+        match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+        }
+    }
+
+    /// Return the hash of the inner Signed.
+    pub fn tx_hash(&self) -> &B256 {
+        match self {
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+        }
+    }
+
+    /// Reference to transaction hash. Used to identify transaction.
+    pub fn hash(&self) -> &B256 {
+        match self {
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+        }
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub const fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub const fn as_eip2930(&self) -> Option<&Signed<TxEip2930>> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_eip1559(&self) -> Option<&Signed<TxEip1559>> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip7702`] variant if the transaction is an EIP-7702 transaction.
+    pub const fn as_eip7702(&self) -> Option<&Signed<TxEip7702>> {
+        match self {
+            Self::Eip7702(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the length of the inner txn, including type byte length.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        match self {
+            Self::Legacy(t) => t.eip2718_encoded_length(),
+            Self::Eip2930(t) => t.eip2718_encoded_length(),
+            Self::Eip1559(t) => t.eip2718_encoded_length(),
+            Self::Eip7702(t) => t.eip2718_encoded_length(),
+        }
+    }
+}
+
+impl SignerRecoverable for MonadTxEnvelope {
+    fn recover_signer(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => SignerRecoverable::recover_signer(tx),
+            Self::Eip2930(tx) => SignerRecoverable::recover_signer(tx),
+            Self::Eip1559(tx) => SignerRecoverable::recover_signer(tx),
+            Self::Eip7702(tx) => SignerRecoverable::recover_signer(tx),
+        }
+    }
+
+    fn recover_signer_unchecked(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+            Self::Eip2930(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+            Self::Eip1559(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+            Self::Eip7702(tx) => SignerRecoverable::recover_signer_unchecked(tx),
+        }
+    }
+
+    fn recover_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => SignerRecoverable::recover_with_buf(tx, buf),
+            Self::Eip2930(tx) => SignerRecoverable::recover_with_buf(tx, buf),
+            Self::Eip1559(tx) => SignerRecoverable::recover_with_buf(tx, buf),
+            Self::Eip7702(tx) => SignerRecoverable::recover_with_buf(tx, buf),
+        }
+    }
+
+    fn recover_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => SignerRecoverable::recover_unchecked_with_buf(tx, buf),
+            Self::Eip2930(tx) => SignerRecoverable::recover_unchecked_with_buf(tx, buf),
+            Self::Eip1559(tx) => SignerRecoverable::recover_unchecked_with_buf(tx, buf),
+            Self::Eip7702(tx) => SignerRecoverable::recover_unchecked_with_buf(tx, buf),
+        }
+    }
+}
+
+impl From<Signed<TxLegacy>> for MonadTxEnvelope {
+    fn from(tx: Signed<TxLegacy>) -> Self {
+        Self::Legacy(tx)
+    }
+}
+
+impl From<Signed<TxEip2930>> for MonadTxEnvelope {
+    fn from(tx: Signed<TxEip2930>) -> Self {
+        Self::Eip2930(tx)
+    }
+}
+
+impl From<Signed<TxEip1559>> for MonadTxEnvelope {
+    fn from(tx: Signed<TxEip1559>) -> Self {
+        Self::Eip1559(tx)
+    }
+}
+
+impl From<Signed<TxEip7702>> for MonadTxEnvelope {
+    fn from(tx: Signed<TxEip7702>) -> Self {
+        Self::Eip7702(tx)
+    }
+}
+
+impl From<MonadTxEnvelope> for TxEnvelope {
+    fn from(tx: MonadTxEnvelope) -> Self {
+        match tx {
+            MonadTxEnvelope::Legacy(tx) => Self::Legacy(tx),
+            MonadTxEnvelope::Eip2930(tx) => Self::Eip2930(tx),
+            MonadTxEnvelope::Eip1559(tx) => Self::Eip1559(tx),
+            MonadTxEnvelope::Eip7702(tx) => Self::Eip7702(tx),
+        }
+    }
+}
+
+/// Returned when a [`TxEnvelope`] contains a variant that [`MonadTxEnvelope`]
+/// cannot represent (currently only EIP-4844).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsupportedTxType;
+
+impl std::fmt::Display for UnsupportedTxType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("transaction type not supported by MonadTxEnvelope")
+    }
+}
+
+impl std::error::Error for UnsupportedTxType {}
+
+impl TryFrom<TxEnvelope> for MonadTxEnvelope {
+    type Error = UnsupportedTxType;
+
+    fn try_from(tx: TxEnvelope) -> Result<Self, Self::Error> {
+        match tx {
+            TxEnvelope::Legacy(tx) => Ok(Self::Legacy(tx)),
+            TxEnvelope::Eip2930(tx) => Ok(Self::Eip2930(tx)),
+            TxEnvelope::Eip1559(tx) => Ok(Self::Eip1559(tx)),
+            TxEnvelope::Eip7702(tx) => Ok(Self::Eip7702(tx)),
+            TxEnvelope::Eip4844(_) => Err(UnsupportedTxType),
+        }
+    }
+}

--- a/rust/crates/monad-tx-envelope/src/lib.rs
+++ b/rust/crates/monad-tx-envelope/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+mod envelope;
+
+pub use envelope::{MonadTxEnvelope, MonadTxType, MonadTypedTransaction, UnsupportedTxType};


### PR DESCRIPTION
Currently equivalent to alloy's TxEnvelope but defining our custom struct allows us to extend new transaction types in the future. 