### PR TITLE
[execution] Fiber synchronization abstraction.

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(
   "lru/lru_cache.hpp"
   "lru/static_lru_cache.hpp"
   "mem/batch_mem_pool.hpp"
+  "synchronization/promise.hpp"
   "synchronization/spin_lock.hpp"
   # cli
   "cli/help_formatter.cpp"

--- a/category/core/synchronization/promise.hpp
+++ b/category/core/synchronization/promise.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+#include <boost/fiber/future/promise.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// This is a zero-cost synchronization abstraction over a reference to a
+// boost::fibers::promise<void>. It is used to coordinate between strands of
+// transaction execution. The point of this thin abstraction is to allow it to
+// be shadowed on a platform that does not have boost::fibers, without having to
+// change the code that uses it.
+class Promise
+{
+    boost::fibers::promise<void> &promise_;
+
+public:
+    explicit Promise(boost::fibers::promise<void> &promise) noexcept
+        : promise_{promise}
+    {
+    }
+
+    void wait() const
+    {
+        promise_.get_future().wait();
+    }
+};
+
+static_assert(
+    sizeof(Promise) == sizeof(void *), "Promise should have no overhead");
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/dispatch_transaction.cpp
+++ b/category/execution/ethereum/dispatch_transaction.cpp
@@ -25,10 +25,9 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
-    boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
-    trace::StateTracer &state_tracer, ChainContext<traits> const &chain_ctx,
-    bool const trace_transfers)
+    BlockState &block_state, BlockMetrics &block_metrics, Promise const prev,
+    CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+    ChainContext<traits> const &chain_ctx, bool const trace_transfers)
 {
     return ExecuteTransaction<traits>{
         chain,

--- a/category/execution/ethereum/dispatch_transaction.hpp
+++ b/category/execution/ethereum/dispatch_transaction.hpp
@@ -18,13 +18,12 @@
 #include <category/core/address.hpp>
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/traits.hpp>
-
-#include <boost/fiber/future/promise.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -48,9 +47,8 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
-    boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
-    trace::StateTracer &state_tracer, ChainContext<traits> const &chain_ctx,
-    bool trace_transfers = false);
+    BlockState &block_state, BlockMetrics &block_metrics, Promise prev,
+    CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+    ChainContext<traits> const &chain_ctx, bool trace_transfers = false);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -22,6 +22,7 @@
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_history.hpp>
 #include <category/execution/ethereum/block_reward.hpp>
@@ -250,7 +251,7 @@ Result<std::vector<Receipt>> execute_block_transactions(
                         block_hash_buffer,
                         block_state,
                         block_metrics,
-                        promises[i],
+                        Promise{promises[i]},
                         call_tracer,
                         state_tracer,
                         chain_ctx,

--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -20,6 +20,7 @@
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -46,7 +47,6 @@
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 
-#include <boost/fiber/future/promise.hpp>
 #include <boost/outcome/try.hpp>
 
 #include <algorithm>
@@ -301,10 +301,9 @@ ExecuteTransaction<traits>::ExecuteTransaction(
     Address const &sender,
     std::span<std::optional<Address> const> const authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
-    boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
-    trace::StateTracer &state_tracer, ChainContext<traits> const &chain_ctx,
-    bool const trace_transfers)
+    BlockState &block_state, BlockMetrics &block_metrics, Promise const prev,
+    CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+    ChainContext<traits> const &chain_ctx, bool const trace_transfers)
     : ExecuteTransactionNoValidation<
           traits>{chain, tx, sender, authorities, header}
     , i_{i}
@@ -430,7 +429,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
             header_.excess_blob_gas,
             chain_.get_chain_id());
         if (validation_result.has_error()) {
-            prev_.get_future().wait();
+            prev_.wait();
             return std::move(validation_result).as_failure();
         }
     }
@@ -448,7 +447,7 @@ Result<Receipt> ExecuteTransaction<traits>::operator()()
 
         {
             TRACE_TXN_EVENT(StartStall);
-            prev_.get_future().wait();
+            prev_.wait();
         }
 
         if (block_state_.can_merge(state)) {

--- a/category/execution/ethereum/execute_transaction.hpp
+++ b/category/execution/ethereum/execute_transaction.hpp
@@ -18,12 +18,12 @@
 #include <category/core/address.hpp>
 #include <category/core/config.hpp>
 #include <category/core/result.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/vm/evm/traits.hpp>
 
-#include <boost/fiber/future/promise.hpp>
 #include <evmc/evmc.hpp>
 
 #include <cstdint>
@@ -79,7 +79,7 @@ class ExecuteTransaction : public ExecuteTransactionNoValidation<traits>
     BlockHashBuffer const &block_hash_buffer_;
     BlockState &block_state_;
     BlockMetrics &block_metrics_;
-    boost::fibers::promise<void> &prev_;
+    Promise prev_;
     CallTracerBase &call_tracer_;
     trace::StateTracer &state_tracer_;
     bool trace_transfers_;
@@ -91,10 +91,9 @@ public:
     ExecuteTransaction(
         Chain const &, uint64_t i, Transaction const &, Address const &,
         std::span<std::optional<Address> const>, BlockHeader const &,
-        BlockHashBuffer const &, BlockState &, BlockMetrics &,
-        boost::fibers::promise<void> &prev, CallTracerBase &,
-        trace::StateTracer &, ChainContext<traits> const &chain_ctx,
-        bool trace_transfers = false);
+        BlockHashBuffer const &, BlockState &, BlockMetrics &, Promise prev,
+        CallTracerBase &, trace::StateTracer &,
+        ChainContext<traits> const &chain_ctx, bool trace_transfers = false);
     ~ExecuteTransaction() = default;
 
     Result<Receipt> operator()();

--- a/category/execution/ethereum/execute_transaction_test.cpp
+++ b/category/execution/ethereum/execute_transaction_test.cpp
@@ -16,6 +16,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
 #include <category/core/runtime/uint256.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
@@ -114,7 +115,7 @@ TYPED_TEST(TraitsTest, irrevocable_gas_and_refund_new_contract)
         block_hash_buffer,
         bs,
         metrics,
-        prev,
+        Promise{prev},
         noop_call_tracer,
         noop_state_tracer,
         chain_ctx)();
@@ -223,7 +224,7 @@ TYPED_TEST(TraitsTest, TopLevelCreate)
         block_hash_buffer,
         bs,
         metrics,
-        prev,
+        Promise{prev},
         noop_call_tracer,
         noop_state_tracer,
         chain_ctx)();
@@ -376,7 +377,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
             block_hash_buffer,
             bs,
             metrics,
-            prev,
+            Promise{prev},
             noop_call_tracer,
             noop_state_tracer,
             chain_ctx)();
@@ -434,7 +435,7 @@ TYPED_TEST(TraitsTest, refunds_delete)
             block_hash_buffer,
             bs,
             metrics,
-            prev,
+            Promise{prev},
             noop_call_tracer,
             noop_state_tracer,
             chain_ctx)();
@@ -538,7 +539,7 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
             block_hash_buffer,
             bs,
             metrics,
-            prev,
+            Promise{prev},
             noop_call_tracer,
             noop_state_tracer,
             chain_ctx)();
@@ -642,7 +643,7 @@ TYPED_TEST(TraitsTest, static_validate_transaction_failure)
         block_hash_buffer,
         bs,
         metrics,
-        prev,
+        Promise{prev},
         noop_call_tracer,
         noop_state_tracer,
         chain_ctx)();

--- a/category/execution/monad/dispatch_transaction.cpp
+++ b/category/execution/monad/dispatch_transaction.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/monad/dispatch_transaction.hpp>
 #include <category/execution/monad/execute_system_transaction.hpp>
@@ -27,10 +28,9 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
-    boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
-    trace::StateTracer &state_tracer, ChainContext<traits> const &chain_ctx,
-    bool const trace_transfers)
+    BlockState &block_state, BlockMetrics &block_metrics, Promise const prev,
+    CallTracerBase &call_tracer, trace::StateTracer &state_tracer,
+    ChainContext<traits> const &chain_ctx, bool const trace_transfers)
 {
     if (traits::monad_rev() >= MONAD_FOUR && sender == SYSTEM_SENDER) {
         // System transactions is a concept used in Monad for consensus to

--- a/category/execution/monad/dispatch_transaction.hpp
+++ b/category/execution/monad/dispatch_transaction.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/dispatch_transaction.hpp>
 #include <category/execution/monad/system_sender.hpp>
 
@@ -26,9 +27,8 @@ Result<Receipt> dispatch_transaction(
     Address const &sender,
     std::vector<std::optional<Address>> const &authorities,
     BlockHeader const &header, BlockHashBuffer const &block_hash_buffer,
-    BlockState &block_state, BlockMetrics &block_metrics,
-    boost::fibers::promise<void> &prev, CallTracerBase &call_tracer,
-    trace::StateTracer &, ChainContext<traits> const &chain_ctx,
-    bool trace_transfers);
+    BlockState &block_state, BlockMetrics &block_metrics, Promise prev,
+    CallTracerBase &call_tracer, trace::StateTracer &,
+    ChainContext<traits> const &chain_ctx, bool trace_transfers);
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/execute_system_transaction.cpp
+++ b/category/execution/monad/execute_system_transaction.cpp
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <boost/fiber/future/promise.hpp>
 #include <boost/outcome/try.hpp>
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
@@ -22,6 +21,7 @@
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/event/record_txn_events.hpp>
@@ -53,7 +53,7 @@ template <Traits traits>
 ExecuteSystemTransaction<traits>::ExecuteSystemTransaction(
     Chain const &chain, uint64_t const i, Transaction const &tx,
     Address const &sender, BlockHeader const &header, BlockState &block_state,
-    BlockMetrics &block_metrics, boost::fibers::promise<void> &prev,
+    BlockMetrics &block_metrics, Promise const prev,
     CallTracerBase &call_tracer, trace::StateTracer &state_tracer)
     : chain_{chain}
     , i_{i}
@@ -78,7 +78,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
         auto system_validation_result =
             static_validate_system_transaction<traits>(tx_, sender_);
         if (system_validation_result.has_error()) {
-            prev_.get_future().wait();
+            prev_.wait();
             return std::move(system_validation_result).as_failure();
         }
         Transaction tx = tx_;
@@ -90,7 +90,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
             std::nullopt /* 0 blob fee to pass validation */,
             chain_.get_chain_id());
         if (tx_validation_result.has_error()) {
-            prev_.get_future().wait();
+            prev_.wait();
             return std::move(tx_validation_result).as_failure();
         }
     }
@@ -108,7 +108,7 @@ Result<Receipt> ExecuteSystemTransaction<traits>::operator()()
 
         {
             TRACE_TXN_EVENT(StartStall);
-            prev_.get_future().wait();
+            prev_.wait();
         }
 
         if (block_state_.can_merge(state)) {

--- a/category/execution/monad/execute_system_transaction.hpp
+++ b/category/execution/monad/execute_system_transaction.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
+#include <category/core/synchronization/promise.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -34,16 +35,15 @@ class ExecuteSystemTransaction
     BlockHeader const &header_;
     BlockState &block_state_;
     BlockMetrics &block_metrics_;
-    boost::fibers::promise<void> &prev_;
+    Promise prev_;
     CallTracerBase &call_tracer_;
     trace::StateTracer &state_tracer_;
 
 public:
     ExecuteSystemTransaction(
         Chain const &, uint64_t i, Transaction const &, Address const &,
-        BlockHeader const &, BlockState &, BlockMetrics &,
-        boost::fibers::promise<void> &prev, CallTracerBase &,
-        trace::StateTracer &);
+        BlockHeader const &, BlockState &, BlockMetrics &, Promise prev,
+        CallTracerBase &, trace::StateTracer &);
 
     Result<Receipt> operator()();
 

--- a/category/execution/monad/execute_system_transaction_test.cpp
+++ b/category/execution/monad/execute_system_transaction_test.cpp
@@ -103,7 +103,7 @@ TEST(SystemTransaction, prestate_trace_staking_epoch_change)
                 header,
                 block_state,
                 block_metrics,
-                promise,
+                Promise{promise},
                 noop_call_tracer,
                 prestate_tracer}();
 
@@ -138,7 +138,7 @@ TEST(SystemTransaction, prestate_trace_staking_epoch_change)
                 header,
                 block_state,
                 block_metrics,
-                promise,
+                Promise{promise},
                 noop_call_tracer,
                 prestate_tracer}();
 
@@ -210,7 +210,7 @@ TEST(SystemTransaction, statediff_trace_staking_epoch_change)
                 header,
                 block_state,
                 block_metrics,
-                promise,
+                Promise{promise},
                 noop_call_tracer,
                 statediff_tracer}();
 
@@ -251,7 +251,7 @@ TEST(SystemTransaction, statediff_trace_staking_epoch_change)
                 header,
                 block_state,
                 block_metrics,
-                promise,
+                Promise{promise},
                 noop_call_tracer,
                 statediff_tracer}();
 
@@ -316,7 +316,7 @@ TEST(SystemTransaction, static_validate_system_transaction_failure)
             header,
             block_state,
             block_metrics,
-            promise,
+            Promise{promise},
             noop_call_tracer,
             noop_state_tracer}();
 
@@ -355,7 +355,7 @@ TEST(SystemTransaction, static_validate_transaction_failure)
             header,
             block_state,
             block_metrics,
-            promise,
+            Promise{promise},
             noop_call_tracer,
             noop_state_tracer}();
 


### PR DESCRIPTION
This patch adds a zero-cost wrapper over Boost fibers promise synchronization. The purpose of this wrapper is to abstract the details of `boost::fibers::promise` such that we can shadow it on platforms that do not support Boost fibers. Behavior is unchanged: fibers still wait on predecessor completion in the same baton-passing flow.