### PR TITLE
[zkvm] Streamline witness binary format + add encode function

### DIFF
--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -697,10 +697,11 @@ Result<PartialTrieDb> PartialTrieDb::from_witness(
     {
         while (!encoded_nodes.empty()) {
             BOOST_OUTCOME_TRY(
-                auto payload, rlp::parse_string_metadata(encoded_nodes));
-            bytes32_t key = to_bytes(keccak256(payload));
+                auto const node_bytes,
+                rlp::parse_list_metadata_raw(encoded_nodes));
+            bytes32_t const key = to_bytes(keccak256(node_bytes));
             node_index.emplace(
-                key, byte_string{payload.data(), payload.size()});
+                key, byte_string{node_bytes.data(), node_bytes.size()});
         }
     }
 

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -140,9 +140,8 @@ using CodeIndex = ankerl::unordered_dense::map<bytes32_t, vm::SharedIntercode>;
 
 /// A sparse Ethereum account + storage MPT that implements the Db interface.
 ///
-/// Built from a Reth witness bundle; serves as a drop-in replacement for
-/// TrieDb during zkVM STF proving. The trie IS the pre-state — there are no
-/// separate account or storage vectors.
+/// Built from an execution witness bundle; serves as a drop-in replacement
+/// for TrieDb during zkVM STF proving.
 class PartialTrieDb final : public Db
 {
     AccountTrie root_;

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -40,28 +40,9 @@ using namespace monad;
 
 namespace
 {
-    constexpr auto PRE_ROOT =
-        0x0101010101010101010101010101010101010101010101010101010101010101_bytes32;
-    constexpr auto POST_ROOT =
-        0x0202020202020202020202020202020202020202020202020202020202020202_bytes32;
-
-    byte_string make_minimal_witness(
-        bytes32_t const &pre, bytes32_t const &post,
-        byte_string nodes_payload = {}, byte_string codes_payload = {})
+    byte_string make_minimal_witness()
     {
-        return rlp::encode_list2(
-            rlp::encode_string2({}), // [0] block_rlp (empty)
-            rlp::encode_string2(
-                byte_string_view{pre.bytes, 32}), // [1] pre_state_root
-            rlp::encode_string2(
-                byte_string_view{post.bytes, 32}), // [2] post_state_root
-            rlp::encode_list2(nodes_payload), // [3] node preimages
-            rlp::encode_list2(codes_payload), // [4] contract bytecodes
-            byte_string{
-                static_cast<unsigned char>(0xc0)}, // [5] preimages (skipped)
-            byte_string{static_cast<unsigned char>(0xc0)}
-            // [6] ancestor headers
-        );
+        return encode_execution_witness({}, {}, {}, {});
     }
 
     void storage_leaf_roundtrip(
@@ -91,12 +72,8 @@ namespace
     {
         bytes32_t const root = to_bytes(
             keccak256(byte_string_view{node_rlp.data(), node_rlp.size()}));
-        byte_string const encoded_nodes = rlp::encode_string2(
-            byte_string_view{node_rlp.data(), node_rlp.size()});
         return PartialTrieDb::from_witness(
-            root,
-            byte_string_view{encoded_nodes.data(), encoded_nodes.size()},
-            {});
+            root, byte_string_view{node_rlp.data(), node_rlp.size()}, {});
     }
 
     PartialTrieDb make_empty_db()
@@ -156,14 +133,16 @@ namespace
 
 TEST(ParseExecutionWitness, ValidMinimalWitness)
 {
-    auto const w = make_minimal_witness(PRE_ROOT, POST_ROOT);
+    auto const w = make_minimal_witness();
     auto const result = parse_execution_witness(w);
     ASSERT_FALSE(result.has_error());
-    EXPECT_EQ(result.value().pre_state_root, PRE_ROOT);
-    EXPECT_EQ(result.value().post_state_root, POST_ROOT);
+    EXPECT_TRUE(result.value().block_rlp.empty());
     EXPECT_TRUE(result.value().encoded_nodes.empty());
     EXPECT_TRUE(result.value().encoded_codes.empty());
     EXPECT_TRUE(result.value().encoded_headers.empty());
+    EXPECT_TRUE(result.value().encoded_parent_senders_and_authorities.empty());
+    EXPECT_TRUE(
+        result.value().encoded_grandparent_senders_and_authorities.empty());
 }
 
 TEST(ParseExecutionWitness, EmptyInput)
@@ -182,27 +161,73 @@ TEST(ParseExecutionWitness, OuterTypeNotList)
 
 TEST(ParseExecutionWitness, Truncated)
 {
-    auto w = make_minimal_witness(PRE_ROOT, POST_ROOT);
-    w.resize(w.size() - 5);
+    auto w = make_minimal_witness();
+    w.resize(w.size() - 1);
     auto const result = parse_execution_witness(w);
     EXPECT_TRUE(result.has_error());
 }
 
-TEST(ParseExecutionWitness, PreRootWrongLength)
+TEST(EncodeExecutionWitness, AllFieldsRoundtrip)
 {
-    // Replace the 32-byte pre_state_root item with a 16-byte one so that
-    // decode_byte_string_fixed<32> returns ArrayLengthUnexpected.
-    byte_string const w = rlp::encode_list2(
-        rlp::encode_string2({}),
-        rlp::encode_string2(
-            byte_string_view{PRE_ROOT.bytes, 16}), // 16 bytes, not 32
-        rlp::encode_string2(byte_string_view{POST_ROOT.bytes, 32}),
-        byte_string{static_cast<unsigned char>(0xc0)},
-        byte_string{static_cast<unsigned char>(0xc0)},
-        byte_string{static_cast<unsigned char>(0xc0)},
-        byte_string{static_cast<unsigned char>(0xc0)});
-    auto const result = parse_execution_witness(w);
-    EXPECT_TRUE(result.has_error());
+    // block_rlp is wrapped by the encoder as an RLP string; the parser hands
+    // back the unwrapped payload.
+    byte_string const block_rlp{0x01, 0x02, 0x03, 0x04};
+
+    // Nodes are already complete RLP items and are emitted raw, so the parsed
+    // [1] payload is their straight concatenation.
+    std::vector<byte_string> const nodes{
+        rlp::encode_list2(rlp::encode_string2(byte_string{0xaa})),
+        rlp::encode_string2(byte_string{0xbb, 0xcc})};
+
+    // Codes and headers are each wrapped as RLP strings by the encoder.
+    std::vector<byte_string> const codes{
+        byte_string{0x60, 0x00, 0x60, 0x00}, byte_string{0x00}};
+    std::vector<byte_string> const headers{
+        byte_string{0xde, 0xad}, byte_string{0xbe, 0xef, 0xfe}};
+
+    ankerl::unordered_dense::segmented_set<Address> parents;
+    parents.insert(ADDR_X);
+    parents.insert(ADDR_Y);
+    ankerl::unordered_dense::segmented_set<Address> grandparents;
+    grandparents.insert(ADDR_Z);
+
+    byte_string const encoded = encode_execution_witness(
+        block_rlp, nodes, codes, headers, &parents, &grandparents);
+
+    auto const result = parse_execution_witness(encoded);
+    ASSERT_FALSE(result.has_error());
+    auto const &w = result.value();
+
+    EXPECT_EQ(w.block_rlp, byte_string_view{block_rlp});
+
+    // [1] nodes: raw concatenation.
+    EXPECT_EQ(w.encoded_nodes, byte_string_view{nodes[0] + nodes[1]});
+
+    // [2] codes / [3] headers: each entry wrapped as an RLP string.
+    EXPECT_EQ(
+        w.encoded_codes,
+        byte_string_view{
+            rlp::encode_string2(codes[0]) + rlp::encode_string2(codes[1])});
+    EXPECT_EQ(
+        w.encoded_headers,
+        byte_string_view{
+            rlp::encode_string2(headers[0]) + rlp::encode_string2(headers[1])});
+
+    // [4]/[5] addresses: emitted in sorted order, each wrapped as an RLP
+    // string.
+    std::vector<Address> sorted_parents{ADDR_X, ADDR_Y};
+    std::sort(sorted_parents.begin(), sorted_parents.end());
+    byte_string expected_parents;
+    for (auto const &a : sorted_parents) {
+        expected_parents += rlp::encode_string2(to_byte_string_view(a.bytes));
+    }
+    EXPECT_EQ(
+        w.encoded_parent_senders_and_authorities,
+        byte_string_view{expected_parents});
+    EXPECT_EQ(
+        w.encoded_grandparent_senders_and_authorities,
+        byte_string_view{
+            rlp::encode_string2(to_byte_string_view(ADDR_Z.bytes))});
 }
 
 TEST(StorageLeafValue, DecodeZeroValue)
@@ -390,33 +415,6 @@ TEST(PartialTrieDb, EmptyInlineNode)
     auto result = db_from_rlp_node(branch);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, NodeIndexEntryTrailingData)
-{
-    // When a hash resolves to a node in the index, the raw entry must be
-    // exactly one RLP list with no trailing bytes.  Append a spurious byte
-    // so that the "!node_enc.empty()" check fires InputTooLong.
-    mpt::Nibbles leaf_path{2};
-    leaf_path.set(0, 0xA);
-    leaf_path.set(1, 0xB);
-
-    unsigned char compact_buf[33];
-    auto const compact_sv = mpt::compact_encode(
-        compact_buf, mpt::NibblesView{leaf_path}, /*terminating=*/true);
-
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-
-    byte_string node_rlp = rlp::encode_list2(
-        rlp::encode_string2(compact_sv),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-    node_rlp.push_back(static_cast<unsigned char>(0xFF));
-
-    auto result = db_from_rlp_node(node_rlp);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
 }
 
 TEST(PartialTrieDb, PathTooLong)

--- a/category/execution/ethereum/rlp/execution_witness.cpp
+++ b/category/execution/ethereum/rlp/execution_witness.cpp
@@ -13,12 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/assert.h>
+#include <category/core/rlp/encode.hpp>
 #include <category/execution/ethereum/rlp/decode.hpp>
 #include <category/execution/ethereum/rlp/execution_witness.hpp>
 
 #include <boost/outcome/try.hpp>
 
+#include <algorithm>
 #include <cstring>
+#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -37,30 +41,121 @@ Result<ExecutionWitness> parse_execution_witness(byte_string_view witness_bytes)
     ExecutionWitness w{};
 
     BOOST_OUTCOME_TRY(w.block_rlp, rlp::parse_string_metadata(outer));
-
-    BOOST_OUTCOME_TRY(
-        auto const pre_root, rlp::decode_byte_string_fixed<32>(outer));
-    std::memcpy(w.pre_state_root.bytes, pre_root.data(), 32);
-
-    BOOST_OUTCOME_TRY(
-        auto const post_root, rlp::decode_byte_string_fixed<32>(outer));
-    std::memcpy(w.post_state_root.bytes, post_root.data(), 32);
-
     BOOST_OUTCOME_TRY(w.encoded_nodes, rlp::parse_list_metadata(outer));
-
     BOOST_OUTCOME_TRY(w.encoded_codes, rlp::parse_list_metadata(outer));
-
-    // preimages — advance past it, do not store.
-    BOOST_OUTCOME_TRY(auto const preimages, rlp::parse_list_metadata(outer));
-    (void)preimages;
-
     BOOST_OUTCOME_TRY(w.encoded_headers, rlp::parse_list_metadata(outer));
+    BOOST_OUTCOME_TRY(
+        w.encoded_parent_senders_and_authorities,
+        rlp::parse_list_metadata(outer));
+    BOOST_OUTCOME_TRY(
+        w.encoded_grandparent_senders_and_authorities,
+        rlp::parse_list_metadata(outer));
 
     if (MONAD_UNLIKELY(!outer.empty())) {
         return rlp::DecodeError::InputTooLong;
     }
 
     return w;
+}
+
+byte_string encode_execution_witness(
+    byte_string_view const block_rlp, std::span<byte_string const> const nodes,
+    std::span<byte_string const> const codes,
+    std::span<byte_string const> const headers,
+    ankerl::unordered_dense::segmented_set<Address> const
+        *const parent_senders_and_authorities,
+    ankerl::unordered_dense::segmented_set<Address> const
+        *const grandparent_senders_and_authorities)
+{
+    // 20-byte address → 1-byte length prefix (0x94) + 20 payload bytes.
+    static_assert(sizeof(Address) == 20);
+    constexpr size_t addr_string_size = 1 + sizeof(Address);
+
+    // Pre-calc: payload size of every nested list, then total output size.
+    size_t nodes_payload = 0;
+    for (auto const &n : nodes) {
+        nodes_payload += n.size();
+    }
+    size_t codes_payload = 0;
+    for (auto const &c : codes) {
+        codes_payload += rlp::string_length(c);
+    }
+    size_t headers_payload = 0;
+    for (auto const &h : headers) {
+        headers_payload += rlp::string_length(h);
+    }
+    size_t const parent_payload =
+        parent_senders_and_authorities
+            ? parent_senders_and_authorities->size() * addr_string_size
+            : 0;
+    size_t const grandparent_payload =
+        grandparent_senders_and_authorities
+            ? grandparent_senders_and_authorities->size() * addr_string_size
+            : 0;
+
+    size_t const outer_payload =
+        rlp::string_length(block_rlp) + rlp::list_length(nodes_payload) +
+        rlp::list_length(codes_payload) + rlp::list_length(headers_payload) +
+        rlp::list_length(parent_payload) +
+        rlp::list_length(grandparent_payload);
+
+    byte_string result;
+    result.resize_and_overwrite(
+        rlp::list_length(outer_payload),
+        [](auto *, size_t const count) { return count; });
+    std::span<unsigned char> d{result};
+
+    // Outer 6-field list
+    d = rlp::encode_list_prefix(d, outer_payload);
+
+    // [0] block_rlp wrapped as RLP string
+    d = rlp::encode_string(d, block_rlp);
+
+    // [1] nodes — each entry is itself a complete RLP list, concatenated raw
+    d = rlp::encode_list_prefix(d, nodes_payload);
+    for (auto const &n : nodes) {
+        std::memcpy(d.data(), n.data(), n.size());
+        d = d.subspan(n.size());
+    }
+
+    // [2] codes — each raw bytecode wrapped as RLP string
+    d = rlp::encode_list_prefix(d, codes_payload);
+    for (auto const &c : codes) {
+        d = rlp::encode_string(d, c);
+    }
+
+    // [3] headers — each pre-encoded header wrapped as RLP string
+    d = rlp::encode_list_prefix(d, headers_payload);
+    for (auto const &h : headers) {
+        d = rlp::encode_string(d, h);
+    }
+
+    // segmented_set has no defined iteration order, so emit addresses in
+    // sorted order to keep the encoding deterministic across runs.
+    auto const encode_addresses =
+        [](std::span<unsigned char> d,
+           ankerl::unordered_dense::segmented_set<Address> const *const set) {
+            if (!set) {
+                return d;
+            }
+            std::vector<Address> sorted(set->begin(), set->end());
+            std::sort(sorted.begin(), sorted.end());
+            for (auto const &a : sorted) {
+                d = rlp::encode_string(d, to_byte_string_view(a.bytes));
+            }
+            return d;
+        };
+
+    // [4] parent senders and authorities — list of address strings
+    d = rlp::encode_list_prefix(d, parent_payload);
+    d = encode_addresses(d, parent_senders_and_authorities);
+
+    // [5] grandparent senders and authorities
+    d = rlp::encode_list_prefix(d, grandparent_payload);
+    d = encode_addresses(d, grandparent_senders_and_authorities);
+
+    MONAD_ASSERT(d.empty());
+    return result;
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/rlp/execution_witness.hpp
+++ b/category/execution/ethereum/rlp/execution_witness.hpp
@@ -15,42 +15,52 @@
 
 #pragma once
 
+#include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
+
+#include <ankerl/unordered_dense.h>
 
 #include <cstdint>
 #include <span>
 
 MONAD_NAMESPACE_BEGIN
 
-/// A shallowly-parsed Reth witness bundle.
-///
-/// Only the two fixed-size root hashes (fields [1] and [2]) are eagerly
-/// decoded. All other fields are represented as byte_string_view spans
+/// A shallowly-parsed witness bundle. Every field is a byte_string_view
 /// pointing into the original witness bytes; the caller must keep that
 /// buffer alive for as long as this struct is used.
 ///
-/// Wire format (7-field RLP list):
-///   [0] block_rlp        RLP-encoded block
-///   [1] pre_state_root   bytes32
-///   [2] post_state_root  bytes32
-///   [3] [node...]        RLP list of MPT node preimages
-///   [4] [code...]        RLP list of contract bytecodes
-///   [5] [key...]         RLP list of address/slot preimages (not stored)
-///   [6] [header...]      RLP list of ancestor block headers
+/// Wire format (6-field RLP list):
+///   [0] block_rlp                     RLP-encoded block
+///   [1] [node...]                     RLP list of MPT node preimages
+///   [2] [code...]                     RLP list of contract bytecodes
+///   [3] [header...]                   RLP list of ancestor block headers
+///   [4] [address...]                  Parent sender+authority set
+///   [5] [address...]                  Grandparent sender+authority set
+///
+/// Fields [4] and [5] can be left unpopulated for chains/revisions where
+/// can_sender_dip_into_reserve is not active (EVM traits, pre-MONAD_FOUR).
 struct ExecutionWitness
 {
     byte_string_view block_rlp;
-    bytes32_t pre_state_root;
-    bytes32_t post_state_root;
     byte_string_view encoded_nodes;
     byte_string_view encoded_codes;
     byte_string_view encoded_headers;
+    byte_string_view encoded_parent_senders_and_authorities;
+    byte_string_view encoded_grandparent_senders_and_authorities;
 };
 
 Result<ExecutionWitness>
 parse_execution_witness(byte_string_view witness_bytes);
+
+byte_string encode_execution_witness(
+    byte_string_view block_rlp, std::span<byte_string const> nodes,
+    std::span<byte_string const> codes, std::span<byte_string const> headers,
+    ankerl::unordered_dense::segmented_set<Address> const
+        *const parent_senders_and_authorities = nullptr,
+    ankerl::unordered_dense::segmented_set<Address> const
+        *const grandparent_senders_and_authorities = nullptr);
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
The witness RLP encoding has the following changes:
- drops pre-/post-state roots
- adds block's parent and grand-parent sender+authority sets 
- changes encoding of MPT nodes from previously double wrapped nodes (RLP encoded node wrapped in an RLP string) to just directly encoded MPT nodes