### PR TITLE
cmake: force BLAKE3 to STATIC under BUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,17 @@ set(ASMJIT_STATIC ON)
 add_subdirectory(third_party/asmjit)
 
 # BLAKE3
+# Force STATIC even when BUILD_SHARED_LIBS=ON (e.g. cargo / cmake-rs).
+# Some monad code calls private BLAKE3 helpers directly for performance.
+# Those helpers have hidden visibility, so a SHARED libblake3.so does not
+# export them; linking SHARED would then leave libmonad_execution.so with
+# unresolved references that fail at runtime when a consumer loads it.
+# Static linkage absorbs blake3's objects directly so the helpers resolve
+# at link time. The default (static) cmake build was already fine.
+block()
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(third_party/BLAKE3/c)
+endblock()
 
 # blst
 set(DOWNLOAD_BLST OFF)


### PR DESCRIPTION
Some monad code calls private BLAKE3 helper functions directly (rather than only the public hasher API) for performance on a hot path. Those helpers are compiled with hidden visibility, so when BLAKE3 is built as a shared library — which happens under BUILD_SHARED_LIBS=ON, e.g. the cmake-rs / cargo build of libmonad_execution.so — they are not exported in the shared object's dynamic symbol table.

The result is that libmonad_execution.so is left with unresolved references to those helpers and crashes at runtime when a consumer loads it (the symbol lookup fails). Forcing BLAKE3 to build STATIC even when BUILD_SHARED_LIBS=ON lets its objects be absorbed directly into libmonad_execution.so, where the helpers become local symbols resolved at link time. The default (static) cmake build was already fine; this only changes the shared-library build path. No monad source change and no third_party patch.