### PR TITLE
[execution] Hoist `ecrecover` into its own TU.

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(
   "ethereum/core/contract/events.hpp"
   "ethereum/core/contract/storage_array.hpp"
   "ethereum/core/contract/storage_variable.hpp"
+  "ethereum/core/ecrecover.cpp"
+  "ethereum/core/ecrecover.hpp"
   "ethereum/core/fmt/account_fmt.hpp"
   "ethereum/core/fmt/address_fmt.hpp"
   "ethereum/core/fmt/block_fmt.hpp"

--- a/category/execution/ethereum/core/ecrecover.cpp
+++ b/category/execution/ethereum/core/ecrecover.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/core/keccak.hpp>
+#include <category/execution/ethereum/core/ecrecover.hpp>
+#include <category/execution/ethereum/core/signature.hpp>
+
+#include <silkpre/ecdsa.h>
+
+#include <secp256k1.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+MONAD_NAMESPACE_BEGIN
+
+std::optional<Address>
+ecrecover(SignatureAndChain const &sc, byte_string_view const encoding)
+{
+    if (sc.y_parity > 1) {
+        return std::nullopt;
+    }
+
+    if (sc.has_upper_s()) {
+        return std::nullopt;
+    }
+
+    auto const encoding_hash = keccak256(encoding);
+
+    uint8_t signature[sizeof(sc.r) * 2];
+    store_be(signature, sc.r);
+    store_be(signature + sizeof(sc.r), sc.s);
+
+    thread_local std::unique_ptr<
+        secp256k1_context,
+        decltype(&secp256k1_context_destroy)> const
+        context(
+            secp256k1_context_create(SILKPRE_SECP256K1_CONTEXT_FLAGS),
+            &secp256k1_context_destroy);
+
+    Address result;
+
+    // TODO: remove silkpre
+    if (!silkpre_recover_address(
+            result.bytes,
+            encoding_hash.bytes,
+            signature,
+            sc.y_parity,
+            context.get())) {
+        return std::nullopt;
+    }
+
+    return result;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/core/ecrecover.hpp
+++ b/category/execution/ethereum/core/ecrecover.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,30 +13,26 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma once
+
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
-#include <category/execution/ethereum/core/ecrecover.hpp>
-#include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
-#include <category/execution/ethereum/core/transaction.hpp>
-#include <category/execution/ethereum/trace/event_trace.hpp>
 
 #include <optional>
 
 MONAD_NAMESPACE_BEGIN
 
-std::optional<Address> recover_authority(AuthorizationEntry const &auth_entry)
-{
-    byte_string const auth_encoding =
-        rlp::encode_authorization_entry_for_signing(auth_entry);
-    return ecrecover(auth_entry.sc, auth_encoding);
-}
+struct SignatureAndChain;
 
-std::optional<Address> recover_sender(Transaction const &tx)
-{
-    TRACE_TXN_EVENT(StartSenderRecovery);
-    byte_string const tx_encoding = rlp::encode_transaction_for_signing(tx);
-    return ecrecover(tx.sc, tx_encoding);
-}
+/// Recovers the Ethereum address that signed `encoding` with the given
+/// (r, s, y_parity) signature. Rejects malformed signatures up-front
+/// (y_parity > 1, malleable s); returns nullopt if ECDSA recovery fails.
+///
+/// Split out of transaction.cpp into its own TU so the silkpre / secp256k1
+/// dependency is confined to a single source file (this one's impl), and
+/// can be substituted on platforms that supply ecrecover via syscall.
+std::optional<Address>
+ecrecover(SignatureAndChain const &, byte_string_view encoding);
 
 MONAD_NAMESPACE_END


### PR DESCRIPTION
This patch puts `ecrecover` into its own separate TU such that it can be shadowed by the zkVM target. ~~The patch also includes the zkVM shadow TU, which implements `ecrecover` by using the `zkvm_secp256k1_ecrecover` accelerator.~~

EDIT: I have punted the zkVM implementation to a future PR, as we need a few more bits before it makes sense to add it.