### PR TITLE
Treat third_party/evmone as a normal submodule

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -50,8 +50,8 @@ You are helping the user configure and build the monad C++ project located at $C
 | Option | Default | Description |
 |--------|---------|-------------|
 | `MONAD_COMPILER_COVERAGE` | OFF | Build with coverage instrumentation |
-| `MONAD_COMPILER_TESTING` | OFF | Build compiler tests (requires `third_party/evmone` — see evmone note below) |
-| `MONAD_COMPILER_BENCHMARKS` | OFF | Build compiler benchmarks (requires `third_party/evmone` — see evmone note below) |
+| `MONAD_COMPILER_TESTING` | OFF | Build compiler tests (requires the `third_party/evmone` submodule) |
+| `MONAD_COMPILER_BENCHMARKS` | OFF | Build compiler benchmarks (requires the `third_party/evmone` submodule) |
 | `MONAD_COMPILER_DUMP_ASM` | OFF | Dump assembly files into `build/asm` |
 | `MONAD_COMPILER_STATS` | OFF | Print JIT compiler statistics |
 | `MONAD_COMPILER_HOT_PATH_STATS` | OFF | Print VM hot-path statistics |
@@ -141,19 +141,6 @@ You are helping the user configure and build the monad C++ project located at $C
    - Remove the `build/` directory
    - Then run configure and build (i.e., proceed to steps 3–5)
 
-### evmone (custom fork — not a submodule)
-
-`third_party/evmone/` is gitignored and must be cloned manually from the Category Labs fork. It is required for `MONAD_COMPILER_TESTING=ON`, `MONAD_COMPILER_BENCHMARKS=ON`, `/lint`, and `/fuzz`. Not needed for standard builds.
-
-**To set up** (run from the project root):
-```bash
-git clone git@github.com:category-labs/evmone.git third_party/evmone
-git -C third_party/evmone checkout v0.18.0-category
-```
-**Do not `cd` into the evmone directory** — subsequent cmake commands use relative paths that break if the working directory has changed.
-
-The branch `v0.18.0-category` is the current stable fork used in CI. Check `.github/workflows/test-vm.yml` for the latest ref if in doubt. This requires SSH access to the `category-labs` GitHub organization.
-
 ### Example configure commands
 
 Default GCC build:
@@ -200,10 +187,8 @@ CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
 
 - If cmake configure fails, check for missing dependencies and suggest install commands
 - If configure fails with "GCC version 15 or higher is required", ensure `CC=gcc-15 CXX=g++-15` is set (or use `CC=clang-19 CXX=clang++-19` for Clang)
-- If configure fails with missing `CMakeLists.txt` in `third_party/`, run `git submodule update --init --recursive`
+- If configure fails with missing `CMakeLists.txt` in `third_party/` (including `third_party/evmone`, which is required for `MONAD_COMPILER_TESTING`, `MONAD_COMPILER_BENCHMARKS`, lint, and fuzz builds), run `git submodule update --init --recursive`
 - If build fails with `#error avx2 or avx512 required`, ensure a toolchain file is being used
-- If configure fails with "third_party/evmone to be present", the custom evmone fork needs to be cloned — see the evmone section above
-- If the evmone clone fails with a permission error, the user needs SSH access to the `category-labs` GitHub organization
 - If build fails, show the relevant error lines and suggest fixes
 
 ### Important

--- a/.claude/commands/fuzz.md
+++ b/.claude/commands/fuzz.md
@@ -16,7 +16,7 @@ You are running fuzzers for the monad C++ project located at $CWD.
 
 ### Build requirements
 
-The compiler fuzzer requires `MONAD_COMPILER_TESTING=ON` at configure time and `third_party/evmone` (see `/build` for evmone setup instructions). The staking contract fuzzer is always built with no special options.
+The compiler fuzzer requires `MONAD_COMPILER_TESTING=ON` at configure time and initialized submodules, including `third_party/evmone` (`git submodule update --init --recursive`). The staking contract fuzzer is always built with no special options.
 
 If the fuzzer binaries don't exist, offer to reconfigure. The CI fuzzing configuration is:
 ```bash

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -17,7 +17,7 @@ Linting requires a specific build configuration to match CI. All of these must b
 - Debug build type
 - `MONAD_COMPILER_TESTING=ON` and `MONAD_COMPILER_BENCHMARKS=ON`
 - `UTILS_CLANG_TIDY_AUTO_CONST=ON`
-- `third_party/evmone` must be present (see `/build` for evmone setup instructions)
+- submodules initialized, including `third_party/evmone` (`git submodule update --init --recursive`)
 
 ### Steps
 
@@ -53,7 +53,7 @@ The project's `.clang-tidy` config treats all warnings as errors and covers bugp
 ### Error handling
 
 - If `build/` doesn't exist or was configured with the wrong compiler/build type, reconfigure as shown above
-- If `third_party/evmone` is missing, tell the user to set it up (see `/build` for instructions)
+- If `third_party/evmone` is missing, run `git submodule update --init --recursive`
 - If `--fix` is used with uncommitted changes, the fix script will error — tell the user to commit or stash first
 
 ### Important

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,5 @@ Test data paths are available via generated header `test/test_resource_data.h`:
 ## Known Pitfalls
 
 - **GCC + ASAN breaks the VM interpreter** — GCC's ASAN implementation is incompatible with the must-tail calling convention used by the interpreter. Use Clang for ASAN builds when working on VM code.
-- **`third_party/evmone` is not a submodule** — it's gitignored and must be manually cloned from `category-labs/evmone` (branch `v0.18.0-category`). Only needed for `MONAD_COMPILER_TESTING`, `MONAD_COMPILER_BENCHMARKS`, lint, and fuzz builds.
-- **Submodules in worktrees** — Fresh clones and git worktrees need `git submodule update --init --recursive` before configuring.
+- **Submodules in worktrees** — Fresh clones and git worktrees need `git submodule update --init --recursive` before configuring. `third_party/evmone` (only needed for `MONAD_COMPILER_TESTING`, `MONAD_COMPILER_BENCHMARKS`, lint, and fuzz builds) is a normal submodule and comes along with that.
 - **Always use toolchain files** — Passing bare `-march=haswell` via `CFLAGS`/`CXXFLAGS` misses assembly sources (e.g., `keccak_impl.S`). Use `-DCMAKE_TOOLCHAIN_FILE=...` instead.

--- a/cmake/evmone.cmake
+++ b/cmake/evmone.cmake
@@ -13,14 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-if (NOT IS_DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/evmone")
-    message(FATAL_ERROR "Building Category Labs internal VM differential      \
-                         testing and benchmarking requires third_party/evmone \
-                         to be present. Unset MONAD_COMPILER_TESTING and      \
-                         MONAD_COMPILER_BENCHMARKS to build without           \
-                         internal code.")
-endif()
-
 # evmone
 set(HUNTER_ENABLED OFF)
 


### PR DESCRIPTION
## Summary

Our fork of evmone is now public, so `third_party/evmone` no longer needs the special-cased build process (gitignored + manually cloned from the `v0.18.0-category` branch). It's already a regular entry in `.gitmodules`, so this just removes the stale references to the old process and treats it like every other submodule.

## Changes

- **`cmake/evmone.cmake`** — remove the bespoke `IS_DIRECTORY` / `FATAL_ERROR` guard. No other submodule has one; evmone now fails the same standard "missing `CMakeLists.txt`" way if submodules aren't initialized.
- **`.claude/commands/build.md`** — delete the dedicated "evmone (custom fork — not a submodule)" section and manual-clone instructions, simplify the options-table notes, and fold the stale troubleshooting bullets (evmone "to be present" + SSH-access permission error) into the generic submodule-init bullet.
- **`.claude/commands/lint.md`, `fuzz.md`** — list evmone as one of the submodules to initialize rather than a special manual prerequisite.
- **`CLAUDE.md`** — drop the standalone evmone "Known Pitfalls" bullet; the generic "Submodules in worktrees" bullet now just notes it's a normal submodule needed only for compiler/lint/fuzz builds.

Docs/build-tooling only — no functional change for a correctly-initialized checkout (the removed CMake guard had no effect once submodules are present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)