### PR TITLE
[mpt] Read version_lower_bound_ with acquire on the reader path

### DIFF
--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -552,7 +552,7 @@ uint64_t DbMetadataContext::db_history_range_lower_bound() const noexcept
                 ? (max_version - version_history_length() + 1)
                 : 0;
         auto const ro_version_lower_bound =
-            copies_[0].main->root_offsets.version_lower_bound_;
+            root_offsets().version_lower_bound();
         MONAD_ASSERT(ro_version_lower_bound >= history_range_min);
         return ro_version_lower_bound;
     }

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -178,6 +178,11 @@ public:
                 return wp - 1;
             }
 
+            uint64_t version_lower_bound() const noexcept
+            {
+                return version_lower_bound_.load(std::memory_order_acquire);
+            }
+
             void reset_all(uint64_t const version)
             {
                 version_lower_bound_.store(0, std::memory_order_release);

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -544,7 +544,7 @@ void UpdateAux::release_unreferenced_chunks()
         chunks_to_remove_before_count_fast_,
         chunks_to_remove_before_count_slow_);
     MONAD_ASSERT(
-        metadata_ctx_->main()->root_offsets.version_lower_bound_ >=
+        metadata_ctx_->root_offsets().version_lower_bound() >=
         min_valid_version);
     free_compacted_chunks();
 }


### PR DESCRIPTION
`db_history_range_lower_bound` and `release_unreferenced_chunks` read `root_offsets.version_lower_bound_` as a plain non-atomic member, while the writer publishes it via `std::atomic_ref` with release ordering and the ring delegator already consumes it with acquire. On the live (incl. cross-process) reader path — `get_root_offset_at_version`, `db_history_min_valid_version` — this is a data race that drops the acquire ordering the lower-bound read needs against the ring slot and `next_version_` stores.

Adds a `version_lower_bound()` acquire accessor to `root_offsets_delegator` and routes both reads through it. No behavior change beyond the memory-ordering fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)