### PR TITLE
core: handle null zero-length input inside vendored sha256/rmd160

### DIFF
--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -115,15 +115,6 @@ static inline PrecompileResult silkpre_execute(byte_string_view const input)
     return {EVMC_SUCCESS, output, output_size};
 }
 
-// Substitute a pointer to the empty string when `input.data()` is null.
-// monad_sha256 / monad_rmd160 invoke undefined behaviour on a null input
-// pointer even when the length is zero.
-static inline uint8_t const *nonnull_input_data(byte_string_view const input)
-{
-    return input.data() != nullptr ? input.data()
-                                   : reinterpret_cast<uint8_t const *>("");
-}
-
 PrecompileResult ecrecover_execute(byte_string_view const input)
 {
     auto const clamped_input = input.substr(0, 128);
@@ -137,7 +128,7 @@ PrecompileResult sha256_execute(byte_string_view const input)
 
     monad_sha256(
         output,
-        nonnull_input_data(input),
+        input.data(),
         input.size(),
         /*use_cpu_extensions=*/true);
 
@@ -152,7 +143,7 @@ PrecompileResult ripemd160_execute(byte_string_view const input)
     // Ethereum's RIPEMD-160 precompile returns the 20-byte digest left-padded
     // with 12 zero bytes to a 32-byte ABI word.
     std::memset(output, 0, 12);
-    monad_rmd160(output + 12, nonnull_input_data(input), input.size());
+    monad_rmd160(output + 12, input.data(), input.size());
 
     return {EVMC_SUCCESS, output, 32};
 }

--- a/category/execution/ethereum/process_requests.cpp
+++ b/category/execution/ethereum/process_requests.cpp
@@ -244,11 +244,9 @@ bytes32_t compute_requests_hash(std::span<BlockRequest const> const requests)
         inner_hashes.append_range(inner.bytes);
     }
 
-    static constexpr uint8_t EMPTY_SHA256_INPUT = 0;
     bytes32_t outer_hash;
-    uint8_t const *outer_input =
-        inner_hashes.empty() ? &EMPTY_SHA256_INPUT : inner_hashes.data();
-    monad_sha256(outer_hash.bytes, outer_input, inner_hashes.size(), true);
+    monad_sha256(
+        outer_hash.bytes, inner_hashes.data(), inner_hashes.size(), true);
     return outer_hash;
 }
 

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.c
@@ -365,6 +365,9 @@ static inline uint32_t load32(const void* src) {
 }
 
 void monad_rmd160(uint8_t out[20], const uint8_t* ptr, size_t len) {
+    // ptr may be null when len is zero: the block loop below and rmd160_finish
+    // only dereference ptr for byte counts derived from len, so a zero length
+    // performs no read.
     uint32_t buf[160 / 32];
 
     rmd160_init(buf);

--- a/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/rmd160.h
@@ -47,6 +47,8 @@
 extern "C" {
 #endif
 
+// Writes the RIPEMD-160 digest of input[0..len) to out. input may be null when
+// len is zero.
 void monad_rmd160(uint8_t out[20], const uint8_t* input, size_t len);
 
 #if defined(__cplusplus)

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.c
@@ -18,6 +18,8 @@
 //   - renamed silkpre_sha256 to monad_sha256
 //   - made internal helper `cpuid` static to avoid colliding with silkpre's
 //     copy at link time
+//   - guarded the chunk copy so a null input pointer with a zero length is
+//     well-defined (see monad_sha256 contract in the header)
 
 // Based on several bits of code released to public domain:
 // https://github.com/amosnier/sha-2 (Author: Alain Mosnier)
@@ -112,10 +114,12 @@ static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state* state) {
         return true;
     }
 
-    memcpy(chunk, state->p, state->len);
-    chunk += state->len;
     size_t space_in_chunk = CHUNK_SIZE - state->len;
-    if (state->len) {  // avoid adding 0 to nullptr
+    if (state->len) {  // Skip when the input pointer may be null: both
+                       // memcpy(dst, NULL, 0) and NULL + 0 are undefined
+                       // behaviour, even though they move/advance nothing.
+        memcpy(chunk, state->p, state->len);
+        chunk += state->len;
         state->p += state->len;
     }
     state->len = 0;

--- a/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/sha256.h
@@ -27,6 +27,9 @@
 extern "C" {
 #endif
 
+// Writes the SHA-256 digest of input[0..len) to hash. input may be null when
+// len is zero. When use_cpu_extensions is true, hardware acceleration is used
+// where available.
 void monad_sha256(uint8_t hash[32], const uint8_t* input, size_t len, bool use_cpu_extensions);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary

Follow-up to the silkpre vendoring PR (#2254). A reviewer noted that `monad_sha256` / `monad_rmd160` invoke undefined behaviour on a null input pointer even when the length is zero, which forced every caller to substitute a non-null dummy pointer. This pushes the `(null, len == 0)` contract into the vendored sources and removes the per-caller workarounds.

The hash precompiles (`0x02`, `0x03`) and EIP-6110 deposit request hashing can be invoked with empty input, whose `data()` pointer may be null — so this path is exercised in practice.

## Changes

**Vendored sources — own the contract:**
- `sha256.c`: guard the chunk copy in `calc_chunk` so the null/zero-length path performs no `memcpy(dst, NULL, 0)` or `NULL + 0` arithmetic (both UB). Functionally identical for non-empty input; recorded in the file's modification log.
- `rmd160.c`: already null-safe (its only dereference is bounded by `i < (lswlen & 63)`); added a comment documenting why.
- `sha256.h` / `rmd160.h`: state the `input may be null when len is zero` contract at the declarations.

**Call sites — drop the workarounds:**
- `precompiles_impl.cpp`: delete the `nonnull_input_data` helper; `sha256_execute` / `ripemd160_execute` pass `input.data()` directly.
- `process_requests.cpp`: delete the `EMPTY_SHA256_INPUT` dummy-byte substitution; pass `inner_hashes.data()` directly.

## Testing

- Builds clean (`monad_execution`, GCC 15, RelWithDebInfo); edited C++ files are clang-format compliant.
- No behavioural change to assert here. Suggested follow-up (per reviewer): exercise the empty-input precompile / `process_requests` paths under UBSan across CPU-extension variants. This pairs with the separately-requested golden/differential `monad_crypto` test follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)