### PR TITLE
[execution/vm] Add in-tree monad_access_status and monad_storage_status

### DIFF
--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -65,7 +65,7 @@ evmc_storage_status EvmcHostBase::set_storage(
     evmc::bytes32 const &value) noexcept
 {
     try {
-        return state_.set_storage(address, key, value);
+        return to_evmc_storage_status(state_.set_storage(address, key, value));
     }
     catch (...) {
         capture_current_exception();

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -30,6 +30,7 @@
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/vm/evm/access_status.h>
 #include <category/vm/evm/delegation.hpp>
+#include <category/vm/evm/storage_status.h>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/host.hpp>
 #include <category/vm/runtime/types.hpp>

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -28,6 +28,7 @@
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
+#include <category/vm/evm/access_status.h>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/host.hpp>
@@ -202,7 +203,7 @@ struct EvmcHost final : public EvmcHostBase
             if (is_precompile<traits>(address)) {
                 return EVMC_ACCESS_WARM;
             }
-            return state_.access_account(address);
+            return to_evmc_access_status(state_.access_account(address));
         }
         catch (...) {
             capture_current_exception();
@@ -215,7 +216,8 @@ struct EvmcHost final : public EvmcHostBase
         evmc::bytes32 const &key) noexcept override
     {
         try {
-            return state_.access_storage<traits>(address, key);
+            return to_evmc_access_status(
+                state_.access_storage<traits>(address, key));
         }
         catch (...) {
             capture_current_exception();

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -213,10 +213,10 @@ TEST_F(InMemoryStateTest, access_account)
 
     State s{bs, Incarnation{1, 1}};
 
-    EXPECT_EQ(s.access_account(a), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_account(a), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_account(b), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_account(b), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_account(a), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_account(a), MONAD_ACCESS_WARM);
+    EXPECT_EQ(s.access_account(b), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_account(b), MONAD_ACCESS_WARM);
 }
 
 TEST_F(InMemoryStateTest, account_exists)
@@ -1035,14 +1035,14 @@ TYPED_TEST(InMemoryStateTraitsTest, access_storage)
     BlockState bs{this->tdb, this->vm};
 
     State s{bs, Incarnation{1, 1}};
-    EXPECT_EQ(s.access_storage<Trait>(a, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage<Trait>(a, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage<Trait>(b, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage<Trait>(b, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage<Trait>(a, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage<Trait>(a, key2), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage<Trait>(b, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage<Trait>(b, key2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(a, key1), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(a, key1), MONAD_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(b, key1), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(b, key1), MONAD_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(a, key2), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(a, key2), MONAD_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<Trait>(b, key2), MONAD_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<Trait>(b, key2), MONAD_ACCESS_WARM);
 }
 
 TEST_F(InMemoryStateTest, get_storage)

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -1091,7 +1091,7 @@ TEST_F(InMemoryStateTest, set_storage_modified)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
-    EXPECT_EQ(s.set_storage(a, key2, value3), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(s.set_storage(a, key2, value3), MONAD_STORAGE_MODIFIED);
     EXPECT_EQ(s.get_storage(a, key2), value3);
 }
 
@@ -1111,11 +1111,11 @@ TEST_F(InMemoryStateTest, set_storage_deleted)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(s.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
     EXPECT_EQ(s.get_storage(b, key1), null);
-    EXPECT_EQ(s.set_storage(b, key1, null), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(b, key1, null), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(b, key1), null);
-    EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_DELETED_ADDED);
+    EXPECT_EQ(s.set_storage(b, key1, value2), MONAD_STORAGE_DELETED_ADDED);
     EXPECT_EQ(s.get_storage(b, key1), value2);
 }
 
@@ -1130,11 +1130,11 @@ TEST_F(InMemoryStateTest, set_storage_added)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key1, value1), EVMC_STORAGE_ADDED);
+    EXPECT_EQ(s.set_storage(b, key1, value1), MONAD_STORAGE_ADDED);
     EXPECT_EQ(s.get_storage(b, key1), value1);
-    EXPECT_EQ(s.set_storage(b, key1, value1), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(b, key1, value1), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(b, key1), value1);
-    EXPECT_EQ(s.set_storage(b, key1, value2), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(b, key1, value2), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(b, key1), value2);
 }
 
@@ -1154,9 +1154,9 @@ TEST_F(InMemoryStateTest, set_storage_different_assigned)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
-    EXPECT_EQ(s.set_storage(a, key2, value3), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(s.set_storage(a, key2, value3), MONAD_STORAGE_MODIFIED);
     EXPECT_EQ(s.get_storage(a, key2), value3);
-    EXPECT_EQ(s.set_storage(a, key2, value1), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(a, key2, value1), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(a, key2), value1);
 }
 
@@ -1176,7 +1176,7 @@ TEST_F(InMemoryStateTest, set_storage_unchanged_assigned)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(a));
-    EXPECT_EQ(s.set_storage(a, key2, value2), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(a, key2, value2), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(a, key2), value2);
 }
 
@@ -1191,9 +1191,9 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key1, value1), EVMC_STORAGE_ADDED);
+    EXPECT_EQ(s.set_storage(b, key1, value1), MONAD_STORAGE_ADDED);
     EXPECT_EQ(s.get_storage(b, key1), value1);
-    EXPECT_EQ(s.set_storage(b, key1, null), EVMC_STORAGE_ADDED_DELETED);
+    EXPECT_EQ(s.set_storage(b, key1, null), MONAD_STORAGE_ADDED_DELETED);
     EXPECT_EQ(s.get_storage(b, key1), null);
 }
 
@@ -1208,9 +1208,9 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted_null)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key1, null), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(b, key1, null), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(b, key1), null);
-    EXPECT_EQ(s.set_storage(b, key1, null), EVMC_STORAGE_ASSIGNED);
+    EXPECT_EQ(s.set_storage(b, key1, null), MONAD_STORAGE_ASSIGNED);
     EXPECT_EQ(s.get_storage(b, key1), null);
 }
 
@@ -1229,9 +1229,9 @@ TEST_F(InMemoryStateTest, set_storage_modify_delete)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key2, value1), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(s.set_storage(b, key2, value1), MONAD_STORAGE_MODIFIED);
     EXPECT_EQ(s.get_storage(b, key2), value1);
-    EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_MODIFIED_DELETED);
+    EXPECT_EQ(s.set_storage(b, key2, null), MONAD_STORAGE_MODIFIED_DELETED);
     EXPECT_EQ(s.get_storage(b, key2), null);
 }
 
@@ -1250,9 +1250,9 @@ TEST_F(InMemoryStateTest, set_storage_delete_restored)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(s.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
     EXPECT_EQ(s.get_storage(b, key2), null);
-    EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
+    EXPECT_EQ(s.set_storage(b, key2, value2), MONAD_STORAGE_DELETED_RESTORED);
     EXPECT_EQ(s.get_storage(b, key2), value2);
 }
 
@@ -1271,9 +1271,9 @@ TEST_F(InMemoryStateTest, set_storage_modified_restored)
 
     State s{bs, Incarnation{1, 1}};
     EXPECT_TRUE(s.account_exists(b));
-    EXPECT_EQ(s.set_storage(b, key2, value1), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(s.set_storage(b, key2, value1), MONAD_STORAGE_MODIFIED);
     EXPECT_EQ(s.get_storage(b, key2), value1);
-    EXPECT_EQ(s.set_storage(b, key2, value2), EVMC_STORAGE_MODIFIED_RESTORED);
+    EXPECT_EQ(s.set_storage(b, key2, value2), MONAD_STORAGE_MODIFIED_RESTORED);
     EXPECT_EQ(s.get_storage(b, key2), value2);
 }
 
@@ -1414,13 +1414,13 @@ TEST_F(InMemoryStateTest, can_merge_same_account_different_storage)
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
-    EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
     EXPECT_TRUE(bs.can_merge(as));
     bs.merge(as);
 
     State cs{bs, Incarnation{1, 2}};
     EXPECT_TRUE(cs.account_exists(b));
-    EXPECT_EQ(cs.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(cs.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
     EXPECT_TRUE(bs.can_merge(cs));
     bs.merge(cs);
 }
@@ -1441,11 +1441,11 @@ TEST_F(InMemoryStateTest, cant_merge_colliding_storage)
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
-    EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
+    EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
 
     State cs{bs, Incarnation{1, 2}};
     EXPECT_TRUE(cs.account_exists(b));
-    EXPECT_EQ(cs.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(cs.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
 
     EXPECT_TRUE(bs.can_merge(as));
     bs.merge(as);
@@ -1455,7 +1455,7 @@ TEST_F(InMemoryStateTest, cant_merge_colliding_storage)
     {
         State cs{bs, Incarnation{1, 2}};
         EXPECT_TRUE(cs.account_exists(b));
-        EXPECT_EQ(cs.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(cs.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
         EXPECT_TRUE(bs.can_merge(cs));
         bs.merge(cs);
     }
@@ -1488,16 +1488,16 @@ TYPED_TEST(InMemoryStateTraitsTest, merge_txn0_and_txn1)
 
     State as{bs, Incarnation{1, 1}};
     EXPECT_TRUE(as.account_exists(b));
-    EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-    EXPECT_EQ(as.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
-    EXPECT_EQ(as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
+    EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
+    EXPECT_EQ(as.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
+    EXPECT_EQ(as.set_storage(b, key2, value2), MONAD_STORAGE_DELETED_RESTORED);
     EXPECT_TRUE(bs.can_merge(as));
     bs.merge(as);
 
     State cs{bs, Incarnation{1, 2}};
     EXPECT_TRUE(cs.account_exists(c));
-    EXPECT_EQ(cs.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
-    EXPECT_EQ(cs.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
+    EXPECT_EQ(cs.set_storage(c, key1, null), MONAD_STORAGE_DELETED);
+    EXPECT_EQ(cs.set_storage(c, key2, null), MONAD_STORAGE_DELETED);
     EXPECT_EQ(
         cs.selfdestruct<typename TestFixture::Trait>(c, a),
         std::make_pair(true, 50'000));
@@ -1543,8 +1543,8 @@ TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
     State as{bs, Incarnation{1, 1}};
 
     as.create_contract(a);
-    EXPECT_EQ(as.set_storage(a, key1, value1), EVMC_STORAGE_ADDED);
-    EXPECT_EQ(as.set_storage(a, key1, null), EVMC_STORAGE_ADDED_DELETED);
+    EXPECT_EQ(as.set_storage(a, key1, value1), MONAD_STORAGE_ADDED);
+    EXPECT_EQ(as.set_storage(a, key1, null), MONAD_STORAGE_ADDED_DELETED);
     bs.merge(as);
     auto [released_state, released_code, _] = std::move(bs).release();
     commit_simple(
@@ -1601,10 +1601,10 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         EXPECT_TRUE(as.account_exists(b));
         as.add_to_balance(b, 42'000);
         as.set_nonce(b, 3);
-        EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-        EXPECT_EQ(as.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
         EXPECT_EQ(
-            as.set_storage(b, key2, value2), EVMC_STORAGE_DELETED_RESTORED);
+            as.set_storage(b, key2, value2), MONAD_STORAGE_DELETED_RESTORED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         auto [released_state, released_code, _] = std::move(bs).release();
@@ -1626,8 +1626,8 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         State cs{bs, Incarnation{2, 1}};
         EXPECT_TRUE(cs.account_exists(a));
         EXPECT_TRUE(cs.account_exists(c));
-        EXPECT_EQ(cs.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
-        EXPECT_EQ(cs.set_storage(c, key2, value1), EVMC_STORAGE_MODIFIED);
+        EXPECT_EQ(cs.set_storage(c, key1, null), MONAD_STORAGE_DELETED);
+        EXPECT_EQ(cs.set_storage(c, key2, value1), MONAD_STORAGE_MODIFIED);
         EXPECT_EQ(
             cs.selfdestruct<typename TestFixture::Trait>(c, a),
             std::make_pair(true, 50'000));
@@ -1711,8 +1711,8 @@ TYPED_TEST(OnDiskTestSuite, commit_multiple_proposals)
         EXPECT_TRUE(as.account_exists(b));
         as.add_to_balance(b, 42'000);
         as.set_nonce(b, 3);
-        EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-        EXPECT_EQ(as.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
 
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
@@ -1740,8 +1740,8 @@ TYPED_TEST(OnDiskTestSuite, commit_multiple_proposals)
         EXPECT_TRUE(as.account_exists(b));
         as.add_to_balance(b, 44'000);
         as.set_nonce(b, 3);
-        EXPECT_EQ(as.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
-        EXPECT_EQ(as.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         // Commit block 11 round 6 on top of block 10 round 5
@@ -1769,9 +1769,9 @@ TYPED_TEST(OnDiskTestSuite, commit_multiple_proposals)
         EXPECT_TRUE(as.account_exists(b));
         as.add_to_balance(b, 32'000);
         as.set_nonce(b, 3);
-        EXPECT_EQ(as.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
-        EXPECT_EQ(as.set_storage(b, key2, value3), EVMC_STORAGE_MODIFIED);
-        EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_DELETED_ADDED);
+        EXPECT_EQ(as.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key2, value3), MONAD_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_DELETED_ADDED);
         EXPECT_TRUE(bs.can_merge(as));
         bs.merge(as);
         // Commit block 11 round 7 on top of block 10 round 5
@@ -1911,8 +1911,8 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
     {
         State as{bs_111, Incarnation{11, 1}};
         as.add_to_balance(b, 40'000);
-        EXPECT_EQ(as.set_storage(b, key1, value2), EVMC_STORAGE_MODIFIED);
-        EXPECT_EQ(as.set_storage(b, key2, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key1, value2), MONAD_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(b, key2, null), MONAD_STORAGE_DELETED);
         EXPECT_TRUE(bs_111.can_merge(as));
         bs_111.merge(as);
     }
@@ -1947,7 +1947,7 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
     {
         State as{bs_121, Incarnation{12, 1}};
         as.add_to_balance(c, 10'000);
-        EXPECT_EQ(as.set_storage(c, key2, value1), EVMC_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(c, key2, value1), MONAD_STORAGE_MODIFIED);
         EXPECT_TRUE(bs_121.can_merge(as));
         bs_121.merge(as);
     }
@@ -1981,8 +1981,8 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
     {
         State as{bs_112, Incarnation{11, 1}};
         as.add_to_balance(a, 20'000);
-        EXPECT_EQ(as.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
-        EXPECT_EQ(as.set_storage(c, key1, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(c, key1, null), MONAD_STORAGE_DELETED);
         EXPECT_TRUE(bs_112.can_merge(as));
         bs_112.merge(as);
     }
@@ -2005,7 +2005,7 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
     {
         State as{bs_122, Incarnation{12, 1}};
         as.add_to_balance(b, 20'000);
-        EXPECT_EQ(as.set_storage(b, key1, value3), EVMC_STORAGE_ADDED);
+        EXPECT_EQ(as.set_storage(b, key1, value3), MONAD_STORAGE_ADDED);
         EXPECT_TRUE(bs_122.can_merge(as));
         bs_122.merge(as);
     }
@@ -2029,9 +2029,9 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
         State as{bs_131, Incarnation{13, 1}};
         as.add_to_balance(a, 30'000);
         as.add_to_balance(b, 20'000);
-        EXPECT_EQ(as.set_storage(b, key2, value1), EVMC_STORAGE_ADDED);
-        EXPECT_EQ(as.set_storage(c, key1, value2), EVMC_STORAGE_MODIFIED);
-        EXPECT_EQ(as.set_storage(c, key2, null), EVMC_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(b, key2, value1), MONAD_STORAGE_ADDED);
+        EXPECT_EQ(as.set_storage(c, key1, value2), MONAD_STORAGE_MODIFIED);
+        EXPECT_EQ(as.set_storage(c, key2, null), MONAD_STORAGE_DELETED);
         EXPECT_TRUE(bs_131.can_merge(as));
         bs_131.merge(as);
     }
@@ -2054,8 +2054,8 @@ TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
     // b13 r132 r122                  --        v3
     {
         State as{bs_132, Incarnation{13, 1}};
-        EXPECT_EQ(as.set_storage(b, key1, null), EVMC_STORAGE_DELETED);
-        EXPECT_EQ(as.set_storage(c, key1, value3), EVMC_STORAGE_ADDED);
+        EXPECT_EQ(as.set_storage(b, key1, null), MONAD_STORAGE_DELETED);
+        EXPECT_EQ(as.set_storage(c, key1, value3), MONAD_STORAGE_ADDED);
         EXPECT_TRUE(bs_132.can_merge(as));
         bs_132.merge(as);
     }

--- a/category/execution/ethereum/state3/account_state.cpp
+++ b/category/execution/ethereum/state3/account_state.cpp
@@ -22,21 +22,21 @@
 
 MONAD_NAMESPACE_BEGIN
 
-evmc_storage_status AccountState::zero_out_key(
+monad_storage_status AccountState::zero_out_key(
     bytes32_t const &key, bytes32_t const &original_value,
     bytes32_t const &current_value)
 {
     auto const status = [&] {
         if (current_value == bytes32_t{}) {
-            return EVMC_STORAGE_ASSIGNED;
+            return MONAD_STORAGE_ASSIGNED;
         }
         else if (original_value == current_value) {
-            return EVMC_STORAGE_DELETED;
+            return MONAD_STORAGE_DELETED;
         }
         else if (original_value == bytes32_t{}) {
-            return EVMC_STORAGE_ADDED_DELETED;
+            return MONAD_STORAGE_ADDED_DELETED;
         }
-        return EVMC_STORAGE_MODIFIED_DELETED;
+        return MONAD_STORAGE_MODIFIED_DELETED;
     }();
 
     storage_ = storage_.insert({key, bytes32_t{}});
@@ -44,27 +44,27 @@ evmc_storage_status AccountState::zero_out_key(
     return status;
 }
 
-evmc_storage_status AccountState::set_current_value(
+monad_storage_status AccountState::set_current_value(
     bytes32_t const &key, bytes32_t const &value,
     bytes32_t const &original_value, bytes32_t const &current_value)
 {
     auto const status = [&] {
         if (current_value == bytes32_t{}) {
             if (original_value == bytes32_t{}) {
-                return EVMC_STORAGE_ADDED;
+                return MONAD_STORAGE_ADDED;
             }
             else if (value == original_value) {
-                return EVMC_STORAGE_DELETED_RESTORED;
+                return MONAD_STORAGE_DELETED_RESTORED;
             }
-            return EVMC_STORAGE_DELETED_ADDED;
+            return MONAD_STORAGE_DELETED_ADDED;
         }
         else if (original_value == current_value && original_value != value) {
-            return EVMC_STORAGE_MODIFIED;
+            return MONAD_STORAGE_MODIFIED;
         }
         else if (original_value == value && original_value != current_value) {
-            return EVMC_STORAGE_MODIFIED_RESTORED;
+            return MONAD_STORAGE_MODIFIED_RESTORED;
         }
-        return EVMC_STORAGE_ASSIGNED;
+        return MONAD_STORAGE_ASSIGNED;
     }();
 
     storage_ = storage_.insert({key, value});

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -23,6 +23,7 @@
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/state3/account_substate.hpp>
 #include <category/execution/ethereum/state3/page_tracker.hpp>
+#include <category/vm/evm/storage_status.h>
 
 #include <evmc/evmc.h>
 
@@ -71,11 +72,11 @@ public:
     StorageMap transient_storage_{};
     PageTracker page_tracker_{};
 
-    evmc_storage_status zero_out_key(
+    monad_storage_status zero_out_key(
         bytes32_t const &key, bytes32_t const &original_value,
         bytes32_t const &current_value);
 
-    evmc_storage_status set_current_value(
+    monad_storage_status set_current_value(
         bytes32_t const &key, bytes32_t const &value,
         bytes32_t const &original_value, bytes32_t const &current_value);
 
@@ -133,7 +134,7 @@ public:
         return {};
     }
 
-    evmc_storage_status set_storage(
+    monad_storage_status set_storage(
         bytes32_t const &key, bytes32_t const &value,
         bytes32_t const &original_value)
     {

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -25,8 +25,6 @@
 #include <category/execution/ethereum/state3/page_tracker.hpp>
 #include <category/vm/evm/storage_status.h>
 
-#include <evmc/evmc.h>
-
 // TODO immer known to trigger incorrect warning
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"

--- a/category/execution/ethereum/state3/account_substate.hpp
+++ b/category/execution/ethereum/state3/account_substate.hpp
@@ -19,8 +19,6 @@
 #include <category/core/config.hpp>
 #include <category/vm/evm/access_status.h>
 
-#include <evmc/evmc.h>
-
 // TODO immer known to trigger incorrect warning
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"

--- a/category/execution/ethereum/state3/account_substate.hpp
+++ b/category/execution/ethereum/state3/account_substate.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/vm/evm/access_status.h>
 
 #include <evmc/evmc.h>
 
@@ -79,24 +80,24 @@ public:
     }
 
     // A_a
-    evmc_access_status access()
+    monad_access_status access()
     {
         bool const inserted = !accessed_;
         accessed_ = true;
         if (inserted) {
-            return EVMC_ACCESS_COLD;
+            return MONAD_ACCESS_COLD;
         }
-        return EVMC_ACCESS_WARM;
+        return MONAD_ACCESS_WARM;
     }
 
     // A_K
-    evmc_access_status access_storage(bytes32_t const &key)
+    monad_access_status access_storage(bytes32_t const &key)
     {
         if (accessed_storage_.count(key) == 0) {
             accessed_storage_ = accessed_storage_.insert(key);
-            return EVMC_ACCESS_COLD;
+            return MONAD_ACCESS_COLD;
         }
-        return EVMC_ACCESS_WARM;
+        return MONAD_ACCESS_WARM;
     }
 };
 

--- a/category/execution/ethereum/state3/page_tracker.hpp
+++ b/category/execution/ethereum/state3/page_tracker.hpp
@@ -18,6 +18,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
+#include <category/vm/evm/access_status.h>
 #include <category/vm/host.hpp>
 
 #include <evmc/evmc.h>
@@ -51,16 +52,16 @@ class PageTracker
     }
 
 public:
-    evmc_access_status access_page(bytes32_t const &key)
+    monad_access_status access_page(bytes32_t const &key)
     {
         auto const pkey = compute_page_key(key);
         PageState s = lookup_page_state(pkey);
         if (s.accessed) {
-            return EVMC_ACCESS_WARM;
+            return MONAD_ACCESS_WARM;
         }
         s.accessed = true;
         pages_ = pages_.set(pkey, s);
-        return EVMC_ACCESS_COLD;
+        return MONAD_ACCESS_COLD;
     }
 
     vm::Host::PageStorageStatus

--- a/category/execution/ethereum/state3/page_tracker_test.cpp
+++ b/category/execution/ethereum/state3/page_tracker_test.cpp
@@ -74,10 +74,10 @@ TEST(PageTracker, cold_read_then_warm_read)
 {
     PageTracker pt;
 
-    EXPECT_EQ(pt.access_page(SLOT_A), EVMC_ACCESS_COLD);
-    EXPECT_EQ(pt.access_page(SLOT_A2), EVMC_ACCESS_WARM);
-    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_COLD);
-    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_WARM);
+    EXPECT_EQ(pt.access_page(SLOT_A), MONAD_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_A2), MONAD_ACCESS_WARM);
+    EXPECT_EQ(pt.access_page(SLOT_B), MONAD_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_B), MONAD_ACCESS_WARM);
 }
 
 TEST(PageTracker, deleted_then_readded_returns_to_baseline)

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -406,14 +406,14 @@ void State::touch(Address const &address)
     account_state.touch();
 }
 
-evmc_access_status State::access_account(Address const &address)
+monad_access_status State::access_account(Address const &address)
 {
     auto &account_state = current_account_state(address);
     return account_state.access();
 }
 
 template <Traits traits>
-evmc_access_status
+monad_access_status
 State::access_storage(Address const &address, bytes32_t const &key)
 {
     auto &account_state = current_account_state(address);

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -365,7 +365,7 @@ void State::subtract_from_balance(
     rb_.on_debit(address);
 }
 
-evmc_storage_status State::set_storage(
+monad_storage_status State::set_storage(
     Address const &address, bytes32_t const &key, bytes32_t const &value)
 {
     bytes32_t original_value;

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -26,6 +26,7 @@
 #include <category/execution/ethereum/state3/version_stack.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
+#include <category/vm/evm/access_status.h>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
 
@@ -165,10 +166,10 @@ public:
 
     void touch(Address const &);
 
-    evmc_access_status access_account(Address const &);
+    monad_access_status access_account(Address const &);
 
     template <Traits traits>
-    evmc_access_status access_storage(Address const &, bytes32_t const &key);
+    monad_access_status access_storage(Address const &, bytes32_t const &key);
 
     vm::Host::PageStorageStatus update_page(
         Address const &, bytes32_t const &key, evmc_storage_status status);

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -27,6 +27,7 @@
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/vm/evm/access_status.h>
+#include <category/vm/evm/storage_status.h>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
 
@@ -158,7 +159,7 @@ public:
 
     void subtract_from_balance(Address const &, uint256_t const &delta);
 
-    evmc_storage_status
+    monad_storage_status
     set_storage(Address const &, bytes32_t const &key, bytes32_t const &value);
 
     void set_transient_storage(

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -1188,7 +1188,7 @@ TEST(PrestateTracer, prestate_access_storage)
     // Touch some of the account's storage.
     // First access the account to bring it into the state object; this is a
     // prerequisite for accessing the storage.
-    EXPECT_EQ(s.access_account(ADDR_A), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_account(ADDR_A), MONAD_ACCESS_COLD);
     EXPECT_TRUE(s.original().find(ADDR_A) != s.original().end());
     EXPECT_TRUE(s.current().find(ADDR_A) != s.current().end());
     EXPECT_EQ(s.get_storage(ADDR_A, key2), value2);
@@ -1617,7 +1617,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_access_storage)
     // Touch some of the account's storage.
     // First access the account to bring it into the state object; this is a
     // prerequisite for accessing the storage.
-    EXPECT_EQ(s.access_account(ADDR_A), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_account(ADDR_A), MONAD_ACCESS_COLD);
     EXPECT_TRUE(s.original().find(ADDR_A) != s.original().end());
     EXPECT_TRUE(s.current().find(ADDR_A) != s.current().end());
     EXPECT_EQ(s.get_storage(ADDR_A, key2), value2);
@@ -1683,7 +1683,7 @@ TEST(PrestateTracer, prestate_omit_beneficiary)
 
     // Touch the account, so it shows up in `state.original` and
     // `state.current`.
-    EXPECT_EQ(s.access_account(ADDR_A), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_account(ADDR_A), MONAD_ACCESS_COLD);
     EXPECT_TRUE(s.original().find(ADDR_A) != s.original().end());
     EXPECT_TRUE(s.current().find(ADDR_A) != s.current().end());
 

--- a/category/vm/evm/CMakeLists.txt
+++ b/category/vm/evm/CMakeLists.txt
@@ -27,6 +27,8 @@ target_sources(monad-vm-evm PRIVATE
     "opcodes_xmacro.hpp"
     "revision.cpp"
     "revision.h"
+    "storage_status.cpp"
+    "storage_status.h"
     "switch_traits.hpp"
     "traits.hpp"
 

--- a/category/vm/evm/CMakeLists.txt
+++ b/category/vm/evm/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(monad-vm-evm OBJECT)
 set_target_properties(monad-vm-evm PROPERTIES LINKER_LANGUAGE CXX)
 
 target_sources(monad-vm-evm PRIVATE
+    "access_status.cpp"
+    "access_status.h"
     "delegation.cpp"
     "delegation.hpp"
     "explicit_traits.hpp"

--- a/category/vm/evm/access_status.cpp
+++ b/category/vm/evm/access_status.cpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/evm/access_status.h>
+
+#include <evmc/evmc.h>
+
+#include <utility>
+
+// Enforce the 1:1 correspondence with evmc_access_status that makes the
+// conversion below a value-preserving cast. If evmc ever renumbers a value,
+// these fire.
+#define MONAD_ASSERT_ACCESS_STATUS_EQ(status)                                  \
+    static_assert(                                                             \
+        std::to_underlying(MONAD_ACCESS_##status) ==                           \
+        std::to_underlying(EVMC_ACCESS_##status))
+
+MONAD_ASSERT_ACCESS_STATUS_EQ(COLD);
+MONAD_ASSERT_ACCESS_STATUS_EQ(WARM);
+
+#undef MONAD_ASSERT_ACCESS_STATUS_EQ
+
+// This is a value-preserving cast: monad_access_status mirrors
+// evmc_access_status 1:1, enforced by the static_asserts above. C linkage
+// matches the declaration in access_status.h.
+evmc_access_status to_evmc_access_status(monad_access_status const status)
+{
+    return static_cast<evmc_access_status>(std::to_underlying(status));
+}

--- a/category/vm/evm/access_status.h
+++ b/category/vm/evm/access_status.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <evmc/evmc.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Monad's in-tree EIP-2929 access status enum. This is a drop-in replacement
+// for evmc's `evmc_access_status`: the enumerators mirror `evmc_access_status`
+// 1:1 (same underlying integer values), which keeps the cold/warm comparisons
+// numerically unchanged. The 1:1 correspondence is enforced by static_assert in
+// access_status.cpp.
+//
+// The enum itself carries no evmc dependency. The only tie to evmc is the
+// conversion function below, which is needed solely at the remaining evmc host
+// interface boundary (the EvmcHost overrides, whose return types are fixed by
+// evmc::HostInterface); it — together with the <evmc/evmc.h> include — is
+// removable in one step once the host interface is ported off evmc.
+enum monad_access_status
+{
+    MONAD_ACCESS_COLD = 0,
+    MONAD_ACCESS_WARM = 1
+};
+
+// Convert monad_access_status to evmc's evmc_access_status. Needed only at the
+// remaining evmc host interface boundary (see the note above).
+enum evmc_access_status to_evmc_access_status(enum monad_access_status status);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/category/vm/evm/storage_status.cpp
+++ b/category/vm/evm/storage_status.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/evm/storage_status.h>
+
+#include <evmc/evmc.h>
+
+#include <utility>
+
+// Enforce the 1:1 correspondence with evmc_storage_status that makes the
+// conversion below a value-preserving cast. If evmc ever renumbers a value,
+// these fire.
+#define MONAD_ASSERT_STORAGE_STATUS_EQ(status)                                 \
+    static_assert(                                                             \
+        std::to_underlying(MONAD_STORAGE_##status) ==                          \
+        std::to_underlying(EVMC_STORAGE_##status))
+
+MONAD_ASSERT_STORAGE_STATUS_EQ(ASSIGNED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(ADDED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(DELETED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(MODIFIED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(DELETED_ADDED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(MODIFIED_DELETED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(DELETED_RESTORED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(ADDED_DELETED);
+MONAD_ASSERT_STORAGE_STATUS_EQ(MODIFIED_RESTORED);
+
+#undef MONAD_ASSERT_STORAGE_STATUS_EQ
+
+// This is a value-preserving cast: monad_storage_status mirrors
+// evmc_storage_status 1:1, enforced by the static_asserts above. C linkage
+// matches the declaration in storage_status.h.
+evmc_storage_status to_evmc_storage_status(monad_storage_status const status)
+{
+    return static_cast<evmc_storage_status>(std::to_underlying(status));
+}

--- a/category/vm/evm/storage_status.h
+++ b/category/vm/evm/storage_status.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <evmc/evmc.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Monad's in-tree EIP-1283/2200 storage status enum. This is a drop-in
+// replacement for evmc's `evmc_storage_status`: the enumerators mirror
+// `evmc_storage_status` 1:1 (same underlying integer values), which keeps the
+// gas/refund table lookups in store_cost numerically unchanged. The 1:1
+// correspondence is enforced by static_assert in storage_status.cpp.
+//
+// The enum itself carries no evmc dependency. The only tie to evmc is the
+// conversion function below, which is needed solely at the remaining evmc host
+// interface boundary (the EvmcHost overrides, whose return types are fixed by
+// evmc::HostInterface); it — together with the <evmc/evmc.h> include — is
+// removable in one step once the host interface is ported off evmc.
+enum monad_storage_status
+{
+    MONAD_STORAGE_ASSIGNED = 0,
+    MONAD_STORAGE_ADDED = 1,
+    MONAD_STORAGE_DELETED = 2,
+    MONAD_STORAGE_MODIFIED = 3,
+    MONAD_STORAGE_DELETED_ADDED = 4,
+    MONAD_STORAGE_MODIFIED_DELETED = 5,
+    MONAD_STORAGE_DELETED_RESTORED = 6,
+    MONAD_STORAGE_ADDED_DELETED = 7,
+    MONAD_STORAGE_MODIFIED_RESTORED = 8
+};
+
+// Convert monad_storage_status to evmc's evmc_storage_status. Needed only at
+// the remaining evmc host interface boundary (see the note above).
+enum evmc_storage_status
+to_evmc_storage_status(enum monad_storage_status status);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/test/utils/from_json.cpp
+++ b/test/utils/from_json.cpp
@@ -173,7 +173,7 @@ namespace nlohmann
                     MONAD_ASSERT(
                         state.set_storage(
                             account_address, key_bytes32, value_bytes32) ==
-                        EVMC_STORAGE_ADDED);
+                        MONAD_STORAGE_ADDED);
                 }
             }
         }


### PR DESCRIPTION
Replaces evmc's `evmc_access_status` and `evmc_storage_status` with in-tree
`monad_access_status` / `monad_storage_status`, continuing the effort to push the
evmc dependency out toward the leaves so it can be cut in one step later. Same
playbook as `monad_eth_revision` (#2304): additive 1:1 enum mirrors with the
correspondence enforced by `static_assert`, and the lone `to_evmc_*` conversion
quarantined to the `.cpp`.

Two commits, each behavior-preserving and independently buildable/testable:

1. **`monad_access_status`** — `AccountSubstate`/`State` access methods return the
   in-tree enum.
2. **`monad_storage_status`** — `AccountState`/`State` storage methods return the
   in-tree enum.

### Boundary handling
The state layer (producer) is migrated. The `EvmcHost` overrides keep their evmc
return types — they're fixed by `evmc::HostInterface` — and bridge with the new
`to_evmc_*` conversions. The VM runtime consumers (cold/warm checks,
`store_cost`) stay evmc because they read the value back through the evmc host
interface vtable. Net effect: the remaining evmc enum usage is pushed down to the
host-interface boundary, where it — along with the `<evmc/evmc.h>` include and
the conversion functions — becomes removable in one step once the host interface
itself is ported off evmc.

### Verification
- Clean full build (GCC 15 / AVX2, RelWithDebInfo).
- Full `ctest`: 3630/3630 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)