### PR TITLE
[vm] Forward declare `Nativecode`.

### DIFF
--- a/category/vm/code.hpp
+++ b/category/vm/code.hpp
@@ -16,10 +16,19 @@
 #pragma once
 
 #include <category/core/assert.h>
-#include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 
 #include <atomic>
+
+// We forward declare `Nativecode` here to avoid including
+// <category/vm/compiler/ir/x86/types.hpp> (which transitively includes
+// <asmjit/x86.h>) since most of the reference and construction sites only need
+// this declaration. This enables the zkVM build (which has no JIT compiler) to
+// compile code.hpp on RISC-V.
+namespace monad::vm::compiler::native
+{
+    class Nativecode;
+}
 
 namespace monad::vm
 {

--- a/category/vm/varcode_cache.cpp
+++ b/category/vm/varcode_cache.cpp
@@ -16,6 +16,7 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/vm/code.hpp>
+#include <category/vm/compiler/ir/x86/types.hpp>
 #include <category/vm/varcode_cache.hpp>
 
 #include <cstdint>
@@ -52,8 +53,10 @@ namespace monad::vm
     {
         MONAD_ASSERT(icode != nullptr);
         MONAD_ASSERT(ncode != nullptr);
+        compiler::native::native_code_size_t const native_code_size_estimate =
+            ncode->code_size_estimate();
         auto const weight = code_size_to_cache_weight(
-            *(icode->code_size() + ncode->code_size_estimate()));
+            *(icode->code_size() + native_code_size_estimate));
         auto const vcode = std::make_shared<Varcode>(icode, ncode);
         weight_cache_.insert(code_hash, vcode, weight);
     }


### PR DESCRIPTION
This patch forward declares `Nativecode` rather than including the header `category/vm/compiler/ir/x86/types.hpp`, which pulls in transitive dependencies that we cannot compile on the zkVM target.