### PR TITLE
Improve block stats

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -180,6 +180,7 @@ add_library(
   "ethereum/validate_transaction_error.hpp"
   # ethereum/metrics
   "ethereum/metrics/block_metrics.hpp"
+  "ethereum/metrics/transaction_stats.hpp"
   # ethereum/rlp
   "ethereum/rlp/config.hpp"
   "ethereum/rlp/decode.hpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -177,6 +177,7 @@ add_library(
   "ethereum/validate_transaction_error.hpp"
   # ethereum/metrics
   "ethereum/metrics/block_metrics.hpp"
+  "ethereum/metrics/transaction_stats.hpp"
   # ethereum/rlp
   "ethereum/rlp/config.hpp"
   "ethereum/rlp/decode.hpp"

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -177,9 +177,12 @@ struct EvmcHost final : public EvmcHostBase
     {
         MONAD_TRY
         {
+            uint64_t *const growth_gas_ptr =
+                runtime_context_ != nullptr ? runtime_context_->growth_gas_ptr
+                                            : nullptr;
             if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2) {
-                auto result =
-                    ::monad::execute_create_message<traits>(this, state_, msg);
+                auto result = ::monad::execute_create_message<traits>(
+                    this, state_, msg, growth_gas_ptr);
 
                 // EIP-211
                 if (result.status_code != EVMC_REVERT) {
@@ -192,7 +195,8 @@ struct EvmcHost final : public EvmcHostBase
                 return result;
             }
             else {
-                return ::monad::execute_call_message<traits>(this, state_, msg);
+                return ::monad::execute_call_message<traits>(
+                    this, state_, msg, growth_gas_ptr);
             }
         }
         MONAD_CATCH(...)

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -174,9 +174,12 @@ struct EvmcHost final : public EvmcHostBase
     {
         MONAD_TRY
         {
+            uint64_t *const growth_gas_ptr =
+                runtime_context_ != nullptr ? runtime_context_->growth_gas_ptr
+                                            : nullptr;
             if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2) {
-                auto result =
-                    ::monad::execute_create_message<traits>(this, state_, msg);
+                auto result = ::monad::execute_create_message<traits>(
+                    this, state_, msg, growth_gas_ptr);
 
                 // EIP-211
                 if (result.status_code != EVMC_REVERT) {
@@ -189,7 +192,8 @@ struct EvmcHost final : public EvmcHostBase
                 return result;
             }
             else {
-                return ::monad::execute_call_message<traits>(this, state_, msg);
+                return ::monad::execute_call_message<traits>(
+                    this, state_, msg, growth_gas_ptr);
             }
         }
         MONAD_CATCH(...)

--- a/category/execution/ethereum/execute_message.cpp
+++ b/category/execution/ethereum/execute_message.cpp
@@ -175,7 +175,8 @@ void post_call(EvmcHost<traits> &host, State &state, evmc::Result const &result)
 
 template <Traits traits>
 evmc::Result execute_create_message(
-    EvmcHost<traits> *const host, State &state, evmc_message const &msg)
+    EvmcHost<traits> *const host, State &state, evmc_message const &msg,
+    uint64_t *const growth_gas_ptr)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
 
@@ -237,6 +238,12 @@ evmc::Result execute_create_message(
         call_tracer.on_exit(result);
         return result;
     }
+    if (growth_gas_ptr != nullptr) {
+        MONAD_DEBUG_ASSERT(
+            traits::create_growth_gas() <=
+            std::numeric_limits<uint64_t>::max() - *growth_gas_ptr);
+        *growth_gas_ptr += traits::create_growth_gas();
+    }
 
     state.push();
 
@@ -264,7 +271,7 @@ evmc::Result execute_create_message(
     };
 
     auto result = state.vm().execute_bytecode<traits>(
-        *host, &m_call, {msg.input_data, msg.input_size});
+        *host, &m_call, {msg.input_data, msg.input_size}, growth_gas_ptr);
 
     if (result.status_code == EVMC_SUCCESS) {
         result = deploy_contract_code<traits>(
@@ -304,7 +311,8 @@ EXPLICIT_TRAITS(execute_create_message);
 
 template <Traits traits>
 evmc::Result execute_call_message(
-    EvmcHost<traits> *const host, State &state, evmc_message const &msg)
+    EvmcHost<traits> *const host, State &state, evmc_message const &msg,
+    uint64_t *const growth_gas_ptr)
 {
     MONAD_ASSERT(
         msg.kind == EVMC_DELEGATECALL || msg.kind == EVMC_CALLCODE ||
@@ -328,7 +336,8 @@ evmc::Result execute_call_message(
         auto const hash = state.get_code_hash(msg.code_address);
         auto const code = state.read_code(hash);
         trace::on_read_code(host->state_tracer_, hash, code->intercode());
-        result = state.vm().execute<traits>(*host, &msg, hash, code);
+        result =
+            state.vm().execute<traits>(*host, &msg, hash, code, growth_gas_ptr);
     }
 
     if (msg.depth == 0) {

--- a/category/execution/ethereum/execute_message.cpp
+++ b/category/execution/ethereum/execute_message.cpp
@@ -175,7 +175,8 @@ void post_call(EvmcHost<traits> &host, State &state, evmc::Result const &result)
 
 template <Traits traits>
 evmc::Result execute_create_message(
-    EvmcHost<traits> *const host, State &state, evmc_message const &msg)
+    EvmcHost<traits> *const host, State &state, evmc_message const &msg,
+    uint64_t *const growth_gas_ptr)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
 
@@ -236,6 +237,12 @@ evmc::Result execute_create_message(
         call_tracer.on_exit(result);
         return result;
     }
+    if (growth_gas_ptr != nullptr) {
+        MONAD_DEBUG_ASSERT(
+            traits::create_growth_gas() <=
+            std::numeric_limits<uint64_t>::max() - *growth_gas_ptr);
+        *growth_gas_ptr += traits::create_growth_gas();
+    }
 
     state.push();
 
@@ -263,7 +270,7 @@ evmc::Result execute_create_message(
     };
 
     auto result = state.vm().execute_bytecode<traits>(
-        *host, &m_call, {msg.input_data, msg.input_size});
+        *host, &m_call, {msg.input_data, msg.input_size}, growth_gas_ptr);
 
     if (result.status_code == EVMC_SUCCESS) {
         result = deploy_contract_code<traits>(
@@ -303,7 +310,8 @@ EXPLICIT_TRAITS(execute_create_message);
 
 template <Traits traits>
 evmc::Result execute_call_message(
-    EvmcHost<traits> *const host, State &state, evmc_message const &msg)
+    EvmcHost<traits> *const host, State &state, evmc_message const &msg,
+    uint64_t *const growth_gas_ptr)
 {
     MONAD_ASSERT(
         msg.kind == EVMC_DELEGATECALL || msg.kind == EVMC_CALLCODE ||
@@ -327,7 +335,8 @@ evmc::Result execute_call_message(
         auto const hash = state.get_code_hash(msg.code_address);
         auto const code = state.read_code(hash);
         trace::on_read_code(host->state_tracer_, hash, code->intercode());
-        result = state.vm().execute<traits>(*host, &msg, hash, code);
+        result =
+            state.vm().execute<traits>(*host, &msg, hash, code, growth_gas_ptr);
     }
 
     if (msg.depth == 0) {

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -29,6 +29,7 @@
 #include <category/execution/ethereum/execute_message.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
+#include <category/execution/ethereum/metrics/transaction_stats.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
@@ -229,7 +230,7 @@ evmc_message ExecuteTransactionNoValidation<traits>::to_message(
 
 template <Traits traits>
 evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
-    State &state, EvmcHost<traits> &host)
+    State &state, EvmcHost<traits> &host, TransactionStats *const stats)
 {
     if constexpr (::monad::is_monad_trait_v<traits>) {
         init_reserve_balance_context<traits>(
@@ -287,10 +288,13 @@ evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
         }
     }
 
-    auto result =
-        (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
-            ? ::monad::execute_create_message<traits>(&host, state, msg)
-            : ::monad::execute_call_message<traits>(&host, state, msg);
+    uint64_t *const growth_gas_ptr =
+        stats != nullptr ? &stats->growth_gas : nullptr;
+    auto result = (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+                      ? ::monad::execute_create_message<traits>(
+                            &host, state, msg, growth_gas_ptr)
+                      : ::monad::execute_call_message<traits>(
+                            &host, state, msg, growth_gas_ptr);
 
     result.gas_refund += auth_refund;
     return result;
@@ -324,7 +328,8 @@ ExecuteTransaction<traits>::ExecuteTransaction(
 }
 
 template <Traits traits>
-Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
+Result<evmc::Result>
+ExecuteTransaction<traits>::execute_impl2(State &state, TransactionStats &stats)
 {
     auto const validate_lambda = [this, &state] {
         auto result = validate_transaction<traits>(
@@ -362,18 +367,25 @@ Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
         chain_ctx_,
         trace_transfers_};
 
-    return ExecuteTransactionNoValidation<traits>::operator()(state, host);
+    return ExecuteTransactionNoValidation<traits>::operator()(
+        state, host, &stats);
 }
 
 template <Traits traits>
 Receipt ExecuteTransaction<traits>::execute_final(
-    State &state, evmc::Result const &result)
+    State &state, TransactionStats const &stats, evmc::Result const &result)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
 
     MONAD_ASSERT(result.gas_left >= 0);
     MONAD_ASSERT(result.gas_refund >= 0);
     MONAD_ASSERT(tx_.gas_limit >= static_cast<uint64_t>(result.gas_left));
+    auto const tx_gas_used =
+        tx_.gas_limit - static_cast<uint64_t>(result.gas_left);
+    block_metrics_.sum_tx_gas_limit += tx_.gas_limit;
+    block_metrics_.gas_used += tx_gas_used;
+    MONAD_DEBUG_ASSERT(stats.growth_gas <= tx_gas_used);
+    block_metrics_.gas_exec += tx_gas_used - stats.growth_gas;
 
     // refund and priority, Eqn. 73-76
     // Monad specification §4.2: Storage Gas Cost and Refunds
@@ -452,12 +464,13 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         TRACE_TXN_EVENT(StartExecution);
 
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        TransactionStats stats{};
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();
         trace::reset(state_tracer_);
 
-        auto result = execute_impl2(state);
+        auto result = execute_impl2(state, stats);
 
         {
             TRACE_TXN_EVENT(StartStall);
@@ -468,7 +481,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             if (result.has_error()) {
                 return std::move(result.error());
             }
-            auto const receipt = execute_final(state, result.value());
+            auto const receipt = execute_final(state, stats, result.value());
             block_state_.merge(state);
             return receipt;
         }
@@ -478,17 +491,18 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         TRACE_TXN_EVENT(StartRetry);
 
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        TransactionStats stats{};
 
         call_tracer_.reset();
         trace::reset(state_tracer_);
 
-        auto result = execute_impl2(state);
+        auto result = execute_impl2(state, stats);
 
         MONAD_ASSERT(block_state_.can_merge(state));
         if (result.has_error()) {
             return std::move(result.error());
         }
-        auto const receipt = execute_final(state, result.value());
+        auto const receipt = execute_final(state, stats, result.value());
         block_state_.merge(state);
         return receipt;
     }

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -29,6 +29,7 @@
 #include <category/execution/ethereum/execute_message.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
+#include <category/execution/ethereum/metrics/transaction_stats.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
@@ -229,7 +230,7 @@ evmc_message ExecuteTransactionNoValidation<traits>::to_message(
 
 template <Traits traits>
 evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
-    State &state, EvmcHost<traits> &host)
+    State &state, EvmcHost<traits> &host, TransactionStats *const stats)
 {
     if constexpr (::monad::is_monad_trait_v<traits>) {
         init_reserve_balance_context<traits>(
@@ -287,10 +288,13 @@ evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
         }
     }
 
-    auto result =
-        (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
-            ? ::monad::execute_create_message<traits>(&host, state, msg)
-            : ::monad::execute_call_message<traits>(&host, state, msg);
+    uint64_t *const growth_gas_ptr =
+        stats != nullptr ? &stats->growth_gas : nullptr;
+    auto result = (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+                      ? ::monad::execute_create_message<traits>(
+                            &host, state, msg, growth_gas_ptr)
+                      : ::monad::execute_call_message<traits>(
+                            &host, state, msg, growth_gas_ptr);
 
     result.gas_refund += auth_refund;
     return result;
@@ -326,7 +330,8 @@ ExecuteTransaction<traits>::ExecuteTransaction(
 }
 
 template <Traits traits>
-Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
+Result<evmc::Result>
+ExecuteTransaction<traits>::execute_impl2(State &state, TransactionStats &stats)
 {
     auto const validate_lambda = [this, &state] {
         auto result = validate_transaction<traits>(
@@ -364,18 +369,25 @@ Result<evmc::Result> ExecuteTransaction<traits>::execute_impl2(State &state)
         chain_ctx_,
         trace_transfers_};
 
-    return ExecuteTransactionNoValidation<traits>::operator()(state, host);
+    return ExecuteTransactionNoValidation<traits>::operator()(
+        state, host, &stats);
 }
 
 template <Traits traits>
 Receipt ExecuteTransaction<traits>::execute_final(
-    State &state, evmc::Result const &result)
+    State &state, TransactionStats const &stats, evmc::Result const &result)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
 
     MONAD_ASSERT(result.gas_left >= 0);
     MONAD_ASSERT(result.gas_refund >= 0);
     MONAD_ASSERT(tx_.gas_limit >= static_cast<uint64_t>(result.gas_left));
+    auto const tx_gas_used =
+        tx_.gas_limit - static_cast<uint64_t>(result.gas_left);
+    block_metrics_.sum_tx_gas_limit += tx_.gas_limit;
+    block_metrics_.gas_used += tx_gas_used;
+    MONAD_DEBUG_ASSERT(stats.growth_gas <= tx_gas_used);
+    block_metrics_.gas_exec += tx_gas_used - stats.growth_gas;
 
     // refund and priority, Eqn. 73-76
     // Monad specification §4.2: Storage Gas Cost and Refunds
@@ -455,12 +467,13 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         TRACE_TXN_EVENT(StartExecution);
 
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        TransactionStats stats{};
         state.set_original_nonce(sender_, tx_.nonce);
 
         call_tracer_.reset();
         trace::reset(state_tracer_);
 
-        auto result = execute_impl2(state);
+        auto result = execute_impl2(state, stats);
 
         {
             TRACE_TXN_EVENT(StartStall);
@@ -471,7 +484,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             if (result.has_error()) {
                 return std::move(result.error());
             }
-            auto const receipt = execute_final(state, result.value());
+            auto const receipt = execute_final(state, stats, result.value());
             block_state_.merge(state);
             return receipt;
         }
@@ -481,17 +494,18 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
         TRACE_TXN_EVENT(StartRetry);
 
         State state{block_state_, Incarnation{header_.number, i_ + 1}};
+        TransactionStats stats{};
 
         call_tracer_.reset();
         trace::reset(state_tracer_);
 
-        auto result = execute_impl2(state);
+        auto result = execute_impl2(state, stats);
 
         MONAD_ASSERT(block_state_.can_merge(state));
         if (result.has_error()) {
             return std::move(result.error());
         }
-        auto const receipt = execute_final(state, result.value());
+        auto const receipt = execute_final(state, stats, result.value());
         block_state_.merge(state);
         return receipt;
     }

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -42,6 +42,7 @@ template <Traits traits>
 struct EvmcHost;
 class State;
 struct Transaction;
+struct TransactionStats;
 
 template <Traits traits>
 class ExecuteTransactionNoValidation
@@ -63,7 +64,8 @@ public:
         Chain const &, Transaction const &, Address const &,
         std::span<std::optional<Address> const>, BlockHeader const &);
 
-    evmc::Result operator()(State &, EvmcHost<traits> &);
+    evmc::Result
+    operator()(State &, EvmcHost<traits> &, TransactionStats *stats = nullptr);
 };
 
 template <Traits traits>
@@ -85,8 +87,9 @@ class ExecuteTransaction : public ExecuteTransactionNoValidation<traits>
     trace::StateTracer &state_tracer_;
     bool trace_transfers_;
 
-    Result<evmc::Result> execute_impl2(State &);
-    Receipt execute_final(State &, evmc::Result const &);
+    Result<evmc::Result> execute_impl2(State &, TransactionStats &);
+    Receipt
+    execute_final(State &, TransactionStats const &, evmc::Result const &);
 
 public:
     ExecuteTransaction(

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -43,6 +43,7 @@ struct EvmcHost;
 class ExecutionEventRecorder;
 class State;
 struct Transaction;
+struct TransactionStats;
 
 template <Traits traits>
 class ExecuteTransactionNoValidation
@@ -64,7 +65,8 @@ public:
         Chain const &, Transaction const &, Address const &,
         std::span<std::optional<Address> const>, BlockHeader const &);
 
-    evmc::Result operator()(State &, EvmcHost<traits> &);
+    evmc::Result
+    operator()(State &, EvmcHost<traits> &, TransactionStats *stats = nullptr);
 };
 
 template <Traits traits>
@@ -87,8 +89,9 @@ class ExecuteTransaction : public ExecuteTransactionNoValidation<traits>
     ExecutionEventRecorder *exec_recorder_;
     bool trace_transfers_;
 
-    Result<evmc::Result> execute_impl2(State &);
-    Receipt execute_final(State &, evmc::Result const &);
+    Result<evmc::Result> execute_impl2(State &, TransactionStats &);
+    Receipt
+    execute_final(State &, TransactionStats const &, evmc::Result const &);
 
 public:
     ExecuteTransaction(

--- a/category/execution/ethereum/metrics/block_metrics.hpp
+++ b/category/execution/ethereum/metrics/block_metrics.hpp
@@ -25,6 +25,9 @@ struct BlockMetrics
 {
     uint32_t num_retries{0};
     std::chrono::microseconds tx_exec_time{1};
+    uint64_t sum_tx_gas_limit{0};
+    uint64_t gas_used{0};
+    uint64_t gas_exec{0};
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/metrics/transaction_stats.hpp
+++ b/category/execution/ethereum/metrics/transaction_stats.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,34 +15,15 @@
 
 #pragma once
 
-#include <category/core/address.hpp>
 #include <category/core/config.hpp>
-#include <category/vm/evm/traits.hpp>
 
-#include <evmc/evmc.h>
-#include <evmc/evmc.hpp>
-
-#include <functional>
+#include <cstdint>
 
 MONAD_NAMESPACE_BEGIN
 
-template <Traits traits>
-struct EvmcHost;
-
-class State;
-
-template <Traits traits>
-evmc::Result
-deploy_contract_code(State &, Address const &, evmc::Result) noexcept;
-
-template <Traits traits>
-evmc::Result execute_create_message(
-    EvmcHost<traits> *, State &, evmc_message const &,
-    uint64_t *growth_gas_ptr = nullptr);
-
-template <Traits traits>
-evmc::Result execute_call_message(
-    EvmcHost<traits> *, State &, evmc_message const &,
-    uint64_t *growth_gas_ptr = nullptr);
+struct TransactionStats
+{
+    uint64_t growth_gas{0};
+};
 
 MONAD_NAMESPACE_END

--- a/category/execution/runloop/runloop_ethereum.cpp
+++ b/category/execution/runloop/runloop_ethereum.cpp
@@ -93,12 +93,11 @@ Result<void> process_ethereum_block(
     fiber::PriorityPool &priority_pool, Block &block,
     BlockHeader const &parent_header, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing,
-    ExecutionEventRecorder *const exec_recorder)
+    ExecutionEventRecorder *const exec_recorder,
+    std::chrono::steady_clock::time_point const block_begin,
+    std::chrono::microseconds const blr_time)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_CONSTANTINOPLE);
-
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
 
     record_block_start(
         exec_recorder,
@@ -222,8 +221,12 @@ Result<void> process_ethereum_block(
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
+    auto const fin_begin = std::chrono::steady_clock::now();
     db.finalize(block.header.number, block_id);
     db.update_verified_block(block.header.number);
+    [[maybe_unused]] auto const fin_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - fin_begin);
     exec_output.eth_block_hash =
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
     block_hash_buffer.set(
@@ -235,31 +238,35 @@ Result<void> process_ethereum_block(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - block_begin);
     LOG_INFO(
-        "__exec_block,bl={:8},ts={}"
+        "__exec_block,bl={:8}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},fin={:>7},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            block_start.time_since_epoch())
-            .count(),
         block.transactions.size(),
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        fin_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -297,11 +304,15 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
     bytes32_t parent_block_id{};
 
     while (block_num <= end_block_num && stop == 0) {
+        auto const block_begin = std::chrono::steady_clock::now();
         Block block;
         MONAD_ASSERT_PRINTF(
             block_db.get(block_num, block),
             "Could not query %lu from blockdb",
             block_num);
+        auto const blr_time =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - block_begin);
 
         BlockHeader const parent_header = db.read_eth_header();
         MONAD_ASSERT_PRINTF(
@@ -327,7 +338,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
                 block_id,
                 parent_block_id,
                 enable_tracing,
-                exec_recorder);
+                exec_recorder,
+                block_begin,
+                blr_time);
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 

--- a/category/execution/runloop/runloop_ethereum.cpp
+++ b/category/execution/runloop/runloop_ethereum.cpp
@@ -92,12 +92,11 @@ Result<void> process_ethereum_block(
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block,
     BlockHeader const &parent_header, bytes32_t const &block_id,
-    bytes32_t const &parent_block_id, bool const enable_tracing)
+    bytes32_t const &parent_block_id, bool const enable_tracing,
+    std::chrono::steady_clock::time_point const block_begin,
+    std::chrono::microseconds const blr_time)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_CONSTANTINOPLE);
-
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
 
     record_block_start(
         block_id,
@@ -219,8 +218,12 @@ Result<void> process_ethereum_block(
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
+    auto const fin_begin = std::chrono::steady_clock::now();
     db.finalize(block.header.number, block_id);
     db.update_verified_block(block.header.number);
+    [[maybe_unused]] auto const fin_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - fin_begin);
     exec_output.eth_block_hash =
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
     block_hash_buffer.set(
@@ -232,31 +235,35 @@ Result<void> process_ethereum_block(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - block_begin);
     LOG_INFO(
-        "__exec_block,bl={:8},ts={}"
+        "__exec_block,bl={:8}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},fin={:>7},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            block_start.time_since_epoch())
-            .count(),
         block.transactions.size(),
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        fin_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -293,11 +300,15 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
     bytes32_t parent_block_id{};
 
     while (block_num <= end_block_num && stop == 0) {
+        auto const block_begin = std::chrono::steady_clock::now();
         Block block;
         MONAD_ASSERT_PRINTF(
             block_db.get(block_num, block),
             "Could not query %lu from blockdb",
             block_num);
+        auto const blr_time =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - block_begin);
 
         BlockHeader const parent_header = db.read_eth_header();
         MONAD_ASSERT_PRINTF(
@@ -322,7 +333,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
                 parent_header,
                 block_id,
                 parent_block_id,
-                enable_tracing);
+                enable_tracing,
+                block_begin,
+                blr_time);
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 

--- a/category/execution/runloop/runloop_monad.cpp
+++ b/category/execution/runloop/runloop_monad.cpp
@@ -183,10 +183,11 @@ Result<BlockExecOutput> propose_block(
     BlockHashChain &block_hash_chain, MonadChain const &chain, Db &db,
     vm::VM &vm, fiber::PriorityPool &priority_pool, bool const is_first_block,
     bool const enable_tracing, BlockCache &block_cache, Db *secondary_db,
-    RunloopMonadOverride const runloop_override)
+    RunloopMonadOverride const runloop_override,
+    [[maybe_unused]] std::chrono::system_clock::time_point const block_start,
+    std::chrono::steady_clock::time_point const block_begin,
+    [[maybe_unused]] std::chrono::microseconds const blr_time)
 {
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
     auto const &block_hash_buffer =
         block_hash_chain.find_chain(consensus_header.parent_id());
 
@@ -389,8 +390,10 @@ Result<BlockExecOutput> propose_block(
     LOG_INFO(
         "__exec_block,bl={:8},id={},ts={}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},etot={:>8},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
         block_id,
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -400,19 +403,24 @@ Result<BlockExecOutput> propose_block(
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        block_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -662,7 +670,8 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
              runloop_override](
                 bytes32_t const &block_id,
                 auto const &header) -> Result<std::pair<uint64_t, uint64_t>> {
-            auto const block_time_start = std::chrono::steady_clock::now();
+            auto const block_start = std::chrono::system_clock::now();
+            auto const block_begin = std::chrono::steady_clock::now();
 
             db.update_voted_metadata(header.seqno - 1, header.parent_id());
             if (secondary_db != nullptr) {
@@ -672,7 +681,11 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
             record_block_qc(header, last_finalized_block_number);
 
             uint64_t const block_number = header.execution_inputs.number;
+            auto const blr_begin = std::chrono::steady_clock::now();
             auto body = read_body(header.block_body_id, body_dir);
+            auto const blr_time =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - blr_begin);
             auto const ntxns = body.transactions.size();
 
             auto const &block_hash_buffer =
@@ -720,7 +733,10 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                     enable_tracing,
                     block_cache,
                     secondary_db,
-                    runloop_override);
+                    runloop_override,
+                    block_start,
+                    block_begin,
+                    blr_time);
                 MONAD_ABORT_PRINTF("handled rev value %d", rev);
             };
             BOOST_OUTCOME_TRY(
@@ -739,7 +755,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 block_id,
                 ntxns,
                 exec_output.eth_header.gas_used,
-                block_time_start);
+                block_begin);
 
             return outcome::success();
         };
@@ -753,6 +769,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
         }
 
         for (auto const &[block, block_id, verified_blocks] : to_finalize) {
+            [[maybe_unused]] auto const fin_start =
+                std::chrono::system_clock::now();
+            auto const fin_begin = std::chrono::steady_clock::now();
             LOG_INFO(
                 "Processing finalization for block {} with block_id {}",
                 block,
@@ -773,6 +792,18 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 }
             }
             record_block_verified(verified_blocks);
+
+            [[maybe_unused]] auto const fin_time =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - fin_begin);
+            LOG_INFO(
+                "__finalize,bl={:8},id={},ts={},dur={:>7}",
+                block,
+                block_id,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    fin_start.time_since_epoch())
+                    .count(),
+                fin_time);
         }
 
         if (!to_finalize.empty()) {

--- a/category/execution/runloop/runloop_monad.cpp
+++ b/category/execution/runloop/runloop_monad.cpp
@@ -184,10 +184,11 @@ Result<BlockExecOutput> propose_block(
     vm::VM &vm, fiber::PriorityPool &priority_pool, bool const is_first_block,
     bool const enable_tracing, BlockCache &block_cache,
     ExecutionEventRecorder *const exec_recorder, Db *secondary_db,
-    RunloopMonadOverride const runloop_override)
+    RunloopMonadOverride const runloop_override,
+    [[maybe_unused]] std::chrono::system_clock::time_point const block_start,
+    std::chrono::steady_clock::time_point const block_begin,
+    [[maybe_unused]] std::chrono::microseconds const blr_time)
 {
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
     auto const &block_hash_buffer =
         block_hash_chain.find_chain(consensus_header.parent_id());
 
@@ -381,8 +382,10 @@ Result<BlockExecOutput> propose_block(
     LOG_INFO(
         "__exec_block,bl={:8},id={},ts={}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},etot={:>8},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
         block_id,
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -392,19 +395,24 @@ Result<BlockExecOutput> propose_block(
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        block_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -656,7 +664,8 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
              runloop_override](
                 bytes32_t const &block_id,
                 auto const &header) -> Result<std::pair<uint64_t, uint64_t>> {
-            auto const block_time_start = std::chrono::steady_clock::now();
+            auto const block_start = std::chrono::system_clock::now();
+            auto const block_begin = std::chrono::steady_clock::now();
 
             for_each_db(db, secondary_db, [&](Db &d) {
                 d.update_voted_metadata(header.seqno - 1, header.parent_id());
@@ -664,7 +673,11 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
             record_block_qc(exec_recorder, header, last_finalized_block_number);
 
             uint64_t const block_number = header.execution_inputs.number;
+            auto const blr_begin = std::chrono::steady_clock::now();
             auto body = read_body(header.block_body_id, body_dir);
+            auto const blr_time =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - blr_begin);
             auto const ntxns = body.transactions.size();
 
             auto const &block_hash_buffer =
@@ -714,7 +727,10 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                     block_cache,
                     exec_recorder,
                     secondary_db,
-                    runloop_override);
+                    runloop_override,
+                    block_start,
+                    block_begin,
+                    blr_time);
                 MONAD_ABORT_PRINTF("handled rev value %d", rev);
             };
             BOOST_OUTCOME_TRY(
@@ -730,7 +746,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 block_id,
                 ntxns,
                 exec_output.eth_header.gas_used,
-                block_time_start);
+                block_begin);
 
             return outcome::success();
         };
@@ -744,6 +760,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
         }
 
         for (auto const &[block, block_id, verified_blocks] : to_finalize) {
+            [[maybe_unused]] auto const fin_start =
+                std::chrono::system_clock::now();
+            auto const fin_begin = std::chrono::steady_clock::now();
             LOG_INFO(
                 "Processing finalization for block {} with block_id {}",
                 block,
@@ -761,6 +780,18 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 });
             }
             record_block_verified(exec_recorder, verified_blocks);
+
+            [[maybe_unused]] auto const fin_time =
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - fin_begin);
+            LOG_INFO(
+                "__finalize,bl={:8},id={},ts={},dur={:>7}",
+                block,
+                block_id,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    fin_start.time_since_epoch())
+                    .count(),
+                fin_time);
         }
 
         if (!to_finalize.empty()) {

--- a/category/execution/runloop/runloop_monad_ethblocks.cpp
+++ b/category/execution/runloop/runloop_monad_ethblocks.cpp
@@ -128,11 +128,10 @@ Result<void> process_monad_block(
     ankerl::unordered_dense::segmented_set<Address> const
         &parent_senders_and_authorities,
     ankerl::unordered_dense::segmented_set<Address>
-        &senders_and_authorities_out)
+        &senders_and_authorities_out,
+    std::chrono::steady_clock::time_point const block_begin,
+    std::chrono::microseconds const blr_time)
 {
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
-
     // This is exactly the same as the recording call in runloop_ethereum.cpp;
     // even though these are historical Monad block inputs, we don't have the
     // additional information from the consensus header here (the consensus
@@ -263,8 +262,12 @@ Result<void> process_monad_block(
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
+    auto const fin_begin = std::chrono::steady_clock::now();
     db.finalize(block.header.number, block_id);
     db.update_verified_block(block.header.number);
+    [[maybe_unused]] auto const fin_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - fin_begin);
     exec_output.eth_block_hash =
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
     block_hash_buffer.set(
@@ -276,31 +279,35 @@ Result<void> process_monad_block(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - block_begin);
     LOG_INFO(
-        "__exec_block,bl={:8},ts={}"
+        "__exec_block,bl={:8}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},fin={:>7},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            block_start.time_since_epoch())
-            .count(),
         block.transactions.size(),
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        fin_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -399,8 +406,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
     }
 
     while (block_num <= end_block_num && stop == 0) {
+        auto const block_begin = std::chrono::steady_clock::now();
         Block block;
         get_block_with_retry(block_db, block_num, block, block_db_timeout);
+        auto const blr_time =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - block_begin);
 
         bytes32_t const block_id = bytes32_t{block.header.number};
         monad_revision const rev =
@@ -434,7 +445,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
                 enable_tracing,
                 grandparent_senders_and_authorities,
                 parent_senders_and_authorities,
-                senders_and_authorities);
+                senders_and_authorities,
+                block_begin,
+                blr_time);
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 

--- a/category/execution/runloop/runloop_monad_ethblocks.cpp
+++ b/category/execution/runloop/runloop_monad_ethblocks.cpp
@@ -129,11 +129,10 @@ Result<void> process_monad_block(
         &parent_senders_and_authorities,
     ankerl::unordered_dense::segmented_set<Address>
         &senders_and_authorities_out,
-    ExecutionEventRecorder *const exec_recorder)
+    ExecutionEventRecorder *const exec_recorder,
+    std::chrono::steady_clock::time_point const block_begin,
+    std::chrono::microseconds const blr_time)
 {
-    [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
-    auto const block_begin = std::chrono::steady_clock::now();
-
     // This is exactly the same as the recording call in runloop_ethereum.cpp;
     // even though these are historical Monad block inputs, we don't have the
     // additional information from the consensus header here (the consensus
@@ -268,10 +267,14 @@ Result<void> process_monad_block(
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
+    auto const fin_begin = std::chrono::steady_clock::now();
     for_each_db(db, mirror_db, [&](Db &d) {
         d.finalize(block.header.number, block_id);
         d.update_verified_block(block.header.number);
     });
+    [[maybe_unused]] auto const fin_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - fin_begin);
     exec_output.eth_block_hash =
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
     block_hash_buffer.set(
@@ -296,31 +299,35 @@ Result<void> process_monad_block(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - block_begin);
     LOG_INFO(
-        "__exec_block,bl={:8},ts={}"
+        "__exec_block,bl={:8}"
         ",tx={:5},rt={:4},rtp={:5.2f}%"
-        ",sr={:>7},txe={:>8},cmt={:>8},tot={:>8},tpse={:5},tps={:5}"
-        ",gas={:9},gpse={:4},gps={:3}{}{}{}",
+        ",blr={:>7},sr={:>7},txe={:>8},cmt={:>8},fin={:>7},tot={:>8}"
+        ",tpse={:5},tps={:5}"
+        ",gase={:9},gasu={:9},gasc={:9},gas={:9},gasl={:9},gpse={:4},gps={:4}{}"
+        "{}{}",
         block.header.number,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            block_start.time_since_epoch())
-            .count(),
         block.transactions.size(),
         block_metrics.num_retries,
         100.0 * (double)block_metrics.num_retries /
             std::max(1.0, (double)block.transactions.size()),
+        blr_time,
         sender_recovery_time,
         block_metrics.tx_exec_time,
         commit_time,
+        fin_time,
         block_time,
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
         block.transactions.size() * 1'000'000 /
             (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec,
+        block_metrics.gas_used,
         exec_output.eth_header.gas_used,
-        exec_output.eth_header.gas_used /
+        exec_output.eth_header.gas_used,
+        block_metrics.sum_tx_gas_limit,
+        block_metrics.gas_exec /
             (uint64_t)std::max(1L, block_metrics.tx_exec_time.count()),
-        exec_output.eth_header.gas_used /
-            (uint64_t)std::max(1L, block_time.count()),
+        block_metrics.gas_exec / (uint64_t)std::max(1L, block_time.count()),
         db.print_stats(),
         vm.print_and_reset_block_counts(),
         vm.print_compiler_stats());
@@ -421,8 +428,12 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
     }
 
     while (block_num <= end_block_num && stop == 0) {
+        auto const block_begin = std::chrono::steady_clock::now();
         Block block;
         get_block_with_retry(block_db, block_num, block, block_db_timeout);
+        auto const blr_time =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - block_begin);
 
         bytes32_t const block_id = bytes32_t{block.header.number};
         monad_revision const rev =
@@ -465,7 +476,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
                 grandparent_senders_and_authorities,
                 parent_senders_and_authorities,
                 senders_and_authorities,
-                exec_recorder);
+                exec_recorder,
+                block_begin,
+                blr_time);
             MONAD_ABORT_PRINTF("unhandled rev switch case: %d", rev);
         }());
 

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -100,6 +100,8 @@ namespace monad
         { T::cold_account_cost() } -> std::same_as<int64_t>;
         { T::cold_storage_cost() } -> std::same_as<int64_t>;
         { T::base_sstore_cost() } -> std::same_as<int64_t>;
+        { T::sstore_growth_gas() } -> std::same_as<uint64_t>;
+        { T::create_growth_gas() } -> std::same_as<uint64_t>;
 
         // Instead of storing a revision, caches should identify revision
         // changes by storing the opaque value returned by this method. No
@@ -245,6 +247,16 @@ namespace monad
         static consteval int64_t base_sstore_cost() noexcept
         {
             return 100;
+        }
+
+        static consteval uint64_t sstore_growth_gas() noexcept
+        {
+            return 17100;
+        }
+
+        static consteval uint64_t create_growth_gas() noexcept
+        {
+            return 31900; // 32000 - 100 (execution cost estimate).
         }
 
         static uint64_t id() noexcept
@@ -458,6 +470,16 @@ namespace monad
                 return 8000;
             }
             return 2000;
+        }
+
+        static consteval uint64_t sstore_growth_gas() noexcept
+        {
+            return 17100;
+        }
+
+        static consteval uint64_t create_growth_gas() noexcept
+        {
+            return 31900; // 32000 - 100 (execution cost estimate).
         }
 
         static uint64_t id() noexcept

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -99,6 +99,8 @@ namespace monad
         { T::cold_account_cost() } -> std::same_as<int64_t>;
         { T::cold_storage_cost() } -> std::same_as<int64_t>;
         { T::base_sstore_cost() } -> std::same_as<int64_t>;
+        { T::sstore_growth_gas() } -> std::same_as<uint64_t>;
+        { T::create_growth_gas() } -> std::same_as<uint64_t>;
 
         // Instead of storing a revision, caches should identify revision
         // changes by storing the opaque value returned by this method. No
@@ -239,6 +241,16 @@ namespace monad
         static consteval int64_t base_sstore_cost() noexcept
         {
             return 100;
+        }
+
+        static consteval uint64_t sstore_growth_gas() noexcept
+        {
+            return 17100;
+        }
+
+        static consteval uint64_t create_growth_gas() noexcept
+        {
+            return 31900; // 32000 - 100 (execution cost estimate).
         }
 
         static uint64_t id() noexcept
@@ -444,6 +456,16 @@ namespace monad
                 return 8000;
             }
             return 2000;
+        }
+
+        static consteval uint64_t sstore_growth_gas() noexcept
+        {
+            return 17100;
+        }
+
+        static consteval uint64_t create_growth_gas() noexcept
+        {
+            return 31900; // 32000 - 100 (execution cost estimate).
         }
 
         static uint64_t id() noexcept

--- a/category/vm/host.hpp
+++ b/category/vm/host.hpp
@@ -68,6 +68,9 @@ namespace monad::vm
             runtime_context_->stack_unwind();
         }
 
+    protected:
+        runtime::Context *runtime_context_{nullptr};
+
     private:
         [[gnu::always_inline]]
         void rethrow_on_active_exception()
@@ -88,7 +91,6 @@ namespace monad::vm
             return prev;
         }
 
-        runtime::Context *runtime_context_{nullptr};
         mutable std::exception_ptr active_exception_;
     };
 }

--- a/category/vm/host.hpp
+++ b/category/vm/host.hpp
@@ -58,6 +58,9 @@ namespace monad::vm
             runtime_context_->stack_unwind();
         }
 
+    protected:
+        runtime::Context *runtime_context_{nullptr};
+
     private:
         [[gnu::always_inline]]
         void rethrow_on_active_exception()
@@ -78,7 +81,6 @@ namespace monad::vm
             return prev;
         }
 
-        runtime::Context *runtime_context_{nullptr};
         mutable std::exception_ptr active_exception_;
     };
 }

--- a/category/vm/runtime/call.cpp
+++ b/category/vm/runtime/call.cpp
@@ -118,6 +118,7 @@ namespace monad::vm::runtime
             ctx->gas_remaining -= 9000;
         }
 
+        bool grew = false;
         if (call_kind == EVMC_CALL) {
             if (MONAD_UNLIKELY(
                     has_value && (ctx->env.evmc_flags & EVMC_STATIC))) {
@@ -131,6 +132,7 @@ namespace monad::vm::runtime
             if (has_value &&
                 !ctx->host->account_exists(ctx->context, &dest_address)) {
                 ctx->gas_remaining -= 25000;
+                grew = true;
             }
         }
 
@@ -152,6 +154,10 @@ namespace monad::vm::runtime
 
         if (MONAD_UNLIKELY(ctx->env.depth >= 1024)) {
             return 0;
+        }
+
+        if (grew) {
+            ctx->add_growth_gas(25000);
         }
 
         auto const message = evmc_message{

--- a/category/vm/runtime/context.cpp
+++ b/category/vm/runtime/context.cpp
@@ -88,8 +88,8 @@ namespace monad::vm::runtime
 
     Context Context::from(
         evmc_host_interface const *const host, evmc_host_context *const context,
-        evmc_message const *const msg,
-        std::span<uint8_t const> const code) noexcept
+        evmc_message const *const msg, std::span<uint8_t const> const code,
+        uint64_t *const growth_gas_ptr) noexcept
     {
         return Context{
             .host = host,
@@ -115,11 +115,13 @@ namespace monad::vm::runtime
             .result = {},
             .memory =
                 Memory(msg->memory_handle, msg->memory, msg->memory_capacity),
+            .growth_gas_ptr = growth_gas_ptr,
         };
     }
 
     Context Context::empty(
-        uint8_t *const memory_handle, uint32_t const memory_capacity) noexcept
+        uint8_t *const memory_handle, uint32_t const memory_capacity,
+        uint64_t *const growth_gas_ptr) noexcept
     {
         return Context{
             .host = nullptr,
@@ -144,6 +146,7 @@ namespace monad::vm::runtime
                 },
             .result = {},
             .memory = Memory(memory_handle, memory_handle, memory_capacity),
+            .growth_gas_ptr = growth_gas_ptr,
         };
     }
 

--- a/category/vm/runtime/selfdestruct.cpp
+++ b/category/vm/runtime/selfdestruct.cpp
@@ -57,6 +57,7 @@ namespace monad::vm::runtime
 
             if (!exists) {
                 ctx->deduct_gas(25000);
+                ctx->add_growth_gas(25000);
             }
         }
 

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -101,6 +101,9 @@ namespace monad::vm::runtime
 
             gas_used -= min_gas;
             ctx->deduct_gas(gas_used);
+            if (grew_state) {
+                ctx->add_growth_gas(traits::page_growth_cost());
+            }
         }
         else {
             auto const access_status = ctx->host->access_storage(
@@ -118,6 +121,9 @@ namespace monad::vm::runtime
 
             ctx->gas_refund += gas_refund;
             ctx->deduct_gas(gas_used);
+            if (storage_status == EVMC_STORAGE_ADDED) {
+                ctx->add_growth_gas(traits::sstore_growth_gas());
+            }
         }
     }
 

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -98,6 +98,9 @@ namespace monad::vm::runtime
 
             gas_used -= min_gas;
             ctx->deduct_gas(gas_used);
+            if (grew_state) {
+                ctx->add_growth_gas(traits::page_growth_cost());
+            }
         }
         else {
             auto const access_status = ctx->host->access_storage(
@@ -115,6 +118,9 @@ namespace monad::vm::runtime
 
             ctx->gas_refund += gas_refund;
             ctx->deduct_gas(gas_used);
+            if (storage_status == EVMC_STORAGE_ADDED) {
+                ctx->add_growth_gas(traits::sstore_growth_gas());
+            }
         }
     }
 

--- a/category/vm/runtime/types.hpp
+++ b/category/vm/runtime/types.hpp
@@ -28,6 +28,7 @@
 #include <evmc/evmc.hpp>
 
 #include <cstddef>
+#include <limits>
 #include <span>
 #include <type_traits>
 #include <variant>
@@ -228,10 +229,12 @@ namespace monad::vm::runtime
     {
         static Context from(
             evmc_host_interface const *host, evmc_host_context *context,
-            evmc_message const *msg, std::span<uint8_t const> code) noexcept;
+            evmc_message const *msg, std::span<uint8_t const> code,
+            uint64_t *growth_gas_ptr = nullptr) noexcept;
 
-        static Context
-        empty(uint8_t *memory_handle, uint32_t memory_capacity) noexcept;
+        static Context empty(
+            uint8_t *memory_handle, uint32_t memory_capacity,
+            uint64_t *growth_gas_ptr = nullptr) noexcept;
 
         evmc_host_interface const *host;
         evmc_host_context *context;
@@ -247,6 +250,8 @@ namespace monad::vm::runtime
 
         exit_stack_ptr_t exit_stack_ptr = nullptr;
         bool is_stack_unwinding_active = false;
+
+        uint64_t *growth_gas_ptr{nullptr};
 
         [[gnu::always_inline]]
         constexpr void deduct_gas(int64_t const gas) noexcept
@@ -391,6 +396,17 @@ namespace monad::vm::runtime
 
         template <Traits traits>
         evmc::Result copy_to_evmc_result();
+
+        [[gnu::always_inline]]
+        constexpr void add_growth_gas(uint64_t const g) noexcept
+        {
+            if (growth_gas_ptr != nullptr) {
+                MONAD_DEBUG_ASSERT(
+                    g <=
+                    std::numeric_limits<uint64_t>::max() - *growth_gas_ptr);
+                *growth_gas_ptr += g;
+            }
+        }
 
     private:
         template <Traits traits>

--- a/category/vm/vm.cpp
+++ b/category/vm/vm.cpp
@@ -62,7 +62,7 @@ namespace monad::vm
     template <Traits traits>
     evmc::Result VM::execute(
         Host &host, evmc_message const *msg, bytes32_t const &code_hash,
-        SharedVarcode const &vcode)
+        SharedVarcode const &vcode, uint64_t *const growth_gas_ptr)
     {
         auto const *const host_itf = &host.get_interface();
         auto *const host_ctx = host.to_context();
@@ -80,8 +80,8 @@ namespace monad::vm
             }
         }
 
-        auto rt_ctx =
-            runtime::Context::from(host_itf, host_ctx, msg, icode->code_span());
+        auto rt_ctx = runtime::Context::from(
+            host_itf, host_ctx, msg, icode->code_span(), growth_gas_ptr);
 
         // Install new runtime context:
         auto *const prev_rt_ctx = host.set_runtime_context(&rt_ctx);
@@ -102,7 +102,8 @@ namespace monad::vm
 
     template <Traits traits>
     evmc::Result VM::execute_bytecode(
-        Host &host, evmc_message const *msg, std::span<uint8_t const> code)
+        Host &host, evmc_message const *msg, std::span<uint8_t const> code,
+        uint64_t *const growth_gas_ptr)
     {
         auto const *const host_itf = &host.get_interface();
         auto *const host_ctx = host.to_context();
@@ -119,7 +120,8 @@ namespace monad::vm
             }
         }
 
-        auto rt_ctx = runtime::Context::from(host_itf, host_ctx, msg, code);
+        auto rt_ctx = runtime::Context::from(
+            host_itf, host_ctx, msg, code, growth_gas_ptr);
 
         // Install new runtime context:
         auto *const prev_rt_ctx = host.set_runtime_context(&rt_ctx);

--- a/category/vm/vm.hpp
+++ b/category/vm/vm.hpp
@@ -200,12 +200,13 @@ namespace monad::vm
         template <Traits traits>
         evmc::Result execute(
             Host &host, evmc_message const *msg, bytes32_t const &code_hash,
-            SharedVarcode const &vcode);
+            SharedVarcode const &vcode, uint64_t *growth_gas_ptr = nullptr);
 
         /// Execute the bytecode `code` with interpreter.
         template <Traits traits>
         evmc::Result execute_bytecode(
-            Host &host, evmc_message const *msg, std::span<uint8_t const> code);
+            Host &host, evmc_message const *msg, std::span<uint8_t const> code,
+            uint64_t *growth_gas_ptr = nullptr);
 
         /// Like `execute`, but without stack unwind support.
         template <Traits traits>


### PR DESCRIPTION
Detailed gas reporting:
- 'gase': gas used - growth gas
- 'gasu': gas used
- 'gasc': gas charged
- 'gasl': gas limit

Before this PR only gas charged was reported as 'gas' and used in gps computation. After this PR 'gase' is used in gps computation for more conservative results.

For real time:
- Report finalization time per block.
- Changed execution total from 'tot' to 'etot' (as it does not include finalization, reported separately).

For replay:
- Report finalization latency as 'fin'.
- Removed the useless timestamp 'ts' field (useful for realtime, but useless for replay).

For both real time and replay:
- Added 'blr' field for block read latency.

[UPDATE 2026-06-02]
Keeping defunct 'gas' (in replay and real time) and 'tot' (in real time) temporarily for compatibility with current scripts. Will remove in a separate PR later after scripts are updated.
