### PR TITLE
Page-store dual-db: 4 integration fixes + MonadDevnetFork test chain

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(
   "ethereum/db/partial_trie_db.cpp"
   "ethereum/db/state_machine_init.cpp"
   "ethereum/db/state_machine_init.hpp"
+  "ethereum/db/storage_key.hpp"
   "ethereum/db/trie_db.cpp"
   "ethereum/db/trie_db.hpp"
   "ethereum/db/trie_rodb.hpp"
@@ -185,6 +186,7 @@ add_library(
   "ethereum/state2/block_state.cpp"
   "ethereum/state2/block_state.hpp"
   "ethereum/state2/fmt/state_deltas_fmt.hpp"
+  "ethereum/state2/proposal_post_state.hpp"
   "ethereum/state2/state_deltas.hpp"
   # ethereum/state3
   "ethereum/state3/account_state.cpp"
@@ -202,6 +204,8 @@ add_library(
 add_library(
   monad_execution_native OBJECT
   # monad/db
+  "monad/db/page_commit_builder.hpp"
+  "monad/db/page_commit_builder.cpp"
   "monad/db/state_machine_init.cpp"
   "monad/db/state_machine_init.hpp"
   "monad/db/storage_page.cpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -202,6 +202,8 @@ add_library(
 add_library(
   monad_execution_native OBJECT
   # monad/db
+  "monad/db/state_machine_init.cpp"
+  "monad/db/state_machine_init.hpp"
   "monad/db/storage_page.cpp"
   "monad/db/storage_page.hpp"
   # monad/chain

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -219,6 +219,8 @@ add_library(
   "monad/chain/monad_devnet.cpp"
   "monad/chain/monad_devnet.hpp"
   "monad/chain/monad_devnet_alloc.hpp"
+  "monad/chain/monad_devnet_fork.cpp"
+  "monad/chain/monad_devnet_fork.hpp"
   "monad/chain/monad_mainnet.cpp"
   "monad/chain/monad_mainnet.hpp"
   "monad/chain/monad_mainnet_alloc.hpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -192,6 +192,7 @@ add_library(
   "ethereum/state3/account_state.cpp"
   "ethereum/state3/account_state.hpp"
   "ethereum/state3/account_substate.hpp"
+  "ethereum/state3/page_tracker.hpp"
   "ethereum/state3/state.cpp"
   "ethereum/state3/state.hpp"
   "ethereum/state3/version_stack.hpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -204,6 +204,8 @@ add_library(
 add_library(
   monad_execution_native OBJECT
   # monad/db
+  "monad/db/commit_block_migration.cpp"
+  "monad/db/commit_block_migration.hpp"
   "monad/db/page_commit_builder.hpp"
   "monad/db/page_commit_builder.cpp"
   "monad/db/state_machine_init.cpp"

--- a/category/execution/ethereum/block_hash_buffer_test.cpp
+++ b/category/execution/ethereum/block_hash_buffer_test.cpp
@@ -217,7 +217,7 @@ TEST(BlockHashBufferTest, init_from_db)
 
     BlockHashBufferFinalized expected;
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
         expected.set(
             i,
             to_bytes(

--- a/category/execution/ethereum/block_reward_test.cpp
+++ b/category/execution/ethereum/block_reward_test.cpp
@@ -51,7 +51,7 @@ TYPED_TEST(TraitsTest, apply_block_reward)
     vm::VM vm;
     commit_sequential(
         tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 

--- a/category/execution/ethereum/chain/chain_config.h
+++ b/category/execution/ethereum/chain/chain_config.h
@@ -27,6 +27,7 @@ enum monad_chain_config
     CHAIN_CONFIG_MONAD_TESTNET = 2,
     CHAIN_CONFIG_MONAD_MAINNET = 3,
     CHAIN_CONFIG_HIVE_NET = 4,
+    CHAIN_CONFIG_MONAD_DEVNET_FORK = 5,
 };
 
 #ifdef __cplusplus

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -110,7 +110,7 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         NULL_HASH_BLAKE3,
         *builder,
         genesis.header,
-        std::make_unique<StateDeltas>(std::move(deltas)),
+        deltas,
         [&](BlockHeader &h) {
             h.receipts_root = db.receipts_root();
             h.state_root = db.state_root();

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -30,6 +30,7 @@
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 #include <category/vm/code.hpp>
 
 #include <nlohmann/json.hpp>
@@ -88,19 +89,26 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         deltas.emplace(addr, state_delta);
     }
 
-    CommitBuilder builder(genesis.header.number);
-    builder.add_state_deltas(deltas)
+    std::unique_ptr<CommitBuilder> builder;
+    if (db.is_page_encoded()) {
+        builder =
+            std::make_unique<PageCommitBuilder>(genesis.header.number, db);
+    }
+    else {
+        builder = std::make_unique<CommitBuilder>(genesis.header.number);
+    }
+    builder->add_state_deltas(deltas)
         .add_code(code_map)
         .add_receipts(std::vector<Receipt>{})
         .add_transactions(std::vector<Transaction>{}, std::vector<Address>{})
         .add_call_frames(std::vector<std::vector<CallFrame>>{})
         .add_ommers(std::vector<BlockHeader>{});
     if (genesis.header.withdrawals_root == NULL_ROOT) {
-        builder.add_withdrawals({});
+        builder->add_withdrawals({});
     }
     db.commit(
         NULL_HASH_BLAKE3,
-        builder,
+        *builder,
         genesis.header,
         std::make_unique<StateDeltas>(std::move(deltas)),
         [&](BlockHeader &h) {

--- a/category/execution/ethereum/core/contract/test_storage.cpp
+++ b/category/execution/ethereum/core/contract/test_storage.cpp
@@ -54,7 +54,7 @@ struct Storage : public ::testing::Test
     {
         commit_sequential(
             tdb,
-            sd(
+            StateDeltas(
                 {{ADDRESS,
                   StateDelta{
                       .account =

--- a/category/execution/ethereum/db/commit_builder.cpp
+++ b/category/execution/ethereum/db/commit_builder.cpp
@@ -27,6 +27,7 @@
 #include <category/execution/ethereum/core/rlp/withdrawal_rlp.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
@@ -73,7 +74,9 @@ CommitBuilder &CommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
         UpdateList storage_updates;
         std::optional<byte_string_view> value;
         auto const &account = delta.account.second;
+        proposal_post_state_.accounts[addr] = account;
         if (account.has_value()) {
+            auto const inc = account->incarnation;
             for (auto const &[key, delta] : delta.storage) {
                 if (delta.first != delta.second) {
                     storage_updates.push_front(
@@ -89,6 +92,10 @@ CommitBuilder &CommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
                             .incarnation = false,
                             .next = UpdateList{},
                             .version = static_cast<int64_t>(block_number_)}));
+                    storage_page_t page;
+                    page.set(0, delta.second);
+                    proposal_post_state_.storage[StorageKey{addr, inc, key}] =
+                        std::move(page);
                 }
             }
             value = bytes_alloc_.emplace_back(

--- a/category/execution/ethereum/db/commit_builder.hpp
+++ b/category/execution/ethereum/db/commit_builder.hpp
@@ -53,6 +53,12 @@ public:
 
     virtual CommitBuilder &add_state_deltas(StateDeltas const &);
 
+    // Identifies the storage encoding this builder produces
+    virtual bool is_page_encoded() const
+    {
+        return false;
+    }
+
     CommitBuilder &add_code(Code const &);
 
     CommitBuilder &add_receipts(std::vector<Receipt> const &);

--- a/category/execution/ethereum/db/commit_builder.hpp
+++ b/category/execution/ethereum/db/commit_builder.hpp
@@ -18,6 +18,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/mpt/update.hpp>
 
@@ -34,16 +35,23 @@ struct Withdrawal;
 
 class CommitBuilder
 {
+protected:
     std::deque<mpt::Update> update_alloc_;
     std::deque<byte_string> bytes_alloc_;
     std::deque<hash256> hash_alloc_;
     mpt::UpdateList updates_;
     uint64_t block_number_;
+    // Per-block post-state assembled by `add_state_deltas`.
+    // Slot based storage fills it with single-slot storage page keyed by
+    // storage slot key, Paged based storage fills it with the actual storage
+    // page keyed by storage page key.
+    ProposalPostState proposal_post_state_;
 
 public:
     explicit CommitBuilder(uint64_t block_number);
+    virtual ~CommitBuilder() = default;
 
-    CommitBuilder &add_state_deltas(StateDeltas const &);
+    virtual CommitBuilder &add_state_deltas(StateDeltas const &);
 
     CommitBuilder &add_code(Code const &);
 
@@ -64,6 +72,14 @@ public:
     // can be added after a build() call (e.g. add_block_header between the
     // two commit stages), but previously built updates are not retained.
     mpt::UpdateList build(mpt::NibblesView);
+
+    // Move out the proposal post-state assembled by `add_state_deltas`.
+    // Must be called after `add_state_deltas`; calling it twice yields an
+    // empty struct the second time.
+    ProposalPostState take_proposal_post_state()
+    {
+        return std::move(proposal_post_state_);
+    }
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -76,7 +76,7 @@ struct Db
     // two-stage commit
     virtual void commit(
         bytes32_t const &block_id, CommitBuilder &builder,
-        BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
+        BlockHeader const &header, StateDeltas const &state_deltas,
         std::function<void(BlockHeader &)> populate_header_fn) = 0;
 
     virtual std::string print_stats()

--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -36,13 +36,22 @@
 MONAD_NAMESPACE_BEGIN
 
 class CommitBuilder;
+struct storage_page_t;
 
 struct Db
 {
+    virtual bool is_page_encoded() const
+    {
+        return false;
+    }
+
     virtual std::optional<Account> read_account(Address const &) = 0;
 
     virtual bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) = 0;
+
+    virtual storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) = 0;
 
     virtual vm::SharedIntercode read_code(bytes32_t const &) = 0;
 

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -21,42 +21,26 @@
 #include <category/core/config.hpp>
 #include <category/core/lru/lru_cache.hpp>
 #include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
 
 #include <cstdint>
-#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
 
 MONAD_NAMESPACE_BEGIN
 
+// Encoding-agnostic LRU + proposal cache for accounts and storage leaves.
+// Storage values are held as storage_page_t, keyed by the trie key the
+// caller passes: slot_key (single slot at index 0) for slot encoding, or
+// page_key (full page) for page encoding. The caller (TrieDb) decides the
+// key and offset based on its encoding; the cache does not.
 class DbCache final
 {
-    struct StorageKey
-    {
-        static constexpr size_t k_bytes =
-            sizeof(Address) + sizeof(Incarnation) + sizeof(bytes32_t);
-
-        uint8_t bytes[k_bytes];
-
-        StorageKey() = default;
-
-        StorageKey(
-            Address const &addr, Incarnation const incarnation,
-            bytes32_t const &key)
-        {
-            memcpy(bytes, addr.bytes, sizeof(Address));
-            memcpy(&bytes[sizeof(Address)], &incarnation, sizeof(Incarnation));
-            memcpy(
-                &bytes[sizeof(Address) + sizeof(Incarnation)],
-                key.bytes,
-                sizeof(bytes32_t));
-        }
-    };
-
     using AddressHashCompare = BytesHashCompare<Address>;
     using StorageKeyHashCompare = BytesHashCompare<StorageKey>;
     using AccountsCache =
@@ -91,23 +75,45 @@ public:
         return false;
     }
 
-    bool try_read_storage(
+    bool try_read_storage_page(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result)
+        bytes32_t const &key, storage_page_t &result)
     {
         storage_page_t page;
         auto const res =
             proposals_.try_read_storage(address, incarnation, key, page);
         if (res.found) {
-            // Single-slot page: the value lives at index 0.
-            result = page[0];
+            result = page;
             return true;
         }
         if (!res.truncated) {
             StorageKey const skey{address, incarnation, key};
             StorageCache::ConstAccessor acc{};
             if (storage_.find(acc, skey)) {
-                result = acc->second.value_[0];
+                result = acc->second.value_;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool try_read_storage(
+        Address const &address, Incarnation const incarnation,
+        bytes32_t const &key, uint8_t const slot_offset, bytes32_t &result)
+    {
+        storage_page_t page;
+        auto const res =
+            proposals_.try_read_storage(address, incarnation, key, page);
+        if (res.found) {
+            // slot_offset is 0 for slot encoding, the in-page offset for page.
+            result = page[slot_offset];
+            return true;
+        }
+        if (!res.truncated) {
+            StorageKey const skey{address, incarnation, key};
+            StorageCache::ConstAccessor acc{};
+            if (storage_.find(acc, skey)) {
+                result = acc->second.value_[slot_offset];
                 return true;
             }
         }
@@ -121,11 +127,10 @@ public:
     }
 
     void update_proposal_state(
-        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
+        ProposalPostState post_state, uint64_t const block_number,
         bytes32_t const &block_id)
     {
-        MONAD_ASSERT(state_deltas);
-        proposals_.commit(std::move(state_deltas), block_number, block_id);
+        proposals_.commit(std::move(post_state), block_number, block_id);
     }
 
     void on_finalize(uint64_t const block_number, bytes32_t const &block_id)
@@ -133,7 +138,7 @@ public:
         std::unique_ptr<ProposalState> const ps =
             proposals_.finalize(block_number, block_id);
         if (ps) {
-            insert_in_lru_caches(ps->state());
+            insert_in_lru_caches(ps->post_state());
         }
         else {
             // Finalizing a truncated proposal. Clear LRU caches.
@@ -153,24 +158,13 @@ public:
     }
 
 private:
-    void insert_in_lru_caches(StateDeltas const &state_deltas)
+    void insert_in_lru_caches(ProposalPostState const &post_state)
     {
-        for (auto const &[address, delta] : state_deltas) {
-            auto const &account_delta = delta.account;
-            accounts_.insert(address, account_delta.second);
-            auto const &storage = delta.storage;
-            auto const &account = account_delta.second;
-            if (account.has_value()) {
-                for (auto const &[key, storage_delta] : storage) {
-                    auto const incarnation = account->incarnation;
-                    // Single-slot page: store the value at index 0. A zero
-                    // value leaves the page empty, so a hit reads back zero.
-                    storage_page_t page;
-                    page.set(0, storage_delta.second);
-                    storage_.insert(
-                        StorageKey(address, incarnation, key), page);
-                }
-            }
+        for (auto const &[addr, acct] : post_state.accounts) {
+            accounts_.insert(addr, acct);
+        }
+        for (auto const &[sk, leaf] : post_state.storage) {
+            storage_.insert(sk, leaf);
         }
     }
 };

--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -24,6 +24,8 @@
 #include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 
@@ -31,6 +33,8 @@
 
 #include <deque>
 #include <limits>
+#include <memory>
+#include <optional>
 
 struct monad_db_snapshot_loader
 {
@@ -40,31 +44,65 @@ struct monad_db_snapshot_loader
     std::array<monad::byte_string, 256> eth_headers;
     std::deque<monad::hash256> hash_alloc;
     std::deque<monad::mpt::Update> update_alloc;
+    std::deque<monad::byte_string> bytes_alloc;
     std::array<
         ankerl::unordered_dense::segmented_map<uint64_t, monad::mpt::Update>,
         MONAD_SNAPSHOT_SHARDS>
         account_offset_to_update;
+    // Per-shard page accumulator used only when page_encoded. Maps
+    // account_offset -> (page_key -> assembled storage_page_t).
+    std::array<
+        ankerl::unordered_dense::segmented_map<
+            uint64_t, ankerl::unordered_dense::map<
+                          monad::bytes32_t, monad::storage_page_t>>,
+        MONAD_SNAPSHOT_SHARDS>
+        page_accumulator;
     monad::mpt::UpdateList state_updates;
     monad::mpt::UpdateList code_updates;
     uint64_t bytes_read;
 
     monad_db_snapshot_loader(
         uint64_t const block, char const *const *const dbname_paths,
-        size_t const len, unsigned const sq_thread_cpu)
+        size_t const len, unsigned const sq_thread_cpu,
+        bool const load_to_secondary)
         : block{block}
-        , db{monad::mpt::OnDiskDbConfig{
-              .append = true,
-              .compaction = false,
-              .rd_buffers = 8192,
-              .wr_buffers = 32,
-              .uring_entries = 128,
-              .sq_thread_cpu =
-                  sq_thread_cpu == std::numeric_limits<unsigned>::max()
-                      ? std::nullopt
-                      : std::make_optional(sq_thread_cpu),
-              .dbname_paths = {dbname_paths, dbname_paths + len}}}
+        , db{open_target_db(
+              dbname_paths, len, sq_thread_cpu, load_to_secondary)}
         , bytes_read{0}
     {
+    }
+
+    bool page_encoded() const
+    {
+        return db.state_machine_type() == monad::mpt::state_machine_kind::monad;
+    }
+
+private:
+    static monad::mpt::Db open_target_db(
+        char const *const *const dbname_paths, size_t const len,
+        unsigned const sq_thread_cpu, bool const load_to_secondary)
+    {
+        monad::mpt::Db primary{monad::mpt::OnDiskDbConfig{
+            .append = true,
+            .compaction = false,
+            .rd_buffers = 8192,
+            .wr_buffers = 32,
+            .uring_entries = 128,
+            .sq_thread_cpu =
+                sq_thread_cpu == std::numeric_limits<unsigned>::max()
+                    ? std::nullopt
+                    : std::make_optional(sq_thread_cpu),
+            .dbname_paths = {dbname_paths, dbname_paths + len}}};
+        if (!load_to_secondary) {
+            return primary;
+        }
+        auto secondary = primary.open_secondary_timeline();
+        MONAD_ASSERT_PRINTF(
+            secondary.has_value(),
+            "secondary timeline is not active; activate it and stamp its "
+            "state_machine_kind using monad-mpt tool before loading a snapshot "
+            "into it");
+        return std::move(*secondary);
     }
 };
 
@@ -81,10 +119,55 @@ uint64_t get_shard(monad::mpt::NibblesView const path)
     return ret;
 }
 
+// When the target is page-encoded, drain the accumulator into per-account
+// `next` lists. Each page becomes one Update keyed by keccak256(page_key)
+// with value encode_storage_page_db(page_key, page) (or std::nullopt if the
+// page is empty so the entry is a deletion). The encoded byte_strings are
+// kept alive in loader->bytes_alloc until the upsert completes; the Update
+// nodes are kept in loader->update_alloc for the same reason.
+void monad_db_snapshot_loader_finalize_pages(
+    monad_db_snapshot_loader *const loader)
+{
+    using namespace monad;
+    using namespace monad::mpt;
+    if (!loader->page_encoded()) {
+        return;
+    }
+    for (size_t shard = 0; shard < MONAD_SNAPSHOT_SHARDS; ++shard) {
+        auto &shard_pages = loader->page_accumulator.at(shard);
+        if (shard_pages.empty()) {
+            continue;
+        }
+        auto &shard_accounts = loader->account_offset_to_update.at(shard);
+        for (auto &[account_offset, pages] : shard_pages) {
+            auto &account_update = shard_accounts.at(account_offset);
+            for (auto const &[page_key, page] : pages) {
+                bool const is_empty = page.is_empty();
+                std::optional<byte_string_view> value;
+                if (!is_empty) {
+                    value = byte_string_view{loader->bytes_alloc.emplace_back(
+                        encode_storage_page_db(page_key, page))};
+                }
+                account_update.next.push_front(
+                    loader->update_alloc.emplace_back(Update{
+                        .key = loader->hash_alloc.emplace_back(keccak256(
+                            {page_key.bytes, sizeof(page_key.bytes)})),
+                        .value = value,
+                        .incarnation = false,
+                        .next = UpdateList{},
+                        .version = static_cast<int64_t>(loader->block)}));
+            }
+        }
+        shard_pages.clear();
+    }
+}
+
 void monad_db_snapshot_loader_flush(monad_db_snapshot_loader *const loader)
 {
     using namespace monad;
     using namespace monad::mpt;
+
+    monad_db_snapshot_loader_finalize_pages(loader);
 
     Update state_update{
         .key = state_nibbles,
@@ -120,7 +203,11 @@ void monad_db_snapshot_loader_flush(monad_db_snapshot_loader *const loader)
         false);
     loader->hash_alloc.clear();
     loader->update_alloc.clear();
+    loader->bytes_alloc.clear();
     for (auto &map : loader->account_offset_to_update) {
+        map.clear();
+    }
+    for (auto &map : loader->page_accumulator) {
         map.clear();
     }
     loader->state_updates.clear();
@@ -438,18 +525,27 @@ bool monad_db_dump_snapshot(
     return success;
 }
 
+// Loads the standard slot-encoded snapshot (the format produced by
+// monad_db_dump_snapshot against a slot db) into one timeline:
+//   * load_to_secondary == false: the primary timeline.
+//   * load_to_secondary == true:  an already-activated secondary timeline.
+// The target's storage encoding is derived from its persisted
+// state_machine_kind; a page-encoded target converts slot leaves to page
+// leaves on the fly. The target's kind must already be stamped on disk.
 monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t const block, char const *const *const dbname_paths,
-    size_t const len, unsigned const sq_thread_cpu)
+    size_t const len, unsigned const sq_thread_cpu,
+    bool const load_to_secondary)
 {
-    // C ABI entry — populate the kind registry before the metadata-driven
-    // Db ctor runs inside monad_db_snapshot_loader. Idempotent.
+    // The metadata-driven Db ctor and open_secondary_timeline() resolve the
+    // persisted kind through the registry, so both factories must be present.
     monad::register_ethereum_state_machines();
-    auto *loader =
-        new monad_db_snapshot_loader(block, dbname_paths, len, sq_thread_cpu);
-    MONAD_ASSERT_PRINTF(
-        loader->db.get_latest_version() == monad::mpt::INVALID_BLOCK_NUM,
-        "database must be hard reset when loading snapshot");
+    monad::register_monad_state_machines();
+    auto *loader = new monad_db_snapshot_loader(
+        block, dbname_paths, len, sq_thread_cpu, load_to_secondary);
+    MONAD_ASSERT(
+        loader->db.load_root_for_version(block) == nullptr,
+        "the block to load already exists in db");
     return loader;
 }
 
@@ -489,18 +585,45 @@ void monad_db_snapshot_loader_load(
             }
             storage_view.remove_prefix(sizeof(account_offset));
             byte_string_view const before{storage_view};
-            auto const res = decode_storage_db_raw(storage_view);
-            MONAD_ASSERT(res.has_value());
-            auto &update = account_offset_to_update.at(account_offset);
-            uint64_t const consumed = before.size() - storage_view.size();
-            update.next.push_front(loader->update_alloc.emplace_back(Update{
-                .key = loader->hash_alloc.emplace_back(
-                    keccak256(to_bytes(res.value().first))),
-                .value = before.substr(0, consumed),
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(loader->block)}));
+            uint64_t consumed;
+            if (loader->page_encoded()) {
+                // The storage byte stream concatenates multiple
+                // [account_offset, leaf.value()] entries, so we use
+                // decode_storage_db_raw which advances the view in place
+                // and tolerates trailing bytes. Convert the raw views to
+                // bytes32_t (right-aligned) for the page accumulator.
+                auto const res = decode_storage_db_raw(storage_view);
+                MONAD_ASSERT(res.has_value());
+                bytes32_t const slot_key = to_bytes(res.value().first);
+                bytes32_t const slot_val = to_bytes(res.value().second);
+                consumed = before.size() - storage_view.size();
+                bytes32_t const pg_key = compute_page_key(slot_key);
+                uint8_t const slot_off = compute_slot_offset(slot_key);
+                auto &shard_pages = loader->page_accumulator.at(shard);
+                shard_pages[account_offset][pg_key].set(slot_off, slot_val);
+            }
+            else {
+                auto const res = decode_storage_db_raw(storage_view);
+                MONAD_ASSERT(res.has_value());
+                auto &update = account_offset_to_update.at(account_offset);
+                consumed = before.size() - storage_view.size();
+                update.next.push_front(loader->update_alloc.emplace_back(Update{
+                    .key = loader->hash_alloc.emplace_back(
+                        keccak256(to_bytes(res.value().first))),
+                    .value = before.substr(0, consumed),
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(loader->block)}));
+            }
             loader->bytes_read += consumed;
-            if (loader->bytes_read >= BYTES_READ_BEFORE_FLUSH) {
+            // When page-encoded, all slots that share a page_key must be in
+            // the same flush. A mid-loop flush would emit a page Update for
+            // the slots seen so far; later slots in the same page would start
+            // a fresh accumulator entry and the next flush would emit another
+            // Update for the same keccak256(page_key), causing the mpt
+            // upsert to overwrite the earlier page (set-not-merge). Defer
+            // flushing until the unconditional final flush at end of load().
+            if (!loader->page_encoded() &&
+                loader->bytes_read >= BYTES_READ_BEFORE_FLUSH) {
                 monad_db_snapshot_loader_flush(loader);
             }
         }

--- a/category/execution/ethereum/db/db_snapshot.h
+++ b/category/execution/ethereum/db/db_snapshot.h
@@ -51,7 +51,7 @@ bool monad_db_dump_snapshot(
 
 struct monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t block, char const *const *dbname_paths, size_t len,
-    unsigned sq_thread_cpu);
+    unsigned sq_thread_cpu, bool load_to_secondary);
 
 void monad_db_snapshot_loader_load(
     struct monad_db_snapshot_loader *loader, uint64_t shard,

--- a/category/execution/ethereum/db/db_snapshot_filesystem.cpp
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.cpp
@@ -125,12 +125,15 @@ uint64_t monad_db_snapshot_write_filesystem(
 void monad_db_snapshot_load_filesystem(
     char const *const *const dbname_paths, size_t const len,
     unsigned const sq_thread_cpu, char const *const snapshot_dir,
-    uint64_t const block)
+    uint64_t const block, bool const load_to_secondary)
 {
     std::filesystem::path const root{std::format("{}/{}", snapshot_dir, block)};
     MONAD_ASSERT(std::filesystem::is_directory(root));
+    // The input snapshot is always slot-encoded (the standard format produced
+    // by monad_db_dump_snapshot from a slot db). If the target timeline is
+    // page-encoded, the loader converts slot leaves to page leaves on the fly.
     monad_db_snapshot_loader *const loader = monad_db_snapshot_loader_create(
-        block, dbname_paths, len, sq_thread_cpu);
+        block, dbname_paths, len, sq_thread_cpu, load_to_secondary);
 
     auto const do_mmap = [](std::filesystem::path const file) {
         using namespace monad;

--- a/category/execution/ethereum/db/db_snapshot_filesystem.h
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.h
@@ -37,7 +37,7 @@ uint64_t monad_db_snapshot_write_filesystem(
 
 void monad_db_snapshot_load_filesystem(
     char const *const *dbname_paths, size_t len, unsigned sq_thread_cpu,
-    char const *snapshot_dir, uint64_t block);
+    char const *snapshot_dir, uint64_t block, bool load_to_secondary);
 
 #ifdef __cplusplus
 }

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -759,6 +759,12 @@ bytes32_t PartialTrieDb::read_storage(
     return !val_result ? bytes32_t{} : val_result->value;
 }
 
+storage_page_t PartialTrieDb::read_storage_page(
+    Address const &, Incarnation, bytes32_t const &)
+{
+    MONAD_ABORT("PartialTrieDb is slot-encoded; read_storage_page unsupported");
+}
+
 vm::SharedIntercode PartialTrieDb::read_code(bytes32_t const &code_hash)
 {
     auto it = codes_.find(code_hash);

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -820,15 +820,13 @@ void PartialTrieDb::set_block_and_prefix(
 
 void PartialTrieDb::commit(
     bytes32_t const &, CommitBuilder &, BlockHeader const &header,
-    std::unique_ptr<StateDeltas> deltas,
+    StateDeltas const &deltas,
     std::function<void(BlockHeader &)> populate_header_fn)
 {
-    MONAD_ASSERT(deltas);
-
     block_number_ = header.number;
 
     // Pass 1: inserts and updates (accounts that exist in post-state)
-    for (auto const &[addr, delta] : *deltas) {
+    for (auto const &[addr, delta] : deltas) {
         auto const &new_account = delta.account.second;
         if (!new_account) {
             continue;
@@ -870,7 +868,7 @@ void PartialTrieDb::commit(
     }
 
     // Pass 2: deletions (accounts removed in post-state)
-    for (auto const &[addr, delta] : *deltas) {
+    for (auto const &[addr, delta] : deltas) {
         if (delta.account.second) {
             continue;
         }

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -168,6 +168,9 @@ public:
     bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
 
+    storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) override;
+
     vm::SharedIntercode read_code(bytes32_t const &code_hash) override;
 
     BlockHeader read_eth_header() override;

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -188,8 +188,7 @@ public:
 
     void commit(
         bytes32_t const &block_id, CommitBuilder &, BlockHeader const &,
-        std::unique_ptr<StateDeltas>,
-        std::function<void(BlockHeader &)>) override;
+        StateDeltas const &, std::function<void(BlockHeader &)>) override;
 
     // No-op overrides for operations that are irrelevant in the witness
     // context.

--- a/category/execution/ethereum/db/storage_key.hpp
+++ b/category/execution/ethereum/db/storage_key.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+
+#include <cstring>
+
+MONAD_NAMESPACE_BEGIN
+
+// Composite cache key combining account address, account incarnation, and
+// the storage trie key. The trie key is slot_key for slot-encoded storage
+// or page_key for page-encoded storage; the cache layer is encoding-agnostic.
+struct StorageKey
+{
+    static constexpr size_t k_bytes =
+        sizeof(Address) + sizeof(Incarnation) + sizeof(bytes32_t);
+
+    uint8_t bytes[k_bytes];
+
+    StorageKey() = default;
+
+    StorageKey(
+        Address const &addr, Incarnation const incarnation,
+        bytes32_t const &key)
+    {
+        memcpy(bytes, addr.bytes, sizeof(Address));
+        memcpy(&bytes[sizeof(Address)], &incarnation, sizeof(Incarnation));
+        memcpy(
+            &bytes[sizeof(Address) + sizeof(Incarnation)],
+            key.bytes,
+            sizeof(bytes32_t));
+    }
+
+    bool operator==(StorageKey const &other) const
+    {
+        return memcmp(bytes, other.bytes, k_bytes) == 0;
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -20,7 +20,6 @@
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
 
-#include <memory>
 #include <optional>
 #include <vector>
 
@@ -29,13 +28,8 @@ MONAD_NAMESPACE_BEGIN
 namespace test
 {
 
-    inline auto sd(StateDeltas v = {})
-    {
-        return std::make_unique<StateDeltas>(std::move(v));
-    }
-
     inline void commit_simple(
-        ::monad::Db &db, std::unique_ptr<StateDeltas> deltas, Code const &code,
+        ::monad::Db &db, StateDeltas const &deltas, Code const &code,
         bytes32_t const &block_id, BlockHeader const &header,
         std::vector<Receipt> const &receipts = {},
         std::vector<std::vector<CallFrame>> const &call_frames = {},
@@ -46,7 +40,7 @@ namespace test
             std::nullopt)
     {
         CommitBuilder builder(header.number);
-        builder.add_state_deltas(*deltas)
+        builder.add_state_deltas(deltas)
             .add_code(code)
             .add_receipts(receipts)
             .add_transactions(txns, senders)
@@ -55,16 +49,15 @@ namespace test
         if (withdrawals.has_value()) {
             builder.add_withdrawals(withdrawals.value());
         }
-        db.commit(
-            block_id, builder, header, std::move(deltas), [&](BlockHeader &h) {
-                h.receipts_root = db.receipts_root();
-                h.state_root = db.state_root();
-                h.withdrawals_root = db.withdrawals_root();
-                h.transactions_root = db.transactions_root();
-                h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-                h.logs_bloom = compute_bloom(receipts);
-                h.ommers_hash = compute_ommers_hash(ommers);
-            });
+        db.commit(block_id, builder, header, deltas, [&](BlockHeader &h) {
+            h.receipts_root = db.receipts_root();
+            h.state_root = db.state_root();
+            h.withdrawals_root = db.withdrawals_root();
+            h.transactions_root = db.transactions_root();
+            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+            h.logs_bloom = compute_bloom(receipts);
+            h.ommers_hash = compute_ommers_hash(ommers);
+        });
     }
 
 } // namespace test

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -19,6 +19,7 @@
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 
 #include <optional>
 #include <vector>
@@ -27,7 +28,6 @@ MONAD_NAMESPACE_BEGIN
 
 namespace test
 {
-
     inline void commit_simple(
         ::monad::Db &db, StateDeltas const &deltas, Code const &code,
         bytes32_t const &block_id, BlockHeader const &header,
@@ -39,7 +39,16 @@ namespace test
         std::optional<std::vector<Withdrawal>> const &withdrawals =
             std::nullopt)
     {
-        CommitBuilder builder(header.number);
+        std::unique_ptr<CommitBuilder> builder_ptr;
+        if (db.is_page_encoded()) {
+            builder_ptr =
+                std::make_unique<PageCommitBuilder>(header.number, db);
+        }
+        else {
+            builder_ptr = std::make_unique<CommitBuilder>(header.number);
+        }
+        CommitBuilder &builder = *builder_ptr;
+
         builder.add_state_deltas(deltas)
             .add_code(code)
             .add_receipts(receipts)

--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -197,7 +197,7 @@ TEST(DBTest, read_only)
         Account const acct1{.nonce = 1};
         commit_sequential(
             rw,
-            sd(
+            StateDeltas(
                 {{ADDR_A,
                   StateDelta{
                       .account = {std::nullopt, acct1}, .storage = {}}}}),
@@ -206,7 +206,7 @@ TEST(DBTest, read_only)
         Account const acct2{.nonce = 2};
         commit_sequential(
             rw,
-            sd(
+            StateDeltas(
                 {{ADDR_A,
                   StateDelta{.account = {acct1, acct2}, .storage = {}}}}),
             Code{},
@@ -224,7 +224,7 @@ TEST(DBTest, read_only)
         Account const acct3{.nonce = 3};
         commit_sequential(
             rw,
-            sd(
+            StateDeltas(
                 {{ADDR_A,
                   StateDelta{.account = {acct2, acct3}, .storage = {}}}}),
             Code{},
@@ -250,7 +250,7 @@ TYPED_TEST(DBTest, read_storage)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, acct},
@@ -290,7 +290,7 @@ TYPED_TEST(DBTest, read_code)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, acct_a}}}}),
+        StateDeltas({{ADDR_A, StateDelta{.account = {std::nullopt, acct_a}}}}),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -300,7 +300,7 @@ TYPED_TEST(DBTest, read_code)
     Account acct_b{.balance = 0, .code_hash = B_CODE_HASH, .nonce = 1};
     commit_sequential(
         tdb,
-        sd({{ADDR_B, StateDelta{.account = {std::nullopt, acct_b}}}}),
+        StateDeltas({{ADDR_B, StateDelta{.account = {std::nullopt, acct_b}}}}),
         Code{{B_CODE_HASH, B_ICODE}},
         BlockHeader{.number = 1});
 
@@ -316,8 +316,8 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     EXPECT_TRUE(get_proposal_block_ids(db, 8).empty());
 
     tdb.set_block_and_prefix(8);
-    auto const round9_block_id =
-        commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 9});
+    auto const round9_block_id = commit_sequential(
+        tdb, StateDeltas({}), Code{}, BlockHeader{.number = 9});
     EXPECT_EQ(db.get_latest_finalized_version(), 9);
     {
         auto const proposals = get_proposal_block_ids(db, 9);
@@ -330,7 +330,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header0{.number = 10};
     bytes32_t const block_id0{header0.number};
     block_ids.emplace(block_id0);
-    commit_simple(tdb, sd({}), Code{}, block_id0, header0);
+    commit_simple(tdb, StateDeltas({}), Code{}, block_id0, header0);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -339,7 +339,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header1{.number = 10};
     bytes32_t const block_id1{header1.number};
     block_ids.emplace(block_id1);
-    commit_simple(tdb, sd({}), Code{}, block_id1, header1);
+    commit_simple(tdb, StateDeltas({}), Code{}, block_id1, header1);
     {
         auto const proposals = get_proposal_block_ids(db, 10);
         EXPECT_EQ(std::set(proposals.begin(), proposals.end()), block_ids);
@@ -349,7 +349,7 @@ TEST_F(OnDiskTrieDbFixture, get_proposal_block_ids)
     BlockHeader const header2{.number = 10};
     bytes32_t const block_id2{header2.number};
     block_ids.emplace(block_id2);
-    commit_simple(tdb, sd({}), Code{}, block_id2, header2);
+    commit_simple(tdb, StateDeltas({}), Code{}, block_id2, header2);
 
     tdb.finalize(10, block_id0);
     EXPECT_EQ(db.get_latest_finalized_version(), 10);
@@ -365,7 +365,7 @@ TYPED_TEST(DBTest, ModifyStorageOfAccount)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, acct},
@@ -378,7 +378,7 @@ TYPED_TEST(DBTest, ModifyStorageOfAccount)
     acct = tdb.read_account(ADDR_A).value();
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {acct, acct},
@@ -396,7 +396,8 @@ TYPED_TEST(DBTest, touch_without_modify_regression)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, std::nullopt}}}}),
+        StateDeltas(
+            {{ADDR_A, StateDelta{.account = {std::nullopt, std::nullopt}}}}),
         Code{},
         BlockHeader{});
 
@@ -410,7 +411,7 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, acct},
@@ -422,7 +423,7 @@ TYPED_TEST(DBTest, delete_account_modify_storage_regression)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {acct, std::nullopt},
@@ -443,7 +444,7 @@ TYPED_TEST(DBTest, storage_deletion)
     TrieDb tdb{this->db};
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, acct},
@@ -456,7 +457,7 @@ TYPED_TEST(DBTest, storage_deletion)
     acct = tdb.read_account(ADDR_A).value();
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {acct, acct},
@@ -474,7 +475,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
 
     TrieDb tdb{this->db};
     // empty receipts
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{});
     EXPECT_EQ(tdb.receipts_root(), NULL_ROOT);
 
     std::vector<Receipt> receipts;
@@ -534,7 +535,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
     std::vector<Address> senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         Code{},
         BlockHeader{.number = first_block},
         receipts,
@@ -625,7 +626,7 @@ TYPED_TEST(DBTest, commit_receipts_transactions)
     senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         Code{},
         BlockHeader{.number = second_block},
         receipts,
@@ -683,7 +684,7 @@ TEST_F(OnDiskTrieDbWithFileFixture, get_transactions)
     std::vector<Address> senders = recover_senders(transactions);
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         Code{},
         BlockHeader{.number = block_number},
         receipts,
@@ -908,7 +909,7 @@ TYPED_TEST(DBTest, commit_call_frames)
     std::vector<Address> const senders{call_frames.size()};
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         Code{},
         BlockHeader{},
         receipts,

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -111,12 +111,7 @@ namespace
         std::function<void(BlockHeader &)> populate = [](BlockHeader &) {})
     {
         CommitBuilder builder(header.number);
-        db.commit(
-            bytes32_t{},
-            builder,
-            header,
-            std::make_unique<StateDeltas>(std::move(deltas)),
-            std::move(populate));
+        db.commit(bytes32_t{}, builder, header, deltas, std::move(populate));
     }
 
     /// Build a witness whose only node is a leaf for `addr` with the given

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -216,6 +216,14 @@ void TrieDb::commit(
     BlockHeader const &header, StateDeltas const & /*state_deltas*/,
     std::function<void(BlockHeader &)> const populate_header_fn)
 {
+    MONAD_ASSERT_PRINTF(
+        builder.is_page_encoded() == is_page_encoded(),
+        "encoding mismatch at block %lu: TrieDb::is_page_encoded=%d but commit "
+        "builder has is_page_encoded=%d",
+        header.number,
+        is_page_encoded(),
+        builder.is_page_encoded());
+
     auto const block_number = header.number;
     MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());
 

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -213,12 +213,11 @@ vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
 
 void TrieDb::commit(
     bytes32_t const &block_id, CommitBuilder &builder,
-    BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
+    BlockHeader const &header, StateDeltas const & /*state_deltas*/,
     std::function<void(BlockHeader &)> const populate_header_fn)
 {
     auto const block_number = header.number;
     MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());
-    MONAD_ASSERT(state_deltas);
 
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk() && block_id != proposal_block_id_) {

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -289,13 +289,15 @@ void TrieDb::set_block_and_prefix(
 void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
 {
     // no re-finalization
-    auto const latest_finalized = db_.get_latest_finalized_version();
-    MONAD_ASSERT_PRINTF(
-        latest_finalized == INVALID_BLOCK_NUM ||
-            block_number == latest_finalized + 1,
-        "block_number %lu is not the next finalized block after %lu",
-        block_number,
-        latest_finalized);
+    if (!is_page_encoded()) {
+        auto const latest_finalized = db_.get_latest_finalized_version();
+        MONAD_ASSERT_PRINTF(
+            latest_finalized == INVALID_BLOCK_NUM ||
+                block_number == latest_finalized + 1,
+            "block_number %lu is not the next finalized block after %lu",
+            block_number,
+            latest_finalized);
+    }
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk()) {
         auto const src_prefix = proposal_prefix(block_id);
@@ -317,12 +319,15 @@ void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
 void TrieDb::update_verified_block(uint64_t const block_number)
 {
     // no re-verification
-    auto const latest_verified = db_.get_latest_verified_version();
-    MONAD_ASSERT_PRINTF(
-        latest_verified == INVALID_BLOCK_NUM || block_number > latest_verified,
-        "block_number %lu must be greater than last_verified %lu",
-        block_number,
-        latest_verified);
+    if (!is_page_encoded()) {
+        auto const latest_verified = db_.get_latest_verified_version();
+        MONAD_ASSERT_PRINTF(
+            latest_verified == INVALID_BLOCK_NUM ||
+                block_number > latest_verified,
+            "block_number %lu must be greater than last_verified %lu",
+            block_number,
+            latest_verified);
+    }
     db_.update_verified_version(block_number);
 }
 

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -37,15 +37,18 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/rlp/call_frame_rlp.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/nibbles_view_fmt.hpp> // NOLINT
 #include <category/mpt/node.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/update.hpp>
 #include <category/mpt/util.hpp>
@@ -80,6 +83,7 @@ TrieDb::TrieDb(mpt::Db &db, bool const enable_multiblock_cache)
     , prefix_{finalized_nibbles}
     , curr_root_{db.load_root_for_version(block_number_)}
     , cache_{enable_multiblock_cache ? std::make_unique<DbCache>() : nullptr}
+    , page_encoded_{db_.state_machine_type() == mpt::state_machine_kind::monad}
 {
 }
 
@@ -121,8 +125,11 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
 bytes32_t TrieDb::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
+    bytes32_t const lookup_key = page_encoded_ ? compute_page_key(key) : key;
+    uint8_t const lookup_offset = page_encoded_ ? compute_slot_offset(key) : 0;
     bytes32_t result{};
-    if (cache_ && cache_->try_read_storage(addr, incarnation, key, result)) {
+    if (cache_ && cache_->try_read_storage(
+                      addr, incarnation, lookup_key, lookup_offset, result)) {
         return result;
     }
     auto const res = db_.find(
@@ -131,7 +138,8 @@ bytes32_t TrieDb::read_storage(
             prefix_,
             STATE_NIBBLE,
             NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
-            NibblesView{keccak256({key.bytes, sizeof(key.bytes)})}),
+            NibblesView{
+                keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
         block_number_);
     if (res.has_error()) {
         stats_storage_no_value();
@@ -139,9 +147,52 @@ bytes32_t TrieDb::read_storage(
     }
     stats_storage_value();
     auto encoded_storage = res.value().node->value();
-    auto const storage = decode_storage_db_ignore_key(encoded_storage);
-    MONAD_ASSERT(!storage.has_error());
-    return to_bytes(storage.value());
+    auto const value = decode_storage_db_ignore_key(encoded_storage);
+    MONAD_ASSERT(!value.has_error());
+    if (page_encoded_) {
+        auto const page = decode_storage_page(value.value());
+        MONAD_ASSERT(!page.has_error());
+        return page.value()[compute_slot_offset(key)];
+    }
+    else {
+        return to_bytes(value.value());
+    }
+}
+
+storage_page_t TrieDb::read_storage_page(
+    Address const &addr, Incarnation const incarnation,
+    bytes32_t const &page_key)
+{
+    if (!page_encoded_) {
+        MONAD_ABORT("read_storage_page is only valid on a page-encoded TrieDb");
+    }
+    else {
+        storage_page_t result;
+        if (cache_ && cache_->try_read_storage_page(
+                          addr, incarnation, page_key, result)) {
+            return result;
+        }
+        auto const res = db_.find(
+            curr_root_,
+            concat(
+                prefix_,
+                STATE_NIBBLE,
+                NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
+                NibblesView{
+                    keccak256({page_key.bytes, sizeof(page_key.bytes)})}),
+            block_number_);
+        if (res.has_error()) {
+            stats_storage_no_value();
+            return {};
+        }
+        stats_storage_value();
+        auto encoded_storage = res.value().node->value();
+        auto const value = decode_storage_db_ignore_key(encoded_storage);
+        MONAD_ASSERT(!value.has_error());
+        auto const page = decode_storage_page(value.value());
+        MONAD_ASSERT(!page.has_error());
+        return page.value();
+    }
 }
 
 vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
@@ -205,7 +256,7 @@ void TrieDb::commit(
 
     if (cache_) {
         cache_->update_proposal_state(
-            std::move(state_deltas), header.number, block_id);
+            builder.take_proposal_post_state(), header.number, block_id);
     }
 }
 
@@ -445,28 +496,61 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             MONAD_ASSERT(node.has_value());
 
             auto encoded_storage = node.value();
-
-            auto const storage = decode_storage_db(encoded_storage);
+            auto raw_res = decode_storage_db_raw(encoded_storage);
+            MONAD_ASSERT(raw_res.has_value());
 
             auto const acct_key = fmt::format(
                 "{}", NibblesView{path}.substr(0, KECCAK256_SIZE * 2));
 
-            auto const key = fmt::format(
-                "{}",
-                NibblesView{path}.substr(
-                    KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
+            if (db.is_page_encoded()) {
+                // Page-encoded leaf: first element of the RLP list is the
+                // page_key (compact), second is the encoded page bytes.
+                // Fan out one JSON entry per populated slot, keyed by
+                // keccak256(slot_key) so the output matches a slot dump.
+                bytes32_t const page_key = to_bytes(raw_res.value().first);
+                auto const page = decode_storage_page(raw_res.value().second);
+                MONAD_ASSERT(page.has_value());
+                for (uint8_t off = 0; off < storage_page_t::SLOTS; ++off) {
+                    auto const &slot_value = page.value()[off];
+                    if (slot_value == bytes32_t{}) {
+                        continue;
+                    }
+                    bytes32_t const slot_key = compute_slot_key(page_key, off);
+                    auto const hashed_slot_key = to_bytes(
+                        keccak256({slot_key.bytes, sizeof(slot_key.bytes)}));
+                    auto const key = fmt::format("{}", hashed_slot_key);
+                    auto storage_data_json = nlohmann::json::object();
+                    storage_data_json["slot"] = fmt::format(
+                        "0x{:02x}",
+                        fmt::join(
+                            std::as_bytes(std::span(slot_key.bytes)), ""));
+                    storage_data_json["value"] = fmt::format(
+                        "0x{:02x}",
+                        fmt::join(
+                            std::as_bytes(std::span(slot_value.bytes)), ""));
+                    json[acct_key]["storage"][key] = storage_data_json;
+                }
+            }
+            else {
+                // Slot-encoded leaf: trie path under the account is
+                // keccak256(slot_key); the leaf carries (slot_key,
+                // slot_value).
+                bytes32_t const slot_key = to_bytes(raw_res.value().first);
+                bytes32_t const slot_value = to_bytes(raw_res.value().second);
+                auto const key = fmt::format(
+                    "{}",
+                    NibblesView{path}.substr(
+                        KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
 
-            auto storage_data_json = nlohmann::json::object();
-            storage_data_json["slot"] = fmt::format(
-                "0x{:02x}",
-                fmt::join(
-                    std::as_bytes(std::span(storage.value().first.bytes)), ""));
-            storage_data_json["value"] = fmt::format(
-                "0x{:02x}",
-                fmt::join(
-                    std::as_bytes(std::span(storage.value().second.bytes)),
-                    ""));
-            json[acct_key]["storage"][key] = storage_data_json;
+                auto storage_data_json = nlohmann::json::object();
+                storage_data_json["slot"] = fmt::format(
+                    "0x{:02x}",
+                    fmt::join(std::as_bytes(std::span(slot_key.bytes)), ""));
+                storage_data_json["value"] = fmt::format(
+                    "0x{:02x}",
+                    fmt::join(std::as_bytes(std::span(slot_value.bytes)), ""));
+                json[acct_key]["storage"][key] = storage_data_json;
+            }
         }
 
         virtual std::unique_ptr<TraverseMachine> clone() const override

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -83,7 +83,7 @@ public:
 
     virtual void commit(
         bytes32_t const &block_id, CommitBuilder &builder,
-        BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
+        BlockHeader const &header, StateDeltas const &state_deltas,
         std::function<void(BlockHeader &)> populate_header_fn) override;
 
     virtual void

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -55,10 +55,18 @@ class TrieDb final : public ::monad::Db
     // We only want to pay that price when the cache is enabled, hence
     // the need for unique_ptr.
     std::unique_ptr<DbCache> cache_;
+    // True iff this trie reads / writes page-encoded storage (MIP-8).
+    // Set at construction; immutable. Exposed via is_page_encoded().
+    bool const page_encoded_;
 
 public:
     explicit TrieDb(mpt::Db &, bool enable_multiblock_cache = false);
     ~TrieDb();
+
+    bool is_page_encoded() const override
+    {
+        return page_encoded_;
+    }
 
     void reset_root(::monad::mpt::Node::SharedPtr root, uint64_t block_number);
     ::monad::mpt::Node::SharedPtr const &get_root() const;
@@ -66,6 +74,8 @@ public:
     virtual std::optional<Account> read_account(Address const &) override;
     virtual bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
+    virtual storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) override;
     virtual vm::SharedIntercode read_code(bytes32_t const &) override;
     virtual void set_block_and_prefix(
         uint64_t block_number,

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -30,6 +30,7 @@
 
 MONAD_NAMESPACE_BEGIN
 
+// TODO: template by page_encoded as well. Will need it for release2
 class TrieRODb final : public ::monad::Db
 {
     ::monad::mpt::RODb &db_;
@@ -110,6 +111,12 @@ public:
         auto const storage = decode_storage_db_ignore_key(encoded_storage);
         MONAD_ASSERT(!storage.has_error());
         return to_bytes(storage.value());
+    }
+
+    virtual storage_page_t
+    read_storage_page(Address const &, Incarnation, bytes32_t const &) override
+    {
+        MONAD_ABORT("TrieRODb is slot-encoded; read_storage_page unsupported");
     }
 
     virtual vm::SharedIntercode read_code(bytes32_t const &code_hash) override

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -140,8 +140,7 @@ public:
 
     virtual void commit(
         bytes32_t const &, CommitBuilder &, BlockHeader const &,
-        std::unique_ptr<StateDeltas>,
-        std::function<void(BlockHeader &)>) override
+        StateDeltas const &, std::function<void(BlockHeader &)>) override
     {
         MONAD_ABORT();
     }

--- a/category/execution/ethereum/evm_test.cpp
+++ b/category/execution/ethereum/evm_test.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(TraitsTest, create_with_insufficient)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{from,
               StateDelta{
                   .account =
@@ -157,7 +157,7 @@ TYPED_TEST(TraitsTest, create_insufficient_balance_nonce_bump)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{from,
               StateDelta{
                   .account =
@@ -240,7 +240,7 @@ TYPED_TEST(TraitsTest, create_revert_preserves_access_list_trace)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{from,
               StateDelta{
                   .account =
@@ -327,14 +327,16 @@ TYPED_TEST(TraitsTest, eip684_existing_code)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 10'000'000'000, .nonce = 7}}}},
-            {to,
-             StateDelta{
-                 .account = {std::nullopt, Account{.code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 10'000'000'000, .nonce = 7}}}},
+             {to,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.code_hash = code_hash}}}}}),
         Code{},
         BlockHeader{});
 
@@ -406,7 +408,7 @@ TYPED_TEST(TraitsTest, create_nonce_out_of_range)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{from,
               StateDelta{
                   .account =
@@ -470,11 +472,12 @@ TYPED_TEST(TraitsTest, static_precompile_execution)
 
     commit_sequential(
         tdb,
-        sd({{code_address,
-             StateDelta{.account = {std::nullopt, Account{.nonce = 4}}}},
-            {from,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 15'000}}}}}),
+        StateDeltas(
+            {{code_address,
+              StateDelta{.account = {std::nullopt, Account{.nonce = 4}}}},
+             {from,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 15'000}}}}}),
         Code{},
         BlockHeader{});
     init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
@@ -539,11 +542,12 @@ TYPED_TEST(TraitsTest, out_of_gas_static_precompile_execution)
 
     commit_sequential(
         tdb,
-        sd({{code_address,
-             StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}},
-            {from,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 15'000}}}}}),
+        StateDeltas(
+            {{code_address,
+              StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}},
+             {from,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 15'000}}}}}),
         Code{},
         BlockHeader{});
     init_rb_for_test<typename TestFixture::Trait>(s, h, Address{from});
@@ -602,7 +606,7 @@ TYPED_TEST(TraitsTest, create_op_max_initcode_size)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {good_code_address,
              StateDelta{
                  .account =
@@ -726,7 +730,7 @@ TYPED_TEST(TraitsTest, create2_op_max_initcode_size)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {good_code_address,
              StateDelta{
                  .account =
@@ -826,7 +830,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_not_enough_of_gas)
     vm::VM vm;
     commit_sequential(
         tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -871,7 +875,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_max_code_size)
     vm::VM vm;
     commit_sequential(
         tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -904,7 +908,7 @@ TYPED_TEST(TraitsTest, deploy_contract_code_validation)
     vm::VM vm;
     commit_sequential(
         tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{a, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
     BlockState bs{tdb, vm};
@@ -959,29 +963,30 @@ TYPED_TEST(TraitsTest, create_inside_delegated_call)
 
     commit_sequential(
         tdb,
-        sd({{eoa,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
-                      }}}},
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                      }}}},
-            {delegated,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = delegated_code_hash,
-                      }}}}}),
+        StateDeltas(
+            {{eoa,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = eoa_code_hash,
+                       }}}},
+             {from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                       }}}},
+             {delegated,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = delegated_code_hash,
+                       }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {delegated_code_hash, delegated_icode},
@@ -1080,37 +1085,38 @@ TYPED_TEST(TraitsTest, create2_inside_delegated_call_via_delegatecall)
 
     commit_sequential(
         tdb,
-        sd({{eoa,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
-                      }}}},
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                      }}}},
-            {delegated,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = delegated_code_hash,
-                      }}}},
-            {creator,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = creator_code_hash,
-                      }}}}}),
+        StateDeltas(
+            {{eoa,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = eoa_code_hash,
+                       }}}},
+             {from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                       }}}},
+             {delegated,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = delegated_code_hash,
+                       }}}},
+             {creator,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = creator_code_hash,
+                       }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {delegated_code_hash, delegated_icode},
@@ -1203,29 +1209,30 @@ TYPED_TEST(TraitsTest, nested_call_to_delegated_precompile)
 
     commit_sequential(
         tdb,
-        sd({{eoa,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = eoa_code_hash,
-                      }}}},
-            {from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                      }}}},
-            {contract,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = contract_code_hash,
-                      }}}}}),
+        StateDeltas(
+            {{eoa,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = eoa_code_hash,
+                       }}}},
+             {from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                       }}}},
+             {contract,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = contract_code_hash,
+                       }}}}}),
         Code{
             {eoa_code_hash, eoa_icode},
             {contract_code_hash, contract_icode},
@@ -1295,20 +1302,21 @@ TYPED_TEST(TraitsTest, cold_account_access)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                      }}}},
-            {contract,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .code_hash = code_hash,
-                      }}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                       }}}},
+             {contract,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .code_hash = code_hash,
+                       }}}}}),
         Code{
             {code_hash, icode},
         },
@@ -1418,38 +1426,39 @@ TYPED_TEST(TraitsTest, defensive_delegation_check)
 
     commit_sequential(
         tdb,
-        sd({{falsely_delegated_1,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = short_code_hash,
-                      }}}},
-            {falsely_delegated_2,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = bad_code_hash2,
-                      }}}},
-            {falsely_delegated_3,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = bad_code_hash,
-                      }}}},
-            {correctly_delegated,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 10'000'000'000,
-                          .code_hash = good_code_hash,
-                      }}}}}),
+        StateDeltas(
+            {{falsely_delegated_1,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = short_code_hash,
+                       }}}},
+             {falsely_delegated_2,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = bad_code_hash2,
+                       }}}},
+             {falsely_delegated_3,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = bad_code_hash,
+                       }}}},
+             {correctly_delegated,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 10'000'000'000,
+                           .code_hash = good_code_hash,
+                       }}}}}),
         Code{
             {bad_code_hash, bad_icode},
             {bad_code_hash2, bad_icode2},

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -171,18 +171,6 @@ void EvmcHostBase::emit_log(
     stack_unwind();
 }
 
-evmc_access_status EvmcHostBase::access_storage(
-    evmc::address const &address, evmc::bytes32 const &key) noexcept
-{
-    try {
-        return state_.access_storage(address, key);
-    }
-    catch (...) {
-        capture_current_exception();
-    }
-    stack_unwind();
-}
-
 evmc::bytes32 EvmcHostBase::get_transient_storage(
     evmc::address const &address, evmc::bytes32 const &key) const noexcept
 {
@@ -201,6 +189,19 @@ void EvmcHostBase::set_transient_storage(
 {
     try {
         return state_.set_transient_storage(address, key, value);
+    }
+    catch (...) {
+        capture_current_exception();
+    }
+    stack_unwind();
+}
+
+EvmcHostBase::PageStorageStatus EvmcHostBase::update_page(
+    evmc::address const &address, evmc::bytes32 const &page_key,
+    evmc_storage_status const status) noexcept
+{
+    try {
+        return state_.update_page(address, page_key, status);
     }
     catch (...) {
         capture_current_exception();

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -91,9 +91,6 @@ public:
         evmc::address const &, uint8_t const *data, size_t data_size,
         evmc::bytes32 const topics[], size_t num_topics) noexcept override;
 
-    virtual evmc_access_status access_storage(
-        evmc::address const &, evmc::bytes32 const &key) noexcept override;
-
     virtual evmc::bytes32 get_transient_storage(
         evmc::address const &,
         evmc::bytes32 const &key) const noexcept override;
@@ -101,6 +98,10 @@ public:
     virtual void set_transient_storage(
         evmc::address const &, evmc::bytes32 const &key,
         evmc::bytes32 const &value) noexcept override;
+
+    virtual PageStorageStatus update_page(
+        evmc::address const &, evmc::bytes32 const &page_key,
+        evmc_storage_status) noexcept override;
 };
 
 static_assert(sizeof(EvmcHostBase) == 64);
@@ -202,6 +203,19 @@ struct EvmcHost final : public EvmcHostBase
                 return EVMC_ACCESS_WARM;
             }
             return state_.access_account(address);
+        }
+        catch (...) {
+            capture_current_exception();
+        }
+        stack_unwind();
+    }
+
+    virtual evmc_access_status access_storage(
+        evmc::address const &address,
+        evmc::bytes32 const &key) noexcept override
+    {
+        try {
+            return state_.access_storage<traits>(address, key);
         }
         catch (...) {
             capture_current_exception();

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -177,39 +177,40 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xffffffffffffffffffffffffffffffff_u256,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {to,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x0fffffffffffff,
-                          .code_hash = STRESS_TEST_CODE_HASH}}}},
-            {ca,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0x1b58, .code_hash = NULL_HASH}}}},
-            {WITHDRAWAL_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
-            {CONSOLIDATION_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0,
-                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xffffffffffffffffffffffffffffffff_u256,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {to,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x0fffffffffffff,
+                           .code_hash = STRESS_TEST_CODE_HASH}}}},
+             {ca,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0x1b58, .code_hash = NULL_HASH}}}},
+             {WITHDRAWAL_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
+             {CONSOLIDATION_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0,
+                           .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -312,7 +313,7 @@ TYPED_TEST(TraitsTest, call_frames_stress_test)
     auto [state, code, _] = std::move(bs).release();
     commit_simple(
         tdb,
-        std::move(state),
+        *state,
         code,
         block_id,
         header,
@@ -346,34 +347,35 @@ TYPED_TEST(TraitsTest, assertion_exception)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {to,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = STRESS_TEST_CODE_HASH}}}},
-            {WITHDRAWAL_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
-            {CONSOLIDATION_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0,
-                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {to,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = STRESS_TEST_CODE_HASH}}}},
+             {WITHDRAWAL_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
+             {CONSOLIDATION_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0,
+                           .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {STRESS_TEST_CODE_HASH, STRESS_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -486,48 +488,49 @@ TYPED_TEST(TraitsTest, call_frames_refund)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x989680,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {to,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x0,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x01}}}},
-            {ca,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x1b58,
-                          .code_hash = REFUND_TEST_CODE_HASH}},
-                 .storage =
-                     {{bytes32_t{0x01}, {bytes32_t{}, bytes32_t{0x01}}},
-                      {bytes32_t{0x02}, {bytes32_t{}, bytes32_t{0x01}}},
-                      {bytes32_t{0x03}, {bytes32_t{}, bytes32_t{0x01}}},
-                      {bytes32_t{0x04}, {bytes32_t{}, bytes32_t{0x01}}},
-                      {bytes32_t{0x05}, {bytes32_t{}, bytes32_t{0x01}}}}}},
-            {WITHDRAWAL_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
-            {CONSOLIDATION_REQUEST_ADDRESS,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0,
-                          .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x989680,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {to,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x0,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x01}}}},
+             {ca,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x1b58,
+                           .code_hash = REFUND_TEST_CODE_HASH}},
+                  .storage =
+                      {{bytes32_t{0x01}, {bytes32_t{}, bytes32_t{0x01}}},
+                       {bytes32_t{0x02}, {bytes32_t{}, bytes32_t{0x01}}},
+                       {bytes32_t{0x03}, {bytes32_t{}, bytes32_t{0x01}}},
+                       {bytes32_t{0x04}, {bytes32_t{}, bytes32_t{0x01}}},
+                       {bytes32_t{0x05}, {bytes32_t{}, bytes32_t{0x01}}}}}},
+             {WITHDRAWAL_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = SYSTEM_STUB_CODE_HASH}}}},
+             {CONSOLIDATION_REQUEST_ADDRESS,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0,
+                           .code_hash = SYSTEM_STUB_CODE_HASH}}}}}),
         Code{
             {REFUND_TEST_CODE_HASH, REFUND_TEST_ICODE},
             {SYSTEM_STUB_CODE_HASH, SYSTEM_STUB_ICODE}},
@@ -630,7 +633,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
     auto [state, code, _] = std::move(bs).release();
     commit_simple(
         tdb,
-        std::move(state),
+        *state,
         code,
         block_id,
         header,

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -260,7 +260,7 @@ evmc::Result ExecuteTransactionNoValidation<traits>::operator()(
     for (auto const &ae : tx_.access_list) {
         state.access_account(ae.a);
         for (auto const &keys : ae.keys) {
-            state.access_storage(ae.a, keys);
+            state.access_storage<traits>(ae.a, keys);
         }
     }
     if (MONAD_LIKELY(tx_.to)) {

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -45,8 +45,9 @@
 
 MONAD_NAMESPACE_BEGIN
 
-BlockState::BlockState(Db &db, vm::VM &monad_vm)
+BlockState::BlockState(Db &db, vm::VM &monad_vm, Db *const secondary_db)
     : db_{db}
+    , secondary_db_{secondary_db}
     , vm_{monad_vm}
     , state_(std::make_unique<StateDeltas>())
 {
@@ -101,9 +102,13 @@ bytes32_t BlockState::read_storage(
     }
     // database
     {
-        auto const result = read_storage
-                                ? db_.read_storage(address, incarnation, key)
-                                : bytes32_t{};
+        bytes32_t result{};
+        if (read_storage) {
+            result = db_.read_storage(address, incarnation, key);
+            MONAD_ASSERT(
+                !secondary_db_ || secondary_db_->read_storage(
+                                      address, incarnation, key) == result);
+        }
         StateDeltas::accessor it{};
         MONAD_ASSERT(state_->find(it, address));
         auto const &account = it->second.account.second;

--- a/category/execution/ethereum/state2/block_state.hpp
+++ b/category/execution/ethereum/state2/block_state.hpp
@@ -41,6 +41,11 @@ using SelfDestructStorageReads = ankerl::unordered_dense::segmented_map<
 class BlockState final
 {
     Db &db_;
+    // Optional cross-check db: when non-null, every storage read is also
+    // performed against this db and the result asserted to match. Used by
+    // the dual-db migration path to detect divergence between the slot-
+    // encoded primary and the page-encoded secondary.
+    Db *secondary_db_;
     vm::VM &vm_;
     std::unique_ptr<StateDeltas> state_;
     Code code_;
@@ -57,7 +62,7 @@ class BlockState final
     SelfDestructStorageReads self_destruct_storage_reads_;
 
 public:
-    BlockState(Db &, vm::VM &);
+    BlockState(Db &, vm::VM &, Db *secondary_db = nullptr);
 
     vm::VM &vm()
     {

--- a/category/execution/ethereum/state2/proposal_post_state.hpp
+++ b/category/execution/ethereum/state2/proposal_post_state.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <optional>
+
+MONAD_NAMESPACE_BEGIN
+
+// Account map keyed by Address. nullopt means the account was deleted (or
+// does not exist) for the proposal at hand. Populated by
+// CommitBuilder::add_state_deltas (one entry per touched account) and drained
+// via CommitBuilder::take_proposal_post_state.
+using AccountPostState =
+    ankerl::unordered_dense::segmented_map<Address, std::optional<Account>>;
+
+// Storage leaf map keyed by StorageKey{addr, incarnation, key}. The key
+// granularity matches the trie's storage subtree: slot_key (single slot at
+// index 0) for slot mode, page_key (full page) for page mode. The
+// key being present marks "touched by this proposal"; an empty
+// storage_page_t means every slot in that entry is zero (deleted), which is
+// stored as a present entry rather than absent.
+using StoragePostState = ankerl::unordered_dense::segmented_map<
+    StorageKey, storage_page_t, BytesHashCompare<StorageKey>>;
+
+struct ProposalPostState
+{
+    AccountPostState accounts;
+    StoragePostState storage;
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -153,7 +153,7 @@ TEST_F(InMemoryStateTest, access_account)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 10'000}}}}}),
@@ -173,7 +173,7 @@ TEST_F(InMemoryStateTest, account_exists)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 10'000}}}}}),
@@ -207,7 +207,7 @@ TEST_F(InMemoryStateTest, get_balance)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 10'000}}}}}),
@@ -226,7 +226,9 @@ TEST_F(InMemoryStateTest, add_to_balance)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{.balance = 1}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{.account = {std::nullopt, Account{.balance = 1}}}}}),
         Code{},
         BlockHeader{});
 
@@ -243,7 +245,8 @@ TEST_F(InMemoryStateTest, get_nonce)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, Account{.nonce = 2}}}}}),
+        StateDeltas(
+            {{a, StateDelta{.account = {std::nullopt, Account{.nonce = 2}}}}}),
         Code{},
         BlockHeader{});
 
@@ -269,7 +272,7 @@ TEST_F(InMemoryStateTest, get_code_hash)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.code_hash = hash1}}}}}),
@@ -299,11 +302,13 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{.account = {std::nullopt, Account{.balance = 18'000}}}},
-            {c,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 38'000}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 18'000}}}},
+             {c,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 38'000}}}}}),
         Code{},
         BlockHeader{});
 
@@ -344,20 +349,21 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_separate_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 18'000,
-                          .incarnation = Incarnation{1, 1}}}}},
-            {c,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 38'000,
-                          .incarnation = Incarnation{1, 1}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 18'000,
+                           .incarnation = Incarnation{1, 1}}}}},
+             {c,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 38'000,
+                           .incarnation = Incarnation{1, 1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -386,20 +392,21 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_same_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 18'000,
-                          .incarnation = Incarnation{1, 1}}}}},
-            {c,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 38'000,
-                          .incarnation = Incarnation{1, 1}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 18'000,
+                           .incarnation = Incarnation{1, 1}}}}},
+             {c,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 38'000,
+                           .incarnation = Incarnation{1, 1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -423,7 +430,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_self_separate_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}}}}}),
@@ -458,7 +465,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_self_same_tx)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account =
@@ -486,7 +493,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -520,7 +527,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_create_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -569,7 +576,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -594,7 +601,7 @@ TYPED_TEST(InMemoryStateTraitsTest, selfdestruct_merge_commit_incarnation)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{1},
             BlockHeader{.number = 1},
@@ -617,7 +624,7 @@ TYPED_TEST(
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{}},
@@ -649,7 +656,7 @@ TYPED_TEST(
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{1},
             BlockHeader{.number = 1},
@@ -709,7 +716,7 @@ TYPED_TEST(
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             NULL_HASH_BLAKE3,
             BlockHeader{.number = 0},
@@ -736,7 +743,7 @@ TYPED_TEST(
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -776,7 +783,7 @@ TYPED_TEST(
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -833,7 +840,7 @@ TYPED_TEST(
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -899,7 +906,7 @@ TEST_F(InMemoryStateTest, create_conflict_address_incarnation)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 18'000}},
@@ -921,9 +928,11 @@ TYPED_TEST(InMemoryStateTraitsTest, destruct_touched_dead)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{.account = {std::nullopt, Account{.balance = 10'000}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 10'000}}}},
+             {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -980,16 +989,17 @@ TEST_F(InMemoryStateTest, get_storage)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}},
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key1, {bytes32_t{}, value1}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}},
+             {b,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key1, {bytes32_t{}, value1}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1009,11 +1019,12 @@ TEST_F(InMemoryStateTest, set_storage_modified)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}},
+             {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1029,7 +1040,7 @@ TEST_F(InMemoryStateTest, set_storage_deleted)
 
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{b,
               StateDelta{
                   .account = {std::nullopt, Account{}},
@@ -1052,7 +1063,7 @@ TEST_F(InMemoryStateTest, set_storage_added)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1071,11 +1082,12 @@ TEST_F(InMemoryStateTest, set_storage_different_assigned)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}},
+             {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1092,11 +1104,12 @@ TEST_F(InMemoryStateTest, set_storage_unchanged_assigned)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{
-                 .account = {std::nullopt, Account{}},
-                 .storage = {{key2, {bytes32_t{}, value2}}}}},
-            {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{}},
+                  .storage = {{key2, {bytes32_t{}, value2}}}}},
+             {b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1111,7 +1124,7 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1128,7 +1141,7 @@ TEST_F(InMemoryStateTest, set_storage_added_deleted_null)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
+        StateDeltas({{b, StateDelta{.account = {std::nullopt, Account{}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1145,7 +1158,7 @@ TEST_F(InMemoryStateTest, set_storage_modify_delete)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{b,
               StateDelta{
                   .account = {std::nullopt, Account{}},
@@ -1166,7 +1179,7 @@ TEST_F(InMemoryStateTest, set_storage_delete_restored)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{b,
               StateDelta{
                   .account = {std::nullopt, Account{}},
@@ -1187,7 +1200,7 @@ TEST_F(InMemoryStateTest, set_storage_modified_restored)
     BlockState bs{this->tdb, this->vm};
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{b,
               StateDelta{
                   .account = {std::nullopt, Account{}},
@@ -1210,7 +1223,7 @@ TEST_F(InMemoryStateTest, get_code_size)
     Account acct{.code_hash = code_hash1};
     commit_sequential(
         this->tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, acct}}}}),
+        StateDeltas({{a, StateDelta{.account = {std::nullopt, acct}}}}),
         Code{{code_hash1, icode1}},
         BlockHeader{});
 
@@ -1226,8 +1239,9 @@ TEST_F(InMemoryStateTest, copy_code)
 
     commit_sequential(
         this->tdb,
-        sd({{a, StateDelta{.account = {std::nullopt, acct_a}}},
-            {b, StateDelta{.account = {std::nullopt, acct_b}}}}),
+        StateDeltas(
+            {{a, StateDelta{.account = {std::nullopt, acct_a}}},
+             {b, StateDelta{.account = {std::nullopt, acct_b}}}}),
         Code{{code_hash1, icode1}, {code_hash2, icode2}},
         BlockHeader{});
 
@@ -1277,7 +1291,7 @@ TEST_F(InMemoryStateTest, get_code)
 
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account =
@@ -1321,18 +1335,19 @@ TEST_F(InMemoryStateTest, can_merge_same_account_different_storage)
 
     commit_sequential(
         this->tdb,
-        sd({{b,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 40'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}},
-            {c,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 50'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}}),
+        StateDeltas(
+            {{b,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 40'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}},
+             {c,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 50'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1355,7 +1370,7 @@ TEST_F(InMemoryStateTest, cant_merge_colliding_storage)
 
     commit_sequential(
         this->tdb,
-        sd(
+        StateDeltas(
             {{b,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 40'000}},
@@ -1391,20 +1406,22 @@ TYPED_TEST(InMemoryStateTraitsTest, merge_txn0_and_txn1)
 
     commit_sequential(
         this->tdb,
-        sd({{a,
-             StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 40'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}},
-            {c,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 50'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 30'000}}}},
+             {b,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 40'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}},
+             {c,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 50'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         BlockHeader{});
 
@@ -1441,7 +1458,7 @@ TEST_F(InMemoryStateTest, commit_storage_and_account_together_regression)
     auto [released_state, released_code, _] = std::move(bs).release();
     commit_simple(
         this->tdb,
-        std::move(released_state),
+        *released_state,
         released_code,
         NULL_HASH_BLAKE3,
         BlockHeader{.number = 0},
@@ -1471,7 +1488,7 @@ TEST_F(InMemoryStateTest, set_and_then_clear_storage_in_same_commit)
     auto [released_state, released_code, _] = std::move(bs).release();
     commit_simple(
         this->tdb,
-        std::move(released_state),
+        *released_state,
         released_code,
         NULL_HASH_BLAKE3,
         {},
@@ -1495,20 +1512,22 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
     this->tdb.set_block_and_prefix(8);
     commit_simple(
         this->tdb,
-        sd({{a,
-             StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 40'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}},
-            {c,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 50'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 30'000}}}},
+             {b,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 40'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}},
+             {c,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 50'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         bytes32_t{9},
         BlockHeader{.number = 9});
@@ -1530,7 +1549,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{10},
             BlockHeader{.number = 10});
@@ -1557,7 +1576,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{11},
             BlockHeader{.number = 11});
@@ -1600,20 +1619,22 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
     this->tdb.set_block_and_prefix(9);
     commit_simple(
         this->tdb,
-        sd({{a,
-             StateDelta{.account = {std::nullopt, Account{.balance = 30'000}}}},
-            {b,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 40'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}},
-            {c,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 50'000}},
-                 .storage =
-                     {{key1, {bytes32_t{}, value1}},
-                      {key2, {bytes32_t{}, value2}}}}}}),
+        StateDeltas(
+            {{a,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 30'000}}}},
+             {b,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 40'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}},
+             {c,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 50'000}},
+                  .storage =
+                      {{key1, {bytes32_t{}, value1}},
+                       {key2, {bytes32_t{}, value2}}}}}}),
         Code{},
         bytes32_t{10},
         BlockHeader{.number = 10},
@@ -1638,7 +1659,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{118},
             BlockHeader{.number = 11});
@@ -1666,7 +1687,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{116},
             BlockHeader{.number = 11});
@@ -1696,7 +1717,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
         auto [released_state, released_code, _] = std::move(bs).release();
         commit_simple(
             this->tdb,
-            std::move(released_state),
+            *released_state,
             released_code,
             bytes32_t{117},
             BlockHeader{.number = 11});
@@ -1725,7 +1746,7 @@ TEST_F(OnDiskStateTestCached, proposal_basics)
     Db &db = this->tdb;
     commit_simple(
         db,
-        sd(
+        StateDeltas(
             {{a,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 30'000}}}}}),
@@ -1744,7 +1765,7 @@ TEST_F(OnDiskStateTestCached, proposal_basics)
          _released_self_destruct_storage_reads1] = std::move(bs1).release();
     commit_simple(
         db,
-        std::move(released_state1),
+        *released_state1,
         released_code1,
         bytes32_t{11},
         BlockHeader{.number = 11});
@@ -1764,7 +1785,7 @@ TEST_F(OnDiskStateTestCached, proposal_basics)
          _released_self_destruct_storage_reads2] = std::move(bs2).release();
     commit_simple(
         db,
-        std::move(released_state2),
+        *released_state2,
         released_code2,
         bytes32_t{12},
         BlockHeader{.number = 12});
@@ -1809,11 +1830,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
                  {key2, {bytes32_t{}, value2}}}}}}};
     db.set_block_and_prefix(9);
     commit_simple(
-        db,
-        std::move(state_deltas),
-        Code{},
-        bytes32_t{10},
-        BlockHeader{.number = 10});
+        db, *state_deltas, Code{}, bytes32_t{10}, BlockHeader{.number = 10});
     db.finalize(10, bytes32_t{10});
     EXPECT_TRUE(db.read_account(a).has_value());
     EXPECT_TRUE(db.read_account(b).has_value());
@@ -1845,7 +1862,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_111).release();
     commit_simple(
         db,
-        std::move(released_state_111),
+        *released_state_111,
         released_code_111,
         bytes32_t{111},
         BlockHeader{.number = 11});
@@ -1880,7 +1897,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_121).release();
     commit_simple(
         db,
-        std::move(released_state_121),
+        *released_state_121,
         released_code_121,
         bytes32_t{121},
         BlockHeader{.number = 12});
@@ -1915,7 +1932,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_112).release();
     commit_simple(
         db,
-        std::move(released_state_112),
+        *released_state_112,
         released_code_112,
         bytes32_t{112},
         BlockHeader{.number = 11});
@@ -1938,7 +1955,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_122).release();
     commit_simple(
         db,
-        std::move(released_state_122),
+        *released_state_122,
         released_code_122,
         bytes32_t{122},
         BlockHeader{.number = 12});
@@ -1964,7 +1981,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_131).release();
     commit_simple(
         db,
-        std::move(released_state_131),
+        *released_state_131,
         released_code_131,
         bytes32_t{131},
         BlockHeader{.number = 13});
@@ -1988,7 +2005,7 @@ TEST_F(OnDiskStateTestCached, undecided_proposals)
             std::move(bs_132).release();
     commit_simple(
         db,
-        std::move(released_state_132),
+        *released_state_132,
         released_code_132,
         bytes32_t{132},
         BlockHeader{.number = 13});
@@ -2277,7 +2294,7 @@ namespace
                 auto [state1, code1, _] = std::move(bs1).release();
                 commit_simple(
                     db1_,
-                    std::move(state1),
+                    *state1,
                     code1,
                     get_dummy_block_id(proposal_seed),
                     BlockHeader{.number = block});
@@ -2286,7 +2303,7 @@ namespace
                 auto [state2, code2, _] = std::move(bs2).release();
                 commit_simple(
                     db2_,
-                    std::move(state2),
+                    *state2,
                     code2,
                     get_dummy_block_id(proposal_seed),
                     BlockHeader{.number = block});

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -974,14 +974,15 @@ TEST_F(InMemoryStateTest, access_storage)
     BlockState bs{this->tdb, this->vm};
 
     State s{bs, Incarnation{1, 1}};
-    EXPECT_EQ(s.access_storage(a, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(a, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(b, key1), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(b, key1), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(a, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(a, key2), EVMC_ACCESS_WARM);
-    EXPECT_EQ(s.access_storage(b, key2), EVMC_ACCESS_COLD);
-    EXPECT_EQ(s.access_storage(b, key2), EVMC_ACCESS_WARM);
+    using T = EvmTraits<EVMC_LATEST_STABLE_REVISION>;
+    EXPECT_EQ(s.access_storage<T>(a, key1), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<T>(a, key1), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<T>(b, key1), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<T>(b, key1), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<T>(a, key2), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<T>(a, key2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(s.access_storage<T>(b, key2), EVMC_ACCESS_COLD);
+    EXPECT_EQ(s.access_storage<T>(b, key2), EVMC_ACCESS_WARM);
 }
 
 TEST_F(InMemoryStateTest, get_storage)

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -22,6 +22,7 @@
 #include <category/core/likely.h>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/state3/account_substate.hpp>
+#include <category/execution/ethereum/state3/page_tracker.hpp>
 
 #include <evmc/evmc.h>
 
@@ -68,6 +69,7 @@ private:
 public:
     StorageMap storage_{};
     StorageMap transient_storage_{};
+    PageTracker page_tracker_{};
 
     evmc_storage_status zero_out_key(
         bytes32_t const &key, bytes32_t const &original_value,
@@ -153,7 +155,7 @@ public:
     }
 };
 
-static_assert(sizeof(AccountState) == 144);
+static_assert(sizeof(AccountState) == 160);
 
 // RELAXED MERGE
 // track the min original balance needed at start of transaction and if the

--- a/category/execution/ethereum/state3/page_tracker.hpp
+++ b/category/execution/ethereum/state3/page_tracker.hpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/vm/host.hpp>
+
+#include <evmc/evmc.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include <immer/map.hpp>
+#pragma GCC diagnostic pop
+
+MONAD_NAMESPACE_BEGIN
+
+// This is temp. Will be removed after the storage_page PR is merged.
+namespace detail
+{
+    inline bytes32_t compute_page_key(bytes32_t const &storage_key)
+    {
+        constexpr size_t PAGE_KEY_SHIFT = 7;
+        return (uint256_t::load_be(storage_key.bytes) >> PAGE_KEY_SHIFT)
+            .store_be<bytes32_t>();
+    }
+}
+
+class PageTracker
+{
+    struct PageState
+    {
+        bool accessed{false}; // read
+        bool dirty{false}; // write
+        int16_t peak_growth{0};
+        int16_t current_growth{0};
+    };
+
+    using PageMap = immer::map<
+        bytes32_t, PageState, ankerl::unordered_dense::hash<monad::bytes32_t>>;
+
+    PageMap pages_{};
+
+    PageState lookup_page_state(bytes32_t const &page_key) const
+    {
+        auto const *cur = pages_.find(page_key);
+        return cur ? *cur : PageState{};
+    }
+
+public:
+    evmc_access_status access_page(bytes32_t const &key)
+    {
+        auto const pkey = detail::compute_page_key(key);
+        PageState s = lookup_page_state(pkey);
+        if (s.accessed) {
+            return EVMC_ACCESS_WARM;
+        }
+        s.accessed = true;
+        pages_ = pages_.set(pkey, s);
+        return EVMC_ACCESS_COLD;
+    }
+
+    vm::Host::PageStorageStatus
+    update_page(bytes32_t const &key, evmc_storage_status status)
+    {
+        auto const pkey = detail::compute_page_key(key);
+        PageState ps = lookup_page_state(pkey);
+
+        bool const value_changed = (status != EVMC_STORAGE_ASSIGNED);
+        bool first_page_write = false;
+        if (!ps.dirty) {
+            first_page_write = value_changed;
+            ps.dirty = value_changed;
+        }
+
+        switch (status) {
+        case EVMC_STORAGE_ADDED:
+        case EVMC_STORAGE_DELETED_ADDED:
+        case EVMC_STORAGE_DELETED_RESTORED:
+            ++ps.current_growth;
+            break;
+        case EVMC_STORAGE_DELETED:
+        case EVMC_STORAGE_MODIFIED_DELETED:
+        case EVMC_STORAGE_ADDED_DELETED:
+            --ps.current_growth;
+            break;
+        default:
+            break;
+        }
+
+        bool const grew_state = ps.current_growth > ps.peak_growth;
+        if (grew_state) {
+            ps.peak_growth = ps.current_growth;
+        }
+        if (value_changed) {
+            pages_ = pages_.set(pkey, ps);
+        }
+
+        return {first_page_write, grew_state};
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state3/page_tracker_test.cpp
+++ b/category/execution/ethereum/state3/page_tracker_test.cpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/state3/page_tracker.hpp>
+
+#include <evmc/evmc.h>
+
+#include <gtest/gtest.h>
+
+using namespace monad;
+
+namespace
+{
+    constexpr bytes32_t SLOT_A{0x1ea0};
+    constexpr bytes32_t SLOT_A2{0x1eaf};
+    constexpr bytes32_t SLOT_B{0xdeadbeef};
+}
+
+TEST(PageTracker, cold_write)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).first_page_write);
+    EXPECT_FALSE(
+        pt.update_page(SLOT_A2, EVMC_STORAGE_MODIFIED).first_page_write);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED).first_page_write);
+}
+
+TEST(PageTracker, state_growth)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_MODIFIED).grew_state);
+}
+
+TEST(PageTracker, intra_txn_free)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED).grew_state);
+    EXPECT_FALSE(pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_ADDED).grew_state);
+}
+
+TEST(PageTracker, distinct_pages)
+{
+    PageTracker pt;
+
+    EXPECT_TRUE(pt.update_page(SLOT_A, EVMC_STORAGE_ADDED).first_page_write);
+    EXPECT_FALSE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).first_page_write);
+
+    auto const r = pt.update_page(SLOT_B, EVMC_STORAGE_ADDED);
+    EXPECT_TRUE(r.first_page_write);
+    EXPECT_TRUE(r.grew_state);
+}
+
+TEST(PageTracker, cold_read_then_warm_read)
+{
+    PageTracker pt;
+
+    EXPECT_EQ(pt.access_page(SLOT_A), EVMC_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_A2), EVMC_ACCESS_WARM);
+    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_COLD);
+    EXPECT_EQ(pt.access_page(SLOT_B), EVMC_ACCESS_WARM);
+}
+
+TEST(PageTracker, deleted_then_readded_returns_to_baseline)
+{
+    PageTracker pt;
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED);
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_ADDED);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+}
+
+TEST(PageTracker, deleted_then_restored_returns_to_baseline)
+{
+    PageTracker pt;
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED);
+    pt.update_page(SLOT_A, EVMC_STORAGE_DELETED_RESTORED);
+    EXPECT_TRUE(pt.update_page(SLOT_A2, EVMC_STORAGE_ADDED).grew_state);
+}

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -412,11 +412,26 @@ evmc_access_status State::access_account(Address const &address)
     return account_state.access();
 }
 
+template <Traits traits>
 evmc_access_status
 State::access_storage(Address const &address, bytes32_t const &key)
 {
     auto &account_state = current_account_state(address);
-    return account_state.access_storage(key);
+    auto const slot_status = account_state.access_storage(key);
+    if constexpr (traits::mip_8_active()) {
+        return account_state.page_tracker_.access_page(key);
+    }
+    return slot_status;
+}
+
+EXPLICIT_TRAITS_MEMBER(State::access_storage);
+
+vm::Host::PageStorageStatus State::update_page(
+    Address const &address, bytes32_t const &key,
+    evmc_storage_status const status)
+{
+    auto &account_state = current_account_state(address);
+    return account_state.page_tracker_.update_page(key, status);
 }
 
 template <Traits traits>

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -167,7 +167,11 @@ public:
 
     evmc_access_status access_account(Address const &);
 
+    template <Traits traits>
     evmc_access_status access_storage(Address const &, bytes32_t const &key);
+
+    vm::Host::PageStorageStatus update_page(
+        Address const &, bytes32_t const &key, evmc_storage_status status);
 
     ////////////////////////////////////////
 

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -133,19 +133,20 @@ TYPED_TEST(TraitsTest, execute_success)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x200000,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x200000,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{});
 
@@ -217,19 +218,20 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0x10000,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0x10000,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{});
 
@@ -306,17 +308,18 @@ TYPED_TEST(TraitsTest, create_call_trace)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -428,17 +431,18 @@ TYPED_TEST(TraitsTest, selfdestruct_logs)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -516,17 +520,18 @@ TYPED_TEST(TraitsTest, selfdestruct_logs_value)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_C,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{ADDR_C,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -618,7 +623,7 @@ TYPED_TEST(TraitsTest, selfdestruct_depth)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account =
@@ -698,14 +703,15 @@ TYPED_TEST(TraitsTest, simulate_v1_trace)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{.account = {std::nullopt, Account{.balance = 0}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{.account = {std::nullopt, Account{.balance = 0}}}}}),
         Code{},
         BlockHeader{});
 
@@ -802,17 +808,18 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_C,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1000u, .code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{ADDR_C,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1000u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -906,17 +913,18 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_selfdestruct_zero_balance)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_C,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max()}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0u, .code_hash = code_hash}}}}}),
+        StateDeltas(
+            {{ADDR_C,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max()}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0u, .code_hash = code_hash}}}}}),
         Code{
             {code_hash, icode},
         },
@@ -1042,24 +1050,25 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs)
 
     commit_sequential(
         tdb,
-        sd({{TX_SENDER_ADDR,
-             StateDelta{
-                 .account =
-                     {std::nullopt, Account{.balance = 1'000'000'000'000u}}}},
-            {INTERMEDIARY_CONTRACT_ADDR,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 1'000'000'000u,
-                          .code_hash = intermediary_code_hash}}}},
-            {SELFDESTRUCT_CONTRACT_ADDR,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 1'000'000,
-                          .code_hash = selfdestruct_code_hash}}}}})
+        StateDeltas(
+            {{TX_SENDER_ADDR,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 1'000'000'000'000u}}}},
+             {INTERMEDIARY_CONTRACT_ADDR,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 1'000'000'000u,
+                           .code_hash = intermediary_code_hash}}}},
+             {SELFDESTRUCT_CONTRACT_ADDR,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 1'000'000,
+                           .code_hash = selfdestruct_code_hash}}}}})
 
             ,
         Code{
@@ -1266,17 +1275,18 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_multiple_selfdestructs_recursive)
 
     commit_sequential(
         tdb,
-        sd({{TX_SENDER_ADDR,
-             StateDelta{
-                 .account =
-                     {std::nullopt, Account{.balance = 1'000'000'000'000UL}}}},
-            {SELFDESTRUCT_CONTRACT_ADDR,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 1'000'000UL,
-                          .code_hash = selfdestruct_code_hash}}}}})
+        StateDeltas(
+            {{TX_SENDER_ADDR,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 1'000'000'000'000UL}}}},
+             {SELFDESTRUCT_CONTRACT_ADDR,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 1'000'000UL,
+                           .code_hash = selfdestruct_code_hash}}}}})
 
             ,
         Code{
@@ -1425,15 +1435,16 @@ TYPED_TEST(TraitsTest, simulate_v1_trace_transfers)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 1'000'000'000'000UL,
-                          .code_hash = a_code_hash}}}},
-            {ADDR_B,
-             StateDelta{.account = {std::nullopt, Account{.balance = 1UL}}}}})
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 1'000'000'000'000UL,
+                           .code_hash = a_code_hash}}}},
+             {ADDR_B,
+              StateDelta{.account = {std::nullopt, Account{.balance = 1UL}}}}})
 
             ,
         Code{{a_code_hash, a_contract}},

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -151,7 +151,7 @@ TEST(DbBinarySnapshot, Basic)
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
         monad::test::commit_simple(
             tdb,
-            monad::test::sd(std::move(deltas)),
+            StateDeltas(std::move(deltas)),
             code_delta,
             bytes32_t{100},
             BlockHeader{.number = 100});
@@ -272,7 +272,7 @@ TEST(DbBinarySnapshot, MultipleShards)
         ASSERT_EQ(tdb.get_block_number(), db.get_latest_version());
         monad::test::commit_simple(
             tdb,
-            monad::test::sd(std::move(deltas)),
+            StateDeltas(std::move(deltas)),
             code_delta,
             bytes32_t{100},
             BlockHeader{.number = 100});

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -16,17 +16,21 @@
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
+#include <category/core/keccak.h>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/db_snapshot_filesystem.h>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
 
 #include <test_resource_data.h>
@@ -196,7 +200,8 @@ TEST(DbBinarySnapshot, Basic)
             1,
             static_cast<unsigned>(-1),
             snapshot_dir.path.c_str(),
-            100);
+            100,
+            /*load_to_secondary=*/false);
     }
 
     {
@@ -355,7 +360,8 @@ TEST(DbBinarySnapshot, MultipleShards)
             1,
             static_cast<unsigned>(-1),
             combined_root.path.c_str(),
-            100);
+            100,
+            /*load_to_secondary=*/false);
     }
     {
         AsyncIOContext io_context{
@@ -376,5 +382,235 @@ TEST(DbBinarySnapshot, MultipleShards)
                 byte_string_view(from_db->code(), from_db->size()),
                 byte_string_view(icode->code(), icode->size()));
         }
+    }
+}
+
+namespace
+{
+    // Counts only storage leaves (entries nested under an account) under the
+    // cursor passed to Db::traverse. The cursor is expected to point at the
+    // state subtree root, so the path depth from there is:
+    //   account leaf at 64 nibbles (keccak256 addr)
+    //   storage leaf at 128 nibbles (account keccak + storage-key keccak)
+    // Anything shallower (the state-marker node, intermediate branches,
+    // account leaves) is skipped.
+    struct LeafCounter final : public monad::mpt::TraverseMachine
+    {
+        static constexpr uint8_t STORAGE_LEAF_DEPTH =
+            static_cast<uint8_t>(KECCAK256_SIZE * 2 * 2);
+        size_t count{0};
+        uint8_t depth{0};
+
+        bool
+        down(unsigned char const branch, monad::mpt::Node const &node) override
+        {
+            if (branch == monad::mpt::INVALID_BRANCH) {
+                return true;
+            }
+            depth = static_cast<uint8_t>(depth + 1 + node.path_nibbles_len());
+            if (depth == STORAGE_LEAF_DEPTH && node.has_value()) {
+                ++count;
+            }
+            return true;
+        }
+
+        void
+        up(unsigned char const branch, monad::mpt::Node const &node) override
+        {
+            if (branch == monad::mpt::INVALID_BRANCH) {
+                return;
+            }
+            depth = static_cast<uint8_t>(depth - 1 - node.path_nibbles_len());
+        }
+
+        std::unique_ptr<TraverseMachine> clone() const override
+        {
+            return std::make_unique<LeafCounter>(*this);
+        }
+    };
+}
+
+TEST(DbBinarySnapshot, LoadPageModeOnSecondaryDb)
+{
+    using namespace monad;
+    using namespace monad::mpt;
+
+    // Slots 0x00, 0x01, 0x7f share page_key 0; slots 0x80, 0x81 share page_key
+    // 1. With storage_page_t::SLOTS == 128, this exercises both grouping
+    // (multiple slots on one page) and separation (slots split across pages).
+    constexpr uint64_t BLOCK = 1;
+    constexpr std::array<uint8_t, 5> SLOT_BYTES{0x00, 0x01, 0x7f, 0x80, 0x81};
+    std::array<Address, 2> const ADDRS{Address{1}, Address{2}};
+
+    auto make_slot = [](uint8_t b) {
+        bytes32_t k{};
+        k.bytes[31] = b;
+        return k;
+    };
+    auto make_val = [](Address const &a, uint8_t b) {
+        bytes32_t v{};
+        v.bytes[30] = a.bytes[19];
+        v.bytes[31] = static_cast<uint8_t>(b ^ 0xa5);
+        return v;
+    };
+
+    ASSERT_EQ(compute_page_key(make_slot(0x00)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x01)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x7f)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x80)), make_slot(0x01));
+    ASSERT_EQ(compute_page_key(make_slot(0x81)), make_slot(0x01));
+
+    TempDb const dbname;
+    TempDir const snapshot_dir;
+
+    // Build slot-encoded source db with two accounts.
+    {
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.dbname_paths = {dbname.path}}};
+        load_header({}, db, BlockHeader{.number = 0});
+        db.update_finalized_version(0);
+        StateDeltas deltas;
+        for (auto const &addr : ADDRS) {
+            StorageDeltas storage;
+            for (auto const b : SLOT_BYTES) {
+                storage.emplace(
+                    make_slot(b), StorageDelta{bytes32_t{}, make_val(addr, b)});
+            }
+            deltas.emplace(
+                addr,
+                StateDelta{
+                    .account = {std::nullopt, Account{.balance = 1}},
+                    .storage = storage});
+        }
+        TrieDb tdb{db};
+        monad::test::commit_simple(
+            tdb,
+            deltas,
+            Code{},
+            bytes32_t{BLOCK},
+            BlockHeader{.number = BLOCK});
+        tdb.finalize(BLOCK, bytes32_t{BLOCK});
+    }
+
+    // Dump slot-encoded snapshot, then load it into a page-encoded secondary.
+    {
+        auto *const context =
+            monad_db_snapshot_filesystem_write_user_context_create(
+                snapshot_dir.path.c_str(), BLOCK);
+        char const *dbpath[] = {dbname.path.c_str()};
+        EXPECT_TRUE(monad_db_dump_snapshot(
+            dbpath,
+            1,
+            static_cast<unsigned>(-1),
+            BLOCK,
+            monad_db_snapshot_write_filesystem,
+            context,
+            2048,
+            1,
+            0));
+        monad_db_snapshot_filesystem_write_user_context_destroy(context);
+
+        // The loader opens (does not activate) the secondary, so activate it
+        // and stamp its kind (= monad) up front. Both handles are destroyed
+        // before the load so the loader holds the only timeline references.
+        {
+            mpt::Db primary{
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.append = true, .dbname_paths = {dbname.path}}};
+            [[maybe_unused]] auto const secondary =
+                primary.activate_secondary_timeline(
+                    std::make_unique<monad::MonadOnDiskMachine>());
+            MONAD_ASSERT(primary.timeline_active(timeline_id::secondary));
+        }
+
+        // Target encoding is derived from the secondary's stamped kind, so
+        // the slot snapshot is converted to page leaves on the fly.
+        monad_db_snapshot_load_filesystem(
+            dbpath,
+            1,
+            static_cast<unsigned>(-1),
+            snapshot_dir.path.c_str(),
+            BLOCK,
+            /*load_to_secondary=*/true);
+    }
+
+    // Verify secondary db is page-encoded and round-trip slot reads match.
+    {
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {dbname.path}}};
+        {
+            auto db2 = db.open_secondary_timeline(
+                std::make_unique<monad::MonadOnDiskMachine>());
+            ASSERT_TRUE(db2.has_value());
+            db = std::move(db2.value());
+        }
+        TrieDb tdb{db};
+        ASSERT_TRUE(tdb.is_page_encoded());
+        tdb.set_block_and_prefix(BLOCK);
+        Incarnation const inc{0, 0};
+
+        for (auto const &addr : ADDRS) {
+            ASSERT_TRUE(tdb.read_account(addr).has_value());
+            for (auto const b : SLOT_BYTES) {
+                EXPECT_EQ(
+                    tdb.read_storage(addr, inc, make_slot(b)),
+                    make_val(addr, b))
+                    << "addr=" << static_cast<int>(addr.bytes[19]) << " slot=0x"
+                    << std::hex << static_cast<int>(b);
+            }
+
+            auto const page0 = tdb.read_storage_page(addr, inc, bytes32_t{});
+            EXPECT_EQ(page0[0], make_val(addr, 0x00));
+            EXPECT_EQ(page0[1], make_val(addr, 0x01));
+            EXPECT_EQ(page0[0x7f], make_val(addr, 0x7f));
+            for (size_t i = 2; i < 0x7f; ++i) {
+                EXPECT_EQ(page0[static_cast<uint8_t>(i)], bytes32_t{});
+            }
+
+            bytes32_t const pk1 = compute_page_key(make_slot(0x80));
+            auto const page1 = tdb.read_storage_page(addr, inc, pk1);
+            EXPECT_EQ(page1[0], make_val(addr, 0x80));
+            EXPECT_EQ(page1[1], make_val(addr, 0x81));
+            for (size_t i = 2; i < storage_page_t::SLOTS; ++i) {
+                EXPECT_EQ(page1[static_cast<uint8_t>(i)], bytes32_t{});
+            }
+
+            // Read raw leaves by hash path and decode the page.
+            auto const account_path = concat(
+                finalized_nibbles,
+                STATE_NIBBLE,
+                NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})});
+            for (bytes32_t const &page_key : {bytes32_t{}, pk1}) {
+                auto const leaf_res = db.find(
+                    concat(
+                        NibblesView{account_path},
+                        NibblesView{keccak256(
+                            {page_key.bytes, sizeof(page_key.bytes)})}),
+                    BLOCK);
+                ASSERT_TRUE(leaf_res.has_value());
+                auto enc = leaf_res.value().node->value();
+                auto const inner = decode_storage_db_ignore_key(enc);
+                ASSERT_TRUE(inner.has_value());
+                auto const decoded = decode_storage_page(inner.value());
+                ASSERT_TRUE(decoded.has_value());
+                EXPECT_EQ(
+                    decoded.value(),
+                    tdb.read_storage_page(addr, inc, page_key));
+            }
+        }
+
+        // Confirm slot grouping happened during load: each account holds
+        // exactly two storage pages (page_key 0 and page_key 1), so the
+        // state subtree should hold ADDRS.size() * 2 storage leaves total
+        // (the source had ADDRS.size() * 5 = 10 slot leaves before grouping).
+        auto const state_cursor =
+            db.find(concat(finalized_nibbles, STATE_NIBBLE), BLOCK);
+        ASSERT_TRUE(state_cursor.has_value());
+        ASSERT_TRUE(state_cursor.value().is_valid());
+        LeafCounter counter;
+        ASSERT_TRUE(db.traverse_blocking(state_cursor.value(), counter, BLOCK));
+        EXPECT_EQ(counter.count, ADDRS.size() * 2);
     }
 }

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -641,7 +641,7 @@ TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
     State s(bs, Incarnation{0, 0});
 
     s.push();
-    s.access_storage(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
     s.pop_reject();
 
     nlohmann::json storage;
@@ -671,7 +671,7 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
         AccessListTracer{storage, addr1, addr2, std::nullopt, authorities};
 
     s.push();
-    s.access_storage(addr4, key4);
+    s.access_storage<typename TestFixture::Trait>(addr4, key4);
     on_frame_reject(tracer, s);
     s.pop_reject();
 
@@ -744,9 +744,9 @@ TYPED_TEST(TraitsTest, access_list_write)
     s.create_account_no_rollback(addr2);
     s.create_account_no_rollback(addr3);
 
-    s.access_storage(addr2, key1);
-    s.access_storage(addr2, key2);
-    s.access_storage(addr3, key3);
+    s.access_storage<typename TestFixture::Trait>(addr2, key1);
+    s.access_storage<typename TestFixture::Trait>(addr2, key2);
+    s.access_storage<typename TestFixture::Trait>(addr3, key3);
 
     nlohmann::json storage;
     auto const authorities = std::vector<std::optional<Address>>{};
@@ -821,7 +821,7 @@ TYPED_TEST(TraitsTest, access_list_regular_account)
         s.create_account_no_rollback(addr3);
         s.create_account_no_rollback(addr4);
 
-        s.access_storage(addr4, key1);
+        s.access_storage<typename TestFixture::Trait>(addr4, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -879,7 +879,7 @@ TYPED_TEST(TraitsTest, access_list_sender)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr1, key1);
+        s.access_storage<typename TestFixture::Trait>(addr1, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -937,7 +937,7 @@ TYPED_TEST(TraitsTest, access_list_beneficiary)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr2, key1);
+        s.access_storage<typename TestFixture::Trait>(addr2, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -995,7 +995,7 @@ TYPED_TEST(TraitsTest, access_list_recipient)
         s.create_account_no_rollback(addr2);
         s.create_account_no_rollback(addr3);
 
-        s.access_storage(addr3, key1);
+        s.access_storage<typename TestFixture::Trait>(addr3, key1);
 
         nlohmann::json storage;
         auto const authorities = std::vector<std::optional<Address>>{};
@@ -1058,8 +1058,8 @@ TYPED_TEST(TraitsTest, access_list_authorities)
         s.create_account_no_rollback(addr4);
         s.create_account_no_rollback(addr5);
 
-        s.access_storage(addr4, key1);
-        s.access_storage(addr5, key2);
+        s.access_storage<typename TestFixture::Trait>(addr4, key1);
+        s.access_storage<typename TestFixture::Trait>(addr5, key2);
 
         nlohmann::json storage;
         auto const authorities =

--- a/category/execution/ethereum/trace/state_tracer_test.cpp
+++ b/category/execution/ethereum/trace/state_tracer_test.cpp
@@ -102,7 +102,10 @@ TEST(PrestateTracer, pre_state_to_json)
     vm::VM vm;
 
     commit_sequential(
-        tdb, sd({}), Code{{A_CODE_HASH, A_ICODE}}, BlockHeader{.number = 0});
+        tdb,
+        StateDeltas({}),
+        Code{{A_CODE_HASH, A_ICODE}},
+        BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -140,7 +143,7 @@ TEST(PrestateTracer, zero_nonce)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -177,7 +180,7 @@ TEST(PrestateTracer, state_deltas_to_json)
 
     commit_sequential(
         tdb,
-        sd(state_deltas),
+        StateDeltas(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -217,7 +220,7 @@ TEST(PrestateTracer, statediff_account_creation)
 
     commit_sequential(
         tdb,
-        sd(state_deltas),
+        StateDeltas(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -256,7 +259,7 @@ TEST(PrestateTracer, statediff_balance_nonce_update)
 
     commit_sequential(
         tdb,
-        sd(state_deltas),
+        StateDeltas(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -307,11 +310,12 @@ TEST(PrestateTracer, statediff_delete_storage)
 
     commit_sequential(
         tdb,
-        sd(state_deltas1),
+        StateDeltas(state_deltas1),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
-    commit_sequential(tdb, sd(state_deltas2), Code{}, BlockHeader{.number = 1});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas2), Code{}, BlockHeader{.number = 1});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -363,7 +367,7 @@ TEST(PrestateTracer, statediff_multiple_fields_update)
 
     commit_sequential(
         tdb,
-        sd(state_deltas),
+        StateDeltas(state_deltas),
         Code{{A_CODE_HASH, A_ICODE}, {B_CODE_HASH, B_ICODE}},
         BlockHeader{.number = 0});
 
@@ -412,13 +416,15 @@ TEST(PrestateTracer, statediff_account_deletion)
         {ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}},
     };
 
-    commit_sequential(tdb, sd(state_deltas1), Code{}, BlockHeader{.number = 0});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas1), Code{}, BlockHeader{.number = 0});
 
     StateDeltas state_deltas2{
         {ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}},
     };
 
-    commit_sequential(tdb, sd(state_deltas2), Code{}, BlockHeader{.number = 1});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas2), Code{}, BlockHeader{.number = 1});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -475,7 +481,10 @@ TEST(PrestateTracer, geth_example_prestate)
     vm::VM vm;
 
     commit_sequential(
-        tdb, sd({}), Code{{A_CODE_HASH, A_ICODE}}, BlockHeader{.number = 0});
+        tdb,
+        StateDeltas({}),
+        Code{{A_CODE_HASH, A_ICODE}},
+        BlockHeader{.number = 0});
 
     BlockState bs0(tdb, vm);
     State s(bs0, Incarnation{0, 0});
@@ -526,7 +535,8 @@ TEST(PrestateTracer, geth_example_statediff)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs0(tdb, vm);
     State s(bs0, Incarnation{0, 0});
@@ -559,7 +569,7 @@ TEST(PrestateTracer, prestate_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -579,7 +589,8 @@ TEST(PrestateTracer, statediff_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -604,7 +615,8 @@ TYPED_TEST(TraitsTest, access_list_empty)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -623,7 +635,7 @@ TYPED_TEST(TraitsTest, access_list_state_view_excludes_rejected_frame)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -648,7 +660,7 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_storage)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -685,7 +697,7 @@ TYPED_TEST(TraitsTest, access_list_records_rejected_frame_regular_account)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -722,7 +734,8 @@ TYPED_TEST(TraitsTest, access_list_write)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd(state_deltas), Code{}, BlockHeader{.number = 0});
+    commit_sequential(
+        tdb, StateDeltas(state_deltas), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});
@@ -768,7 +781,7 @@ TYPED_TEST(TraitsTest, access_list_regular_account)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -837,7 +850,7 @@ TYPED_TEST(TraitsTest, access_list_sender)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -895,7 +908,7 @@ TYPED_TEST(TraitsTest, access_list_beneficiary)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -953,7 +966,7 @@ TYPED_TEST(TraitsTest, access_list_recipient)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1011,7 +1024,7 @@ TYPED_TEST(TraitsTest, access_list_authorities)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1082,7 +1095,7 @@ TYPED_TEST(TraitsTest, access_list_precompiles)
     TrieDb tdb{db};
     vm::VM vm;
 
-    commit_sequential(tdb, sd({}), Code{}, BlockHeader{.number = 0});
+    commit_sequential(tdb, StateDeltas({}), Code{}, BlockHeader{.number = 0});
 
     BlockState bs(tdb, vm);
 
@@ -1139,7 +1152,7 @@ TEST(PrestateTracer, prestate_access_storage)
     // Block 0
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, a},
@@ -1210,7 +1223,9 @@ TEST(PrestateTracer, prestate_retain_beneficiary_set_storage)
     // Block 0
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1278,7 +1293,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_storage)
     // Block 0
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, a},
@@ -1355,7 +1370,9 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_balance)
     // Block 0
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1425,7 +1442,9 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_nonce)
     // Block 0
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1491,7 +1510,9 @@ TEST(PrestateTracer, prestate_retain_beneficiary_modified_code_hash)
     // Block 0
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         Code{{A_CODE_HASH, A_ICODE}},
         BlockHeader{.number = 0});
 
@@ -1560,7 +1581,7 @@ TEST(PrestateTracer, prestate_retain_beneficiary_access_storage)
     // Block 0
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, a},
@@ -1631,7 +1652,9 @@ TEST(PrestateTracer, prestate_omit_beneficiary)
     // Block 0
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         {},
         BlockHeader{.number = 0});
 
@@ -1683,7 +1706,7 @@ TEST(PrestateTracer, prestate_empty_block_no_reward)
     Block const block{header, {}, {}};
 
     // Block 0
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     BlockState bs(tdb, vm);
     State s(bs, Incarnation{0, 0});

--- a/category/execution/monad/chain/monad_devnet_fork.cpp
+++ b/category/execution/monad/chain/monad_devnet_fork.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/core/hex.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/monad/chain/monad_devnet_alloc.hpp>
+#include <category/execution/monad/chain/monad_devnet_fork.hpp>
+#include <category/vm/evm/monad/revision.h>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+
+MONAD_NAMESPACE_BEGIN
+
+monad_revision
+MonadDevnetFork::get_monad_revision(uint64_t const timestamp) const
+{
+    // Cached on first call: the fork timestamp is read from
+    // MONAD_DEVNETFORK_NEXT_AT (UNIX seconds). Unset -> sentinel that
+    // never compares <= any real timestamp, so the chain stays MONAD_NINE.
+    // The test harness sets this before launching node containers so the
+    // fork lands a configurable wall-clock interval after genesis.
+    static auto const next_at = []() -> uint64_t {
+        char const *const env = std::getenv("MONAD_DEVNETFORK_NEXT_AT");
+        if (env == nullptr || *env == '\0') {
+            return std::numeric_limits<uint64_t>::max();
+        }
+        return std::strtoull(env, nullptr, 10);
+    }();
+    return timestamp >= next_at ? MONAD_NEXT : MONAD_NINE;
+}
+
+uint256_t MonadDevnetFork::get_chain_id() const
+{
+    // Devnet (20143) + 1. Distinct so a test cluster can't accidentally
+    // mix with a regular devnet pool.
+    return 20144;
+}
+
+GenesisState MonadDevnetFork::get_genesis_state() const
+{
+    BlockHeader header;
+    header.difficulty = 17179869184;
+    header.gas_limit = 5000;
+    store_be(header.nonce.data(), uint64_t{66});
+    header.extra_data = from_hex("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33a"
+                                 "db3db69cbdb7a38e1e50b1b82fa")
+                            .value();
+    return {header, MONAD_DEVNET_ALLOC};
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/chain/monad_devnet_fork.hpp
+++ b/category/execution/monad/chain/monad_devnet_fork.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/vm/evm/monad/revision.h>
+
+MONAD_NAMESPACE_BEGIN
+
+// Test-only chain: same alloc as MonadDevnet but with a MONAD_NINE ->
+// MONAD_NEXT revision fork at a runtime-configurable timestamp. The fork
+// timestamp is read from the MONAD_DEVNETFORK_NEXT_AT environment variable
+// (UNIX seconds); if unset, the chain stays pre-fork forever. Drives the slot
+// -> page DB migration integration test.
+struct MonadDevnetFork : MonadChain
+{
+    virtual monad_revision
+    get_monad_revision(uint64_t timestamp) const override;
+
+    virtual uint256_t get_chain_id() const override;
+
+    virtual GenesisState get_genesis_state() const override;
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/commit_block_migration.cpp
+++ b/category/execution/monad/db/commit_block_migration.cpp
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/vm/evm/explicit_traits.hpp>
+#include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/traits.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void commit_block(
+    Db &primary_db, Db *secondary_db, bytes32_t const &block_id,
+    BlockHeader const &header, StateDeltas const &state,
+    BlockCommitAncillaries const &anc)
+{
+    auto add_common_deltas = [&](CommitBuilder &b) {
+        b.add_code(anc.code)
+            .add_receipts(anc.receipts)
+            .add_transactions(anc.transactions, anc.senders)
+            .add_call_frames(anc.call_frames)
+            .add_ommers(anc.ommers);
+        if (anc.withdrawals.has_value()) {
+            b.add_withdrawals(anc.withdrawals.value());
+        }
+    };
+
+    // Dual-write migration path. Db1 (primary, slot) and Db2 (*secondary_db,
+    // page) write the same data to every table; the only difference is
+    // state encoding. state_deltas is added separately to each builder so
+    // MonadCommitBuilder's override can kick in for Db2; everything else
+    // goes through the shared helper.
+
+    // `correct_db` is the "source of truth" Db the header populator reads
+    // roots from. Both the Db1 and Db2 commits call populate_header via
+    // this same pointer, so both end up with identical block headers. The
+    // pointer is assigned just before commits run (see the if constexpr
+    // block below). Non-state roots are the same on Db1 and Db2 (same
+    // inputs, only state encoding differs), so the choice only really
+    // changes which state_root is stamped into the header.
+    Db *correct_db = nullptr;
+    auto populate_header = [&](BlockHeader &h) {
+        MONAD_ASSERT(correct_db != nullptr);
+        h.receipts_root = correct_db->receipts_root();
+        h.state_root = correct_db->state_root();
+        h.withdrawals_root = correct_db->withdrawals_root();
+        h.transactions_root = correct_db->transactions_root();
+        h.gas_used = anc.receipts.empty() ? 0 : anc.receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(anc.receipts);
+        h.ommers_hash = compute_ommers_hash(anc.ommers);
+    };
+
+    if (secondary_db == nullptr) {
+        std::unique_ptr<CommitBuilder> builder;
+        if constexpr (traits::monad_rev() >= MONAD_NEXT) {
+            builder =
+                std::make_unique<PageCommitBuilder>(header.number, primary_db);
+        }
+        else {
+            builder = std::make_unique<CommitBuilder>(header.number);
+        }
+        builder->add_state_deltas(state);
+        add_common_deltas(*builder);
+        correct_db = &primary_db;
+        primary_db.commit(block_id, *builder, header, state, populate_header);
+        return;
+    }
+
+    CommitBuilder builder(header.number);
+    builder.add_state_deltas(state);
+    add_common_deltas(builder);
+
+    PageCommitBuilder builder2(header.number, *secondary_db);
+    builder2.add_state_deltas(state);
+    add_common_deltas(builder2);
+
+    // Whichever Db owns the canonical state_root commits first, so its
+    // state_root is live when the later commit's populate_header runs.
+    //
+    // Pre-fork: Db1 is canonical. Commit Db1 first with correct_db=&primary_db;
+    // Db2 commits after, reading Db1's now-live roots.
+    //
+    // Post-fork: Db2 owns the page-based state_root. Commit Db2 first with
+    // correct_db=secondary_db; Db1 commits after, reading Db2's roots.
+    if constexpr (traits::monad_rev() >= MONAD_NEXT) {
+        correct_db = secondary_db;
+        secondary_db->commit(
+            block_id, builder2, header, state, populate_header);
+        primary_db.commit(block_id, builder, header, state, populate_header);
+    }
+    else {
+        correct_db = &primary_db;
+        primary_db.commit(block_id, builder, header, state, populate_header);
+        secondary_db->commit(
+            block_id, builder2, header, state, populate_header);
+    }
+}
+
+EXPLICIT_MONAD_TRAITS(commit_block);
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/commit_block_migration.hpp
+++ b/category/execution/monad/db/commit_block_migration.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/vm/evm/traits.hpp>
+
+#include <optional>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+struct BlockHeader;
+struct CallFrame;
+struct Receipt;
+struct Transaction;
+struct Withdrawal;
+struct Db;
+
+// Per-block ancillary inputs that the dual commit path forwards to the
+// shared CommitBuilder helpers. State deltas are passed separately because
+// each builder (slot for Db1, page for Db2) has its own add_state_deltas
+// override that needs the same StateDeltas instance.
+struct BlockCommitAncillaries
+{
+    Code const &code;
+    std::vector<Receipt> const &receipts;
+    std::vector<Transaction> const &transactions;
+    std::vector<Address> const &senders;
+    std::vector<std::vector<CallFrame>> const &call_frames;
+    std::vector<BlockHeader> const &ommers;
+    std::optional<std::vector<Withdrawal>> const &withdrawals;
+};
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void commit_block(
+    Db &primary_db, Db *secondary_db, bytes32_t const &block_id,
+    BlockHeader const &header, StateDeltas const &state,
+    BlockCommitAncillaries const &anc);
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.cpp
+++ b/category/execution/monad/db/page_commit_builder.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/keccak.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+#include <category/mpt/update.hpp>
+#include <category/mpt/util.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+MONAD_NAMESPACE_BEGIN
+
+using namespace monad::mpt;
+
+PageCommitBuilder::PageCommitBuilder(uint64_t const block_number, monad::Db &db)
+    : CommitBuilder{block_number}
+    , db_{db}
+{
+}
+
+CommitBuilder &
+PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
+{
+    UpdateList account_updates;
+    for (auto const &[addr, delta] : state_deltas) {
+        UpdateList storage_updates;
+        std::optional<byte_string_view> value;
+        auto const &account = delta.account.second;
+        proposal_post_state_.accounts[addr] = account;
+        if (account.has_value()) {
+            Incarnation const inc = account->incarnation;
+
+            // Page granularity per account: keyed by page_key, value is the
+            // mutable storage_page_t being merged. Each first-touch of a
+            // page reads the current page from the db so subsequent slot
+            // writes at the same page_key compose into one update.
+            ankerl::unordered_dense::segmented_map<
+                bytes32_t,
+                storage_page_t,
+                BytesHashCompare<bytes32_t>>
+                pages;
+
+            for (auto const &[key, slot_delta] : delta.storage) {
+                if (slot_delta.first != slot_delta.second) {
+                    auto const pg_key = compute_page_key(key);
+                    auto const slot_off = compute_slot_offset(key);
+                    auto [it, inserted] = pages.try_emplace(pg_key);
+                    if (inserted) {
+                        it->second = db_.read_storage_page(addr, inc, pg_key);
+                    }
+                    it->second.set(slot_off, slot_delta.second);
+                }
+            }
+
+            for (auto const &[page_key, page] : pages) {
+                bool const is_empty = page.is_empty();
+                // Record the post-commit page for the proposal cache. An empty
+                // page is still stored (entry present, all slots zero); the
+                // trie gets a deletion (nullopt) since it holds no empty leaf.
+                StorageKey const sk{addr, inc, page_key};
+                proposal_post_state_.storage[sk] = page;
+                storage_updates.push_front(update_alloc_.emplace_back(Update{
+                    .key = hash_alloc_.emplace_back(
+                        keccak256({page_key.bytes, sizeof(page_key.bytes)})),
+                    .value = is_empty ? std::nullopt
+                                      : std::make_optional<byte_string_view>(
+                                            bytes_alloc_.emplace_back(
+                                                encode_storage_page_db(
+                                                    page_key, page))),
+                    .incarnation = false,
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(block_number_)}));
+            }
+            value = bytes_alloc_.emplace_back(
+                encode_account_db(addr, account.value()));
+        }
+
+        if (!storage_updates.empty() || delta.account.first != account) {
+            bool const incarnation =
+                account.has_value() && delta.account.first.has_value() &&
+                delta.account.first->incarnation != account->incarnation;
+            account_updates.push_front(update_alloc_.emplace_back(Update{
+                .key = hash_alloc_.emplace_back(
+                    keccak256({addr.bytes, sizeof(addr.bytes)})),
+                .value = value,
+                .incarnation = incarnation,
+                .next = std::move(storage_updates),
+                .version = static_cast<int64_t>(block_number_)}));
+        }
+    }
+
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = state_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(account_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.hpp
+++ b/category/execution/monad/db/page_commit_builder.hpp
@@ -35,6 +35,11 @@ public:
     // storage_page_t entries. Use `take_proposal_post_state()` after this to
     // consume the result.
     CommitBuilder &add_state_deltas(StateDeltas const &) override;
+
+    bool is_page_encoded() const override
+    {
+        return true;
+    }
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.hpp
+++ b/category/execution/monad/db/page_commit_builder.hpp
@@ -15,37 +15,26 @@
 
 #pragma once
 
-#include <category/core/config.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#include <komihash.h>
-#pragma GCC diagnostic pop
+#include <memory>
 
 MONAD_NAMESPACE_BEGIN
 
-template <class Bytes>
-struct BytesHashCompare
+struct Db;
+
+class PageCommitBuilder : public CommitBuilder
 {
-    // Ankerl-style hasher requirement.
-    using is_avalanching = void;
+    Db &db_;
 
-    size_t hash(Bytes const &a) const
-    {
-        return komihash(a.bytes, sizeof(Bytes), 0);
-    }
+public:
+    PageCommitBuilder(uint64_t block_number, Db &db);
 
-    // TBB concurrent_hash_map calls hash() / equal(); ankerl::unordered_dense
-    // calls operator() / equal(). Provide both shapes from the same type.
-    size_t operator()(Bytes const &a) const
-    {
-        return hash(a);
-    }
-
-    bool equal(Bytes const &a, Bytes const &b) const
-    {
-        return memcmp(a.bytes, b.bytes, sizeof(Bytes)) == 0;
-    }
+    // Materializes pages from slot deltas, writes per-page updates, and
+    // populates the inherited `proposal_post_state_` with page-keyed
+    // storage_page_t entries. Use `take_proposal_post_state()` after this to
+    // consume the result.
+    CommitBuilder &add_state_deltas(StateDeltas const &) override;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/db/state_machine_init.cpp
+++ b/category/execution/monad/db/state_machine_init.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+
+#include <memory>
+
+MONAD_NAMESPACE_BEGIN
+
+void register_monad_state_machines()
+{
+    // Only MonadOnDiskMachine participates in metadata-driven open. The
+    // in-memory production path keeps the StateMachine&-passing ctor and
+    // never reads from disk, so MonadInMemoryMachine is not registered.
+    mpt::register_state_machine(mpt::state_machine_kind::monad, [] {
+        return std::unique_ptr<mpt::StateMachine>(new MonadOnDiskMachine{});
+    });
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/state_machine_init.hpp
+++ b/category/execution/monad/db/state_machine_init.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// Populate the mpt::state_machine_kind registry with the page-encoded Monad
+// StateMachine (state_machine_kind::monad, backed by MonadOnDiskMachine).
+// Must run once at process start before any page-encoded mpt::Db is opened
+// via the metadata-driven Db(OnDiskDbConfig const &) ctor; otherwise
+// create_state_machine() aborts at open time.
+//
+// Complements register_ethereum_state_machines() (state_machine_kind::
+// ethereum). A process that may open either encoding should call both.
+//
+// Idempotent: re-registering the same kind overwrites the prior factory.
+void register_monad_state_machines();
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/test_monad_storage_page.cpp
+++ b/category/execution/monad/db/test_monad_storage_page.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 
 #include <gtest/gtest.h>
@@ -230,4 +231,62 @@ TEST(MonadDb, page_commit_asymmetric_pair)
     EXPECT_NE(c_left, c_right);
     EXPECT_NE(c_left, bytes32_t{});
     EXPECT_NE(c_right, bytes32_t{});
+}
+
+// Slots on the same page are merged into a single page on commit.
+// Block 0 writes slots 0 and 1. Block 1 updates slot 0 only.
+// After block 1 commit, both the updated slot 0 and the untouched slot 1
+// must be present in the same page.
+TEST(MonadDb, page_write_merges_slots)
+{
+    constexpr auto slot_key_0 = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_key_1 = bytes32_t{uint64_t{0x01}};
+    constexpr auto val_0 =
+        0x000000000000000000000000000000000000000000000000000000000000aaaa_bytes32;
+    constexpr auto val_1 =
+        0x000000000000000000000000000000000000000000000000000000000000bbbb_bytes32;
+    constexpr auto val_0_updated =
+        0x000000000000000000000000000000000000000000000000000000000000dddd_bytes32;
+
+    Account const acct{.nonce = 1};
+    mpt::Db mpt_db{std::make_unique<MonadInMemoryMachine>()};
+    TrieDb tdb{mpt_db};
+    ASSERT_TRUE(tdb.is_page_encoded()) << "test requires page-encoded storage";
+
+    // Block 0: seed two slots on the same page.
+    {
+        PageCommitBuilder builder(0, tdb);
+        builder.add_state_deltas(StateDeltas{
+            {ADDR_A,
+             StateDelta{
+                 .account = {std::nullopt, acct},
+                 .storage = {
+                     {slot_key_0, {bytes32_t{}, val_0}},
+                     {slot_key_1, {bytes32_t{}, val_1}}}}}});
+        auto root = mpt_db.upsert(nullptr, builder.build(finalized_nibbles), 0);
+        tdb.reset_root(std::move(root), 0);
+    }
+
+    // Block 1: update slot 0, leave slot 1 untouched.
+    {
+        ASSERT_EQ(
+            tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_0), val_0);
+        ASSERT_EQ(
+            tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_1), val_1);
+
+        PageCommitBuilder builder(1, tdb);
+        builder.add_state_deltas(StateDeltas{
+            {ADDR_A,
+             StateDelta{
+                 .account = {acct, acct},
+                 .storage = {{slot_key_0, {val_0, val_0_updated}}}}}});
+        auto root =
+            mpt_db.upsert(tdb.get_root(), builder.build(finalized_nibbles), 1);
+        tdb.reset_root(std::move(root), 1);
+    }
+
+    // Verify: db reads back both values from the committed page.
+    EXPECT_EQ(
+        tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_0), val_0_updated);
+    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_1), val_1);
 }

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -97,6 +97,7 @@ namespace
         uint64_t const block_number, bytes32_t const &block_id,
         StateDeltas const &deltas)
     {
+        MONAD_ASSERT(!tdb1.is_page_encoded() && tdb2.is_page_encoded());
         BlockHeader const header{.number = block_number};
         BlockCommitAncillaries const anc = make_empty_ancillaries();
 

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -1,0 +1,302 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+#include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/ondisk_db_config.hpp>
+#include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/traits.hpp>
+
+#include <gtest/gtest.h>
+
+#include <test_resource_data.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+// End to end test for the slot to page storage migration. Drives the
+// shared monad::commit_block helper used by cmd/monad/runloop_monad.cpp:
+// pre fork the Db1 (slot encoded) state_root is stamped into the canonical
+// header; post fork the Db2 (page encoded) state_root is stamped instead.
+// Both Db1 and Db2 receive the same block header.
+
+using namespace monad;
+using namespace monad::test;
+
+namespace
+{
+    // Slots 0x00 and 0x01 share one page; slot 0x80 is on a different page.
+    // This forces MonadCommitBuilder to merge two slot deltas onto the same
+    // page within a single block, exercising the page grouping path.
+    constexpr auto slot_0 = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_1 = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_far = bytes32_t{uint64_t{0x80}};
+
+    enum class Fork
+    {
+        Pre,
+        Post
+    };
+
+    // Empty ancillary buckets reused for every block: the test only cares
+    // about state_deltas, so receipts/txns/etc. stay empty across calls.
+    Code const empty_code{};
+    std::vector<Receipt> const empty_receipts{};
+    std::vector<Transaction> const empty_transactions{};
+    std::vector<Address> const empty_senders{};
+    std::vector<std::vector<CallFrame>> const empty_call_frames{};
+    std::vector<BlockHeader> const empty_ommers{};
+    std::optional<std::vector<Withdrawal>> const empty_withdrawals{};
+
+    BlockCommitAncillaries make_empty_ancillaries()
+    {
+        return BlockCommitAncillaries{
+            .code = empty_code,
+            .receipts = empty_receipts,
+            .transactions = empty_transactions,
+            .senders = empty_senders,
+            .call_frames = empty_call_frames,
+            .ommers = empty_ommers,
+            .withdrawals = empty_withdrawals};
+    }
+
+    // Drive monad::commit_block for one block, mirroring how the runloop
+    // calls it. `fork` toggles which Monad revision (and therefore which
+    // trait instantiation) is used: Fork::Pre picks MONAD_ZERO (primary
+    // commits first), Fork::Post picks MONAD_NEXT (secondary commits first).
+    void drive_commit(
+        TrieDb &tdb1, TrieDb &tdb2, Fork const fork,
+        uint64_t const block_number, bytes32_t const &block_id,
+        StateDeltas const &deltas)
+    {
+        BlockHeader const header{.number = block_number};
+        BlockCommitAncillaries const anc = make_empty_ancillaries();
+
+        if (fork == Fork::Post) {
+            commit_block<MonadTraits<MONAD_NEXT>>(
+                tdb1, &tdb2, block_id, header, deltas, anc);
+        }
+        else {
+            commit_block<MonadTraits<MONAD_ZERO>>(
+                tdb1, &tdb2, block_id, header, deltas, anc);
+        }
+
+        tdb1.finalize(block_number, block_id);
+        tdb2.finalize(block_number, block_id);
+    }
+
+    StateDeltas make_deltas(
+        std::optional<Account> const &prev_acct,
+        std::optional<Account> const &new_acct,
+        std::vector<std::tuple<bytes32_t, bytes32_t, bytes32_t>> const &slots)
+    {
+        StorageDeltas storage;
+        for (auto const &[k, prev, next] : slots) {
+            storage.emplace(k, StorageDelta{prev, next});
+        }
+        StateDeltas deltas;
+        deltas.emplace(
+            ADDR_A,
+            StateDelta{
+                .account = {prev_acct, new_acct},
+                .storage = std::move(storage)});
+        return deltas;
+    }
+}
+
+TEST(MigrationFork, dual_write_state_root_handoff)
+{
+    ASSERT_EQ(compute_page_key(slot_0), compute_page_key(slot_1));
+    ASSERT_NE(compute_page_key(slot_0), compute_page_key(slot_far));
+
+    mpt::Db db1{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
+    mpt::Db db2 =
+        db1.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+    TrieDb tdb1{db1};
+    TrieDb tdb2{db2};
+    ASSERT_TRUE(tdb1.is_page_encoded() == false);
+    ASSERT_TRUE(tdb2.is_page_encoded() == true);
+
+    GenesisState const GENESIS_STATE = MonadTestnet{}.get_genesis_state();
+    load_genesis_state(GENESIS_STATE, tdb1);
+    load_genesis_state(GENESIS_STATE, tdb2);
+
+    auto const make_block_id = [](uint64_t const n) { return bytes32_t{n}; };
+
+    // Three pre fork blocks, then two post fork. Acct lifetime: created at
+    // block 1, mutated each block. Slots are seeded then updated.
+    Account acct{.nonce = 1};
+    bytes32_t prev_id = {}; // genesis block_id
+
+    // The canonical header populated by populate_header is the same lambda
+    // for both Dbs in propose_block, so both Dbs end up with the same
+    // header bytes. Pre fork the canonical state_root is Db1's; post fork
+    // it is Db2's. These helpers express that invariant.
+    auto check_pre_fork_headers = [&](char const *tag) {
+        SCOPED_TRACE(tag);
+        auto const h1 = tdb1.read_eth_header();
+        auto const h2 = tdb2.read_eth_header();
+        EXPECT_EQ(h1.state_root, h2.state_root)
+            << "Db1 and Db2 must share the same canonical header";
+        EXPECT_EQ(h1.state_root, tdb1.state_root())
+            << "pre fork header carries Db1 (slot encoded) state_root";
+        EXPECT_NE(tdb1.state_root(), tdb2.state_root())
+            << "slot and page encodings should produce different roots";
+    };
+    auto check_post_fork_headers = [&](char const *tag) {
+        SCOPED_TRACE(tag);
+        auto const h1 = tdb1.read_eth_header();
+        auto const h2 = tdb2.read_eth_header();
+        EXPECT_EQ(h1.state_root, h2.state_root)
+            << "Db1 and Db2 must share the same canonical header";
+        EXPECT_EQ(h1.state_root, tdb2.state_root())
+            << "post fork header carries Db2 (page encoded) state_root";
+        EXPECT_NE(h1.state_root, tdb1.state_root())
+            << "post fork header should not carry Db1 (slot) root";
+    };
+
+    // Block 1 (pre fork): create account, seed slot_0 and slot_1 (same page).
+    {
+        tdb1.set_block_and_prefix(0, prev_id);
+        tdb2.set_block_and_prefix(0, prev_id);
+        auto deltas = make_deltas(
+            std::nullopt,
+            acct,
+            {{slot_0, bytes32_t{}, bytes32_t{uint64_t{0xa1}}},
+             {slot_1, bytes32_t{}, bytes32_t{uint64_t{0xb1}}}});
+        drive_commit(tdb1, tdb2, Fork::Pre, 1, make_block_id(1), deltas);
+
+        check_pre_fork_headers("block 1");
+
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_0),
+            bytes32_t{uint64_t{0xa1}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_1),
+            bytes32_t{uint64_t{0xb1}});
+
+        prev_id = make_block_id(1);
+    }
+
+    // Block 2 (pre fork): touch slot_0 and seed slot_far (different page).
+    {
+        tdb1.set_block_and_prefix(1, prev_id);
+        tdb2.set_block_and_prefix(1, prev_id);
+        auto next = acct;
+        next.nonce = 2;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_0, bytes32_t{uint64_t{0xa1}}, bytes32_t{uint64_t{0xa2}}},
+             {slot_far, bytes32_t{}, bytes32_t{uint64_t{0xfa}}}});
+        drive_commit(tdb1, tdb2, Fork::Pre, 2, make_block_id(2), deltas);
+        acct = next;
+
+        check_pre_fork_headers("block 2");
+        prev_id = make_block_id(2);
+    }
+
+    // Block 3 (pre fork): account only churn (no storage writes).
+    {
+        tdb1.set_block_and_prefix(2, prev_id);
+        tdb2.set_block_and_prefix(2, prev_id);
+        auto next = acct;
+        next.nonce = 3;
+        auto deltas = make_deltas(acct, next, {});
+        drive_commit(tdb1, tdb2, Fork::Pre, 3, make_block_id(3), deltas);
+        acct = next;
+
+        check_pre_fork_headers("block 3");
+        prev_id = make_block_id(3);
+    }
+
+    // Capture pre fork Db1 root for the boundary check below.
+    bytes32_t const db1_root_pre_fork = tdb1.state_root();
+    bytes32_t const db2_root_pre_fork = tdb2.state_root();
+    ASSERT_NE(db1_root_pre_fork, bytes32_t{});
+    ASSERT_NE(db2_root_pre_fork, bytes32_t{});
+
+    // Block 4 (fork point, post fork): the canonical header now stamps
+    // Db2's page based state_root. Db1's own state_root keeps advancing
+    // (it still commits its slot encoded view) but the header points at
+    // Db2's root.
+    {
+        tdb1.set_block_and_prefix(3, prev_id);
+        tdb2.set_block_and_prefix(3, prev_id);
+        auto next = acct;
+        next.nonce = 4;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_1, bytes32_t{uint64_t{0xb1}}, bytes32_t{uint64_t{0xb4}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 4, make_block_id(4), deltas);
+        acct = next;
+
+        // Db1 advanced its slot encoded state root.
+        EXPECT_NE(tdb1.state_root(), db1_root_pre_fork);
+        EXPECT_NE(tdb1.state_root(), bytes32_t{});
+        EXPECT_NE(tdb2.state_root(), db2_root_pre_fork);
+
+        // Db1's stored header carries Db2's page based state root, and
+        // Db2 sees the same header bytes.
+        check_post_fork_headers("block 4 (fork)");
+
+        prev_id = make_block_id(4);
+    }
+
+    // Block 5 (post fork): another post fork block reusing the same accounts
+    // and a new slot value. Verifies the post fork path keeps working block
+    // over block, not just at the fork boundary.
+    {
+        tdb1.set_block_and_prefix(4, prev_id);
+        tdb2.set_block_and_prefix(4, prev_id);
+        auto next = acct;
+        next.nonce = 5;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_far, bytes32_t{uint64_t{0xfa}}, bytes32_t{uint64_t{0xf5}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 5, make_block_id(5), deltas);
+        acct = next;
+
+        check_post_fork_headers("block 5");
+
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_far),
+            bytes32_t{uint64_t{0xf5}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_1),
+            bytes32_t{uint64_t{0xb4}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_0),
+            bytes32_t{uint64_t{0xa2}});
+    }
+}

--- a/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
+++ b/category/execution/monad/staking/fuzzer/staking_contract_model.cpp
@@ -49,7 +49,7 @@ namespace monad::staking::test
     {
         commit_simple(
             trie_db_,
-            sd(
+            StateDeltas(
                 {{STAKING_CA,
                   StateDelta{
                       .account =

--- a/category/execution/monad/staking/test_read_valset.cpp
+++ b/category/execution/monad/staking/test_read_valset.cpp
@@ -122,7 +122,7 @@ protected:
             auto [state_deltas, code, _] = std::move(bs).release();
             test::commit_simple(
                 tdb,
-                std::move(state_deltas),
+                *state_deltas,
                 code,
                 NULL_HASH_BLAKE3,
                 BlockHeader{.number = TEST_BLOCK_NUM});

--- a/category/execution/monad/staking/test_staking_contract.cpp
+++ b/category/execution/monad/staking/test_staking_contract.cpp
@@ -120,7 +120,7 @@ struct StakeTraits : public MonadTraitsTest<MonadRevisionT>
     {
         commit_sequential(
             tdb,
-            sd(
+            StateDeltas(
                 {{STAKING_CA,
                   StateDelta{
                       .account =

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -19,29 +19,27 @@
 #include <category/core/config.hpp>
 #include <category/core/log.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
-#include <category/execution/ethereum/core/fmt/int_fmt.hpp>
-#include <category/execution/ethereum/state2/state_deltas.hpp>
-#include <category/execution/monad/db/storage_page.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/vm/vm.hpp>
-
-#include <category/core/hex.hpp>
 
 #include <map>
 #include <memory>
+#include <utility>
 
 MONAD_NAMESPACE_BEGIN
 
 class ProposalState
 {
-    std::unique_ptr<StateDeltas> state_;
+    ProposalPostState post_state_;
     uint64_t parent_block_;
     bytes32_t parent_id_;
 
 public:
     ProposalState(
-        std::unique_ptr<StateDeltas> state, uint64_t const parent_block_number,
+        ProposalPostState post_state, uint64_t const parent_block_number,
         bytes32_t const &parent_id)
-        : state_(std::move(state))
+        : post_state_(std::move(post_state))
         , parent_block_(parent_block_number)
         , parent_id_(parent_id)
     {
@@ -52,17 +50,17 @@ public:
         return {parent_block_, parent_id_};
     }
 
-    StateDeltas const &state() const
+    ProposalPostState const &post_state() const
     {
-        return *state_;
+        return post_state_;
     }
 
     bool try_read_account(
         Address const &address, std::optional<Account> &result) const
     {
-        StateDeltas::const_accessor it{};
-        if (state_->find(it, address)) {
-            result = it->second.account.second;
+        auto const it = post_state_.accounts.find(address);
+        if (it != post_state_.accounts.end()) {
+            result = it->second;
             return true;
         }
         return false;
@@ -72,21 +70,20 @@ public:
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, storage_page_t &result) const
     {
-        StateDeltas::const_accessor it{};
-        if (!state_->find(it, address)) {
-            return false;
+        auto const acct_it = post_state_.accounts.find(address);
+        if (acct_it != post_state_.accounts.end()) {
+            auto const &acct = acct_it->second;
+            if (!acct.has_value() || acct->incarnation != incarnation) {
+                // Account deleted or incarnation cleared in this proposal:
+                // all storage at the requested incarnation is gone.
+                result = {};
+                return true;
+            }
         }
-        auto const &account = it->second.account.second;
-        if (!account || incarnation != account->incarnation) {
-            result = storage_page_t{};
-            return true;
-        }
-        auto const &storage = it->second.storage;
-        StorageDeltas::const_accessor it2{};
-        if (storage.find(it2, key)) {
-            // Use storage_page_t for single slot storage, key is slot key,
-            // offset in a page is always 0
-            result.set(0, it2->second.second);
+        StorageKey const sk{address, incarnation, key};
+        auto const it = post_state_.storage.find(sk);
+        if (it != post_state_.storage.end()) {
+            result = it->second;
             return true;
         }
         return false;
@@ -155,7 +152,7 @@ public:
     }
 
     void commit(
-        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
+        ProposalPostState post_state, uint64_t const block_number,
         bytes32_t const &block_id)
     {
         if (proposal_map_.size() >= MAX_PROPOSAL_MAP_SIZE) {
@@ -167,7 +164,7 @@ public:
                 .insert(
                     {key,
                      std::unique_ptr<ProposalState>(new ProposalState(
-                         std::move(state_deltas), block_, block_id_))})
+                         std::move(post_state), block_, block_id_))})
                 .second == true);
         block_ = block_number;
         block_id_ = block_id;

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1113,8 +1113,8 @@ Db::Db(OnDiskDbConfig const &config)
     MONAD_ASSERT(impl_->aux().is_on_disk());
 }
 
-Db::Db(AsyncIOContext &io_ctx)
-    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, timeline_id::primary)}
+Db::Db(AsyncIOContext &io_ctx, timeline_id const tid)
+    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, tid)}
 {
 }
 

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -114,7 +114,9 @@ public:
     // and owns the SM internally. Caller must have registered the relevant
     // kinds at process start (e.g. monad::register_ethereum_state_machines()).
     explicit Db(OnDiskDbConfig const &);
-    explicit Db(AsyncIOContext &); // on-disk RO blocking
+    explicit Db(
+        AsyncIOContext &,
+        timeline_id const tid = timeline_id::primary); // on-disk RO blocking
 
     Db(Db const &) = delete;
     Db(Db &&) noexcept;

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -2141,19 +2141,3 @@ TEST(update_aux_test, rewind_state_survives_reopen)
         mctx2.root_offsets(timeline_id::secondary)[1], secondary_root_at_v1);
     aux2.deactivate_secondary_timeline();
 }
-
-// clear_ondisk_db must deactivate secondary at entry — otherwise the
-// chunk-trim path would destroy secondary's data.
-TEST(update_aux_test, clear_ondisk_db_deactivates_secondary)
-{
-    with_rw_aux([](UpdateAux &aux) {
-        aux.activate_secondary_timeline();
-        EXPECT_TRUE(aux.metadata_ctx().timeline_active(timeline_id::secondary));
-        aux.clear_ondisk_db();
-        EXPECT_FALSE(
-            aux.metadata_ctx().timeline_active(timeline_id::secondary));
-        EXPECT_EQ(
-            aux.metadata_ctx().db_history_max_version(timeline_id::primary),
-            INVALID_BLOCK_NUM);
-    });
-}

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -236,9 +236,6 @@ void UpdateAux::clear_ondisk_db()
 {
     MONAD_ASSERT(is_on_disk());
     // No finalized version means no anchor for either timeline; wipe both.
-    if (metadata_ctx_->timeline_active(timeline_id::secondary)) {
-        deactivate_secondary_timeline();
-    }
     auto do_ = [&](unsigned const which) {
         auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
         metadata_ctx_->root_offsets(which).reset_all(0);

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -63,6 +63,7 @@
 #include <category/execution/ethereum/validate_transaction_error.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_devnet_fork.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
@@ -1357,6 +1358,8 @@ struct monad_executor
                             return std::make_unique<EthereumMainnet>();
                         case CHAIN_CONFIG_MONAD_DEVNET:
                             return std::make_unique<MonadDevnet>();
+                        case CHAIN_CONFIG_MONAD_DEVNET_FORK:
+                            return std::make_unique<MonadDevnetFork>();
                         case CHAIN_CONFIG_MONAD_TESTNET:
                             return std::make_unique<MonadTestnet>();
                         case CHAIN_CONFIG_MONAD_MAINNET:
@@ -1652,6 +1655,8 @@ struct monad_executor
                             return std::make_unique<EthereumMainnet>();
                         case CHAIN_CONFIG_MONAD_DEVNET:
                             return std::make_unique<MonadDevnet>();
+                        case CHAIN_CONFIG_MONAD_DEVNET_FORK:
+                            return std::make_unique<MonadDevnetFork>();
                         case CHAIN_CONFIG_MONAD_TESTNET:
                             return std::make_unique<MonadTestnet>();
                         case CHAIN_CONFIG_MONAD_MAINNET:
@@ -1919,6 +1924,8 @@ struct monad_executor
                                 return std::make_unique<EthereumMainnet>();
                             case CHAIN_CONFIG_MONAD_DEVNET:
                                 return std::make_unique<MonadDevnet>();
+                            case CHAIN_CONFIG_MONAD_DEVNET_FORK:
+                                return std::make_unique<MonadDevnetFork>();
                             case CHAIN_CONFIG_MONAD_TESTNET:
                                 return std::make_unique<MonadTestnet>();
                             case CHAIN_CONFIG_MONAD_MAINNET:

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -1096,7 +1096,7 @@ TEST_F(EthCallFixture, from_contract_account)
     EXPECT_EQ(ctx.result->output_data_len, 0);
     EXPECT_EQ(ctx.result->encoded_trace_len, 0);
     EXPECT_EQ(ctx.result->gas_refund, 0);
-    EXPECT_EQ(ctx.result->gas_used, 62094);
+    EXPECT_EQ(ctx.result->gas_used, 29594);
 
     monad_state_override_destroy(state_override);
     monad_executor_destroy(executor);
@@ -1182,7 +1182,7 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
         EXPECT_EQ(ctx->result->output_data_len, 0);
         EXPECT_EQ(ctx->result->encoded_trace_len, 0);
         EXPECT_EQ(ctx->result->gas_refund, 0);
-        EXPECT_EQ(ctx->result->gas_used, 62094);
+        EXPECT_EQ(ctx->result->gas_used, 29594);
 
         monad_state_override_destroy(state_override);
     }

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -187,26 +187,28 @@ namespace
     void EthCallFixture::test_transfer_call_with_trace(bool const gas_specified)
     {
         for (uint64_t i = 0; i < 256; ++i) {
-            commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+            commit_sequential(
+                tdb, StateDeltas({}), {}, BlockHeader{.number = i});
         }
 
         BlockHeader const header{.number = 256};
 
         commit_sequential(
             tdb,
-            sd({{ADDR_A,
-                 StateDelta{
-                     .account =
-                         {std::nullopt,
-                          Account{
-                              .balance = 20'000'000u,
-                              .code_hash = NULL_HASH,
-                              .nonce = 0x0}}}},
-                {ADDR_B,
-                 StateDelta{
-                     .account =
-                         {std::nullopt,
-                          Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
+            StateDeltas(
+                {{ADDR_A,
+                  StateDelta{
+                      .account =
+                          {std::nullopt,
+                           Account{
+                               .balance = 20'000'000u,
+                               .code_hash = NULL_HASH,
+                               .nonce = 0x0}}}},
+                 {ADDR_B,
+                  StateDelta{
+                      .account =
+                          {std::nullopt,
+                           Account{.balance = 0, .code_hash = NULL_HASH}}}}}),
             Code{},
             header);
 
@@ -291,7 +293,7 @@ namespace
 TEST_F(EthCallFixture, simple_success_call)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -303,7 +305,7 @@ TEST_F(EthCallFixture, simple_success_call)
         .gas_limit = 100000u, .to = to, .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -347,7 +349,7 @@ TEST_F(EthCallFixture, simple_success_call)
 TEST_F(EthCallFixture, insufficient_balance)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -362,7 +364,7 @@ TEST_F(EthCallFixture, insufficient_balance)
         .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -407,7 +409,7 @@ TEST_F(EthCallFixture, insufficient_balance)
 TEST_F(EthCallFixture, on_proposed_block)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -419,7 +421,7 @@ TEST_F(EthCallFixture, on_proposed_block)
         .gas_limit = 100000u, .to = to, .type = TransactionType::eip1559};
     BlockHeader const header{.number = 256};
 
-    commit_simple(tdb, sd({}), {}, bytes32_t{256}, header);
+    commit_simple(tdb, StateDeltas({}), {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
@@ -467,7 +469,7 @@ TEST_F(EthCallFixture, blockhash_before_fork)
 
     // The behavior in evmc is that, if eip-2935 is
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -497,7 +499,7 @@ TEST_F(EthCallFixture, blockhash_before_fork)
         .data = byte_string{bytecode.data(), bytecode.size()}};
     BlockHeader const header{.number = 256};
 
-    commit_simple(tdb, sd({}), {}, bytes32_t{256}, header);
+    commit_simple(tdb, StateDeltas({}), {}, bytes32_t{256}, header);
     tdb.set_block_and_prefix(header.number, bytes32_t{256});
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
@@ -555,7 +557,7 @@ TEST_F(EthCallFixture, failed_to_read)
     // missing 256 previous blocks
     tdb.reset_root(load_header(nullptr, db, BlockHeader{.number = 1199}), 1199);
     for (uint64_t i = 1200; i < 1256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from{
@@ -575,7 +577,7 @@ TEST_F(EthCallFixture, failed_to_read)
         .data = byte_string{bytecode.data(), bytecode.size()}};
     BlockHeader const header{.number = 1256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -620,7 +622,7 @@ TEST_F(EthCallFixture, failed_to_read)
 TEST_F(EthCallFixture, contract_deployment_success)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -631,7 +633,7 @@ TEST_F(EthCallFixture, contract_deployment_success)
     Transaction const tx{.gas_limit = 200000u, .data = tx_data};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -691,18 +693,19 @@ TEST_F(EthCallFixture, assertion_exception_depth1)
 
     commit_sequential(
         tdb,
-        sd({{from,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1, .code_hash = NULL_HASH}}}},
-            {to,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}}}),
+        StateDeltas(
+            {{from,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1, .code_hash = NULL_HASH}}}},
+             {to,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}}}),
         Code{},
         BlockHeader{.number = 0});
 
@@ -781,23 +784,24 @@ TEST_F(EthCallFixture, assertion_exception_depth2)
 
     commit_sequential(
         tdb,
-        sd({{addr1,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1, .code_hash = NULL_HASH}}}},
-            {addr2,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 1, .code_hash = hash2}}}},
-            {addr3,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max() - 1,
-                          .code_hash = NULL_HASH}}}}}),
+        StateDeltas(
+            {{addr1,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1, .code_hash = NULL_HASH}}}},
+             {addr2,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 1, .code_hash = hash2}}}},
+             {addr3,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max() - 1,
+                           .code_hash = NULL_HASH}}}}}),
         Code{{hash2, icode2}},
         BlockHeader{.number = 0});
 
@@ -861,7 +865,7 @@ TEST_F(EthCallFixture, loop_out_of_gas)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ca,
               StateDelta{
                   .account =
@@ -980,7 +984,7 @@ TEST_F(EthCallFixture, expensive_read_out_of_gas)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ca,
               StateDelta{
                   .account =
@@ -1045,7 +1049,7 @@ TEST_F(EthCallFixture, from_contract_account)
 
     commit_sequential(
         tdb,
-        sd(
+        StateDeltas(
             {{ca,
               StateDelta{
                   .account =
@@ -1111,7 +1115,7 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
 
             commit_sequential(
                 tdb,
-                sd(
+                StateDeltas(
                     {{ca,
                       StateDelta{
                           .account =
@@ -1123,7 +1127,8 @@ TEST_F(EthCallFixture, concurrent_eth_calls)
                 BlockHeader{.number = i});
         }
         else {
-            commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+            commit_sequential(
+                tdb, StateDeltas({}), {}, BlockHeader{.number = i});
         }
     }
 
@@ -1235,33 +1240,34 @@ TEST_F(EthCallFixture, call_trace_with_logs)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {a_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = a_code_hash}}}},
-            {b_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}},
-            {c_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = c_code_hash}}}},
-            {d_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = d_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {a_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = a_code_hash}}}},
+             {b_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = b_code_hash}}}},
+             {c_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = c_code_hash}}}},
+             {d_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = d_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -1432,23 +1438,24 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
     byte_string_view const data = to_byte_string_view(s);
 
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     BlockHeader const header{.number = 256};
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 22000,
-                          .code_hash = NULL_HASH,
-                          .nonce = 0x0}}}},
-            {precompile_address,
-             StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 22000,
+                           .code_hash = NULL_HASH,
+                           .nonce = 0x0}}}},
+             {precompile_address,
+              StateDelta{.account = {std::nullopt, Account{.nonce = 6}}}}}),
         Code{},
         header);
 
@@ -1531,7 +1538,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
 TEST_F(EthCallFixture, transfer_success_with_state_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     BlockHeader const header{.number = 256};
@@ -1546,8 +1553,9 @@ TEST_F(EthCallFixture, transfer_success_with_state_trace)
 
     commit_sequential(
         tdb,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, acct_from}}},
-            {ADDR_B, StateDelta{.account = {std::nullopt, acct_to}}}}),
+        StateDeltas(
+            {{ADDR_A, StateDelta{.account = {std::nullopt, acct_from}}},
+             {ADDR_B, StateDelta{.account = {std::nullopt, acct_to}}}}),
         Code{},
         header);
 
@@ -1680,7 +1688,7 @@ TEST_F(EthCallFixture, transfer_success_with_state_trace)
 TEST_F(EthCallFixture, contract_deployment_success_with_state_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -1691,7 +1699,7 @@ TEST_F(EthCallFixture, contract_deployment_success_with_state_trace)
     Transaction const tx{.gas_limit = 200000u, .data = tx_data};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -1823,12 +1831,12 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
         };
 
         commit_sequential(
-            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
+            tdb, StateDeltas(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -1868,7 +1876,10 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                         .nonce = transaction.nonce}}});
     }
     commit_sequential(
-        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
+        tdb,
+        StateDeltas(std::move(senders_state)),
+        {},
+        BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{.number = 256};
@@ -1885,7 +1896,7 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
 
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         {},
         BlockHeader{.number = 256},
         receipts,
@@ -2061,12 +2072,12 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
         };
 
         commit_sequential(
-            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
+            tdb, StateDeltas(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -2106,7 +2117,10 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
                         .nonce = transaction.nonce}}});
     }
     commit_sequential(
-        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
+        tdb,
+        StateDeltas(std::move(senders_state)),
+        {},
+        BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{.number = 256};
@@ -2123,7 +2137,7 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
 
     commit_sequential(
         tdb,
-        sd({}),
+        StateDeltas({}),
         {},
         BlockHeader{.number = 256},
         receipts,
@@ -2388,12 +2402,12 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
         };
 
         commit_sequential(
-            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
+            tdb, StateDeltas(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 255
     for (uint64_t i = 1; i < 254; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     // Setup parent block transactions.
@@ -2426,7 +2440,7 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
 
         commit_sequential(
             tdb,
-            sd({
+            StateDeltas({
                 {
                     sender,
                     StateDelta{.account = {sender_acc, sender_acc2}},
@@ -2456,7 +2470,7 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {
                 sender,
                 StateDelta{.account = {sender_acc2, sender_acc3}},
@@ -2625,7 +2639,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
                          .nonce = block2_tx.nonce}}}}};
 
         commit_sequential(
-            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
+            tdb, StateDeltas(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Genesis block
@@ -2681,7 +2695,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
 
         commit_sequential(
             tdb,
-            sd({}),
+            StateDeltas({}),
             {},
             header,
             receipts,
@@ -2744,7 +2758,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
 
         commit_sequential(
             tdb,
-            sd({}),
+            StateDeltas({}),
             {},
             header,
             receipts,
@@ -2801,7 +2815,7 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
 TEST_F(EthCallFixture, access_list_trace)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -2818,19 +2832,20 @@ TEST_F(EthCallFixture, access_list_trace)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {contract_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {contract_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -2902,7 +2917,7 @@ TEST_F(EthCallFixture, access_list_trace)
 TEST_F(EthCallFixture, access_list_trace_reverted_call)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -2919,19 +2934,20 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {contract_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {contract_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -3007,7 +3023,7 @@ TEST_F(EthCallFixture, access_list_trace_reverted_call)
 TEST_F(EthCallFixture, access_list_trace_empty)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3024,19 +3040,20 @@ TEST_F(EthCallFixture, access_list_trace_empty)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {contract_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0, .code_hash = contract_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {contract_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = contract_code_hash}}}}}),
         Code{
             {contract_code_hash, contract_icode},
         },
@@ -3112,23 +3129,24 @@ TEST_F(EthCallFixture, access_list_trace_nested)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {a_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = a_code_hash}}}},
-            {b_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {a_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = a_code_hash}}}},
+             {b_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = b_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -3226,23 +3244,24 @@ TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .code_hash = NULL_HASH}}}},
-            {a_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = a_code_hash}}}},
-            {b_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = b_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .code_hash = NULL_HASH}}}},
+             {a_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = a_code_hash}}}},
+             {b_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0, .code_hash = b_code_hash}}}}}),
         Code{
             {a_code_hash, a_icode},
             {b_code_hash, b_icode},
@@ -3323,7 +3342,7 @@ TEST_F(EthCallFixture, access_list_trace_nested_reverted_call)
 TEST_F(EthCallFixture, prestate_state_overrides)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -3337,7 +3356,7 @@ TEST_F(EthCallFixture, prestate_state_overrides)
         .gas_limit = 200000u, .data = from_hex(tx_data).value()};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -3517,7 +3536,7 @@ TEST_F(EthCallFixture, prestate_override_state)
 
     commit_sequential(
         tdb,
-        sd(std::move(deltas)),
+        StateDeltas(std::move(deltas)),
         {{code_hash, compiled_code}},
         BlockHeader{.number = 0});
 
@@ -3528,7 +3547,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     ASSERT_EQ(storage, to_bytes(to_big_endian(uint256_t{uint64_t{64}})));
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -3536,7 +3555,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     Transaction const tx{.gas_limit = 200000u, .to = CONTRACT_ADDR};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, sd({}), {}, header);
+    commit_sequential(tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -3720,7 +3739,7 @@ TEST_F(EthCallFixture, prestate_override_state)
 TEST_F(EthCallFixture, eth_call_reserve_balance)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     // Scenario:
@@ -3768,7 +3787,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {sender,
              StateDelta{
                  .account =
@@ -3855,7 +3874,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
 TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3868,7 +3887,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {sender,
              StateDelta{
                  .account =
@@ -3934,7 +3953,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto sender =
@@ -3968,7 +3987,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
 
     commit_sequential(
         tdb,
-        sd({
+        StateDeltas({
             {sender,
              StateDelta{
                  .account =
@@ -4070,12 +4089,12 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
         };
 
         commit_sequential(
-            tdb, sd(std::move(deltas)), {}, BlockHeader{.number = 0});
+            tdb, StateDeltas(std::move(deltas)), {}, BlockHeader{.number = 0});
     }
 
     // Advance to block 256
     for (uint64_t i = 1; i < 255; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     // Setup block 256 transactions. Before committing them, we setup the
@@ -4116,7 +4135,10 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                         .nonce = transaction.nonce}}});
     }
     commit_sequential(
-        tdb, sd(std::move(senders_state)), {}, BlockHeader{.number = 255});
+        tdb,
+        StateDeltas(std::move(senders_state)),
+        {},
+        BlockHeader{.number = 255});
 
     // Now commit block 256.
     BlockHeader const header{
@@ -4133,7 +4155,14 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
     auto const rlp_grandparent_id = to_vec(rlp::encode_bytes32(bytes32_t{254}));
 
     commit_sequential(
-        tdb, sd({}), {}, header, receipts, call_frames, senders, transactions);
+        tdb,
+        StateDeltas({}),
+        {},
+        header,
+        receipts,
+        call_frames,
+        senders,
+        transactions);
 
     auto *executor = create_executor(dbname.string());
 
@@ -4679,20 +4708,21 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = uint256_t{1'000'000}, .nonce = 0}}}},
-            {recipient,
-             StateDelta{
-                 .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+        StateDeltas{
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = uint256_t{1'000'000}, .nonce = 0}}}},
+             {recipient,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -4783,7 +4813,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -4795,12 +4825,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
             {recipient,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -4899,7 +4929,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
 TEST_F(EthCallFixture, eth_simulate_v1_single_call_block_255)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -4969,7 +4999,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_single_call_block_255)
 TEST_F(EthCallFixture, eth_simulate_v1_empty_input)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -5026,7 +5056,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_empty_input)
 TEST_F(EthCallFixture, eth_simulate_v1_block_override_synthetic_gap)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -5113,7 +5143,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_synthetic_gap)
 TEST_F(EthCallFixture, eth_simulate_v1_block_override_no_synthetic_gaps)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto const encode_rlp_list =
@@ -5214,7 +5244,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_no_synthetic_gaps)
 TEST_F(EthCallFixture, eth_simulate_v1_stress_queue_rejection)
 {
     for (uint64_t i = 0; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     // Create executor with a tiny queue limit (2) for the block pool
@@ -5364,7 +5394,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender_a,
              StateDelta{
                  .account =
@@ -5382,12 +5412,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
             {recipient,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -5529,7 +5559,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender_x,
              StateDelta{
                  .account =
@@ -5553,12 +5583,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
             {recipient,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     // Case 1: Sender in parent / grandparent
@@ -5885,7 +5915,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -5918,7 +5948,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{.balance = 0, .code_hash = callcode_cc.hash}}}}}),
+                      Account{.balance = 0, .code_hash = callcode_cc.hash}}}}},
         Code{
             {target_cc.hash, target_cc.icode},
             {call_cc.hash, call_cc.icode},
@@ -5929,7 +5959,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6047,7 +6077,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {account_a,
              StateDelta{
                  .account =
@@ -6065,12 +6095,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
             {recipient,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6253,7 +6283,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -6264,12 +6294,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
             {beneficiary,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6474,7 +6504,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -6497,7 +6527,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
                       Account{
                           .balance = 0,
                           .code_hash = fwd_code_hash,
-                          .nonce = 0}}}}}),
+                          .nonce = 0}}}}},
         Code{
             {sink_code_hash, sink_icode},
             {fwd_code_hash, fwd_icode},
@@ -6505,7 +6535,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6634,7 +6664,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -6648,7 +6678,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
                      {std::nullopt,
                       Account{
                           .balance = 0, .code_hash = code_hash, .nonce = 0}},
-                 .storage = {{bytes32_t{}, {bytes32_t{}, unlock_time}}}}}}),
+                 .storage = {{bytes32_t{}, {bytes32_t{}, unlock_time}}}}}},
         Code{
             {code_hash, icode},
         },
@@ -6656,7 +6686,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
 
     for (uint64_t i = 1; i < 256; ++i) {
         commit_sequential(
-            tdb, sd({}), {}, BlockHeader{.number = i, .timestamp = i});
+            tdb, {}, {}, BlockHeader{.number = i, .timestamp = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6766,7 +6796,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -6779,14 +6809,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = 0,
-                          .code_hash = code_hash,
-                          .nonce = 0}}}}}),
+                          .balance = 0, .code_hash = code_hash, .nonce = 0}}}}},
         Code{{code_hash, icode}},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -6906,7 +6934,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
 
     commit_sequential(
         tdb,
-        sd(StateDeltas{
+        StateDeltas{
             {sender,
              StateDelta{
                  .account =
@@ -6917,12 +6945,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
             {recipient,
              StateDelta{
                  .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}},
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -7027,23 +7055,25 @@ TEST_F(EthCallFixture, eth_simulate_v1_gas_limit_enforcement)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = std::numeric_limits<uint256_t>::max(),
-                          .nonce = 0}}}},
-            {burner,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0, .code_hash = burner_code_hash}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = std::numeric_limits<uint256_t>::max(),
+                           .nonce = 0}}}},
+             {burner,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0, .code_hash = burner_code_hash}}}}}),
         Code{{burner_code_hash, burner_icode}},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());
@@ -7130,20 +7160,21 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfer_withdrawals_monad)
 
     commit_sequential(
         tdb,
-        sd({{sender,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = uint256_t{1'000'000}, .nonce = 0}}}},
-            {recipient,
-             StateDelta{
-                 .account =
-                     {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
+        StateDeltas(
+            {{sender,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = uint256_t{1'000'000}, .nonce = 0}}}},
+             {recipient,
+              StateDelta{
+                  .account =
+                      {std::nullopt, Account{.balance = 0, .nonce = 0}}}}}),
         {},
         BlockHeader{.number = 0});
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, sd({}), {}, BlockHeader{.number = i});
+        commit_sequential(tdb, {}, {}, BlockHeader{.number = i});
     }
 
     auto *executor = create_executor(dbname.string());

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -23,6 +23,7 @@
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
@@ -50,6 +51,7 @@ monad_statesync_client_context *monad_statesync_client_context_create(
     // factories so the kind-driven Db ctor can resolve `ethereum`.
     // Idempotent: re-registration overwrites the prior factory.
     register_ethereum_state_machines();
+    register_monad_state_machines();
     return new monad_statesync_client_context{
         paths,
         sq_thread_cpu == MONAD_SQPOLL_DISABLED

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -39,6 +39,7 @@ using namespace monad::mpt;
 unsigned const MONAD_SQPOLL_DISABLED = unsigned(-1);
 
 monad_statesync_client_context *monad_statesync_client_context_create(
+    monad_chain_config const chain_config,
     char const *const *const dbname_paths, size_t const len,
     unsigned const sq_thread_cpu, monad_statesync_client *const sync,
     void (*statesync_send_request)(
@@ -53,6 +54,7 @@ monad_statesync_client_context *monad_statesync_client_context_create(
     register_ethereum_state_machines();
     register_monad_state_machines();
     return new monad_statesync_client_context{
+        chain_config,
         paths,
         sq_thread_cpu == MONAD_SQPOLL_DISABLED
             ? std::nullopt
@@ -223,9 +225,16 @@ bool monad_statesync_client_finalize(monad_statesync_client_context *const ctx)
     }
     ctx->db.update_finalized_version(tgrt.number);
 
-    TrieDb db{ctx->db};
+    // Pick the right TrieDb to read state_root from based on the target's
+    // revision.
+    auto const monad_rev = ctx->chain->get_monad_revision(tgrt.timestamp);
+    bool const page_encoded = monad_rev >= MONAD_NEXT;
+    TrieDb &db = (!page_encoded || !ctx->tdb.is_page_encoded())
+                     ? ctx->tdb
+                     : *ctx->secondary_tdb;
+    MONAD_ASSERT(page_encoded == db.is_page_encoded());
+    db.set_block_and_prefix(ctx->db.get_latest_finalized_version());
     MONAD_ASSERT(db.get_block_number() == tgrt.number);
-
     return db.state_root() == tgrt.state_root;
 }
 

--- a/category/statesync/statesync_client.h
+++ b/category/statesync/statesync_client.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/execution/ethereum/chain/chain_config.h>
 #include <category/statesync/statesync_messages.h>
 
 #ifdef __cplusplus
@@ -28,8 +29,8 @@ struct monad_statesync_client;
 struct monad_statesync_client_context;
 
 struct monad_statesync_client_context *monad_statesync_client_context_create(
-    char const *const *dbname_paths, size_t len, unsigned sq_thread_cpu,
-    struct monad_statesync_client *,
+    enum monad_chain_config chain_config, char const *const *dbname_paths,
+    size_t len, unsigned sq_thread_cpu, struct monad_statesync_client *,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request));
 

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -20,6 +20,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_devnet_fork.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
@@ -45,6 +46,8 @@ namespace
         switch (cfg) {
         case CHAIN_CONFIG_MONAD_DEVNET:
             return std::make_unique<monad::MonadDevnet>();
+        case CHAIN_CONFIG_MONAD_DEVNET_FORK:
+            return std::make_unique<monad::MonadDevnetFork>();
         case CHAIN_CONFIG_MONAD_TESTNET:
             return std::make_unique<monad::MonadTestnet>();
         case CHAIN_CONFIG_MONAD_MAINNET:

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -13,14 +13,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/assert.h>
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/keccak.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_mainnet.hpp>
+#include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/update.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
+
+#include <ankerl/unordered_dense.h>
 
 #include <deque>
 #include <sys/sysinfo.h>
@@ -28,13 +37,36 @@
 using namespace monad;
 using namespace monad::mpt;
 
+namespace
+{
+    std::unique_ptr<monad::MonadChain const>
+    make_chain(monad_chain_config const cfg)
+    {
+        switch (cfg) {
+        case CHAIN_CONFIG_MONAD_DEVNET:
+            return std::make_unique<monad::MonadDevnet>();
+        case CHAIN_CONFIG_MONAD_TESTNET:
+            return std::make_unique<monad::MonadTestnet>();
+        case CHAIN_CONFIG_MONAD_MAINNET:
+            return std::make_unique<monad::MonadMainnet>();
+        case CHAIN_CONFIG_ETHEREUM_MAINNET:
+        case CHAIN_CONFIG_HIVE_NET:
+            MONAD_ABORT_PRINTF(
+                "statesync client requires a Monad chain config, got %d", cfg);
+        }
+        MONAD_ABORT_PRINTF("unknown chain config %d", cfg);
+    }
+} // namespace
+
 monad_statesync_client_context::monad_statesync_client_context(
+    monad_chain_config const chain_config,
     std::vector<std::filesystem::path> const dbname_paths,
     std::optional<unsigned> const sq_thread_cpu, unsigned const wr_buffers,
     monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
-    : db{mpt::OnDiskDbConfig{
+    : chain{make_chain(chain_config)}
+    , db{mpt::OnDiskDbConfig{
           .append = true,
           .compaction = false,
           .rewind_to_latest_finalized = true,
@@ -44,6 +76,17 @@ monad_statesync_client_context::monad_statesync_client_context(
           .sq_thread_cpu = sq_thread_cpu,
           .dbname_paths = dbname_paths}}
     , tdb{db} // open with latest finalized if valid, otherwise init as block 0
+    , secondary_db{[this] {
+        if (db.timeline_active(timeline_id::secondary)) {
+            auto ret = db.open_secondary_timeline();
+            MONAD_ASSERT(ret.has_value());
+            MONAD_ASSERT(
+                ret->state_machine_type() == state_machine_kind::monad);
+            return std::make_unique<mpt::Db>(std::move(ret.value()));
+        }
+        return std::unique_ptr<mpt::Db>{};
+    }()}
+    , secondary_tdb{secondary_db ? std::make_unique<TrieDb>(*secondary_db) : nullptr}
     , progress(
           monad_statesync_client_prefixes(),
           {db.get_latest_version(), db.get_latest_version()})
@@ -55,59 +98,69 @@ monad_statesync_client_context::monad_statesync_client_context(
     , statesync_send_request{statesync_send_request}
 {
     MONAD_ASSERT(db.get_latest_version() == db.get_latest_finalized_version());
+    MONAD_ASSERT((secondary_db != nullptr) == (secondary_tdb != nullptr));
+    MONAD_ASSERT(secondary_tdb == nullptr || secondary_tdb->is_page_encoded());
 }
 
 void monad_statesync_client_context::prepare_current_state()
 {
-    auto const latest_version = db.get_latest_version();
-    // First commit an empty finalized state to the current one.
-    // This requires incarnation=true so the compaction process in latest root
-    // value (`src_root->value()`) is correctly preserved.
-    UpdateList finalized_empty;
-    Update finalized{
-        .key = finalized_nibbles,
-        .value = byte_string_view{},
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(current)};
-    finalized_empty.push_front(finalized);
-    auto const src_root = db.load_root_for_version(latest_version);
-    bool write_root = false;
-    auto dest_root = db.upsert(
-        src_root,
-        std::move(finalized_empty),
-        current,
-        false,
-        false,
-        write_root);
-    MONAD_ASSERT(db.find(dest_root, finalized_nibbles, current).has_value());
+    // Roll forward `target_db`: upsert an empty finalized marker for the
+    // `current` version and carry the state + code subtries over from
+    // `latest_version`.
+    auto const roll_forward = [&](mpt::Db &target_db, auto &target_tdb) {
+        auto const latest_version = target_db.get_latest_version();
+        UpdateList finalized_empty;
+        Update finalized{
+            .key = finalized_nibbles,
+            .value = byte_string_view{},
+            .incarnation = true,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(current)};
+        finalized_empty.push_front(finalized);
+        auto const src_root = target_db.load_root_for_version(latest_version);
+        bool write_root = false;
+        auto dest_root = target_db.upsert(
+            src_root,
+            std::move(finalized_empty),
+            current,
+            false,
+            false,
+            write_root);
+        MONAD_ASSERT(
+            target_db.find(dest_root, finalized_nibbles, current).has_value());
 
-    // move state and code from latest finalized to current
-    auto const state_key = concat(FINALIZED_NIBBLE, STATE_NIBBLE);
-    auto const code_key = concat(FINALIZED_NIBBLE, CODE_NIBBLE);
-    dest_root = db.copy_trie(
-        src_root,
-        state_key,
-        std::move(dest_root),
-        state_key,
-        current,
-        write_root);
-    write_root = true;
-    dest_root = db.copy_trie(
-        src_root,
-        code_key,
-        std::move(dest_root),
-        code_key,
-        current,
-        write_root);
-    auto const finalized_res = db.find(dest_root, finalized_nibbles, current);
-    MONAD_ASSERT(finalized_res.has_value());
-    MONAD_ASSERT(finalized_res.value().node->number_of_children() == 2);
-    MONAD_ASSERT(db.find(dest_root, state_key, current).has_value());
-    MONAD_ASSERT(db.find(dest_root, code_key, current).has_value());
-    MONAD_ASSERT(dest_root->value() == src_root->value());
-    tdb.reset_root(dest_root, current);
-    MONAD_ASSERT(db.get_latest_version() == current);
+        auto const state_key = concat(FINALIZED_NIBBLE, STATE_NIBBLE);
+        auto const code_key = concat(FINALIZED_NIBBLE, CODE_NIBBLE);
+        dest_root = target_db.copy_trie(
+            src_root,
+            state_key,
+            std::move(dest_root),
+            state_key,
+            current,
+            write_root);
+        write_root = true;
+        dest_root = target_db.copy_trie(
+            src_root,
+            code_key,
+            std::move(dest_root),
+            code_key,
+            current,
+            write_root);
+        auto const finalized_res =
+            target_db.find(dest_root, finalized_nibbles, current);
+        MONAD_ASSERT(finalized_res.has_value());
+        MONAD_ASSERT(finalized_res.value().node->number_of_children() == 2);
+        MONAD_ASSERT(target_db.find(dest_root, state_key, current).has_value());
+        MONAD_ASSERT(target_db.find(dest_root, code_key, current).has_value());
+        MONAD_ASSERT(dest_root->value() == src_root->value());
+        target_tdb.reset_root(dest_root, current);
+        MONAD_ASSERT(target_db.get_latest_version() == current);
+    };
+
+    roll_forward(db, tdb);
+    if (secondary_tdb) {
+        roll_forward(*secondary_db, *secondary_tdb);
+    }
 }
 
 void monad_statesync_client_context::commit()
@@ -116,88 +169,212 @@ void monad_statesync_client_context::commit()
         db.get_latest_version() != current) {
         prepare_current_state();
     }
-    std::deque<mpt::Update> alloc;
-    std::deque<byte_string> bytes_alloc;
-    std::deque<hash256> hash_alloc;
-    UpdateList accounts;
-    for (auto const &[addr, delta] : deltas) {
+
+    // Build the encoded block header once; it's identical for both dbs.
+    auto const header_rlp = rlp::encode_block_header(tgrt);
+
+    // Build a slot-encoded storage UpdateList for an account's deltas.
+    auto build_slot_storage = [this](
+                                  TrieDb &,
+                                  StorageDeltas const &slot_deltas,
+                                  std::deque<mpt::Update> &alloc,
+                                  std::deque<byte_string> &bytes_alloc,
+                                  std::deque<hash256> &hash_alloc) {
         UpdateList storage;
-        std::optional<byte_string_view> value;
-        if (delta.has_value()) {
-            auto const &[acct, deltas] = delta.value();
-            value = bytes_alloc.emplace_back(encode_account_db(addr, acct));
-            for (auto const &[key, val] : deltas) {
-                storage.push_front(alloc.emplace_back(Update{
-                    .key = hash_alloc.emplace_back(keccak256(key.bytes)),
-                    .value = val == bytes32_t{}
-                                 ? std::nullopt
-                                 : std::make_optional<byte_string_view>(
-                                       bytes_alloc.emplace_back(
-                                           encode_storage_db(key, val))),
-                    .incarnation = false,
-                    .next = UpdateList{},
-                    .version = static_cast<int64_t>(current)}));
-            }
+        for (auto const &[key, val] : slot_deltas) {
+            storage.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(keccak256(key.bytes)),
+                .value = val == bytes32_t{}
+                             ? std::nullopt
+                             : std::make_optional<byte_string_view>(
+                                   bytes_alloc.emplace_back(
+                                       encode_storage_db(key, val))),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
         }
-        accounts.push_front(alloc.emplace_back(Update{
-            .key = hash_alloc.emplace_back(keccak256(addr.bytes)),
-            .value = value,
-            .incarnation = false,
-            .next = std::move(storage),
-            .version = static_cast<int64_t>(current)}));
-    }
-    UpdateList code_updates;
+        return storage;
+    };
 
-    for (auto const &[hash, bytes] : code) {
-        code_updates.push_front(alloc.emplace_back(Update{
-            .key = NibblesView{hash},
-            .value = bytes,
+    // Build a page-encoded storage UpdateList for Db2. Slots are grouped by
+    // page_key and merged onto any existing page contents read from the
+    // secondary trie. A page that ends up empty becomes a delete on the
+    // page entry.
+    auto build_page_storage = [this](
+                                  TrieDb &paged_db,
+                                  Address const &addr,
+                                  StorageDeltas const &slot_deltas,
+                                  std::deque<mpt::Update> &alloc,
+                                  std::deque<byte_string> &bytes_alloc,
+                                  std::deque<hash256> &hash_alloc) {
+        UpdateList storage;
+        // Per-account page granularity: keyed by page_key, value is the
+        // mutable storage_page_t being merged. Each first-touch of a page
+        // reads the current page from the secondary trie so subsequent slot
+        // writes at the same page_key compose into one update.
+        ankerl::unordered_dense::segmented_map<
+            bytes32_t,
+            storage_page_t,
+            BytesHashCompare<bytes32_t>>
+            pages;
+        for (auto const &[slot_key, slot_val] : slot_deltas) {
+            auto const pg_key = compute_page_key(slot_key);
+            auto const slot_off = compute_slot_offset(slot_key);
+            auto [it, inserted] = pages.try_emplace(pg_key);
+            if (inserted) {
+                // Incarnation isn't tracked in statesync deltas; TrieDb
+                // ignores it for storage reads, so a fixed value is fine.
+                it->second =
+                    paged_db.read_storage_page(addr, Incarnation{0, 0}, pg_key);
+            }
+            it->second.set(slot_off, slot_val);
+        }
+        for (auto const &[page_key, page] : pages) {
+            bool const is_empty = page.is_empty();
+            storage.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(
+                    keccak256({page_key.bytes, sizeof(page_key.bytes)})),
+                .value = is_empty
+                             ? std::nullopt
+                             : std::make_optional<byte_string_view>(
+                                   bytes_alloc.emplace_back(
+                                       encode_storage_page_db(page_key, page))),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
+        }
+        return storage;
+    };
+
+    auto build_and_upsert = [this, &header_rlp](
+                                mpt::Db &target_db,
+                                auto &target_tdb,
+                                auto build_storage) {
+        std::deque<mpt::Update> alloc;
+        std::deque<byte_string> bytes_alloc;
+        std::deque<hash256> hash_alloc;
+
+        UpdateList accounts;
+        for (auto const &[addr, delta] : deltas) {
+            UpdateList storage;
+            std::optional<byte_string_view> value;
+            if (delta.has_value()) {
+                auto const &[acct, slot_deltas] = delta.value();
+                value = bytes_alloc.emplace_back(encode_account_db(addr, acct));
+                storage = build_storage(
+                    addr, slot_deltas, alloc, bytes_alloc, hash_alloc);
+            }
+            accounts.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(keccak256(addr.bytes)),
+                .value = value,
+                .incarnation = false,
+                .next = std::move(storage),
+                .version = static_cast<int64_t>(current)}));
+        }
+        UpdateList code_updates;
+        for (auto const &[hash, bytes] : code) {
+            code_updates.push_front(alloc.emplace_back(Update{
+                .key = NibblesView{hash},
+                .value = bytes,
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
+        }
+
+        // Stamp the page-encoding marker on the state subtrie root for
+        // page-encoded dbs; slot-encoded dbs leave it empty.
+        auto state_update = Update{
+            .key = state_nibbles,
+            .value = byte_string_view{},
             .incarnation = false,
+            .next = std::move(accounts),
+            .version = static_cast<int64_t>(current)};
+        auto code_update = Update{
+            .key = code_nibbles,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(code_updates),
+            .version = static_cast<int64_t>(current)};
+        auto block_header_update = Update{
+            .key = block_header_nibbles,
+            .value = header_rlp,
+            .incarnation = true,
             .next = UpdateList{},
-            .version = static_cast<int64_t>(current)}));
+            .version = static_cast<int64_t>(current)};
+        UpdateList updates;
+        updates.push_front(state_update);
+        updates.push_front(code_update);
+        updates.push_front(block_header_update);
+
+        UpdateList finalized_updates;
+        Update finalized{
+            .key = finalized_nibbles,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(updates),
+            .version = static_cast<int64_t>(current)};
+        finalized_updates.push_front(finalized);
+
+        target_tdb.reset_root(
+            target_db.upsert(
+                target_tdb.get_root(),
+                std::move(finalized_updates),
+                current,
+                false,
+                false),
+            current);
+    };
+
+    // Primary Db
+    if (!tdb.is_page_encoded()) {
+        build_and_upsert(
+            db,
+            tdb,
+            [&](Address const &,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_slot_storage(
+                    tdb, slot_deltas, alloc, bytes_alloc, hash_alloc);
+            });
+    }
+    else {
+        build_and_upsert(
+            db,
+            tdb,
+            [&](Address const &addr,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_page_storage(
+                    tdb, addr, slot_deltas, alloc, bytes_alloc, hash_alloc);
+            });
     }
 
-    auto state_update = Update{
-        .key = state_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(accounts),
-        .version = static_cast<int64_t>(current)};
-    auto code_update = Update{
-        .key = code_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(code_updates),
-        .version = static_cast<int64_t>(current)};
-    auto const rlp = rlp::encode_block_header(tgrt);
-    auto block_header_update = Update{
-        .key = block_header_nibbles,
-        .value = rlp,
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(current)};
-    UpdateList updates;
-    updates.push_front(state_update);
-    updates.push_front(code_update);
-    updates.push_front(block_header_update);
+    // Secondary: page-encoded storage. Each per-account call builds its
+    // own page map; pages from one account never collide with another's,
+    // so no cross-account cache is needed.
+    if (secondary_tdb) {
+        build_and_upsert(
+            *secondary_db,
+            *secondary_tdb,
+            [&](Address const &addr,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_page_storage(
+                    *secondary_tdb,
+                    addr,
+                    slot_deltas,
+                    alloc,
+                    bytes_alloc,
+                    hash_alloc);
+            });
+    }
 
-    UpdateList finalized_updates;
-    Update finalized{
-        .key = finalized_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates),
-        .version = static_cast<int64_t>(current)};
-    finalized_updates.push_front(finalized);
-
-    tdb.reset_root(
-        db.upsert(
-            tdb.get_root(),
-            std::move(finalized_updates),
-            current,
-            false,
-            false),
-        current);
     code.clear();
     deltas.clear();
 }

--- a/category/statesync/statesync_client_context.hpp
+++ b/category/statesync/statesync_client_context.hpp
@@ -18,9 +18,11 @@
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/execution/ethereum/chain/chain_config.h>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/mpt/db.hpp>
 #include <category/statesync/statesync_protocol.hpp>
 
@@ -45,8 +47,17 @@ struct monad_statesync_client_context
 
     using StateDelta = std::pair<monad::Account, StorageDeltas>;
 
+    // Chain instance for revision lookups (e.g. determining whether the
+    // sync target is at MONAD_NEXT, which decides whether the slot or
+    // page state_root is canonical at finalize time). Owned.
+    std::unique_ptr<monad::MonadChain const> chain;
+
     monad::mpt::Db db;
     monad::TrieDb tdb;
+
+    std::unique_ptr<monad::mpt::Db> secondary_db;
+    std::unique_ptr<monad::TrieDb> secondary_tdb;
+
     std::vector<std::pair<uint64_t, uint64_t>> progress;
     std::vector<std::unique_ptr<monad::StatesyncProtocol>> protocol;
     std::array<monad::BlockHeader, 256> hdrs;
@@ -62,6 +73,7 @@ struct monad_statesync_client_context
         struct monad_statesync_client *, struct monad_sync_request);
 
     monad_statesync_client_context(
+        monad_chain_config chain_config,
         std::vector<std::filesystem::path> dbname_paths,
         std::optional<unsigned> sq_thread_cpu, unsigned wr_buffers,
         monad_statesync_client *,

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
@@ -216,6 +217,14 @@ bool statesync_server_handle_request(
         {
         }
 
+        // When the server's primary is page-encoded, storage leaves hold
+        // encoded pages rather than single slots; we expand each page into
+        // slot-format upserts so v1 clients sync unchanged.
+        bool server_is_page_encoded() const
+        {
+            return sync->context->is_page_encoded();
+        }
+
         virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
@@ -271,6 +280,36 @@ bool statesync_server_handle_request(
                     *upsert_bytes += size1 + size2;
                 };
 
+                // Expand a page-encoded storage leaf into one slot-format
+                // upsert per non-zero slot, so the wire stays identical to a
+                // slot-encoded server. The leaf value is
+                // encode_storage_page_db(page_key, page); compute_slot_key
+                // recovers each original storage key from (page_key, offset).
+                auto const send_storage_page = [&](byte_string_view enc) {
+                    auto const raw = decode_storage_db_raw(enc);
+                    MONAD_ASSERT(raw.has_value());
+                    auto const page_key = to_bytes(raw.value().first);
+                    auto const page = decode_storage_page(raw.value().second);
+                    MONAD_ASSERT(page.has_value());
+                    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
+                        bytes32_t const v = page.value()[i];
+                        if (v == bytes32_t{}) {
+                            continue;
+                        }
+                        auto const entry =
+                            encode_storage_db(compute_slot_key(page_key, i), v);
+                        sync->statesync_server_send_upsert(
+                            sync->net,
+                            SYNC_TYPE_UPSERT_STORAGE,
+                            reinterpret_cast<unsigned char const *>(&addr),
+                            sizeof(addr),
+                            entry.data(),
+                            entry.size());
+                        ++(*num_upserts);
+                        *upsert_bytes += sizeof(addr) + entry.size();
+                    }
+                };
+
                 if (nibble == CODE_NIBBLE) {
                     MONAD_ASSERT(depth == HASH_SIZE);
                     send_upsert(SYNC_TYPE_UPSERT_CODE);
@@ -282,10 +321,15 @@ bool statesync_server_handle_request(
                     }
                     else {
                         MONAD_ASSERT(depth == (HASH_SIZE * 2));
-                        send_upsert(
-                            SYNC_TYPE_UPSERT_STORAGE,
-                            reinterpret_cast<unsigned char *>(&addr),
-                            sizeof(addr));
+                        if (server_is_page_encoded()) {
+                            send_storage_page(node.value());
+                        }
+                        else {
+                            send_upsert(
+                                SYNC_TYPE_UPSERT_STORAGE,
+                                reinterpret_cast<unsigned char *>(&addr),
+                                sizeof(addr));
+                        }
                     }
                 }
             }

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -219,6 +219,11 @@ monad_statesync_server_context::monad_statesync_server_context(TrieDb &rw)
 {
 }
 
+bool monad_statesync_server_context::is_page_encoded() const
+{
+    return rw.is_page_encoded();
+}
+
 std::optional<Account>
 monad_statesync_server_context::read_account(Address const &addr)
 {
@@ -229,6 +234,13 @@ bytes32_t monad_statesync_server_context::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
     return rw.read_storage(addr, incarnation, key);
+}
+
+storage_page_t monad_statesync_server_context::read_storage_page(
+    Address const &addr, Incarnation const incarnation,
+    bytes32_t const &page_key)
+{
+    return rw.read_storage_page(addr, incarnation, page_key);
 }
 
 monad::vm::SharedIntercode

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -307,17 +307,12 @@ void monad_statesync_server_context::update_proposed_metadata(
 
 void monad_statesync_server_context::commit(
     bytes32_t const &block_id, CommitBuilder &builder,
-    BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
+    BlockHeader const &header, StateDeltas const &state_deltas,
     std::function<void(BlockHeader &)> populate_header_fn)
 {
-    MONAD_ASSERT(state_deltas);
-    on_commit(*this, *state_deltas, header.number, block_id);
+    on_commit(*this, state_deltas, header.number, block_id);
     rw.commit(
-        block_id,
-        builder,
-        header,
-        std::move(state_deltas),
-        std::move(populate_header_fn));
+        block_id, builder, header, state_deltas, std::move(populate_header_fn));
 }
 
 uint64_t monad_statesync_server_context::get_block_number() const

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -137,7 +137,7 @@ struct monad_statesync_server_context final : public monad::Db
 
     virtual void commit(
         monad::bytes32_t const &, monad::CommitBuilder &,
-        monad::BlockHeader const &, std::unique_ptr<monad::StateDeltas>,
+        monad::BlockHeader const &, monad::StateDeltas const &,
         std::function<void(monad::BlockHeader &)>) override;
 
     virtual uint64_t get_block_number() const override;

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -98,12 +98,18 @@ struct monad_statesync_server_context final : public monad::Db
 
     explicit monad_statesync_server_context(monad::TrieDb &rw);
 
+    virtual bool is_page_encoded() const override;
+
     virtual std::optional<monad::Account>
     read_account(monad::Address const &addr) override;
 
     virtual monad::bytes32_t read_storage(
         monad::Address const &addr, monad::Incarnation,
         monad::bytes32_t const &key) override;
+
+    virtual monad::storage_page_t read_storage_page(
+        monad::Address const &addr, monad::Incarnation,
+        monad::bytes32_t const &page_key) override;
 
     virtual monad::vm::SharedIntercode
     read_code(monad::bytes32_t const &hash) override;

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -331,7 +331,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     // write the genesis block
     {
         monad::test::commit_simple(
-            *sctx, monad::test::sd({}), Code{}, NULL_HASH_BLAKE3, hdr);
+            *sctx, StateDeltas({}), Code{}, NULL_HASH_BLAKE3, hdr);
         sctx->finalize(0, NULL_HASH_BLAKE3);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));
@@ -374,7 +374,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
         bytes32_t const curr_block_id = bytes32_t{hdr.number};
         sctx->set_block_and_prefix(hdr.number - 1);
         monad::test::commit_simple(
-            *sctx, monad::test::sd(std::move(deltas)), {}, curr_block_id, hdr);
+            *sctx, StateDeltas(std::move(deltas)), {}, curr_block_id, hdr);
         sctx->finalize(hdr.number, curr_block_id);
         auto const rlp = rlp::encode_block_header(sctx->read_eth_header());
         parent_hash = to_bytes(keccak256(rlp));

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -129,13 +129,13 @@ namespace
         uint64_t end{0};
     };
 
-    struct State : Range
+    struct FuzzState : Range
     {
         ankerl::unordered_dense::segmented_map<uint64_t, Range> storage;
     };
 
     void new_account(
-        StateDeltas &deltas, State &state, Incarnation const incarnation,
+        StateDeltas &deltas, FuzzState &state, Incarnation const incarnation,
         uint64_t const n)
     {
         bool const success = deltas.emplace(
@@ -149,7 +149,7 @@ namespace
     }
 
     void update_account(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n,
         Incarnation const incarnation)
     {
         if (state.begin == state.end) {
@@ -175,7 +175,7 @@ namespace
         }
     }
 
-    void remove_account(StateDeltas &deltas, State &state, TrieDb &db)
+    void remove_account(StateDeltas &deltas, FuzzState &state, TrieDb &db)
     {
         if (state.begin == state.end) {
             return;
@@ -192,7 +192,7 @@ namespace
     }
 
     void
-    new_storage(StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+    new_storage(StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         if (state.begin == state.end) {
             return;
@@ -212,7 +212,7 @@ namespace
     }
 
     void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n,
         bool const erase)
     {
         if (state.storage.empty()) {
@@ -243,13 +243,13 @@ namespace
     }
 
     void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         update_storage(deltas, state, db, n, false);
     }
 
     void remove_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         update_storage(deltas, state, db, n, true);
     }
@@ -294,6 +294,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     monad_statesync_client client;
     monad_statesync_client_context *const cctx =
         monad_statesync_client_context_create(
+            CHAIN_CONFIG_MONAD_DEVNET,
             &cdbname_str,
             1,
             static_cast<unsigned>(get_nprocs() - 1),
@@ -323,7 +324,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
         &statesync_server_send_done);
 
     std::span<uint8_t const> raw{data, size};
-    State state{};
+    FuzzState state{};
 
     bytes32_t parent_hash{};
     BlockHeader hdr{.number = 0};

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -27,7 +27,9 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -189,9 +191,19 @@ namespace
             , ro{io_ctx}
         {
             sctx.ro = &ro;
+            // The client context now requires a secondary timeline to
+            // already be active on the client db.
+            mpt::Db primary{
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            [[maybe_unused]] mpt::Db secondary =
+                primary.activate_secondary_timeline(
+                    std::make_unique<MonadOnDiskMachine>());
+            MONAD_ASSERT(primary.timeline_active(mpt::timeline_id::secondary));
         }
 
-        void init()
+        void
+        init(monad_chain_config const chain_config = CHAIN_CONFIG_MONAD_TESTNET)
         {
             // Production C ABI (monad_statesync_client_context_create) does
             // this; tests that bypass the C ABI and call the C++ ctor
@@ -199,6 +211,7 @@ namespace
             monad::register_ethereum_state_machines();
             monad::register_monad_state_machines();
             cctx = new monad_statesync_client_context{
+                chain_config,
                 {cdbname},
                 std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),
                 4,
@@ -348,7 +361,13 @@ TEST_F(StateSyncFixture, sync_from_some)
             std::make_unique<OnDiskMachine>(),
             OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
+        auto db2_opt =
+            db.open_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+        MONAD_ASSERT(db2_opt.has_value());
+        TrieDb tdb2{db2_opt.value()};
+        ASSERT_TRUE(tdb2.is_page_encoded());
         load_genesis_state(GENESIS_STATE, tdb);
+        load_genesis_state(GENESIS_STATE, tdb2);
         // commit some proposal to client db
         commit_simple(
             tdb,
@@ -356,9 +375,17 @@ TEST_F(StateSyncFixture, sync_from_some)
             {},
             NULL_HASH_BLAKE3,
             BlockHeader{.number = 1});
+        commit_simple(
+            tdb2,
+            StateDeltas({}),
+            {},
+            NULL_HASH_BLAKE3,
+            BlockHeader{.number = 1});
+        EXPECT_TRUE(db2_opt->load_root_for_version(0) != nullptr);
         load_genesis_state(GENESIS_STATE, stdb);
         init();
     }
+
     ASSERT_TRUE(stdb.get_root() != nullptr);
     auto const res = sdb.find(
         stdb.get_root(), concat(FINALIZED_NIBBLE, BLOCKHEADER_NIBBLE), 0);
@@ -550,7 +577,14 @@ TEST_F(StateSyncFixture, deletion_proposal)
             std::make_unique<OnDiskMachine>(),
             OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
         TrieDb tdb{db};
+        auto db2_opt =
+            db.open_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+        MONAD_ASSERT(db2_opt.has_value());
+        TrieDb tdb2{db2_opt.value()};
+        ASSERT_TRUE(tdb2.is_page_encoded());
         load_genesis_state(GENESIS_STATE, tdb);
+        load_genesis_state(GENESIS_STATE, tdb2);
+
         load_genesis_state(GENESIS_STATE, stdb);
         init();
     }
@@ -639,6 +673,96 @@ TEST_F(StateSyncFixture, sync_one_account)
             .number = N});
     run();
     EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+}
+
+TEST_F(StateSyncFixture, sync_check_secondary_db_state_root)
+{
+    mpt::Db secondary_sdb =
+        sdb.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+    TrieDb secondary_stdb{secondary_sdb};
+    ASSERT_TRUE(secondary_stdb.is_page_encoded());
+
+    // Server stores ADDR_A with five slots: three share one page_key, two
+    // share a different page_key. Client receives slot-encoded upserts and
+    // dual-writes them to Db1 (slot encoding) and Db2 (page encoding).
+    // The server keeps its own page-encoded mirror so the test can compare
+    // state_roots on the two page tries at the end.
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    load_header(
+        secondary_sdb.load_root_for_version(N - 257),
+        secondary_sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        secondary_stdb.set_block_and_prefix(i - 1);
+        commit_sequential(
+            stdb, {}, {}, BlockHeader{.parent_hash = parent_hash, .number = i});
+        commit_sequential(
+            secondary_stdb,
+            {},
+            {},
+            BlockHeader{.parent_hash = parent_hash, .number = i});
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    // Slots 0x00, 0x01, 0x7f all map to page_key 0 (low 7 bits are offset).
+    // Slots 0x80, 0x81 map to page_key 1.
+    constexpr auto slot_a = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_b = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_c = bytes32_t{uint64_t{0x7f}};
+    constexpr auto slot_d = bytes32_t{uint64_t{0x80}};
+    constexpr auto slot_e = bytes32_t{uint64_t{0x81}};
+    constexpr auto val_a =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto val_b =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto val_c =
+        0x00000000000000000000000000000000000000000000000000000000000000cc_bytes32;
+    constexpr auto val_d =
+        0x00000000000000000000000000000000000000000000000000000000000000dd_bytes32;
+    constexpr auto val_e =
+        0x00000000000000000000000000000000000000000000000000000000000000ee_bytes32;
+
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_b));
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_c));
+    ASSERT_EQ(compute_page_key(slot_d), compute_page_key(slot_e));
+    ASSERT_NE(compute_page_key(slot_a), compute_page_key(slot_d));
+
+    StateDeltas const storage_deltas{
+        {ADDR_A,
+         StateDelta{
+             .account = {std::nullopt, Account{.balance = 100}},
+             .storage = {
+                 {slot_a, {bytes32_t{}, val_a}},
+                 {slot_b, {bytes32_t{}, val_b}},
+                 {slot_c, {bytes32_t{}, val_c}},
+                 {slot_d, {bytes32_t{}, val_d}},
+                 {slot_e, {bytes32_t{}, val_e}}}}}};
+
+    // Server commits the slot-encoded view to both primary and secondary dbs.
+    commit_sequential(stdb, storage_deltas, Code{}, BlockHeader{.number = N});
+    commit_sequential(
+        secondary_stdb, storage_deltas, Code{}, BlockHeader{.number = N});
+
+    init();
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.state_root(),
+            .number = N});
+    run();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    EXPECT_EQ(secondary_stdb.state_root(), cctx->secondary_tdb->state_root());
 }
 
 TEST_F(StateSyncFixture, sync_empty)

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -251,7 +251,7 @@ TEST_F(StateSyncFixture, sync_from_latest)
         for (size_t i = N - 256; i < N; ++i) {
             BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
             tdb.set_block_and_prefix(i - 1);
-            commit_sequential(tdb, sd({}), {}, hdr);
+            commit_sequential(tdb, StateDeltas({}), {}, hdr);
             parent_hash = to_bytes(
                 keccak256(rlp::encode_block_header(tdb.read_eth_header())));
         }
@@ -259,7 +259,11 @@ TEST_F(StateSyncFixture, sync_from_latest)
         // commit some proposal to client db
         tdb.set_block_and_prefix(N);
         commit_simple(
-            tdb, sd({}), {}, bytes32_t{N + 1}, BlockHeader{.number = N + 1});
+            tdb,
+            StateDeltas({}),
+            {},
+            bytes32_t{N + 1},
+            BlockHeader{.number = N + 1});
         init();
     }
     handle_target(
@@ -287,7 +291,7 @@ TEST_F(StateSyncFixture, sync_from_empty)
             stdb.set_block_and_prefix(i - 1);
             commit_sequential(
                 stdb,
-                sd({}),
+                StateDeltas({}),
                 {},
                 BlockHeader{.parent_hash = parent_hash, .number = i});
             parent_hash = to_bytes(
@@ -347,7 +351,11 @@ TEST_F(StateSyncFixture, sync_from_some)
         load_genesis_state(GENESIS_STATE, tdb);
         // commit some proposal to client db
         commit_simple(
-            tdb, sd({}), {}, NULL_HASH_BLAKE3, BlockHeader{.number = 1});
+            tdb,
+            StateDeltas({}),
+            {},
+            NULL_HASH_BLAKE3,
+            BlockHeader{.number = 1});
         load_genesis_state(GENESIS_STATE, stdb);
         init();
     }
@@ -368,7 +376,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         commit_sequential(
             sctx,
-            sd({{ADDR1, {.account = {acct, std::nullopt}}}}),
+            StateDeltas({{ADDR1, {.account = {acct, std::nullopt}}}}),
             Code{},
             hdr1);
         EXPECT_EQ(stdb.read_eth_header(), hdr1);
@@ -385,7 +393,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const acct = stdb.read_account(ADDR1);
         commit_sequential(
             sctx,
-            sd(
+            StateDeltas(
                 {{ADDR1,
                   {.account = {acct, acct},
                    .storage =
@@ -414,7 +422,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const icode = vm::make_shared_intercode(code);
         commit_sequential(
             sctx,
-            sd(
+            StateDeltas(
                 {{ADDR1,
                   {.account =
                        {std::nullopt,
@@ -445,7 +453,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         auto const acct = stdb.read_account(ADDR1);
         commit_sequential(
             sctx,
-            sd(
+            StateDeltas(
                 {{ADDR1,
                   {.account = {acct, acct},
                    .storage =
@@ -470,7 +478,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         acct->incarnation = Incarnation{5, 0};
         commit_sequential(
             sctx,
-            sd(
+            StateDeltas(
                 {{ADDR1,
                   {.account = {old, acct},
                    .storage =
@@ -494,7 +502,7 @@ TEST_F(StateSyncFixture, sync_from_some)
         MONAD_ASSERT(acct.has_value());
         commit_sequential(
             sctx,
-            sd({{ADDR1, {.account = {acct, std::nullopt}}}}),
+            StateDeltas({{ADDR1, {.account = {acct, std::nullopt}}}}),
             Code{},
             hdr6);
         EXPECT_EQ(stdb.read_eth_header(), hdr6);
@@ -560,7 +568,7 @@ TEST_F(StateSyncFixture, deletion_proposal)
         sctx.set_block_and_prefix(0);
         commit_simple(
             sctx,
-            sd(std::move(deltas)),
+            StateDeltas(std::move(deltas)),
             Code{},
             bytes32_t{1},
             BlockHeader{.number = 1});
@@ -575,7 +583,7 @@ TEST_F(StateSyncFixture, deletion_proposal)
         sctx.set_block_and_prefix(0);
         commit_simple(
             sctx,
-            sd(std::move(deltas)),
+            StateDeltas(std::move(deltas)),
             Code{},
             bytes32_t{2},
             BlockHeader{.number = 1});
@@ -607,7 +615,7 @@ TEST_F(StateSyncFixture, sync_one_account)
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -615,7 +623,7 @@ TEST_F(StateSyncFixture, sync_one_account)
     }
     commit_sequential(
         stdb,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 100}},
@@ -645,13 +653,14 @@ TEST_F(StateSyncFixture, sync_empty)
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
-    commit_sequential(stdb, sd({}), Code{}, BlockHeader{.number = 1'000'000});
+    commit_sequential(
+        stdb, StateDeltas({}), Code{}, BlockHeader{.number = 1'000'000});
     init();
     handle_target(cctx, BlockHeader{.parent_hash = parent_hash, .number = N});
     run();
@@ -669,7 +678,11 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
         tdb.reset_root(load_header({}, db, BlockHeader{.number = 0}), 0);
         for (uint64_t n = 1; n <= 249; ++n) {
             commit_simple(
-                tdb, sd({}), {}, bytes32_t{n}, BlockHeader{.number = n});
+                tdb,
+                StateDeltas({}),
+                {},
+                bytes32_t{n},
+                BlockHeader{.number = n});
         }
     }
 
@@ -684,7 +697,7 @@ TEST_F(StateSyncFixture, sync_client_has_proposals)
         for (size_t i = N - 256; i < N; ++i) {
             BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
             stdb.set_block_and_prefix(i - 1);
-            commit_sequential(stdb, sd({}), {}, hdr);
+            commit_sequential(stdb, StateDeltas({}), {}, hdr);
             parent_hash = to_bytes(
                 keccak256(rlp::encode_block_header(stdb.read_eth_header())));
         }
@@ -707,14 +720,14 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
     bytes32_t parent_hash{NULL_HASH};
     for (size_t i = 0; i < 100; ++i) {
         BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
-        commit_sequential(stdb, sd({}), {}, hdr);
+        commit_sequential(stdb, StateDeltas({}), {}, hdr);
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
     BlockHeader hdr{.parent_hash = parent_hash, .number = 100};
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 100}},
@@ -728,14 +741,14 @@ TEST_F(StateSyncFixture, account_updated_after_storage)
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr = BlockHeader{.parent_hash = parent_hash, .number = 101};
-    commit_sequential(sctx, sd({}), {}, hdr);
+    commit_sequential(sctx, StateDeltas({}), {}, hdr);
     parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr = BlockHeader{.parent_hash = parent_hash, .number = 102};
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {Account{.balance = 100}, Account{.balance = 200}},
@@ -754,14 +767,14 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
     bytes32_t parent_hash{NULL_HASH};
     for (size_t i = 0; i < 100; ++i) {
         BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
-        commit_sequential(stdb, sd({}), {}, hdr);
+        commit_sequential(stdb, StateDeltas({}), {}, hdr);
         parent_hash = to_bytes(
             keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     }
     BlockHeader hdr{.parent_hash = parent_hash, .number = 100};
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 100}},
@@ -775,14 +788,14 @@ TEST_F(StateSyncFixture, account_deleted_after_storage)
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr.number = 101;
-    commit_sequential(sctx, sd({}), {}, hdr);
+    commit_sequential(sctx, StateDeltas({}), {}, hdr);
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
     hdr.number = 102;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {Account{.balance = 100}, std::nullopt},
@@ -799,7 +812,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
 {
     init();
     BlockHeader hdr{.parent_hash = NULL_HASH};
-    commit_sequential(sctx, sd({}), Code{}, hdr);
+    commit_sequential(sctx, StateDeltas({}), Code{}, hdr);
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     hdr.number = 1;
@@ -807,7 +820,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
         0x7537c605448f37499129a14743eb442cd09e5b2ec50ef7e73a5e715ee82d0453_bytes32;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, Account{.balance = 100}},
@@ -824,7 +837,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
     hdr.state_root = NULL_ROOT;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {Account{.balance = 100}, std::nullopt},
@@ -839,7 +852,7 @@ TEST_F(StateSyncFixture, account_deleted_and_prefix_skipped)
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
     hdr.number = 3;
     hdr.state_root = NULL_ROOT;
-    commit_sequential(sctx, sd({}), Code{}, hdr);
+    commit_sequential(sctx, StateDeltas({}), Code{}, hdr);
     EXPECT_EQ(sctx.state_root(), hdr.state_root);
     handle_target(cctx, hdr);
     run();
@@ -850,7 +863,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
 {
     init();
     BlockHeader hdr{.parent_hash = NULL_HASH};
-    commit_sequential(sctx, sd({}), Code{}, hdr);
+    commit_sequential(sctx, StateDeltas({}), Code{}, hdr);
 
     Account const a{.balance = 100, .incarnation = Incarnation{1, 0}};
 
@@ -861,7 +874,9 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 1;
     commit_sequential(
         sctx,
-        sd({{ADDR_A, StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {std::nullopt, a}, .storage = {}}}}),
         Code{},
         hdr);
     handle_target(cctx, hdr);
@@ -874,7 +889,7 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 2;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {a, a},
@@ -893,7 +908,9 @@ TEST_F(StateSyncFixture, delete_updated_account)
     hdr.number = 3;
     commit_sequential(
         sctx,
-        sd({{ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
         Code{},
         hdr);
     handle_target(cctx, hdr);
@@ -917,7 +934,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -931,7 +948,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
         .number = 1'000'000};
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, a},
@@ -949,7 +966,9 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'001;
     commit_sequential(
         sctx,
-        sd({{ADDR_A, StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
+        StateDeltas(
+            {{ADDR_A,
+              StateDelta{.account = {a, std::nullopt}, .storage = {}}}}),
         Code{},
         hdr);
     hdr.parent_hash =
@@ -957,7 +976,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'002;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {std::nullopt, a},
@@ -971,7 +990,7 @@ TEST_F(StateSyncFixture, delete_storage_after_account_deletion)
     hdr.number = 1'000'003;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR_A,
               StateDelta{
                   .account = {a, a},
@@ -989,7 +1008,7 @@ TEST_F(StateSyncFixture, update_contract_twice)
     init();
 
     BlockHeader hdr{.parent_hash = NULL_HASH, .number = 0};
-    commit_sequential(sctx, sd({}), Code{}, hdr);
+    commit_sequential(sctx, StateDeltas({}), Code{}, hdr);
 
     constexpr auto ADDR1 = 0x5353535353535353535353535353535353535353_address;
     hdr.parent_hash =
@@ -1014,7 +1033,7 @@ TEST_F(StateSyncFixture, update_contract_twice)
     hdr.number = 1;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR1,
               {.account = {std::nullopt, a},
                .storage =
@@ -1036,7 +1055,7 @@ TEST_F(StateSyncFixture, update_contract_twice)
     hdr.number = 2;
     commit_sequential(
         sctx,
-        sd(
+        StateDeltas(
             {{ADDR1,
               {.account = {a, a},
                .storage =
@@ -1087,7 +1106,7 @@ TEST_F(StateSyncFixture, benchmark)
         stdb.set_block_and_prefix(i - 1);
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -1100,7 +1119,7 @@ TEST_F(StateSyncFixture, benchmark)
             0x50510e4f9ecc40a8cc5819bdc589a0e09c172ed268490d5f755dba939f7e8997_bytes32,
         .number = N};
     StateDeltas deltas{v.begin(), v.end()};
-    commit_sequential(stdb, sd(std::move(deltas)), Code{}, hdr);
+    commit_sequential(stdb, StateDeltas(std::move(deltas)), Code{}, hdr);
     init();
     handle_target(cctx, hdr);
     run();
@@ -1273,7 +1292,7 @@ TEST_F(StateSyncFixture, validation_prefix_bytes_too_large)
         }
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -1304,7 +1323,7 @@ TEST_F(StateSyncFixture, validation_target_invalid)
         }
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -1334,7 +1353,7 @@ TEST_F(StateSyncFixture, validation_from_greater_than_until)
         }
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -1364,7 +1383,7 @@ TEST_F(StateSyncFixture, validation_until_greater_than_target)
         }
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(
@@ -1394,7 +1413,7 @@ TEST_F(StateSyncFixture, validation_old_target_greater_than_target)
         }
         commit_sequential(
             stdb,
-            sd({}),
+            StateDeltas({}),
             {},
             BlockHeader{.parent_hash = parent_hash, .number = i});
         parent_hash = to_bytes(

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -27,6 +27,7 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -196,6 +197,7 @@ namespace
             // this; tests that bypass the C ABI and call the C++ ctor
             // directly must populate the registry themselves.
             monad::register_ethereum_state_machines();
+            monad::register_monad_state_machines();
             cctx = new monad_statesync_client_context{
                 {cdbname},
                 std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),

--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -770,7 +770,9 @@ namespace monad::vm::compiler
     consteval std::array<OpCodeInfo, 256>
     make_opcode_table<MonadTraits<MONAD_NEXT>>()
     {
-        return make_opcode_table<MonadTraits<MONAD_NEXT>::evm_base>();
+        auto table = make_opcode_table<MonadTraits<MONAD_NEXT>::evm_base>();
+        table[SSTORE].min_gas = MonadTraits<MONAD_NEXT>::base_sstore_cost();
+        return table;
     }
 
     /**

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -56,6 +56,7 @@ namespace monad
         { T::eip_7883_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
+        { T::mip_8_active() } -> std::same_as<bool>;
         { T::can_create_inside_delegated() } -> std::same_as<bool>;
 
         // Constants
@@ -115,6 +116,11 @@ namespace monad
         static consteval bool eip_7951_active() noexcept
         {
             return Rev >= EVMC_OSAKA;
+        }
+
+        static consteval bool mip_8_active() noexcept
+        {
+            return false;
         }
 
         static consteval bool mip_3_active() noexcept
@@ -236,15 +242,43 @@ namespace monad
             return false;
         }
 
+        static consteval bool mip_8_active() noexcept
+        {
+            return Rev >= MONAD_NEXT;
+        }
+
         // Pricing version 1 activates the changes in:
         // Monad specification §4: Opcode Gas Costs and Gas Refunds
         static consteval uint8_t monad_pricing_version() noexcept
         {
+            if constexpr (mip_8_active()) {
+                return 2;
+            }
             if constexpr (Rev >= MONAD_SEVEN) {
                 return 1;
             }
 
             return 0;
+        }
+
+        static consteval int64_t base_sload_cost() noexcept
+        {
+            return 100;
+        }
+
+        static consteval int64_t base_sstore_cost() noexcept
+        {
+            return 100;
+        }
+
+        static consteval int64_t page_write_cost() noexcept
+        {
+            return 2800;
+        }
+
+        static consteval int64_t page_growth_cost() noexcept
+        {
+            return 17000;
         }
 
         static consteval size_t max_code_size() noexcept

--- a/category/vm/host.hpp
+++ b/category/vm/host.hpp
@@ -30,6 +30,16 @@ namespace monad::vm
         friend class VM;
 
     public:
+        struct PageStorageStatus
+        {
+            bool first_page_write;
+            bool grew_state;
+        };
+
+        virtual PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept = 0;
+
         /// Capture `std::current_exception()`.
         /// IMPORTANT: Make sure to call this from inside a `catch` block.
         void capture_current_exception() const noexcept

--- a/category/vm/runtime/storage.cpp
+++ b/category/vm/runtime/storage.cpp
@@ -18,12 +18,14 @@
 #include <category/core/runtime/uint256.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
+#include <category/vm/host.hpp>
 #include <category/vm/runtime/storage.hpp>
 #include <category/vm/runtime/storage_costs.hpp>
 #include <category/vm/runtime/transmute.hpp>
 #include <category/vm/runtime/types.hpp>
 
 #include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
 
 #include <cstdint>
 
@@ -75,28 +77,51 @@ namespace monad::vm::runtime
         auto key = bytes32_from_uint256(*key_ptr);
         auto value = bytes32_from_uint256(*value_ptr);
 
-        auto access_status = EVMC_ACCESS_COLD;
-        if constexpr (traits::eip_2929_active()) {
-            access_status = ctx->host->access_storage(
+        if constexpr (traits::mip_8_active()) {
+            auto const access_status = ctx->host->access_storage(
                 ctx->context, &ctx->env.recipient, &key);
             if (access_status == EVMC_ACCESS_COLD) {
-                ctx->deduct_gas(traits::cold_storage_cost() + min_gas);
+                ctx->deduct_gas(traits::cold_storage_cost());
             }
+
+            auto const storage_status = ctx->host->set_storage(
+                ctx->context, &ctx->env.recipient, &key, &value);
+
+            auto *monad_host = evmc::Host::from_context<vm::Host>(ctx->context);
+            auto const [first_page_write, grew_state] = monad_host->update_page(
+                ctx->env.recipient, key, storage_status);
+
+            int64_t gas_used = traits::base_sstore_cost();
+            if (first_page_write) {
+                gas_used += traits::page_write_cost();
+            }
+            if (grew_state) {
+                gas_used += traits::page_growth_cost();
+            }
+
+            gas_used -= min_gas;
+            ctx->deduct_gas(gas_used);
         }
+        else {
+            auto access_status = EVMC_ACCESS_COLD;
+            if constexpr (traits::eip_2929_active()) {
+                access_status = ctx->host->access_storage(
+                    ctx->context, &ctx->env.recipient, &key);
+                if (access_status == EVMC_ACCESS_COLD) {
+                    ctx->deduct_gas(traits::cold_storage_cost() + min_gas);
+                }
+            }
 
-        auto const storage_status = ctx->host->set_storage(
-            ctx->context, &ctx->env.recipient, &key, &value);
+            auto const storage_status = ctx->host->set_storage(
+                ctx->context, &ctx->env.recipient, &key, &value);
 
-        auto [gas_used, gas_refund] = store_cost<traits>(storage_status);
+            auto [gas_used, gas_refund] = store_cost<traits>(storage_status);
 
-        // The code generator has taken care of accounting for the minimum base
-        // gas cost of this SSTORE already, but to keep the table of costs
-        // readable it encodes the total gas usage of each combination, rather
-        // than the amount relative to the minimum gas.
-        gas_used -= min_gas;
+            gas_used -= min_gas;
 
-        ctx->gas_refund += gas_refund;
-        ctx->deduct_gas(gas_used);
+            ctx->gas_refund += gas_refund;
+            ctx->deduct_gas(gas_used);
+        }
     }
 
     EXPLICIT_TRAITS(sstore);

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <category/core/address.hpp>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/keccak.hpp>
-#include <category/core/address.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/vm/vm.hpp>
@@ -111,8 +111,18 @@ inline bytes32_t commit_sequential(
     bytes32_t const block_id =
         eth_header.number ? bytes32_t{eth_header.number} : NULL_HASH_BLAKE3;
 
-    commit_simple(db, deltas, code, block_id, eth_header,
-        receipts, call_frames, senders, txns, ommers, withdrawals);
+    commit_simple(
+        db,
+        deltas,
+        code,
+        block_id,
+        eth_header,
+        receipts,
+        call_frames,
+        senders,
+        txns,
+        ommers,
+        withdrawals);
 
     db.finalize(eth_header.number, block_id);
     db.set_block_and_prefix(eth_header.number); // set to finalized
@@ -125,61 +135,61 @@ inline void load_db(TrieDb &db, uint64_t const n)
 {
     commit_sequential(
         db,
-        monad::StateDeltas({
-            {ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = A_CODE_HASH}},
-                 .storage =
-                     {{bytes32_t{},
-                       {bytes32_t{},
-                        0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = B_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000102_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = C_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000103_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = D_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000104_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = E_CODE_HASH}}}},
-            {0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 0x7024c}}}},
-            {0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}}}},
-            {0xcccccccccccccccccccccccccccccccccccccccc_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9cf,
-                          .code_hash = H_CODE_HASH}}}}}),
+        monad::StateDeltas(
+            {{ADDR_A,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9ce,
+                           .code_hash = A_CODE_HASH}},
+                  .storage =
+                      {{bytes32_t{},
+                        {bytes32_t{},
+                         0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}}},
+             {ADDR_B,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9ce,
+                           .code_hash = B_CODE_HASH}}}},
+             {0x0000000000000000000000000000000000000102_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9ce,
+                           .code_hash = C_CODE_HASH}}}},
+             {0x0000000000000000000000000000000000000103_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9ce,
+                           .code_hash = D_CODE_HASH}}}},
+             {0x0000000000000000000000000000000000000104_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9ce,
+                           .code_hash = E_CODE_HASH}}}},
+             {0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address,
+              StateDelta{
+                  .account = {std::nullopt, Account{.balance = 0x7024c}}}},
+             {0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}}}},
+             {0xcccccccccccccccccccccccccccccccccccccccc_address,
+              StateDelta{
+                  .account =
+                      {std::nullopt,
+                       Account{
+                           .balance = 0xba1a9ce0ba1a9cf,
+                           .code_hash = H_CODE_HASH}}}}}),
         Code{
             {A_CODE_HASH, A_ICODE},
             {B_CODE_HASH, B_ICODE},

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -98,10 +98,9 @@ inline auto const H_CODE_HASH = to_bytes(keccak256(H_CODE));
 inline auto const H_ICODE = vm::make_shared_intercode(H_CODE);
 
 using monad::test::commit_simple;
-using monad::test::sd;
 
 inline bytes32_t commit_sequential(
-    monad::Db &db, std::unique_ptr<StateDeltas> deltas, Code const &code,
+    monad::Db &db, StateDeltas const &deltas, Code const &code,
     BlockHeader const &eth_header, std::vector<Receipt> const &receipts = {},
     std::vector<std::vector<CallFrame>> const &call_frames = {},
     std::vector<Address> const &senders = {},
@@ -112,7 +111,7 @@ inline bytes32_t commit_sequential(
     bytes32_t const block_id =
         eth_header.number ? bytes32_t{eth_header.number} : NULL_HASH_BLAKE3;
 
-    commit_simple(db, std::move(deltas), code, block_id, eth_header,
+    commit_simple(db, deltas, code, block_id, eth_header,
         receipts, call_frames, senders, txns, ommers, withdrawals);
 
     db.finalize(eth_header.number, block_id);
@@ -126,7 +125,7 @@ inline void load_db(TrieDb &db, uint64_t const n)
 {
     commit_sequential(
         db,
-        monad::test::sd({
+        monad::StateDeltas({
             {ADDR_A,
              StateDelta{
                  .account =

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -46,6 +46,7 @@
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_server_network.hpp>
 #include <category/statesync/statesync_thread.hpp>
@@ -440,6 +441,7 @@ try {
         case CHAIN_CONFIG_MONAD_DEVNET:
         case CHAIN_CONFIG_MONAD_TESTNET:
         case CHAIN_CONFIG_MONAD_MAINNET:
+            register_monad_state_machines();
             if (as_eth_blocks) {
                 return runloop_monad_ethblocks(
                     dynamic_cast<MonadChain const &>(*chain),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -505,13 +505,22 @@ try {
                         "dual db migration mode does not work with "
                         "page-encoded primary db");
                 }
-                else {
-                    MONAD_ASSERT(raw_db.timeline_active(
-                        monad::mpt::timeline_id::secondary));
+                else if (raw_db.timeline_active(
+                             monad::mpt::timeline_id::secondary)) {
                     secondary_db = raw_db.open_secondary_timeline();
                     MONAD_ASSERT(secondary_db.has_value());
                     secondary_triedb.emplace(*secondary_db);
                     MONAD_ASSERT(secondary_triedb->is_page_encoded());
+                }
+                else {
+                    // slot primary with no secondary: pre-migration state,
+                    // run single-db on the previous revision. Reject the
+                    // explicit migration flag — that mode requires a
+                    // secondary to dual-write into.
+                    MONAD_ASSERT(
+                        !dual_db_migration_mode,
+                        "dual db migration mode requires an active "
+                        "secondary timeline");
                 }
                 return runloop_monad(
                     dynamic_cast<MonadChain const &>(*chain),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -300,8 +300,12 @@ try {
     // The on-disk Db ctor reads the persisted state_machine_kind from
     // db_metadata and constructs the StateMachine via the registry. The
     // in-memory path has no metadata to read from and constructs the SM
-    // inline.
+    // inline. Encoding follows the persisted kind, not --chain, so both
+    // factories must be registered before the Db open — a page-encoded
+    // pool created under monad_devnet must still open under, e.g., a
+    // service restart that re-reads the kind from metadata.
     register_ethereum_state_machines();
+    register_monad_state_machines();
     mpt::Db raw_db = [&] {
         if (!db_in_memory) {
             return mpt::Db{mpt::OnDiskDbConfig{
@@ -465,7 +469,6 @@ try {
         case CHAIN_CONFIG_MONAD_DEVNET:
         case CHAIN_CONFIG_MONAD_TESTNET:
         case CHAIN_CONFIG_MONAD_MAINNET:
-            register_monad_state_machines();
             if (as_eth_blocks) {
                 return runloop_monad_ethblocks(
                     dynamic_cast<MonadChain const &>(*chain),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -350,6 +350,9 @@ try {
 
     std::unique_ptr<monad::StateSyncServer> sync_server;
     if (!statesync.empty()) {
+        // Works for either encoding: a page-encoded primary expands each
+        // page leaf into slot-format upserts in the server traversal, so no
+        // protocol changes are needed.
         sync_server = monad::make_statesync_server(monad::StateSyncServerConfig{
             .triedb = &triedb,
             .network = &net.value(),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -45,6 +45,7 @@
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/event_trace.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_devnet_fork.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/execution/monad/db/state_machine_init.hpp>
@@ -146,6 +147,7 @@ try {
     std::unordered_map<std::string, monad_chain_config> const CHAIN_CONFIG_MAP =
         {{"ethereum_mainnet", CHAIN_CONFIG_ETHEREUM_MAINNET},
          {"monad_devnet", CHAIN_CONFIG_MONAD_DEVNET},
+         {"monad_devnet_fork", CHAIN_CONFIG_MONAD_DEVNET_FORK},
          {"monad_testnet", CHAIN_CONFIG_MONAD_TESTNET},
          {"monad_mainnet", CHAIN_CONFIG_MONAD_MAINNET},
          {"hive_net", CHAIN_CONFIG_HIVE_NET}};
@@ -287,6 +289,8 @@ try {
             return std::make_unique<EthereumMainnet>();
         case CHAIN_CONFIG_MONAD_DEVNET:
             return std::make_unique<MonadDevnet>();
+        case CHAIN_CONFIG_MONAD_DEVNET_FORK:
+            return std::make_unique<MonadDevnetFork>();
         case CHAIN_CONFIG_MONAD_TESTNET:
             return std::make_unique<MonadTestnet>();
         case CHAIN_CONFIG_MONAD_MAINNET:
@@ -467,6 +471,7 @@ try {
                 trace_calls,
                 chain_rlp_path);
         case CHAIN_CONFIG_MONAD_DEVNET:
+        case CHAIN_CONFIG_MONAD_DEVNET_FORK:
         case CHAIN_CONFIG_MONAD_TESTNET:
         case CHAIN_CONFIG_MONAD_MAINNET:
             if (as_eth_blocks) {

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -38,6 +38,7 @@
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/precompiles.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
@@ -279,25 +280,6 @@ try {
     if (!statesync.empty()) {
         net.emplace(statesync.c_str());
     }
-    // The on-disk Db ctor reads the persisted state_machine_kind from
-    // db_metadata and constructs the StateMachine via the registry. The
-    // in-memory path has no metadata to read from and constructs the SM
-    // inline.
-    register_ethereum_state_machines();
-    mpt::Db raw_db = [&] {
-        if (!db_in_memory) {
-            return mpt::Db{mpt::OnDiskDbConfig{
-                .append = true,
-                .compaction = !no_compaction,
-                .rewind_to_latest_finalized = true,
-                .rd_buffers = 8192,
-                .wr_buffers = 32,
-                .uring_entries = 128,
-                .sq_thread_cpu = sq_thread_cpu,
-                .dbname_paths = dbname_paths}};
-        }
-        return mpt::Db{std::make_unique<InMemoryMachine>()};
-    }();
 
     auto chain = [chain_config] -> std::unique_ptr<Chain> {
         switch (chain_config) {
@@ -315,10 +297,39 @@ try {
         MONAD_ASSERT(false);
     }();
 
+    // The on-disk Db ctor reads the persisted state_machine_kind from
+    // db_metadata and constructs the StateMachine via the registry. The
+    // in-memory path has no metadata to read from and constructs the SM
+    // inline.
+    register_ethereum_state_machines();
+    mpt::Db raw_db = [&] {
+        if (!db_in_memory) {
+            return mpt::Db{mpt::OnDiskDbConfig{
+                .append = true,
+                .compaction = !no_compaction,
+                .rewind_to_latest_finalized = true,
+                .rd_buffers = 8192,
+                .wr_buffers = 32,
+                .uring_entries = 128,
+                .sq_thread_cpu = sq_thread_cpu,
+                .dbname_paths = dbname_paths}};
+        }
+        auto const *const monad_chain =
+            dynamic_cast<MonadChain const *>(chain.get());
+        GenesisState const genesis_state = chain->get_genesis_state();
+        if (monad_chain != nullptr &&
+            monad_chain->get_monad_revision(genesis_state.header.timestamp) >=
+                MONAD_NEXT) {
+            return mpt::Db{std::make_unique<MonadInMemoryMachine>()};
+        }
+        else {
+            return mpt::Db{std::make_unique<InMemoryMachine>()};
+        }
+    }();
+
     TrieDb triedb{
         raw_db,
-        /*enable_multiblock_cache=*/true}; // init block number to latest
-                                           // finalized block
+        /*enable_multiblock_cache=*/true};
     // Note: in memory db block number is always zero
     uint64_t const init_block_num = [&] {
         if (!snapshot.empty()) {
@@ -424,19 +435,6 @@ try {
     Db &db = sync_server ? static_cast<Db &>(*sync_server->ctx)
                          : static_cast<Db &>(triedb);
 
-    // Optional secondary db for migration: commits go through both the
-    // primary (slot storage, DbCache) and the secondary (page storage, raw).
-    std::optional<mpt::Db> secondary_db;
-    std::optional<TrieDb> secondary_triedb;
-    if (dual_db_migration_mode) {
-        MONAD_ASSERT(
-            raw_db.timeline_active(monad::mpt::timeline_id::secondary) == true);
-        secondary_db = raw_db.open_secondary_timeline();
-        MONAD_ASSERT(secondary_db.has_value());
-        secondary_triedb.emplace(*secondary_db);
-        MONAD_ASSERT(secondary_triedb->is_page_encoded());
-    }
-
     auto const result = [&] {
         switch (chain_config) {
         case CHAIN_CONFIG_ETHEREUM_MAINNET:
@@ -483,9 +481,38 @@ try {
                     block_db_timeout);
             }
             else {
-                // Live monad must be running in dual db migration mode, which
-                // provides the secondary_triedb.
-                MONAD_ASSERT(secondary_triedb.has_value());
+                // Live monad. Two valid configurations:
+                //   * dual_db_migration_mode + slot-encoded primary:
+                //     dual-write to a page-encoded secondary so state
+                //     gets migrated across the MONAD_NEXT fork.
+                //   * page-encoded primary + no secondary: single-db
+                //     mode for a chain that's already past the fork.
+                if (chain_config == CHAIN_CONFIG_MONAD_TESTNET ||
+                    chain_config == CHAIN_CONFIG_MONAD_MAINNET) {
+                    MONAD_ASSERT_PRINTF(
+                        dual_db_migration_mode,
+                        "live monad %s requires a page-encoded "
+                        "secondary; pass --dual-db-migration-mode",
+                        chain_config == CHAIN_CONFIG_MONAD_TESTNET
+                            ? "monad_testnet"
+                            : "monad_mainnet"); // can remove at release2
+                }
+                std::optional<mpt::Db> secondary_db;
+                std::optional<TrieDb> secondary_triedb;
+                if (db.is_page_encoded()) {
+                    MONAD_ASSERT(
+                        !dual_db_migration_mode,
+                        "dual db migration mode does not work with "
+                        "page-encoded primary db");
+                }
+                else {
+                    MONAD_ASSERT(raw_db.timeline_active(
+                        monad::mpt::timeline_id::secondary));
+                    secondary_db = raw_db.open_secondary_timeline();
+                    MONAD_ASSERT(secondary_db.has_value());
+                    secondary_triedb.emplace(*secondary_db);
+                    MONAD_ASSERT(secondary_triedb->is_page_encoded());
+                }
                 return runloop_monad(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
@@ -543,7 +570,7 @@ try {
             .dbname_paths = dbname_paths,
             .concurrent_read_io_limit = 128});
         mpt::Db db{io_ctx};
-        TrieDb ro_db{db};
+        TrieDb ro_db{db, false};
         write_to_file(ro_db.to_json(), dump_snapshot, block_num);
     }
     return result.has_error() ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -139,6 +139,7 @@ try {
     fs::path dump_snapshot;
     std::string statesync;
     fs::path chain_rlp_path;
+    bool dual_db_migration_mode = false;
     auto log_level = quill::LogLevel::Info;
 
     std::unordered_map<std::string, monad_chain_config> const CHAIN_CONFIG_MAP =
@@ -169,12 +170,20 @@ try {
         ro_sq_thread_cpu,
         "sq_thread_cpu for the read only db (optional, disables SQPOLL if not "
         "specified)");
-    cli.add_option(
+    auto *const db_option = cli.add_option(
         "--db",
         dbname_paths,
         "A comma-separated list of previously created database paths. You can "
         "configure the storage pool with one or more files/devices. If no "
         "value is passed, the replay will run with an in-memory triedb");
+    cli.add_flag(
+           "--dual-db-migration-mode",
+           dual_db_migration_mode,
+           "enable dual db migration mode for MIP-8, which opens two databases "
+           "(one with the slot based storage format and one with page based "
+           "format) on the same disk and cross-checks them for consistency on "
+           "every storage read")
+        ->needs(db_option);
     cli.add_option(
         "--dump-snapshot,--dump_snapshot",
         dump_snapshot,
@@ -411,6 +420,20 @@ try {
 
     Db &db = sync_server ? static_cast<Db &>(*sync_server->ctx)
                          : static_cast<Db &>(triedb);
+
+    // Optional secondary db for migration: commits go through both the
+    // primary (slot storage, DbCache) and the secondary (page storage, raw).
+    std::optional<mpt::Db> secondary_db;
+    std::optional<TrieDb> secondary_triedb;
+    if (dual_db_migration_mode) {
+        MONAD_ASSERT(
+            raw_db.timeline_active(monad::mpt::timeline_id::secondary) == true);
+        secondary_db = raw_db.open_secondary_timeline();
+        MONAD_ASSERT(secondary_db.has_value());
+        secondary_triedb.emplace(*secondary_db);
+        MONAD_ASSERT(secondary_triedb->is_page_encoded());
+    }
+
     auto const result = [&] {
         switch (chain_config) {
         case CHAIN_CONFIG_ETHEREUM_MAINNET:
@@ -457,6 +480,9 @@ try {
                     block_db_timeout);
             }
             else {
+                // Live monad must be running in dual db migration mode, which
+                // provides the secondary_triedb.
+                MONAD_ASSERT(secondary_triedb.has_value());
                 return runloop_monad(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
@@ -468,7 +494,9 @@ try {
                     block_num,
                     end_block_num,
                     stop,
-                    trace_calls);
+                    trace_calls,
+                    secondary_triedb.has_value() ? &*secondary_triedb
+                                                 : nullptr);
             }
         }
         MONAD_ABORT_PRINTF("Unsupported chain");

--- a/cmd/monad/runloop_ethereum.cpp
+++ b/cmd/monad/runloop_ethereum.cpp
@@ -186,17 +186,16 @@ Result<void> process_ethereum_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(
-        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
-            // second stage: populate block header
-            h.receipts_root = db.receipts_root();
-            h.state_root = db.state_root();
-            h.withdrawals_root = db.withdrawals_root();
-            h.transactions_root = db.transactions_root();
-            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-            h.logs_bloom = compute_bloom(receipts);
-            h.ommers_hash = compute_ommers_hash(block.ommers);
-        });
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        h.receipts_root = db.receipts_root();
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(receipts);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -46,6 +46,7 @@
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
 #include <category/execution/monad/core/rlp/monad_block_rlp.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
 #include <category/execution/monad/event/record_consensus_events.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/execution/monad/validate_monad_block.hpp>
@@ -179,7 +180,7 @@ Result<BlockExecOutput> propose_block(
     MonadConsensusBlockHeader const &consensus_header, Block block,
     BlockHashChain &block_hash_chain, MonadChain const &chain, Db &db,
     vm::VM &vm, fiber::PriorityPool &priority_pool, bool const is_first_block,
-    bool const enable_tracing, BlockCache &block_cache)
+    bool const enable_tracing, BlockCache &block_cache, Db *secondary_db)
 {
     [[maybe_unused]] auto const block_start = std::chrono::system_clock::now();
     auto const block_begin = std::chrono::steady_clock::now();
@@ -279,12 +280,18 @@ Result<BlockExecOutput> propose_block(
     db.set_block_and_prefix(
         block.header.number - 1,
         is_first_block ? bytes32_t{} : consensus_header.parent_id());
+    if (secondary_db != nullptr) {
+        secondary_db->set_block_and_prefix(
+            block.header.number - 1,
+            is_first_block ? bytes32_t{} : consensus_header.parent_id());
+    }
     block.header.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(db.read_eth_header())));
 
     BlockExecOutput exec_output;
     BlockMetrics block_metrics;
-    BlockState block_state(db, vm);
+
+    BlockState block_state(db, vm, secondary_db);
     record_block_marker_event(MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
     BOOST_OUTCOME_TRY(
         auto const results,
@@ -308,26 +315,15 @@ Result<BlockExecOutput> propose_block(
     auto [state, code, _] = std::move(block_state).release();
     MONAD_ASSERT(state);
 
-    CommitBuilder builder(block.header.number);
-    builder.add_state_deltas(*state)
-        .add_code(code)
-        .add_receipts(results)
-        .add_transactions(block.transactions, senders)
-        .add_call_frames(call_frames)
-        .add_ommers(block.ommers);
-    if (block.withdrawals.has_value()) {
-        builder.add_withdrawals(block.withdrawals.value());
-    }
-    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
-        // second stage: populate block header
-        h.receipts_root = db.receipts_root();
-        h.state_root = db.state_root();
-        h.withdrawals_root = db.withdrawals_root();
-        h.transactions_root = db.transactions_root();
-        h.gas_used = results.empty() ? 0 : results.back().gas_used;
-        h.logs_bloom = compute_bloom(results);
-        h.ommers_hash = compute_ommers_hash(block.ommers);
-    });
+    BlockCommitAncillaries const anc{
+        .code = code,
+        .receipts = results,
+        .transactions = block.transactions,
+        .senders = senders,
+        .call_frames = call_frames,
+        .ommers = block.ommers,
+        .withdrawals = block.withdrawals};
+    commit_block<traits>(db, secondary_db, block_id, block.header, *state, anc);
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);
@@ -476,7 +472,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
-    bool const enable_tracing)
+    bool const enable_tracing, Db *secondary_db)
 {
     constexpr auto SLEEP_TIME = std::chrono::microseconds(100);
     uint64_t const start_block_num = block_num;
@@ -627,12 +623,17 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
              chain_id,
              start_block_num,
              enable_tracing,
-             &block_cache](
+             &block_cache,
+             secondary_db](
                 bytes32_t const &block_id,
                 auto const &header) -> Result<std::pair<uint64_t, uint64_t>> {
             auto const block_time_start = std::chrono::steady_clock::now();
 
             db.update_voted_metadata(header.seqno - 1, header.parent_id());
+            if (secondary_db != nullptr) {
+                secondary_db->update_voted_metadata(
+                    header.seqno - 1, header.parent_id());
+            }
             record_block_qc(header, last_finalized_block_number);
 
             uint64_t const block_number = header.execution_inputs.number;
@@ -682,7 +683,8 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                     priority_pool,
                     block_number == start_block_num,
                     enable_tracing,
-                    block_cache);
+                    block_cache,
+                    secondary_db);
                 MONAD_ABORT_PRINTF("handled rev value %d", rev);
             };
             BOOST_OUTCOME_TRY(
@@ -690,6 +692,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 record_block_result(propose_dispatch()));
 
             db.update_proposed_metadata(header.seqno, block_id);
+            if (secondary_db != nullptr) {
+                secondary_db->update_proposed_metadata(header.seqno, block_id);
+            }
 
             log_tps(
                 block_number,
@@ -715,6 +720,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 block,
                 block_id);
             db.finalize(block, block_id);
+            if (secondary_db != nullptr) {
+                secondary_db->finalize(block, block_id);
+            }
             block_hash_chain.finalize(block_id);
             record_block_finalized(block_id, block);
             finalized_block_num = block;
@@ -722,6 +730,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
             if (!verified_blocks.empty() &&
                 verified_blocks.back() != mpt::INVALID_BLOCK_NUM) {
                 db.update_verified_block(verified_blocks.back());
+                if (secondary_db != nullptr) {
+                    secondary_db->update_verified_block(verified_blocks.back());
+                }
             }
             record_block_verified(verified_blocks);
         }

--- a/cmd/monad/runloop_monad.cpp
+++ b/cmd/monad/runloop_monad.cpp
@@ -318,17 +318,16 @@ Result<BlockExecOutput> propose_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(
-        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
-            // second stage: populate block header
-            h.receipts_root = db.receipts_root();
-            h.state_root = db.state_root();
-            h.withdrawals_root = db.withdrawals_root();
-            h.transactions_root = db.transactions_root();
-            h.gas_used = results.empty() ? 0 : results.back().gas_used;
-            h.logs_bloom = compute_bloom(results);
-            h.ommers_hash = compute_ommers_hash(block.ommers);
-        });
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        h.receipts_root = db.receipts_root();
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = results.empty() ? 0 : results.back().gas_used;
+        h.logs_bloom = compute_bloom(results);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);

--- a/cmd/monad/runloop_monad.hpp
+++ b/cmd/monad/runloop_monad.hpp
@@ -44,6 +44,7 @@ namespace fiber
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &, std::filesystem::path const &, mpt::Db &, Db &,
     vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
-    uint64_t, sig_atomic_t const volatile &, bool enable_tracing);
+    uint64_t, sig_atomic_t const volatile &, bool enable_tracing,
+    Db *secondary_db);
 
 MONAD_NAMESPACE_END

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -402,6 +402,19 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
         monad_revision const rev =
             chain.get_monad_revision(block.header.timestamp);
 
+        // Storage encoding is fixed for the lifetime of the runloop (it
+        // matches the TrieDbImpl<page_encoded> backing `db`). If the
+        // replay crosses the MONAD_NEXT cutoff in either direction, the
+        // encoding the caller picked at startup no longer matches what
+        // this block's revision expects.
+        MONAD_ASSERT_PRINTF(
+            (rev >= MONAD_NEXT) == db.is_page_encoded(),
+            "monad revision %d at block %lu crosses MONAD_NEXT cutoff "
+            "but db was opened with page_encoded=%d",
+            rev,
+            block.header.number,
+            db.is_page_encoded());
+
         ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
         BOOST_OUTCOME_TRY([&] {
             SWITCH_MONAD_TRAITS(

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -241,17 +241,16 @@ Result<void> process_monad_block(
     if (block.withdrawals.has_value()) {
         builder.add_withdrawals(block.withdrawals.value());
     }
-    db.commit(
-        block_id, builder, block.header, std::move(state), [&](BlockHeader &h) {
-            // second stage: populate block header
-            h.receipts_root = db.receipts_root();
-            h.state_root = db.state_root();
-            h.withdrawals_root = db.withdrawals_root();
-            h.transactions_root = db.transactions_root();
-            h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-            h.logs_bloom = compute_bloom(receipts);
-            h.ommers_hash = compute_ommers_hash(block.ommers);
-        });
+    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
+        // second stage: populate block header
+        h.receipts_root = db.receipts_root();
+        h.state_root = db.state_root();
+        h.withdrawals_root = db.withdrawals_root();
+        h.transactions_root = db.transactions_root();
+        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(receipts);
+        h.ommers_hash = compute_ommers_hash(block.ommers);
+    });
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);

--- a/cmd/monad/runloop_monad_ethblocks.cpp
+++ b/cmd/monad/runloop_monad_ethblocks.cpp
@@ -41,6 +41,7 @@
 #include <category/execution/ethereum/validate_block.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/execution/monad/validate_monad_block.hpp>
 #include <category/vm/evm/switch_traits.hpp>
@@ -231,26 +232,16 @@ Result<void> process_monad_block(
     auto const commit_begin = std::chrono::steady_clock::now();
     auto [state, code, _] = std::move(block_state).release();
 
-    CommitBuilder builder(block.header.number);
-    builder.add_state_deltas(*state)
-        .add_code(code)
-        .add_receipts(receipts)
-        .add_transactions(block.transactions, senders)
-        .add_call_frames(call_frames)
-        .add_ommers(block.ommers);
-    if (block.withdrawals.has_value()) {
-        builder.add_withdrawals(block.withdrawals.value());
-    }
-    db.commit(block_id, builder, block.header, *state, [&](BlockHeader &h) {
-        // second stage: populate block header
-        h.receipts_root = db.receipts_root();
-        h.state_root = db.state_root();
-        h.withdrawals_root = db.withdrawals_root();
-        h.transactions_root = db.transactions_root();
-        h.gas_used = receipts.empty() ? 0 : receipts.back().gas_used;
-        h.logs_bloom = compute_bloom(receipts);
-        h.ommers_hash = compute_ommers_hash(block.ommers);
-    });
+    BlockCommitAncillaries const anc{
+        .code = code,
+        .receipts = receipts,
+        .transactions = block.transactions,
+        .senders = senders,
+        .call_frames = call_frames,
+        .ommers = block.ommers,
+        .withdrawals = block.withdrawals};
+    commit_block<traits>(db, nullptr, block_id, block.header, *state, anc);
+
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - commit_begin);

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -796,6 +796,7 @@ int main(int const argc, char *argv[])
     bool interactive = false;
     std::optional<std::filesystem::path> dump_binary_snapshot;
     std::optional<std::filesystem::path> load_binary_snapshot;
+    bool load_to_secondary = false;
     uint64_t version;
     unsigned dump_concurrency_limit = 2048;
     uint64_t total_shards = 1;
@@ -849,13 +850,25 @@ int main(int const argc, char *argv[])
             "Each "
             "shard writes its portion of data and headers.")
         ->needs(dump_binary_snapshot_option);
+    auto *const load_binary_snapshot_option =
+        cli_group
+            ->add_option(
+                "--load-binary-snapshot,--load_binary_snapshot",
+                load_binary_snapshot,
+                "Load a binary snapshot to db")
+            ->check(CLI::ExistingDirectory)
+            ->excludes(dump_binary_snapshot_option);
     cli_group
-        ->add_option(
-            "--load-binary-snapshot,--load_binary_snapshot",
-            load_binary_snapshot,
-            "Load a binary snapshot to db")
-        ->check(CLI::ExistingDirectory)
-        ->excludes(dump_binary_snapshot_option);
+        ->add_flag(
+            "--secondary",
+            load_to_secondary,
+            "When loading, load into the secondary timeline instead of the "
+            "primary. The target's storage encoding is derived from its "
+            "persisted state_machine_kind, which must already be stamped on "
+            "disk (e.g. via monad-mpt --activate-secondary --state-machine). "
+            "The snapshot itself must be slot-encoded (the standard format "
+            "produced by --dump-binary-snapshot from a slot db).")
+        ->needs(load_binary_snapshot_option);
     mode_group->require_option(0, 1);
     try {
         cli.parse(argc, argv);
@@ -937,11 +950,14 @@ int main(int const argc, char *argv[])
             c_dbname_paths.size(),
             sq_thread_cpu.value_or(std::numeric_limits<unsigned>::max()),
             load_binary_snapshot.value().c_str(),
-            version);
+            version,
+            load_to_secondary);
         LOG_INFO(
-            "snapshot version={} load_binary_snapshot={} elapsed={}",
+            "snapshot version={} load_binary_snapshot={} load_to_secondary={} "
+            "elapsed={}",
             version,
             load_binary_snapshot.value(),
+            load_to_secondary,
             std::chrono::steady_clock::now() - begin);
     }
     return 0;

--- a/rust/crates/monad-statesync/src/ffi.rs
+++ b/rust/crates/monad-statesync/src/ffi.rs
@@ -14,9 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub use self::bindings::{
-    monad_statesync_client, monad_statesync_client_context, monad_statesync_client_handle_done,
-    monad_statesync_client_handle_target, monad_statesync_client_handle_upsert, monad_sync_done,
-    monad_sync_request, monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
+    monad_chain_config, monad_statesync_client, monad_statesync_client_context,
+    monad_statesync_client_handle_done, monad_statesync_client_handle_target,
+    monad_statesync_client_handle_upsert, monad_sync_done, monad_sync_request,
+    monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
     monad_sync_type_SYNC_TYPE_TARGET, monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT,
     monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT_DELETE, monad_sync_type_SYNC_TYPE_UPSERT_CODE,
     monad_sync_type_SYNC_TYPE_UPSERT_HEADER, monad_sync_type_SYNC_TYPE_UPSERT_STORAGE,
@@ -57,6 +58,7 @@ fn add_client_prefixes_as_new_peers(ctx: *mut monad_statesync_client_context, cl
 /// Thin unsafe wrapper around statesync_client_context that handles destruction and finalization
 /// checking
 pub struct StateSyncCtx {
+    chain_config: monad_chain_config,
     dbname_paths: *const *const ::std::os::raw::c_char,
     len: usize,
     sq_thread_cpu: Option<::std::os::raw::c_uint>,
@@ -72,6 +74,7 @@ pub struct StateSyncCtx {
 impl StateSyncCtx {
     /// Initialize StateSyncCtx. There should only ever be *one* StateSyncCtx at any given time.
     pub fn new(
+        chain_config: monad_chain_config,
         dbname_paths: *const *const ::std::os::raw::c_char,
         len: usize,
         sq_thread_cpu: Option<::std::os::raw::c_uint>,
@@ -84,6 +87,7 @@ impl StateSyncCtx {
         assert!(unsafe { bindings::monad_statesync_client_compatible(client_version) });
 
         Self {
+            chain_config,
             dbname_paths,
             len,
             sq_thread_cpu,
@@ -102,6 +106,7 @@ impl StateSyncCtx {
     pub fn get_or_create_ctx(&mut self) -> *mut monad_statesync_client_context {
         *self.ctx.get_or_insert_with(|| unsafe {
             self::bindings::monad_statesync_client_context_create(
+                self.chain_config,
                 self.dbname_paths,
                 self.len,
                 self.sq_thread_cpu
@@ -117,6 +122,7 @@ impl StateSyncCtx {
     ) -> *mut monad_statesync_client_context {
         *self.ctx.get_or_insert_with(|| unsafe {
             let ctx = self::bindings::monad_statesync_client_context_create(
+                self.chain_config,
                 self.dbname_paths,
                 self.len,
                 self.sq_thread_cpu

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -321,7 +321,7 @@ Result<BlockExecOutput> execute(
         bytes32_t{block.header.number},
         builder,
         block.header,
-        std::move(state),
+        *state,
         [&](BlockHeader &h) {
             h.receipts_root = db.receipts_root();
             h.state_root = db.state_root();

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -33,9 +33,7 @@
 #include <category/core/keccak.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
-#include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
-#include <category/execution/ethereum/chain/genesis_state.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/fmt/address_fmt.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
@@ -43,8 +41,7 @@
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/int_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
-#include <category/execution/ethereum/core/withdrawal.hpp>
-#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
@@ -56,17 +53,15 @@
 #include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
-#include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
-#include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/execution/monad/validate_monad_transaction.hpp>
 #include <category/mpt/nibbles_view.hpp>
-#include <category/vm/evm/monad/revision.h>
 #include <category/vm/evm/switch_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -86,23 +81,31 @@
 #include <memory>
 #include <test_resource_data.h>
 
-#include <ankerl/unordered_dense.h>
-
 #include <algorithm>
+#include <bit>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <optional>
 #include <set>
 #include <span>
 #include <string>
-#include <variant>
 #include <vector>
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
 using BOOST_OUTCOME_V2_NAMESPACE::success;
+
+// True for MonadTraits at MONAD_NEXT or later, false for everything else
+// (EvmTraits, pre-fork MonadTraits). EvmTraits has no monad_rev(), so the
+// primary template returns false and a constrained partial specialization
+// supplies the real check for MonadTraits.
+template <Traits T>
+constexpr bool is_post_fork_monad_v = false;
+
+template <Traits T>
+    requires is_monad_trait_v<T>
+constexpr bool is_post_fork_monad_v<T> = T::monad_rev() >= MONAD_NEXT;
 
 template <Traits traits>
 struct TraitsMainnet : MonadChain
@@ -220,7 +223,7 @@ void validate_post_state(nlohmann::json const &json, nlohmann::json const &db)
 
 template <Traits traits>
 Result<BlockExecOutput> execute(
-    Block &block, monad::TrieDb &db, vm::VM &vm,
+    Block &block, monad::Db &db, vm::VM &vm,
     BlockHashBuffer const &block_hash_buffer,
     std::map<uint64_t, ankerl::unordered_dense::segmented_set<Address>>
         &senders_and_authorities_map,
@@ -306,7 +309,15 @@ Result<BlockExecOutput> execute(
     block_state.log_debug();
     auto [state, code, _] = std::move(block_state).release();
 
-    CommitBuilder builder(block.header.number);
+    std::unique_ptr<CommitBuilder> builder_ptr;
+    if constexpr (is_post_fork_monad_v<traits>) {
+        builder_ptr =
+            std::make_unique<PageCommitBuilder>(block.header.number, db);
+    }
+    else {
+        builder_ptr = std::make_unique<CommitBuilder>(block.header.number);
+    }
+    CommitBuilder &builder = *builder_ptr;
     builder.add_state_deltas(*state)
         .add_code(code)
         .add_receipts(receipts)
@@ -347,7 +358,7 @@ Result<BlockExecOutput> execute(
 
 template <Traits traits>
 Result<std::vector<Receipt>> execute_and_record(
-    Block &block, monad::TrieDb &db, vm::VM &vm,
+    Block &block, monad::Db &db, vm::VM &vm,
     BlockHashBuffer const &block_hash_buffer,
     std::map<uint64_t, ankerl::unordered_dense::segmented_set<Address>>
         &senders_and_authorities_map,
@@ -360,7 +371,7 @@ Result<std::vector<Receipt>> execute_and_record(
         block.header.parent_hash,
         block.header.number,
         0,
-        uint128_t{block.header.timestamp} * uint128_t{1'000'000'000UL},
+        block.header.timestamp * 1'000'000'000UL,
         size(block.transactions),
         std::nullopt,
         std::nullopt);
@@ -396,10 +407,11 @@ void process_test(
     using namespace test;
 
     auto const json_state = load_blockchain_json_state<traits>(j_contents);
-    auto const test_state = json_state.make_test_state();
+    auto const test_state =
+        json_state.template make_test_state<is_post_fork_monad_v<traits>>();
     vm::VM vm{vm_mode};
     mpt::Db &db = test_state->db;
-    monad::TrieDb &tdb = test_state->trie_db;
+    auto &tdb = test_state->trie_db;
 
     auto db_post_state = tdb.to_json();
 

--- a/test/utils/json_state.cpp
+++ b/test/utils/json_state.cpp
@@ -16,20 +16,24 @@
 #include "from_json.hpp"
 
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 
 #include <category/vm/vm.hpp>
 
+#include <memory>
+
 #include <test_resource_data.h>
 
 MONAD_TEST_NAMESPACE_BEGIN
 
-TestStateRef JsonState::make_test_state() const
+template <bool page_encoded>
+TestStateRef<page_encoded> JsonState::make_test_state() const
 {
     using namespace ::monad;
 
-    auto test_state = std::make_shared<TestState>();
+    auto test_state = std::make_shared<TestState<page_encoded>>();
 
     if (!init_state.has_value()) {
         return test_state;
@@ -60,6 +64,9 @@ TestStateRef JsonState::make_test_state() const
 
     return test_state;
 }
+
+template TestStateRef<false> JsonState::make_test_state<false>() const;
+template TestStateRef<true> JsonState::make_test_state<true>() const;
 
 std::vector<monad::Address> JsonState::initial_accounts() const
 {

--- a/test/utils/json_state.cpp
+++ b/test/utils/json_state.cpp
@@ -43,7 +43,7 @@ TestStateRef JsonState::make_test_state() const
     auto [released_state, released_code, _] = std::move(bs).release();
     commit_simple(
         test_state->trie_db,
-        std::move(released_state),
+        *released_state,
         released_code,
         NULL_HASH_BLAKE3,
         header,

--- a/test/utils/json_state.hpp
+++ b/test/utils/json_state.hpp
@@ -26,7 +26,8 @@ struct JsonState
     std::optional<nlohmann::json> init_state;
     std::optional<monad::bytes32_t> init_state_hash;
 
-    TestStateRef make_test_state() const;
+    template <bool page_encoded = false>
+    TestStateRef<page_encoded> make_test_state() const;
     std::vector<monad::Address> initial_accounts() const;
 };
 

--- a/test/utils/test_state.hpp
+++ b/test/utils/test_state.hpp
@@ -23,18 +23,22 @@
 
 MONAD_TEST_NAMESPACE_BEGIN
 
+template <bool page_encoded = false>
 struct TestState
 {
     monad::mpt::Db db;
     monad::TrieDb trie_db;
 
     TestState()
-        : db{std::make_unique<monad::InMemoryMachine>()}
+        : db{page_encoded ? std::make_unique<monad::MonadInMemoryMachine>()
+                          : std::make_unique<monad::InMemoryMachine>()}
         , trie_db{db}
     {
+        MONAD_ASSERT(page_encoded == trie_db.is_page_encoded());
     }
 };
 
-using TestStateRef = std::shared_ptr<TestState>;
+template <bool page_encoded = false>
+using TestStateRef = std::shared_ptr<TestState<page_encoded>>;
 
 MONAD_TEST_NAMESPACE_END

--- a/test/vm/unit/monad_vm_interface_tests.cpp
+++ b/test/vm/unit/monad_vm_interface_tests.cpp
@@ -200,6 +200,13 @@ namespace
             evmc::bytes32 const &) noexcept override
         {
         }
+
+        PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept override
+        {
+            return {};
+        }
     };
 }
 

--- a/test/vm/unit/runtime/fixture.cpp
+++ b/test/vm/unit/runtime/fixture.cpp
@@ -41,10 +41,10 @@ namespace monad::vm::compiler::test
 {
     namespace
     {
-        evmc::MockedHost init_host(std::array<evmc_bytes32, 2> &blob_hashes_)
+        void init_host(
+            monad::vm::test::MockedHost &host,
+            std::array<evmc_bytes32, 2> &blob_hashes_)
         {
-            auto host = evmc::MockedHost{};
-
             host.tx_context = evmc_tx_context{
                 .tx_gas_price = bytes32_from_uint256(56762),
                 .tx_origin = 0x000000000000000000000000000000005CA1AB1E_address,
@@ -65,14 +65,12 @@ namespace monad::vm::compiler::test
 
             host.block_hash = bytes32_from_uint256(
                 0x105DF6064F84551C4100A368056B8AF0E491077245DAB1536D2CFA6AB78421CE_u256);
-
-            return host;
         }
     }
 
     RuntimeTestBase::RuntimeTestBase()
         : blob_hashes_{bytes32_from_uint256(1), bytes32_from_uint256(2)}
-        , host_{init_host(blob_hashes_)}
+        , host_{}
         , test_ctx_{[&](auto &x) {
             x.host = &host_.get_interface(), x.context = host_.to_context(),
             x.gas_remaining = std::numeric_limits<std::int64_t>::max(),
@@ -95,6 +93,7 @@ namespace monad::vm::compiler::test
         }}
         , ctx_{*test_ctx_}
     {
+        init_host(host_, blob_hashes_);
         std::iota(code_.rbegin(), code_.rend(), 0);
         std::iota(call_data_.begin(), call_data_.end(), 0);
         std::iota(call_return_data_.begin(), call_return_data_.end(), 0);

--- a/test/vm/unit/runtime/fixture.hpp
+++ b/test/vm/unit/runtime/fixture.hpp
@@ -20,12 +20,12 @@
 #include <category/vm/runtime/detail.hpp>
 #include <category/vm/runtime/types.hpp>
 #include <monad/test/traits_test.hpp>
+#include <test/vm/unit/runtime/mocked_host.hpp>
 #include <test/vm/utils/test_context.hpp>
 
 #include <gtest/gtest.h>
 
 #include <evmc/evmc.hpp>
-#include <evmc/mocked_host.hpp>
 
 #include <limits>
 
@@ -46,7 +46,7 @@ namespace monad::vm::compiler::test
         std::array<std::uint8_t, 128> call_return_data_;
 
         std::array<evmc_bytes32, 2> blob_hashes_;
-        evmc::MockedHost host_;
+        monad::vm::test::MockedHost host_;
         monad::vm::test::TestContext test_ctx_;
         vm::runtime::Context &ctx_;
 

--- a/test/vm/unit/runtime/memory_tests.cpp
+++ b/test/vm/unit/runtime/memory_tests.cpp
@@ -36,10 +36,10 @@ namespace
     {
         vm::test::TestMemory init_memory_;
         Context *prev_rt_ctx_;
-        evmc::MockedHost &host_;
+        monad::vm::test::MockedHost &host_;
 
     public:
-        MemoryTestMachine(evmc::MockedHost &host)
+        MemoryTestMachine(monad::vm::test::MockedHost &host)
             : prev_rt_ctx_{}
             , host_{host}
         {
@@ -175,7 +175,7 @@ namespace
 
     template <Traits traits>
     void run_memory_test_machine(
-        evmc::MockedHost &host, MemoryTestMachineConfig config)
+        monad::vm::test::MockedHost &host, MemoryTestMachineConfig config)
     {
         MemoryTestMachine<traits> machine{host};
         machine.call([&](auto &ctx) {

--- a/test/vm/unit/runtime/mocked_host.hpp
+++ b/test/vm/unit/runtime/mocked_host.hpp
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/int.hpp>
+#include <category/vm/host.hpp>
+
+#include <evmc/evmc.hpp>
+#include <evmc/mocked_host.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <utility>
+
+namespace monad::vm::test
+{
+    class MockedHost : public Host
+    {
+        evmc::MockedHost inner_;
+
+        static constexpr size_t PAGE_KEY_SHIFT = 7;
+
+        struct PageGrowth
+        {
+            int current_state_growth{0};
+            int net_state_growth{0};
+        };
+
+        using PageKey = std::pair<evmc::address, evmc::bytes32>;
+
+        std::set<PageKey> read_accessed_pages_;
+        std::set<PageKey> write_accessed_pages_;
+        std::map<PageKey, PageGrowth> growth_;
+        PageStorageStatus last_write_page_status_{};
+
+        static evmc::bytes32
+        compute_page_key(evmc::bytes32 const &slot_key) noexcept
+        {
+            return (uint256_t::load_be(slot_key.bytes) >> PAGE_KEY_SHIFT)
+                .store_be<evmc::bytes32>();
+        }
+
+    public:
+        decltype(inner_.accounts) &accounts = inner_.accounts;
+        decltype(inner_.recorded_calls) &recorded_calls = inner_.recorded_calls;
+        decltype(inner_.recorded_logs) &recorded_logs = inner_.recorded_logs;
+        decltype(inner_.recorded_selfdestructs) &recorded_selfdestructs =
+            inner_.recorded_selfdestructs;
+        decltype(inner_.recorded_account_accesses) &recorded_account_accesses =
+            inner_.recorded_account_accesses;
+        decltype(inner_.recorded_blockhashes) &recorded_blockhashes =
+            inner_.recorded_blockhashes;
+        decltype(inner_.tx_context) &tx_context = inner_.tx_context;
+        decltype(inner_.block_hash) &block_hash = inner_.block_hash;
+        decltype(inner_.call_result) &call_result = inner_.call_result;
+
+        bool account_exists(evmc::address const &addr) const noexcept override
+        {
+            return inner_.account_exists(addr);
+        }
+
+        evmc::bytes32 get_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) const noexcept override
+        {
+            return inner_.get_storage(addr, key);
+        }
+
+        evmc_storage_status set_storage(
+            evmc::address const &addr, evmc::bytes32 const &key,
+            evmc::bytes32 const &v_new) noexcept override
+        {
+            auto const v_current = inner_.get_storage(addr, key);
+            auto const p = PageKey{addr, compute_page_key(key)};
+
+            bool first_page_write = false;
+            if (v_current != v_new) {
+                auto const [it, inserted] = write_accessed_pages_.insert(p);
+                if (inserted) {
+                    first_page_write = true;
+                    growth_[p] = PageGrowth{};
+                }
+            }
+
+            auto const zero = evmc::bytes32{};
+            if (v_current == zero && v_new != zero) {
+                growth_[p].current_state_growth += 1;
+            }
+            else if (v_current != zero && v_new == zero) {
+                growth_[p].current_state_growth -= 1;
+            }
+
+            bool grew_state = false;
+            if (growth_[p].current_state_growth > growth_[p].net_state_growth) {
+                growth_[p].net_state_growth = growth_[p].current_state_growth;
+                grew_state = true;
+            }
+
+            last_write_page_status_ = {first_page_write, grew_state};
+
+            return inner_.set_storage(addr, key, v_new);
+        }
+
+        evmc::uint256be
+        get_balance(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_balance(addr);
+        }
+
+        size_t get_code_size(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_code_size(addr);
+        }
+
+        evmc::bytes32
+        get_code_hash(evmc::address const &addr) const noexcept override
+        {
+            return inner_.get_code_hash(addr);
+        }
+
+        size_t copy_code(
+            evmc::address const &addr, size_t code_offset, uint8_t *buffer_data,
+            size_t buffer_size) const noexcept override
+        {
+            return inner_.copy_code(
+                addr, code_offset, buffer_data, buffer_size);
+        }
+
+        bool selfdestruct(
+            evmc::address const &addr,
+            evmc::address const &beneficiary) noexcept override
+        {
+            return inner_.selfdestruct(addr, beneficiary);
+        }
+
+        evmc::Result call(evmc_message const &msg) noexcept override
+        {
+            return inner_.call(msg);
+        }
+
+        evmc_tx_context const *get_tx_context() const noexcept override
+        {
+            return inner_.get_tx_context();
+        }
+
+        evmc::bytes32
+        get_block_hash(int64_t block_number) const noexcept override
+        {
+            return inner_.get_block_hash(block_number);
+        }
+
+        void emit_log(
+            evmc::address const &addr, uint8_t const *data, size_t data_size,
+            evmc::bytes32 const topics[], size_t topics_count) noexcept override
+        {
+            inner_.emit_log(addr, data, data_size, topics, topics_count);
+        }
+
+        evmc_access_status
+        access_account(evmc::address const &addr) noexcept override
+        {
+            return inner_.access_account(addr);
+        }
+
+        evmc_access_status access_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) noexcept override
+        {
+            inner_.access_storage(addr, key);
+            auto const p = PageKey{addr, compute_page_key(key)};
+            auto const [it, inserted] = read_accessed_pages_.insert(p);
+            return inserted ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
+        }
+
+        evmc::bytes32 get_transient_storage(
+            evmc::address const &addr,
+            evmc::bytes32 const &key) const noexcept override
+        {
+            return inner_.get_transient_storage(addr, key);
+        }
+
+        void set_transient_storage(
+            evmc::address const &addr, evmc::bytes32 const &key,
+            evmc::bytes32 const &value) noexcept override
+        {
+            inner_.set_transient_storage(addr, key, value);
+        }
+
+        PageStorageStatus update_page(
+            evmc::address const &, evmc::bytes32 const &,
+            evmc_storage_status) noexcept override
+        {
+            return last_write_page_status_;
+        }
+    };
+}

--- a/test/vm/unit/runtime/storage_tests.cpp
+++ b/test/vm/unit/runtime/storage_tests.cpp
@@ -131,6 +131,9 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalEmpty)
     };
 
     if constexpr (is_monad_trait_v<traits>) {
+        if constexpr (traits::mip_8_active()) {
+            return do_test(27800, 0);
+        }
         if constexpr (traits::monad_rev() >= MONAD_SEVEN) {
             return do_test(28000, 19900);
         }
@@ -187,7 +190,10 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
         store(key, 0);
         ASSERT_EQ(ctx_.result.status, StatusCode::Success);
         ASSERT_EQ(ctx_.gas_remaining, 2301);
-        if constexpr (traits::evm_rev() <= EVMC_BERLIN) {
+        if constexpr (traits::mip_8_active()) {
+            ASSERT_EQ(ctx_.gas_refund, 0);
+        }
+        else if constexpr (traits::evm_rev() <= EVMC_BERLIN) {
             ASSERT_EQ(ctx_.gas_refund, 15000);
         }
         else {
@@ -198,6 +204,9 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
     };
 
     if constexpr (is_monad_trait_v<traits>) {
+        if constexpr (traits::mip_8_active()) {
+            return do_test(100, 2800);
+        }
         if constexpr (traits::monad_rev() >= MONAD_SEVEN) {
             return do_test(0, 2800);
         }
@@ -213,5 +222,43 @@ TYPED_TEST(RuntimeTraitsTest, StorageOriginalNonEmpty)
     }
     else {
         do_test(6000, 2800);
+    }
+}
+
+TYPED_TEST(RuntimeTraitsTest, StorageLoadDifferentSlotsSamePage)
+{
+    using traits = TestFixture::Trait;
+    if constexpr (!traits::mip_8_active()) {
+        GTEST_SKIP();
+    }
+    else {
+        auto load = TestFixture::wrap(sload<traits>);
+
+        this->ctx_.gas_remaining = traits::cold_storage_cost();
+        ASSERT_EQ(load(0), 0);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+
+        this->ctx_.gas_remaining = 0;
+        ASSERT_EQ(load(1), 0);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+    }
+}
+
+TYPED_TEST(RuntimeTraitsTest, StorageColdAddChargesSpecTotal)
+{
+    using traits = TestFixture::Trait;
+    if constexpr (!traits::mip_8_active()) {
+        GTEST_SKIP();
+    }
+    else {
+        auto store = TestFixture::wrap(sstore<traits>);
+
+        this->ctx_.gas_remaining = 27800;
+        store(key, val);
+        ASSERT_EQ(this->ctx_.gas_remaining, 0);
+        static_assert(
+            traits::cold_storage_cost() + traits::page_write_cost() +
+                traits::page_growth_cost() ==
+            27800);
     }
 }


### PR DESCRIPTION
## Summary

Surfaced and fixed while building a full-cluster end-to-end test of the slot → page DB migration on `vicky/page-store-release1-dual-db`. Four small, scoped commits:

- `cmd/monad: allow booting single-db on a slot primary with no secondary` — the live runloop required a slot primary to have an active page secondary, making the pre-migration state unrepresentable. With this change: slot + active secondary → dual-write; slot + no secondary → single-db on the previous revision; page primary → single-db.
- `monad-statesync/ffi: pass chain_config to client_context_create` — the C API gained a leading `enum monad_chain_config` but the Rust FFI shim had not been updated. Paired with the monad-bft side, which threads `chain_config` from `monad-node`'s `chain_id`.
- `cmd/monad: register monad state machine before opening the on-disk Db` — `Db(OnDiskDbConfig)` resolves the `StateMachine` factory from the DB's persisted `state_machine_kind` at open time, so the monad (page) factory must be registered before the open call. Previously it was registered later in the per-chain runloop dispatch, which made a page-encoded DB unopenable.
- `Add MonadDevnetFork test-only chain (chain_id 20144)` — env-var-driven `MONAD_NINE → MONAD_NEXT` fork via `MONAD_DEVNETFORK_NEXT_AT`. Test-only chain, not registered for production. Needed by the integration test to exercise the slot→page migration across a fork crossing.

The monad-execution docker fix (skip C++ tests in the `runner` stage) is being submitted as a separate PR.

Verified by the monad-integration test `test_offline_dual_db_lifecycle` (PASS 134 s, single-node). Full status in `docs/dual_timeline_migration_poc.md` of the integration test PR.

## Test plan

- [x] Local single-node integration test passes end-to-end (full migration lifecycle, balances survive promote)
- [ ] CI build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)