### PR TITLE
cmd/monad: add --disable-sq-thread-cpu flag

### DIFF
--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -133,6 +133,7 @@ try {
     std::chrono::seconds block_db_timeout = std::chrono::seconds::zero();
     std::string exec_event_ring_config;
     unsigned sq_thread_cpu = static_cast<unsigned>(get_nprocs() - 1);
+    bool disable_sq_thread_cpu = false;
     std::optional<unsigned> ro_sq_thread_cpu;
     std::vector<fs::path> dbname_paths;
     fs::path snapshot;
@@ -164,6 +165,11 @@ try {
         sq_thread_cpu,
         "sq_thread_cpu field in io_uring_params, to specify the cpu set "
         "kernel poll thread is bound to in SQPOLL mode");
+    cli.add_flag(
+        "--disable-sq-thread-cpu,--disable_sq_thread_cpu",
+        disable_sq_thread_cpu,
+        "disable SQPOLL for the rw db (skip the kernel io_uring poll "
+        "thread); --sq-thread-cpu is ignored when set");
     cli.add_option(
         "--ro-sq-thread-cpu,--ro_sq_thread_cpu",
         ro_sq_thread_cpu,
@@ -281,7 +287,10 @@ try {
                     .rd_buffers = 8192,
                     .wr_buffers = 32,
                     .uring_entries = 128,
-                    .sq_thread_cpu = sq_thread_cpu,
+                    .sq_thread_cpu =
+                        disable_sq_thread_cpu
+                            ? std::optional<unsigned>{}
+                            : std::optional<unsigned>{sq_thread_cpu},
                     .dbname_paths = dbname_paths}};
         }
         return mpt::Db{std::make_unique<InMemoryMachine>()};


### PR DESCRIPTION
Opt-in flag to disable kernel io_uring SQPOLL polling on the rw db. Default behavior unchanged: SQPOLL is still on, bound to get_nprocs() - 1 (same default as before this change).

When set, the rw db's OnDiskDbConfig.sq_thread_cpu becomes nullopt (--sq-thread-cpu is ignored), which causes Ring (category/core/io/ ring.cpp:33-40) to drop IORING_SETUP_SQPOLL and IORING_SETUP_SQ_AFF. Submissions then go through io_uring_enter syscalls instead of a dedicated kernel poll thread — slower per submission but no kernel- thread CPU usage. Intended for tests that run multiple monad instances on a small host (e.g. 4-node integration tests on a 16- core box) where N SQPOLL kernel threads add measurable CPU contention with the rest of the cluster.

Mirrors the existing --ro-sq-thread-cpu absence-disables semantic, but as a separate opt-in flag so the default for the rw db is unchanged.