### PR TITLE
[cmake] build libhugetlbfs, don't take it from the system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "third_party/fiber"]
 	path = third_party/fiber
 	url = https://github.com/category-labs/fiber.git
+[submodule "third_party/libhugetlbfs/src"]
+	path = third_party/libhugetlbfs/src
+	url = https://github.com/libhugetlbfs/libhugetlbfs.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,11 @@ endif()
 add_library(komihash INTERFACE)
 target_include_directories(komihash INTERFACE "third_party/komihash")
 
+# libhugetlbfs
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_subdirectory("third_party/libhugetlbfs")
+endif()
+
 # magic_enum
 add_subdirectory("third_party/magic_enum")
 

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -224,7 +224,7 @@ target_link_libraries(monad_core PUBLIC quill)
 target_link_libraries(monad_core PUBLIC unordered_dense)
 target_link_libraries(monad_core PUBLIC PkgConfig::zstd)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_link_libraries(monad_core PUBLIC hugetlbfs uring)
+  target_link_libraries(monad_core PUBLIC libhugetlbfs uring)
 endif()
 
 add_library(

--- a/category/core/mem/hugetlb_path.c
+++ b/category/core/mem/hugetlb_path.c
@@ -28,6 +28,28 @@
 #include <fcntl.h>
 #include <linux/limits.h>
 
+#if MONAD_LIBHUGETLBFS_STATIC
+
+// We're statically linking, and won't get the constructor that initializes
+// the library because it is `static`; we just manually kick the tires here,
+// see `init.c` in the libhugetlbfs source code
+static void __attribute__((constructor)) setup_libhugetlbfs(void)
+{
+    // NOLINTBEGIN(bugprone-reserved-identifier)
+    extern void __lh_hugetlbfs_setup_env();
+    extern void __lh_setup_mounts();
+    extern void __lh__hugetlbfs_setup_kernel_page_size();
+    extern void __lh__probe_default_hpage_size();
+    // NOLINTEND(bugprone-reserved-identifier)
+
+    __lh_hugetlbfs_setup_env();
+    __lh__hugetlbfs_setup_kernel_page_size();
+    __lh_setup_mounts();
+    __lh__probe_default_hpage_size();
+}
+
+#endif
+
 thread_local char g_error_buf[PATH_MAX];
 
 #define FORMAT_ERRC(...)                                                       \

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -88,11 +88,13 @@ target_compile_options(monad_event PRIVATE -Wall -Wextra -Wconversion -Werror)
 target_link_libraries(monad_event PRIVATE ${libzstd_file})
 
 if(MONAD_EVENT_USE_LIBHUGETLBFS)
-  find_library(libhugetlbfs NAMES hugetlbfs REQUIRED)
+  if (NOT ${CMAKE_PROJECT_NAME} STREQUAL "monad")
+    add_subdirectory("third_party/libhugetlbfs")
+  endif()
   target_sources(monad_event PRIVATE
     "../core/mem/hugetlb_path.c"
     "../core/mem/hugetlb_path.h")
-  target_link_libraries(monad_event PRIVATE hugetlbfs)
+  target_link_libraries(monad_event PRIVATE libhugetlbfs)
 else()
   target_compile_definitions(monad_event PRIVATE MONAD_EVENT_DISABLE_LIBHUGETLBFS)
 endif()

--- a/category/event/third_party/libhugetlbfs
+++ b/category/event/third_party/libhugetlbfs
@@ -1,0 +1,1 @@
+../../../third_party/libhugetlbfs

--- a/rust/crates/monad-build/src/cmake.rs
+++ b/rust/crates/monad-build/src/cmake.rs
@@ -59,7 +59,7 @@ impl MonadCMake {
         self
     }
 
-    pub fn build(self, target: &'static str) {
+    pub fn build(self, target: &'static str) -> String {
         let Self {
             mut cmake,
             linkage,
@@ -82,5 +82,7 @@ impl MonadCMake {
         if with_rpath {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}/build", dst.display());
         }
+
+        dst.to_string_lossy().into_owned()
     }
 }

--- a/rust/crates/monad-event-ring/build.rs
+++ b/rust/crates/monad-event-ring/build.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 fn main() {
-    monad_build::MonadCMake::new(
+    let cmake_binary_dir = monad_build::MonadCMake::new(
         monad_build::repository_root().join("category/event"),
         monad_build::MonadCMakeLinkage::Static,
     )
@@ -22,7 +22,12 @@ fn main() {
 
     println!("cargo:rustc-link-lib=zstd");
     #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-lib=hugetlbfs");
+    println!(
+        "cargo:rustc-link-search=native={}/build/libhugetlbfs-install/lib64",
+        cmake_binary_dir
+    );
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-lib=static=hugetlbfs");
     #[cfg(not(target_os = "linux"))]
     println!("cargo:rustc-link-lib=monad_event_os_compat");
 

--- a/scripts/ubuntu-build/install-deps.sh
+++ b/scripts/ubuntu-build/install-deps.sh
@@ -12,7 +12,6 @@ packages=(
   libgmock-dev
   libgmp-dev
   libgtest-dev
-  libhugetlbfs-dev
   libtbb-dev
   liburing-dev
   libzstd-dev

--- a/scripts/ubuntu-build/install-tools.sh
+++ b/scripts/ubuntu-build/install-tools.sh
@@ -2,6 +2,8 @@
 
 packages=(
   apt-utils
+  autoconf
+  automake
   ca-certificates
   clang-19
   clang-tools-19
@@ -16,7 +18,6 @@ packages=(
   gnupg
   libclang-common-19-dev
   libclang-rt-19-dev
-  libhugetlbfs-bin
   llvm-19-dev
   make
   ninja-build

--- a/third_party/libhugetlbfs/CMakeLists.txt
+++ b/third_party/libhugetlbfs/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This cmake project can be used to build just the execution event SDK library
+# (as `libmonad_event.a`) without building all of the monolithic
+# libmonad_execution.a or including the rest of the CMake build system. This
+# is useful for external third-party clients, and for the Rust build system.
+
+include(ExternalProject)
+
+# libhugetlbfs
+set(LIBHUGETLBFS_INSTALL_DIR ${CMAKE_BINARY_DIR}/libhugetlbfs-install)
+ExternalProject_Add(
+  libhugetlbfs_ext
+  DOWNLOAD_COMMAND ""
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  PREFIX ${CMAKE_BINARY_DIR}/libhugetlbfs
+  INSTALL_DIR ${LIBHUGETLBFS_INSTALL_DIR}
+  CONFIGURE_COMMAND COMMAND /bin/sh autogen.sh
+                   COMMAND env CC=${CMAKE_C_COMPILER} ./configure --prefix=${LIBHUGETLBFS_INSTALL_DIR}
+  BUILD_COMMAND make -C <SOURCE_DIR> libs CC=${CMAKE_C_COMPILER} PREFIX=${LIBHUGETLBFS_INSTALL_DIR}
+               BUILDTYPE=NATIVEONLY
+  INSTALL_COMMAND make -C <SOURCE_DIR> install-libs CC=${CMAKE_C_COMPILER} PREFIX=${LIBHUGETLBFS_INSTALL_DIR}
+                  BUILDTYPE=NATIVEONLY
+  BUILD_IN_SOURCE 1
+  BUILD_BYPRODUCTS ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.a
+                   ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.so)
+add_library(libhugetlbfs_shared SHARED IMPORTED GLOBAL)
+add_library(libhugetlbfs_static STATIC IMPORTED GLOBAL)
+add_dependencies(libhugetlbfs_shared libhugetlbfs_ext)
+add_dependencies(libhugetlbfs_static libhugetlbfs_ext)
+file(MAKE_DIRECTORY ${LIBHUGETLBFS_INSTALL_DIR}/include)
+set_target_properties(
+  libhugetlbfs_shared libhugetlbfs_static
+  PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBHUGETLBFS_INSTALL_DIR}/include)
+set_target_properties(libhugetlbfs_shared
+  PROPERTIES IMPORTED_LOCATION ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.so)
+set_target_properties(libhugetlbfs_static
+  PROPERTIES IMPORTED_LOCATION ${LIBHUGETLBFS_INSTALL_DIR}/lib64/libhugetlbfs.a)
+target_compile_definitions(libhugetlbfs_static INTERFACE MONAD_LIBHUGETLBFS_STATIC)
+if(BUILD_SHARED_LIBS)
+  add_library(libhugetlbfs ALIAS libhugetlbfs_shared)
+else()
+  add_library(libhugetlbfs ALIAS libhugetlbfs_static)
+endif()


### PR DESCRIPTION
libhugetlbfs does not meet our requirements for what dependencies can come from the system, namely it is not common enough: some popular Linux distributions do not contain it in their package manager.

In this commit we consume it as a third_party submodule, and kick off the local autotools-based build using ExternalProject_Add.