### PR TITLE
Upgrade Docker build base image to Ubuntu 26.04 LTS

### DIFF
--- a/category/vm/README.md
+++ b/category/vm/README.md
@@ -11,7 +11,7 @@ aim of merging the compiler into the core Monad monorepo.
 
 ## Building & Running
 
-The compiler is built and tested in CI on Ubuntu 24.04. To build locally, first
+The compiler is built and tested in CI on Ubuntu 26.04. To build locally, first
 install the following dependencies via `apt`:
 ```
 build-essential

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1-labs
 
-FROM ubuntu:25.10 AS base
+FROM ubuntu:26.04 AS base
 
 COPY scripts/ubuntu-build/ /opt
 


### PR DESCRIPTION
## Summary

Bumps the build/test/CI Docker base image from `ubuntu:25.10` (interim) to `ubuntu:26.04` (LTS), and updates the VM README's CI reference to match.

## Verification

All apt packages pinned by `scripts/ubuntu-build/*.sh` were confirmed to resolve on 26.04 (checked against a live 26.04 host):

- **Boost 1.83** — all 9 pinned component packages present (`1.83.0-5ubuntu5`). Note 1.83 is no longer the *default* on 26.04 (1.90 is), but the explicit pins still install cleanly.
- **clang-19 suite** — `clang-19`, `clang-tools-19`, `clang-tidy-19`, `libclang-*-19-dev`, `llvm-19-dev` (`19.1.7-20ubuntu4`).
- **gcc-15 / g++-15** — `15.2.0-16ubuntu1`.
- **All `install-deps.sh` packages** — present (liburing, tbb, gtest/gmock, crypto++, cli11, brotli, etc.).

Package resolution ≠ a clean build, so CI's `docker build` + test run is the real gate — this is a drop-in intended to be exercised there.

## Out of scope (intentional)

- **CI `runs-on` labels** left at `ubuntu-24.04` / `ubuntu-24.04-32`. The build runs *inside* the container, so only the base image needs bumping; the `-32` runners are org-managed and would need 26.04 images provisioned separately. Happy to bump them in a follow-up if desired.
- **Boost pin** kept at 1.83. It still resolves but is no longer the 26.04 default — worth a future follow-up to decide whether to track the default boost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)