### PR TITLE
Disable spurious `maybe-musttail-local-addr` in instruction_table.hpp

### DIFF
--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -84,6 +84,16 @@
     }                                                                          \
     while (false);
 
+// Some versions of GCC 15 spuriously warn when a reference-bound parameter
+// is forwarded through a musttail call (-Wmaybe-musttail-local-addr). The
+// threaded dispatch below passes gas_remaining by value through the musttail
+// tail call; the reference binding happens inside an always-inlined helper
+// (checked_runtime_call) and does not escape, so this is a false positive.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 15
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmaybe-musttail-local-addr"
+#endif
+
 namespace monad::vm::interpreter
 {
     using enum runtime::StatusCode;
@@ -1801,6 +1811,10 @@ namespace monad::vm::interpreter
         ctx.exit(Error);
     }
 }
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 15
+    #pragma GCC diagnostic pop
+#endif
 
 #undef MONAD_VM_MUST_TAIL
 #undef MONAD_VM_NEXT


### PR DESCRIPTION
Some versions of GCC 15 (e.g. `gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0`) produce the following warnings which are turned into errors in our build:

```
/home/sbal/monad/category/vm/interpreter/instruction_table.hpp: In function 'void monad::vm::interpreter::delegatecall(monad::vm::runtime::Context&, const Intercode&, const monad::uint256_t*, monad::uint256_t*, int64_t, const uint8_t*) [with traits = monad::MonadTraits<MONAD_NEXT>]':
/home/sbal/monad/category/vm/interpreter/instruction_table.hpp:57:72: error: address of parameter 'gas_remaining' can escape to 'musttail' call [-Werror=maybe-musttail-local-addr]
   57 |         MONAD_VM_MUST_TAIL return instruction_table<traits>[*instr_ptr](       \
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
   58 |             ctx,                                                               \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   59 |             analysis,                                                          \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   60 |             stack_bottom,                                                      \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   61 |             stack_top + delta,                                                 \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   62 |             gas_remaining,                                                     \
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   63 |             instr_ptr);                                                        \
      |             ~~~~~~~~~~
```