### PR TITLE
[execution/ethereum] Activate Prague on mainnet

### DIFF
--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -46,9 +46,10 @@ uint256_t EthereumMainnet::get_chain_id() const
 evmc_revision EthereumMainnet::get_revision(
     uint64_t const block_number, uint64_t const timestamp) const
 {
-    // TODO: update to include Prague once we can replay those blocks
-
-    if (MONAD_LIKELY(timestamp >= 1710338135)) {
+    if (MONAD_LIKELY(timestamp >= 1746612311)) {
+        return EVMC_PRAGUE;
+    }
+    else if (timestamp >= 1710338135) {
         return EVMC_CANCUN;
     }
     else if (timestamp >= 1681338455) {


### PR DESCRIPTION
Activate Prague/Pectra for Ethereum mainnet by returning `EVMC_PRAGUE` from
`EthereumMainnet::get_revision` at the mainnet Prague activation timestamp.

This PR depends on:

- #2277
- #2300

being merged first (in no particular order).