### PR TITLE
feat: unified clap-style --help output for C++ binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,23 @@ function(monad_add_test_death target)
 endfunction()
 
 # ##############################################################################
+# version
+# ##############################################################################
+
+# Embedded in --help output of the C++ binaries. Honors a build-time override
+# (e.g. set by CI) so containerized builds without a .git directory can still
+# stamp the binary.
+if(DEFINED ENV{GIT_COMMIT_HASH})
+  set(GIT_COMMIT_HASH $ENV{GIT_COMMIT_HASH})
+else()
+  execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# ##############################################################################
 # libs
 # ##############################################################################
 

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -119,6 +119,9 @@ add_library(
   "lru/static_lru_cache.hpp"
   "mem/batch_mem_pool.hpp"
   "synchronization/spin_lock.hpp"
+  # cli
+  "cli/help_formatter.cpp"
+  "cli/help_formatter.hpp"
   # event
   "event/event_iterator.h"
   "event/event_iterator_inline.h"
@@ -219,6 +222,7 @@ endif()
 
 target_link_libraries(monad_core PUBLIC ankerl_hash)
 target_link_libraries(monad_core PUBLIC Boost::fiber TBB::tbb)
+target_link_libraries(monad_core PUBLIC CLI11::CLI11)
 target_link_libraries(monad_core PUBLIC komihash)
 target_link_libraries(monad_core PUBLIC blake3)
 target_link_libraries(monad_core PUBLIC ethash::keccak)

--- a/category/core/cli/help_formatter.cpp
+++ b/category/core/cli/help_formatter.cpp
@@ -1,0 +1,320 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/cli/help_formatter.hpp>
+
+#include <category/core/config.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <cstdlib>
+#include <format>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <unistd.h>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace cli
+{
+    namespace
+    {
+        // ANSI escape sequences kept short; \x1b[0m fully resets attributes.
+        constexpr std::string_view ANSI_BOLD = "\x1b[1m";
+        constexpr std::string_view ANSI_BOLD_UNDERLINE = "\x1b[1;4m";
+        constexpr std::string_view ANSI_RESET = "\x1b[0m";
+
+        bool detect_color()
+        {
+            char const *const no_color = std::getenv("NO_COLOR");
+            if (no_color != nullptr && no_color[0] != '\0') {
+                return false;
+            }
+            return ::isatty(STDOUT_FILENO) != 0;
+        }
+
+        std::string to_placeholder(std::string s)
+        {
+            for (char &c : s) {
+                if (c == '-') {
+                    c = '_';
+                }
+                else {
+                    c = static_cast<char>(
+                        std::toupper(static_cast<unsigned char>(c)));
+                }
+            }
+            return s;
+        }
+
+        bool is_option_group(CLI::App const *const sub)
+        {
+            return dynamic_cast<CLI::Option_group const *>(sub) != nullptr;
+        }
+
+        void collect_options(
+            CLI::App const *const app, std::vector<CLI::Option const *> &out,
+            bool const is_nested)
+        {
+            CLI::Option const *const help_ptr = app->get_help_ptr();
+            for (auto const *opt :
+                 app->get_options([](CLI::Option const *) { return true; })) {
+                if (opt->get_group().empty()) {
+                    // hidden / internal option
+                    continue;
+                }
+                if (opt->get_positional()) {
+                    // positionals are emitted from make_help's Arguments
+                    // section so they appear together, separately from flags
+                    continue;
+                }
+                if (is_nested && opt == help_ptr) {
+                    // option_groups inherit their own help flag from CLI::App;
+                    // surface it once at the top level only
+                    continue;
+                }
+                out.push_back(opt);
+            }
+            for (auto const *sub :
+                 app->get_subcommands([](CLI::App const *) { return true; })) {
+                if (is_option_group(sub)) {
+                    collect_options(sub, out, /*is_nested=*/true);
+                }
+            }
+        }
+    } // namespace
+
+    HelpFormatter::HelpFormatter(std::string version)
+        : version_{std::move(version)}
+        , use_color_{detect_color()}
+    {
+    }
+
+    std::string HelpFormatter::styled(
+        std::string_view const escape, std::string_view const inner) const
+    {
+        if (!use_color_) {
+            return std::string{inner};
+        }
+        return std::format("{}{}{}", escape, inner, ANSI_RESET);
+    }
+
+    std::string HelpFormatter::make_description(CLI::App const *const app) const
+    {
+        auto const styled_name = styled(ANSI_BOLD, app->get_name());
+        auto const &desc = app->get_description();
+        auto const desc_line =
+            desc.empty() ? std::string{} : std::format("{}\n", desc);
+        return version_.empty()
+                   ? std::format("{}\n{}", styled_name, desc_line)
+                   : std::format("{} {}\n{}", styled_name, version_, desc_line);
+    }
+
+    std::string
+    HelpFormatter::make_usage(CLI::App const *const app, std::string name) const
+    {
+        if (name.empty()) {
+            name = app->get_name();
+        }
+
+        std::string out = std::format(
+            "\n{} {} [OPTIONS]",
+            styled(ANSI_BOLD_UNDERLINE, "Usage:"),
+            styled(ANSI_BOLD, name));
+
+        auto const real_subs = app->get_subcommands(
+            [](CLI::App const *const s) { return !is_option_group(s); });
+        if (!real_subs.empty()) {
+            out += " [COMMAND]";
+        }
+
+        auto const positionals = app->get_options(
+            [](CLI::Option const *const o) { return o->get_positional(); });
+        if (!positionals.empty()) {
+            out += " <ARGS>...";
+        }
+
+        out += '\n';
+        return out;
+    }
+
+    std::string HelpFormatter::make_subcommands(
+        CLI::App const *const app, CLI::AppFormatMode /*mode*/) const
+    {
+        auto const subs = app->get_subcommands(
+            [](CLI::App const *const s) { return !is_option_group(s); });
+        if (subs.empty()) {
+            return {};
+        }
+
+        std::size_t max_name = 0;
+        for (auto const *sub : subs) {
+            max_name = std::max(max_name, sub->get_name().size());
+        }
+
+        std::string out =
+            std::format("\n{}\n", styled(ANSI_BOLD_UNDERLINE, "Commands:"));
+        for (auto const *sub : subs) {
+            std::string const &n = sub->get_name();
+            out += std::format(
+                "  {}{}{}\n",
+                styled(ANSI_BOLD, n),
+                std::string(max_name - n.size() + 2, ' '),
+                sub->get_description());
+        }
+        return out;
+    }
+
+    std::string HelpFormatter::make_help(
+        CLI::App const *const app, std::string name,
+        CLI::AppFormatMode const mode) const
+    {
+        if (name.empty()) {
+            name = app->get_name();
+        }
+
+        auto const render_section = [&](std::string_view const title,
+                                        auto const &items,
+                                        bool const is_positional) {
+            if (items.empty()) {
+                return std::string{};
+            }
+            std::string s =
+                std::format("\n{}\n", styled(ANSI_BOLD_UNDERLINE, title));
+            for (auto const *opt : items) {
+                s += make_option(opt, is_positional);
+            }
+            return s;
+        };
+
+        auto const positionals = app->get_options(
+            [](CLI::Option const *const o) { return o->get_positional(); });
+        std::vector<CLI::Option const *> opts;
+        collect_options(app, opts, /*is_nested=*/false);
+
+        return std::format(
+            "{}{}{}{}{}{}",
+            make_description(app),
+            make_usage(app, name),
+            render_section("Arguments:", positionals, /*is_positional=*/true),
+            render_section("Options:", opts, /*is_positional=*/false),
+            make_subcommands(app, mode),
+            make_footer(app));
+    }
+
+    std::string HelpFormatter::make_option_name(
+        CLI::Option const *const opt, bool const is_positional) const
+    {
+        if (is_positional) {
+            return std::format(
+                "  <{}>", to_placeholder(opt->get_name(true, false)));
+        }
+
+        auto const &snames = opt->get_snames();
+        auto const &lnames = opt->get_lnames();
+
+        if (lnames.empty()) {
+            // short-only option: render as "  -s"
+            return snames.empty() ? std::string{"  "}
+                                  : std::format("  -{}", snames.front());
+        }
+
+        // Show only the first long name — CLI11 lets binaries register
+        // snake_case aliases (e.g. "--block-db,--block_db") which would
+        // otherwise clutter the help output.  Long-only options pad past
+        // the "-x, " slot reserved for a short flag.
+        return snames.empty()
+                   ? std::format("      --{}", lnames.front())
+                   : std::format("  -{}, --{}", snames.front(), lnames.front());
+    }
+
+    std::string
+    HelpFormatter::make_option_opts(CLI::Option const *const opt) const
+    {
+        if (opt->get_positional()) {
+            return {};
+        }
+        if (opt->get_expected_max() == 0) {
+            // flag — consumes no value, no placeholder
+            return {};
+        }
+        // Respect an explicitly-set type_name when the caller wrote a
+        // bracketed/structured placeholder (e.g.
+        // type_name("<ring-name-or-path>[:<descriptor-shift>:<buf-shift>]")).
+        // Bare CLI11 defaults like "TEXT"/"UINT"/"INT" are skipped so we keep
+        // the clap-style derived placeholder.
+        std::string const &type_name = opt->get_type_name();
+        if (!type_name.empty() && type_name.front() == '<') {
+            return std::format(" {}", type_name);
+        }
+        auto const &lnames = opt->get_lnames();
+        auto const &snames = opt->get_snames();
+        std::string base = !lnames.empty()
+                               ? lnames.front()
+                               : (!snames.empty() ? snames.front() : "value");
+        return std::format(" <{}>", to_placeholder(std::move(base)));
+    }
+
+    std::string
+    HelpFormatter::make_option_desc(CLI::Option const *const opt) const
+    {
+        std::string desc = opt->get_description();
+        if (opt->get_expected_max() != 0) {
+            std::string const def = opt->get_default_str();
+            if (!def.empty() && def != "false") {
+                if (!desc.empty()) {
+                    desc += ' ';
+                }
+                desc += std::format("[default: {}]", def);
+            }
+        }
+        if (opt->get_required()) {
+            if (!desc.empty()) {
+                desc += ' ';
+            }
+            desc += "[required]";
+        }
+        return desc;
+    }
+
+    std::string HelpFormatter::make_option(
+        CLI::Option const *const opt, bool const is_positional) const
+    {
+        std::string const name_plain = make_option_name(opt, is_positional);
+        std::string const opts_part = make_option_opts(opt);
+        std::string const desc = make_option_desc(opt);
+
+        // Match clap's long-help layout: each option's description appears
+        // on the line below the flag, indented to column 10 (4 spaces past
+        // the long-only option indent).
+        auto const desc_line =
+            desc.empty() ? std::string{} : std::format("          {}\n", desc);
+        return std::format(
+            "{}{}\n{}", styled(ANSI_BOLD, name_plain), opts_part, desc_line);
+    }
+
+    void HelpFormatter::install(CLI::App &app)
+    {
+        app.set_help_flag("-h,--help", "Print help");
+        app.formatter(std::make_shared<HelpFormatter>(*this));
+    }
+} // namespace cli
+
+MONAD_NAMESPACE_END

--- a/category/core/cli/help_formatter.hpp
+++ b/category/core/cli/help_formatter.hpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+#include <CLI/CLI.hpp>
+
+#include <string>
+#include <string_view>
+
+MONAD_NAMESPACE_BEGIN
+
+namespace cli
+{
+    // CLI11 Formatter that emits clap-style --help output so the Monad
+    // execution binaries (monad, monad-cli, monad-mpt) match the help layout
+    // produced by the Rust binaries that go through monad-ctl.
+    class HelpFormatter : public CLI::Formatter
+    {
+        std::string version_;
+        bool use_color_;
+
+        // Wrap `inner` in an ANSI escape sequence when color is enabled,
+        // otherwise return `inner` unchanged.
+        std::string
+        styled(std::string_view escape, std::string_view inner) const;
+
+    public:
+        // `version` is rendered on the first line of --help output ("<bin>
+        // <version>").  ANSI bold / underline is enabled when stdout is a
+        // TTY and the NO_COLOR environment variable is unset or empty.
+        explicit HelpFormatter(std::string version);
+
+        std::string make_help(
+            CLI::App const *app, std::string name,
+            CLI::AppFormatMode mode) const override;
+
+        std::string make_description(CLI::App const *app) const override;
+
+        std::string
+        make_usage(CLI::App const *app, std::string name) const override;
+
+        std::string make_subcommands(
+            CLI::App const *app, CLI::AppFormatMode mode) const override;
+
+        std::string
+        make_option(CLI::Option const *opt, bool is_positional) const override;
+
+        std::string make_option_name(
+            CLI::Option const *opt, bool is_positional) const override;
+
+        std::string make_option_opts(CLI::Option const *opt) const override;
+
+        std::string make_option_desc(CLI::Option const *opt) const override;
+
+        // Configure `app` to use this formatter and install a clap-style
+        // help flag ("-h, --help").  Does not install a --version printer
+        // (the existing binaries do not expose one today).
+        void install(CLI::App &app);
+    };
+} // namespace cli
+
+MONAD_NAMESPACE_END

--- a/category/core/cli/help_formatter_test.cpp
+++ b/category/core/cli/help_formatter_test.cpp
@@ -1,0 +1,266 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/cli/help_formatter.hpp>
+#include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <gtest/gtest.h>
+
+#include <CLI/CLI.hpp>
+
+#include <cstddef>
+#include <string>
+
+using namespace monad::cli;
+
+namespace
+{
+    // Strip ANSI CSI escape sequences (\x1b[…m) so the string assertions
+    // below stay deterministic regardless of whether the test binary is
+    // invoked from a TTY or not.
+    std::string strip_ansi(std::string s)
+    {
+        std::string out;
+        out.reserve(s.size());
+        for (std::size_t i = 0; i < s.size(); ++i) {
+            if (s[i] == '\x1b' && i + 1 < s.size() && s[i + 1] == '[') {
+                i += 2;
+                while (i < s.size() && s[i] != 'm') {
+                    ++i;
+                }
+                continue;
+            }
+            out += s[i];
+        }
+        return out;
+    }
+
+    std::string render_help(CLI::App &app)
+    {
+        return strip_ansi(app.help());
+    }
+} // namespace
+
+TEST(HelpFormatter, header_has_bin_name_and_version)
+{
+    CLI::App app{"Test description.", "monad-test"};
+    HelpFormatter{"abc123"}.install(app);
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("monad-test abc123"), std::string::npos)
+        << "expected 'monad-test abc123' header in:\n"
+        << out;
+    EXPECT_NE(out.find("Test description."), std::string::npos);
+}
+
+TEST(HelpFormatter, usage_line_uses_clap_style)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("Usage: monad-test [OPTIONS]"), std::string::npos)
+        << out;
+}
+
+TEST(HelpFormatter, help_flag_uses_space_separator)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("-h, --help"), std::string::npos)
+        << "expected '-h, --help' (with space) in:\n"
+        << out;
+    EXPECT_EQ(out.find("-h,--help"), std::string::npos)
+        << "must not emit comma-without-space form";
+}
+
+TEST(HelpFormatter, options_section_renders_with_value_placeholder)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string db;
+    app.add_option("--db", db, "database path");
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("Options:"), std::string::npos) << out;
+    EXPECT_NE(out.find("--db <DB>"), std::string::npos)
+        << "expected angle-bracketed placeholder '<DB>' in:\n"
+        << out;
+    EXPECT_NE(out.find("database path"), std::string::npos);
+}
+
+TEST(HelpFormatter, description_appears_on_separate_line)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string s;
+    app.add_option("--db", s, "database path");
+
+    auto const out = render_help(app);
+    // Description is on its own line, indented to column 10 (matching clap's
+    // long-help layout).
+    EXPECT_NE(out.find("--db <DB>\n          database path"), std::string::npos)
+        << "expected description on a separate line indented 10 spaces:\n"
+        << out;
+}
+
+TEST(HelpFormatter, required_suffix_is_appended)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string db;
+    app.add_option("--db", db, "database path")->required();
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("[required]"), std::string::npos) << out;
+}
+
+TEST(HelpFormatter, default_suffix_renders_for_value_options)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    int n = 42;
+    app.add_option("--n", n, "an integer")->capture_default_str();
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("[default: 42]"), std::string::npos) << out;
+}
+
+TEST(HelpFormatter, boolean_flag_omits_default_false)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    app.option_defaults()->always_capture_default();
+    bool verbose = false;
+    app.add_flag("--verbose", verbose, "verbose mode");
+
+    auto const out = render_help(app);
+    EXPECT_EQ(out.find("[default: false]"), std::string::npos)
+        << "boolean flag should not advertise '[default: false]' in:\n"
+        << out;
+}
+
+TEST(HelpFormatter, long_only_option_is_indented_past_short_slot)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string s;
+    app.add_option("--only-long", s, "long-only");
+
+    auto const out = render_help(app);
+    // Long-only options indent six spaces (2 for the column + 4 to align past
+    // the "-x, " slot reserved for a short flag).
+    EXPECT_NE(out.find("      --only-long"), std::string::npos)
+        << "expected long-only option indented past the short-flag slot in:\n"
+        << out;
+}
+
+TEST(HelpFormatter, dashes_in_option_names_become_underscores_in_placeholder)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string s;
+    app.add_option("--log-level", s, "level");
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("--log-level <LOG_LEVEL>"), std::string::npos) << out;
+}
+
+TEST(HelpFormatter, explicit_type_name_is_honored_when_bracketed)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string s;
+    app.add_option("--ring", s, "event ring config")
+        ->type_name("<name>[:<shift>]");
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("--ring <name>[:<shift>]"), std::string::npos)
+        << "expected explicit type_name preserved verbatim in:\n"
+        << out;
+    EXPECT_EQ(out.find("--ring <RING>"), std::string::npos)
+        << "must not override an explicit type_name with the derived "
+           "placeholder in:\n"
+        << out;
+}
+
+TEST(HelpFormatter, positional_arguments_render_in_arguments_section)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string path;
+    app.add_option("path", path, "input path");
+
+    auto const out = render_help(app);
+    EXPECT_NE(
+        out.find("Usage: monad-test [OPTIONS] <ARGS>..."), std::string::npos)
+        << out;
+    EXPECT_NE(out.find("Arguments:"), std::string::npos)
+        << "expected an Arguments: section for positional options in:\n"
+        << out;
+    EXPECT_NE(out.find("<PATH>"), std::string::npos)
+        << "positional placeholder should render under Arguments:\n"
+        << out;
+    EXPECT_NE(out.find("input path"), std::string::npos);
+}
+
+TEST(HelpFormatter, snake_case_aliases_are_collapsed_to_first_long_name)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    std::string s;
+    // The first listed long name is the one shown; the alias is consumed by
+    // CLI11 for parsing but suppressed in the help layout.
+    app.add_option("--block-db,--block_db", s, "block_db dir");
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("--block-db"), std::string::npos) << out;
+    EXPECT_EQ(out.find("--block_db"), std::string::npos)
+        << "snake_case alias must not appear in --help in:\n"
+        << out;
+}
+
+TEST(HelpFormatter, no_version_flag_is_installed)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+
+    auto const out = render_help(app);
+    EXPECT_EQ(out.find("--version"), std::string::npos)
+        << "install() must not install a --version flag in:\n"
+        << out;
+    EXPECT_EQ(out.find("Print version"), std::string::npos);
+}
+
+TEST(HelpFormatter, option_group_options_appear_in_flat_options_section)
+{
+    CLI::App app{"desc", "monad-test"};
+    HelpFormatter{"v0"}.install(app);
+    auto *group = app.add_option_group("mode", "mode group");
+    bool interactive = false;
+    group->add_flag("--interactive", interactive, "set interactive mode");
+
+    auto const out = render_help(app);
+    EXPECT_NE(out.find("Options:"), std::string::npos) << out;
+    EXPECT_NE(out.find("--interactive"), std::string::npos)
+        << "options added via add_option_group must surface in the flat "
+           "Options: block:\n"
+        << out;
+    EXPECT_EQ(out.find("Commands:"), std::string::npos)
+        << "option_groups must not surface as user-facing Commands in:\n"
+        << out;
+}

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -81,6 +81,9 @@ monad_compile_options(monad-mpt)
 target_link_libraries(monad-mpt PUBLIC monad_execution PkgConfig::zstd
                                        PkgConfig::archive CLI11::CLI11)
 
+target_compile_definitions(monad-mpt
+                           PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+
 function(add_trie_test)
   set(ONE_VALUE_ARGS TARGET TEST_FILTER)
   set(MULTI_VALUE_ARGS SOURCES LINK_LIBRARIES)

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -21,6 +21,7 @@
 #include <category/async/storage_pool.hpp>
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
+#include <category/core/cli/help_formatter.hpp>
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/io/buffers.hpp>
@@ -1381,6 +1382,7 @@ int main_impl(
     std::span<std::string_view> const args)
 {
     CLI::App cli("Tool for managing MPT databases", "monad-mpt");
+    monad::cli::HelpFormatter{GIT_COMMIT_HASH}.install(cli);
     cli.footer(R"(Suitable sources of block storage:
 
 1. Raw partitions on a storage device.

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -25,6 +25,8 @@ add_trie_test(
   LINK_LIBRARIES
   PkgConfig::zstd
   PkgConfig::archive)
+target_compile_definitions(cli_tool_test
+                           PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
 add_trie_test(TARGET compact_encode_test SOURCES "compact_encode_test.cpp")
 add_trie_test(TARGET compaction_test SOURCES "compaction_test.cpp")
 add_trie_test(TARGET db_metadata_test SOURCES "db_metadata_test.cpp")

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -39,16 +39,6 @@ add_executable(monad-cli monad_cli.cpp)
 monad_compile_options(monad-cli)
 target_link_libraries(monad-cli PUBLIC monad_execution CLI11::CLI11)
 
-if(DEFINED ENV{GIT_COMMIT_HASH})
-  set(GIT_COMMIT_HASH $ENV{GIT_COMMIT_HASH})
-else()
-  execute_process(
-    COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_COMMIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-
 target_compile_definitions(monad PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
 target_compile_definitions(monad-cli
                            PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -20,6 +20,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/basic_formatter.hpp>
+#include <category/core/cli/help_formatter.hpp>
 #include <category/core/config.hpp>
 #include <category/core/fiber/priority_pool.hpp>
 #include <category/core/likely.h>
@@ -114,7 +115,9 @@ try {
     cxx_runtime_terminate_handler = std::get_terminate();
     std::set_terminate(backtrace_terminate_handler);
 
-    CLI::App cli{"monad"};
+    CLI::App cli{
+        "Run the Monad execution engine against a block database.", "monad"};
+    monad::cli::HelpFormatter{GIT_COMMIT_HASH}.install(cli);
     cli.option_defaults()->always_capture_default();
 
     monad_chain_config chain_config;

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -17,6 +17,7 @@
 #include <category/core/basic_formatter.hpp> // NOLINT
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/cli/help_formatter.hpp>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/keccak.h>
@@ -800,7 +801,10 @@ int main(int const argc, char *argv[])
     uint64_t total_shards = 1;
     uint64_t shard_number = 0;
 
-    CLI::App cli{"monad-cli"};
+    CLI::App cli{
+        "Inspection and snapshot tooling for a Monad execution database.",
+        "monad-cli"};
+    monad::cli::HelpFormatter{GIT_COMMIT_HASH}.install(cli);
     cli.add_option(
            "--db",
            dbname_paths,


### PR DESCRIPTION
 ## Summary

  `monad-ctl` (in [monad-bft](https://github.com/category-labs/monad-bft)) dispatches `--help` across a mix of Rust binaries (`monad-keystore`,
  `monad-ledger-tail`, `monad-sign-name-record`) and the three C++ binaries shipped from this repo (`monad`, `monad-cli`, `monad-mpt`). The two languages use different argparsers — `clap` (Rust) vs `CLI11` (C++) — and their default `--help` layouts diverge in section headers, flag separators, value placeholders, and defaults rendering.

  This PR adds a shared `monad::cli::HelpFormatter` (subclass of `CLI::Formatter`) and installs it in all three C++ binaries so they emit `clap`-style help that matches the Rust binaries' output.

  ## What changed

  - **New** `category/core/cli/help_formatter.{hpp,cpp}` — clap-style overrides for `make_help`, `make_description`, `make_usage`, `make_subcommands`, `make_option*`.
  - **New** `category/core/cli/help_formatter_test.cpp` — 13 gtest cases covering header, usage line, separator (`-h, --help` with space), placeholder rendering, `[default: …]` / `[required]` suffixes, boolean-flag default suppression, snake_case alias collapsing, long-only indent, no `--version` flag, and option-group flattening.
  - Install the formatter in `cmd/monad/main.cpp`, `cmd/monad_cli.cpp`, `category/mpt/cli_tool_impl.cpp`. Each call site is a one-liner: `monad::cli::HelpFormatter{GIT_COMMIT_HASH}.install(cli);`.
  - Hoist `GIT_COMMIT_HASH` computation from `cmd/CMakeLists.txt` to root `CMakeLists.txt` so `monad-mpt` and `cli_tool_test` can use the same value without duplicating the `git rev-parse` block. `target_compile_definitions` for the new consumers added in `category/mpt/CMakeLists.txt` and `category/mpt/test/CMakeLists.txt`.

  ## Layout details

  Matches clap's "long" help style:
  - `<bin> <git_commit>` header line; binary name in bold.
  - `Usage:`, `Options:`, `Commands:` — bold + underlined.
  - Option names in bold; first canonical long name only (snake_case aliases like `--block-db,--block_db` collapse to `--block-db`).
  - `<UPPER_SNAKE>` value placeholders; descriptions on the next line indented to column 10.
  - `[default: X]` and `[required]` suffixes. Boolean flag defaults (`false`) suppressed.
  - ANSI escapes emitted only when stdout is a TTY and `NO_COLOR` is unset/empty.
  - No `--version` printer (this PR does not add one; left as a follow-up — the existing `--version` in `monad-cli` is an unrelated business option).
