### PR TITLE
[fiber]: Silence Boost.Bind pragma message in upstream fiber tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,18 @@ endforeach()
 add_subdirectory("third_party/fiber" SYSTEM)
 # Boost.Fiber triggers warnings under C++23 strict flags.
 target_compile_options(boost_fiber PRIVATE -Wno-deprecated-declarations -Wno-conversion)
+# Some upstream fiber tests include <boost/bind.hpp>, which emits a #pragma
+# message about global-namespace placeholders. It's a raw message (not a
+# deprecation warning), so -Wno-* can't suppress it; retain the legacy
+# behavior to silence it. The test subdirectory is only traversed under the
+# same condition fiber itself uses, so mirror it before querying the targets.
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/fiber/test/CMakeLists.txt")
+  get_property(_fiber_test_targets DIRECTORY "third_party/fiber/test"
+    PROPERTY BUILDSYSTEM_TARGETS)
+  foreach(_t ${_fiber_test_targets})
+    target_compile_definitions(${_t} PRIVATE BOOST_BIND_GLOBAL_PLACEHOLDERS)
+  endforeach()
+endif()
 
 # immer
 option(immer_BUILD_TESTS OFF)


### PR DESCRIPTION
## What

Silences the Boost.Bind `#pragma message` that started appearing in the build output for the upstream Boost.Fiber tests:

```
/usr/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. ...'
```

## Why now

The message isn't from a new deprecation — it became *visible* because these tests only just started getting compiled. The previous commit on `main` (`3bdb734d9 [fiber]: Add CMake test support and install Boost.Test dependency`) bumped the fiber submodule to a revision whose only change is a brand-new `test/CMakeLists.txt` that compiles the upstream test sources into ctest targets for the first time. Those sources have always `#include <boost/bind.hpp>` (the include was added upstream in 2015).

## Fix

Define `BOOST_BIND_GLOBAL_PLACEHOLDERS` on the fiber test targets, retaining the legacy global-placeholder behavior the upstream tests rely on. The Boost output is a raw `#pragma message` (a *note*), not a deprecation *warning*, so the existing `-Wno-deprecated-declarations` on `boost_fiber` cannot suppress it — the macro is the only lever.

The define is applied from monad's `CMakeLists.txt` (next to the existing fiber post-processing) rather than in the submodule, because the affected test sources are pristine upstream Boost code — keeping the fork a clean mirror of upstream. The fix is scoped exactly to the fiber test targets via the directory's `BUILDSYSTEM_TARGETS` property.

## Testing

Clean-rebuilt all six affected targets (`test_async_dispatch`, `test_async_post`, `test_condition_mt_dispatch`, `test_condition_mt_post`, `test_fiber_dispatch`, `test_fiber_post`) — the message is gone, with no new warnings or errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)