### PR TITLE
[event] remove libhugetlbfs

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -231,7 +231,7 @@ target_link_libraries(monad_core PUBLIC quill)
 target_link_libraries(monad_core PUBLIC unordered_dense)
 target_link_libraries(monad_core PUBLIC PkgConfig::zstd)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_link_libraries(monad_core PUBLIC hugetlbfs uring)
+  target_link_libraries(monad_core PUBLIC uring)
 endif()
 
 add_library(

--- a/category/core/event/event_ring_util.c
+++ b/category/core/event/event_ring_util.c
@@ -43,7 +43,7 @@
 #include <category/core/path_util.h>
 #include <category/core/srcloc.h>
 
-#if !MONAD_EVENT_DISABLE_LIBHUGETLBFS
+#ifdef __linux__
     #include <category/core/mem/hugetlb_path.h>
 #endif
 
@@ -321,16 +321,7 @@ int monad_event_ring_query_excl_writer_pid(int const ring_fd, pid_t *const pid)
     return 0;
 }
 
-// libhugetlbfs is always present for Category Labs, but when this is compiled
-// by third parties using the SDK, it is optional
-#if MONAD_EVENT_DISABLE_LIBHUGETLBFS
-
-int monad_event_open_hugetlbfs_dir_fd(int *, char *, size_t)
-{
-    return FORMAT_ERRC(ENOSYS, "compiled without libhugetlbfs support");
-}
-
-#else
+#ifdef __linux__
 
 int monad_event_open_hugetlbfs_dir_fd(
     int *const dirfd, char *const pathbuf, size_t const pathbuf_size)
@@ -352,6 +343,32 @@ int monad_event_open_hugetlbfs_dir_fd(
     return rc;
 }
 
+int monad_check_path_supports_map_hugetlb(
+    char const *const path, bool *const supported)
+{
+    int const rc = monad_hugetlbfs_check_path(path, supported);
+    if (rc != 0) {
+        strlcpy(
+            _g_monad_event_ring_error_buf,
+            monad_hugetlbfs_get_last_error(),
+            sizeof _g_monad_event_ring_error_buf);
+    }
+    return rc;
+}
+
+#else
+
+int monad_event_open_hugetlbfs_dir_fd(int *, char *, size_t)
+{
+    return FORMAT_ERRC(ENOSYS, "system does not support hugetlbfs");
+}
+
+int monad_check_path_supports_map_hugetlb(char const *, bool *const supported)
+{
+    *supported = false;
+    return 0;
+}
+
 #endif
 
 int monad_event_resolve_ring_file(
@@ -371,7 +388,7 @@ int monad_event_resolve_ring_file(
         // relative to the current working directory
         if (strlcpy(pathbuf, file, pathbuf_size) >= pathbuf_size) {
             return FORMAT_ERRC(
-                ENAMETOOLONG,
+                ERANGE,
                 "file %s overflows %zu size pathbuf",
                 file,
                 pathbuf_size);

--- a/category/core/event/event_ring_util.h
+++ b/category/core/event/event_ring_util.h
@@ -36,7 +36,8 @@ enum monad_event_content_type : uint16_t;
 struct monad_event_ring;
 
 /// Value passed to monad_event_resolve_ring_file's `default_path` parameter,
-/// to request the hugetlbfs path that is dynamically computed by libhugetlbfs
+/// to request the hugetlbfs path that is dynamically computed by the
+/// monad_hugetlbfs_open_dir_fd function
 constexpr char const *MONAD_EVENT_DEFAULT_HUGETLBFS = nullptr;
 
 /// Value passed to the `monad_event_decompress_snapshot_{fd,mem}` functions

--- a/category/core/event/event_ring_util_linux.c
+++ b/category/core/event/event_ring_util_linux.c
@@ -20,11 +20,9 @@
 #include <string.h>
 
 #include <fcntl.h>
-#include <linux/magic.h>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/vfs.h>
 
 #include <category/core/cleanup.h> // NOLINT(misc-include-cleaner)
 #include <category/core/event/event_ring_util.h>
@@ -40,48 +38,6 @@ extern thread_local char _g_monad_event_ring_error_buf[1024];
         sizeof(_g_monad_event_ring_error_buf),                                 \
         &MONAD_SOURCE_LOCATION_CURRENT(),                                      \
         __VA_ARGS__)
-
-// Given a path which may not exist, walk backward until we find a parent path
-// that does exist; the caller must free(3) parent_path
-static int
-find_existing_parent_path(char const *const path, char **const parent_path)
-{
-    struct stat path_stat;
-
-    *parent_path = nullptr;
-    if (strlen(path) == 0) {
-        return FORMAT_ERRC(EINVAL, "path cannot be nullptr or empty");
-    }
-    *parent_path = strdup(path); // Freed by the caller
-    if (*parent_path == nullptr) {
-        return FORMAT_ERRC(errno, "strdup of %s failed", path);
-    }
-
-StatAgain:
-    if (stat(*parent_path, &path_stat) == -1) {
-        if (errno != ENOENT) {
-            // stat failed for some reason other than ENOENT; we just give up
-            // in this case
-            return FORMAT_ERRC(errno, "stat of `%s` failed", *parent_path);
-        }
-
-        // For ENOENT failures, climb up the path until we find a path that
-        // does exist. If we were given an absolute path, we'll eventually
-        // succeed in stat'ing `/` (and thus won't always get ENOENT). If we
-        // were given a relative path, we'll eventually run out of `/`
-        // characters, in which case the path of interest is assumed to be
-        // the current working directory, "."
-        char *const last_path_sep = strrchr(*parent_path, '/');
-        if (last_path_sep == nullptr) {
-            strcpy(*parent_path, ".");
-        }
-        else {
-            *last_path_sep = '\0';
-            goto StatAgain;
-        }
-    }
-    return 0;
-}
 
 static bool check_flock_entry(
     char *const lock_line, ino_t const ring_ino,
@@ -166,34 +122,4 @@ int monad_event_ring_query_flocks(
         }
     }
     return 0; // NOLINT(clang-analyzer-unix.Stream)
-}
-
-int monad_check_path_supports_map_hugetlb(
-    char const *const path, bool *const supported)
-{
-    char *parent_path;
-    struct statfs fs_stat;
-    int rc;
-
-    *supported = false;
-    rc = find_existing_parent_path(path, &parent_path);
-    if (rc != 0) {
-        goto Done;
-    }
-#if defined(__clang__)
-    // True when rc == 0, but clang-tidy cannot figure this out
-    __builtin_assume(parent_path != nullptr);
-#endif
-    if (statfs(parent_path, &fs_stat) == -1) {
-        rc = FORMAT_ERRC(errno, "statfs of `%s` failed", parent_path);
-        goto Done;
-    }
-    else {
-        // Only hugetlbfs supports MAP_HUGETLB
-        *supported = fs_stat.f_type == HUGETLBFS_MAGIC;
-        rc = 0;
-    }
-Done:
-    free(parent_path);
-    return rc;
 }

--- a/category/core/event/event_ring_util_posix.c
+++ b/category/core/event/event_ring_util_posix.c
@@ -35,9 +35,3 @@ int monad_event_ring_query_flocks(
 {
     return FORMAT_ERRC(ENOSYS, "function not available on non-Linux platforms");
 }
-
-int monad_check_path_supports_map_hugetlb(char const *, bool *supported)
-{
-    *supported = false;
-    return 0;
-}

--- a/category/core/mem/hugetlb_path.c
+++ b/category/core/mem/hugetlb_path.c
@@ -19,14 +19,20 @@
 #include <category/core/path_util.h>
 #include <category/core/srcloc.h>
 
-#include <hugetlbfs.h>
-
+#include <ctype.h>
 #include <errno.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <fcntl.h>
 #include <linux/limits.h>
+#include <linux/magic.h>
+#include <mntent.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#include <unistd.h>
 
 thread_local char g_error_buf[PATH_MAX];
 
@@ -37,12 +43,145 @@ thread_local char g_error_buf[PATH_MAX];
         &MONAD_SOURCE_LOCATION_CURRENT(),                                      \
         __VA_ARGS__)
 
+// Simple function for parsing human-readable sizes like "256 kB", "8M" or "1G"
+static int expand_byte_size(char const *const text, size_t *const size)
+{
+    char code;
+
+    // Match <number> <any number of spaces> <unit>
+    // <unit> can be absent or equal to 'k', 'M', 'G'
+    switch (sscanf(text, "%zu %c", size, &code)) {
+    case 1:
+        return 0;
+    case 2:
+        break;
+    default:
+        return FORMAT_ERRC(EBADMSG, "number does not have expected format");
+    }
+    switch (tolower((unsigned char)code)) {
+    case 'k':
+        *size <<= 10;
+        break;
+    case 'm':
+        *size <<= 20;
+        break;
+    case 'g':
+        *size <<= 30;
+        break;
+    default:
+        return FORMAT_ERRC(EBADMSG, "unrecognized size code %c", code);
+    }
+    return 0;
+}
+
+// NOLINTBEGIN(clang-analyzer-unix.Stream)
+
+static int find_hugetlbfs_path_for_size(
+    size_t const required_pagesize, char *const pathbuf,
+    size_t const pathbuf_size, size_t *const mount_path_len)
+{
+    // Linux limits the mount options string to the size of one page and
+    // PATH_MAX is also one page; strbuf has to hold both of these, plus extra
+    constexpr size_t BUFFER_SIZE = 4096 * 3;
+    char strbuf[BUFFER_SIZE];
+    struct mntent mount;
+    constexpr char MOUNTS_PATH[] = "/proc/mounts";
+    FILE *mounts_file [[gnu::cleanup(cleanup_fclose)]] = nullptr;
+
+    *mount_path_len = 0;
+    mounts_file = fopen(MOUNTS_PATH, "r");
+    if (mounts_file == nullptr) {
+        return FORMAT_ERRC(errno, "fopen of %s failed", MOUNTS_PATH);
+    }
+
+    // Walk the mount table described by `mounts_file` (has fstab(5) format)
+    while (getmntent_r(mounts_file, &mount, strbuf, sizeof strbuf)) {
+        struct statfs mnt_stat;
+
+        if (statfs(mount.mnt_dir, &mnt_stat) != 0 ||
+            mnt_stat.f_type != HUGETLBFS_MAGIC ||
+            (size_t)mnt_stat.f_bsize != required_pagesize) {
+            // Couldn't stat, or not hugetlbfs, or wrong pagesize; keep looking
+            continue;
+        }
+
+        // We found a hugetlbfs mount with the required hugepage size, check
+        // if we can access it; if so, return success
+        if (access(mount.mnt_dir, R_OK | W_OK | X_OK) == 0) {
+            *mount_path_len = strlcpy(pathbuf, mount.mnt_dir, pathbuf_size);
+            if (*mount_path_len >= pathbuf_size) {
+                return FORMAT_ERRC(
+                    ERANGE, "pathbuf too small to hold %s", mount.mnt_dir);
+            }
+            return 0;
+        }
+    }
+
+    if (ferror(mounts_file)) {
+        // getmntent_r(3) returned nullptr because of a file read error
+        return FORMAT_ERRC(
+            errno, "getmntent_r(3) error while reading %s", MOUNTS_PATH);
+    }
+
+    // getmntent_r(3) returned nullptr because we visited all mounts; no
+    // accessible hugetlbfs mount was found
+    return FORMAT_ERRC(
+        ENODEV,
+        "no mounted hugetlbfs with pagesize %zu is accessible to this user",
+        required_pagesize);
+}
+
+// NOLINTEND(clang-analyzer-unix.Stream)
+
+// Given a path which may not exist, walk backward until we find a parent path
+// that does exist; the caller must free(3) parent_path
+static int
+find_existing_parent_path(char const *const path, char **const parent_path)
+{
+    struct stat path_stat;
+
+    *parent_path = nullptr;
+    if (strlen(path) == 0) {
+        return FORMAT_ERRC(EINVAL, "path cannot be nullptr or empty");
+    }
+    *parent_path = strdup(path); // Freed by the caller
+    if (*parent_path == nullptr) {
+        return FORMAT_ERRC(errno, "strdup of %s failed", path);
+    }
+
+StatAgain:
+    if (stat(*parent_path, &path_stat) == -1) {
+        if (errno != ENOENT) {
+            // stat failed for some reason other than ENOENT; we just give up
+            // in this case
+            return FORMAT_ERRC(errno, "stat of `%s` failed", *parent_path);
+        }
+
+        // For ENOENT failures, climb up the path until we find a path that
+        // does exist. If we were given an absolute path, we'll eventually
+        // succeed in stat'ing `/` (and thus won't always get ENOENT). If we
+        // were given a relative path, we'll eventually run out of `/`
+        // characters, in which case the path of interest is assumed to be
+        // the current working directory, "."
+        char *const last_path_sep = strrchr(*parent_path, '/');
+        if (last_path_sep == nullptr) {
+            strcpy(*parent_path, ".");
+        }
+        else {
+            *last_path_sep = '\0';
+            goto StatAgain;
+        }
+    }
+    return 0;
+}
+
 int monad_hugetlbfs_open_dir_fd(
     struct monad_hugetlbfs_resolve_params const *const params, int *const dirfd,
     char *pathbuf, size_t pathbuf_size)
 {
+    int rc;
     size_t resolve_size;
-    char const *hugetlbfs_mount_path;
+    size_t mount_path_len;
     char local_pathbuf[PATH_MAX];
 #ifdef O_PATH
     constexpr int OPEN_FLAGS = O_DIRECTORY | O_PATH;
@@ -60,33 +199,25 @@ int monad_hugetlbfs_open_dir_fd(
         pathbuf_size = sizeof local_pathbuf;
     }
     if (params->page_size == 0) {
-        long default_size = gethugepagesize();
-        if (default_size == -1) {
-            return FORMAT_ERRC(errno, "no default huge page size configured");
+        rc = monad_get_default_hugepage_size(&resolve_size);
+        if (rc != 0) {
+            return rc;
         }
-        resolve_size = (size_t)default_size;
     }
     else {
         resolve_size = params->page_size;
     }
-    hugetlbfs_mount_path = hugetlbfs_find_path_for_size((long)resolve_size);
-    if (hugetlbfs_mount_path == nullptr) {
-        return FORMAT_ERRC(
-            ENODEV, "no mounted hugetlbfs is accessible to this user");
+    rc = find_hugetlbfs_path_for_size(
+        resolve_size, pathbuf, pathbuf_size, &mount_path_len);
+    if (rc != 0) {
+        return rc;
     }
-    size_t const mount_path_len =
-        strlcpy(pathbuf, hugetlbfs_mount_path, pathbuf_size);
-    if (mount_path_len >= pathbuf_size) {
-        return FORMAT_ERRC(
-            ENAMETOOLONG, "pathbuf cannot hold %s", hugetlbfs_mount_path);
-    }
-    int mountfd [[gnu::cleanup(cleanup_close)]] =
-        open(hugetlbfs_mount_path, OPEN_FLAGS);
+    int mountfd [[gnu::cleanup(cleanup_close)]] = open(pathbuf, OPEN_FLAGS);
     if (mountfd == -1) {
         return FORMAT_ERRC(
-            errno, "open of hugetlbfs mount `%s` failed", hugetlbfs_mount_path);
+            errno, "open of hugetlbfs mount `%s` failed", pathbuf);
     }
-    int const rc = monad_path_open_subdir(
+    rc = monad_path_open_subdir(
         mountfd,
         params->path_suffix,
         params->create_dirs ? params->dir_create_mode : MONAD_PATH_NO_CREATE,
@@ -96,13 +227,78 @@ int monad_hugetlbfs_open_dir_fd(
     if (rc != 0) {
         return FORMAT_ERRC(
             rc,
-            "monad_path_open_subdir of `%s` underneath `%s` failed at last "
+            "monad_path_open_subdir of `%s` underneath `%.*s` failed at last "
             "path component of `%s`",
             params->path_suffix,
-            hugetlbfs_mount_path,
+            (int)mount_path_len,
+            pathbuf,
             pathbuf);
     }
     return 0;
+}
+
+// NOLINTBEGIN(clang-analyzer-unix.Stream)
+
+int monad_get_default_hugepage_size(size_t *const pagesize)
+{
+    char info_buf[256];
+    constexpr char MEMINFO_PATH[] = "/proc/meminfo";
+    constexpr char HUGEPAGE_SIZE[] = "Hugepagesize:";
+    FILE *meminfo_file [[gnu::cleanup(cleanup_fclose)]] = nullptr;
+
+    if (pagesize == nullptr) {
+        return FORMAT_ERRC(EFAULT, "pagesize must not be null");
+    }
+    meminfo_file = fopen(MEMINFO_PATH, "r");
+    if (meminfo_file == nullptr) {
+        return FORMAT_ERRC(errno, "fopen of %s failed", MEMINFO_PATH);
+    }
+    while (fgets(info_buf, sizeof info_buf, meminfo_file) != nullptr) {
+        char const *p;
+
+        if (strncmp(info_buf, HUGEPAGE_SIZE, sizeof(HUGEPAGE_SIZE) - 1) != 0) {
+            continue;
+        }
+        p = info_buf + sizeof HUGEPAGE_SIZE - 1;
+        while (isspace((unsigned char)*p)) {
+            ++p;
+        }
+        return expand_byte_size(p, pagesize);
+    }
+    return FORMAT_ERRC(EOPNOTSUPP, "no system default hugepage size");
+}
+
+// NOLINTEND(clang-analyzer-unix.Stream)
+
+int monad_hugetlbfs_check_path(char const *const path, bool *const is_hugetlbfs)
+{
+    char *parent_path;
+    struct statfs fs_stat;
+    int rc;
+
+    if (path == nullptr || is_hugetlbfs == nullptr) {
+        return FORMAT_ERRC(EFAULT, "nullptr not allowed here");
+    }
+    *is_hugetlbfs = false;
+    rc = find_existing_parent_path(path, &parent_path);
+    if (rc != 0) {
+        goto Done;
+    }
+#if defined(__clang__)
+    // True when rc == 0, but clang-tidy cannot figure this out
+    __builtin_assume(parent_path != nullptr);
+#endif
+    if (statfs(parent_path, &fs_stat) == -1) {
+        rc = FORMAT_ERRC(errno, "statfs of `%s` failed", parent_path);
+        goto Done;
+    }
+    else {
+        *is_hugetlbfs = fs_stat.f_type == HUGETLBFS_MAGIC;
+        rc = 0;
+    }
+Done:
+    free(parent_path);
+    return rc;
 }
 
 char const *monad_hugetlbfs_get_last_error()

--- a/category/core/mem/hugetlb_path.h
+++ b/category/core/mem/hugetlb_path.h
@@ -51,6 +51,14 @@ int monad_hugetlbfs_open_dir_fd(
     struct monad_hugetlbfs_resolve_params const *, int *dirfd, char *pathbuf,
     size_t pathbuf_size);
 
+/// Given a path to a file (which does not need to exist), check if the
+/// associated file system (i.e., the closest mount point) is hugetlbfs
+int monad_hugetlbfs_check_path(char const *path, bool *is_hugetlbfs);
+
+/// Return the default hugepage size of the system; if hugepages are not
+/// enabled at the kernel level, return EOPNOTSUPP
+int monad_get_default_hugepage_size(size_t *pagesize);
+
 /// Return the last error that occurred on this thread
 char const *monad_hugetlbfs_get_last_error();
 

--- a/category/core/mem/hugetlbfs_path_test.cpp
+++ b/category/core/mem/hugetlbfs_path_test.cpp
@@ -14,15 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <cerrno>
+#include <cstddef>
+#include <cstdio>
 #include <print>
 
 #include <gtest/gtest.h>
 #include <unistd.h>
-
-extern "C"
-{
-#include <hugetlbfs.h>
-}
 
 #include <category/core/mem/hugetlb_path.h>
 
@@ -30,12 +27,17 @@ TEST(HugetlbfsPath, Basic)
 {
     int rc;
     int dirfd = -1;
+    bool is_hugetlbfs;
+    size_t default_hpage_size;
     char hugetlbfs_path[2048];
 
-    if (gethugepagesize() == -1) {
+    rc = monad_get_default_hugepage_size(&default_hpage_size);
+    if (rc == EOPNOTSUPP) {
         // Huge pages aren't available; skip the test
         GTEST_SKIP();
     }
+    ASSERT_EQ(rc, 0);
+    std::println(stderr, "default hugepage size: {}", default_hpage_size);
 
     monad_hugetlbfs_resolve_params params = {
         .page_size = 0, // Default huge page size
@@ -66,7 +68,8 @@ TEST(HugetlbfsPath, Basic)
     ASSERT_EQ(rc, 0);
     ASSERT_NE(dirfd, -1);
     std::println(stderr, "full path is: {}", hugetlbfs_path);
-    ASSERT_EQ(hugetlbfs_test_path(hugetlbfs_path), 1);
+    ASSERT_EQ(monad_hugetlbfs_check_path(hugetlbfs_path, &is_hugetlbfs), 0);
+    ASSERT_TRUE(is_hugetlbfs);
     (void)close(dirfd);
 
     // Try again; we can't create it, but that's OK: it's there now
@@ -75,7 +78,8 @@ TEST(HugetlbfsPath, Basic)
         &params, &dirfd, hugetlbfs_path, sizeof hugetlbfs_path);
     ASSERT_EQ(rc, 0);
     ASSERT_NE(dirfd, -1);
-    ASSERT_EQ(hugetlbfs_test_path(hugetlbfs_path), 1);
+    ASSERT_EQ(monad_hugetlbfs_check_path(hugetlbfs_path, &is_hugetlbfs), 0);
+    ASSERT_TRUE(is_hugetlbfs);
     (void)close(dirfd);
 
     // Remove the file

--- a/category/core/path_util.c
+++ b/category/core/path_util.c
@@ -46,7 +46,7 @@ int monad_path_append(
         return EINVAL;
     }
     if (*size == 0) {
-        return ENAMETOOLONG;
+        return ERANGE;
     }
     **dst = '/';
     *dst += 1;
@@ -55,7 +55,7 @@ int monad_path_append(
     if (n >= *size) {
         *dst += *size;
         *size = 0;
-        return ENAMETOOLONG;
+        return ERANGE;
     }
     *dst += n;
     *size -= n;

--- a/category/core/path_util.h
+++ b/category/core/path_util.h
@@ -36,7 +36,7 @@ constexpr mode_t MONAD_PATH_NO_CREATE = (mode_t)0;
 
 // Appends a '/' followed by the contents of src to dst; this behaves like
 // stpecpy (always null-terminated and designed for chain-copying, so dst and
-// size are adjusted); if truncated, ENAMETOOLONG is returned; dst must be set
+// size are adjusted); if truncated, ERANGE is returned; dst must be set
 // up to append when called, i.e., EINVAL is returned unless **dst == '\0'
 int monad_path_append(char **dst, char const *src, size_t *size);
 

--- a/category/event/CMakeLists.txt
+++ b/category/event/CMakeLists.txt
@@ -22,16 +22,6 @@ cmake_minimum_required(VERSION 3.23)
 
 project(monad_event LANGUAGES C)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(MONAD_EVENT_HUGETLBFS_DEFAULT ON)
-else()
-  set(MONAD_EVENT_HUGETLBFS_DEFAULT OFF)
-endif()
-
-option(MONAD_EVENT_USE_LIBHUGETLBFS
-  "Build with libhugetlbfs support (enables the `monad_event_open_hugetlbfs_dir_fd` API function)"
-  ${MONAD_EVENT_HUGETLBFS_DEFAULT})
-
 find_library(libzstd_file zstd REQUIRED)
 
 add_library(
@@ -77,7 +67,12 @@ target_include_directories(monad_event PUBLIC
     $<INSTALL_INTERFACE:include>)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  target_sources(monad_event PRIVATE "../core/event/event_ring_util_linux.c")
+  target_sources(monad_event PRIVATE
+      "../core/event/event_ring_util_linux.c"
+      "../core/mem/hugetlb_path.c")
+  target_sources(monad_event PUBLIC
+      FILE_SET event_headers
+      FILES "../core/mem/hugetlb_path.h")
 else()
   target_sources(monad_event PRIVATE "../core/event/event_ring_util_posix.c")
 endif()
@@ -86,16 +81,6 @@ target_compile_definitions(monad_event PUBLIC _GNU_SOURCE)
 target_compile_features(monad_event PUBLIC c_std_23)
 target_compile_options(monad_event PRIVATE -Wall -Wextra -Wconversion -Werror)
 target_link_libraries(monad_event PRIVATE ${libzstd_file})
-
-if(MONAD_EVENT_USE_LIBHUGETLBFS)
-  find_library(libhugetlbfs NAMES hugetlbfs REQUIRED)
-  target_sources(monad_event PRIVATE
-    "../core/mem/hugetlb_path.c"
-    "../core/mem/hugetlb_path.h")
-  target_link_libraries(monad_event PRIVATE hugetlbfs)
-else()
-  target_compile_definitions(monad_event PRIVATE MONAD_EVENT_DISABLE_LIBHUGETLBFS)
-endif()
 
 option(MONAD_EVENT_BUILD_EXAMPLE
     "Build the example program that shows how to use the API" ON)

--- a/rust/crates/monad-event-ring/build.rs
+++ b/rust/crates/monad-event-ring/build.rs
@@ -14,18 +14,16 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 fn main() {
+    let mut link_libs = vec!["zstd"];
+    if build_rs::input::cargo_cfg_target_os() != "linux" {
+        link_libs.push("monad_event_os_compat");
+    }
+
     monad_build::MonadCMake::new(
         monad_build::repository_root().join("category/event"),
         monad_build::MonadCMakeLinkage::Static,
     )
-    .link_libraries([
-        "zstd",
-        if build_rs::input::cargo_cfg_target_os() == "linux" {
-            "hugetlbfs"
-        } else {
-            "monad_event_os_compat"
-        },
-    ])
+    .link_libraries(link_libs)
     .build("monad_event");
 
     monad_build::bindgen::MonadBindgen::default()

--- a/scripts/ubuntu-build/install-deps.sh
+++ b/scripts/ubuntu-build/install-deps.sh
@@ -12,7 +12,6 @@ packages=(
   libgmock-dev
   libgmp-dev
   libgtest-dev
-  libhugetlbfs-dev
   libtbb-dev
   liburing-dev
   libzstd-dev

--- a/scripts/ubuntu-build/install-tools.sh
+++ b/scripts/ubuntu-build/install-tools.sh
@@ -16,7 +16,6 @@ packages=(
   gnupg
   libclang-common-19-dev
   libclang-rt-19-dev
-  libhugetlbfs-bin
   llvm-19-dev
   make
   ninja-build


### PR DESCRIPTION
We only needed a few functions from hugeutils.c and maintaining the build system around this was becoming a pain. Here we just do the same thing libhugetlbfs does, but do it ourselves.

As a ninja change, various functions (some unrelated to this exact change) returning ENAMETOOLONG when a user-provided path buffer was too small now return ERANGE. I realized ERANGE was the better option (matching getcwd(2)) for a small buffer vs. ENAMETOOLONG which is for PATH_MAX overflow. A function added in the commit uses ERANGE that way, and to keep the other C APIs in sync they were all changed.