### PR TITLE
[execution] New TU `execute_block_header`

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -139,6 +139,8 @@ add_library(
   "ethereum/evmc_host.hpp"
   "ethereum/execute_block.cpp"
   "ethereum/execute_block.hpp"
+  "ethereum/execute_block_header.cpp"
+  "ethereum/execute_block_header.hpp"
   "ethereum/execute_message.cpp"
   "ethereum/execute_message.hpp"
   "ethereum/execute_transaction.cpp"

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -24,7 +24,6 @@
 #include <category/core/monad_exception.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
-#include <category/execution/ethereum/block_hash_history.hpp>
 #include <category/execution/ethereum/block_reward.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/block.hpp>
@@ -37,6 +36,7 @@
 #include <category/execution/ethereum/event/exec_event_recorder.hpp>
 #include <category/execution/ethereum/event/record_txn_events.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
+#include <category/execution/ethereum/execute_block_header.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/metrics/block_metrics.hpp>
 #include <category/execution/ethereum/process_requests.hpp>
@@ -46,7 +46,6 @@
 #include <category/execution/ethereum/trace/event_trace.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
-#include <category/execution/monad/staking/execute_block_prelude.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -79,25 +78,6 @@ void process_withdrawal(
                 withdrawal.recipient,
                 uint256_t{withdrawal.amount} * uint256_t{1'000'000'000u});
         }
-    }
-}
-
-// EIP-4788
-void set_beacon_root(State &state, BlockHeader const &header)
-{
-    constexpr auto BEACON_ROOTS_ADDRESS{
-        0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address};
-    constexpr uint256_t HISTORY_BUFFER_LENGTH{8191};
-
-    if (state.account_exists(BEACON_ROOTS_ADDRESS)) {
-        uint256_t timestamp{header.timestamp};
-        bytes32_t k1{store_be_as<bytes32_t>(timestamp % HISTORY_BUFFER_LENGTH)};
-        bytes32_t k2{store_be_as<bytes32_t>(
-            timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH)};
-        state.set_storage(
-            BEACON_ROOTS_ADDRESS, k1, store_be_as<bytes32_t>(timestamp));
-        state.set_storage(
-            BEACON_ROOTS_ADDRESS, k2, header.parent_beacon_block_root.value());
     }
 }
 
@@ -169,32 +149,6 @@ std::vector<std::vector<std::optional<Address>>> recover_authorities(
 
     return authorities;
 }
-
-template <Traits traits>
-void execute_block_header(BlockState &block_state, BlockHeader const &header)
-{
-    static_assert(traits::evm_rev() >= MONAD_ETH_TANGERINE_WHISTLE);
-
-    State state{block_state, Incarnation{header.number, 0}};
-
-    deploy_block_hash_history_contract<traits>(state);
-    set_block_hash_history<traits>(state, header);
-
-    if constexpr (traits::evm_rev() >= MONAD_ETH_CANCUN) {
-        set_beacon_root(state, header);
-    }
-
-    // TODO: move to execute_monad_block eventually
-    if constexpr (is_monad_trait_v<traits>) {
-        staking::execute_block_prelude<traits>(state);
-    }
-
-    MONAD_ASSERT(block_state.can_merge(state));
-    block_state.merge(state);
-    record_account_access_events(MONAD_ACCT_ACCESS_BLOCK_PROLOGUE, state);
-}
-
-EXPLICIT_TRAITS(execute_block_header);
 
 template <Traits traits>
 Result<std::vector<Receipt>> execute_block_transactions(

--- a/category/execution/ethereum/execute_block.hpp
+++ b/category/execution/ethereum/execute_block.hpp
@@ -47,9 +47,6 @@ namespace fiber
 } // namespace fiber
 
 template <Traits traits>
-void execute_block_header(BlockState &, BlockHeader const &);
-
-template <Traits traits>
 Result<std::vector<Receipt>> execute_block_transactions(
     Chain const &, BlockHeader const &, std::span<Transaction const>,
     std::span<Address const> senders,

--- a/category/execution/ethereum/execute_block_header.cpp
+++ b/category/execution/ethereum/execute_block_header.cpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/endian.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/block_hash_history.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/event/exec_event_ctypes.h>
+#include <category/execution/ethereum/event/record_txn_events.hpp>
+#include <category/execution/ethereum/execute_block_header.hpp>
+#include <category/execution/ethereum/state2/block_state.hpp>
+#include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+#include <category/execution/monad/staking/execute_block_prelude.hpp>
+#include <category/vm/evm/explicit_traits.hpp>
+#include <category/vm/evm/traits.hpp>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+using namespace monad::literals;
+
+// EIP-4788
+void set_beacon_root(State &state, BlockHeader const &header)
+{
+    constexpr auto BEACON_ROOTS_ADDRESS{
+        0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address};
+    constexpr uint256_t HISTORY_BUFFER_LENGTH{8191};
+
+    if (state.account_exists(BEACON_ROOTS_ADDRESS)) {
+        uint256_t timestamp{header.timestamp};
+        bytes32_t k1{store_be_as<bytes32_t>(timestamp % HISTORY_BUFFER_LENGTH)};
+        bytes32_t k2{store_be_as<bytes32_t>(
+            timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH)};
+        state.set_storage(
+            BEACON_ROOTS_ADDRESS, k1, store_be_as<bytes32_t>(timestamp));
+        state.set_storage(
+            BEACON_ROOTS_ADDRESS, k2, header.parent_beacon_block_root.value());
+    }
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
+
+template <Traits traits>
+void execute_block_header(BlockState &block_state, BlockHeader const &header)
+{
+    static_assert(traits::evm_rev() >= MONAD_ETH_TANGERINE_WHISTLE);
+
+    State state{block_state, Incarnation{header.number, 0}};
+
+    deploy_block_hash_history_contract<traits>(state);
+    set_block_hash_history<traits>(state, header);
+
+    if constexpr (traits::evm_rev() >= MONAD_ETH_CANCUN) {
+        set_beacon_root(state, header);
+    }
+
+    // TODO: move to execute_monad_block eventually
+    if constexpr (is_monad_trait_v<traits>) {
+        staking::execute_block_prelude<traits>(state);
+    }
+
+    MONAD_ASSERT(block_state.can_merge(state));
+    block_state.merge(state);
+    record_account_access_events(MONAD_ACCT_ACCESS_BLOCK_PROLOGUE, state);
+}
+
+EXPLICIT_TRAITS(execute_block_header);
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block_header.hpp
+++ b/category/execution/ethereum/execute_block_header.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/vm/evm/traits.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+struct BlockHeader;
+class BlockState;
+
+// Block-prelude actions: deploys block-hash-history contract, sets the
+// block-hash history, sets EIP-4788 beacon root (Cancun+), runs Monad's
+// staking prelude. Lifted out of execute_block.cpp into its own TU so the
+// zkVM guest can pull it without dragging in execute_block.cpp's fiber/
+// dispatch_transaction deps.
+template <Traits traits>
+void execute_block_header(BlockState &, BlockHeader const &);
+
+MONAD_NAMESPACE_END

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -48,6 +48,7 @@
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/execute_block.hpp>
+#include <category/execution/ethereum/execute_block_header.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
 #include <category/execution/ethereum/rlp/decode.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>


### PR DESCRIPTION
This patch hoists the functions `execute_block_header` and `set_beacon_root` into a separate translation unit. The reason for this change is to enable those functions to be reused by the zkVM target.