### PR TITLE
Remove redundant stack_top adjustment. 

### DIFF
--- a/category/vm/interpreter/call_runtime.hpp
+++ b/category/vm/interpreter/call_runtime.hpp
@@ -24,7 +24,7 @@ namespace monad::vm::interpreter
     template <typename... FnArgs>
     [[gnu::always_inline]]
     inline void call_runtime(
-        void (*f)(FnArgs...), runtime::Context &ctx, uint256_t *&stack_top,
+        void (*f)(FnArgs...), runtime::Context &ctx, uint256_t *const stack_top,
         int64_t &gas_remaining)
     {
         constexpr auto use_context = runtime::detail::uses_context_v<FnArgs...>;
@@ -79,11 +79,6 @@ namespace monad::vm::interpreter
         ctx.gas_remaining = gas_remaining;
         std::apply(f, all_args);
 
-        static_assert(stack_arg_count <= std::numeric_limits<ptrdiff_t>::max());
-        constexpr ptrdiff_t stack_adjustment =
-            static_cast<ptrdiff_t>(stack_arg_count) - (use_result ? 1 : 0);
-
-        stack_top -= stack_adjustment;
         gas_remaining = ctx.gas_remaining;
     }
 }


### PR DESCRIPTION
The sole caller of `call_runtime` is `checked_runtime_call`, which receives `stack_top` as a pointer not a reference to a pointer, so the change to `stack_top` does not get propagated back to the caller of `checked_runtime_call`. The actual stack_top adjustment happens in the MONAD_VM_NEXT macro