### PR TITLE
[core]: Consolidate uint256_t load/store/byteswap API into free funct…

### DIFF
--- a/category/core/int.hpp
+++ b/category/core/int.hpp
@@ -79,8 +79,20 @@ template <typename T>
     return reinterpret_cast<uint8_t const *>(&x);
 }
 
+// Block rvalue binding: as_bytes(make_T()) would return a pointer into
+// a temporary that dies at the end of the full expression. Lvalue calls
+// prefer the references above; rvalues pick this deleted overload.
 template <typename T>
-[[nodiscard]] inline constexpr T bswap(T const x) noexcept
+uint8_t const *as_bytes(T const &&) = delete;
+
+// Byte-swap primitive: converts between native and big-endian byte order on
+// the little-endian-only platform this codebase targets (see
+// `static_assert(std::endian::native == std::endian::little)` above). Prefer
+// the higher-level load_* / store_* helpers below when working with byte
+// buffers — they handle the surrounding memcpy / bit_cast. Use bswap
+// directly when the value is already in a register.
+template <typename T>
+[[nodiscard, gnu::always_inline]] inline constexpr T bswap(T const x) noexcept
 {
     if constexpr (std::same_as<T, uint256_t>) {
         return byteswap(x);
@@ -96,47 +108,90 @@ template <typename T>
     }
 }
 
+// Load a little-endian encoded integer from an unaligned byte buffer.
 template <typename T>
-[[nodiscard]] inline constexpr T to_big_endian(T const x) noexcept
-{
-    return bswap(x);
-}
-
-// Load a big-endian encoded integer from an unaligned byte buffer.
-template <typename T>
-[[nodiscard]] inline T load_be_unsafe(uint8_t const *src) noexcept
+[[nodiscard, gnu::always_inline]] inline T
+load_le_unsafe(uint8_t const *src) noexcept
 {
     static_assert(std::is_trivially_copyable_v<T>);
     T x;
     std::memcpy(&x, src, sizeof(x));
-    return bswap(x);
+    return x;
+}
+
+// Load a big-endian encoded integer from an unaligned byte buffer.
+template <typename T>
+[[nodiscard, gnu::always_inline]] inline T
+load_be_unsafe(uint8_t const *src) noexcept
+{
+    return bswap(load_le_unsafe<T>(src));
+}
+
+// Load a little-endian encoded integer from a struct with a .bytes member.
+template <typename T, FixedBytes Src>
+[[nodiscard, gnu::always_inline]] inline constexpr T
+load_le(Src const &src) noexcept
+{
+    static_assert(sizeof(Src::bytes) == sizeof(T));
+    return std::bit_cast<T>(src);
 }
 
 // Load a big-endian encoded integer from a struct with a .bytes member.
 template <typename T, FixedBytes Src>
-[[nodiscard]] inline T load_be(Src const &src) noexcept
+[[nodiscard, gnu::always_inline]] inline constexpr T
+load_be(Src const &src) noexcept
 {
-    static_assert(sizeof(Src::bytes) == sizeof(T));
-    return load_be_unsafe<T>(src.bytes);
+    return bswap(load_le<T>(src));
+}
+
+// Load a little-endian encoded integer from a sized byte array.
+template <typename T, size_t N>
+[[nodiscard, gnu::always_inline]] inline constexpr T
+load_le(uint8_t const (&src)[N]) noexcept
+{
+    static_assert(N == sizeof(T));
+    return std::bit_cast<T>(src);
+}
+
+// Load a big-endian encoded integer from a sized byte array.
+template <typename T, size_t N>
+[[nodiscard, gnu::always_inline]] inline constexpr T
+load_be(uint8_t const (&src)[N]) noexcept
+{
+    return bswap(load_le<T>(src));
+}
+
+// Store an integer as little-endian bytes into an unaligned byte buffer.
+// The width constraint blocks accidental truncation when T is deduced
+// from a narrow integer (e.g. store_le(buf, 77u) writing only 4 bytes).
+template <typename T>
+    requires(sizeof(T) >= 8)
+[[gnu::always_inline]] inline void store_le(uint8_t *dst, T const x) noexcept
+{
+    static_assert(std::is_trivially_copyable_v<T>);
+    std::memcpy(dst, &x, sizeof(x));
 }
 
 // Store an integer as big-endian bytes into an unaligned byte buffer.
+// The width constraint blocks accidental truncation when T is deduced
+// from a narrow integer (e.g. store_be(buf, 77u) writing only 4 bytes).
 template <typename T>
-inline void store_be(uint8_t *dst, T const x) noexcept
+    requires(sizeof(T) >= 8)
+[[gnu::always_inline]] inline void store_be(uint8_t *dst, T const x) noexcept
 {
-    T const be = bswap(x);
-    std::memcpy(dst, &be, sizeof(be));
+    store_le(dst, bswap(x));
 }
 
 // Store an integer as big-endian bytes into a new value of type DstT
 // (which must have a .bytes member of matching size).
 template <FixedBytes DstT, typename SrcT>
-[[nodiscard]] inline DstT store_be_as(SrcT const x) noexcept
+    requires(sizeof(SrcT) >= 8)
+[[nodiscard, gnu::always_inline]] inline constexpr DstT
+store_be_as(SrcT const x) noexcept
 {
     static_assert(sizeof(DstT::bytes) == sizeof(SrcT));
-    DstT dst{};
-    store_be(dst.bytes, x);
-    return dst;
+    static_assert(std::is_trivially_copyable_v<DstT>);
+    return std::bit_cast<DstT>(bswap(x));
 }
 
 MONAD_NAMESPACE_END

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -232,18 +232,6 @@ public:
     }
 
     [[gnu::always_inline]]
-    inline uint8_t *as_bytes() noexcept
-    {
-        return reinterpret_cast<uint8_t *>(&words_);
-    }
-
-    [[gnu::always_inline]]
-    inline uint8_t const *as_bytes() const noexcept
-    {
-        return reinterpret_cast<uint8_t const *>(&words_);
-    }
-
-    [[gnu::always_inline]]
     inline constexpr std::array<uint64_t, 4> &as_words() noexcept
     {
         return words_;
@@ -501,68 +489,6 @@ public:
     inline constexpr uint256_t &operator>>=(uint256_t const &shift) noexcept
     {
         return *this = *this >> shift;
-    }
-
-    [[gnu::always_inline]]
-    inline constexpr uint256_t to_be() const noexcept
-    {
-        static_assert(
-            std::endian::native == std::endian::little,
-            "to_be only supported on little-endian platforms");
-        return byteswap(*this);
-    }
-
-    [[gnu::always_inline]]
-    static inline constexpr uint256_t
-    load_be(uint8_t const (&bytes)[num_bytes]) noexcept
-    {
-        return load_le(bytes).to_be();
-    }
-
-    [[gnu::always_inline]]
-    static inline constexpr uint256_t
-    load_le(uint8_t const (&bytes)[num_bytes]) noexcept
-    {
-        return load_le_unsafe(bytes);
-    }
-
-    [[gnu::always_inline]]
-    static inline constexpr uint256_t
-    load_be_unsafe(uint8_t const *bytes) noexcept
-    {
-        return load_le_unsafe(bytes).to_be();
-    }
-
-    [[gnu::always_inline]] static inline constexpr uint256_t
-    load_le_unsafe(uint8_t const *bytes) noexcept
-    {
-        static_assert(std::endian::native == std::endian::little);
-        uint256_t result;
-        std::memcpy(&result.words_, bytes, num_bytes);
-        return result;
-    }
-
-    template <typename DstT>
-    [[gnu::always_inline]]
-    inline DstT store_be() const noexcept
-    {
-        DstT result;
-        static_assert(sizeof(result.bytes) == sizeof(words_));
-        store_be(result.bytes);
-        return result;
-    }
-
-    [[gnu::always_inline]]
-    inline void store_be(uint8_t *dest) const noexcept
-    {
-        uint256_t const be = to_be();
-        std::memcpy(dest, &be.words_, num_bytes);
-    }
-
-    [[gnu::always_inline]]
-    inline void store_le(uint8_t *dest) const noexcept
-    {
-        std::memcpy(dest, &words_, num_bytes);
     }
 
     // String conversion functions
@@ -1117,7 +1043,9 @@ inline uint256_t from_bytes(size_t n, size_t remaining, uint8_t const *src)
 
     std::memcpy(&dst[32 - n], src, std::min(n, remaining));
 
-    return uint256_t::load_be(dst);
+    uint256_t result;
+    std::memcpy(&result, dst, sizeof(result));
+    return byteswap(result);
 }
 
 /**

--- a/category/execution/ethereum/block_hash_history.cpp
+++ b/category/execution/ethereum/block_hash_history.cpp
@@ -98,7 +98,7 @@ void set_block_hash_history(State &state, BlockHeader const &header)
     if (MONAD_LIKELY(state.account_exists(BLOCK_HISTORY_ADDRESS))) {
         uint64_t const parent_number = header.number - 1;
         uint256_t const index{parent_number % BLOCK_HISTORY_LENGTH};
-        bytes32_t const key{to_bytes(to_big_endian(index))};
+        bytes32_t const key{store_be_as<bytes32_t>(index)};
         state.set_storage(BLOCK_HISTORY_ADDRESS, key, header.parent_hash);
     }
 }
@@ -116,7 +116,7 @@ bytes32_t get_block_hash_history(State &state, uint64_t const block_number)
 
     uint256_t const index{block_number % BLOCK_HISTORY_LENGTH};
     return state.get_storage(
-        BLOCK_HISTORY_ADDRESS, to_bytes(to_big_endian(index)));
+        BLOCK_HISTORY_ADDRESS, store_be_as<bytes32_t>(index));
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/block_hash_history_test.cpp
+++ b/category/execution/ethereum/block_hash_history_test.cpp
@@ -43,7 +43,7 @@ namespace
     // Byte encode 64 bit integers in 256 bit big endian format.
     bytes32_t enc(uint64_t const x)
     {
-        return to_bytes(to_big_endian(uint256_t{x}));
+        return store_be_as<bytes32_t>(uint256_t{x});
     }
 
     struct BlockHashHistoryTest : public ::testing::Test

--- a/category/execution/ethereum/core/contract/big_endian.hpp
+++ b/category/execution/ethereum/core/contract/big_endian.hpp
@@ -50,7 +50,7 @@ struct BigEndian
 
     [[nodiscard]] constexpr native_type native() const noexcept
     {
-        return bswap(std::bit_cast<native_type>(bytes));
+        return load_be<native_type>(bytes);
     }
 
     constexpr BigEndian<T> &operator=(T const &x) noexcept

--- a/category/execution/ethereum/core/contract/storage_array.hpp
+++ b/category/execution/ethereum/core/contract/storage_array.hpp
@@ -47,7 +47,7 @@ public:
         : state_{state}
         , address_{address}
         , length_{StorageVariable<u64_be>(state, address, slot)}
-        , start_index_{uint256_t::load_be(slot.bytes) + 1}
+        , start_index_{load_be<uint256_t>(slot) + 1}
     {
     }
 

--- a/category/execution/ethereum/core/contract/storage_variable.hpp
+++ b/category/execution/ethereum/core/contract/storage_variable.hpp
@@ -69,7 +69,7 @@ public:
     StorageVariable(State &state, Address const &address, bytes32_t const &key)
         : state_{state}
         , address_{address}
-        , offset_{uint256_t::load_be(key.bytes)}
+        , offset_{load_be<uint256_t>(key)}
     {
     }
 

--- a/category/execution/ethereum/evm.cpp
+++ b/category/execution/ethereum/evm.cpp
@@ -18,6 +18,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
@@ -46,7 +47,7 @@ namespace
 
     bool sender_has_balance(State &state, evmc_message const &msg) noexcept
     {
-        uint256_t const value = uint256_t::load_be(msg.value.bytes);
+        uint256_t const value = load_be<uint256_t>(msg.value);
         // for optimistic execution, we do NOT require the original balance to
         // match exactly, just add a lower bound constraint to suffice for this
         // debit
@@ -58,7 +59,7 @@ namespace
         State &state, EvmcHost<traits> &host, evmc_message const &msg,
         Address const &to)
     {
-        uint256_t const value = uint256_t::load_be(msg.value.bytes);
+        uint256_t const value = load_be<uint256_t>(msg.value);
         state.subtract_from_balance(msg.sender, value);
         state.add_to_balance(to, value);
         host.emit_native_transfer_event(msg.sender, to, value);

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -116,7 +116,7 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
         .memory_capacity = vm.message_memory_capacity(),
     };
     uint256_t const v{70'000'000'000'000'000}; // too much
-    store_be(m.value.bytes, v);
+    m.value = store_be_as<evmc::uint256be>(v);
 
     BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
@@ -180,7 +180,7 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
         .memory_capacity = vm.message_memory_capacity(),
     };
     uint256_t const v{70'000'000'000'000'000}; // too much balance required
-    store_be(m.value.bytes, v);
+    m.value = store_be_as<evmc::uint256be>(v);
 
     BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
@@ -349,7 +349,7 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
         .memory_capacity = vm.message_memory_capacity(),
     };
     uint256_t const v{70'000'000};
-    store_be(m.value.bytes, v);
+    m.value = store_be_as<evmc::uint256be>(v);
 
     BlockHashBufferFinalized const block_hash_buffer;
     NoopCallTracer call_tracer;
@@ -428,7 +428,7 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
         .memory_capacity = vm.message_memory_capacity(),
     };
     uint256_t const v{70'000'000};
-    store_be(m.value.bytes, v);
+    m.value = store_be_as<evmc::uint256be>(v);
 
     init_rb_for_test<typename TestFixture::Trait>(s, h, Address{m.sender});
     auto const result =

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -90,12 +90,11 @@ void set_beacon_root(State &state, BlockHeader const &header)
 
     if (state.account_exists(BEACON_ROOTS_ADDRESS)) {
         uint256_t timestamp{header.timestamp};
-        bytes32_t k1{
-            to_bytes(to_big_endian(timestamp % HISTORY_BUFFER_LENGTH))};
-        bytes32_t k2{to_bytes(to_big_endian(
-            timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH))};
+        bytes32_t k1{store_be_as<bytes32_t>(timestamp % HISTORY_BUFFER_LENGTH)};
+        bytes32_t k2{store_be_as<bytes32_t>(
+            timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH)};
         state.set_storage(
-            BEACON_ROOTS_ADDRESS, k1, to_bytes(to_big_endian(timestamp)));
+            BEACON_ROOTS_ADDRESS, k1, store_be_as<bytes32_t>(timestamp));
         state.set_storage(
             BEACON_ROOTS_ADDRESS, k2, header.parent_beacon_block_root.value());
     }

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -115,7 +115,7 @@ uint64_t ExecuteTransactionNoValidation<traits>::process_authorizations(
         // 1. Verify the chain ID is 0 or the ID of the current chain.
         auto const &chain_id = *auth_entry.sc.chain_id;
         auto const host_chain_id =
-            uint256_t::load_be(host.get_tx_context()->chain_id.bytes);
+            load_be<uint256_t>(host.get_tx_context()->chain_id);
 
         if (!(chain_id == 0 || chain_id == host_chain_id)) {
             continue;
@@ -215,14 +215,13 @@ evmc_message ExecuteTransactionNoValidation<traits>::to_message(
         .sender = sender_,
         .input_data = tx_.data.data(),
         .input_size = tx_.data.size(),
-        .value = {},
+        .value = store_be_as<evmc::uint256be>(tx_.value),
         .create2_salt = {},
         .code_address = to_address.second,
         .memory_handle = msg_memory.get(),
         .memory = msg_memory.get(),
         .memory_capacity = msg_memory_capacity,
     };
-    store_be(msg.value.bytes, tx_.value);
     return msg;
 }
 

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/byte_string.hpp>
+#include <category/core/int.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -75,14 +76,14 @@ Result<byte_string> system_call(
         .block_timestamp = static_cast<int64_t>(header.timestamp),
         .block_gas_limit = static_cast<int64_t>(header.gas_limit),
         .block_prev_randao = header.difficulty
-                                 ? to_bytes(to_big_endian(header.difficulty))
+                                 ? store_be_as<bytes32_t>(header.difficulty)
                                  : header.prev_randao,
-        .chain_id = to_bytes(to_big_endian(chain.get_chain_id())),
+        .chain_id = store_be_as<bytes32_t>(chain.get_chain_id()),
         .block_base_fee =
-            to_bytes(to_big_endian(header.base_fee_per_gas.value_or(0))),
+            store_be_as<bytes32_t>(header.base_fee_per_gas.value_or(0)),
         .blob_base_fee =
-            to_bytes(to_big_endian(get_base_fee_per_blob_gas<traits>(
-                header.excess_blob_gas.value_or(0)))),
+            store_be_as<bytes32_t>(get_base_fee_per_blob_gas<traits>(
+                header.excess_blob_gas.value_or(0))),
         .blob_hashes = nullptr,
         .blob_hashes_count = 0,
         .initcodes = nullptr,

--- a/category/execution/ethereum/rlp/decode.hpp
+++ b/category/execution/ethereum/rlp/decode.hpp
@@ -18,6 +18,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
 #include <category/core/rlp/config.hpp>
@@ -49,8 +50,7 @@ inline Result<T> decode_raw_num(byte_string_view const enc)
     T result{};
     std::memcpy(
         &as_bytes(result)[sizeof(T) - enc.size()], enc.data(), enc.size());
-    result = to_big_endian(result);
-    return result;
+    return bswap(result);
 }
 
 inline Result<size_t> decode_length(byte_string_view const enc)

--- a/category/execution/ethereum/rlp/encode2.hpp
+++ b/category/execution/ethereum/rlp/encode2.hpp
@@ -38,7 +38,7 @@ inline byte_string_view zeroless_view(byte_string_view const string_view)
 
 inline byte_string to_big_compact(unsigned_integral auto n)
 {
-    n = to_big_endian(n);
+    n = bswap(n);
     return byte_string(
         zeroless_view({reinterpret_cast<unsigned char *>(&n), sizeof(n)}));
 }

--- a/category/execution/ethereum/trace/call_tracer.cpp
+++ b/category/execution/ethereum/trace/call_tracer.cpp
@@ -17,6 +17,7 @@
 #include <category/core/assert.h>
 #include <category/core/basic_formatter.hpp>
 #include <category/core/config.hpp>
+#include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
@@ -139,7 +140,7 @@ void CallTracer::on_enter(evmc_message const &msg)
         .flags = msg.flags,
         .from = from,
         .to = to,
-        .value = uint256_t::load_be(msg.value.bytes),
+        .value = load_be<uint256_t>(msg.value),
         .gas = depth == 0 ? tx_.gas_limit : static_cast<uint64_t>(msg.gas),
         .gas_used = 0,
         .input = msg.input_data == nullptr

--- a/category/execution/ethereum/tx_context.cpp
+++ b/category/execution/ethereum/tx_context.cpp
@@ -36,22 +36,21 @@ evmc_tx_context get_tx_context(
     uint256_t const &chain_id)
 {
     return {
-        .tx_gas_price = to_bytes(to_big_endian(
-            gas_price<traits>(tx, hdr.base_fee_per_gas.value_or(0)))),
+        .tx_gas_price = store_be_as<bytes32_t>(
+            gas_price<traits>(tx, hdr.base_fee_per_gas.value_or(0))),
         .tx_origin = sender,
         .block_coinbase = hdr.beneficiary,
         .block_number = static_cast<int64_t>(hdr.number),
         .block_timestamp = static_cast<int64_t>(hdr.timestamp),
         .block_gas_limit = static_cast<int64_t>(hdr.gas_limit),
         .block_prev_randao = hdr.difficulty
-                                 ? to_bytes(to_big_endian(hdr.difficulty))
+                                 ? store_be_as<bytes32_t>(hdr.difficulty)
                                  : hdr.prev_randao,
-        .chain_id = to_bytes(to_big_endian(chain_id)),
+        .chain_id = store_be_as<bytes32_t>(chain_id),
         .block_base_fee =
-            to_bytes(to_big_endian(hdr.base_fee_per_gas.value_or(0))),
-        .blob_base_fee =
-            to_bytes(to_big_endian(get_base_fee_per_blob_gas<traits>(
-                hdr.excess_blob_gas.value_or(0)))),
+            store_be_as<bytes32_t>(hdr.base_fee_per_gas.value_or(0)),
+        .blob_base_fee = store_be_as<bytes32_t>(
+            get_base_fee_per_blob_gas<traits>(hdr.excess_blob_gas.value_or(0))),
         .blob_hashes = tx.blob_versioned_hashes.data(),
         .blob_hashes_count = tx.blob_versioned_hashes.size(),
         .initcodes = nullptr, // TODO

--- a/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_machine.cpp
@@ -1178,7 +1178,7 @@ namespace monad::staking::test
         auto const val_id = result.value();
 
         all_val_ids_.push_back(val_id);
-        if (uint256_t::load_be(value.bytes) <= MAX_DELEGABLE_STAKE) {
+        if (load_be<uint256_t>(value) <= MAX_DELEGABLE_STAKE) {
             MONAD_ASSERT(model_.val_execution(val_id).exists());
             auto const ins = delegable_val_ids_.insert(val_id.native());
             MONAD_ASSERT(ins);
@@ -1211,7 +1211,7 @@ namespace monad::staking::test
 
         auto const balance_after = model_.balance_of(STAKING_CA);
 
-        auto const stake = uint256_t::load_be(value.bytes);
+        auto const stake = load_be<uint256_t>(value);
 
         MONAD_ASSERT(balance_after - balance_before == stake);
 
@@ -1307,7 +1307,7 @@ namespace monad::staking::test
         auto result = model_.precompile_delegate<traits>(val_id, sender, value);
         MONAD_ASSERT(result.has_value());
 
-        if (uint256_t::load_be(value.bytes) == 0) {
+        if (load_be<uint256_t>(value) == 0) {
             return;
         }
 
@@ -1351,7 +1351,7 @@ namespace monad::staking::test
 
         auto const balance_after = model_.balance_of(STAKING_CA);
 
-        auto const stake = uint256_t::load_be(value.bytes);
+        auto const stake = load_be<uint256_t>(value);
 
         if (!stake) {
             return;
@@ -1965,7 +1965,7 @@ namespace monad::staking::test
         }
         auto const [val_id, sender, value] = *input;
 
-        auto const reward = uint256_t::load_be(value.bytes);
+        auto const reward = load_be<uint256_t>(value);
 
         auto const error_bound_before = model_.error_bound();
 

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/address.hpp>
+#include <category/core/int.hpp>
 #include <category/execution/ethereum/core/contract/abi_encode.hpp>
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
@@ -394,7 +395,7 @@ namespace monad::staking::test
                                : contract_.vars.epoch.load().native() + 1;
 
         add_delegator_stake(
-            val_id.native(), addr, epoch, uint256_t::load_be(value.bytes));
+            val_id.native(), addr, epoch, load_be<uint256_t>(value));
 
         val_id_to_historic_delegators_[val_id.native()].insert(addr);
 
@@ -420,7 +421,7 @@ namespace monad::staking::test
                                : contract_.vars.epoch.load().native() + 1;
 
         add_delegator_stake(
-            val_id.native(), sender, epoch, uint256_t::load_be(value.bytes));
+            val_id.native(), sender, epoch, load_be<uint256_t>(value));
 
         val_id_to_historic_delegators_[val_id.native()].insert(sender);
 
@@ -581,7 +582,7 @@ namespace monad::staking::test
         auto const input = encoder.encode_final();
         auto res = dispatch<traits>(input, sender, value);
         if (res.has_value()) {
-            auto const rew = uint256_t::load_be(value.bytes);
+            auto const rew = load_be<uint256_t>(value);
             distribute_reward(val_id, u256_be{rew});
             error_bound_ += 1;
         }
@@ -675,7 +676,7 @@ namespace monad::staking::test
     void StakingContractModel::pre_call(uint256_be_t const &value)
     {
         state_.push();
-        state_.add_to_balance(STAKING_CA, uint256_t::load_be(value.bytes));
+        state_.add_to_balance(STAKING_CA, load_be<uint256_t>(value));
     }
 
     template <typename T>

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -1162,7 +1162,7 @@ Result<byte_string> StakingContract::precompile_add_validator(
         return StakingError::InvalidInput;
     }
 
-    auto const stake = uint256_t::load_be(msg_value.bytes);
+    auto const stake = load_be<uint256_t>(msg_value);
     if (MONAD_UNLIKELY(stake < limits::min_auth_address_stake())) {
         return StakingError::InsufficientStake;
     }
@@ -1330,7 +1330,7 @@ Result<byte_string> StakingContract::precompile_delegate(
     if (MONAD_UNLIKELY(!input.empty())) {
         return StakingError::InvalidInput;
     }
-    auto const stake = uint256_t::load_be(msg_value.bytes);
+    auto const stake = load_be<uint256_t>(msg_value);
 
     if (MONAD_LIKELY(stake != 0)) {
         BOOST_OUTCOME_TRY(delegate<traits>(val_id, stake, msg_sender));
@@ -1578,7 +1578,7 @@ Result<byte_string> StakingContract::precompile_external_reward(
     byte_string_view input, Address const &sender,
     uint256_be_t const &msg_value)
 {
-    auto const external_reward = uint256_t::load_be(msg_value.bytes);
+    auto const external_reward = load_be<uint256_t>(msg_value);
     BOOST_OUTCOME_TRY(auto const val_id, abi_decode_fixed<u64_be>(input));
     if (MONAD_UNLIKELY(!input.empty())) {
         return StakingError::InvalidInput;

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -150,7 +150,7 @@ TEST_F(ReadValsetBeforeBoundary, get_this_epoch_valset)
     ASSERT_TRUE(set.has_value());
     EXPECT_EQ(set.value().size(), CONSENSUS_VALSET_LENGTH);
     for (auto const &validator : set.value()) {
-        EXPECT_EQ(uint256_t::load_be(validator.stake.bytes), CONSENSUS_STAKE);
+        EXPECT_EQ(load_be<uint256_t>(validator.stake), CONSENSUS_STAKE);
     }
 }
 
@@ -188,7 +188,7 @@ TEST_F(ReadValsetAfterBoundary, get_this_epoch_valset)
     ASSERT_TRUE(set.has_value());
     EXPECT_EQ(set.value().size(), SNAPSHOT_VALSET_LENGTH);
     for (auto const &validator : set.value()) {
-        EXPECT_EQ(uint256_t::load_be(validator.stake.bytes), SNAPSHOT_STAKE);
+        EXPECT_EQ(load_be<uint256_t>(validator.stake), SNAPSHOT_STAKE);
     }
 }
 
@@ -200,7 +200,7 @@ TEST_F(ReadValsetAfterBoundary, get_next_epoch_valset)
     ASSERT_TRUE(set.has_value());
     EXPECT_EQ(set.value().size(), CONSENSUS_VALSET_LENGTH);
     for (auto const &validator : set.value()) {
-        EXPECT_EQ(uint256_t::load_be(validator.stake.bytes), CONSENSUS_STAKE);
+        EXPECT_EQ(load_be<uint256_t>(validator.stake), CONSENSUS_STAKE);
     }
 }
 

--- a/category/execution/monad/staking/util/consensus_view.cpp
+++ b/category/execution/monad/staking/util/consensus_view.cpp
@@ -26,7 +26,7 @@ ConsensusView::ConsensusView(
     State &state, Address const &address, bytes32_t const &key)
     : state_{state}
     , address_{address}
-    , key_{uint256_t::load_be(key.bytes)}
+    , key_{load_be<uint256_t>(key)}
 {
 }
 

--- a/category/execution/monad/staking/util/delegator.cpp
+++ b/category/execution/monad/staking/util/delegator.cpp
@@ -25,7 +25,7 @@ MONAD_STAKING_NAMESPACE_BEGIN
 Delegator::Delegator(State &state, Address const &address, bytes32_t const key)
     : state_{state}
     , address_{address}
-    , key_{uint256_t::load_be(key.bytes)}
+    , key_{load_be<uint256_t>(key)}
 {
 }
 

--- a/category/execution/monad/staking/util/val_execution.cpp
+++ b/category/execution/monad/staking/util/val_execution.cpp
@@ -26,7 +26,7 @@ ValExecution::ValExecution(
     State &state, Address const &address, bytes32_t const key)
     : state_{state}
     , address_{address}
-    , key_{uint256_t::load_be(key.bytes)}
+    , key_{load_be<uint256_t>(key)}
 {
 }
 

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -3498,17 +3498,17 @@ TEST_F(EthCallFixture, prestate_override_state)
     auto const code_hash = to_bytes(keccak256(bytecode_view));
     auto const compiled_code = vm::make_shared_intercode(bytecode_view);
 
-    bytes32_t const storage_key = to_bytes(to_big_endian(uint256_t{0}));
-    bytes32_t const storage_value = to_bytes(to_big_endian(uint256_t{64}));
+    bytes32_t const storage_key = store_be_as<bytes32_t>(uint256_t{0});
+    bytes32_t const storage_value = store_be_as<bytes32_t>(uint256_t{64});
 
-    bytes32_t const other_storage_key = to_bytes(to_big_endian(uint256_t{1}));
+    bytes32_t const other_storage_key = store_be_as<bytes32_t>(uint256_t{1});
     bytes32_t const other_storage_value =
-        to_bytes(to_big_endian(uint256_t{128}));
+        store_be_as<bytes32_t>(uint256_t{128});
 
     bytes32_t const untouched_storage_key =
-        to_bytes(to_big_endian(uint256_t{2}));
+        store_be_as<bytes32_t>(uint256_t{2});
     bytes32_t const untouched_storage_value =
-        to_bytes(to_big_endian(uint256_t{256}));
+        store_be_as<bytes32_t>(uint256_t{256});
 
     StateDeltas deltas{
         {CONTRACT_ADDR,
@@ -3531,10 +3531,8 @@ TEST_F(EthCallFixture, prestate_override_state)
         BlockHeader{.number = 0});
 
     auto const storage = tdb.read_storage(
-        CONTRACT_ADDR,
-        Incarnation{0, 0},
-        to_bytes(to_big_endian(uint256_t{0})));
-    ASSERT_EQ(storage, to_bytes(to_big_endian(uint256_t{uint64_t{64}})));
+        CONTRACT_ADDR, Incarnation{0, 0}, store_be_as<bytes32_t>(uint256_t{0}));
+    ASSERT_EQ(storage, store_be_as<bytes32_t>(uint256_t{uint64_t{64}}));
 
     for (uint64_t i = 1; i < 256; ++i) {
         commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
@@ -3607,7 +3605,7 @@ TEST_F(EthCallFixture, prestate_override_state)
             result.bytes, ctx_state.result->output_data, sizeof(bytes32_t));
 
         bytes32_t const expected =
-            to_bytes(to_big_endian(uint256_t{uint64_t{128}}));
+            store_be_as<bytes32_t>(uint256_t{uint64_t{128}});
 
         EXPECT_EQ(result, expected);
 
@@ -3689,7 +3687,7 @@ TEST_F(EthCallFixture, prestate_override_state)
             result.bytes, ctx_statediff.result->output_data, sizeof(bytes32_t));
 
         bytes32_t const expected =
-            to_bytes(to_big_endian(uint256_t{uint64_t{192}}));
+            store_be_as<bytes32_t>(uint256_t{uint64_t{192}});
 
         EXPECT_EQ(result, expected);
 
@@ -6396,7 +6394,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
     EXPECT_EQ(output[1]["calls"][0]["status"], "0x1");
 
     auto const expected_half = uint256_t{5} * WEI_PER_MON;
-    auto const expected_bytes = expected_half.store_be<bytes32_t>();
+    auto const expected_bytes = store_be_as<bytes32_t>(expected_half);
     auto const expected_return_data =
         std::format("0x{}", to_hex(expected_bytes));
     EXPECT_EQ(output[1]["calls"][0]["returnData"], expected_return_data);
@@ -6599,7 +6597,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
     EXPECT_EQ(logs[0]["topics"][0], std::format("0x{}", to_hex(transfer_sig)));
     EXPECT_EQ(logs[0]["topics"][1], format_address_topic(sender));
     EXPECT_EQ(logs[0]["topics"][2], format_address_topic(forwarder_addr));
-    auto const ten_mon = (uint256_t{10} * WEI_PER_MON).store_be<bytes32_t>();
+    auto const ten_mon = store_be_as<bytes32_t>(uint256_t{10} * WEI_PER_MON);
     EXPECT_EQ(logs[0]["data"], std::format("0x{}", to_hex(ten_mon)));
 
     // Log 1: forwarder -> sink (5 MON)
@@ -6609,7 +6607,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
     EXPECT_EQ(logs[1]["topics"][0], std::format("0x{}", to_hex(transfer_sig)));
     EXPECT_EQ(logs[1]["topics"][1], format_address_topic(forwarder_addr));
     EXPECT_EQ(logs[1]["topics"][2], format_address_topic(sink));
-    auto const five_mon = (uint256_t{5} * WEI_PER_MON).store_be<bytes32_t>();
+    auto const five_mon = store_be_as<bytes32_t>(uint256_t{5} * WEI_PER_MON);
     EXPECT_EQ(logs[1]["data"], std::format("0x{}", to_hex(five_mon)));
 
     monad_block_override_vec_destroy(bo);
@@ -6639,7 +6637,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
     auto const code_hash = to_bytes(keccak256(code));
     auto const icode = vm::make_shared_intercode(code);
 
-    bytes32_t const unlock_time = uint256_t{512}.store_be<bytes32_t>();
+    bytes32_t const unlock_time = store_be_as<bytes32_t>(uint256_t{512});
 
     commit_sequential(
         tdb,

--- a/category/rpc/overrides.cpp
+++ b/category/rpc/overrides.cpp
@@ -16,6 +16,7 @@
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/rpc/overrides.h>
@@ -71,7 +72,7 @@ void set_override_balance(
 
     MONAD_ASSERT(balance);
     MONAD_ASSERT(balance_len == sizeof(uint256_t));
-    m->override_sets[address].balance = uint256_t::load_be_unsafe(balance);
+    m->override_sets[address].balance = load_be_unsafe<uint256_t>(balance);
 }
 
 void set_override_nonce(
@@ -301,7 +302,7 @@ void set_block_override_base_fee_per_gas(
     MONAD_ASSERT(fee);
     MONAD_ASSERT(fee_len == sizeof(uint256_t));
     MONAD_ASSERT(!m->base_fee_per_gas.has_value());
-    m->base_fee_per_gas = uint256_t::load_be_unsafe(fee);
+    m->base_fee_per_gas = load_be_unsafe<uint256_t>(fee);
 }
 
 void add_block_override_withdrawal(

--- a/category/vm/compiler/ir/x86/emitter.cpp
+++ b/category/vm/compiler/ir/x86/emitter.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/cases.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
@@ -343,7 +344,7 @@ namespace monad::vm::compiler::native
         }
 
         std::array<uint8_t, 32> a;
-        x.store_le(a.data());
+        store_le(a.data(), x);
         int32_t const next_offset = static_cast<int32_t>(data_.size()) << 5;
         auto const [it, is_new] = sub32_.offmap.emplace(a, next_offset);
         if (is_new) {
@@ -425,7 +426,7 @@ namespace monad::vm::compiler::native
                 static_cast<size_t>(next_partial_index) < data_.size());
             static_assert(sizeof(size_t) >= sizeof(next_partial_index));
             auto &a = data_[static_cast<size_t>(next_partial_index)];
-            std::memcpy(a.as_bytes() + next_partial_sub_index, &x, N);
+            std::memcpy(as_bytes(a) + next_partial_sub_index, &x, N);
             partial_index_ = next_partial_index;
             partial_sub_index_ = next_partial_sub_index + n;
         }
@@ -2281,8 +2282,7 @@ namespace monad::vm::compiler::native
     void Emitter::mov_stack_elem_to_mem_be(StackElemRef const e, x86::Mem m)
     {
         if (e->literal()) {
-            auto const x =
-                uint256_t::load_be_unsafe(e->literal()->value.as_bytes());
+            auto const x = bswap(e->literal()->value);
             mov_literal_to_mem<false>(Literal{x}, m);
         }
         else if (e->general_reg()) {
@@ -4411,7 +4411,7 @@ namespace monad::vm::compiler::native
         auto const tmp_y = avx_reg_to_ymm(*tmp->avx_reg());
 
         uint256_t shuf = std::numeric_limits<uint256_t>::max();
-        std::memset(shuf.as_bytes() + ix + 1, ix, static_cast<size_t>(31 - ix));
+        std::memset(as_bytes(shuf) + ix + 1, ix, static_cast<size_t>(31 - ix));
         as_.vmovaps(tmp_y, rodata_.add32(shuf));
         // tmp_y[0] = -1
         // tmp_y[1] = -1

--- a/category/vm/fuzzing/generator/generator.hpp
+++ b/category/vm/fuzzing/generator/generator.hpp
@@ -19,10 +19,10 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/cases.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/fuzzing/generator/choice.hpp>
 #include <category/vm/fuzzing/generator/instruction_data.hpp>
-#include <category/vm/runtime/transmute.hpp>
 
 #include <evmc/evmc.hpp>
 
@@ -288,7 +288,7 @@ namespace monad::vm::fuzzing
         auto ret = Address{};
         auto const value = random_constant<192>(eng);
 
-        auto const *bytes = value.value.as_bytes();
+        auto const *bytes = as_bytes(value.value);
         std::copy_n(bytes, 20, &ret.bytes[0]);
 
         return ret;
@@ -731,7 +731,7 @@ namespace monad::vm::fuzzing
     {
         program.push_back(PUSH32);
 
-        auto const *bs = c.value.as_bytes();
+        auto const *bs = as_bytes(c.value);
         for (auto i = 31; i >= 0; --i) {
             program.push_back(bs[i]);
         }
@@ -865,7 +865,7 @@ namespace monad::vm::fuzzing
                 [&](Constant const &c) {
                     program.push_back(PUSH32);
 
-                    auto const *bs = c.value.as_bytes();
+                    auto const *bs = as_bytes(c.value);
                     for (auto i = 31; i >= 0; --i) {
                         program.push_back(bs[i]);
                     }
@@ -908,7 +908,7 @@ namespace monad::vm::fuzzing
 
                     program.push_back(PUSH0 + static_cast<uint8_t>(byte_size));
 
-                    auto const *bs = safe_value.value.as_bytes();
+                    auto const *bs = as_bytes(safe_value.value);
                     for (auto i = 0u; i < byte_size; ++i) {
                         program.push_back(bs[byte_size - 1 - i]);
                     }
@@ -1215,10 +1215,9 @@ namespace monad::vm::fuzzing
             .sender = sender,
             .input_data = input_data,
             .input_size = input_size,
-            .value = static_cast<evmc::bytes32>(
-                value.template store_be<bytes32_t>()),
+            .value = static_cast<evmc::bytes32>(store_be_as<bytes32_t>(value)),
             .create2_salt =
-                static_cast<evmc::bytes32>(salt.template store_be<bytes32_t>()),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(salt)),
             .code_address = target,
             .memory_handle = memory_handle,
             .memory = memory_handle,

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/evm/traits.hpp>
@@ -899,7 +900,7 @@ namespace monad::vm::interpreter
     {
         check_requirements<CALLVALUE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
-        push(stack_top, runtime::uint256_from_bytes32(ctx.env.value));
+        push(stack_top, load_be<uint256_t>(ctx.env.value));
 
         MONAD_VM_NEXT(CALLVALUE);
     }
@@ -992,9 +993,7 @@ namespace monad::vm::interpreter
     {
         check_requirements<GASPRICE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
-        push(
-            stack_top,
-            runtime::uint256_from_bytes32(ctx.env.tx_context->tx_gas_price));
+        push(stack_top, load_be<uint256_t>(ctx.env.tx_context->tx_gas_price));
 
         MONAD_VM_NEXT(GASPRICE);
     }
@@ -1153,8 +1152,7 @@ namespace monad::vm::interpreter
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
         push(
             stack_top,
-            runtime::uint256_from_bytes32(
-                ctx.env.tx_context->block_prev_randao));
+            load_be<uint256_t>(ctx.env.tx_context->block_prev_randao));
 
         MONAD_VM_NEXT(DIFFICULTY);
     }
@@ -1180,9 +1178,7 @@ namespace monad::vm::interpreter
     {
         check_requirements<CHAINID, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
-        push(
-            stack_top,
-            runtime::uint256_from_bytes32(ctx.env.tx_context->chain_id));
+        push(stack_top, load_be<uint256_t>(ctx.env.tx_context->chain_id));
 
         MONAD_VM_NEXT(CHAINID);
     }
@@ -1213,9 +1209,7 @@ namespace monad::vm::interpreter
     {
         check_requirements<BASEFEE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
-        push(
-            stack_top,
-            runtime::uint256_from_bytes32(ctx.env.tx_context->block_base_fee));
+        push(stack_top, load_be<uint256_t>(ctx.env.tx_context->block_base_fee));
 
         MONAD_VM_NEXT(BASEFEE);
     }
@@ -1246,9 +1240,7 @@ namespace monad::vm::interpreter
     {
         check_requirements<BLOBBASEFEE, traits>(
             ctx, analysis, stack_bottom, stack_top, gas_remaining);
-        push(
-            stack_top,
-            runtime::uint256_from_bytes32(ctx.env.tx_context->blob_base_fee));
+        push(stack_top, load_be<uint256_t>(ctx.env.tx_context->blob_base_fee));
 
         MONAD_VM_NEXT(BLOBBASEFEE);
     }
@@ -1731,7 +1723,7 @@ namespace monad::vm::interpreter
         {
             for (auto *result_loc : {&ctx.result.offset, &ctx.result.size}) {
                 std::copy_n(
-                    stack_top->as_bytes(),
+                    as_bytes(*stack_top),
                     32,
                     reinterpret_cast<uint8_t *>(result_loc));
 

--- a/category/vm/runtime/call.cpp
+++ b/category/vm/runtime/call.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/delegation.hpp>
@@ -208,7 +209,7 @@ namespace monad::vm::runtime
             *gas_ptr,
             *address_ptr,
             *value_ptr != 0,
-            bytes32_from_uint256(*value_ptr),
+            store_be_as<bytes32_t>(*value_ptr),
             *args_offset_ptr,
             *args_size_ptr,
             *ret_offset_ptr,
@@ -233,7 +234,7 @@ namespace monad::vm::runtime
             *gas_ptr,
             *address_ptr,
             *value_ptr != 0,
-            bytes32_from_uint256(*value_ptr),
+            store_be_as<bytes32_t>(*value_ptr),
             *args_offset_ptr,
             *args_size_ptr,
             *ret_offset_ptr,

--- a/category/vm/runtime/create.cpp
+++ b/category/vm/runtime/create.cpp
@@ -14,6 +14,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/delegation.hpp>
@@ -102,9 +104,9 @@ namespace monad::vm::runtime
             .sender = ctx->env.recipient,
             .input_data = (*size > 0) ? ctx->memory.data + *offset : nullptr,
             .input_size = *size,
-            .value = static_cast<evmc::bytes32>(bytes32_from_uint256(value)),
+            .value = static_cast<evmc::bytes32>(store_be_as<bytes32_t>(value)),
             .create2_salt =
-                static_cast<evmc::bytes32>(bytes32_from_uint256(salt_word)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(salt_word)),
             .code_address = {},
             .memory_handle = ctx->memory.data_handle,
             .memory = ctx->memory.data + ctx->memory.size,

--- a/category/vm/runtime/data.cpp
+++ b/category/vm/runtime/data.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -46,7 +47,7 @@ namespace monad::vm::runtime
 
         auto const balance = static_cast<bytes32_t>(
             ctx->host->get_balance(ctx->context, &address));
-        *result_ptr = uint256_from_bytes32(balance);
+        *result_ptr = load_be<uint256_t>(balance);
     }
 
     EXPLICIT_TRAITS(balance);
@@ -206,7 +207,7 @@ namespace monad::vm::runtime
 
         auto const hash = static_cast<bytes32_t>(
             ctx->host->get_code_hash(ctx->context, &address));
-        *result_ptr = uint256_from_bytes32(hash);
+        *result_ptr = load_be<uint256_t>(hash);
     }
 
     EXPLICIT_TRAITS(extcodehash);

--- a/category/vm/runtime/environment.cpp
+++ b/category/vm/runtime/environment.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/runtime/environment.hpp>
 #include <category/vm/runtime/transmute.hpp>
@@ -43,7 +44,7 @@ namespace monad::vm::runtime
             block_number < tx_context.block_number) {
             auto const hash = static_cast<bytes32_t>(
                 ctx->host->get_block_hash(ctx->context, block_number));
-            *result_ptr = uint256_from_bytes32(hash);
+            *result_ptr = load_be<uint256_t>(hash);
         }
         else {
             *result_ptr = 0;
@@ -54,7 +55,7 @@ namespace monad::vm::runtime
     {
         auto const balance = static_cast<bytes32_t>(
             ctx->host->get_balance(ctx->context, &ctx->env.recipient));
-        *result_ptr = uint256_from_bytes32(balance);
+        *result_ptr = load_be<uint256_t>(balance);
     }
 
     void blobhash(
@@ -63,7 +64,7 @@ namespace monad::vm::runtime
     {
         auto const &c = *ctx->env.tx_context;
         *result_ptr = (*index < c.blob_hashes_count)
-                          ? uint256_from_bytes32(static_cast<bytes32_t>(
+                          ? load_be<uint256_t>(static_cast<bytes32_t>(
                                 c.blob_hashes[static_cast<size_t>(*index)]))
                           : 0;
     }

--- a/category/vm/runtime/keccak.hpp
+++ b/category/vm/runtime/keccak.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/bin.hpp>
@@ -42,6 +43,6 @@ namespace monad::vm::runtime
         }
 
         auto const hash = ethash::keccak256(ctx->memory.data + *offset, *size);
-        *result_ptr = uint256_t::load_be(hash.bytes);
+        *result_ptr = load_be<uint256_t>(hash);
     }
 }

--- a/category/vm/runtime/log.cpp
+++ b/category/vm/runtime/log.cpp
@@ -13,13 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/bin.hpp>
 #include <category/vm/runtime/log.hpp>
-#include <category/vm/runtime/transmute.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <evmc/evmc.h>
@@ -77,7 +78,7 @@ namespace monad::vm::runtime
             *offset_ptr,
             *size_ptr,
             {{
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic1_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic1_ptr)),
             }});
     }
 
@@ -93,8 +94,8 @@ namespace monad::vm::runtime
             *offset_ptr,
             *size_ptr,
             {{
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic1_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic2_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic1_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic2_ptr)),
             }});
     }
 
@@ -111,9 +112,9 @@ namespace monad::vm::runtime
             *offset_ptr,
             *size_ptr,
             {{
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic1_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic2_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic3_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic1_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic2_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic3_ptr)),
             }});
     }
 
@@ -130,10 +131,10 @@ namespace monad::vm::runtime
             *offset_ptr,
             *size_ptr,
             {{
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic1_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic2_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic3_ptr)),
-                static_cast<evmc::bytes32>(bytes32_from_uint256(*topic4_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic1_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic2_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic3_ptr)),
+                static_cast<evmc::bytes32>(store_be_as<bytes32_t>(*topic4_ptr)),
             }});
     }
 

--- a/category/vm/runtime/memory.hpp
+++ b/category/vm/runtime/memory.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/bin.hpp>
@@ -30,7 +31,7 @@ namespace monad::vm::runtime
     {
         auto const offset = ctx->get_memory_offset(*offset_ptr);
         ctx->expand_memory<traits>(offset + bin<32>);
-        *result_ptr = uint256_t::load_be_unsafe(ctx->memory.data + *offset);
+        *result_ptr = load_be_unsafe<uint256_t>(ctx->memory.data + *offset);
     }
 
     template <Traits traits>
@@ -39,7 +40,7 @@ namespace monad::vm::runtime
     {
         auto const offset = ctx->get_memory_offset(*offset_ptr);
         ctx->expand_memory<traits>(offset + bin<32>);
-        value_ptr->store_be(ctx->memory.data + *offset);
+        store_be(ctx->memory.data + *offset, *value_ptr);
     }
 
     template <Traits traits>
@@ -48,7 +49,7 @@ namespace monad::vm::runtime
     {
         auto const offset = ctx->get_memory_offset(*offset_ptr);
         ctx->expand_memory<traits>(offset + bin<1>);
-        ctx->memory.data[*offset] = value_ptr->as_bytes()[0];
+        ctx->memory.data[*offset] = as_bytes(*value_ptr)[0];
     }
 
     template <Traits traits>

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -21,7 +22,6 @@
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/storage.hpp>
 #include <category/vm/runtime/storage_costs.hpp>
-#include <category/vm/runtime/transmute.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <evmc/evmc.h>
@@ -36,7 +36,7 @@ namespace monad::vm::runtime
     template <Traits traits>
     void sload(Context *ctx, uint256_t *result_ptr, uint256_t const *key_ptr)
     {
-        auto key = bytes32_from_uint256(*key_ptr);
+        auto key = store_be_as<bytes32_t>(*key_ptr);
 
         if constexpr (traits::eip_2929_active()) {
             auto const access_status = ctx->host->access_storage(
@@ -49,7 +49,7 @@ namespace monad::vm::runtime
         auto const value =
             ctx->host->get_storage(ctx->context, &ctx->env.recipient, &key);
 
-        *result_ptr = uint256_from_bytes32(value);
+        *result_ptr = load_be<uint256_t>(value);
     }
 
     EXPLICIT_TRAITS(sload);
@@ -73,8 +73,8 @@ namespace monad::vm::runtime
             }
         }
 
-        auto key = bytes32_from_uint256(*key_ptr);
-        auto value = bytes32_from_uint256(*value_ptr);
+        auto key = store_be_as<bytes32_t>(*key_ptr);
+        auto value = store_be_as<bytes32_t>(*value_ptr);
 
         auto access_status = EVMC_ACCESS_COLD;
         if constexpr (traits::eip_2929_active()) {
@@ -110,7 +110,7 @@ namespace monad::vm::runtime
         auto const magic = uint256_t{0xdeb009};
         auto const base = (magic + base_offset) * 1024;
         if (offset == 0) {
-            auto const base_key = bytes32_from_uint256(base);
+            auto const base_key = store_be_as<bytes32_t>(base);
             auto const base_value = ctx->host->get_transient_storage(
                 ctx->context, &ctx->env.recipient, &base_key);
             if (base_value != bytes32_t{}) {
@@ -121,12 +121,12 @@ namespace monad::vm::runtime
             }
         }
         for (uint64_t i = 0; i < stack_size; ++i) {
-            auto const key = bytes32_from_uint256(base + i + offset);
+            auto const key = store_be_as<bytes32_t>(base + i + offset);
             auto const &x = stack[static_cast<int64_t>(-i) - 1];
             // Make sure we do not store zero, because incorrect non-zero is
             // more likely to be noticed, due to zero being the default:
             auto const s = x < magic ? x + 1 : x;
-            auto const value = bytes32_from_uint256(s);
+            auto const value = store_be_as<bytes32_t>(s);
             ctx->host->set_transient_storage(
                 ctx->context, &ctx->env.recipient, &key, &value);
         }

--- a/category/vm/runtime/storage.hpp
+++ b/category/vm/runtime/storage.hpp
@@ -16,7 +16,8 @@
 #pragma once
 
 #include <category/core/assert.h>
-#include <category/vm/runtime/transmute.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <cstdint>
@@ -35,12 +36,12 @@ namespace monad::vm::runtime
         Context *const ctx, uint256_t *const result_ptr,
         uint256_t const *const key_ptr)
     {
-        auto key = bytes32_from_uint256(*key_ptr);
+        auto key = store_be_as<bytes32_t>(*key_ptr);
 
         auto const value = ctx->host->get_transient_storage(
             ctx->context, &ctx->env.recipient, &key);
 
-        *result_ptr = uint256_from_bytes32(value);
+        *result_ptr = load_be<uint256_t>(value);
     }
 
     inline void tstore(
@@ -51,8 +52,8 @@ namespace monad::vm::runtime
             ctx->exit(StatusCode::Error);
         }
 
-        auto key = bytes32_from_uint256(*key_ptr);
-        auto val = bytes32_from_uint256(*val_ptr);
+        auto key = store_be_as<bytes32_t>(*key_ptr);
+        auto val = store_be_as<bytes32_t>(*val_ptr);
 
         ctx->host->set_transient_storage(
             ctx->context, &ctx->env.recipient, &key, &val);

--- a/category/vm/runtime/transmute.hpp
+++ b/category/vm/runtime/transmute.hpp
@@ -18,6 +18,7 @@
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 
 #include <evmc/evmc.h>
@@ -48,7 +49,7 @@ namespace monad::vm::runtime
     uint256_load_bounded_le(uint8_t const *const bytes, int64_t const max_len)
     {
         if (MONAD_LIKELY(max_len >= 32)) {
-            return uint256_t::load_le_unsafe(bytes);
+            return load_le_unsafe<uint256_t>(bytes);
         }
         return uint256_t{monad_vm_runtime_load_bounded_le(bytes, max_len)};
     }
@@ -57,21 +58,13 @@ namespace monad::vm::runtime
     inline uint256_t
     uint256_load_bounded_be(uint8_t const *const bytes, int64_t const max_len)
     {
-        return uint256_load_bounded_le(bytes, max_len).to_be();
-    }
-
-    [[gnu::always_inline]]
-    inline bytes32_t bytes32_from_uint256(uint256_t const &x)
-    {
-        bytes32_t ret;
-        x.store_be(ret.bytes);
-        return ret;
+        return bswap(uint256_load_bounded_le(bytes, max_len));
     }
 
     [[gnu::always_inline]]
     inline Address address_from_uint256(uint256_t const &x)
     {
-        auto const *bytes = x.as_bytes();
+        auto const *bytes = as_bytes(x);
 
         uint64_t t2;
         std::memcpy(&t2, bytes, 8);
@@ -90,12 +83,6 @@ namespace monad::vm::runtime
         std::memcpy(ret.bytes + 4, &t1, 8);
         std::memcpy(ret.bytes + 12, &t2, 8);
         return ret;
-    }
-
-    [[gnu::always_inline]]
-    inline uint256_t uint256_from_bytes32(bytes32_t const &x)
-    {
-        return uint256_t::load_be(x.bytes);
     }
 
     [[gnu::always_inline]]

--- a/category/vm/utils/evm-as/compiler.hpp
+++ b/category/vm/utils/evm-as/compiler.hpp
@@ -19,6 +19,7 @@
 #include <category/core/assert.h>
 #include <category/core/cases.hpp>
 #include <category/core/hex.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/evm/traits.hpp>
@@ -192,7 +193,7 @@ namespace monad::vm::utils::evm_as
                         emit_byte(push.opcode);
                         // SAFETY: The buffer `imm_bytes` is
                         // large enough to hold an uint256_t.
-                        push.imm.store_be(imm_bytes.data());
+                        store_be(imm_bytes.data(), push.imm);
                         auto const n = push.n();
                         for (size_t i = 0; i < n; i++) {
                             emit_byte(imm_bytes[32 - n + i]);

--- a/cmd/vm/mce/mce.cpp
+++ b/cmd/vm/mce/mce.cpp
@@ -20,6 +20,7 @@
 #include <instrumentation_device.hpp>
 #include <stopwatch.hpp>
 
+#include <category/core/int.hpp>
 #include <category/core/log.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
@@ -150,7 +151,7 @@ static void dump_result(arguments const &args, evmc::Result const &result)
             object["result"] = json("");
         }
         else {
-            auto const x = uint256_t::load_be_unsafe(&result.output_data[0]);
+            auto const x = load_be_unsafe<uint256_t>(&result.output_data[0]);
             object["result"] = json(x.to_string(16));
         }
     }

--- a/test/vm/micro_benchmarks/main.cpp
+++ b/test/vm/micro_benchmarks/main.cpp
@@ -16,6 +16,7 @@
 #include "test_state.hpp"
 
 #include <category/core/address.hpp>
+#include <category/core/int.hpp>
 #include <category/vm/evm/revision.h>
 #include <category/vm/utils/evm-as/kernel-builder.hpp>
 
@@ -780,7 +781,7 @@ int main(int argc, char **argv)
             auto const off = KernelBuilder<traits>::free_memory_start;
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                uint256_t{off}.store_be(&cd[i]);
+                store_be(&cd[i], uint256_t{off});
             }
             return cd;
         })
@@ -800,8 +801,8 @@ int main(int argc, char **argv)
             auto const off = KernelBuilder<traits>::free_memory_start;
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                uint256_t{off + i * 2}.store_be(&cd[i]);
-                uint256_t{off + i * 2}.store_be(&cd[i + 32]);
+                store_be(&cd[i], uint256_t{off + i * 2});
+                store_be(&cd[i + 32], uint256_t{off + i * 2});
             }
             return cd;
         })
@@ -833,7 +834,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(4'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                rand_uint256().store_be(&cd[i]);
+                store_be(&cd[i], rand_uint256());
             }
             return cd;
         })
@@ -850,8 +851,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(100'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                (rand_uint256() & 31).store_be(&cd[i]);
-                rand_uint256().store_be(&cd[i + 32]);
+                store_be(&cd[i], (rand_uint256() & 31));
+                store_be(&cd[i + 32], rand_uint256());
             }
             return cd;
         })
@@ -869,8 +870,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                uint256_t{3}.store_be(&cd[i]);
-                uint256_t{-1, -1, -1, -1}.store_be(&cd[i + 32]);
+                store_be(&cd[i], uint256_t{3});
+                store_be(&cd[i + 32], uint256_t{-1, -1, -1, -1});
             }
             return cd;
         })
@@ -888,8 +889,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                uint256_t{3}.store_be(&cd[i]);
-                uint256_t{-1, -1, -1, -1}.store_be(&cd[i + 32]);
+                store_be(&cd[i], uint256_t{3});
+                store_be(&cd[i + 32], uint256_t{-1, -1, -1, -1});
             }
             return cd;
         })
@@ -908,8 +909,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                uint256_t{3}.store_be(&cd[i]);
-                uint256_t{-1, -1, -1, -1}.store_be(&cd[i + 32]);
+                store_be(&cd[i], uint256_t{3});
+                store_be(&cd[i + 32], uint256_t{-1, -1, -1, -1});
             }
             return cd;
         })
@@ -927,8 +928,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(100'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                (rand_uint256() & 255).store_be(&cd[i]);
-                rand_uint256().store_be(&cd[i + 32]);
+                store_be(&cd[i], (rand_uint256() & 255));
+                store_be(&cd[i + 32], rand_uint256());
             }
             return cd;
         })
@@ -946,8 +947,8 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 64) {
-                uint256_t{129}.store_be(&cd[i]);
-                uint256_t{-1, -1, -1, -1}.store_be(&cd[i + 32]);
+                store_be(&cd[i], uint256_t{129});
+                store_be(&cd[i + 32], uint256_t{-1, -1, -1, -1});
             }
             return cd;
         })
@@ -965,7 +966,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                rand_uint256().store_be(&cd[i]);
+                store_be(&cd[i], rand_uint256());
             }
             return cd;
         })
@@ -1025,7 +1026,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                uint256_t{77}.store_be(&cd[i]);
+                store_be(&cd[i], uint256_t{77});
             }
             return cd;
         })
@@ -1045,7 +1046,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                uint256_t{77}.store_be(&cd[i]);
+                store_be(&cd[i], uint256_t{77});
             }
             return cd;
         })
@@ -1064,7 +1065,7 @@ int main(int argc, char **argv)
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 100 * 32) {
                 for (size_t j = 0; j < 100; ++j) {
-                    uint256_t{j}.store_be(&cd[i + 32 * j]);
+                    store_be(&cd[i + 32 * j], uint256_t{j});
                 }
             }
             return cd;
@@ -1086,7 +1087,7 @@ int main(int argc, char **argv)
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 100 * 32) {
                 for (size_t j = 0; j < 100; ++j) {
-                    uint256_t{j}.store_be(&cd[i + 32 * j]);
+                    store_be(&cd[i + 32 * j], uint256_t{j});
                 }
             }
             return cd;
@@ -1105,7 +1106,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                uint256_t{22}.store_be(&cd[i]);
+                store_be(&cd[i], uint256_t{22});
             }
             return cd;
         })
@@ -1125,7 +1126,7 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 32) {
-                uint256_t{22}.store_be(&cd[i]);
+                store_be(&cd[i], uint256_t{22});
             }
             return cd;
         })
@@ -1144,7 +1145,7 @@ int main(int argc, char **argv)
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 30 * 32) {
                 for (size_t j = 0; j < 30; ++j) {
-                    uint256_t{j}.store_be(&cd[i + 32 * j]);
+                    store_be(&cd[i + 32 * j], uint256_t{j});
                 }
             }
             return cd;
@@ -1166,7 +1167,7 @@ int main(int argc, char **argv)
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 30 * 32) {
                 for (size_t j = 0; j < 30; ++j) {
-                    uint256_t{j}.store_be(&cd[i + 32 * j]);
+                    store_be(&cd[i + 32 * j], uint256_t{j});
                 }
             }
             return cd;
@@ -1185,9 +1186,9 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += 96) {
-                uint256_t{0}.store_be(&cd[i]); // value
-                uint256_t{32}.store_be(&cd[i + 32]); // offset
-                uint256_t{32}.store_be(&cd[i + 64]); // size
+                store_be(&cd[i], uint256_t{0}); // value
+                store_be(&cd[i + 32], uint256_t{32}); // offset
+                store_be(&cd[i + 64], uint256_t{32}); // size
             }
             return cd;
         })
@@ -1204,13 +1205,13 @@ int main(int argc, char **argv)
         .make_calldata([](size_t num_inputs) {
             std::vector<uint8_t> cd(10'000 * num_inputs * 32, 0);
             for (size_t i = 0; i < cd.size(); i += num_inputs * 32) {
-                uint256_t{100'000}.store_be(&cd[i]); // gas
-                uint256_t{0}.store_be(&cd[i + 32]); // address
-                uint256_t{0}.store_be(&cd[i + 64]); // value
-                uint256_t{0}.store_be(&cd[i + 96]); // argsOffset
-                uint256_t{64}.store_be(&cd[i + 128]); // argsSize
-                uint256_t{64}.store_be(&cd[i + 160]); // retOffset
-                uint256_t{32}.store_be(&cd[i + 192]); // retSize
+                store_be(&cd[i], uint256_t{100'000}); // gas
+                store_be(&cd[i + 32], uint256_t{0}); // address
+                store_be(&cd[i + 64], uint256_t{0}); // value
+                store_be(&cd[i + 96], uint256_t{0}); // argsOffset
+                store_be(&cd[i + 128], uint256_t{64}); // argsSize
+                store_be(&cd[i + 160], uint256_t{64}); // retOffset
+                store_be(&cd[i + 192], uint256_t{32}); // retSize
             }
             return cd;
         })

--- a/test/vm/unit/async_compile_tests.cpp
+++ b/test/vm/unit/async_compile_tests.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/int.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/compiler.hpp>
 #include <category/vm/compiler/types.hpp>
@@ -114,8 +115,8 @@ TEST(async_compile_test, stress)
 
             auto const &ret = ctx->result;
             ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-            ASSERT_EQ(uint256_t::load_le(ret.offset), index);
-            ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), index);
+            ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
         }
     };
 

--- a/test/vm/unit/emitter_tests.cpp
+++ b/test/vm/unit/emitter_tests.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/address.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86/emitter.hpp>
@@ -302,7 +303,7 @@ namespace
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
         if (dup) {
-            ASSERT_EQ(uint256_t::load_le(ret.offset), result)
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), result)
                 << std::format(
                        "Left operand: {} ({}), ",
                        left,
@@ -313,7 +314,7 @@ namespace
                        Emitter::location_type_to_string(right_loc));
         }
         else {
-            ASSERT_EQ(uint256_t::load_le(ret.offset), 0)
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), 0)
                 << std::format(
                        "Left operand: {} ({}), ",
                        left,
@@ -323,7 +324,7 @@ namespace
                        right,
                        Emitter::location_type_to_string(right_loc));
         }
-        ASSERT_EQ(uint256_t::load_le(ret.size), result)
+        ASSERT_EQ(load_le<uint256_t>(ret.size), result)
             << std::format(
                    "Left operand: {} ({}), ",
                    left,
@@ -382,12 +383,12 @@ namespace
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
         if (dup) {
-            ASSERT_EQ(uint256_t::load_le(ret.offset), result);
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), result);
         }
         else {
-            ASSERT_EQ(uint256_t::load_le(ret.offset), 0);
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), 0);
         }
-        ASSERT_EQ(uint256_t::load_le(ret.size), result);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), result);
     }
 
     void pure_bin_instr_test(
@@ -481,7 +482,7 @@ namespace
         entry(&*ctx, stack_memory.get());
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-        ASSERT_EQ(uint256_t::load_le(ret.offset), expected_gas)
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), expected_gas)
             << std::format(
                    "Left operand: {} ({}), ",
                    left,
@@ -615,8 +616,8 @@ namespace
         auto stack_memory = test_stack_memory();
         entry(&*ctx, stack_memory.get());
 
-        ASSERT_EQ(uint256_t::load_le(ret.offset), 2);
-        ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), 2);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
     }
 
     basic_blocks::BasicBlocksIR get_jumpi_ir(
@@ -765,8 +766,8 @@ namespace
         else {
             ASSERT_EQ(ret.status, runtime::StatusCode::Success);
         }
-        ASSERT_EQ(uint256_t::load_le(ret.offset), dest);
-        ASSERT_EQ(uint256_t::load_le(ret.size), cond);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), dest);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), cond);
     }
 
     void block_epilogue_test(
@@ -851,8 +852,8 @@ namespace
         entry(&*ctx, stack_memory.get());
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-        ASSERT_EQ(uint256_t::load_le(ret.offset), 869);
-        ASSERT_EQ(uint256_t::load_le(ret.size), 2);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), 869);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), 2);
     }
 
     void runtime_test_12_arg_fun(
@@ -1087,8 +1088,8 @@ TEST(Emitter, return_)
     entry(&*ctx, nullptr);
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), offset_value);
-    ASSERT_EQ(uint256_t::load_le(ret.size), size_value);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), offset_value);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), size_value);
 }
 
 TEST(Emitter, revert)
@@ -1112,8 +1113,8 @@ TEST(Emitter, revert)
     entry(&*ctx, nullptr);
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Revert);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), offset_value);
-    ASSERT_EQ(uint256_t::load_le(ret.size), size_value);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), offset_value);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), size_value);
 }
 
 TEST(Emitter, mov_stack_index_to_avx_reg)
@@ -1173,8 +1174,8 @@ TEST(Emitter, mov_stack_index_to_avx_reg)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 2);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 2);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
 }
 
 TEST(Emitter, mov_literal_to_ymm)
@@ -1226,8 +1227,8 @@ TEST(Emitter, mov_literal_to_ymm)
             entry(&*ctx, stack_memory.get());
 
             ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-            ASSERT_EQ(uint256_t::load_le(ret.offset), lit1);
-            ASSERT_EQ(uint256_t::load_le(ret.size), lit0);
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), lit1);
+            ASSERT_EQ(load_le<uint256_t>(ret.size), lit0);
         }
     }
 }
@@ -1289,8 +1290,8 @@ TEST(Emitter, mov_stack_index_to_general_reg)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 2);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 2);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
 }
 
 TEST(Emitter, mov_stack_index_to_stack_offset)
@@ -1362,8 +1363,8 @@ TEST(Emitter, mov_stack_index_to_stack_offset)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 2);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 2);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
 }
 
 TEST(Emitter, discharge_deferred_comparison)
@@ -1414,8 +1415,8 @@ TEST(Emitter, discharge_deferred_comparison)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
 }
 
 TEST(Emitter, discharge_negated_deferred_comparison)
@@ -1505,8 +1506,8 @@ TEST(Emitter, discharge_negated_deferred_comparison)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 1);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 1);
 }
 
 TEST(Emitter, lt)
@@ -3169,8 +3170,8 @@ TEST(Emitter, call_runtime_12_arg_fun)
     auto stack_memory = test_stack_memory();
     entry(&*ctx, stack_memory.get());
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 5);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 5);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0);
 }
 
 TEST(Emitter, call_runtime_11_arg_fun)
@@ -3207,8 +3208,8 @@ TEST(Emitter, call_runtime_11_arg_fun)
     auto stack_memory = test_stack_memory();
     entry(&*ctx, stack_memory.get());
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 5);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 5);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0);
 }
 
 TEST(Emitter, runtime_exit)
@@ -3257,15 +3258,15 @@ TEST(Emitter, address)
         ctx->env.recipient.bytes[19 - i] = i + 1;
     }
     uint256_t result;
-    uint8_t *result_bytes = result.as_bytes();
+    uint8_t *result_bytes = as_bytes(result);
     for (uint8_t i = 0; i < 20; ++i) {
         result_bytes[i] = i + 1;
     }
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), result);
-    ASSERT_EQ(uint256_t::load_le(ret.size), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), result);
 }
 
 TEST(Emitter, origin)
@@ -3288,8 +3289,8 @@ TEST(Emitter, origin)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0x200);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0x200);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0x200);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0x200);
 }
 
 TEST(Emitter, gasprice)
@@ -3312,8 +3313,8 @@ TEST(Emitter, gasprice)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0x300);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0x300);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0x300);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0x300);
 }
 
 TEST(Emitter, gaslimit)
@@ -3336,8 +3337,8 @@ TEST(Emitter, gaslimit)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 4);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 4);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 4);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 4);
 }
 
 TEST(Emitter, coinbase)
@@ -3360,8 +3361,8 @@ TEST(Emitter, coinbase)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0x500);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0x500);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0x500);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0x500);
 }
 
 TEST(Emitter, timestamp)
@@ -3384,8 +3385,8 @@ TEST(Emitter, timestamp)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 6);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 6);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 6);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 6);
 }
 
 TEST(Emitter, number)
@@ -3408,8 +3409,8 @@ TEST(Emitter, number)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 7);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 7);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 7);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 7);
 }
 
 TEST(Emitter, prevrandao)
@@ -3433,8 +3434,8 @@ TEST(Emitter, prevrandao)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0x800);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0x800);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0x800);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0x800);
 }
 
 TEST(Emitter, chainid)
@@ -3457,8 +3458,8 @@ TEST(Emitter, chainid)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0x900);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0x900);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0x900);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0x900);
 }
 
 TEST(Emitter, basefee)
@@ -3481,8 +3482,8 @@ TEST(Emitter, basefee)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0xa00);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0xa00);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0xa00);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0xa00);
 }
 
 TEST(Emitter, blobbasefee)
@@ -3506,8 +3507,8 @@ TEST(Emitter, blobbasefee)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0xb00);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0xb00);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0xb00);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0xb00);
 }
 
 TEST(Emitter, caller)
@@ -3530,15 +3531,15 @@ TEST(Emitter, caller)
         ctx->env.sender.bytes[19 - i] = i + 1;
     }
     uint256_t result;
-    uint8_t *result_bytes = result.as_bytes();
+    uint8_t *result_bytes = as_bytes(result);
     for (uint8_t i = 0; i < 20; ++i) {
         result_bytes[i] = i + 1;
     }
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), result);
-    ASSERT_EQ(uint256_t::load_le(ret.size), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), result);
 }
 
 TEST(Emitter, calldatasize)
@@ -3561,8 +3562,8 @@ TEST(Emitter, calldatasize)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 5);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 5);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 5);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 5);
 }
 
 TEST(Emitter, returndatasize)
@@ -3585,8 +3586,8 @@ TEST(Emitter, returndatasize)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 6);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 6);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 6);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 6);
 }
 
 TEST(Emitter, msize)
@@ -3608,8 +3609,8 @@ TEST(Emitter, msize)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 0xffffffff);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 0xffffffff);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 0xffffffff);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 0xffffffff);
 
     // Override back to 0 to prevent memory invariant violation
     ctx->memory.size = 0;
@@ -3691,15 +3692,15 @@ static void memory_instructions_test_impl()
 
         if (m8) {
             ASSERT_EQ(
-                uint256_t::load_le(ret.offset),
+                load_le<uint256_t>(ret.offset),
                 uint256_t(0, 0, 0, uint64_t{1} << 56));
             ASSERT_EQ(
-                uint256_t::load_le(ret.size),
+                load_le<uint256_t>(ret.size),
                 uint256_t(0, 0, 0, uint64_t{1} << 56));
         }
         else {
-            ASSERT_EQ(uint256_t::load_le(ret.offset), uint256_t(1, 2, 3, 4));
-            ASSERT_EQ(uint256_t::load_le(ret.size), uint256_t(1, 2, 3, 4));
+            ASSERT_EQ(load_le<uint256_t>(ret.offset), uint256_t(1, 2, 3, 4));
+            ASSERT_EQ(load_le<uint256_t>(ret.size), uint256_t(1, 2, 3, 4));
         }
     };
 
@@ -3960,12 +3961,12 @@ TEST(Emitter, calldataload)
 
                 uint256_t expected;
                 std::memcpy(
-                    expected.as_bytes(),
+                    as_bytes(expected),
                     calldata + offset,
                     std::min(sizeof(expected), sizeof(calldata) - offset));
 
-                ASSERT_EQ(uint256_t::load_le(ret.offset), expected.to_be());
-                ASSERT_EQ(uint256_t::load_le(ret.size), expected.to_be());
+                ASSERT_EQ(load_be<uint256_t>(ret.offset), expected);
+                ASSERT_EQ(load_be<uint256_t>(ret.size), expected);
             }
         }
     }
@@ -4003,8 +4004,8 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
         entry(&*ctx, stack_memory.get());
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-        ASSERT_EQ(uint256_t::load_le(ret.offset), uint256_t{0xff} << 248);
-        ASSERT_EQ(uint256_t::load_le(ret.size), uint256_t{0xff} << 248);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), uint256_t{0xff} << 248);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), uint256_t{0xff} << 248);
     }
 
     for (auto loc : all_locations) {
@@ -4029,8 +4030,8 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
         entry(&*ctx, stack_memory.get());
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-        ASSERT_EQ(uint256_t::load_le(ret.offset), 0);
-        ASSERT_EQ(uint256_t::load_le(ret.size), 0);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), 0);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), 0);
     }
 
     for (auto loc : all_locations) {
@@ -4055,8 +4056,8 @@ TEST(Emitter, calldataload_not_bounded_by_bits)
         entry(&*ctx, stack_memory.get());
 
         ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-        ASSERT_EQ(uint256_t::load_le(ret.offset), 0);
-        ASSERT_EQ(uint256_t::load_le(ret.size), 0);
+        ASSERT_EQ(load_le<uint256_t>(ret.offset), 0);
+        ASSERT_EQ(load_le<uint256_t>(ret.size), 0);
     }
 }
 
@@ -4078,8 +4079,8 @@ TEST(Emitter, gas)
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 12);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 12);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 12);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 12);
 }
 
 TEST(Emitter, callvalue)
@@ -4102,15 +4103,15 @@ TEST(Emitter, callvalue)
         ctx->env.value.bytes[31 - i] = i + 1;
     }
     uint256_t result;
-    uint8_t *result_bytes = result.as_bytes();
+    uint8_t *result_bytes = as_bytes(result);
     for (uint8_t i = 0; i < 32; ++i) {
         result_bytes[i] = i + 1;
     }
 
     entry(&*ctx, nullptr);
 
-    ASSERT_EQ(uint256_t::load_le(ret.offset), result);
-    ASSERT_EQ(uint256_t::load_le(ret.size), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), result);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), result);
 }
 
 TEST(Emitter, iszero)
@@ -4373,8 +4374,8 @@ TEST(Emitter, SpillInMovGeneralRegToAvxRegRegression)
     entry(&*ctx, stack_memory.get());
 
     ASSERT_EQ(ret.status, runtime::StatusCode::Success);
-    ASSERT_EQ(uint256_t::load_le(ret.offset), 16);
-    ASSERT_EQ(uint256_t::load_le(ret.size), 15);
+    ASSERT_EQ(load_le<uint256_t>(ret.offset), 16);
+    ASSERT_EQ(load_le<uint256_t>(ret.size), 15);
 }
 
 TEST(Emitter, ReleaseSrcAndDestRegression)

--- a/test/vm/unit/evm-as_tests.cpp
+++ b/test/vm/unit/evm-as_tests.cpp
@@ -21,6 +21,7 @@
 #include "category/vm/utils/evm-as/compiler.hpp"
 #include "evmc/evmc.hpp"
 #include <category/core/address.hpp>
+#include <category/core/int.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86.hpp>
 #include <category/vm/evm/opcodes.hpp>
@@ -150,7 +151,7 @@ namespace
             [&]() { ASSERT_EQ(ret.status, runtime::StatusCode::Success); }();
 
             // TODO: artificial restriction on result offset and size.
-            return uint256_t::load_be_unsafe(ctx->memory.data);
+            return load_be_unsafe<uint256_t>(ctx->memory.data);
         }
     };
 
@@ -159,7 +160,7 @@ namespace
         auto const sz = 3000 * 32 * (args_size == 0 ? 1 : args_size);
         std::vector<uint8_t> ret(sz, 0);
         for (size_t i = 0; i < ret.size() / 32; ++i) {
-            uint256_t{i + 1}.store_be(&ret[i * 32]);
+            store_be(&ret[i * 32], uint256_t{i + 1});
         }
         return ret;
     }
@@ -1184,12 +1185,12 @@ TEST(EvmAs, KernelBuilderRepetitionCount)
 
         ASSERT_EQ(ctx->result.status, runtime::StatusCode::Success);
         ASSERT_EQ(
-            uint256_t::load_le(ctx->result.size), KB::resulting_memory_size);
+            load_le<uint256_t>(ctx->result.size), KB::resulting_memory_size);
         ASSERT_EQ(
-            uint256_t::load_le(ctx->result.offset), KB::free_memory_start);
+            load_le<uint256_t>(ctx->result.offset), KB::free_memory_start);
 
         auto const n =
-            uint256_t::load_be_unsafe(&ctx->memory.data[KB::free_memory_start]);
+            load_be_unsafe<uint256_t>(&ctx->memory.data[KB::free_memory_start]);
         ASSERT_EQ(
             n, KB::get_sequence_repetition_count(args_size, calldata.size()));
     };
@@ -1290,9 +1291,9 @@ TEST(EvmAs, KernelBuilderCalldata)
 
         ASSERT_EQ(ctx->result.status, runtime::StatusCode::Success);
         ASSERT_EQ(
-            uint256_t::load_le(ctx->result.size), KB::resulting_memory_size);
+            load_le<uint256_t>(ctx->result.size), KB::resulting_memory_size);
         ASSERT_EQ(
-            uint256_t::load_le(ctx->result.offset), KB::free_memory_start);
+            load_le<uint256_t>(ctx->result.offset), KB::free_memory_start);
     };
 
     for (size_t args_size = 0; args_size <= 10; ++args_size) {
@@ -1884,7 +1885,7 @@ struct fixed_bytes
     explicit fixed_bytes(uint256_t const &value)
     {
         uint8_t buf[32] = {};
-        value.store_be(buf);
+        store_be(buf, value);
         std::memcpy(bytes, buf + (32 - N), N);
     }
 

--- a/test/vm/unit/evm_fixture.hpp
+++ b/test/vm/unit/evm_fixture.hpp
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/vm/evm/revision.h>
 #include <category/vm/evm/switch_traits.hpp>
 #include <category/vm/runtime/allocator.hpp>
@@ -104,8 +106,7 @@ namespace monad::vm::compiler::test
             output_data_ = {};
 
             host_.accounts[msg_.sender].balance =
-                std::numeric_limits<uint256_t>::max()
-                    .template store_be<bytes32_t>();
+                store_be_as<bytes32_t>(std::numeric_limits<uint256_t>::max());
 
             msg_.gas = gas_limit;
             msg_.input_data = calldata.data();

--- a/test/vm/unit/evm_tests.cpp
+++ b/test/vm/unit/evm_tests.cpp
@@ -16,6 +16,7 @@
 #include "evm_fixture.hpp"
 
 #include <category/core/hex.hpp>
+#include <category/core/int.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/compiler.hpp>
 #include <category/vm/compiler/types.hpp>
@@ -41,6 +42,7 @@
 namespace fs = std::filesystem;
 
 using monad::EvmTraits;
+using monad::load_be_unsafe;
 using namespace monad::vm;
 using namespace monad::vm::compiler;
 using namespace monad::vm::compiler::test;
@@ -143,12 +145,14 @@ TYPED_TEST(VMTraitsTest, ResultDataAtBound)
     auto const return_size = [&] {
         switch (memory_version) {
         case runtime::Memory::Version::V1:
-            return (uint256_t{1} << runtime::Memory::offset_bits - 1).to_be();
+            return uint256_t{1} << runtime::Memory::offset_bits - 1;
         case runtime::Memory::Version::MIP3:
-            return uint256_t{8 * 1024 * 1024}.to_be();
+            return uint256_t{8 * 1024 * 1024};
         }
         MONAD_ABORT();
     }();
+    uint8_t return_size_be[32];
+    store_be(return_size_be, return_size);
 
     auto const impls = {
         TestFixture::Implementation::Compiler,
@@ -157,10 +161,10 @@ TYPED_TEST(VMTraitsTest, ResultDataAtBound)
         constexpr auto gas = 35'000'000'000;
         std::vector<uint8_t> bytecode;
         bytecode.push_back(PUSH32);
-        uint8_t const *const return_size_bytes = return_size.as_bytes();
-        for (size_t i = 0; i < 32; ++i) {
-            bytecode.push_back(return_size_bytes[i]);
-        }
+        bytecode.insert(
+            bytecode.end(),
+            std::begin(return_size_be),
+            std::end(return_size_be));
         bytecode.push_back(PUSH1);
         bytecode.push_back(0);
         bytecode.push_back(RETURN);
@@ -184,12 +188,14 @@ TYPED_TEST(VMTraitsTest, ResultDataOutOfBound)
     auto const return_size = [&] {
         switch (memory_version) {
         case runtime::Memory::Version::V1:
-            return (uint256_t{1} << runtime::Memory::offset_bits).to_be();
+            return uint256_t{1} << runtime::Memory::offset_bits;
         case runtime::Memory::Version::MIP3:
-            return uint256_t{8 * 1024 * 1024 + 1}.to_be();
+            return uint256_t{8 * 1024 * 1024 + 1};
         }
         MONAD_ABORT();
     }();
+    uint8_t return_size_be[32];
+    store_be(return_size_be, return_size);
 
     auto const impls = {
         TestFixture::Implementation::Compiler,
@@ -198,10 +204,10 @@ TYPED_TEST(VMTraitsTest, ResultDataOutOfBound)
         constexpr auto gas = 35'000'000'000;
         std::vector<uint8_t> bytecode;
         bytecode.push_back(PUSH32);
-        uint8_t const *const return_size_bytes = return_size.as_bytes();
-        for (size_t i = 0; i < 32; ++i) {
-            bytecode.push_back(return_size_bytes[i]);
-        }
+        bytecode.insert(
+            bytecode.end(),
+            std::begin(return_size_be),
+            std::end(return_size_be));
         bytecode.push_back(PUSH1);
         bytecode.push_back(0);
         bytecode.push_back(RETURN);
@@ -331,7 +337,7 @@ TYPED_TEST(VMTraitsTest, SignextendLiveIndexBug)
          RETURN});
     ASSERT_EQ(this->result_.output_size, 32);
     ASSERT_EQ(
-        uint256_t::load_be_unsafe(this->result_.output_data), uint256_t{98});
+        load_be_unsafe<uint256_t>(this->result_.output_data), uint256_t{98});
 }
 
 TYPED_TEST(VMTraitsTest, JumpiLiveDestDeferredComparisonBug)

--- a/test/vm/unit/monad_vm_interface_tests.cpp
+++ b/test/vm/unit/monad_vm_interface_tests.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/int.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/evm/opcodes.hpp>
 #include <category/vm/host.hpp>
@@ -335,8 +336,8 @@ TEST(MonadVmInterface, compile)
     test::TestContext ctx1;
     entry1(&*ctx1, nullptr);
 
-    ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.size), 0);
-    ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.offset), 1);
+    ASSERT_EQ(load_le<uint256_t>(ctx1->result.size), 0);
+    ASSERT_EQ(load_le<uint256_t>(ctx1->result.offset), 1);
 
     ASSERT_FALSE(vm.find_varcode(hash1).has_value());
 }
@@ -355,8 +356,8 @@ TEST(MonadVmInterface, cached_compile)
     test::TestContext ctx1;
     entry1(&*ctx1, nullptr);
 
-    ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.size), 0);
-    ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.offset), 1);
+    ASSERT_EQ(load_le<uint256_t>(ctx1->result.size), 0);
+    ASSERT_EQ(load_le<uint256_t>(ctx1->result.offset), 1);
 
     auto vcode1 = vm.find_varcode(hash1);
     ASSERT_TRUE(vcode1.has_value());
@@ -385,8 +386,8 @@ TEST(MonadVmInterface, async_compile)
             ASSERT_NE(entry1, nullptr);
             test::TestContext ctx1;
             entry1(&*ctx1, nullptr);
-            ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.size), 0);
-            ASSERT_EQ(compiler::uint256_t::load_le(ctx1->result.offset), 1);
+            ASSERT_EQ(load_le<uint256_t>(ctx1->result.size), 0);
+            ASSERT_EQ(load_le<uint256_t>(ctx1->result.offset), 1);
         }
         else {
             ASSERT_EQ(entry1, nullptr);

--- a/test/vm/unit/runtime/data_tests.cpp
+++ b/test/vm/unit/runtime/data_tests.cpp
@@ -15,6 +15,8 @@
 
 #include "fixture.hpp"
 
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/runtime/data.hpp>
 #include <category/vm/runtime/transmute.hpp>
@@ -370,7 +372,7 @@ TYPED_TEST(RuntimeTraitsTest, ExtCodeHash)
     auto hash = TestFixture::wrap(extcodehash<traits>);
 
     this->host_.accounts[address_from_uint256(addr)].codehash =
-        bytes32_from_uint256(713682);
+        store_be_as<bytes32_t>(uint256_t{713682});
 
     this->ctx_.gas_remaining = 10'000;
 

--- a/test/vm/unit/runtime/fixture.cpp
+++ b/test/vm/unit/runtime/fixture.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <category/core/address.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/runtime/transmute.hpp>
 
@@ -46,24 +47,24 @@ namespace monad::vm::compiler::test
             auto host = evmc::MockedHost{};
 
             host.tx_context = evmc_tx_context{
-                .tx_gas_price = bytes32_from_uint256(56762),
+                .tx_gas_price = store_be_as<bytes32_t>(uint256_t{56762}),
                 .tx_origin = 0x000000000000000000000000000000005CA1AB1E_address,
                 .block_coinbase =
                     0x00000000000000000000000000000000BA5EBA11_address,
                 .block_number = 23784,
                 .block_timestamp = 1733494490,
                 .block_gas_limit = 30000000,
-                .block_prev_randao = bytes32_from_uint256(89273),
-                .chain_id = bytes32_from_uint256(2342),
-                .block_base_fee = bytes32_from_uint256(389),
-                .blob_base_fee = bytes32_from_uint256(98988),
+                .block_prev_randao = store_be_as<bytes32_t>(uint256_t{89273}),
+                .chain_id = store_be_as<bytes32_t>(uint256_t{2342}),
+                .block_base_fee = store_be_as<bytes32_t>(uint256_t{389}),
+                .blob_base_fee = store_be_as<bytes32_t>(uint256_t{98988}),
                 .blob_hashes = blob_hashes_.data(),
                 .blob_hashes_count = blob_hashes_.size(),
                 .initcodes = nullptr,
                 .initcodes_count = 0,
             };
 
-            host.block_hash = bytes32_from_uint256(
+            host.block_hash = store_be_as<bytes32_t>(
                 0x105DF6064F84551C4100A368056B8AF0E491077245DAB1536D2CFA6AB78421CE_u256);
 
             return host;
@@ -71,7 +72,7 @@ namespace monad::vm::compiler::test
     }
 
     RuntimeTestBase::RuntimeTestBase()
-        : blob_hashes_{bytes32_from_uint256(1), bytes32_from_uint256(2)}
+        : blob_hashes_{store_be_as<bytes32_t>(uint256_t{1}), store_be_as<bytes32_t>(uint256_t{2})}
         , host_{init_host(blob_hashes_)}
         , test_ctx_{[&](auto &x) {
             x.host = &host_.get_interface(), x.context = host_.to_context(),
@@ -152,7 +153,7 @@ namespace monad::vm::compiler::test
     RuntimeTestBase::set_balance(uint256_t const addr, uint256_t const balance)
     {
         host_.accounts[address_from_uint256(addr)].balance =
-            bytes32_from_uint256(balance);
+            store_be_as<bytes32_t>(balance);
     }
 
     std::basic_string_view<uint8_t> RuntimeTestBase::result_data()

--- a/test/vm/unit/runtime/storage_tests.cpp
+++ b/test/vm/unit/runtime/storage_tests.cpp
@@ -15,9 +15,10 @@
 
 #include "fixture.hpp"
 
+#include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/runtime/storage.hpp>
-#include <category/vm/runtime/transmute.hpp>
 
 #include <evmc/evmc.h>
 
@@ -86,7 +87,7 @@ TYPED_TEST(RuntimeTraitsTest, StorageLoadWarm)
     auto load = TestFixture::wrap(sload<traits>);
 
     this->host_.access_storage(
-        this->ctx_.env.recipient, bytes32_from_uint256(key));
+        this->ctx_.env.recipient, store_be_as<bytes32_t>(key));
 
     this->ctx_.gas_remaining = 0;
     ASSERT_EQ(load(key), 0);
@@ -159,9 +160,9 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
 
     // current == original
     auto &loc = this->host_.accounts[this->ctx_.env.recipient]
-                    .storage[bytes32_from_uint256(key)];
-    loc.original = bytes32_from_uint256(val);
-    loc.current = bytes32_from_uint256(val);
+                    .storage[store_be_as<bytes32_t>(key)];
+    loc.original = store_be_as<bytes32_t>(val);
+    loc.current = store_be_as<bytes32_t>(val);
 
     auto do_test = [&load, &store, &ctx_ = this->ctx_](
                        int64_t nonempty_same_nonempty_cold_remaining,

--- a/test/vm/unit/runtime/transmute_tests.cpp
+++ b/test/vm/unit/runtime/transmute_tests.cpp
@@ -17,6 +17,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/runtime/transmute.hpp>
 
@@ -53,7 +54,7 @@ namespace
     uint256_t get_test_uint256()
     {
         uint256_t u;
-        uint8_t *b = u.as_bytes();
+        uint8_t *b = as_bytes(u);
         for (uint8_t i = 0; i < 32; ++i) {
             b[i] = i + 1;
         }
@@ -65,8 +66,8 @@ TEST_F(RuntimeTest, TransmuteBytes32)
 {
     bytes32_t const b = get_test_bytes32();
     uint256_t const u = get_test_uint256();
-    ASSERT_EQ(bytes32_from_uint256(u), b);
-    ASSERT_EQ(u, uint256_from_bytes32(b));
+    ASSERT_EQ(store_be_as<bytes32_t>(u), b);
+    ASSERT_EQ(u, load_be<uint256_t>(b));
 }
 
 TEST_F(RuntimeTest, TransmuteAddress)
@@ -74,7 +75,7 @@ TEST_F(RuntimeTest, TransmuteAddress)
     Address const a = get_test_address();
     uint256_t u = get_test_uint256();
     ASSERT_EQ(address_from_uint256(u), a);
-    uint8_t *b = u.as_bytes();
+    uint8_t *b = as_bytes(u);
     for (auto i = 20; i < 32; ++i) {
         b[i] = 0;
     }
@@ -91,7 +92,7 @@ TEST_F(RuntimeTest, LoadBounded)
         uint256_t expected_le;
         if (n > 0) {
             std::memcpy(
-                expected_le.as_bytes(),
+                as_bytes(expected_le),
                 src_buffer,
                 static_cast<size_t>(std::min(n, int64_t{32})));
         }
@@ -105,6 +106,6 @@ TEST_F(RuntimeTest, LoadBounded)
         ASSERT_EQ(le2, expected_le);
 
         uint256_t be = uint256_load_bounded_be(src_buffer, n);
-        ASSERT_EQ(be, expected_le.to_be());
+        ASSERT_EQ(be, bswap(expected_le));
     }
 }

--- a/test/vm/unit/uint256_tests.cpp
+++ b/test/vm/unit/uint256_tests.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
 
 #include <intx/intx.hpp>
@@ -706,25 +707,25 @@ TEST(uint256, shifts)
 TEST(uint256, load_store)
 {
     for (auto x : test_inputs) {
-        auto *le_bytes = std::bit_cast<uint8_t(*)[32]>(x.as_bytes());
-        ASSERT_EQ(x, uint256_t::load_le_unsafe(x.as_bytes()));
-        ASSERT_EQ(x, uint256_t::load_le(*le_bytes));
+        auto *le_bytes = std::bit_cast<uint8_t(*)[32]>(as_bytes(x));
+        ASSERT_EQ(x, load_le_unsafe<uint256_t>(as_bytes(x)));
+        ASSERT_EQ(x, load_le<uint256_t>(*le_bytes));
 
         uint8_t le_stored[32];
-        x.store_le(le_stored);
+        store_le(le_stored, x);
         ASSERT_EQ(0, std::memcmp(le_bytes, le_stored, 32));
-        ASSERT_EQ(x, uint256_t::load_le(le_stored));
+        ASSERT_EQ(x, load_le<uint256_t>(le_stored));
 
-        auto const x_be = x.to_be();
+        auto const x_be = bswap(x);
 
-        auto *be_bytes = std::bit_cast<uint8_t(*)[32]>(x_be.as_bytes());
-        ASSERT_EQ(x, uint256_t::load_be_unsafe(x_be.as_bytes()));
-        ASSERT_EQ(x, uint256_t::load_be(*be_bytes));
+        auto *be_bytes = std::bit_cast<uint8_t(*)[32]>(as_bytes(x_be));
+        ASSERT_EQ(x, load_be_unsafe<uint256_t>(as_bytes(x_be)));
+        ASSERT_EQ(x, load_be<uint256_t>(*be_bytes));
 
         uint8_t be_stored[32];
-        x.store_be(be_stored);
+        store_be(be_stored, x);
         ASSERT_EQ(0, std::memcmp(be_bytes, be_stored, 32));
-        ASSERT_EQ(x, uint256_t::load_be(be_stored));
+        ASSERT_EQ(x, load_be<uint256_t>(be_stored));
     }
 }
 

--- a/test/vm/utils/evm-as_utils.hpp
+++ b/test/vm/utils/evm-as_utils.hpp
@@ -15,8 +15,11 @@
 
 #pragma once
 
+#include <category/core/int.hpp>
 #include <category/vm/interpreter/execute.hpp>
 #include <test/vm/utils/test_context.hpp>
+
+#include <cstring>
 
 namespace monad::vm::test
 {
@@ -82,8 +85,7 @@ namespace monad::vm::test
             for (size_t j = 0; j < max_stack_values; j += n) {
                 for (size_t k = 0; k < n; ++k) {
                     size_t const c = i + 32 * (max_stack_values - j - n + k);
-                    uint256_t::load_be_unsafe(&base_calldata[count * 32])
-                        .store_be(&ret[c]);
+                    std::memcpy(&ret[c], &base_calldata[count * 32], 32);
                     ++count;
                 }
             }
@@ -121,8 +123,8 @@ namespace monad::vm::test
                    KB::get_sequence_repetition_count(
                        args_size, throughput_calldata.size());
         MONAD_ASSERT(ctx->result.status == runtime::StatusCode::Success);
-        MONAD_ASSERT(uint256_t::load_le(ctx->result.size) == n);
-        MONAD_ASSERT(uint256_t::load_le(ctx->result.offset) == 0);
+        MONAD_ASSERT(load_le<uint256_t>(ctx->result.size) == n);
+        MONAD_ASSERT(load_le<uint256_t>(ctx->result.offset) == 0);
 
         KernelCalldata ret{throughput_calldata.size()};
         std::memcpy(ret.data(), ctx->memory.data, n);


### PR DESCRIPTION
Consolidate the load/store/byte-swap API onto uniform free-function
  templates in `category/core/int.hpp` covering all integer widths,
  replacing the `uint256_t` member methods and the redundant
  `to_big_endian` wrapper (now `bswap`), and migrate all call sites.