### PR TITLE
Shrink riscv toolchain stage in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,17 +126,13 @@ COPY scripts/ubuntu-build/ /opt
 RUN apt-get update && \
     /opt/install-riscv-deps.sh && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Clone, build, install, strip, and remove the build tree in a single layer.
+# Only /root/riscv is consumed downstream; the build tree must be removed in
+# the same RUN it was created or it persists in the layer.
+RUN /opt/build-riscv-toolchain.sh && \
     rm -rf /opt
-
-RUN git clone --depth 1 --branch 2026.06.06 https://github.com/riscv-collab/riscv-gnu-toolchain /riscv-gnu-toolchain
-WORKDIR /riscv-gnu-toolchain
-
-RUN ./configure --prefix=/root/riscv \
-    --with-arch=rv64ima \
-    --with-abi=lp64
-    
-RUN make -j$(nproc)
 
 ENV PATH="/root/riscv/bin:${PATH}"
 

--- a/scripts/ubuntu-build/build-riscv-toolchain.sh
+++ b/scripts/ubuntu-build/build-riscv-toolchain.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="https://github.com/riscv-collab/riscv-gnu-toolchain"
+BRANCH="2026.06.06"
+SRC="/riscv-gnu-toolchain"
+PREFIX="/root/riscv"
+
+git clone --depth 1 --branch "${BRANCH}" "${REPO}" "${SRC}"
+cd "${SRC}"
+
+./configure --prefix="${PREFIX}" \
+  --with-arch=rv64ima \
+  --with-abi=lp64
+
+make -j"$(nproc)"
+
+# Strip debug info from the installed toolchain (kept artifacts).
+find "${PREFIX}" -type f -executable -exec strip --strip-unneeded {} + 2>/dev/null || true
+
+# Remove the entire build tree — only ${PREFIX} is consumed downstream.
+cd /
+rm -rf "${SRC}"


### PR DESCRIPTION
The base_riscv_gnu_toolchain stage built the cross-toolchain in three separate RUN layers and kept the ~14 GB in-tree build directory, since a later rm in its own layer only adds a whiteout. The installed toolchain also shipped unstripped (~83% debug info). Together this pushed the stage to ~18 GB, overflowing the 10 GB GHA cache limit and causing blob-eviction failures in ZK Tests.

Move clone/configure/make into build-riscv-toolchain.sh so the build tree is removed in the same layer it is created, and strip the installed toolchain (only /root/riscv is consumed downstream). The cached stage drops to ~2 GB.

Verified by building the build_zk target end-to-end: monad-zkvm still links against the stripped toolchain.