### PR TITLE
[dual-timeline] Support monad-mpt --archive with secondary active

### DIFF
--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -1264,10 +1264,7 @@ public:
                 throw std::runtime_error("libarchive failed");
             }
 
-            uint32_t additional_cnv_chunks_to_archive = 0;
-            auto map_chunk_into_memory = [this,
-                                          &additional_cnv_chunks_to_archive](
-                                             chunk_info_archive_t &i) {
+            auto map_chunk_into_memory = [this](chunk_info_archive_t &i) {
                 auto [fd2, offset] = i.chunk_ptr->read_fd();
                 i.uncompressed_storage = ::mmap(
                     nullptr,
@@ -1295,20 +1292,6 @@ public:
                                 monad::mpt::detail::db_metadata::chunk_info_t);
                     i.uncompressed =
                         i.uncompressed.subspan(0, db_metadata_size);
-                    auto const *m = monad::start_lifetime_as<
-                        monad::mpt::detail::db_metadata>(i.uncompressed.data());
-                    // The archive loop below walks contiguous cnv chunk
-                    // ids [0, additional_cnv_chunks_to_archive]; that
-                    // assumption breaks once activate_secondary_header
-                    // has split chunks between root_offsets and
-                    // secondary_timeline. Deactivate before archiving.
-                    MONAD_ASSERT_PRINTF(
-                        m->secondary_timeline_active_ == 0,
-                        "archive of a pool with an active secondary "
-                        "timeline is not supported; run monad-mpt "
-                        "--deactivate-secondary first");
-                    additional_cnv_chunks_to_archive =
-                        m->root_offsets.cnv_chunks_len();
                 }
                 i.compression_thread =
                     std::async(std::launch::async, [i = &i, this] {
@@ -1316,19 +1299,63 @@ public:
                     });
             };
 
-            std::vector<chunk_info_archive_t *> tocompress;
-            tocompress.reserve(
-                pool->chunks(pool->cnv) + fast.size() + slow.size());
+            // The non-primary ring's cnv_chunks[] is garbage unless
+            // secondary_timeline_active_ is set.
             std::vector<chunk_info_archive_t> cnv_infos;
             cnv_infos.reserve(pool->chunks(pool->cnv));
-            for (uint32_t n = 0; n <= additional_cnv_chunks_to_archive; n++) {
-                cnv_infos.emplace_back(
-                    std::addressof(pool->chunk(pool->cnv, n)), -1);
-                tocompress.push_back(&cnv_infos.back());
-                if (n == 0) {
-                    // Need to determine additional_cnv_chunks_to_archive
-                    map_chunk_into_memory(cnv_infos.back());
+            cnv_infos.emplace_back(
+                std::addressof(pool->chunk(pool->cnv, 0)), -1);
+            map_chunk_into_memory(cnv_infos.back());
+
+            std::vector<uint32_t> cnv_chunk_ids;
+            cnv_chunk_ids.reserve(pool->chunks(pool->cnv));
+            cnv_chunk_ids.push_back(0);
+            {
+                auto const *m =
+                    monad::start_lifetime_as<monad::mpt::detail::db_metadata>(
+                        cnv_infos.back().uncompressed.data());
+                auto const &primary_ring = (m->primary_ring_idx == 0)
+                                               ? m->root_offsets
+                                               : m->secondary_timeline;
+                auto const &secondary_ring = (m->primary_ring_idx == 0)
+                                                 ? m->secondary_timeline
+                                                 : m->root_offsets;
+                auto add_ring = [&cnv_chunk_ids, this](auto const &ring) {
+                    MONAD_ASSERT(ring.cnv_chunks_len() <= ring.SIZE_ - 1);
+                    for (uint32_t k = 0; k < ring.cnv_chunks_len(); k++) {
+                        uint32_t const id = ring.cnv_chunk_id(k);
+                        // Sentinel slots remain in cnv_chunks[] after a
+                        // crash mid-activate_secondary_header until
+                        // replay_pending_shrink_grow_ repairs them on the
+                        // next writable open. --archive does not run
+                        // replay; skip them to match the runtime readers.
+                        if (id == monad::mpt::detail::db_metadata::NULL_CHUNK) {
+                            continue;
+                        }
+                        MONAD_ASSERT(id < pool->chunks(pool->cnv));
+                        if (std::find(
+                                cnv_chunk_ids.begin(),
+                                cnv_chunk_ids.end(),
+                                id) == cnv_chunk_ids.end()) {
+                            cnv_chunk_ids.push_back(id);
+                        }
+                    }
+                };
+                add_ring(primary_ring);
+                if (m->secondary_timeline_active_ != 0) {
+                    add_ring(secondary_ring);
                 }
+            }
+
+            std::vector<chunk_info_archive_t *> tocompress;
+            tocompress.reserve(
+                cnv_chunk_ids.size() + fast.size() + slow.size());
+            tocompress.push_back(&cnv_infos.back());
+            for (size_t k = 1; k < cnv_chunk_ids.size(); k++) {
+                cnv_infos.emplace_back(
+                    std::addressof(pool->chunk(pool->cnv, cnv_chunk_ids[k])),
+                    -1);
+                tocompress.push_back(&cnv_infos.back());
             }
             if (debug_printing) {
                 std::cerr << "Fast list:";

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -140,6 +140,11 @@ namespace detail
                 return storage_.cnv_chunks_len;
             }
 
+            uint32_t cnv_chunk_id(uint32_t const k) const noexcept
+            {
+                return storage_.cnv_chunks[k].cnv_chunk_id;
+            }
+
             void restore_from(root_offsets_ring_t const &other) noexcept
             {
                 version_lower_bound_ = other.version_lower_bound_;

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -20,6 +20,8 @@
 #include <category/async/detail/scope_polyfill.hpp>
 #include <category/async/io.hpp>
 #include <category/async/storage_pool.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/hex.hpp>
 #include <category/core/io/buffers.hpp>
 #include <category/core/io/ring.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
@@ -33,6 +35,7 @@
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/trie.hpp>
+#include <category/mpt/update.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -41,10 +44,13 @@
 #include <filesystem>
 #include <future>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <stdlib.h>
@@ -208,6 +214,17 @@ namespace
         ASSERT_NE(fd, -1);
         ::close(fd);
         ASSERT_EQ(0, ::truncate(temppath, 6ULL * 1024 * 1024 * 1024));
+    }
+
+    monad::mpt::Node::SharedPtr upsert_one(
+        monad::mpt::Db &target, monad::byte_string const &key,
+        monad::byte_string const &value, monad::mpt::Node::SharedPtr root)
+    {
+        monad::mpt::UpdateList ul;
+        auto u = monad::mpt::make_update(
+            monad::mpt::NibblesView{key}, monad::byte_string_view{value});
+        ul.push_front(u);
+        return target.upsert(std::move(root), std::move(ul), 0);
     }
 }
 
@@ -783,6 +800,246 @@ TEST_F(cli_tool_restore_preserves_kind, restore_preserves_state_machine_kind)
             return read_kind(dbpath2, monad::mpt::timeline_id::primary);
         }).get();
     EXPECT_EQ(restored_kind, synthetic_kind);
+}
+
+// Round-trips a Db whose secondary timeline is active and holds a key
+// distinct from the primary. The archive must capture both rings' cnv
+// chunks; otherwise the restored secondary's root_offsets come up
+// zeroed and the find below fails.
+TEST(cli_tool, archives_restores_with_secondary_active)
+{
+    using namespace monad::mpt;
+    using monad::literals::operator""_bytes;
+
+    auto const src_dbname = create_temp_file(8);
+    auto const dst_dbname = create_temp_file(8);
+    char arc_path[] = "cli_tool_test_XXXXXX";
+    int const arc_fd = ::mkstemp(arc_path);
+    ASSERT_NE(arc_fd, -1);
+    ::close(arc_fd);
+    auto const unfiles = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(src_dbname);
+        std::filesystem::remove(dst_dbname);
+        ::unlink(arc_path);
+    });
+
+    auto const k_primary = 0xaabbccdd_bytes;
+    auto const v_primary = 0x11223344_bytes;
+    auto const k_secondary = 0xeeff0011_bytes;
+    auto const v_secondary = 0x55667788_bytes;
+
+    {
+        OnDiskDbConfig const config{
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {src_dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+
+        Node::SharedPtr const primary_root =
+            upsert_one(db, k_primary, v_primary, nullptr);
+        ASSERT_NE(primary_root, nullptr);
+
+        {
+            Db secondary_db = db.activate_secondary_timeline(
+                std::make_unique<StateMachineAlwaysMerkle>());
+            Node::SharedPtr const secondary_root =
+                upsert_one(secondary_db, k_secondary, v_secondary, nullptr);
+            ASSERT_NE(secondary_root, nullptr);
+        }
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            src_dbname.c_str(),
+            "--archive",
+            arc_path};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0)
+            << "stderr: " << cerr.str() << "\nstdout: " << cout.str();
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Database has been archived to"));
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            dst_dbname.c_str(),
+            "--root-offsets-chunk-count",
+            "2",
+            "--yes",
+            "--restore",
+            arc_path};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0)
+            << "stderr: " << cerr.str() << "\nstdout: " << cout.str();
+        EXPECT_NE(
+            std::string::npos,
+            cout.str().find("Database has been restored from"));
+    }
+
+    EXPECT_TRUE(read_secondary_active(dst_dbname.c_str()));
+    EXPECT_EQ(0u, read_primary_ring_idx(dst_dbname.c_str()));
+
+    {
+        OnDiskDbConfig const config{
+            .append = true,
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dst_dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+        ASSERT_TRUE(db.timeline_active(timeline_id::secondary));
+
+        Node::SharedPtr const primary_root = db.load_root_for_version(0);
+        ASSERT_NE(primary_root, nullptr);
+        auto const pres =
+            db.find(NodeCursor{primary_root}, NibblesView{k_primary}, 0);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(monad::byte_string{pres.value().node->value()}, v_primary);
+
+        auto secondary_db_opt = db.open_secondary_timeline(
+            std::make_unique<StateMachineAlwaysMerkle>());
+        ASSERT_TRUE(secondary_db_opt.has_value());
+        Node::SharedPtr const secondary_root =
+            secondary_db_opt->load_root_for_version(0);
+        ASSERT_NE(secondary_root, nullptr);
+        auto const sres = secondary_db_opt->find(
+            NodeCursor{secondary_root}, NibblesView{k_secondary}, 0);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(monad::byte_string{sres.value().node->value()}, v_secondary);
+    }
+}
+
+// Round-trips a Db after promote_secondary_to_primary +
+// deactivate_secondary_timeline, where primary_ring_idx == 1 and the
+// live data sits on the physical ring named by secondary_timeline (now
+// playing the primary role). The archive must dispatch by role, not by
+// physical ring slot; walking m->root_offsets unconditionally would
+// archive the stale, deactivated ring and lose the only live data.
+TEST(cli_tool, archives_restores_after_promote_and_deactivate)
+{
+    using namespace monad::mpt;
+    using monad::literals::operator""_bytes;
+
+    auto const src_dbname = create_temp_file(8);
+    auto const dst_dbname = create_temp_file(8);
+    char arc_path[] = "cli_tool_test_XXXXXX";
+    int const arc_fd = ::mkstemp(arc_path);
+    ASSERT_NE(arc_fd, -1);
+    ::close(arc_fd);
+    auto const unfiles = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(src_dbname);
+        std::filesystem::remove(dst_dbname);
+        ::unlink(arc_path);
+    });
+
+    auto const k_kept = 0xeeff0011_bytes;
+    auto const v_kept = 0x55667788_bytes;
+    auto const k_discarded = 0xaabbccdd_bytes;
+    auto const v_discarded = 0x11223344_bytes;
+
+    OnDiskDbConfig const config{
+        .compaction = true,
+        .sq_thread_cpu = std::nullopt,
+        .dbname_paths = {src_dbname},
+        .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+
+    {
+        Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+
+        Node::SharedPtr const primary_root =
+            upsert_one(db, k_discarded, v_discarded, nullptr);
+        ASSERT_NE(primary_root, nullptr);
+
+        {
+            Db secondary_db = db.activate_secondary_timeline(
+                std::make_unique<StateMachineAlwaysMerkle>());
+            Node::SharedPtr const secondary_root =
+                upsert_one(secondary_db, k_kept, v_kept, nullptr);
+            ASSERT_NE(secondary_root, nullptr);
+        }
+
+        db.promote_secondary_to_primary();
+    }
+
+    OnDiskDbConfig reopen_config = config;
+    reopen_config.append = true;
+    {
+        Db db{std::make_unique<StateMachineAlwaysMerkle>(), reopen_config};
+        db.deactivate_secondary_timeline();
+    }
+
+    ASSERT_EQ(1u, read_primary_ring_idx(src_dbname.c_str()));
+    ASSERT_FALSE(read_secondary_active(src_dbname.c_str()));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            src_dbname.c_str(),
+            "--archive",
+            arc_path};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0)
+            << "stderr: " << cerr.str() << "\nstdout: " << cout.str();
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            dst_dbname.c_str(),
+            "--root-offsets-chunk-count",
+            "2",
+            "--yes",
+            "--restore",
+            arc_path};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(retcode, 0)
+            << "stderr: " << cerr.str() << "\nstdout: " << cout.str();
+    }
+
+    EXPECT_EQ(1u, read_primary_ring_idx(dst_dbname.c_str()));
+    EXPECT_FALSE(read_secondary_active(dst_dbname.c_str()));
+
+    {
+        OnDiskDbConfig const restored_config{
+            .append = true,
+            .compaction = true,
+            .sq_thread_cpu = std::nullopt,
+            .dbname_paths = {dst_dbname},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        Db const db{
+            std::make_unique<StateMachineAlwaysMerkle>(), restored_config};
+        EXPECT_FALSE(db.timeline_active(timeline_id::secondary));
+
+        Node::SharedPtr const root = db.load_root_for_version(0);
+        ASSERT_NE(root, nullptr);
+        auto const res = db.find(NodeCursor{root}, NibblesView{k_kept}, 0);
+        ASSERT_TRUE(res.has_value());
+        EXPECT_EQ(monad::byte_string{res.value().node->value()}, v_kept);
+    }
 }
 
 /* There was a bug found whereby if the DB being archived used the lastmost


### PR DESCRIPTION
The archive loop walked cnv chunk ids as a contiguous prefix [0..root_offsets.cnv_chunks_len], which was the live set only before activate_secondary_header. Once the secondary ring holds half the chunks (and primary_ring_idx may have flipped after a promote), the prefix neither matches the primary nor includes the secondary's chunks, so the prior guard refused to archive when secondary_timeline_active_ != 0. The post-promote+deactivate case (primary_ring_idx == 1, secondary inactive) was silently wrong on top: the loop kept reading root_offsets.cnv_chunks_len, which by then named the stale, deactivated ring.

Map chunk 0 first, then walk root_offsets.storage_.cnv_chunks[] and secondary_timeline.storage_.cnv_chunks[] by role: always archive the ring named by primary_ring_idx, and the other ring only when secondary_timeline_active_ is set (otherwise its chunks are garbage and must not be archived). Dedupe by chunk id. Skip uint32_t(-1) sentinel slots left mid-crash by activate_secondary_header / deactivate_secondary_header: the runtime ring readers tolerate them until replay_pending_shrink_grow_ heals the metadata on the next writable open, and --archive opens read-only without replaying. Restore needs no change: the metadata fix-up already copies primary_ring_idx, secondary_timeline_active_, and
secondary_timeline.storage_ verbatim, and per-chunk decompression keys by the chunk id parsed from the archive entry path.

Two new regression tests in cli_tool_test.cpp cover the live-secondary and post-promote+deactivate cases by writing distinct keys on each timeline (or on the surviving primary), archiving, restoring into a fresh pool, and verifying the round-trip via Db + open_secondary_timeline
+ find.