### PR TITLE
[mpt] Make root_offsets ring scalars private to force atomic access

### DIFF
--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -884,14 +884,8 @@ public:
                     });
                     do_([&](monad::mpt::detail::db_metadata *metadata) {
                         metadata->db_offsets.store(old_metadata->db_offsets);
-                        metadata->root_offsets.next_version_ =
-                            old_metadata->root_offsets.next_version_;
-                        metadata->root_offsets.version_lower_bound_ =
-                            old_metadata->root_offsets.version_lower_bound_;
-                        memcpy(
-                            &metadata->root_offsets.storage_,
-                            &old_metadata->root_offsets.storage_,
-                            sizeof(metadata->root_offsets.storage_));
+                        metadata->root_offsets.restore_from(
+                            old_metadata->root_offsets);
                         metadata->history_length = old_metadata->history_length;
                         metadata->latest_finalized_version =
                             old_metadata->latest_finalized_version;
@@ -1232,7 +1226,7 @@ public:
                     auto const *m = monad::start_lifetime_as<
                         monad::mpt::detail::db_metadata>(i.uncompressed.data());
                     additional_cnv_chunks_to_archive =
-                        m->root_offsets.storage_.cnv_chunks_len;
+                        m->root_offsets.cnv_chunks_len();
                 }
                 i.compression_thread =
                     std::async(std::launch::async, [i = &i, this] {

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -117,12 +117,13 @@ public:
             }
 
         public:
-            explicit root_offsets_delegator(metadata_copy const *const m)
-                : version_lower_bound_(
-                      m->main->root_offsets.version_lower_bound_)
-                , next_version_(m->main->root_offsets.next_version_)
-                , root_offsets_chunks_(
-                      std::span<chunk_offset_t>(m->root_offsets))
+            explicit root_offsets_delegator(
+                std::atomic_ref<uint64_t> const version_lower_bound,
+                std::atomic_ref<uint64_t> const next_version,
+                std::span<chunk_offset_t> const root_offsets_chunks)
+                : version_lower_bound_(version_lower_bound)
+                , next_version_(next_version)
+                , root_offsets_chunks_(root_offsets_chunks)
             {
                 MONAD_ASSERT_PRINTF(
                     root_offsets_chunks_.size() ==
@@ -212,7 +213,12 @@ public:
             }
         };
 
-        return root_offsets_delegator{&copies_[which]};
+        auto const &c = copies_[which];
+        return root_offsets_delegator{
+            std::atomic_ref<uint64_t>(
+                c.main->root_offsets.version_lower_bound_),
+            std::atomic_ref<uint64_t>(c.main->root_offsets.next_version_),
+            std::span<chunk_offset_t>(c.root_offsets)};
     }
 
     // Version metadata getters/setters

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -92,6 +92,11 @@ namespace detail
         {
             static constexpr size_t SIZE_ = 65536;
 
+            friend class MONAD_MPT_NAMESPACE::DbMetadataContext;
+            friend inline void
+            db_copy(db_metadata *dest, db_metadata const *src, size_t bytes);
+
+        private:
             uint64_t version_lower_bound_;
             uint64_t
                 next_version_; // all bits zero turns into INVALID_BLOCK_NUM
@@ -109,6 +114,20 @@ namespace detail
                     uint32_t cnv_chunk_id; // The read-write chunk id
                 } cnv_chunks[SIZE_ - 1];
             } storage_;
+
+        public:
+            // no atomic needed: write-once at pool init, then immutable.
+            uint32_t cnv_chunks_len() const noexcept
+            {
+                return storage_.cnv_chunks_len;
+            }
+
+            void restore_from(root_offsets_ring_t const &other) noexcept
+            {
+                version_lower_bound_ = other.version_lower_bound_;
+                next_version_ = other.next_version_;
+                storage_ = other.storage_;
+            }
         } root_offsets;
 
         struct db_offsets_info_t

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -201,8 +201,7 @@ TEST(update_aux_test, configurable_root_offset_chunks)
 
         // Verify that exactly 4 chunks were allocated to hold two copies of
         // root offsets, since chunk 0 is used for metadata
-        EXPECT_EQ(
-            aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(aux.metadata_ctx().main()->root_offsets.cnv_chunks_len(), 4);
         EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     {
@@ -214,8 +213,7 @@ TEST(update_aux_test, configurable_root_offset_chunks)
         EXPECT_EQ(pool.chunks(monad::async::storage_pool::cnv), 5);
         monad::async::AsyncIO testio(pool, testbuf);
         monad::mpt::UpdateAux const aux(testio);
-        EXPECT_EQ(
-            aux.metadata_ctx().main()->root_offsets.storage_.cnv_chunks_len, 4);
+        EXPECT_EQ(aux.metadata_ctx().main()->root_offsets.cnv_chunks_len(), 4);
         EXPECT_EQ(aux.metadata_ctx().root_offsets().capacity(), 2ULL << 25);
     }
     remove(filename);


### PR DESCRIPTION
version_lower_bound_ and next_version_ in root_offsets_ring_t are published/consumed via std::atomic_ref with release/acquire ordering, but as public members they could be read as plain non-atomic loads, dropping that ordering (the bug fixed in 4d1a349b).

Make both scalars private so the only way to touch them is through the atomic accessors. storage_ moves into the same private section too: cnv_chunks_len is write-once at pool init and immutable after, so it gets a plain accessor. Keeping all three members in one access section preserves the on-disk layout exactly .

DbMetadataContext already has an existing friend grant to reach into members of DbMetadata.  The atomic_ref binding moves out of the local root_offsets_delegator (which is not a friend) into the body of DbMetadataContext::root_offsets(), which is, and the bound refs are passed into the delegator. The CLI restore path's raw field copy becomes a named restore_from().