### PR TITLE
[execution/monad]: validation: Enforce staking syscall ordering

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -264,6 +264,7 @@ add_library(
   "monad/staking/util/bls.hpp"
   "monad/staking/util/consensus_view.cpp"
   "monad/staking/util/consensus_view.hpp"
+  "monad/staking/util/constants.cpp"
   "monad/staking/util/constants.hpp"
   "monad/staking/util/delegator.cpp"
   "monad/staking/util/delegator.hpp"

--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -23,7 +23,6 @@
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
-#include <category/execution/ethereum/core/contract/abi_signatures.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
@@ -45,24 +44,6 @@
 #include <cstdint>
 
 #include <optional>
-
-MONAD_ANONYMOUS_NAMESPACE_BEGIN
-
-struct SyscallSelector
-{
-    static constexpr uint32_t REWARD =
-        abi_encode_selector("syscallReward(address)");
-    static constexpr uint32_t SNAPSHOT =
-        abi_encode_selector("syscallSnapshot()");
-    static constexpr uint32_t ON_EPOCH_CHANGE =
-        abi_encode_selector("syscallOnEpochChange(uint64)");
-};
-
-static_assert(SyscallSelector::REWARD == 0x791bdcf3);
-static_assert(SyscallSelector::SNAPSHOT == 0x157eeb21);
-static_assert(SyscallSelector::ON_EPOCH_CHANGE == 0x1d4e9f02);
-
-MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
@@ -236,11 +217,11 @@ Result<void> ExecuteSystemTransaction<traits>::execute_staking_syscall(
     calldata.remove_prefix(4);
 
     switch (signature) {
-    case SyscallSelector::REWARD:
+    case staking::selector::REWARD:
         return contract.syscall_reward<traits>(calldata, value);
-    case SyscallSelector::SNAPSHOT:
+    case staking::selector::SNAPSHOT:
         return contract.syscall_snapshot(calldata, value);
-    case SyscallSelector::ON_EPOCH_CHANGE:
+    case staking::selector::ON_EPOCH_CHANGE:
         return contract.syscall_on_epoch_change(calldata, value);
     }
     return staking::StakingError::MethodNotSupported;

--- a/category/execution/monad/staking/util/constants.cpp
+++ b/category/execution/monad/staking/util/constants.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/core/contract/abi_signatures.hpp>
+#include <category/execution/monad/staking/util/constants.hpp>
+
+MONAD_STAKING_NAMESPACE_BEGIN
+
+// assertions go in cpp file so compile-time hash functions don't get
+// re-executed in each translation unit.
+static_assert(
+    selector::REWARD == abi_encode_selector("syscallReward(address)"));
+
+static_assert(selector::SNAPSHOT == abi_encode_selector("syscallSnapshot()"));
+
+static_assert(
+    selector::ON_EPOCH_CHANGE ==
+    abi_encode_selector("syscallOnEpochChange(uint64)"));
+
+MONAD_STAKING_NAMESPACE_END

--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -104,7 +104,15 @@ namespace limits
     {
         return 1;
     }
-};
+}
+
+// staking contract function selectors
+namespace selector
+{
+    inline constexpr uint32_t REWARD = 0x791bdcf3;
+    inline constexpr uint32_t SNAPSHOT = 0x157eeb21;
+    inline constexpr uint32_t ON_EPOCH_CHANGE = 0x1d4e9f02;
+}
 
 // sanity check: commission rate doesn't exceed 100% (1e18)
 // note that: delegator_reward = (raw_reward * COMMISSION) / 1e18

--- a/category/execution/monad/validate_monad_block.cpp
+++ b/category/execution/monad/validate_monad_block.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/config.hpp>
+#include <category/core/int.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
 #include <category/execution/monad/staking/util/constants.hpp>
@@ -22,6 +23,9 @@
 #include <category/vm/evm/explicit_traits.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
 
 // TODO unstable paths between versions
 #if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
@@ -33,6 +37,18 @@
 #endif
 
 #include <concepts>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+enum class SyscallKind : uint8_t
+{
+    Snapshot = 0,
+    OnEpochChange = 1,
+    Reward = 2,
+    Other = 3,
+};
+
+MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
@@ -86,26 +102,46 @@ Result<void> static_validate_monad_body(
 
     auto const end_system_txn =
         txns.begin() + std::distance(senders.begin(), first_user_sender);
-    auto const is_reward = [](Transaction const &tx) { return tx.value > 0; };
 
-    // Find first reward txn.
-    auto const first_reward_txn =
-        std::find_if(txns.begin(), end_system_txn, is_reward);
-    if (MONAD_UNLIKELY(first_reward_txn == end_system_txn)) {
-        return outcome::success();
-    }
+    auto const classify = [](Transaction const &tx) -> SyscallKind {
+        if (MONAD_UNLIKELY(tx.data.size() < 4)) {
+            return SyscallKind::Other;
+        }
+        switch (load_be_unsafe<uint32_t>(tx.data.data())) {
+        case staking::selector::SNAPSHOT:
+            return SyscallKind::Snapshot;
+        case staking::selector::ON_EPOCH_CHANGE:
+            return SyscallKind::OnEpochChange;
+        case staking::selector::REWARD:
+            return SyscallKind::Reward;
+        }
+        return SyscallKind::Other;
+    };
 
-    // No other reward txn should come after it.
-    auto const another_reward =
-        std::find_if(std::next(first_reward_txn), end_system_txn, is_reward);
-    if (MONAD_UNLIKELY(another_reward != end_system_txn)) {
-        return MonadBlockError::MultipleRewardTransactions;
-    }
-
-    // Reward should not exceed 25 MON.
     constexpr uint256_t MAXIMUM_BLOCK_REWARD = 25 * staking::MON;
-    if (MONAD_UNLIKELY(first_reward_txn->value > MAXIMUM_BLOCK_REWARD)) {
-        return MonadBlockError::InvalidRewardValue;
+
+    std::array<bool, 3> seen{};
+    std::optional<SyscallKind> last_kind;
+    for (auto it = txns.begin(); it != end_system_txn; ++it) {
+        auto const kind = classify(*it);
+        if (MONAD_UNLIKELY(kind == SyscallKind::Other)) {
+            return MonadBlockError::UnknownSystemTransaction;
+        }
+
+        if (MONAD_UNLIKELY(seen[static_cast<uint8_t>(kind)])) {
+            return MonadBlockError::DuplicateSystemTransaction;
+        }
+        seen[static_cast<uint8_t>(kind)] = true;
+
+        if (MONAD_UNLIKELY(last_kind.has_value() && kind < *last_kind)) {
+            return MonadBlockError::SystemTransactionOutOfOrder;
+        }
+        last_kind = kind;
+
+        if (kind == SyscallKind::Reward &&
+            MONAD_UNLIKELY(it->value > MAXIMUM_BLOCK_REWARD)) {
+            return MonadBlockError::InvalidRewardValue;
+        }
     }
 
     return outcome::success();
@@ -130,8 +166,14 @@ quick_status_code_from_enum<monad::MonadBlockError>::value_mappings()
         {MonadBlockError::SystemTransactionNotFirstInBlock,
          "system transaction not first in block",
          {}},
-        {MonadBlockError::MultipleRewardTransactions,
-         "multiple reward transactions",
+        {MonadBlockError::SystemTransactionOutOfOrder,
+         "system transaction out of order",
+         {}},
+        {MonadBlockError::DuplicateSystemTransaction,
+         "duplicate system transaction",
+         {}},
+        {MonadBlockError::UnknownSystemTransaction,
+         "unknown system transaction",
          {}},
         {MonadBlockError::InvalidRewardValue, "invalid reward value", {}},
     };

--- a/category/execution/monad/validate_monad_block.hpp
+++ b/category/execution/monad/validate_monad_block.hpp
@@ -42,7 +42,9 @@ enum class MonadBlockError
     TimestampMismatch,
     BaseFeeMismatch,
     SystemTransactionNotFirstInBlock,
-    MultipleRewardTransactions,
+    SystemTransactionOutOfOrder,
+    DuplicateSystemTransaction,
+    UnknownSystemTransaction,
     InvalidRewardValue,
 };
 

--- a/category/execution/monad/validate_monad_block_test.cpp
+++ b/category/execution/monad/validate_monad_block_test.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/core/contract/big_endian.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/monad/staking/util/constants.hpp>
 #include <category/execution/monad/system_sender.hpp>
@@ -26,33 +27,31 @@
 #include <gtest/gtest.h>
 
 using namespace monad;
+using staking::selector::ON_EPOCH_CHANGE;
+using staking::selector::REWARD;
+using staking::selector::SNAPSHOT;
 
-TYPED_TEST(MonadTraitsTest, no_system_txns)
+namespace
 {
-    std::vector<Address> senders{
-        0xaaaa_address,
-        0xbbbb_address,
-        0xcccc_address,
-    };
-    std::vector<Transaction> txns(senders.size());
-    auto const res =
-        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
-    EXPECT_FALSE(res.has_error());
-}
+    byte_string syscall_calldata(uint32_t const selector)
+    {
+        u32_be const be{selector};
+        return byte_string{be.bytes, sizeof(be.bytes)};
+    }
 
-TYPED_TEST(MonadTraitsTest, multiple_system_txns_ok)
-{
-    std::vector<Address> senders{
-        SYSTEM_SENDER,
-        SYSTEM_SENDER,
-        0xaaaa_address,
-        0xbbbb_address,
-    };
-    std::vector<Transaction> txns(senders.size());
-    txns[1].value = 25 * staking::MON;
-    auto const res =
-        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
-    EXPECT_FALSE(res.has_error());
+    std::vector<Address> system_senders(size_t const n)
+    {
+        return std::vector<Address>(n, SYSTEM_SENDER);
+    }
+
+    std::vector<Transaction> system_txns(std::vector<uint32_t> const &selectors)
+    {
+        std::vector<Transaction> txns(selectors.size());
+        for (size_t i = 0; i < selectors.size(); ++i) {
+            txns[i].data = syscall_calldata(selectors[i]);
+        }
+        return txns;
+    }
 }
 
 TYPED_TEST(MonadTraitsTest, system_txn_comes_after_user_txn)
@@ -78,10 +77,8 @@ TYPED_TEST(MonadTraitsTest, system_txn_comes_after_user_txn)
     }
 }
 
-TYPED_TEST(MonadTraitsTest, multiple_reward_txns_error)
+TYPED_TEST(MonadTraitsTest, system_txns_then_user_txns_ok)
 {
-    using Trait = typename TestFixture::Trait;
-
     std::vector<Address> senders{
         SYSTEM_SENDER,
         SYSTEM_SENDER,
@@ -89,16 +86,116 @@ TYPED_TEST(MonadTraitsTest, multiple_reward_txns_error)
         0xbbbb_address,
     };
     std::vector<Transaction> txns(senders.size());
-    txns[0].value = 25 * staking::MON;
-    txns[1].value = 1 * staking::MON;
+    txns[0].data = syscall_calldata(SNAPSHOT);
+    txns[1].data = syscall_calldata(REWARD);
     auto const res =
         static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
-    if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+    EXPECT_FALSE(res.has_error());
+}
+
+TYPED_TEST(MonadTraitsTest, valid_syscall_ordering)
+{
+    std::vector<std::vector<uint32_t>> const orders{
+        {},
+        {SNAPSHOT},
+        {ON_EPOCH_CHANGE},
+        {REWARD},
+        {SNAPSHOT, ON_EPOCH_CHANGE},
+        {SNAPSHOT, REWARD},
+        {ON_EPOCH_CHANGE, REWARD},
+        {SNAPSHOT, ON_EPOCH_CHANGE, REWARD},
+    };
+
+    for (auto const &order : orders) {
+        auto const senders = system_senders(order.size());
+        auto const txns = system_txns(order);
+        auto const res =
+            static_validate_monad_body<typename TestFixture::Trait>(
+                senders, txns);
         EXPECT_FALSE(res.has_error());
     }
-    else {
-        ASSERT_TRUE(res.has_error());
-        EXPECT_EQ(res.error(), MonadBlockError::MultipleRewardTransactions);
+}
+
+TYPED_TEST(MonadTraitsTest, invalid_syscall_ordering)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<std::vector<uint32_t>> const orders{
+        {ON_EPOCH_CHANGE, SNAPSHOT},
+        {REWARD, SNAPSHOT},
+        {REWARD, ON_EPOCH_CHANGE},
+        {SNAPSHOT, REWARD, ON_EPOCH_CHANGE},
+        {ON_EPOCH_CHANGE, SNAPSHOT, REWARD},
+        {ON_EPOCH_CHANGE, REWARD, SNAPSHOT},
+        {REWARD, SNAPSHOT, ON_EPOCH_CHANGE},
+        {REWARD, ON_EPOCH_CHANGE, SNAPSHOT},
+    };
+
+    for (auto const &order : orders) {
+        auto const senders = system_senders(order.size());
+        auto const txns = system_txns(order);
+        auto const res = static_validate_monad_body<Trait>(senders, txns);
+        if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+            EXPECT_FALSE(res.has_error());
+        }
+        else {
+            ASSERT_TRUE(res.has_error());
+            EXPECT_EQ(
+                res.error(), MonadBlockError::SystemTransactionOutOfOrder);
+        }
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, duplicate_syscalls_error)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<std::vector<uint32_t>> const orders{
+        {SNAPSHOT, SNAPSHOT},
+        {ON_EPOCH_CHANGE, ON_EPOCH_CHANGE},
+        {REWARD, REWARD},
+        {SNAPSHOT, SNAPSHOT, ON_EPOCH_CHANGE},
+        {SNAPSHOT, ON_EPOCH_CHANGE, ON_EPOCH_CHANGE},
+        {ON_EPOCH_CHANGE, ON_EPOCH_CHANGE, REWARD},
+        {SNAPSHOT, REWARD, REWARD},
+    };
+
+    for (auto const &order : orders) {
+        auto const senders = system_senders(order.size());
+        auto const txns = system_txns(order);
+        auto const res = static_validate_monad_body<Trait>(senders, txns);
+        if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+            EXPECT_FALSE(res.has_error());
+        }
+        else {
+            ASSERT_TRUE(res.has_error());
+            EXPECT_EQ(res.error(), MonadBlockError::DuplicateSystemTransaction);
+        }
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, unknown_syscall_error)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<byte_string> const datas{
+        syscall_calldata(0xdeadbeef),
+        byte_string{},
+        byte_string{0x15, 0x7e, 0xeb},
+    };
+
+    for (auto const &data : datas) {
+        auto const senders = system_senders(1);
+        std::vector<Transaction> txns(1);
+        txns[0].data = data;
+        auto const res = static_validate_monad_body<Trait>(senders, txns);
+        if constexpr (Trait::monad_rev() < MONAD_FOUR) {
+            EXPECT_FALSE(res.has_error());
+        }
+        else {
+            ASSERT_TRUE(res.has_error());
+            EXPECT_EQ(res.error(), MonadBlockError::UnknownSystemTransaction);
+        }
     }
 }
 
@@ -111,6 +208,7 @@ TYPED_TEST(MonadTraitsTest, reward_txn_exceeds_maximum)
         0xaaaa_address,
     };
     std::vector<Transaction> txns(senders.size());
+    txns[0].data = syscall_calldata(REWARD);
     txns[0].value = 26 * staking::MON;
     auto const res =
         static_validate_monad_body<typename TestFixture::Trait>(senders, txns);


### PR DESCRIPTION
Classify each system transaction by selector and require the staking syscalls to appear in canonical order: snapshot, then epoch change, then reward. Zero of any kind is permitted. Duplicates, out-of-order calls, and unrecognized system transactions are rejected. Each of these combinations is exercised in the new validate_monad_block_test.cpp.

This logic is no more restrictive than the logic implemented by consensus. Their mental model is slightly easier, because they can generate the expected syscalls and compare that to the transactions in the proposal. Execution is opaque to the consensus logic and enforces relative ordering of transactions.