### PR TITLE
Only apply apply-clang-format/check-clang-tidy to git tracked files

### DIFF
--- a/scripts/apply-clang-format.sh
+++ b/scripts/apply-clang-format.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 script_dir="$(dirname "$0")"
 root_dir="$(realpath "$script_dir/..")"
 
-clang-format-19 \
-  -i $(\
-    find \
-      "${root_dir}"/category \
-      "${root_dir}"/cmd      \
-      "${root_dir}"/test     \
-        -name '*.hpp' -or \
-        -name '*.cpp' -or \
-        -name '*.c'   -or \
-        -name '*.h')
+# Only format unignored files.
+cd "${root_dir}"
+rg --files -0 -g '*.hpp' -g '*.cpp' -g '*.c' -g '*.h' \
+  category cmd test \
+  | xargs -0 -r clang-format-19 -i

--- a/scripts/check-clang-tidy.sh
+++ b/scripts/check-clang-tidy.sh
@@ -48,14 +48,15 @@ if [ -f $CONST_CORRECTNESS_PLUGIN ]; then
 fi
 
 
-mapfile -t inputs < <(\
-  find \
+# Restrict linting to files that aren't in a .gitignore.
+mapfile -d '' -t inputs < <(\
+    rg --files -0 \
+    -g '*.cpp' -g '*.c' \
     category/async \
     category/core  \
     category/mpt   \
     category/rpc   \
-    category/vm    \
-    \( -name '*.cpp' -or -name '*.c' \))
+    category/vm)
 
 "${RUN_CLANG_TIDY}"                               \
   "${inputs[@]}"                                  \

--- a/scripts/ubuntu-build/install-tools.sh
+++ b/scripts/ubuntu-build/install-tools.sh
@@ -22,6 +22,7 @@ packages=(
   pkg-config
   python-is-python3
   python3-pytest
+  ripgrep
   software-properties-common
   valgrind
   wget


### PR DESCRIPTION
Due to various cruft like `.cargo` folder inside `zkvm/`, clang-format grinds to a halt as it finds a lot of untracked files