### PR TITLE
[mpt] Name the empty-list sentinel INVALID_CHUNK_INDEX

### DIFF
--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -744,7 +744,8 @@ public:
                     break;
                 }
                 auto const chunkid = item->index(aux.metadata_ctx().main());
-                MONAD_ASSERT(chunkid != UINT32_MAX);
+                MONAD_ASSERT(
+                    chunkid != monad::mpt::detail::db_metadata::NULL_CHUNK);
                 aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
@@ -754,7 +755,8 @@ public:
                     break;
                 }
                 auto const chunkid = item->index(aux.metadata_ctx().main());
-                MONAD_ASSERT(chunkid != UINT32_MAX);
+                MONAD_ASSERT(
+                    chunkid != monad::mpt::detail::db_metadata::NULL_CHUNK);
                 aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
@@ -764,7 +766,8 @@ public:
                     break;
                 }
                 auto const chunkid = item->index(aux.metadata_ctx().main());
-                MONAD_ASSERT(chunkid != UINT32_MAX);
+                MONAD_ASSERT(
+                    chunkid != monad::mpt::detail::db_metadata::NULL_CHUNK);
                 aux.metadata_ctx().remove(chunkid);
                 chunks.push_back(chunkid);
             }
@@ -817,10 +820,14 @@ public:
             UINT32_MAX);
         monad::mpt::detail::unsigned_20 slow_list_base_insertion_count(
             UINT32_MAX);
-        uint32_t fast_list_begin_index{UINT32_MAX};
-        uint32_t fast_list_end_index{UINT32_MAX};
-        uint32_t slow_list_begin_index{UINT32_MAX};
-        uint32_t slow_list_end_index{UINT32_MAX};
+        uint32_t fast_list_begin_index{
+            monad::mpt::detail::db_metadata::NULL_CHUNK};
+        uint32_t fast_list_end_index{
+            monad::mpt::detail::db_metadata::NULL_CHUNK};
+        uint32_t slow_list_begin_index{
+            monad::mpt::detail::db_metadata::NULL_CHUNK};
+        uint32_t slow_list_end_index{
+            monad::mpt::detail::db_metadata::NULL_CHUNK};
         for (auto &i : todecompress) {
             if (i.type == monad::async::storage_pool::cnv) {
                 if (i.chunk_id == 0) {
@@ -901,8 +908,12 @@ public:
                         old_metadata->fast_list_begin()->insertion_count();
                     slow_list_base_insertion_count =
                         old_metadata->slow_list_begin()->insertion_count();
-                    MONAD_ASSERT(old_metadata->fast_list.begin != UINT32_MAX);
-                    MONAD_ASSERT(old_metadata->slow_list.begin != UINT32_MAX);
+                    MONAD_ASSERT(
+                        old_metadata->fast_list.begin !=
+                        monad::mpt::detail::db_metadata::NULL_CHUNK);
+                    MONAD_ASSERT(
+                        old_metadata->slow_list.begin !=
+                        monad::mpt::detail::db_metadata::NULL_CHUNK);
                     fast_list_begin_index = old_metadata->fast_list.begin;
                     slow_list_begin_index = old_metadata->slow_list.begin;
                     if (auto const max_seq_chunk = std::max(
@@ -1027,7 +1038,7 @@ public:
                     auto const it =
                         std::find(chunks.begin(), chunks.end(), i.chunk_id);
                     MONAD_ASSERT(it != chunks.end());
-                    *it = UINT32_MAX;
+                    *it = monad::mpt::detail::db_metadata::NULL_CHUNK;
                 }
             }
         }
@@ -1041,7 +1052,7 @@ public:
             auto const it =
                 std::find(chunks.begin(), chunks.end(), fast_list_begin_index);
             MONAD_ASSERT(it != chunks.end());
-            *it = UINT32_MAX;
+            *it = monad::mpt::detail::db_metadata::NULL_CHUNK;
             // override the first insertion count
             aux.metadata_ctx().modify_metadata(
                 override_insertion_count,
@@ -1060,7 +1071,7 @@ public:
             auto const it =
                 std::find(chunks.begin(), chunks.end(), slow_list_begin_index);
             MONAD_ASSERT(it != chunks.end());
-            *it = UINT32_MAX;
+            *it = monad::mpt::detail::db_metadata::NULL_CHUNK;
             // override the first insertion count
             aux.metadata_ctx().modify_metadata(
                 override_insertion_count,
@@ -1074,7 +1085,7 @@ public:
             aux.metadata_ctx().main()->slow_list.end == slow_list_end_index);
 
         for (unsigned int const &chunk : chunks) {
-            if (chunk != UINT32_MAX) {
+            if (chunk != monad::mpt::detail::db_metadata::NULL_CHUNK) {
                 aux.metadata_ctx().append(
                     monad::mpt::UpdateAux::chunk_list::free, chunk);
             }

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -176,6 +176,11 @@ namespace detail
             uint32_t begin, end;
         } free_list, fast_list, slow_list;
 
+        // Empty-list sentinel for id_pair begin/end: a full-width uint32
+        // array index, unlike the 20-bit chunk_info_t::INVALID_CHUNK_ID node
+        // id used in the prev/next links.
+        static constexpr uint32_t NULL_CHUNK = UINT32_MAX;
+
         struct chunk_info_t
         {
             static constexpr uint32_t INVALID_CHUNK_ID = 0xfffff;
@@ -284,7 +289,7 @@ namespace detail
 
         chunk_info_t const *free_list_begin() const noexcept
         {
-            if (free_list.begin == UINT32_MAX) {
+            if (free_list.begin == NULL_CHUNK) {
                 return nullptr;
             }
             return at(free_list.begin);
@@ -292,7 +297,7 @@ namespace detail
 
         chunk_info_t const *free_list_end() const noexcept
         {
-            if (free_list.end == UINT32_MAX) {
+            if (free_list.end == NULL_CHUNK) {
                 return nullptr;
             }
             return at(free_list.end);
@@ -300,7 +305,7 @@ namespace detail
 
         chunk_info_t const *fast_list_begin() const noexcept
         {
-            if (fast_list.begin == UINT32_MAX) {
+            if (fast_list.begin == NULL_CHUNK) {
                 return nullptr;
             }
             return at(fast_list.begin);
@@ -308,7 +313,7 @@ namespace detail
 
         chunk_info_t const *fast_list_end() const noexcept
         {
-            if (fast_list.end == UINT32_MAX) {
+            if (fast_list.end == NULL_CHUNK) {
                 return nullptr;
             }
             return at(fast_list.end);
@@ -316,7 +321,7 @@ namespace detail
 
         chunk_info_t const *slow_list_begin() const noexcept
         {
-            if (slow_list.begin == UINT32_MAX) {
+            if (slow_list.begin == NULL_CHUNK) {
                 return nullptr;
             }
             return at(slow_list.begin);
@@ -324,7 +329,7 @@ namespace detail
 
         chunk_info_t const *slow_list_end() const noexcept
         {
-            if (slow_list.end == UINT32_MAX) {
+            if (slow_list.end == NULL_CHUNK) {
                 return nullptr;
             }
             return at(slow_list.end);
@@ -346,8 +351,8 @@ namespace detail
             info.in_slow_list = (&list == &slow_list);
             info.insertion_count0_ = info.insertion_count1_ = 0;
             info.next_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
-            if (list.end == UINT32_MAX) {
-                MONAD_ASSERT(list.begin == UINT32_MAX);
+            if (list.end == NULL_CHUNK) {
+                MONAD_ASSERT(list.begin == NULL_CHUNK);
                 info.prev_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
                 list.begin = list.end = i->index(this);
             }
@@ -393,7 +398,7 @@ namespace detail
                 id_pair &list = get_list();
                 MONAD_ASSERT(list.begin == i->index(this));
                 MONAD_ASSERT(list.end == i->index(this));
-                list.begin = list.end = UINT32_MAX;
+                list.begin = list.end = NULL_CHUNK;
 #ifndef NDEBUG
                 i->in_fast_list = i->in_slow_list = false;
 #endif


### PR DESCRIPTION
The free/fast/slow chunk lists in `db_metadata` compare `id_pair` begin/end against a bare `UINT32_MAX` to mean "empty list / no chunk index." This names that sentinel — `db_metadata::INVALID_CHUNK_INDEX = UINT32_MAX` — and uses it at the nine list-management sites, mirroring the existing `chunk_info_t::INVALID_CHUNK_ID` precedent and making it visibly distinct from that 20-bit prev/next sentinel.