### PR TITLE
Unify rust bindgen usage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1453,7 +1453,9 @@ dependencies = [
 name = "monad-build"
 version = "0.1.0"
 dependencies = [
+ "bindgen",
  "cargo_metadata",
+ "cc",
  "cmake",
 ]
 
@@ -1461,7 +1463,6 @@ dependencies = [
 name = "monad-cxx"
 version = "0.1.0"
 dependencies = [
- "bindgen",
  "monad-build",
  "tracing",
 ]
@@ -1475,9 +1476,9 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
- "bindgen",
  "futures",
  "hex",
+ "monad-build",
  "monad-cxx",
  "serde",
  "tracing",
@@ -1487,8 +1488,6 @@ dependencies = [
 name = "monad-event-ring"
 version = "0.1.0"
 dependencies = [
- "bindgen",
- "cc",
  "clap",
  "criterion",
  "itertools 0.10.5",
@@ -1504,14 +1503,13 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types",
- "bindgen",
- "cc",
  "chrono",
  "clap",
  "criterion",
  "hex",
  "itertools 0.10.5",
  "lazy_static",
+ "monad-build",
  "monad-event-ring",
  "ratatui",
  "serde",
@@ -1524,7 +1522,7 @@ dependencies = [
 name = "monad-statesync"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "monad-build",
  "monad-cxx",
 ]
 
@@ -1532,7 +1530,6 @@ dependencies = [
 name = "monad-triedb"
 version = "0.1.0"
 dependencies = [
- "bindgen",
  "futures",
  "monad-build",
  "monad-cxx",

--- a/rust/crates/monad-build/Cargo.toml
+++ b/rust/crates/monad-build/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bindgen        = { workspace = true, optional = true }
 cargo_metadata = { workspace = true, optional = true }
+cc             = { workspace = true, optional = true }
 cmake          = { workspace = true, optional = true }
 
 [features]
+bindgen = ["dep:bindgen", "metadata"]
+bindgen-static = ["bindgen", "dep:cc"]
 cmake = ["dep:cmake"]
 metadata = ["dep:cargo_metadata"]

--- a/rust/crates/monad-build/src/bindgen.rs
+++ b/rust/crates/monad-build/src/bindgen.rs
@@ -1,0 +1,151 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::path::PathBuf;
+
+pub struct MonadBindgen {
+    builder: bindgen::Builder,
+    out_dir: PathBuf,
+    repo_root: PathBuf,
+}
+
+impl Default for MonadBindgen {
+    fn default() -> Self {
+        let out_dir =
+            PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR environment variable not set"));
+
+        let repo_root = crate::repository_root();
+        let include_path = format!("-I{}", repo_root.display());
+
+        let builder = bindgen::Builder::default()
+            .parse_callbacks(Box::new(::bindgen::CargoCallbacks::new()))
+            .clang_args(["-x", "c", "-std=c23", &include_path])
+            .prepend_enum_name(true)
+            .allowlist_recursively(true)
+            .derive_debug(true);
+
+        Self {
+            builder,
+            out_dir,
+            repo_root,
+        }
+    }
+}
+
+impl MonadBindgen {
+    pub fn header(mut self, header: &str) -> Self {
+        self.builder = self.builder.header(header);
+        self
+    }
+
+    pub fn derive_copy(mut self) -> Self {
+        self.builder = self.builder.derive_copy(true);
+        self
+    }
+
+    pub fn derive_hash(mut self, except: Option<&'static str>) -> Self {
+        self.builder = self.builder.derive_hash(true);
+        if let Some(pattern) = except {
+            self.builder = self.builder.no_hash(pattern);
+        }
+        self
+    }
+
+    pub fn derive_partialeq_eq(mut self, except: Option<&'static str>) -> Self {
+        self.builder = self.builder.derive_partialeq(true).derive_eq(true);
+
+        if let Some(pattern) = except {
+            self.builder = self.builder.no_partialeq(pattern);
+        }
+
+        self
+    }
+
+    pub fn allowlist_files<S>(mut self, files: impl IntoIterator<Item = S>) -> Self
+    where
+        S: AsRef<str>,
+    {
+        self.builder = self.builder.allowlist_recursively(false);
+
+        for file in files {
+            let file_ref = file.as_ref();
+
+            let file_path = self.repo_root.join(file_ref);
+            assert!(
+                file_path.exists(),
+                "allowlist_files: {} not found at {}",
+                file_ref,
+                file_path.display()
+            );
+
+            self.builder = self.builder.allowlist_file(file_path.to_string_lossy());
+        }
+
+        self
+    }
+
+    pub fn blocklist_types<S>(mut self, types: impl IntoIterator<Item = S>) -> Self
+    where
+        S: AsRef<str>,
+    {
+        for ty in types {
+            self.builder = self.builder.blocklist_type(ty.as_ref());
+        }
+
+        self
+    }
+
+    pub fn no_prepend_enum_name(mut self) -> Self {
+        self.builder = self.builder.prepend_enum_name(false);
+        self
+    }
+
+    pub fn generate(self) {
+        let Self {
+            builder,
+            out_dir,
+            repo_root: _,
+        } = self;
+
+        let bindings = builder.generate().expect("Unable to generate bindings");
+
+        let bindings_str = bindings
+            .to_string()
+            .replace(r#"#[doc = "<"#, r#"#[doc = ""#)
+            .replace(r#"#[doc = " "#, r#"#[doc = ""#);
+
+        std::fs::write(out_dir.join("bindings.rs"), bindings_str)
+            .expect("Failed to write bindings.rs");
+    }
+
+    #[cfg(feature = "bindgen-static")]
+    pub fn generate_and_build_static(mut self, static_file_name: &'static str) {
+        self.builder = self
+            .builder
+            .wrap_static_fns(true)
+            .wrap_static_fns_path(self.out_dir.join(static_file_name));
+
+        let mut cc_build = cc::Build::new();
+        cc_build
+            .std("c2x")
+            .include(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .include(&self.repo_root)
+            .file(self.out_dir.join(format!("{}.c", static_file_name)));
+
+        self.generate();
+
+        cc_build.compile(static_file_name);
+    }
+}

--- a/rust/crates/monad-build/src/lib.rs
+++ b/rust/crates/monad-build/src/lib.rs
@@ -16,6 +16,9 @@
 #[cfg(feature = "cmake")]
 pub use self::cmake::{MonadCMake, MonadCMakeLinkage};
 
+#[cfg(feature = "bindgen")]
+pub mod bindgen;
+
 #[cfg(feature = "cmake")]
 mod cmake;
 

--- a/rust/crates/monad-cxx/Cargo.toml
+++ b/rust/crates/monad-cxx/Cargo.toml
@@ -8,6 +8,4 @@ links = "monad_execution"
 tracing = { workspace = true, features = ["log"] }
 
 [build-dependencies]
-monad-build = { workspace = true, features = ["cmake", "metadata"] }
-
-bindgen = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen", "cmake", "metadata"] }

--- a/rust/crates/monad-ethcall/Cargo.toml
+++ b/rust/crates/monad-ethcall/Cargo.toml
@@ -22,4 +22,4 @@ serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 
 [build-dependencies]
-bindgen = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen"] }

--- a/rust/crates/monad-ethcall/build.rs
+++ b/rust/crates/monad-ethcall/build.rs
@@ -13,22 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-
 fn main() {
-    println!("cargo:rerun-if-changed=../../../");
-
-    let bindings = bindgen::Builder::default()
-        .header("../../../category/execution/ethereum/chain/chain_config.h")
-        .header("../../../category/rpc/monad_executor.h")
-        .clang_arg("-I../../../")
-        .clang_arg("-std=c23")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .generate()
-        .expect("Unable to generate bindings");
-
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+    monad_build::bindgen::MonadBindgen::default()
+        .header("wrapper.h")
+        .generate();
 }

--- a/rust/crates/monad-ethcall/wrapper.h
+++ b/rust/crates/monad-ethcall/wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,18 +13,5 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-fn main() {
-    if monad_build::should_build_execution() {
-        monad_build::MonadCMake::new(
-            monad_build::repository_root(),
-            monad_build::MonadCMakeLinkage::Dynamic,
-        )
-        .build("monad_execution");
-    }
-
-    monad_build::bindgen::MonadBindgen::default()
-        .header("wrapper.h")
-        .derive_copy()
-        .allowlist_files(["category/core/log_ffi.h"])
-        .generate();
-}
+#include <category/execution/ethereum/chain/chain_config.h>
+#include <category/rpc/monad_executor.h>

--- a/rust/crates/monad-event-ring/Cargo.toml
+++ b/rust/crates/monad-event-ring/Cargo.toml
@@ -13,10 +13,7 @@ criterion = { workspace = true }
 itertools = { workspace = true }
 
 [build-dependencies]
-monad-build = { workspace = true, features = ["cmake", "metadata"] }
-
-bindgen = { workspace = true }
-cc = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen-static", "cmake", "metadata"] }
 
 [[bench]]
 name = "snapshot_raw"

--- a/rust/crates/monad-event-ring/build.rs
+++ b/rust/crates/monad-event-ring/build.rs
@@ -13,25 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-
-const INCLUDES: [(&str, &[&str]); 1] = [(
-    "../../../",
-    &[
-        "category/core/event/event_iterator_inline.h",
-        "category/core/event/event_iterator.h",
-        "category/core/event/event_metadata.h",
-        "category/core/event/event_ring_util.h",
-        "category/core/event/event_ring.h",
-    ],
-)];
-
-const STATIC_FNS_PATH: &str = "monad_event__wrap_static_fns";
-
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=../../../category");
-
     monad_build::MonadCMake::new(
         monad_build::repository_root().join("category/event"),
         monad_build::MonadCMakeLinkage::Static,
@@ -44,47 +26,17 @@ fn main() {
     #[cfg(not(target_os = "linux"))]
     println!("cargo:rustc-link-lib=monad_event_os_compat");
 
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-
-    let mut builder = bindgen::Builder::default()
+    monad_build::bindgen::MonadBindgen::default()
         .header("wrapper.h")
-        .clang_args(["-x", "c", "-std=c23"])
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .wrap_static_fns(true)
-        .wrap_static_fns_path(out_dir.join(STATIC_FNS_PATH))
-        .derive_copy(true)
-        .derive_debug(true)
-        .derive_partialeq(true)
-        .derive_eq(true)
-        .prepend_enum_name(false)
-        .allowlist_recursively(false);
-
-    for (lib_path, lib_files) in INCLUDES {
-        builder = builder.clang_arg(format!("-I{lib_path}"));
-
-        for lib_file in lib_files {
-            builder = builder.allowlist_file(format!("{lib_path}{lib_file}"));
-        }
-    }
-
-    let bindings = builder.generate().expect("Unable to generate bindings");
-
-    let bindings_str = bindings
-        .to_string()
-        .replace(r#"#[doc = "<"#, r#"#[doc = ""#)
-        .replace(r#"#[doc = " "#, r#"#[doc = ""#);
-
-    std::fs::write(out_dir.join("bindings.rs"), bindings_str).expect("Couldn't write bindings!");
-
-    cc::Build::new()
-        .std("c2x")
-        .file(out_dir.join(format!("{STATIC_FNS_PATH}.c")))
-        .includes(
-            std::iter::once(PathBuf::from(env!("CARGO_MANIFEST_DIR"))).chain(
-                INCLUDES
-                    .iter()
-                    .map(|(include_path, _)| PathBuf::from(include_path)),
-            ),
-        )
-        .compile(STATIC_FNS_PATH);
+        .derive_copy()
+        .derive_partialeq_eq(None)
+        .allowlist_files([
+            "category/core/event/event_iterator_inline.h",
+            "category/core/event/event_iterator.h",
+            "category/core/event/event_metadata.h",
+            "category/core/event/event_ring_util.h",
+            "category/core/event/event_ring.h",
+        ])
+        .no_prepend_enum_name()
+        .generate_and_build_static("monad_event__wrap_static_fns");
 }

--- a/rust/crates/monad-exec-events/Cargo.toml
+++ b/rust/crates/monad-exec-events/Cargo.toml
@@ -17,8 +17,7 @@ strum = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 
 [build-dependencies]
-bindgen = { workspace = true }
-cc = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen-static"] }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/rust/crates/monad-exec-events/build.rs
+++ b/rust/crates/monad-exec-events/build.rs
@@ -13,77 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-
-const INCLUDES: &[(&str, &[&str])] = &[
-    ("../../../", &["category/core/event/event_metadata.h"]),
-    (
-        "../../../",
-        &[
+fn main() {
+    monad_build::bindgen::MonadBindgen::default()
+        .header("wrapper.h")
+        .derive_copy()
+        .derive_hash(Some(r"monad_exec_.+"))
+        .derive_partialeq_eq(Some(r"monad_exec_.+"))
+        .allowlist_files([
+            "category/core/event/event_metadata.h",
             "category/execution/ethereum/core/base_ctypes.h",
             "category/execution/ethereum/core/eth_ctypes.h",
             "category/execution/ethereum/event/exec_event_ctypes.h",
             "category/execution/ethereum/event/exec_iter_help.h",
             "category/execution/monad/core/monad_ctypes.h",
-        ],
-    ),
-];
-
-const STATIC_FNS_PATH: &str = "monad_exec_events__wrap_static_fns";
-
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=../../category");
-
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-
-    let mut builder = bindgen::Builder::default()
-        .header("wrapper.h")
-        .clang_args(["-x", "c", "-std=c23"])
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .wrap_static_fns(true)
-        .wrap_static_fns_path(out_dir.join(STATIC_FNS_PATH))
-        .derive_copy(true)
-        .derive_debug(true)
-        .derive_hash(true)
-        .derive_default(false)
-        .derive_eq(true)
-        .derive_partialeq(true)
-        .no_hash(r"monad_exec_.+")
-        .no_partialeq(r"monad_exec_.+")
-        .prepend_enum_name(false)
-        .allowlist_recursively(false);
-
-    for (lib_path, lib_files) in INCLUDES {
-        builder = builder.clang_arg(format!("-I{lib_path}"));
-
-        for lib_file in lib_files.iter() {
-            builder = builder.allowlist_file(format!("{lib_path}{lib_file}"));
-        }
-    }
-
-    builder = builder
-        .blocklist_type("monad_exec_record_error")
-        .blocklist_type("monad_event_record_error");
-
-    let bindings = builder.generate().expect("Unable to generate bindings");
-
-    let bindings_str = bindings
-        .to_string()
-        .replace(r#"#[doc = "<"#, r#"#[doc = ""#)
-        .replace(r#"#[doc = " "#, r#"#[doc = ""#);
-
-    std::fs::write(out_dir.join("bindings.rs"), &bindings_str).expect("Couldn't write bindings!");
-
-    cc::Build::new()
-        .std("c2x")
-        .file(out_dir.join(format!("{STATIC_FNS_PATH}.c")))
-        .includes(
-            std::iter::once(PathBuf::from(env!("CARGO_MANIFEST_DIR"))).chain(
-                INCLUDES
-                    .iter()
-                    .map(|(include_path, _)| PathBuf::from(include_path)),
-            ),
-        )
-        .compile(STATIC_FNS_PATH);
+        ])
+        .blocklist_types(["monad_exec_record_error", "monad_event_record_error"])
+        .no_prepend_enum_name()
+        .generate_and_build_static("monad_exec_events__wrap_static_fns");
 }

--- a/rust/crates/monad-statesync/Cargo.toml
+++ b/rust/crates/monad-statesync/Cargo.toml
@@ -10,4 +10,4 @@ ignored = ["monad-cxx"]
 monad-cxx = { workspace = true }
 
 [build-dependencies]
-bindgen = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen"] }

--- a/rust/crates/monad-statesync/build.rs
+++ b/rust/crates/monad-statesync/build.rs
@@ -13,24 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-
 fn main() {
-    println!("cargo:rerun-if-changed=../../../");
-
-    let bindings = bindgen::Builder::default()
-        .header("../../../category/statesync/statesync_messages.h")
-        .header("../../../category/statesync/statesync_client.h")
-        .header("../../../category/statesync/statesync_version.h")
-        .clang_arg("-I../../../")
-        .clang_arg("-std=c23")
-        // invalidate on header change
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .generate()
-        .expect("Unable to generate bindings");
-
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+    monad_build::bindgen::MonadBindgen::default()
+        .header("wrapper.h")
+        .generate();
 }

--- a/rust/crates/monad-statesync/wrapper.h
+++ b/rust/crates/monad-statesync/wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025-26 Category Labs, Inc.
+// Copyright (C) 2025 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,18 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-fn main() {
-    if monad_build::should_build_execution() {
-        monad_build::MonadCMake::new(
-            monad_build::repository_root(),
-            monad_build::MonadCMakeLinkage::Dynamic,
-        )
-        .build("monad_execution");
-    }
-
-    monad_build::bindgen::MonadBindgen::default()
-        .header("wrapper.h")
-        .derive_copy()
-        .allowlist_files(["category/core/log_ffi.h"])
-        .generate();
-}
+#include <category/statesync/statesync_messages.h>
+#include <category/statesync/statesync_client.h>
+#include <category/statesync/statesync_version.h>

--- a/rust/crates/monad-triedb/Cargo.toml
+++ b/rust/crates/monad-triedb/Cargo.toml
@@ -15,6 +15,4 @@ futures = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
-monad-build = { workspace = true, features = ["cmake", "metadata"] }
-
-bindgen = { workspace = true }
+monad-build = { workspace = true, features = ["bindgen", "cmake", "metadata"] }

--- a/rust/crates/monad-triedb/build.rs
+++ b/rust/crates/monad-triedb/build.rs
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
-
 fn main() {
     println!("cargo:rerun-if-changed=CMakeLists.txt");
     println!("cargo:rerun-if-changed=include/ffi.h");
@@ -28,16 +26,7 @@ fn main() {
             .build("triedb_driver");
     }
 
-    let bindings = bindgen::Builder::default()
+    monad_build::bindgen::MonadBindgen::default()
         .header("include/ffi.h")
-        .clang_arg("-I../../../")
-        // invalidate on header change
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .generate()
-        .expect("Unable to generate bindings");
-
-    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+        .generate();
 }


### PR DESCRIPTION
This change introduces the `MonadBindgen` module which dramatically simplifies our FFI wrapper crate build scripts. We also remove many redundant build script rerun triggers which should help prevent rebuilds when developing in `monad-bft`.