### PR TITLE
[test] Port hardcoded-bytecode unit tests to evm-as EvmBuilder (tier 1)

### DIFF
--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -27,6 +27,7 @@
 #include <category/execution/ethereum/rlp/execution_witness.hpp>
 #include <category/mpt/merkle/compact_encode.hpp>
 #include <category/mpt/nibbles_view.hpp>
+#include <category/vm/utils/evm-as.hpp>
 
 #include <gtest/gtest.h>
 
@@ -492,9 +493,12 @@ TEST(PartialTrieDb, Read_LeafWitness_FoundAndAbsent)
 
 TEST(PartialTrieDb, ReadCode_PresentAndMissing)
 {
-    byte_string const code1{
-        std::initializer_list<unsigned char>{0x60, 0x01, 0x60, 0x02, 0x01}};
-    byte_string const code2{std::initializer_list<unsigned char>{0x00}};
+    // PUSH1 0x01; PUSH1 0x02; ADD
+    byte_string const code1 = vm::utils::evm_as::assemble(
+        vm::utils::evm_as::latest().push(0x01).push(0x02).add());
+    // STOP
+    byte_string const code2 =
+        vm::utils::evm_as::assemble(vm::utils::evm_as::latest().stop());
     bytes32_t const hash1 = to_bytes(keccak256(code1));
     bytes32_t const hash2 = to_bytes(keccak256(code2));
 

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -46,6 +46,7 @@
 #include <category/mpt/util.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/evm/monad/revision.h>
+#include <category/vm/utils/evm-as.hpp>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
 
@@ -80,15 +81,35 @@ namespace
     auto const STRESS_TEST_CODE_HASH = to_bytes(keccak256(STRESS_TEST_CODE));
     auto const STRESS_TEST_ICODE = vm::make_shared_intercode(STRESS_TEST_CODE);
 
-    auto const REFUND_TEST_CODE =
-        0x6000600155600060025560006003556000600455600060055500_bytes;
+    // PUSH1 0x00; PUSH1 0xNN; SSTORE for NN = 1..5; then STOP
+    auto const REFUND_TEST_CODE = [] {
+        auto eb = vm::utils::evm_as::latest();
+        eb.push(1, 0)
+            .push(0x01)
+            .sstore()
+            .push(1, 0)
+            .push(0x02)
+            .sstore()
+            .push(1, 0)
+            .push(0x03)
+            .sstore()
+            .push(1, 0)
+            .push(0x04)
+            .sstore()
+            .push(1, 0)
+            .push(0x05)
+            .sstore()
+            .stop();
+        return vm::utils::evm_as::assemble(eb);
+    }();
     auto const REFUND_TEST_CODE_HASH = to_bytes(keccak256(REFUND_TEST_CODE));
     auto const REFUND_TEST_ICODE = vm::make_shared_intercode(REFUND_TEST_CODE);
 
     // EIP-7002/7251 system contract stub (just the STOP opcode).
     // Deployed at the two predeploy addresses so that execute_block's
     // process_requests path works for Prague+ traits.
-    auto const SYSTEM_STUB_CODE = 0x00_bytes;
+    auto const SYSTEM_STUB_CODE =
+        vm::utils::evm_as::assemble(vm::utils::evm_as::latest().stop());
     auto const SYSTEM_STUB_CODE_HASH = to_bytes(keccak256(SYSTEM_STUB_CODE));
     auto const SYSTEM_STUB_ICODE = vm::make_shared_intercode(SYSTEM_STUB_CODE);
 

--- a/category/execution/ethereum/execute_transaction_test.cpp
+++ b/category/execution/ethereum/execute_transaction_test.cpp
@@ -35,6 +35,7 @@
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/vm/evm/monad/revision.h>
+#include <category/vm/utils/evm-as.hpp>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
 
@@ -325,8 +326,21 @@ TYPED_TEST(TraitsTest, refunds_delete)
     BlockMetrics metrics;
 
     // Sets s[0] = 1 if passed any data, clears s[0] if data is empty.
-    auto const contract_code =
-        from_hex("0x3615600b576001600055005b6000600055").value();
+    // CALLDATASIZE; ISZERO; JUMPI clear; PUSH1 0x01; PUSH1 0x00; SSTORE; STOP;
+    // clear: PUSH1 0x00; PUSH1 0x00; SSTORE
+    auto eb = vm::utils::evm_as::latest();
+    eb.calldatasize()
+        .iszero()
+        .jumpi("clear")
+        .push(0x01)
+        .push(1, 0)
+        .sstore()
+        .stop()
+        .jumpdest("clear")
+        .push(1, 0)
+        .push(1, 0)
+        .sstore();
+    auto const contract_code = vm::utils::evm_as::assemble(eb);
 
     {
         State state{bs, Incarnation{0, 0}};
@@ -484,7 +498,10 @@ TYPED_TEST(TraitsTest, refunds_delete_then_set)
     BlockMetrics metrics;
 
     // s[0] = 0; s[0] = 1
-    auto const contract_code = from_hex("0x60006000556001600055").value();
+    // PUSH1 0x00; PUSH1 0x00; SSTORE; PUSH1 0x01; PUSH1 0x00; SSTORE
+    auto eb = vm::utils::evm_as::latest();
+    eb.push(1, 0).push(1, 0).sstore().push(0x01).push(1, 0).sstore();
+    auto const contract_code = vm::utils::evm_as::assemble(eb);
 
     {
         State state{bs, Incarnation{0, 0}};

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -35,6 +35,7 @@
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/util.hpp>
 #include <category/vm/code.hpp>
+#include <category/vm/utils/evm-as.hpp>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
 
@@ -1271,7 +1272,9 @@ TEST_F(InMemoryStateTest, copy_code)
 
 TEST_F(InMemoryStateTest, get_code)
 {
-    byte_string const contract{0x60, 0x34, 0x00};
+    // PUSH1 0x34; STOP
+    byte_string const contract = vm::utils::evm_as::assemble(
+        vm::utils::evm_as::latest().push(0x34).stop());
 
     BlockState bs{this->tdb, this->vm};
 

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -39,6 +39,7 @@
 #include <category/mpt/db.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
 #include <category/vm/evm/traits.hpp>
+#include <category/vm/utils/evm-as.hpp>
 #include <monad/test/traits_test.hpp>
 
 #include <bitset>
@@ -624,7 +625,9 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
             state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
         state.subtract_from_balance(SENDER, gas_cost);
         state.subtract_from_balance(NEW_CONTRACT, to_wei(3));
-        byte_string const contract_code{0x60, 0x00};
+        // PUSH1 0x00
+        byte_string const contract_code =
+            vm::utils::evm_as::assemble(vm::utils::evm_as::latest().push(1, 0));
         state.set_code(NEW_CONTRACT, contract_code);
     };
 

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -32,6 +32,7 @@
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
 #include <category/statesync/statesync_version.h>
+#include <category/vm/utils/evm-as.hpp>
 #include <test_resource_data.h>
 
 #include <ethash/keccak.hpp>
@@ -374,11 +375,15 @@ TEST_F(StateSyncFixture, sync_from_some)
     {
         constexpr auto ADDR1 =
             0x5353535353535353535353535353535353535353_address;
-        auto const code =
-            from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                     "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
-                     "ffffffffffffffffffffff0160005500")
-                .value();
+        // PUSH32 0xFF..FF; PUSH32 0xFF..FF; ADD; PUSH1 0x00; SSTORE; STOP
+        auto const code = vm::utils::evm_as::assemble(
+            vm::utils::evm_as::latest()
+                .push(32, ~uint256_t{0})
+                .push(32, ~uint256_t{0})
+                .add()
+                .push(1, 0) // PUSH1 0x00 (kept 2-byte to match original)
+                .sstore()
+                .stop());
         auto const code_hash = to_bytes(keccak256(code));
         auto const icode = vm::make_shared_intercode(code);
         commit_sequential(
@@ -964,11 +969,15 @@ TEST_F(StateSyncFixture, update_contract_twice)
     hdr.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(stdb.read_eth_header())));
 
-    auto const code =
-        from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                 "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
-                 "ffffffffffffffffffffff0160005500")
-            .value();
+    // PUSH32 0xFF..FF; PUSH32 0xFF..FF; ADD; PUSH1 0x00; SSTORE; STOP
+    auto const code = vm::utils::evm_as::assemble(
+        vm::utils::evm_as::latest()
+            .push(32, ~uint256_t{0})
+            .push(32, ~uint256_t{0})
+            .add()
+            .push(1, 0) // PUSH1 0x00 (kept 2-byte to match original)
+            .sstore()
+            .stop());
     auto const code_hash = to_bytes(keccak256(code));
     auto const icode = vm::make_shared_intercode(code);
 

--- a/category/vm/utils/evm-as/compiler.hpp
+++ b/category/vm/utils/evm-as/compiler.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
 #include <category/core/cases.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
@@ -290,6 +291,18 @@ namespace monad::vm::utils::evm_as
         std::stringstream ss{};
         compile<traits>(eb, ss);
         return ss.str();
+    }
+
+    // Assembles the provided builder object and returns the corresponding
+    // byte code as a byte_string.
+    template <Traits traits>
+    inline byte_string assemble(EvmBuilder<traits> const &eb)
+    {
+        byte_string bytecode{};
+        bytecode.reserve(eb.size());
+        compile<traits>(
+            eb, [&](uint8_t const byte) -> void { bytecode.push_back(byte); });
+        return bytecode;
     }
 
     // Mnemonic compiler config

--- a/test/vm/unit/evm-as_tests.cpp
+++ b/test/vm/unit/evm-as_tests.cpp
@@ -735,6 +735,22 @@ TEST(EvmAs, BytecodeCompile4)
     }
 }
 
+TEST(EvmAs, Assemble)
+{
+    // assemble() returns the same bytes as compile(), as a byte_string.
+    auto eb = evm_as::latest();
+    eb.push0().push0().add();
+    ASSERT_TRUE(evm_as::validate(eb));
+
+    byte_string const bytecode = evm_as::assemble(eb);
+    std::string const as_string = evm_as::compile(eb);
+
+    ASSERT_EQ(bytecode.size(), as_string.size());
+    for (size_t i = 0; i < bytecode.size(); i++) {
+        ASSERT_EQ(bytecode[i], static_cast<uint8_t>(as_string[i]));
+    }
+}
+
 TEST(EvmAs, Execution1)
 {
     auto eb = evm_as::latest();


### PR DESCRIPTION
## What

Phase 1 of porting unit tests that hardcode EVM bytecode (hex strings / byte vectors) to the `evm-as` `EvmBuilder` API, so test contracts read as self-documenting opcode sequences instead of opaque hex.

Two commits:

1. **`[vm] Add evm_as::assemble returning a byte_string`** — the compiler exposed `compile(eb, vector<uint8_t>&)` and `std::string compile(eb)`, but bytecode is canonically a `byte_string` here (`keccak256`, `set_code`, `make_shared_intercode` all take it), forcing a compile-into-vector-then-convert dance. `assemble(eb)` returns a `byte_string` directly. Covered by a new `EvmAs.Assemble` unit test that asserts it matches `compile()`'s bytes.
2. **`[test] Port hardcoded-bytecode unit tests…`** — the six ports, using `assemble`.

All built + tested green:

| File | Sites | Tests |
|------|-------|-------|
| `statesync/test/test_statesync.cpp` | 2 | 22/22 |
| `execution/ethereum/db/test/test_partial_trie_db.cpp` | 2 | 24/24 |
| `execution/ethereum/state2/test/test_state.cpp` | 1 | 357/357 |
| `execution/ethereum/execute_transaction_test.cpp` | 2 (label-based JUMPI) | 95/95 |
| `execution/ethereum/execute_block_test.cpp` | 2 (REFUND, SYSTEM_STUB) | 57/57 |
| `execution/ethereum/test/test_monad_chain.cpp` | 1 | 154/154 |
| `test/vm/unit/evm-as_tests.cpp` | new `EvmAs.Assemble` | 47/47 |

## Byte-exactness

Bytecode is reproduced **byte-for-byte**. Note `push(0)` emits `PUSH0` (0x5f, 2 gas), not `PUSH1 0x00` (0x6000, 3 gas), because `byte_width(0) == 0`. Zero operands therefore use `push(1, 0)`, keeping code hashes, state roots, and gas-refund assertions unchanged.

## Scope notes

- `STRESS_TEST_CODE` in `execute_block_test` is intentionally left hardcoded: its back-jump to offset 0 would resolve to `PUSH0` under a label, breaking byte/gas-exactness in a hot loop.
- `reserve_balance_contract_test.cpp` is deferred — its `0xFE` sites are embedded in helpers that already build code with named opcode constants + `code.size()` offset math; a real port is a larger label-based rewrite (tracked for a later phase).

Draft pending CI; `clang-tidy` not yet run locally (needs the Clang+Debug+`MONAD_COMPILER_TESTING` config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)