### PR TITLE
persist state machine kind in db metadata

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -103,6 +103,8 @@ add_library(
   "ethereum/db/file_db.hpp"
   "ethereum/db/partial_trie_db.hpp"
   "ethereum/db/partial_trie_db.cpp"
+  "ethereum/db/state_machine_init.cpp"
+  "ethereum/db/state_machine_init.hpp"
   "ethereum/db/trie_db.cpp"
   "ethereum/db/trie_db.hpp"
   "ethereum/db/trie_rodb.hpp"

--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -22,6 +22,7 @@
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/db_snapshot.h>
+#include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -51,18 +52,17 @@ struct monad_db_snapshot_loader
         uint64_t const block, char const *const *const dbname_paths,
         size_t const len, unsigned const sq_thread_cpu)
         : block{block}
-        , db{std::make_unique<monad::OnDiskMachine>(),
-             monad::mpt::OnDiskDbConfig{
-                 .append = true,
-                 .compaction = false,
-                 .rd_buffers = 8192,
-                 .wr_buffers = 32,
-                 .uring_entries = 128,
-                 .sq_thread_cpu =
-                     sq_thread_cpu == std::numeric_limits<unsigned>::max()
-                         ? std::nullopt
-                         : std::make_optional(sq_thread_cpu),
-                 .dbname_paths = {dbname_paths, dbname_paths + len}}}
+        , db{monad::mpt::OnDiskDbConfig{
+              .append = true,
+              .compaction = false,
+              .rd_buffers = 8192,
+              .wr_buffers = 32,
+              .uring_entries = 128,
+              .sq_thread_cpu =
+                  sq_thread_cpu == std::numeric_limits<unsigned>::max()
+                      ? std::nullopt
+                      : std::make_optional(sq_thread_cpu),
+              .dbname_paths = {dbname_paths, dbname_paths + len}}}
         , bytes_read{0}
     {
     }
@@ -442,6 +442,9 @@ monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t const block, char const *const *const dbname_paths,
     size_t const len, unsigned const sq_thread_cpu)
 {
+    // C ABI entry — populate the kind registry before the metadata-driven
+    // Db ctor runs inside monad_db_snapshot_loader. Idempotent.
+    monad::register_ethereum_state_machines();
     auto *loader =
         new monad_db_snapshot_loader(block, dbname_paths, len, sq_thread_cpu);
     MONAD_ASSERT_PRINTF(

--- a/category/execution/ethereum/db/state_machine_init.cpp
+++ b/category/execution/ethereum/db/state_machine_init.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/db/state_machine_init.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+
+#include <memory>
+
+MONAD_NAMESPACE_BEGIN
+
+void register_ethereum_state_machines()
+{
+    // Only OnDiskMachine participates in metadata-driven open. The
+    // in-memory production path keeps the StateMachine&-passing ctor and
+    // never reads from disk, so InMemoryMachine is not registered.
+    mpt::register_state_machine(mpt::state_machine_kind::ethereum, [] {
+        return std::unique_ptr<mpt::StateMachine>(new OnDiskMachine{});
+    });
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/state_machine_init.hpp
+++ b/category/execution/ethereum/db/state_machine_init.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// Populate the mpt::state_machine_kind registry with every concrete
+// StateMachine subclass that lives under category/execution/ethereum/db.
+// Must run once at process start before any mpt::Db is constructed via
+// the metadata-driven Db(OnDiskDbConfig const &) ctor; otherwise
+// create_state_machine() aborts at open time.
+//
+// Idempotent — re-registering the same kind overwrites the prior factory.
+void register_ethereum_state_machines();
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -23,7 +23,11 @@
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
 #include <category/mpt/db.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/trie.hpp>
 
 #include <test_resource_data.h>
 
@@ -31,6 +35,21 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+
+namespace monad::mpt::test
+{
+    // Friend-of-Db accessor (db.hpp friends monad::mpt::test::DbAccessor).
+    // Lets tests stamp the persisted state_machine_kind on a freshly-
+    // truncated pool before the snapshot loader (which uses the
+    // metadata-driven Db ctor internally) reads from it.
+    struct DbAccessor
+    {
+        static UpdateAux &aux(Db &db)
+        {
+            return const_cast<UpdateAux &>(db.aux());
+        }
+    };
+}
 
 namespace
 {
@@ -163,6 +182,13 @@ TEST(DbBinarySnapshot, Basic)
             mpt::Db dest_init{
                 std::make_unique<OnDiskMachine>(),
                 OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+            // Stamp the kind so the snapshot loader's metadata-driven
+            // Db ctor (via monad_db_snapshot_loader_create) can resolve
+            // it.
+            monad::mpt::test::DbAccessor::aux(dest_init)
+                .metadata_ctx()
+                .set_state_machine_kind(
+                    timeline_id::primary, state_machine_kind::ethereum);
         }
         char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(
@@ -315,6 +341,13 @@ TEST(DbBinarySnapshot, MultipleShards)
             mpt::Db dest_init{
                 std::make_unique<OnDiskMachine>(),
                 OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+            // Stamp the kind so the snapshot loader's metadata-driven
+            // Db ctor (via monad_db_snapshot_loader_create) can resolve
+            // it.
+            monad::mpt::test::DbAccessor::aux(dest_init)
+                .metadata_ctx()
+                .set_state_machine_kind(
+                    timeline_id::primary, state_machine_kind::ethereum);
         }
         char const *dbname_paths_new[] = {dest_db.path.c_str()};
         monad_db_snapshot_load_filesystem(

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -62,6 +62,8 @@ add_library(
   "request.hpp"
   "read_node_blocking.cpp"
   "state_machine.hpp"
+  "state_machine_kind.cpp"
+  "state_machine_kind.hpp"
   "traverse.hpp"
   "traverse_util.hpp"
   "trie.cpp"

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -32,6 +32,7 @@
 #include <category/mpt/detail/kbhit.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/detail/unsigned_20.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
 
@@ -53,6 +54,7 @@
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <map>
 #include <memory>
 #include <optional>
 #include <span>
@@ -110,6 +112,16 @@ std::string print_bytes(MONAD_ASYNC_NAMESPACE::file_offset_t const bytes_)
     }
     s << bytes << " bytes";
     return std::move(s).str();
+}
+
+static char const *
+state_machine_kind_name(MONAD_MPT_NAMESPACE::state_machine_kind const kind)
+{
+    switch (kind) {
+    case MONAD_MPT_NAMESPACE::state_machine_kind::ethereum:
+        return "ethereum";
+    }
+    return "unknown";
 }
 
 static size_t const true_hardware_concurrency = [] {
@@ -405,6 +417,11 @@ struct impl_t
     bool truncate_database = false;
     bool create_empty_database = false;
     bool upgrade_database = false;
+    bool activate_secondary = false;
+    bool deactivate_secondary = false;
+    bool promote_secondary = false;
+    MONAD_MPT_NAMESPACE::state_machine_kind state_machine =
+        MONAD_MPT_NAMESPACE::state_machine_kind::ethereum;
     std::optional<uint64_t> rewind_database_to;
     std::optional<uint64_t> reset_history_length;
     bool create_chunk_increasing = false;
@@ -488,17 +505,35 @@ public:
         return total_used;
     }
 
+    void print_timeline_info(
+        MONAD_MPT_NAMESPACE::UpdateAux &aux, monad::mpt::timeline_id const tid,
+        char const *const name)
+    {
+        MONAD_ASSERT(aux.metadata_ctx().timeline_active(tid));
+        cout << "     " << name << ":\n        State machine kind: "
+             << state_machine_kind_name(
+                    aux.metadata_ctx().get_state_machine_kind(tid))
+             << "\n        History: ";
+        auto const max_v = aux.metadata_ctx().db_history_max_version(tid);
+        if (max_v == monad::mpt::INVALID_BLOCK_NUM) {
+            cout << "empty (no roots written yet)";
+        }
+        else {
+            auto const min_v =
+                aux.metadata_ctx().db_history_min_valid_version(tid);
+            cout << (1 + max_v - min_v) << " versions, earliest is " << min_v
+                 << ", latest is " << max_v;
+        }
+        cout << "\n        Auto expire version: "
+             << aux.metadata_ctx().get_auto_expire_version_metadata(tid)
+             << "\n";
+    }
+
     void print_db_history_summary(MONAD_MPT_NAMESPACE::UpdateAux &aux)
     {
-        cout << "MPT database has "
-             << (1 + aux.metadata_ctx().db_history_max_version() -
-                 aux.metadata_ctx().db_history_min_valid_version())
-             << " history, earliest is "
-             << aux.metadata_ctx().db_history_min_valid_version()
-             << " latest is " << aux.metadata_ctx().db_history_max_version()
-             << ".\n     It has been configured to retain no more than "
+        cout << "MPT database has been configured to retain no more than "
              << aux.metadata_ctx().version_history_length()
-             << ".\n     Latest proposed is ("
+             << " versions.\n     Latest proposed is ("
              << aux.metadata_ctx().get_latest_proposed_version() << ", "
              << monad::to_hex(monad::byte_string_view(
                     aux.metadata_ctx().get_latest_proposed_block_id().bytes,
@@ -511,32 +546,13 @@ public:
              << ").\n     Latest finalized is "
              << aux.metadata_ctx().get_latest_finalized_version()
              << ", latest verified is "
-             << aux.metadata_ctx().get_latest_verified_version()
-             << ", auto expire version is "
-             << aux.metadata_ctx().get_auto_expire_version_metadata(
-                    monad::mpt::timeline_id::primary)
-             << " (primary), "
-             << aux.metadata_ctx().get_auto_expire_version_metadata(
-                    monad::mpt::timeline_id::secondary)
-             << " (secondary)\n";
-
+             << aux.metadata_ctx().get_latest_verified_version() << "\n";
+        cout << "Active timelines:\n";
+        print_timeline_info(aux, monad::mpt::timeline_id::primary, "Primary");
         if (aux.metadata_ctx().timeline_active(
                 monad::mpt::timeline_id::secondary)) {
-            auto const max_v = aux.metadata_ctx().db_history_max_version(
-                monad::mpt::timeline_id::secondary);
-            cout << "Secondary timeline is active: ";
-            if (max_v == monad::mpt::INVALID_BLOCK_NUM) {
-                cout << "empty (no roots written yet — version_lower_bound "
-                        "and next_version are seeded by the first secondary "
-                        "upsert).\n";
-            }
-            else {
-                auto const min_v =
-                    aux.metadata_ctx().db_history_min_valid_version(
-                        monad::mpt::timeline_id::secondary);
-                cout << (1 + max_v - min_v) << " history, earliest is " << min_v
-                     << ", latest is " << max_v << ".\n";
-            }
+            print_timeline_info(
+                aux, monad::mpt::timeline_id::secondary, "Secondary");
         }
     }
 
@@ -926,9 +942,12 @@ public:
                             old_metadata->latest_voted_block_id;
                         metadata->latest_proposed_block_id =
                             old_metadata->latest_proposed_block_id;
-                        metadata->root_offsets_state.auto_expire_version_ =
-                            old_metadata->root_offsets_state
-                                .auto_expire_version_;
+                        // Carries auto_expire_version_ and state_machine_kind_;
+                        // copying it preserves the source DB's kind (a zeroed
+                        // byte would default to ethereum, silently
+                        // mis-restoring a non-ethereum DB).
+                        metadata->root_offsets_state =
+                            old_metadata->root_offsets_state;
                         // Dual-timeline role + secondary ring header.
                         // Without primary_ring_idx the restored DB would
                         // route the primary role at ring_a even when the
@@ -942,10 +961,8 @@ public:
                             old_metadata->secondary_timeline_active_;
                         metadata->secondary_timeline.restore_from(
                             old_metadata->secondary_timeline);
-                        metadata->secondary_timeline_state
-                            .auto_expire_version_ =
-                            old_metadata->secondary_timeline_state
-                                .auto_expire_version_;
+                        metadata->secondary_timeline_state =
+                            old_metadata->secondary_timeline_state;
                         // Deliberately NOT copied: pending_shrink_grow stays
                         // at its zero-initialised value (op_kind NONE) so the
                         // restored DB starts quiescent and does not replay an
@@ -1501,6 +1518,26 @@ opened.
                 impl.create_empty_database,
                 "create a new database if needed, otherwise truncate "
                 "existing.");
+            cli_ops_group->add_flag(
+                "--activate-secondary",
+                impl.activate_secondary,
+                "activate the secondary timeline on an existing database. "
+                "Stamps the secondary ring with the kind given via "
+                "--state-machine and shrinks the primary ring to make room "
+                "(see Db::activate_secondary_timeline). Operator must run "
+                "this with the daemon stopped.");
+            cli_ops_group->add_flag(
+                "--deactivate-secondary",
+                impl.deactivate_secondary,
+                "deactivate the secondary timeline; returns its chunks to "
+                "the primary ring.");
+            cli_ops_group->add_flag(
+                "--promote-secondary",
+                impl.promote_secondary,
+                "atomically flip primary_ring_idx so the secondary becomes "
+                "the new primary. Per-ring metadata (kind, auto_expire) "
+                "travels with the physical data; the daemon picks up the new "
+                "primary kind on next open.");
             cli_ops_group->add_option(
                 "--reset-history-length",
                 impl.reset_history_length,
@@ -1555,6 +1592,23 @@ opened.
                 impl.create_chunk_increasing,
                 "if creating a new database, order the chunks sequentially "
                 "increasing instead of randomly mixed.");
+            cli.add_option(
+                   "--state-machine",
+                   impl.state_machine,
+                   "StateMachine kind to stamp on the affected timeline. "
+                   "Persisted per-timeline in db_metadata; consumed by "
+                   "mpt::Db on open to pick the right StateMachine "
+                   "implementation via the registry. Defaults to 'ethereum'; "
+                   "honored on --create, --create-empty, --truncate (stamps "
+                   "the primary) and --activate-secondary (stamps the "
+                   "secondary); ignored on other subcommands.")
+                ->transform(CLI::CheckedTransformer(
+                    std::map<
+                        std::string,
+                        MONAD_MPT_NAMESPACE::state_machine_kind>{
+                        {"ethereum",
+                         MONAD_MPT_NAMESPACE::state_machine_kind::ethereum}},
+                    CLI::ignore_case));
             cli.add_option(
                 "--compression-level",
                 impl.compression_level,
@@ -1636,6 +1690,12 @@ opened.
                 impl.flags.open_read_only_allow_dirty = false;
                 impl.flags.allow_migration = true;
             }
+            else if (
+                impl.activate_secondary || impl.deactivate_secondary ||
+                impl.promote_secondary) {
+                impl.flags.open_read_only = false;
+                impl.flags.open_read_only_allow_dirty = false;
+            }
             if (mode == MONAD_ASYNC_NAMESPACE::storage_pool::mode::truncate) {
                 MONAD_ASYNC_NAMESPACE::storage_pool const pool{
                     {impl.storage_paths}, mode, impl.flags};
@@ -1651,12 +1711,16 @@ opened.
 
         monad::io::Ring ring(monad::io::RingConfig{1});
 
+        bool const needs_write_ring =
+            impl.rewind_database_to || impl.reset_history_length ||
+            impl.activate_secondary || impl.deactivate_secondary ||
+            impl.promote_secondary;
         auto wr_ring(
-            (impl.rewind_database_to || impl.reset_history_length)
+            needs_write_ring
                 ? std::optional<monad::io::Ring>(monad::io::RingConfig{4})
                 : std::nullopt);
         monad::io::Buffers rwbuf =
-            (impl.rewind_database_to || impl.reset_history_length)
+            needs_write_ring
                 ? monad::io::make_buffers_for_segregated_read_write(
                       ring,
                       *wr_ring,
@@ -1673,6 +1737,61 @@ opened.
                           MONAD_IO_BUFFERS_READ_SIZE);
         auto io = MONAD_ASYNC_NAMESPACE::AsyncIO{*impl.pool, rwbuf};
         MONAD_MPT_NAMESPACE::UpdateAux aux(io);
+
+        // Stamp the persisted StateMachine kind on freshly-created or
+        // truncated pools. Existing pools keep whatever was previously
+        // stamped — passing --state-machine on an open here is a no-op.
+        if (aux.metadata_ctx().is_new_pool()) {
+            aux.metadata_ctx().set_state_machine_kind(
+                MONAD_MPT_NAMESPACE::timeline_id::primary, impl.state_machine);
+            cout << "Stamped state-machine kind on primary timeline.\n";
+        }
+
+        // Secondary timeline lifecycle. These execute against the open
+        // UpdateAux; the daemon must be stopped beforehand (UpdateAux's
+        // open holds the storage pool exclusively). On the next daemon
+        // start, the metadata-driven Db ctor / open_secondary_timeline()
+        // picks up the new state.
+        if (impl.activate_secondary) {
+            if (aux.metadata_ctx().timeline_active(
+                    MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                cerr << "Secondary timeline already active; nothing to do.\n";
+                return 1;
+            }
+            // Order matters: stamp the kind first, then flip the active bit.
+            // open_secondary_timeline gates on the active bit, so flipping it
+            // first and crashing before the stamp would expose a secondary
+            // whose kind byte is still the zero (ethereum) default, silently
+            // building an ethereum StateMachine even when the secondary is
+            // another kind. Stamping first makes that window impossible.
+            aux.metadata_ctx().set_state_machine_kind(
+                MONAD_MPT_NAMESPACE::timeline_id::secondary,
+                impl.state_machine);
+            aux.activate_secondary_timeline();
+            cout << "Activated secondary timeline; stamped state-machine "
+                    "kind.\n";
+        }
+        else if (impl.deactivate_secondary) {
+            if (!aux.metadata_ctx().timeline_active(
+                    MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                cerr << "Secondary timeline is not active; nothing to do.\n";
+                return 1;
+            }
+            // The kind byte is left as-is; readers gate on the active bit,
+            // and the next activate restamps it before flipping active.
+            aux.deactivate_secondary_timeline();
+            cout << "Deactivated secondary timeline.\n";
+        }
+        else if (impl.promote_secondary) {
+            if (!aux.metadata_ctx().timeline_active(
+                    MONAD_MPT_NAMESPACE::timeline_id::secondary)) {
+                cerr << "Secondary timeline is not active; cannot promote.\n";
+                return 1;
+            }
+            aux.promote_secondary_to_primary();
+            cout << "Promoted secondary timeline to primary "
+                    "(primary_ring_idx flipped).\n";
+        }
 
         {
             cout << R"(MPT database on storages:

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -40,6 +40,7 @@
 #include <category/mpt/node_cache.hpp>
 #include <category/mpt/node_cursor.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
@@ -1069,6 +1070,20 @@ Db::Db(std::unique_ptr<StateMachine> machine, OnDiskDbConfig const &config)
     MONAD_ASSERT(impl_->aux().is_on_disk());
 }
 
+Db::Db(OnDiskDbConfig const &config)
+{
+    auto worker = std::make_shared<OnDiskDbServiceThread>(config);
+    auto machine = create_state_machine(
+        worker->aux().metadata_ctx().get_state_machine_kind(
+            timeline_id::primary));
+    impl_ = std::make_unique<RWOnDisk>(
+        std::move(worker),
+        std::move(machine),
+        timeline_id::primary,
+        config.compaction);
+    MONAD_ASSERT(impl_->aux().is_on_disk());
+}
+
 Db::Db(AsyncIOContext &io_ctx)
     : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, timeline_id::primary)}
 {
@@ -1336,6 +1351,22 @@ Db::open_secondary_timeline(std::unique_ptr<StateMachine> secondary_machine)
     }
     return Db{rw->spawn_sibling(
         std::move(secondary_machine), timeline_id::secondary)};
+}
+
+std::optional<Db> Db::open_secondary_timeline()
+{
+    MONAD_ASSERT(impl_);
+    MONAD_ASSERT(is_on_disk() && !is_read_only());
+    auto *const rw = static_cast<RWOnDisk *>(impl_.get());
+    MONAD_ASSERT(rw->tid() == timeline_id::primary);
+    MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    if (!rw->aux().metadata_ctx().timeline_active(timeline_id::secondary)) {
+        return std::nullopt;
+    }
+    auto const kind =
+        rw->aux().metadata_ctx().get_state_machine_kind(timeline_id::secondary);
+    auto machine = create_state_machine(kind);
+    return Db{rw->spawn_sibling(std::move(machine), timeline_id::secondary)};
 }
 
 void Db::promote_secondary_to_primary()

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -106,6 +106,13 @@ private:
 public:
     explicit Db(std::unique_ptr<StateMachine>); // in-memory
     Db(std::unique_ptr<StateMachine>, OnDiskDbConfig const &); // on-disk RW
+    // Production on-disk RW: reads the primary timeline's state_machine_kind
+    // from db_metadata (routed via primary_ring_idx, so it follows the role
+    // label across promote, not a fixed physical ring), constructs the
+    // StateMachine via the registry in category/mpt/state_machine_kind.hpp,
+    // and owns the SM internally. Caller must have registered the relevant
+    // kinds at process start (e.g. monad::register_ethereum_state_machines()).
+    explicit Db(OnDiskDbConfig const &);
     explicit Db(AsyncIOContext &); // on-disk RO blocking
 
     Db(Db const &) = delete;
@@ -207,6 +214,14 @@ public:
     // and persisted on disk. Returns nullopt if no secondary is active.
     [[nodiscard]] std::optional<Db>
     open_secondary_timeline(std::unique_ptr<StateMachine> secondary_machine);
+
+    // Production variant: read the secondary timeline's persisted
+    // state_machine_kind from db_metadata (routed via primary_ring_idx ^ 1,
+    // so it tracks the secondary role across promote, not a fixed physical
+    // ring) and construct the StateMachine via the registry. Returns nullopt
+    // if no secondary is active. Stamping the kind is the operator's job
+    // (monad-mpt --activate-secondary --state-machine <kind>).
+    [[nodiscard]] std::optional<Db> open_secondary_timeline();
 
     // Swap primary and secondary slots. Clears the primary Db's
     // StateMachine binding so a missed close+reopen (the expected next

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -25,6 +25,7 @@
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
 
@@ -259,18 +260,24 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
             // MONAD007 had no secondary, so the saved value belongs on
             // what is now the primary.
             m->root_offsets_state.auto_expire_version_ = saved_auto_expire;
-            // The bytes overlapping
-            // root_offsets_state.reserved_for_future_fields_ were inside
-            // MONAD007's huge cnv_chunks[] array (filled with 0xff for unused
-            // slots). Zero them so subsequent PRs adding fields to
-            // timeline_state_t start from a clean slate.
+            // Stamp the primary timeline's state_machine_kind. The byte
+            // sat inside MONAD007's huge cnv_chunks[] (0xff for unused
+            // slots), which would trip create_state_machine()'s range
+            // check on the next open. MONAD007 only supported ethereum.
+            m->root_offsets_state.state_machine_kind_ =
+                static_cast<uint8_t>(state_machine_kind::ethereum);
             memset(
-                m->root_offsets_state.reserved_for_future_fields_,
+                m->root_offsets_state.reserved_sm_,
                 0,
-                sizeof(m->root_offsets_state.reserved_for_future_fields_));
+                sizeof(m->root_offsets_state.reserved_sm_));
 
             // 5. Zero the region between secondary_timeline and the live
             //    block list (relocated in step 3).
+            //    secondary_timeline_state.state_machine_kind_ is left at
+            //    zero (state_machine_kind::ethereum);
+            //    secondary_timeline_active_ is also zero, so the byte is
+            //    unreachable until a later monad-mpt --activate-secondary
+            //    stamps the real kind.
             auto *const new_fields_begin =
                 m_bytes + offsetof(detail::db_metadata, secondary_timeline);
             auto *const new_fields_end =
@@ -593,6 +600,39 @@ void DbMetadataContext::set_auto_expire_version_metadata(
                             : &m->secondary_timeline_state.auto_expire_version_;
         start_lifetime_as<std::atomic_int64_t>(slot)->store(
             version, std::memory_order_release);
+    };
+    do_(copies_[0].main);
+    do_(copies_[1].main);
+}
+
+state_machine_kind
+DbMetadataContext::get_state_machine_kind(timeline_id const tid) const noexcept
+{
+    auto const *const m = copies_[0].main;
+    uint8_t const ring_idx = (tid == timeline_id::primary)
+                                 ? primary_ring_idx()
+                                 : (primary_ring_idx() ^ 1u);
+    auto const *const slot =
+        (ring_idx == 0) ? &m->root_offsets_state.state_machine_kind_
+                        : &m->secondary_timeline_state.state_machine_kind_;
+    auto const raw = start_lifetime_as<std::atomic_uint8_t const>(slot)->load(
+        std::memory_order_acquire);
+    return static_cast<state_machine_kind>(raw);
+}
+
+void DbMetadataContext::set_state_machine_kind(
+    timeline_id const tid, state_machine_kind const kind) noexcept
+{
+    uint8_t const ring_idx = (tid == timeline_id::primary)
+                                 ? primary_ring_idx()
+                                 : (primary_ring_idx() ^ 1u);
+    auto do_ = [&](detail::db_metadata *m) {
+        auto const g = m->hold_dirty();
+        auto *const slot =
+            (ring_idx == 0) ? &m->root_offsets_state.state_machine_kind_
+                            : &m->secondary_timeline_state.state_machine_kind_;
+        start_lifetime_as<std::atomic_uint8_t>(slot)->store(
+            static_cast<uint8_t>(kind), std::memory_order_release);
     };
     do_(copies_[0].main);
     do_(copies_[1].main);

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -23,6 +23,7 @@
 #include <category/mpt/config.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/util.hpp>
 
 #include <atomic>
@@ -276,6 +277,15 @@ public:
     int64_t get_auto_expire_version_metadata(timeline_id tid) const noexcept;
     void
     set_auto_expire_version_metadata(timeline_id tid, int64_t version) noexcept;
+
+    // Read the persisted StateMachine kind for the given timeline. Stamped
+    // at pool create time by monad-mpt --state-machine and on
+    // activate-secondary for the non-primary ring; consumed by mpt::Db's
+    // production-open ctor to pick the right SM via the registry in
+    // state_machine_kind.hpp.
+    state_machine_kind get_state_machine_kind(timeline_id tid) const noexcept;
+    void
+    set_state_machine_kind(timeline_id tid, state_machine_kind kind) noexcept;
     void update_history_length_metadata(uint64_t history_len) noexcept;
 
     // Root offsets operations. All wrap the two-copy mutation in

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -157,11 +157,14 @@ namespace detail
             // Last upsert's auto-expire version threshold for this timeline.
             // Accessed via start_lifetime_as<std::atomic_int64_t>.
             int64_t auto_expire_version_;
-            // Reserved for fields added in subsequent dual-timeline PRs
-            // (e.g. per-timeline state_machine_kind). Reserving the bytes
-            // here pins the db_metadata layout so future additions don't
-            // require another magic bump.
-            uint8_t reserved_for_future_fields_[8];
+            // mpt::state_machine_kind for the timeline currently bound to
+            // this physical ring. Stamped at pool create time by monad-mpt
+            // --state-machine, and on activate-secondary for whichever ring
+            // hosts the secondary at that moment. Read by mpt::Db ctor to
+            // pick the right StateMachine via the registry in
+            // state_machine_kind.hpp.
+            uint8_t state_machine_kind_;
+            uint8_t reserved_sm_[7]; // alignment + future per-ring scalars
         } root_offsets_state;
 
         struct db_offsets_info_t

--- a/category/mpt/state_machine_kind.cpp
+++ b/category/mpt/state_machine_kind.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/mpt/config.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+namespace
+{
+    std::array<state_machine_factory, NUM_STATE_MACHINE_KINDS> &registry()
+    {
+        static std::array<state_machine_factory, NUM_STATE_MACHINE_KINDS> r{};
+        return r;
+    }
+}
+
+void register_state_machine(
+    state_machine_kind const kind, state_machine_factory factory)
+{
+    auto const i = static_cast<uint8_t>(kind);
+    MONAD_ASSERT(i < NUM_STATE_MACHINE_KINDS);
+    registry()[i] = std::move(factory);
+}
+
+std::unique_ptr<StateMachine>
+create_state_machine(state_machine_kind const kind)
+{
+    auto const i = static_cast<uint8_t>(kind);
+    MONAD_ASSERT(i < NUM_STATE_MACHINE_KINDS);
+    auto const &factory = registry()[i];
+    // Aborts here mean external init (register_ethereum_state_machines or
+    // similar) didn't run before mpt::Db tried to construct a SM, or the
+    // on-disk kind names a SM no longer compiled in.
+    MONAD_ASSERT(static_cast<bool>(factory));
+    return factory();
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/category/mpt/state_machine_kind.hpp
+++ b/category/mpt/state_machine_kind.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/mpt/config.hpp>
+#include <category/mpt/state_machine.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+// Identifies which StateMachine implementation a timeline was created with.
+// Persisted per-timeline in db_metadata::root_offsets_ring_t so that opens
+// reconstruct the right SM via the registry below.
+enum class state_machine_kind : uint8_t
+{
+    // OnDiskMachine; registered by register_ethereum_state_machines. Value 0
+    // so a zeroed metadata byte (DBs created before the kind was persisted,
+    // freshly-created pools) reads back as ethereum with no migration step.
+    ethereum = 0,
+    // Future kinds (e.g. the dual-timeline hash migration target) extend here.
+    // Never reorder or reuse values: they are persisted on disk.
+};
+
+constexpr uint8_t NUM_STATE_MACHINE_KINDS = 8;
+
+using state_machine_factory = std::function<std::unique_ptr<StateMachine>()>;
+
+// Register a factory for a given kind. The mpt module never knows about
+// concrete StateMachine subclasses; external init code (e.g.
+// register_ethereum_state_machines() in execution/ethereum/db) populates
+// the registry at process start before any mpt::Db is constructed.
+//
+// Idempotent: re-registering the same kind overwrites the previous factory.
+void register_state_machine(state_machine_kind, state_machine_factory);
+
+// Construct a StateMachine for the given kind via the registered factory.
+// Aborts (MONAD_ASSERT) if the kind is out of range or has no registered
+// factory.
+std::unique_ptr<StateMachine> create_state_machine(state_machine_kind);
+
+MONAD_MPT_NAMESPACE_END

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -55,6 +55,10 @@ add_trie_test(TARGET node_writer_test SOURCES "node_writer_test.cpp")
 add_trie_test(TARGET plain_trie_test SOURCES "plain_trie_test.cpp")
 add_trie_test(TARGET rewind_test SOURCES "rewind_test.cpp")
 add_trie_test(TARGET state_machine_test SOURCES "state_machine_test.cpp")
+add_trie_test(TARGET state_machine_kind_test SOURCES
+              "state_machine_kind_test.cpp")
+add_trie_test(TARGET db_state_machine_kind_open_test SOURCES
+              "db_state_machine_kind_open_test.cpp")
 add_trie_test(TARGET subtrie_version_test SOURCES "subtrie_version_test.cpp")
 add_trie_test(TARGET unsigned_20_test SOURCES "unsigned_20_test.cpp")
 add_trie_test(TARGET virtual_offset_test SOURCES "virtual_offset_test.cpp")

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -24,11 +24,14 @@
 #include <category/core/io/ring.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/mpt/cli_tool_impl.hpp>
+#include <category/mpt/db.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cursor.hpp>
+#include <category/mpt/ondisk_db_config.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/trie.hpp>
 
 #include <algorithm>
@@ -103,7 +106,305 @@ TEST(cli_tool, create)
             std::string::npos,
             cout.str().find(
                 "1 chunks with capacity 256.00 Mb used 0.00 bytes"));
+        // --state-machine defaults to ethereum on a fresh pool; confirm it
+        // was stamped during pool init.
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Stamped state-machine kind on primary timeline"));
     }
+}
+
+TEST(cli_tool, create_with_explicit_state_machine_flag)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt",
+        "--storage",
+        temppath,
+        "--create",
+        "--state-machine",
+        "ethereum"};
+    int const retcode = main_impl(cout, cerr, args);
+    ASSERT_EQ(retcode, 0);
+    EXPECT_NE(
+        std::string::npos,
+        cout.str().find("Stamped state-machine kind on primary timeline"));
+}
+
+TEST(cli_tool, state_machine_unknown_kind_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt",
+        "--storage",
+        temppath,
+        "--create",
+        "--state-machine",
+        "nonsense"};
+    int const retcode = main_impl(cout, cerr, args);
+    EXPECT_NE(retcode, 0);
+}
+
+namespace
+{
+    // Helper: open the pool RO and read back the persisted kind via
+    // UpdateAux + DbMetadataContext public API. Lets CLI tests verify that
+    // the bytes actually landed, not just that monad-mpt printed a success
+    // line.
+    monad::mpt::state_machine_kind
+    read_kind(char const *const path, monad::mpt::timeline_id const tid)
+    {
+        monad::mpt::AsyncIOContext io_ctx{monad::mpt::ReadOnlyOnDiskDbConfig{
+            .dbname_paths = {std::filesystem::path{path}}}};
+        monad::mpt::UpdateAux const aux(io_ctx.io);
+        return aux.metadata_ctx().get_state_machine_kind(tid);
+    }
+
+    bool read_secondary_active(char const *const path)
+    {
+        monad::mpt::AsyncIOContext io_ctx{monad::mpt::ReadOnlyOnDiskDbConfig{
+            .dbname_paths = {std::filesystem::path{path}}}};
+        monad::mpt::UpdateAux const aux(io_ctx.io);
+        return aux.metadata_ctx().timeline_active(
+            monad::mpt::timeline_id::secondary);
+    }
+
+    uint8_t read_primary_ring_idx(char const *const path)
+    {
+        monad::mpt::AsyncIOContext io_ctx{monad::mpt::ReadOnlyOnDiskDbConfig{
+            .dbname_paths = {std::filesystem::path{path}}}};
+        monad::mpt::UpdateAux const aux(io_ctx.io);
+        return aux.metadata_ctx().primary_ring_idx();
+    }
+
+    // Provision a temp pool file. Caller owns the unlink scope.
+    void make_temp_pool(char *const temppath)
+    {
+        auto const fd = ::mkstemp(temppath);
+        ASSERT_NE(fd, -1);
+        ::close(fd);
+        ASSERT_EQ(0, ::truncate(temppath, 6ULL * 1024 * 1024 * 1024));
+    }
+}
+
+TEST(cli_tool, activate_secondary_stamps_secondary_kind)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--activate-secondary",
+            "--state-machine",
+            "ethereum"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find(
+                "Activated secondary timeline; stamped state-machine"));
+    }
+
+    EXPECT_TRUE(read_secondary_active(temppath));
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::ethereum);
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::secondary),
+        monad::mpt::state_machine_kind::ethereum);
+}
+
+TEST(cli_tool, activate_secondary_defaults_to_ethereum_when_flag_omitted)
+{
+    // Pins the design choice that --state-machine defaults to ethereum on
+    // --activate-secondary (matching the --create default), so existing
+    // operator scripts work unmodified. If you change this default, this
+    // test should fail and force a deliberate choice.
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--activate-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::secondary),
+        monad::mpt::state_machine_kind::ethereum);
+}
+
+TEST(cli_tool, deactivate_secondary_clears_active_flag)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--activate-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    ASSERT_TRUE(read_secondary_active(temppath));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--deactivate-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Deactivated secondary timeline"));
+    }
+
+    EXPECT_FALSE(read_secondary_active(temppath));
+}
+
+TEST(cli_tool, promote_secondary_flips_primary_ring_idx)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--activate-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    ASSERT_EQ(0u, read_primary_ring_idx(temppath));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--promote-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Promoted secondary timeline to primary"));
+    }
+
+    EXPECT_EQ(1u, read_primary_ring_idx(temppath));
+}
+
+TEST(cli_tool, activate_secondary_on_already_active_is_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--activate-secondary"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    // Second activate must refuse without mutating state.
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt", "--storage", temppath, "--activate-secondary"};
+    EXPECT_NE(0, main_impl(cout, cerr, args));
+    EXPECT_NE(std::string::npos, cerr.str().find("already active"));
+}
+
+TEST(cli_tool, deactivate_secondary_on_inactive_is_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt", "--storage", temppath, "--deactivate-secondary"};
+    EXPECT_NE(0, main_impl(cout, cerr, args));
+    EXPECT_NE(std::string::npos, cerr.str().find("not active"));
 }
 
 struct config
@@ -391,6 +692,97 @@ struct cli_tool_archives_restores
 TEST_F(cli_tool_archives_restores, archives_restores)
 {
     run_test();
+}
+
+struct cli_tool_restore_preserves_kind
+    : public cli_tool_fixture<config{.chunks_to_fill = 8, .chunks_max = 16}>
+{
+};
+
+// Regression: do_restore_database() once copied only
+// root_offsets_state.auto_expire_version_ out of the source metadata, leaving
+// state_machine_kind_ at the destination's freshly-initialised ethereum
+// default — silently dropping a non-ethereum source DB's kind on --restore.
+// ethereum (== 0) is the only registered kind, so comparing reads back can't
+// tell a copied byte from a zero-initialised one; stamp a synthetic non-zero
+// kind to make the archive/restore round-trip observable.
+TEST_F(cli_tool_restore_preserves_kind, restore_preserves_state_machine_kind)
+{
+    constexpr auto synthetic_kind =
+        static_cast<monad::mpt::state_machine_kind>(uint8_t{3});
+
+    auto const dbpath1 =
+        this->state()->pool.devices().front().current_path().string();
+    this->state()->aux.metadata_ctx().set_state_machine_kind(
+        monad::mpt::timeline_id::primary, synthetic_kind);
+
+    constexpr unsigned default_num_cnv_chunks = 17;
+    char archivepath[] = "cli_tool_test_XXXXXX";
+    char dbpath2[] = "cli_tool_test_XXXXXX";
+    {
+        auto const fd = mkstemp(archivepath);
+        ASSERT_NE(fd, -1);
+        ::close(fd);
+    }
+    {
+        auto const fd = mkstemp(dbpath2);
+        ASSERT_NE(fd, -1);
+        ::close(fd);
+    }
+    ASSERT_EQ(
+        0,
+        truncate(
+            dbpath2,
+            (default_num_cnv_chunks +
+             16) * MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE +
+                24576));
+    auto const cleanup = monad::make_scope_exit([&]() noexcept {
+        unlink(archivepath);
+        unlink(dbpath2);
+    });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            dbpath1.c_str(),
+            "--archive",
+            archivepath};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0) << cerr.str();
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--chunk-capacity",
+            "23",
+            "--yes",
+            "--restore",
+            archivepath,
+            "--storage",
+            dbpath2};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0) << cerr.str();
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Database has been restored from"));
+    }
+
+    // read_kind opens its own AsyncIO; the fixture already holds one on this
+    // thread, so run it on a fresh thread (one AsyncIO per thread).
+    auto const restored_kind =
+        std::async(std::launch::async, [&] {
+            return read_kind(dbpath2, monad::mpt::timeline_id::primary);
+        }).get();
+    EXPECT_EQ(restored_kind, synthetic_kind);
 }
 
 /* There was a bug found whereby if the DB being archived used the lastmost

--- a/category/mpt/test/db_state_machine_kind_open_test.cpp
+++ b/category/mpt/test/db_state_machine_kind_open_test.cpp
@@ -1,0 +1,217 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Verifies that the production-shaped Db ctors (no StateMachine argument)
+// route through the kind registry: persisted ring_a/ring_b state_machine_kind
+// drives StateMachine construction at open time.
+
+#include "test_fixtures_base.hpp"
+#include "test_fixtures_gtest.hpp"
+
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/hex.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/node.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/trie.hpp>
+#include <category/mpt/update.hpp>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <utility>
+
+using namespace monad::mpt;
+using namespace monad::test;
+using namespace monad::literals;
+
+namespace monad::mpt::test
+{
+    // Friend-of-Db accessor (db.hpp friends monad::mpt::test::DbAccessor).
+    // Each test TU defines its own; tests stay isolated because every test
+    // file becomes a standalone gtest binary via add_trie_test.
+    struct DbAccessor
+    {
+        static UpdateAux &aux(Db &db)
+        {
+            // Db::aux() returns const&; the underlying Impl::aux() is
+            // non-const. Tests stamping per-timeline metadata need write
+            // access; the const_cast is safe because we never read from a
+            // truly-const Db.
+            return const_cast<UpdateAux &>(db.aux());
+        }
+    };
+}
+
+namespace
+{
+    using monad::mpt::test::DbAccessor;
+
+    Update make_kv(monad::byte_string_view key, monad::byte_string_view value)
+    {
+        return make_update(key, value);
+    }
+
+    // Register the ethereum kind to mint a fresh StateMachineAlwaysMerkle
+    // every call. Real production registers OnDiskMachine; the test substitutes
+    // a trie-compatible test machine so this test stays inside mpt.
+    void register_test_state_machines()
+    {
+        register_state_machine(state_machine_kind::ethereum, [] {
+            return std::unique_ptr<StateMachine>(
+                new StateMachineAlwaysMerkle{});
+        });
+    }
+
+    TEST(db_state_machine_kind_open, primary_open_uses_registered_factory)
+    {
+        std::filesystem::path const dbname = create_temp_file(8);
+        auto const unfile = monad::make_scope_exit(
+            [&]() noexcept { std::filesystem::remove(dbname); });
+
+        OnDiskDbConfig const create_config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+
+        // Stage 1: open with the SM-owning test ctor, stamp the kind on
+        // ring_a, then close. Mirrors what monad-mpt --create
+        // --state-machine ethereum produces on a fresh pool.
+        {
+            Db db{std::make_unique<StateMachineAlwaysMerkle>(), create_config};
+            DbAccessor::aux(db).metadata_ctx().set_state_machine_kind(
+                timeline_id::primary, state_machine_kind::ethereum);
+        }
+
+        // Stage 2: reopen with the production ctor (no SM). The Db ctor
+        // must read the kind from db_metadata and instantiate the SM via
+        // the registry.
+        register_test_state_machines();
+        OnDiskDbConfig reopen_config = create_config;
+        reopen_config.append = true;
+        Db db{reopen_config};
+
+        // Perform a basic upsert + find to confirm the registry-built SM is
+        // actually wired into the worker thread.
+        auto const k = 0xCAFE_bytes;
+        UpdateList ul;
+        auto u = make_kv(k, k);
+        ul.push_front(u);
+        auto const root = db.upsert(nullptr, std::move(ul), 0);
+        ASSERT_NE(root, nullptr);
+        auto const res = db.find(NodeCursor{root}, NibblesView{k}, 0);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(res.value().node->value(), monad::byte_string_view{k});
+    }
+
+    TEST(db_state_machine_kind_open, secondary_open_no_arg_reads_ring_b_kind)
+    {
+        std::filesystem::path const dbname = create_temp_file(8);
+        auto const unfile = monad::make_scope_exit(
+            [&]() noexcept { std::filesystem::remove(dbname); });
+
+        OnDiskDbConfig const create_config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+
+        // Stage 1: open + activate secondary via the test API, stamp both
+        // rings' kinds, then close everything. Mirrors what an operator
+        // sees after monad-mpt --create followed by monad-mpt
+        // --activate-secondary.
+        {
+            Db db{std::make_unique<StateMachineAlwaysMerkle>(), create_config};
+            DbAccessor::aux(db).metadata_ctx().set_state_machine_kind(
+                timeline_id::primary, state_machine_kind::ethereum);
+            auto secondary_db = db.activate_secondary_timeline(
+                std::make_unique<StateMachineAlwaysMerkle>());
+            DbAccessor::aux(secondary_db)
+                .metadata_ctx()
+                .set_state_machine_kind(
+                    timeline_id::secondary, state_machine_kind::ethereum);
+        }
+
+        register_test_state_machines();
+        OnDiskDbConfig reopen_config = create_config;
+        reopen_config.append = true;
+
+        // Stage 2: reopen primary via the production ctor, then attach to
+        // the persisted secondary via the no-arg overload.
+        Db db{reopen_config};
+        auto secondary = db.open_secondary_timeline();
+        ASSERT_TRUE(secondary.has_value());
+        EXPECT_EQ(secondary->tid(), timeline_id::secondary);
+
+        // Both timelines should be writable + readable through their
+        // respective registry-constructed SMs.
+        auto const k_primary = 0x1111_bytes;
+        auto const k_secondary = 0x2222_bytes;
+        UpdateList up;
+        auto up_kv = make_kv(k_primary, k_primary);
+        up.push_front(up_kv);
+        auto const proot = db.upsert(nullptr, std::move(up), 0);
+        ASSERT_NE(proot, nullptr);
+
+        UpdateList us;
+        auto us_kv = make_kv(k_secondary, k_secondary);
+        us.push_front(us_kv);
+        auto const sroot = secondary->upsert(nullptr, std::move(us), 0);
+        ASSERT_NE(sroot, nullptr);
+
+        auto const pres = db.find(NodeCursor{proot}, NibblesView{k_primary}, 0);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(
+            pres.value().node->value(), monad::byte_string_view{k_primary});
+
+        auto const sres =
+            secondary->find(NodeCursor{sroot}, NibblesView{k_secondary}, 0);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(
+            sres.value().node->value(), monad::byte_string_view{k_secondary});
+    }
+
+    TEST(db_state_machine_kind_open, secondary_open_inactive_returns_nullopt)
+    {
+        std::filesystem::path const dbname = create_temp_file(8);
+        auto const unfile = monad::make_scope_exit(
+            [&]() noexcept { std::filesystem::remove(dbname); });
+
+        OnDiskDbConfig const create_config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+
+        {
+            Db db{std::make_unique<StateMachineAlwaysMerkle>(), create_config};
+            DbAccessor::aux(db).metadata_ctx().set_state_machine_kind(
+                timeline_id::primary, state_machine_kind::ethereum);
+        }
+
+        register_test_state_machines();
+        OnDiskDbConfig reopen_config = create_config;
+        reopen_config.append = true;
+        Db db{reopen_config};
+        EXPECT_FALSE(db.open_secondary_timeline().has_value());
+    }
+}

--- a/category/mpt/test/state_machine_kind_test.cpp
+++ b/category/mpt/test/state_machine_kind_test.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/mpt/compute.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+
+using namespace monad::mpt;
+
+namespace
+{
+    // Stand-in StateMachine that records which factory invocation produced
+    // it. Tests use this in place of a real OnDiskMachine so the registry
+    // test stays inside the mpt module — production SMs live in execution/.
+    struct FakeStateMachine final : public StateMachine
+    {
+        explicit FakeStateMachine(int const tag)
+            : tag_(tag)
+        {
+        }
+
+        std::unique_ptr<StateMachine> clone() const override
+        {
+            return std::make_unique<FakeStateMachine>(tag_);
+        }
+
+        void down(unsigned char) override {}
+
+        void up(size_t) override {}
+
+        Compute &get_compute() const override
+        {
+            std::abort(); // not exercised
+        }
+
+        bool cache() const override
+        {
+            return false;
+        }
+
+        bool compact() const override
+        {
+            return false;
+        }
+
+        bool is_variable_length() const override
+        {
+            return false;
+        }
+
+        int tag_;
+    };
+}
+
+TEST(state_machine_kind, register_then_create_returns_factory_output)
+{
+    register_state_machine(state_machine_kind::ethereum, [] {
+        return std::unique_ptr<StateMachine>(new FakeStateMachine{42});
+    });
+    auto const sm = create_state_machine(state_machine_kind::ethereum);
+    ASSERT_NE(sm, nullptr);
+    auto *const fake = dynamic_cast<FakeStateMachine *>(sm.get());
+    ASSERT_NE(fake, nullptr);
+    EXPECT_EQ(fake->tag_, 42);
+}
+
+TEST(state_machine_kind, re_register_overwrites)
+{
+    register_state_machine(state_machine_kind::ethereum, [] {
+        return std::unique_ptr<StateMachine>(new FakeStateMachine{1});
+    });
+    register_state_machine(state_machine_kind::ethereum, [] {
+        return std::unique_ptr<StateMachine>(new FakeStateMachine{2});
+    });
+    auto const sm = create_state_machine(state_machine_kind::ethereum);
+    auto *const fake = dynamic_cast<FakeStateMachine *>(sm.get());
+    ASSERT_NE(fake, nullptr);
+    EXPECT_EQ(fake->tag_, 2);
+}
+
+TEST(state_machine_kind, create_unregistered_aborts)
+{
+    // An in-range kind with no registered factory aborts. Use the top slot
+    // so it stays unregistered as real kinds are added at the bottom.
+    EXPECT_DEATH(
+        (void)create_state_machine(
+            static_cast<state_machine_kind>(NUM_STATE_MACHINE_KINDS - 1)),
+        "");
+}

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
 #include <category/async/io.hpp>
 #include <category/async/storage_pool.hpp>
 #include <category/async/util.hpp>
@@ -23,6 +24,7 @@
 #include <category/core/io/ring.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 #include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/test/db_metadata_test_access.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/util.hpp>
@@ -359,6 +361,115 @@ TEST(update_aux_test, secondary_inactive_by_default)
     });
 }
 
+// -------------------------------------------------------------------
+// State machine kind: per-timeline metadata round-trip
+// -------------------------------------------------------------------
+
+TEST(update_aux_test, state_machine_kind_default_ethereum)
+{
+    // A freshly-initialised pool is zeroed by init_new_pool; ethereum is the
+    // zero value, so both rings read back as ethereum until a real kind is
+    // stamped (e.g. via monad-mpt --state-machine).
+    with_rw_aux([](UpdateAux &aux) {
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::primary),
+            state_machine_kind::ethereum);
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::secondary),
+            state_machine_kind::ethereum);
+    });
+}
+
+TEST(update_aux_test, state_machine_kind_primary_round_trip)
+{
+    // A non-default value (no registered factory needed for a storage
+    // round-trip) proves the byte persists on the primary ring while the
+    // secondary keeps its ethereum-zero default.
+    auto const other = static_cast<state_machine_kind>(1);
+    with_rw_aux([other](UpdateAux &aux) {
+        aux.metadata_ctx().set_state_machine_kind(timeline_id::primary, other);
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::primary),
+            other);
+        // Secondary unaffected.
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::secondary),
+            state_machine_kind::ethereum);
+    });
+}
+
+TEST(update_aux_test, state_machine_kind_secondary_independent)
+{
+    // Distinct non-default values prove the two timelines route to
+    // independent bytes.
+    auto const a = static_cast<state_machine_kind>(1);
+    auto const b = static_cast<state_machine_kind>(2);
+    with_rw_aux([a, b](UpdateAux &aux) {
+        aux.metadata_ctx().set_state_machine_kind(timeline_id::primary, a);
+        aux.metadata_ctx().set_state_machine_kind(timeline_id::secondary, b);
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::primary), a);
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::secondary),
+            b);
+    });
+}
+
+TEST(update_aux_test, state_machine_kind_persists_across_reopen)
+{
+    // Verifies the kind written through DbMetadataContext lands in stable
+    // on-disk bytes (both metadata copies) and is observable after a full
+    // close+reopen of the storage pool. Use a non-default value so the
+    // assertion can't pass on a freshly-zeroed (ethereum) pool.
+    auto const kind = static_cast<state_machine_kind>(1);
+    monad::async::storage_pool::creation_flags flags;
+    flags.chunk_capacity = 24;
+    flags.num_cnv_chunks = 2 + UpdateAux::cnv_chunks_for_db_metadata;
+
+    auto path_template = (MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+                          "state_machine_kind_persists_XXXXXX")
+                             .native();
+    {
+        int const fd = ::mkstemp(path_template.data());
+        ASSERT_GE(fd, 0);
+        ASSERT_EQ(::ftruncate(fd, 8LL << 30), 0);
+        ::close(fd);
+    }
+    auto const filename = std::filesystem::path(path_template);
+    auto const unfilename = monad::make_scope_exit(
+        [&]() noexcept { std::filesystem::remove(filename); });
+
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    auto testbuf = monad::io::make_buffers_for_segregated_read_write(
+        ring1,
+        ring2,
+        2,
+        4,
+        monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+        monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::truncate,
+            flags);
+        monad::async::AsyncIO testio(pool, testbuf);
+        monad::mpt::UpdateAux aux(testio);
+        aux.metadata_ctx().set_state_machine_kind(timeline_id::primary, kind);
+    }
+    {
+        monad::async::storage_pool pool(
+            std::span{&filename, 1},
+            monad::async::storage_pool::mode::open_existing,
+            flags);
+        monad::async::AsyncIO testio(pool, testbuf);
+        monad::mpt::UpdateAux const aux(testio);
+        EXPECT_EQ(
+            aux.metadata_ctx().get_state_machine_kind(timeline_id::primary),
+            kind);
+    }
+}
+
 // Simulates opening a DB created by pre-dual-timeline code (MONAD007), whose
 // future_variables_unused region — now overlapping secondary_timeline — was
 // filled with 0xff. On reopen the constructor must rewrite the magic and zero
@@ -534,10 +645,21 @@ TEST(update_aux_test, migrates_monad007_layout_to_monad008)
                 m->root_offsets_state.auto_expire_version_,
                 test_auto_expire_version);
             EXPECT_EQ(m->secondary_timeline_state.auto_expire_version_, 0);
-            // The reserved bytes overlap MONAD007's cnv_chunks[] (0xff
-            // for unused slots); migration must zero them.
-            for (uint8_t const b :
-                 m->root_offsets_state.reserved_for_future_fields_) {
+            // state_machine_kind_ overlapped MONAD007's cnv_chunks[] (0xff
+            // for unused slots); migration must overwrite it with
+            // state_machine_kind::ethereum so the next Db open doesn't
+            // trip create_state_machine()'s range check.
+            EXPECT_EQ(
+                m->root_offsets_state.state_machine_kind_,
+                static_cast<uint8_t>(state_machine_kind::ethereum));
+            // Secondary's kind stays at zero (ethereum); it's gated by
+            // secondary_timeline_active_ = 0, so the byte is unreachable
+            // until a later --activate-secondary stamps the real kind.
+            EXPECT_EQ(
+                m->secondary_timeline_state.state_machine_kind_,
+                static_cast<uint8_t>(state_machine_kind::ethereum));
+            // reserved_sm_ must be zeroed (was 0xff in MONAD007 cnv_chunks[]).
+            for (uint8_t const b : m->root_offsets_state.reserved_sm_) {
                 EXPECT_EQ(b, 0u);
             }
             // List triple relocated from offset 528488 to 4456.

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -20,6 +20,7 @@
 #include <category/core/likely.h>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
+#include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/statesync/statesync_client.h>
@@ -45,6 +46,10 @@ monad_statesync_client_context *monad_statesync_client_context_create(
     std::vector<std::filesystem::path> const paths{
         dbname_paths, dbname_paths + len};
     MONAD_ASSERT(!paths.empty());
+    // C ABI entry — runs in a foreign process; register the state machine
+    // factories so the kind-driven Db ctor can resolve `ethereum`.
+    // Idempotent: re-registration overwrites the prior factory.
+    register_ethereum_state_machines();
     return new monad_statesync_client_context{
         paths,
         sq_thread_cpu == MONAD_SQPOLL_DISABLED

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -34,16 +34,15 @@ monad_statesync_client_context::monad_statesync_client_context(
     monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
-    : db{std::make_unique<OnDiskMachine>(),
-         mpt::OnDiskDbConfig{
-             .append = true,
-             .compaction = false,
-             .rewind_to_latest_finalized = true,
-             .rd_buffers = 8192,
-             .wr_buffers = wr_buffers,
-             .uring_entries = 128,
-             .sq_thread_cpu = sq_thread_cpu,
-             .dbname_paths = dbname_paths}}
+    : db{mpt::OnDiskDbConfig{
+          .append = true,
+          .compaction = false,
+          .rewind_to_latest_finalized = true,
+          .rd_buffers = 8192,
+          .wr_buffers = wr_buffers,
+          .uring_entries = 128,
+          .sq_thread_cpu = sq_thread_cpu,
+          .dbname_paths = dbname_paths}}
     , tdb{db} // open with latest finalized if valid, otherwise init as block 0
     , progress(
           monad_statesync_client_prefixes(),

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -23,6 +23,10 @@
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/timeline.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/trie.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_messages.h>
@@ -100,6 +104,19 @@ void statesync_server_send_done(
     monad_statesync_server_network *const net, monad_sync_done const done)
 {
     monad_statesync_client_handle_done(net->cctx, done);
+}
+
+namespace monad::mpt::test
+{
+    // Friend-of-Db accessor (db.hpp friends monad::mpt::test::DbAccessor).
+    // Lets the fresh-pool helper stamp the persisted state_machine_kind.
+    struct DbAccessor
+    {
+        static UpdateAux &aux(Db &db)
+        {
+            return const_cast<UpdateAux &>(db.aux());
+        }
+    };
 }
 
 MONAD_NAMESPACE_BEGIN
@@ -249,9 +266,13 @@ namespace
             ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
         ::close(fd);
         char const *const path = dbname.c_str();
-        mpt::Db const db{
+        mpt::Db db{
             std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
+        monad::mpt::test::DbAccessor::aux(db)
+            .metadata_ctx()
+            .set_state_machine_kind(
+                timeline_id::primary, state_machine_kind::ethereum);
         return dbname;
     }
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -23,10 +23,15 @@
 #include <category/execution/ethereum/chain/genesis_state.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
+#include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/trie.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_server.h>
@@ -45,6 +50,20 @@
 using namespace monad;
 using namespace monad::mpt;
 using namespace monad::test;
+
+namespace monad::mpt::test
+{
+    // Friend-of-Db accessor: lets the temp-db helper stamp the persisted
+    // state_machine_kind on a fresh pool, simulating what monad-mpt --create
+    // --state-machine ethereum does in production.
+    struct DbAccessor
+    {
+        static UpdateAux &aux(Db &db)
+        {
+            return const_cast<UpdateAux &>(db.aux());
+        }
+    };
+}
 
 struct monad_statesync_client
 {
@@ -75,9 +94,15 @@ namespace
             ::ftruncate(fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
         ::close(fd);
         char const *const path = dbname.c_str();
-        mpt::Db const db{
+        // Stamp the kind so a later open via Db(OnDiskDbConfig const&) — which
+        // monad_statesync_client_context uses internally — finds a valid kind.
+        mpt::Db db{
             std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.append = false, .dbname_paths = {path}}};
+        monad::mpt::test::DbAccessor::aux(db)
+            .metadata_ctx()
+            .set_state_machine_kind(
+                timeline_id::primary, state_machine_kind::ethereum);
         return dbname;
     }
 
@@ -167,6 +192,10 @@ namespace
 
         void init()
         {
+            // Production C ABI (monad_statesync_client_context_create) does
+            // this; tests that bypass the C ABI and call the C++ ctor
+            // directly must populate the registry themselves.
+            monad::register_ethereum_state_machines();
             cctx = new monad_statesync_client_context{
                 {cdbname},
                 std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -36,6 +36,7 @@
 #include <category/execution/ethereum/core/log_level_map.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
+#include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/precompiles.hpp>
@@ -276,22 +277,24 @@ try {
     if (!statesync.empty()) {
         net.emplace(statesync.c_str());
     }
+    // The on-disk Db ctor reads the persisted state_machine_kind from
+    // db_metadata and constructs the StateMachine via the registry. The
+    // in-memory path has no metadata to read from and constructs the SM
+    // inline.
+    register_ethereum_state_machines();
     mpt::Db raw_db = [&] {
         if (!db_in_memory) {
-            return mpt::Db{
-                std::make_unique<OnDiskMachine>(),
-                mpt::OnDiskDbConfig{
-                    .append = true,
-                    .compaction = !no_compaction,
-                    .rewind_to_latest_finalized = true,
-                    .rd_buffers = 8192,
-                    .wr_buffers = 32,
-                    .uring_entries = 128,
-                    .sq_thread_cpu =
-                        disable_sq_thread_cpu
-                            ? std::optional<unsigned>{}
-                            : std::optional<unsigned>{sq_thread_cpu},
-                    .dbname_paths = dbname_paths}};
+            return mpt::Db{mpt::OnDiskDbConfig{
+                .append = true,
+                .compaction = !no_compaction,
+                .rewind_to_latest_finalized = true,
+                .rd_buffers = 8192,
+                .wr_buffers = 32,
+                .uring_entries = 128,
+                .sq_thread_cpu = disable_sq_thread_cpu
+                                     ? std::optional<unsigned>{}
+                                     : std::optional<unsigned>{sq_thread_cpu},
+                .dbname_paths = dbname_paths}};
         }
         return mpt::Db{std::make_unique<InMemoryMachine>()};
     }();


### PR DESCRIPTION
Persists the StateMachine kind for each timeline in db_metadata and moves SM construction inside mpt::Db, so production callers no longer pass a StateMachine.

- mpt::state_machine_kind enum + function-static factory registry (state_machine_kind.{hpp,cpp}).
- Per-timeline timeline_state_t repurposes the 8 bytes the base dual-timeline PR reserved (reserved_for_future_fields_) into a 1-byte state_machine_kind_ + 7-byte reserved_sm_ pad; same hold_dirty + atomic access pattern as auto_expire_version_. sizeof(db_metadata) stays 4480 and every field offset is unchanged, so the MONAD008 magic is not bumped: existing pools read the previously-zero byte as ethereum (kind 0), no migration required. The base MONAD007 -> MONAD008 migration now names that byte and stamps it ethereum explicitly.
- mpt::Db gains Db(OnDiskDbConfig const&) and a no-arg Db::open_secondary_timeline(); both read the kind from the relevant ring's metadata and call create_state_machine. The SM-passing ctors remain for in-memory and tests.
- monad-mpt grows --state-machine on --create / --create-empty / --truncate / --activate-secondary, plus --deactivate-secondary and --promote-secondary subcommands.
- register_ethereum_state_machines() in category/execution/ethereum/db registers ethereum -> OnDiskMachine at startup from cmd/monad/main.cpp and the C ABI entry points (monad_statesync_client_context_create, monad_db_snapshot_loader_create).
