### PR TITLE
[executor] teach eth_simulateV1 to record execution events

### DIFF
--- a/category/core/event/event_ring_util.c
+++ b/category/core/event/event_ring_util.c
@@ -279,6 +279,52 @@ int monad_event_ring_init_simple(
         error_name);
 }
 
+int monad_event_ring_create_ephemeral(
+    struct monad_event_ring_simple_config const *const ring_config,
+    char const *const error_name, unsigned const memfd_create_flags,
+    int const mmap_extra_flags, int *const ring_fd,
+    struct monad_event_ring *const ring)
+{
+    struct monad_event_ring_size ring_size;
+    *ring_fd = -1;
+    int rc = monad_event_ring_init_size(
+        ring_config->descriptors_shift,
+        ring_config->payload_buf_shift,
+        ring_config->context_large_pages,
+        &ring_size);
+    if (rc != 0) {
+        return rc;
+    }
+    size_t const ring_bytes = monad_event_ring_calc_storage(&ring_size);
+    *ring_fd = memfd_create(error_name, memfd_create_flags);
+    if (*ring_fd == -1) {
+        return FORMAT_ERRC(
+            errno,
+            "memfd_create failed for ephemeral event ring `%s`, size %lu",
+            error_name,
+            ring_bytes);
+    }
+    rc = monad_event_ring_init_simple(ring_config, *ring_fd, 0, error_name);
+    if (rc != 0) {
+        goto Error;
+    }
+    rc = monad_event_ring_mmap(
+        ring,
+        PROT_READ | PROT_WRITE,
+        mmap_extra_flags,
+        *ring_fd,
+        0,
+        error_name);
+    if (rc != 0) {
+        goto Error;
+    }
+    return 0;
+Error:
+    (void)close(*ring_fd);
+    *ring_fd = -1;
+    return rc;
+}
+
 int monad_event_ring_check_content_type(
     struct monad_event_ring const *const event_ring,
     enum monad_event_content_type const content_type,

--- a/category/core/event/event_ring_util.h
+++ b/category/core/event/event_ring_util.h
@@ -69,6 +69,16 @@ int monad_event_ring_init_simple(
     struct monad_event_ring_simple_config const *, int ring_fd,
     off_t ring_offset, char const *error_name);
 
+/// "All in one" convenience function for allocating temporary "anonymous"
+/// event rings which have no filesystem identity and thus are not shared with
+/// external processes; the file is created as if by the Linux system call
+/// memfd_create(2); the user must close(2) it whenever *ring_fd != -1; `*ring`
+/// is mapped into this process' address space with PROT_READ | PROT_WRITE
+int monad_event_ring_create_ephemeral(
+    struct monad_event_ring_simple_config const *, char const *error_name,
+    unsigned memfd_create_flags, int mmap_extra_flags, int *ring_fd,
+    struct monad_event_ring *ring);
+
 /// Check that the event ring content type and schema hash match the assumed
 /// values
 int monad_event_ring_check_content_type(

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -20,6 +20,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/event/event_ring.h>
 #include <category/core/fiber/fiber_group.hpp>
 #include <category/core/fiber/fiber_thread_pool.hpp>
 #include <category/core/fiber/priority_pool.hpp>
@@ -44,6 +45,9 @@
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/db/trie_rodb.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_block_events.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_block_header.hpp>
@@ -755,7 +759,7 @@ namespace
         struct monad_state_override_vec const &state_overrides,
         struct monad_block_override_vec const &block_overrides,
         uint64_t const gas_limit, size_t const max_calls,
-        bool emit_native_transfer_logs)
+        bool emit_native_transfer_logs, monad_event_ring const *exec_event_ring)
     {
         // TODO(dhil): Decide on the default timestamp increment.
         static constexpr uint64_t DEFAULT_TIMESTAMP_INCREMENT = 1;
@@ -791,6 +795,23 @@ namespace
             state_overrides,
             base_header,
             is_monad_trait_v<traits>);
+
+        // Create the execution event recorder, if we have an event ring
+        // to record to
+        std::optional<ExecutionEventRecorder> opt_event_recorder;
+        if (exec_event_ring != nullptr) {
+            auto ex_recorder =
+                ExecutionEventRecorder::from_event_ring(exec_event_ring);
+            MONAD_ASSERT_THROW(
+                ex_recorder,
+                std::format(
+                    "error constructing event recorder: {}",
+                    std::error_condition{ex_recorder.error()}.message())
+                    .c_str());
+            opt_event_recorder = std::move(*ex_recorder);
+        }
+        ExecutionEventRecorder *const exec_recorder =
+            opt_event_recorder ? std::addressof(*opt_event_recorder) : nullptr;
 
         TrieRODb tdb{db};
         tdb.set_block_and_prefix(base_block_number, block_id);
@@ -888,6 +909,23 @@ namespace
                 auto const chain_context =
                     context_buffer.advance(empty_senders, empty_authorities);
 
+                // TODO(ken): do we want to record events for these synthetic
+                //   blocks?
+                record_block_start(
+                    exec_recorder,
+                    bytes32_t{synthetic_block.header.number},
+                    chain.get_chain_id(),
+                    synthetic_block.header,
+                    synthetic_block.header.parent_hash,
+                    synthetic_block.header.number,
+                    0,
+                    synthetic_block.header.timestamp * 1'000'000'000UL,
+                    synthetic_block.transactions.size(),
+                    std::nullopt,
+                    std::nullopt);
+
+                record_block_marker_event(
+                    exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
                 BOOST_OUTCOME_TRY(
                     auto const receipts,
                     execute_block<traits>(
@@ -903,8 +941,10 @@ namespace
                         state_tracers,
                         system_call_state_tracer,
                         chain_context,
-                        /*exec_recorder=*/nullptr,
+                        exec_recorder,
                         emit_native_transfer_logs));
+                record_block_marker_event(
+                    exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 
                 // NOTE(dhil): Synthetic blocks are free, so we don't update
                 // `gas_consumed_so_far`.
@@ -912,6 +952,13 @@ namespace
                 bytes32_t const synthetic_block_hash = to_bytes(keccak256(
                     rlp::encode_block_header(synthetic_block.header)));
                 block_hash_buffer.advance(synthetic_block_hash);
+
+                (void)record_block_result(
+                    exec_recorder,
+                    BlockExecOutput{
+                        .eth_header = synthetic_block.header,
+                        .eth_block_hash = synthetic_block_hash,
+                    });
 
                 save_eth_simulate_log_entry(
                     synthetic_block,
@@ -953,6 +1000,9 @@ namespace
             // Construct state
             // State overrides are applied with an incarnation in the *previous*
             // block, rather than with the current header's block number.
+            // TODO(ken): state overrides are not recorded by execution events,
+            //   but eventually should be. This will wait until the release of
+            //   the execution events V2 schema
             auto const override_incarnation = Incarnation{
                 base_block_number + block_idx, Incarnation::LAST_TX - 1u};
             apply_state_overrides(
@@ -1008,6 +1058,21 @@ namespace
                     is_monad_trait_v<traits> ? std::nullopt : bo.withdrawals,
             };
 
+            record_block_start(
+                exec_recorder,
+                bytes32_t{block.header.number},
+                chain.get_chain_id(),
+                block.header,
+                block.header.parent_hash,
+                block.header.number,
+                0,
+                block.header.timestamp * 1'000'000'000UL,
+                block.transactions.size(),
+                std::nullopt,
+                std::nullopt);
+
+            record_block_marker_event(
+                exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
             BOOST_OUTCOME_TRY(
                 auto const receipts,
                 execute_block<traits>(
@@ -1023,8 +1088,10 @@ namespace
                     state_tracers,
                     system_call_state_tracer,
                     chain_context,
-                    /*exec_recorder=*/nullptr,
+                    exec_recorder,
                     emit_native_transfer_logs));
+            record_block_marker_event(
+                exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 
             // Receipts have cumulative gas_used (YP eq. 22), so
             // the last receipt's value is the total for the block.
@@ -1056,6 +1123,11 @@ namespace
             bytes32_t const block_hash =
                 to_bytes(keccak256(rlp::encode_block_header(block.header)));
             block_hash_buffer.advance(block_hash);
+
+            (void)record_block_result(
+                exec_recorder,
+                BlockExecOutput{
+                    .eth_header = block.header, .eth_block_hash = block_hash});
 
             std::vector<bytes32_t> txn_hashes{};
             txn_hashes.reserve(block.transactions.size());
@@ -1853,7 +1925,7 @@ struct monad_executor
         BlockHeader const &block_header, uint64_t const block_number,
         bytes32_t const &block_id, bytes32_t const &grandparent_id,
         uint64_t const gas_limit, size_t const max_calls,
-        bool emit_native_transfer_logs,
+        bool emit_native_transfer_logs, monad_event_ring const *exec_event_ring,
         void (*complete)(monad_executor_result *, void *user), void *const user)
     {
         monad_executor_result *const result = new monad_executor_result();
@@ -1886,6 +1958,7 @@ struct monad_executor
              fiber_group = &trace_block_group_,
              tx_exec_group = &trace_tx_exec_group_,
              &vm = vm_,
+             exec_event_ring = exec_event_ring,
              complete = complete,
              result = result,
              user = user]() {
@@ -1951,7 +2024,8 @@ struct monad_executor
                                 *block_overrides,
                                 gas_limit,
                                 max_calls,
-                                emit_native_transfer_logs);
+                                emit_native_transfer_logs,
+                                exec_event_ring);
                             MONAD_ASSERT(false);
                         }
                         else {
@@ -1976,7 +2050,8 @@ struct monad_executor
                                 *block_overrides,
                                 gas_limit,
                                 max_calls,
-                                emit_native_transfer_logs);
+                                emit_native_transfer_logs,
+                                exec_event_ring);
                             MONAD_ASSERT(false);
                         }
                     }();
@@ -2233,7 +2308,7 @@ void monad_executor_eth_simulate_submit(
     size_t max_calls,
     struct monad_state_override_vec const *const state_overrides,
     struct monad_block_override_vec const *const block_overrides,
-    bool emit_native_transfer_logs,
+    bool emit_native_transfer_logs, monad_event_ring const *exec_event_ring,
     void (*complete)(monad_executor_result *, void *user), void *user)
 {
 
@@ -2295,6 +2370,7 @@ void monad_executor_eth_simulate_submit(
         gas_limit,
         max_calls,
         emit_native_transfer_logs,
+        exec_event_ring,
         complete,
         user);
 }

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -20,6 +20,7 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/event/event_recorder.hpp>
 #include <category/core/fiber/fiber_group.hpp>
 #include <category/core/fiber/fiber_thread_pool.hpp>
 #include <category/core/fiber/priority_pool.hpp>
@@ -45,6 +46,10 @@
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/db/trie_rodb.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/exec_event_recorder.hpp>
+#include <category/execution/ethereum/event/record_block_events.hpp>
+#include <category/execution/ethereum/event/record_consensus_events.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
 #include <category/execution/ethereum/execute_block_header.hpp>
@@ -756,7 +761,9 @@ namespace
         struct monad_state_override_vec const &state_overrides,
         struct monad_block_override_vec const &block_overrides,
         uint64_t const gas_limit, size_t const max_calls,
-        bool emit_native_transfer_logs)
+        bool emit_native_transfer_logs,
+        monad_executor_event_record_options const *const event_record_opts,
+        ExecutionEventRecorder *const exec_recorder)
     {
         // TODO(dhil): Decide on the default timestamp increment.
         static constexpr uint64_t DEFAULT_TIMESTAMP_INCREMENT = 1;
@@ -960,6 +967,9 @@ namespace
             // Construct state
             // State overrides are applied with an incarnation in the *previous*
             // block, rather than with the current header's block number.
+            // TODO(ken): state overrides are not recorded by execution events,
+            //   but eventually should be. This will wait until the release of
+            //   the execution events V2 schema
             auto const override_incarnation = Incarnation{
                 base_block_number + block_idx, Incarnation::LAST_TX - 1u};
             apply_state_overrides(
@@ -1015,6 +1025,21 @@ namespace
                     is_monad_trait_v<traits> ? std::nullopt : bo.withdrawals,
             };
 
+            record_block_start(
+                exec_recorder,
+                bytes32_t{block.header.number},
+                chain.get_chain_id(),
+                block.header,
+                block.header.parent_hash,
+                block.header.number,
+                0,
+                block.header.timestamp * 1'000'000'000UL,
+                block.transactions.size(),
+                std::nullopt,
+                std::nullopt);
+
+            record_block_marker_event(
+                exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
             BOOST_OUTCOME_TRY(
                 auto const receipts,
                 execute_block<traits>(
@@ -1030,8 +1055,10 @@ namespace
                     state_tracers,
                     system_call_state_tracer,
                     chain_context,
-                    /*exec_recorder=*/nullptr,
+                    exec_recorder,
                     emit_native_transfer_logs));
+            record_block_marker_event(
+                exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_EXIT);
 
             // Receipts have cumulative gas_used (YP eq. 22), so
             // the last receipt's value is the total for the block.
@@ -1045,6 +1072,7 @@ namespace
                   gas_consumed_so_far >
                       std::numeric_limits<uint64_t>::max() - gas_used),
                 "gas limit exceeded");
+
             // No overflow. Add the consumed gas.
             gas_consumed_so_far += gas_used;
             // We may have exceeded the gas limit.
@@ -1064,6 +1092,18 @@ namespace
                 to_bytes(keccak256(rlp::encode_block_header(block.header)));
             block_hash_buffer.advance(block_hash);
 
+            (void)record_block_result(
+                exec_recorder,
+                BlockExecOutput{
+                    .eth_header = block.header, .eth_block_hash = block_hash});
+
+            if (event_record_opts->emit_mock_consensus_events) {
+                record_mock_consensus_events(
+                    exec_recorder,
+                    bytes32_t{block.header.number},
+                    block.header.number);
+            }
+
             std::vector<bytes32_t> txn_hashes{};
             txn_hashes.reserve(block.transactions.size());
             for (Transaction const &txn : block.transactions) {
@@ -1078,6 +1118,31 @@ namespace
         }
 
         return result;
+    }
+
+    void record_eth_simulate_exception(
+        ExecutionEventRecorder *const exec_recorder, int const status_code)
+    {
+        // The below domain ID was chosen to not conflict with any other real
+        // domain ID; the value was derived by following the random generation
+        // procedure described in status_code_domain.hpp; it is only used to
+        // report the presence of thrown exceptions along the eth_simulate path.
+        // The status code is the same value reported in the associated
+        // `struct monad_executor_result`. We don't expect to see this in
+        // production and this will be all be redone when Daniel refactors
+        // the error handling, so it's OK to define this locally.
+        constexpr uint64_t SIMULATE_EXCEPTION_DOMAIN_ID = 0xab8d8c53b915ed81;
+
+        if (exec_recorder == nullptr) {
+            return;
+        }
+        ReservedEvent const evm_error =
+            exec_recorder->reserve_block_event<monad_exec_evm_error>(
+                MONAD_EXEC_EVM_ERROR);
+        *evm_error.payload = monad_exec_evm_error{
+            .domain_id = SIMULATE_EXCEPTION_DOMAIN_ID,
+            .status_code = status_code};
+        exec_recorder->commit(evm_error);
     }
 }
 
@@ -1885,6 +1950,7 @@ struct monad_executor
         bytes32_t const &block_id, bytes32_t const &grandparent_id,
         uint64_t const gas_limit, size_t const max_calls,
         bool emit_native_transfer_logs,
+        monad_executor_event_record_options const *const event_record_opts,
         void (*complete)(monad_executor_result *, void *user), void *const user)
     {
         monad_executor_result *const result = new monad_executor_result();
@@ -1917,20 +1983,48 @@ struct monad_executor
              fiber_group = &trace_block_group_,
              tx_exec_group = &trace_tx_exec_group_,
              &vm = vm_,
+             event_record_opts = event_record_opts != nullptr
+                                     ? *event_record_opts
+                                     : monad_executor_event_record_options{},
              complete = complete,
              result = result,
              user = user]() {
-                try {
-                    fiber_group->queued_count.fetch_sub(
+                // Do the fiber accounting immediately, so we are free to exit
+                // along any path
+                fiber_group->queued_count.fetch_sub(
+                    1, std::memory_order_relaxed);
+                fiber_group->executing_count.fetch_add(
+                    1, std::memory_order_relaxed);
+                BOOST_SCOPE_EXIT_ALL(&fiber_group)
+                {
+                    fiber_group->executing_count.fetch_sub(
                         1, std::memory_order_relaxed);
-                    fiber_group->executing_count.fetch_add(
-                        1, std::memory_order_relaxed);
-                    BOOST_SCOPE_EXIT_ALL(&fiber_group)
-                    {
-                        fiber_group->executing_count.fetch_sub(
-                            1, std::memory_order_relaxed);
-                    };
+                };
 
+                // Create the execution event recorder, if we have an event
+                // ring to record to
+                std::optional<ExecutionEventRecorder> opt_event_recorder;
+                if (event_record_opts.exec_event_ring != nullptr) {
+                    auto ex_recorder = ExecutionEventRecorder::from_event_ring(
+                        event_record_opts.exec_event_ring);
+                    if (!ex_recorder) {
+                        result->status_code = EVMC_INTERNAL_ERROR;
+                        std::string const error = std::format(
+                            "error constructing event recorder: {}",
+                            std::error_condition{ex_recorder.error()}
+                                .message());
+                        result->message = strdup(error.c_str());
+                        MONAD_ASSERT(result->message);
+                        complete(result, user);
+                        return;
+                    }
+                    opt_event_recorder = std::move(*ex_recorder);
+                }
+                ExecutionEventRecorder *const exec_recorder =
+                    opt_event_recorder ? std::addressof(*opt_event_recorder)
+                                       : nullptr;
+
+                try {
                     auto const res = [&]() -> Result<nlohmann::json> {
                         auto authorities = std::vector<
                             std::vector<std::vector<std::optional<Address>>>>(
@@ -1982,7 +2076,9 @@ struct monad_executor
                                 *block_overrides,
                                 gas_limit,
                                 max_calls,
-                                emit_native_transfer_logs);
+                                emit_native_transfer_logs,
+                                &event_record_opts,
+                                exec_recorder);
                             MONAD_ASSERT(false);
                         }
                         else {
@@ -2007,12 +2103,16 @@ struct monad_executor
                                 *block_overrides,
                                 gas_limit,
                                 max_calls,
-                                emit_native_transfer_logs);
+                                emit_native_transfer_logs,
+                                &event_record_opts,
+                                exec_recorder);
                             MONAD_ASSERT(false);
                         }
                     }();
 
                     if (MONAD_UNLIKELY(res.has_error())) {
+                        (void)record_block_result(
+                            exec_recorder, res.error().clone());
                         result->status_code = EVMC_REJECTED;
                         result->message = strdup(res.error().message().c_str());
                         MONAD_ASSERT(result->message);
@@ -2035,12 +2135,16 @@ struct monad_executor
                     result->status_code = EVMC_INTERNAL_ERROR;
                     result->message = strdup(e.message());
                     MONAD_ASSERT(result->message);
+                    record_eth_simulate_exception(
+                        exec_recorder, result->status_code);
                     complete(result, user);
                 }
                 catch (...) {
                     result->status_code = EVMC_INTERNAL_ERROR;
                     result->message = strdup(UNEXPECTED_EXCEPTION_ERR_MSG);
                     MONAD_ASSERT(result->message);
+                    record_eth_simulate_exception(
+                        exec_recorder, result->status_code);
                     complete(result, user);
                 }
             });
@@ -2268,6 +2372,7 @@ void monad_executor_eth_simulate_submit(
     struct monad_state_override_vec const *const state_overrides,
     struct monad_block_override_vec const *const block_overrides,
     bool emit_native_transfer_logs,
+    monad_executor_event_record_options const *const event_record_opts,
     void (*complete)(monad_executor_result *, void *user), void *user)
 {
 
@@ -2329,6 +2434,7 @@ void monad_executor_eth_simulate_submit(
         gas_limit,
         max_calls,
         emit_native_transfer_logs,
+        event_record_opts,
         complete,
         user);
 }

--- a/category/rpc/monad_executor.h
+++ b/category/rpc/monad_executor.h
@@ -29,6 +29,7 @@ extern "C"
 
 static uint64_t const MONAD_ETH_CALL_LOW_GAS_LIMIT = 8'100'000;
 
+struct monad_event_ring;
 struct monad_executor;
 
 typedef struct monad_executor_result
@@ -130,7 +131,7 @@ void monad_executor_eth_simulate_submit(
     size_t rlp_grandparent_block_id_len, uint64_t gas_limit, size_t max_calls,
     struct monad_state_override_vec const *const state_overrides,
     struct monad_block_override_vec const *const block_overrides,
-    bool emit_native_transfer_logs,
+    bool emit_native_transfer_logs, struct monad_event_ring const *,
     void (*complete)(monad_executor_result *, void *user), void *user);
 
 #ifdef __cplusplus

--- a/category/rpc/monad_executor.h
+++ b/category/rpc/monad_executor.h
@@ -29,7 +29,15 @@ extern "C"
 
 static uint64_t const MONAD_ETH_CALL_LOW_GAS_LIMIT = 8'100'000;
 
+struct monad_event_ring;
 struct monad_executor;
+
+// Execution event recording options
+struct monad_executor_event_record_options
+{
+    struct monad_event_ring *exec_event_ring;
+    bool emit_mock_consensus_events;
+};
 
 typedef struct monad_executor_result
 {
@@ -131,6 +139,7 @@ void monad_executor_eth_simulate_submit(
     struct monad_state_override_vec const *const state_overrides,
     struct monad_block_override_vec const *const block_overrides,
     bool emit_native_transfer_logs,
+    struct monad_executor_event_record_options const *,
     void (*complete)(monad_executor_result *, void *user), void *user);
 
 #ifdef __cplusplus

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -4990,6 +4990,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer)
         state_override,
         block_override,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5100,6 +5101,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5201,6 +5203,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_single_call_block_255)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5258,6 +5261,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_empty_input)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5332,6 +5336,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_synthetic_gap)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5433,6 +5438,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_no_synthetic_gaps)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5539,6 +5545,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_stress_queue_rejection)
             subs[i]->so,
             subs[i]->bo,
             false,
+            nullptr, // exec_event_ring
             complete_callback,
             (void *)&subs[i]->ctx);
     }
@@ -5708,6 +5715,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
         so,
         bo,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5868,6 +5876,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
             so,
             bo,
             false,
+            nullptr, // exec_event_ring
             complete_callback,
             (void *)&ctx);
         f.get();
@@ -6009,6 +6018,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
             so,
             bo,
             false,
+            nullptr, // exec_event_ring
             complete_callback,
             (void *)&ctx);
         f.get();
@@ -6239,6 +6249,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
         so,
         bo,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6391,6 +6402,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
         so,
         bo,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6616,6 +6628,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
         so,
         bo,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6805,6 +6818,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
         so,
         bo,
         true, // emit_native_transfer_logs
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6956,6 +6970,7 @@ TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
         so,
         bo,
         true, // emit_native_transfer_logs
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7088,6 +7103,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
         so,
         bo,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7235,6 +7251,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7353,6 +7370,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7485,6 +7503,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7645,6 +7664,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_all_transaction_formats_single_block)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7768,6 +7788,7 @@ TEST_F(
         state_overrides,
         block_overrides,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7891,6 +7912,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_gas_limit_enforcement)
         state_override,
         block_override,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7984,6 +8006,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer_withdrawals_monad)
         state_override,
         block_override,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -8122,6 +8145,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_override_graceful_failure)
         state_override,
         block_override,
         false,
+        nullptr, // exec_event_ring
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -8195,6 +8219,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_transaction_input_too_long_causes_death)
             state_override,
             block_override,
             false,
+            nullptr, // exec_event_ring
             nullptr,
             nullptr),
         "maybe_txns\\.has_value\\(\\)"); // Pattern match on the expected

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -19,6 +19,9 @@
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/core/event/event_iterator.h>
+#include <category/core/event/event_ring.h>
+#include <category/core/event/event_ring_util.h>
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
@@ -38,6 +41,7 @@
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/reserve_balance.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
@@ -96,6 +100,7 @@
 #include <variant>
 #include <vector>
 
+#include <sys/mman.h>
 #include <unistd.h>
 
 using namespace monad;
@@ -4990,6 +4995,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer)
         state_override,
         block_override,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5014,6 +5020,235 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer)
     ASSERT_TRUE(sender_account.has_value());
     EXPECT_EQ(sender_account->balance, uint256_t{1'000'000});
 
+    monad_block_override_vec_destroy(block_override);
+    monad_state_override_vec_destroy(state_override);
+    monad_executor_destroy(executor);
+}
+
+// The same setup as `eth_simulate_v1_simple_transfer`, but this records
+// execution events to an ephemeral event ring
+TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer_exec_events)
+{
+    static constexpr Address sender =
+        0x00000000000000000000000000000000deadbeef_address;
+    static constexpr Address recipient =
+        0x00000000000000000000000000000000feedface_address;
+    static constexpr uint64_t gas_limit = 200'000'000;
+    static constexpr uint256_t transfer_value = 1000;
+    static constexpr uint256_t initial_balance = 1'000'000;
+
+    commit_sequential(
+        tdb,
+        StateDeltas{
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = initial_balance, .nonce = 0}}}},
+             {recipient,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}},
+        {},
+        BlockHeader{.number = 0});
+
+    for (uint64_t i = 1; i < 256; ++i) {
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
+    }
+
+    auto *executor = create_executor(dbname.string());
+
+    auto *const state_override = monad_state_override_vec_create(1);
+    auto *const block_override = monad_block_override_vec_create(1);
+
+    auto const rlp_senders = to_vec(rlp::encode_list2(
+        rlp::encode_list2(rlp::encode_address(std::make_optional(sender)))));
+
+    // A simple transfer
+    Transaction const tx{
+        .gas_limit = gas_limit,
+        .value = transfer_value,
+        .to = recipient,
+    };
+    auto const encoded_tx = rlp::encode_transaction(tx);
+    auto const rlp_calls = to_vec(rlp::encode_list2(
+        rlp::encode_list2(rlp::encode_string2(byte_string_view(encoded_tx)))));
+
+    // Header for the base block (block 1).
+    BlockHeader const header{
+        .number = 1,
+        .gas_limit = gas_limit,
+    };
+    auto const rlp_header = to_vec(rlp::encode_block_header(header));
+    auto const rlp_block_id = to_vec(rlp_finalized_id);
+
+    struct callback_context ctx;
+    boost::fibers::future<void> f = ctx.promise.get_future();
+
+    int event_ring_fd;
+    monad_event_ring event_ring;
+    monad_event_ring_simple_config const event_ring_cfg = {
+        .descriptors_shift = 20,
+        .payload_buf_shift = 28,
+        .context_large_pages = 0,
+        .content_type = MONAD_EVENT_CONTENT_TYPE_EXEC,
+        .schema_hash = g_monad_exec_event_schema_hash,
+    };
+
+    int rc = monad_event_ring_create_ephemeral(
+        &event_ring_cfg,
+        "eth_simulate_v1_test_ring",
+        0,
+        MAP_NORESERVE,
+        &event_ring_fd,
+        &event_ring);
+    ASSERT_EQ(rc, 0);
+
+    monad_executor_event_record_options const event_record_opts = {
+        .exec_event_ring = &event_ring,
+        .emit_mock_consensus_events = true,
+    };
+
+    monad_executor_eth_simulate_submit(
+        executor,
+        CHAIN_CONFIG_MONAD_DEVNET,
+        rlp_senders.data(),
+        rlp_senders.size(),
+        rlp_calls.data(),
+        rlp_calls.size(),
+        1, // block_number
+        rlp_header.data(),
+        rlp_header.size(),
+        rlp_block_id.data(),
+        rlp_block_id.size(),
+        rlp_finalized_id.data(),
+        rlp_finalized_id.size(),
+        simulate_gas_limit,
+        simulate_max_calls,
+        state_override,
+        block_override,
+        false,
+        &event_record_opts,
+        complete_callback,
+        (void *)&ctx);
+    f.get();
+
+    ASSERT_EQ(ctx.result->status_code, EVMC_SUCCESS);
+    ASSERT_TRUE(ctx.result->encoded_trace_len > 0);
+
+    // Check that the events are as expected
+    monad_event_descriptor event{};
+    monad_event_iterator event_iter;
+    monad_event_iter_result iter_result;
+    unsigned event_count = 0;
+    unsigned txn_count = 0;
+    unsigned call_frame_count = 0;
+    rc = monad_event_ring_init_iterator(&event_ring, &event_iter);
+    ASSERT_EQ(rc, 0);
+    monad_event_iterator_set_seqno(&event_iter, 1);
+
+ReadNextEvent:
+    iter_result = monad_event_iterator_try_next(&event_iter, &event);
+    ASSERT_EQ(iter_result, MONAD_EVENT_SUCCESS);
+    void const *const event_payload =
+        monad_event_ring_payload_peek(&event_ring, &event);
+    ASSERT_NE(event_payload, nullptr);
+    ++event_count;
+
+    // To avoid making the test too brittle, we don't want to assume too much
+    // about the exact execution event schema. Consequently, we don't specify
+    // exactly how many events the simulation should generate. However, we
+    // specify an upper limit so we can die in case the iteration isn't
+    // terminating in the way we expect.
+    ASSERT_LT(event_count, 128);
+
+    // We don't want to check every field here, because we're _not_ trying
+    // to check the correctness of the execution events recording in general,
+    // only that simulation infrastructure records the events related to the
+    // simulation.
+    switch (event.event_type) {
+    case MONAD_EXEC_BLOCK_START: {
+        monad_exec_block_start const *const block_start =
+            static_cast<monad_exec_block_start const *>(event_payload);
+        ASSERT_EQ(block_start->eth_block_input.txn_count, 1);
+        ASSERT_EQ(block_start->eth_block_input.gas_limit, gas_limit);
+    }
+        goto ReadNextEvent;
+
+    case MONAD_EXEC_TXN_HEADER_START: {
+        monad_exec_txn_header_start const *const txn_header =
+            static_cast<monad_exec_txn_header_start const *>(event_payload);
+
+        // There should be only one transaction; in the future if blocks
+        // contain injected system transactions this check would need to
+        // be more sophisticated.
+        ASSERT_EQ(++txn_count, 1);
+
+        ASSERT_EQ(Address{txn_header->sender}, sender);
+        ASSERT_EQ(Address{txn_header->txn_header.to}, recipient);
+        ASSERT_EQ(txn_header->txn_header.value, transfer_value);
+    }
+        goto ReadNextEvent;
+
+    case MONAD_EXEC_TXN_EVM_OUTPUT: {
+        monad_exec_txn_evm_output const *const txn_output =
+            static_cast<monad_exec_txn_evm_output const *>(event_payload);
+        ASSERT_TRUE(txn_output->receipt.status);
+        ASSERT_EQ(txn_output->receipt.gas_used, gas_limit);
+        ASSERT_EQ(txn_output->receipt.log_count, 0);
+    }
+        goto ReadNextEvent;
+
+    case MONAD_EXEC_TXN_CALL_FRAME: {
+        monad_exec_txn_call_frame const *const call_frame =
+            static_cast<monad_exec_txn_call_frame const *>(event_payload);
+
+        // There should be only one call frame
+        ASSERT_EQ(++call_frame_count, 1);
+
+        ASSERT_EQ(Address{call_frame->caller}, sender);
+        ASSERT_EQ(Address{call_frame->call_target}, recipient);
+        ASSERT_EQ(call_frame->value, transfer_value);
+        ASSERT_EQ(call_frame->gas, gas_limit);
+        ASSERT_EQ(call_frame->gas_used, gas_limit);
+        ASSERT_EQ(call_frame->evmc_status, 0);
+        ASSERT_EQ(call_frame->depth, 0);
+    }
+        goto ReadNextEvent;
+
+    case MONAD_EXEC_ACCOUNT_ACCESS: {
+        monad_exec_account_access const *const acct_access =
+            static_cast<monad_exec_account_access const *>(event_payload);
+        if (Address{acct_access->address} == sender) {
+            ASSERT_TRUE(acct_access->is_balance_modified);
+            ASSERT_TRUE(acct_access->is_nonce_modified);
+            ASSERT_EQ(acct_access->prestate.nonce, 0);
+            ASSERT_EQ(acct_access->prestate.balance, initial_balance);
+            ASSERT_EQ(acct_access->modified_nonce, 1);
+            ASSERT_EQ(
+                acct_access->modified_balance,
+                initial_balance - transfer_value);
+        }
+        if (Address{acct_access->address} == recipient) {
+            ASSERT_TRUE(acct_access->is_balance_modified);
+            ASSERT_FALSE(acct_access->is_nonce_modified);
+            ASSERT_EQ(acct_access->prestate.balance, uint256_t{0});
+            ASSERT_EQ(acct_access->modified_balance, transfer_value);
+        }
+    }
+        goto ReadNextEvent;
+
+    case MONAD_EXEC_BLOCK_FINALIZED:
+        // Seeing the mock finalization consensus event is the only way we can
+        // exit successfully; all other paths jump back to ReadNextEvent.
+        break;
+
+    default:
+        goto ReadNextEvent;
+    }
+
+    close(event_ring_fd);
+    monad_event_ring_unmap(&event_ring);
     monad_block_override_vec_destroy(block_override);
     monad_state_override_vec_destroy(state_override);
     monad_executor_destroy(executor);
@@ -5097,6 +5332,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5196,6 +5432,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_single_call_block_255)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5253,6 +5490,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_empty_input)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5327,6 +5565,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_synthetic_gap)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5428,6 +5667,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_no_synthetic_gaps)
         so_overrides,
         bo_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5534,6 +5774,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_stress_queue_rejection)
             subs[i]->so,
             subs[i]->bo,
             false,
+            nullptr, // event_record_opts
             complete_callback,
             (void *)&subs[i]->ctx);
     }
@@ -5696,6 +5937,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
         so,
         bo,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -5852,6 +6094,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
             so,
             bo,
             false,
+            nullptr, // event_record_opts
             complete_callback,
             (void *)&ctx);
         f.get();
@@ -5993,6 +6236,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
             so,
             bo,
             false,
+            nullptr, // event_record_opts
             complete_callback,
             (void *)&ctx);
         f.get();
@@ -6223,6 +6467,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
         so,
         bo,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6369,6 +6614,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
         so,
         bo,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6590,6 +6836,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
         so,
         bo,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6775,6 +7022,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
         so,
         bo,
         true, // emit_native_transfer_logs
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -6922,6 +7170,7 @@ TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
         so,
         bo,
         true, // emit_native_transfer_logs
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7050,6 +7299,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
         so,
         bo,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7193,6 +7443,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7305,6 +7556,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7431,6 +7683,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7585,6 +7838,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_all_transaction_formats_single_block)
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7702,6 +7956,7 @@ TEST_F(
         state_overrides,
         block_overrides,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7823,6 +8078,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_gas_limit_enforcement)
         state_override,
         block_override,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -7916,6 +8172,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer_withdrawals_monad)
         state_override,
         block_override,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -8054,6 +8311,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_override_graceful_failure)
         state_override,
         block_override,
         false,
+        nullptr, // event_record_opts
         complete_callback,
         (void *)&ctx);
     f.get();
@@ -8127,6 +8385,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_transaction_input_too_long_causes_death)
             state_override,
             block_override,
             false,
+            nullptr, // event_record_opts
             nullptr,
             nullptr),
         "maybe_txns\\.has_value\\(\\)"); // Pattern match on the expected
@@ -8210,6 +8469,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_beacon_roots)
             state_overrides,
             block_overrides,
             false,
+            nullptr, // event_record_opts
             complete_callback,
             (void *)&ctx);
 

--- a/rust/crates/monad-ethcall/src/executor/simulate.rs
+++ b/rust/crates/monad-ethcall/src/executor/simulate.rs
@@ -230,6 +230,7 @@ impl MonadExecutor {
                 state_overrides.as_mut_ptr(),
                 block_overrides.as_mut_ptr(),
                 emit_native_transfer_logs,
+                std::ptr::null(),
                 Some(eth_simulate_v1_submit_callback),
                 Box::into_raw(sender_ctx) as *mut std::ffi::c_void,
             );

--- a/rust/crates/monad-ethcall/src/lib.rs
+++ b/rust/crates/monad-ethcall/src/lib.rs
@@ -1138,6 +1138,7 @@ pub async fn eth_simulate_v1(
             state_overrides.as_mut_ptr(),
             block_overrides.as_mut_ptr(),
             emit_native_transfer_logs,
+            /*exec_event_ring*/ std::ptr::null(),
             Some(eth_simulate_v1_submit_callback),
             sender_ctx_ptr as *mut std::ffi::c_void,
         );


### PR DESCRIPTION
After this change, if a `monad_event_ring` is passed into the eth_simulateV1 C API (monad_executor_eth_simulate_submit), execution events will be recorded to that ring.

In the normal usage of execution events (in live blockchain daemon mode) we're recording to a single event ring file that is:

  - Owned and created by the `cmd/monad` binary

  - Resident in the filesystem as a rendezvous mechanism for others to find it (and "import" it with mmap(2))

For the eth_simulateV1 use case, the event ring will be a temporary, anonymous in-memory one, created by the call site that wants to read the event output. To help create such a ring, `event_ring_util.h` gains a new utility function, `monad_event_ring_create_ephemeral`.