### PR TITLE
Align Hive chain config with Monad execution support

### DIFF
--- a/category/execution/ethereum/chain/hive_net.cpp
+++ b/category/execution/ethereum/chain/hive_net.cpp
@@ -26,9 +26,8 @@ uint256_t HiveNet::get_chain_id() const
     return 3503995874084926;
 }
 
-// Fork schedule from the hive tests:
-// see: https://github.com/ethereum/execution-apis/blob/main/tests/genesis.json
-// see: https://github.com/ethereum/execution-apis/blob/main/tests/forkenv.json
+// Fork schedule from the Hive runner tests. Monad execution currently supports
+// Istanbul and later, so the fixture activates earlier forks as Istanbul.
 monad_eth_revision HiveNet::get_revision(
     uint64_t const block_number, uint64_t const timestamp) const
 {
@@ -53,14 +52,14 @@ monad_eth_revision HiveNet::get_revision(
     if (block_number >= 18) {
         return MONAD_ETH_ISTANBUL;
     }
-    MONAD_ASSERT(false, "unsupported fork");
+    return MONAD_ETH_ISTANBUL;
 }
 
 GenesisState HiveNet::get_genesis_state() const
 {
     BlockHeader header;
     header.difficulty = 0x20000;
-    header.gas_limit = 0x23f3e20;
+    header.gas_limit = 0x5f5e100;
     store_be(header.nonce.data(), uint64_t{0x0});
     header.extra_data = from_hex("0x68697665636861696e").value();
     return {header, HIVE_NET_ALLOC};

--- a/category/execution/ethereum/chain/hive_net_alloc.hpp
+++ b/category/execution/ethereum/chain/hive_net_alloc.hpp
@@ -100,6 +100,10 @@ constexpr char const *HIVE_NET_ALLOC = R"(
         "nonce": "0x1",
         "wei_balance": "1"
     },
+    "8dcd17433742f4c0ca53122ab541d0ba67fc27ff": {
+        "code": "0x6202e6306000a0",
+        "wei_balance": "0"
+    },
     "c7b99a164efd027a93f147376cc7da7c67c6bbe0": {
         "wei_balance": "1000000000000000000000000000000000000"
     },

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -17,6 +17,7 @@
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/ethereum/chain/hive_net.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
@@ -57,6 +58,30 @@ TYPED_TEST(MonadTraitsTest, compute_gas_refund)
     else {
         EXPECT_EQ(refund, 20'200);
     }
+}
+
+TEST(HiveNet, ChainConfig)
+{
+    HiveNet const chain;
+
+    EXPECT_EQ(chain.get_chain_id(), uint256_t{3503995874084926ULL});
+    EXPECT_EQ(chain.get_revision(0, 0), MONAD_ETH_ISTANBUL);
+    EXPECT_EQ(chain.get_revision(17, 0), MONAD_ETH_ISTANBUL);
+    EXPECT_EQ(chain.get_revision(18, 0), MONAD_ETH_ISTANBUL);
+    EXPECT_EQ(chain.get_revision(23, 0), MONAD_ETH_ISTANBUL);
+    EXPECT_EQ(chain.get_revision(24, 0), MONAD_ETH_BERLIN);
+    EXPECT_EQ(chain.get_revision(27, 0), MONAD_ETH_LONDON);
+    EXPECT_EQ(chain.get_revision(36, 0), MONAD_ETH_PARIS);
+    EXPECT_EQ(chain.get_revision(36, 390), MONAD_ETH_SHANGHAI);
+    EXPECT_EQ(chain.get_revision(36, 420), MONAD_ETH_CANCUN);
+    EXPECT_EQ(chain.get_revision(36, 450), MONAD_ETH_PRAGUE);
+
+    GenesisState const genesis_state = chain.get_genesis_state();
+    EXPECT_EQ(genesis_state.header.difficulty, uint256_t{0x20000});
+    EXPECT_EQ(genesis_state.header.gas_limit, 0x5f5e100);
+    EXPECT_EQ(
+        genesis_state.header.extra_data,
+        from_hex("0x68697665636861696e").value());
 }
 
 TYPED_TEST(TraitsTest, Genesis)


### PR DESCRIPTION
Updates the `hive_net` chain configuration so the Hive RPC fixture chain starts at the earliest Ethereum fork supported by Monad execution, while preserving the later Hive fork boundaries used by the runner.