### PR TITLE
Add monad-build crate to unify execution build process

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -473,6 +473,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,11 +1450,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-build"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "cmake",
+]
+
+[[package]]
 name = "monad-cxx"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "cmake",
+ "monad-build",
  "tracing",
 ]
 
@@ -1449,10 +1490,10 @@ dependencies = [
  "bindgen",
  "cc",
  "clap",
- "cmake",
  "criterion",
  "itertools 0.10.5",
  "libc",
+ "monad-build",
 ]
 
 [[package]]
@@ -1492,8 +1533,8 @@ name = "monad-triedb"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "cmake",
  "futures",
+ "monad-build",
  "monad-cxx",
  "tracing",
 ]
@@ -2002,6 +2043,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,7 @@ ignored = [
 ]
 
 [workspace.dependencies]
+monad-build = { path = "./crates/monad-build" }
 monad-cxx = { path = "./crates/monad-cxx" }
 monad-ethcall = { path = "./crates/monad-ethcall" }
 monad-event-ring = { path = "./crates/monad-event-ring" }
@@ -30,6 +31,7 @@ alloy-rlp        = { version = "0.3",     default-features = false }
 alloy-rpc-types  = { version = "2.0",     default-features = false, features = ["eth"] }
 alloy-sol-types  = { version = "1.5",     default-features = false }
 bindgen          = { version = "0.71.1",  default-features = false, features = ["logging", "runtime"] }
+cargo_metadata   = { version = "0.23.1",  default-features = false }
 cc               = { version = "1.2.27",  default-features = false }
 chrono           = { version = "0.4.34",  default-features = false, features = ["std", "clock"] }
 clap             = { version = "4.2",     default-features = false }

--- a/rust/crates/monad-build/Cargo.toml
+++ b/rust/crates/monad-build/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "monad-build"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cargo_metadata = { workspace = true, optional = true }
+cmake          = { workspace = true, optional = true }
+
+[features]
+cmake = ["dep:cmake"]
+metadata = ["dep:cargo_metadata"]

--- a/rust/crates/monad-build/src/cmake.rs
+++ b/rust/crates/monad-build/src/cmake.rs
@@ -1,0 +1,86 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Debug)]
+pub enum MonadCMakeLinkage {
+    Static,
+    Dynamic,
+}
+
+pub struct MonadCMake {
+    cmake: cmake::Config,
+    linkage: MonadCMakeLinkage,
+    with_rpath: bool,
+}
+
+impl MonadCMake {
+    pub fn new<P>(path: P, linkage: MonadCMakeLinkage) -> Self
+    where
+        P: AsRef<std::path::Path>,
+    {
+        let mut cmake = cmake::Config::new(path);
+
+        match linkage {
+            MonadCMakeLinkage::Static => {}
+            MonadCMakeLinkage::Dynamic => {
+                cmake.define("BUILD_SHARED_LIBS", "ON");
+            }
+        }
+
+        Self {
+            cmake,
+            linkage,
+            with_rpath: false,
+        }
+    }
+
+    pub fn define<V>(mut self, var: &str, value: V) -> Self
+    where
+        V: AsRef<std::ffi::OsStr>,
+    {
+        self.cmake.define(var, value);
+        self
+    }
+
+    pub fn with_rpath(mut self) -> Self {
+        self.with_rpath = true;
+        self
+    }
+
+    pub fn build(self, target: &'static str) {
+        let Self {
+            mut cmake,
+            linkage,
+            with_rpath,
+        } = self;
+
+        let dst = cmake.build_target(target).build();
+
+        println!("cargo:rustc-link-search=native={}/build", dst.display());
+        println!(
+            "cargo:rustc-link-lib={}={}",
+            match linkage {
+                MonadCMakeLinkage::Static => "static",
+                MonadCMakeLinkage::Dynamic => "dylib",
+            },
+            target
+        );
+        println!("cargo:CMAKE_BINARY_DIR={}/build", dst.display());
+
+        if with_rpath {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}/build", dst.display());
+        }
+    }
+}

--- a/rust/crates/monad-build/src/lib.rs
+++ b/rust/crates/monad-build/src/lib.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#[cfg(feature = "cmake")]
+pub use self::cmake::{MonadCMake, MonadCMakeLinkage};
+
+#[cfg(feature = "cmake")]
+mod cmake;
+
+#[cfg(feature = "metadata")]
+pub fn repository_root() -> std::path::PathBuf {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("Failed to get cargo metadata");
+
+    let workspace_root = metadata.workspace_root.as_std_path();
+    assert_eq!(
+        workspace_root.file_name().and_then(|n| n.to_str()),
+        Some("rust"),
+        "Failed to verify workspace root is named 'rust', got: {}",
+        workspace_root.display()
+    );
+
+    let repository_root = workspace_root
+        .parent()
+        .expect("Failed to get repository root from workspace root")
+        .to_path_buf();
+
+    let category_dir = repository_root.join("category");
+    assert!(
+        category_dir.exists(),
+        "Failed to find category directory at {}",
+        category_dir.display()
+    );
+
+    repository_root
+}
+
+pub fn should_build_execution() -> bool {
+    println!("cargo:rerun-if-env-changed=TRIEDB_TARGET");
+
+    std::env::var("TRIEDB_TARGET").is_ok_and(|target| target == "triedb_driver")
+}
+
+pub fn execution_dir() -> Option<String> {
+    if !should_build_execution() {
+        return None;
+    }
+
+    Some(
+        std::env::var("DEP_MONAD_EXECUTION_CMAKE_BINARY_DIR")
+            .expect("DEP_MONAD_EXECUTION_CMAKE_BINARY_DIR not set"),
+    )
+}

--- a/rust/crates/monad-cxx/Cargo.toml
+++ b/rust/crates/monad-cxx/Cargo.toml
@@ -8,5 +8,6 @@ links = "monad_execution"
 tracing = { workspace = true, features = ["log"] }
 
 [build-dependencies]
+monad-build = { workspace = true, features = ["cmake", "metadata"] }
+
 bindgen = { workspace = true }
-cmake = { workspace = true }

--- a/rust/crates/monad-cxx/build.rs
+++ b/rust/crates/monad-cxx/build.rs
@@ -21,22 +21,13 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rerun-if-changed=../../../category");
-    println!("cargo:rerun-if-env-changed=TRIEDB_TARGET");
 
-    let build_execution_lib =
-        std::env::var("TRIEDB_TARGET").is_ok_and(|target| target == "triedb_driver");
-    if build_execution_lib {
-        let target = "monad_execution";
-        let dst = cmake::Config::new("../../../")
-            .define("BUILD_SHARED_LIBS", "ON")
-            .build_target(target)
-            .build();
-
-        println!("cargo:rustc-link-search=native={}/build", dst.display());
-        println!("cargo:rustc-link-lib=dylib={}", &target);
-
-        // Tell dependent packages where libmonad_execution.so is
-        println!("cargo:CMAKE_BINARY_DIR={}/build", dst.display())
+    if monad_build::should_build_execution() {
+        monad_build::MonadCMake::new(
+            monad_build::repository_root(),
+            monad_build::MonadCMakeLinkage::Dynamic,
+        )
+        .build("monad_execution");
     }
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());

--- a/rust/crates/monad-ethcall/build.rs
+++ b/rust/crates/monad-ethcall/build.rs
@@ -13,15 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=../../../");
-
-    let has_execution_lib = env::var("TRIEDB_TARGET").is_ok_and(|target| target == "triedb_driver");
-    if has_execution_lib {
-        println!("cargo:rustc-link-lib=dylib=monad_execution");
-    }
 
     let bindings = bindgen::Builder::default()
         .header("../../../category/execution/ethereum/chain/chain_config.h")
@@ -32,7 +27,7 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/rust/crates/monad-event-ring/Cargo.toml
+++ b/rust/crates/monad-event-ring/Cargo.toml
@@ -13,9 +13,10 @@ criterion = { workspace = true }
 itertools = { workspace = true }
 
 [build-dependencies]
+monad-build = { workspace = true, features = ["cmake", "metadata"] }
+
 bindgen = { workspace = true }
 cc = { workspace = true }
-cmake = { workspace = true }
 
 [[bench]]
 name = "snapshot_raw"

--- a/rust/crates/monad-event-ring/build.rs
+++ b/rust/crates/monad-event-ring/build.rs
@@ -32,16 +32,12 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../../../category");
 
-    let client_target = "monad_event";
-    let client_dst = cmake::Config::new("../../../category/event")
-        .build_target(client_target)
-        .build();
+    monad_build::MonadCMake::new(
+        monad_build::repository_root().join("category/event"),
+        monad_build::MonadCMakeLinkage::Static,
+    )
+    .build("monad_event");
 
-    println!(
-        "cargo:rustc-link-search=native={}/build",
-        client_dst.display()
-    );
-    println!("cargo:rustc-link-lib=static=monad_event");
     println!("cargo:rustc-link-lib=zstd");
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-lib=hugetlbfs");

--- a/rust/crates/monad-statesync/build.rs
+++ b/rust/crates/monad-statesync/build.rs
@@ -13,16 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=../../../");
-    println!("cargo:rerun-if-env-changed=TRIEDB_TARGET");
-
-    let has_execution_lib = env::var("TRIEDB_TARGET").is_ok_and(|target| target == "triedb_driver");
-    if has_execution_lib {
-        println!("cargo:rustc-link-lib=dylib=monad_execution");
-    }
 
     let bindings = bindgen::Builder::default()
         .header("../../../category/statesync/statesync_messages.h")
@@ -35,7 +29,7 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/rust/crates/monad-triedb/Cargo.toml
+++ b/rust/crates/monad-triedb/Cargo.toml
@@ -15,5 +15,6 @@ futures = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
+monad-build = { workspace = true, features = ["cmake", "metadata"] }
+
 bindgen = { workspace = true }
-cmake = { workspace = true }

--- a/rust/crates/monad-triedb/build.rs
+++ b/rust/crates/monad-triedb/build.rs
@@ -13,31 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=CMakeLists.txt");
     println!("cargo:rerun-if-changed=include/ffi.h");
     println!("cargo:rerun-if-changed=src/ffi.cpp");
     println!("cargo:rerun-if-changed=../../../category");
-    println!("cargo:rerun-if-env-changed=TRIEDB_TARGET");
-    let build_execution_lib =
-        env::var("TRIEDB_TARGET").is_ok_and(|target| target == "triedb_driver");
-    if build_execution_lib {
-        // monad-cxx must set this
-        let monad_execution_dir = env::var("DEP_MONAD_EXECUTION_CMAKE_BINARY_DIR").unwrap();
 
-        let target = "triedb_driver";
-
-        let dst = cmake::Config::new(".")
-            .define("BUILD_SHARED_LIBS", "ON")
-            .define("MONAD_EXECUTION_DIR", monad_execution_dir)
-            .build_target(target)
-            .build();
-
-        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", dst.display());
-        println!("cargo:rustc-link-search=native={}/build", dst.display());
-        println!("cargo:rustc-link-lib=dylib={}", target);
+    if let Some(execution_dir) = monad_build::execution_dir() {
+        monad_build::MonadCMake::new(".", monad_build::MonadCMakeLinkage::Dynamic)
+            .define("MONAD_EXECUTION_DIR", execution_dir)
+            .with_rpath()
+            .build("triedb_driver");
     }
 
     let bindings = bindgen::Builder::default()
@@ -48,7 +36,7 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");


### PR DESCRIPTION
This change introduces a `monad-build` crate which will house all the shared build config / patterns. For now, we expose `MonadCmake` to build execution in `monad-cxx` and cleanup some unnecessary statements in the `build.rs` scripts of some of the crates.

In the next change (https://github.com/category-labs/monad/pull/2284), we'll introduce a shared bindgen wrapper with monad-specific defaults and behaviors that dramatically simplifies our FFI setup. After that, we'll port over `monad-triedb` to use `cxx` and the `MonadCmake` structure introduced in this change.