### PR TITLE
[execution/ethereum] Add EIP-7691 blob parameters

### DIFF
--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -73,7 +73,7 @@ constexpr void irrevocable_change(
     uint256_t blob_gas = 0;
     if constexpr (traits::evm_rev() >= EVMC_CANCUN) {
         blob_gas = (tx.type == TransactionType::eip4844)
-                       ? calc_blob_fee(tx, excess_blob_gas)
+                       ? calc_blob_fee<traits>(tx, excess_blob_gas)
                        : 0;
     }
     auto const upfront_cost =

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -79,8 +79,9 @@ Result<byte_string> system_call(
         .chain_id = to_bytes(to_big_endian(chain.get_chain_id())),
         .block_base_fee =
             to_bytes(to_big_endian(header.base_fee_per_gas.value_or(0))),
-        .blob_base_fee = to_bytes(to_big_endian(
-            get_base_fee_per_blob_gas(header.excess_blob_gas.value_or(0)))),
+        .blob_base_fee =
+            to_bytes(to_big_endian(get_base_fee_per_blob_gas<traits>(
+                header.excess_blob_gas.value_or(0)))),
         .blob_hashes = nullptr,
         .blob_hashes_count = 0,
         .initcodes = nullptr,

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -210,25 +210,30 @@ uint256_t calculate_txn_award(
 
 EXPLICIT_TRAITS(calculate_txn_award);
 
+template <Traits traits>
 uint256_t
 calc_blob_fee(Transaction const &tx, uint64_t const excess_blob_gas) noexcept
 {
-    return get_base_fee_per_blob_gas(excess_blob_gas) * get_total_blob_gas(tx);
+    return get_base_fee_per_blob_gas<traits>(excess_blob_gas) *
+           get_total_blob_gas(tx);
 }
 
+EXPLICIT_TRAITS(calc_blob_fee);
+
+template <Traits traits>
 uint256_t get_base_fee_per_blob_gas(uint64_t const excess_blob_gas) noexcept
 {
     constexpr uint256_t MIN_BASE_FEE_PER_BLOB_GAS = 1;
-    constexpr uint256_t BLOB_BASE_FEE_UPDATE_FRACTION = 3338477;
     return fake_exponential(
         MIN_BASE_FEE_PER_BLOB_GAS,
         uint256_t{excess_blob_gas},
-        BLOB_BASE_FEE_UPDATE_FRACTION);
+        uint256_t{blob_base_fee_update_fraction<traits>()});
 }
+
+EXPLICIT_TRAITS(get_base_fee_per_blob_gas);
 
 uint64_t get_total_blob_gas(Transaction const &tx) noexcept
 {
-    constexpr uint64_t GAS_PER_BLOB{131072};
     return GAS_PER_BLOB * tx.blob_versioned_hashes.size();
 }
 

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -60,8 +60,45 @@ max_gas_cost(uint64_t const gas_limit, uint256_t const max_fee_per_gas) noexcept
     return checked_mul(uint256_t{gas_limit}, max_fee_per_gas);
 }
 
+// EIP-4844
+inline constexpr uint64_t GAS_PER_BLOB = 131'072;
+
+template <Traits traits>
+inline constexpr uint64_t max_blobs_per_block() noexcept
+{
+    // EIP-7691 increases the blob count where active.
+    if constexpr (traits::eip_7691_active()) {
+        return 9;
+    }
+    else {
+        return 6;
+    }
+}
+
+template <Traits traits>
+inline constexpr uint64_t max_blob_gas_per_block() noexcept
+{
+    return max_blobs_per_block<traits>() * GAS_PER_BLOB;
+}
+
+template <Traits traits>
+inline constexpr uint64_t blob_base_fee_update_fraction() noexcept
+{
+    // EIP-7691 adjusts the blob base fee update fraction where active.
+    if constexpr (traits::eip_7691_active()) {
+        return 5'007'716;
+    }
+    else {
+        return 3'338'477;
+    }
+}
+
+template <Traits traits>
 uint256_t calc_blob_fee(Transaction const &, uint64_t) noexcept;
+
+template <Traits traits>
 uint256_t get_base_fee_per_blob_gas(uint64_t) noexcept;
+
 uint64_t get_total_blob_gas(Transaction const &) noexcept;
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/transaction_gas_test.cpp
+++ b/category/execution/ethereum/transaction_gas_test.cpp
@@ -191,3 +191,19 @@ TYPED_TEST(TraitsTest, txn_award)
             Transaction{.max_fee_per_gas = 100'000'000'000}, 0, 90'000'000),
         uint256_t{9'000'000'000'000'000'000});
 }
+
+TYPED_TEST(TraitsTest, blob_schedule)
+{
+    if constexpr (TestFixture::Trait::eip_7691_active()) {
+        EXPECT_EQ(max_blobs_per_block<typename TestFixture::Trait>(), 9);
+        EXPECT_EQ(
+            blob_base_fee_update_fraction<typename TestFixture::Trait>(),
+            5'007'716);
+    }
+    else {
+        EXPECT_EQ(max_blobs_per_block<typename TestFixture::Trait>(), 6);
+        EXPECT_EQ(
+            blob_base_fee_update_fraction<typename TestFixture::Trait>(),
+            3'338'477);
+    }
+}

--- a/category/execution/ethereum/tx_context.cpp
+++ b/category/execution/ethereum/tx_context.cpp
@@ -49,8 +49,9 @@ evmc_tx_context get_tx_context(
         .chain_id = to_bytes(to_big_endian(chain_id)),
         .block_base_fee =
             to_bytes(to_big_endian(hdr.base_fee_per_gas.value_or(0))),
-        .blob_base_fee = to_bytes(to_big_endian(
-            get_base_fee_per_blob_gas(hdr.excess_blob_gas.value_or(0)))),
+        .blob_base_fee =
+            to_bytes(to_big_endian(get_base_fee_per_blob_gas<traits>(
+                hdr.excess_blob_gas.value_or(0)))),
         .blob_hashes = tx.blob_versioned_hashes.data(),
         .blob_hashes_count = tx.blob_versioned_hashes.size(),
         .initcodes = nullptr, // TODO

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -212,8 +212,7 @@ constexpr Result<void> static_validate_4844(Block const &block)
                 blob_gas_used += get_total_blob_gas(tx);
             }
         }
-        constexpr uint64_t MAX_BLOB_GAS_PER_BLOCK = 786432;
-        if (MONAD_UNLIKELY(blob_gas_used > MAX_BLOB_GAS_PER_BLOCK)) {
+        if (MONAD_UNLIKELY(blob_gas_used > max_blob_gas_per_block<traits>())) {
             return BlockError::GasAboveLimit;
         }
         if (MONAD_UNLIKELY(

--- a/category/execution/ethereum/validate_transaction.cpp
+++ b/category/execution/ethereum/validate_transaction.cpp
@@ -212,7 +212,8 @@ Result<void> static_validate_transaction(
 
             if (MONAD_UNLIKELY(
                     tx.max_fee_per_blob_gas <
-                    get_base_fee_per_blob_gas(excess_blob_gas.value()))) {
+                    get_base_fee_per_blob_gas<traits>(
+                        excess_blob_gas.value_or(0)))) {
                 return TransactionError::GasLimitOverflow;
             }
         }

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -52,6 +52,7 @@ namespace monad
         { T::eip_2929_active() } -> std::same_as<bool>;
         { T::eip_4844_active() } -> std::same_as<bool>;
         { T::eip_7685_active() } -> std::same_as<bool>;
+        { T::eip_7691_active() } -> std::same_as<bool>;
         { T::eip_7823_active() } -> std::same_as<bool>;
         { T::eip_7883_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
@@ -98,6 +99,11 @@ namespace monad
         }
 
         static consteval bool eip_7685_active() noexcept
+        {
+            return Rev >= EVMC_PRAGUE;
+        }
+
+        static consteval bool eip_7691_active() noexcept
         {
             return Rev >= EVMC_PRAGUE;
         }
@@ -209,6 +215,11 @@ namespace monad
             // monad-bft currently proposes and validates it as zero rather
             // than as an Ethereum EIP-7685 request-list hash. Keep those
             // paths paired before enabling real request hash processing.
+            return false;
+        }
+
+        static consteval bool eip_7691_active() noexcept
+        {
             return false;
         }
 

--- a/test/ethereum_test/exclude/cancun.cmake
+++ b/test/ethereum_test/exclude/cancun.cmake
@@ -1,7 +1,21 @@
 set(cancun_excluded_tests
     # Blobs (EIP-4844)
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/*"
-    "BlockchainTests.cancun/eip4844_blobs/*"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_above_target_change.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_change.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_negative_excess_blob_gas.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_non_multiple_excess_blob_gas.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_static_excess_blob_gas.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
+    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_zero_excess_blob_gas_in_header.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
 
     # withdrawals root
     "BlockchainTests.InvalidBlocks/bc4895_withdrawals/incorrectWithdrawalsRoot.json"

--- a/test/ethereum_test/exclude/osaka.cmake
+++ b/test/ethereum_test/exclude/osaka.cmake
@@ -1,6 +1,13 @@
 set(osaka_excluded_tests
     # Blobs (EIP-4844, EIP-7918)
-    "BlockchainTests.cancun/eip4844_blobs/*"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
     "BlockchainTests.osaka/eip7918_blob_reserve_price/test_reserve_price_boundary.json"
 
     # Unimplemented Prague EIPs

--- a/test/ethereum_test/exclude/prague.cmake
+++ b/test/ethereum_test/exclude/prague.cmake
@@ -1,6 +1,13 @@
 set(prague_excluded_tests
     # Blobs (EIP-4844)
-    "BlockchainTests.cancun/eip4844_blobs/*"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
+    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
 
 
     # Long-running tests


### PR DESCRIPTION
This PR adds the minimal EIP-7691 blob-parameter support needed to unblock Prague Ethereum replay.  The PR introduces `eip_7691_active()` to gate the blob gas helpers rather than gating on the EVMC revision.

It makes the existing blob fee and blob gas limit calculations fork-aware:

- Cancun keeps the EIP-4844 values:
  - max blobs per block: 6
  - blob base fee update fraction: 3,338,477
- Prague and later Ethereum revisions use the EIP-7691 values:
  - max blobs per block: 9
  - blob base fee update fraction: 5,007,716

The change intentionally stays smaller than a general blob schedule implementation.  It deliberately does not implement:

- parent-aware header validation of excess_blob_gas
- target_blobs_per_block (required only by parent header validation)
- EIP-7840-style chain-config blob schedules

A separate draft PR will be opened for parent-aware header validation to workshop the best approach.  That PR will be able to remove the remaining eip4844_blobs excess-blob-gas exclusions.

Co-Authored-By: Codex GPT 5.5