### PR TITLE
Storage Page 2/N: Make TrieDb page encoding aware, and add PageCommitBuilder

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -211,6 +211,8 @@ add_library(
 add_library(
   monad_execution_native OBJECT
   # monad/db
+  "monad/db/commit_block_migration.cpp"
+  "monad/db/commit_block_migration.hpp"
   "monad/db/page_commit_builder.hpp"
   "monad/db/page_commit_builder.cpp"
   "monad/db/storage_page.cpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(
   "ethereum/db/partial_trie_db.cpp"
   "ethereum/db/state_machine_init.cpp"
   "ethereum/db/state_machine_init.hpp"
+  "ethereum/db/storage_key.hpp"
   "ethereum/db/trie_db.cpp"
   "ethereum/db/trie_db.hpp"
   "ethereum/db/trie_rodb.hpp"
@@ -191,6 +192,7 @@ add_library(
   "ethereum/state2/block_state.cpp"
   "ethereum/state2/block_state.hpp"
   "ethereum/state2/fmt/state_deltas_fmt.hpp"
+  "ethereum/state2/proposal_post_state.hpp"
   "ethereum/state2/state_deltas.hpp"
   # ethereum/state3
   "ethereum/state3/account_state.cpp"
@@ -209,6 +211,8 @@ add_library(
 add_library(
   monad_execution_native OBJECT
   # monad/db
+  "monad/db/page_commit_builder.hpp"
+  "monad/db/page_commit_builder.cpp"
   "monad/db/storage_page.cpp"
   "monad/db/storage_page.hpp"
   # monad/chain

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -89,14 +89,8 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         deltas.emplace(addr, state_delta);
     }
 
-    std::unique_ptr<CommitBuilder> builder;
-    if (db.is_page_encoded()) {
-        builder =
-            std::make_unique<PageCommitBuilder>(genesis.header.number, db);
-    }
-    else {
-        builder = std::make_unique<CommitBuilder>(genesis.header.number);
-    }
+    std::unique_ptr<CommitBuilder> builder =
+        make_commit_builder(genesis.header.number, db);
     builder->add_state_deltas(deltas)
         .add_code(code_map)
         .add_receipts(std::vector<Receipt>{})

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -30,6 +30,7 @@
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 #include <category/vm/code.hpp>
 
 #include <nlohmann/json.hpp>
@@ -88,19 +89,26 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         deltas.emplace(addr, state_delta);
     }
 
-    CommitBuilder builder(genesis.header.number);
-    builder.add_state_deltas(deltas)
+    std::unique_ptr<CommitBuilder> builder;
+    if (db.is_page_encoded()) {
+        builder =
+            std::make_unique<PageCommitBuilder>(genesis.header.number, db);
+    }
+    else {
+        builder = std::make_unique<CommitBuilder>(genesis.header.number);
+    }
+    builder->add_state_deltas(deltas)
         .add_code(code_map)
         .add_receipts(std::vector<Receipt>{})
         .add_transactions(std::vector<Transaction>{}, std::vector<Address>{})
         .add_call_frames(std::vector<std::vector<CallFrame>>{})
         .add_ommers(std::vector<BlockHeader>{});
     if (genesis.header.withdrawals_root == NULL_ROOT) {
-        builder.add_withdrawals({});
+        builder->add_withdrawals({});
     }
     db.commit(
         NULL_HASH_BLAKE3,
-        builder,
+        *builder,
         genesis.header,
         std::make_unique<StateDeltas>(std::move(deltas)),
         [&](BlockHeader &h) {

--- a/category/execution/ethereum/db/commit_builder.cpp
+++ b/category/execution/ethereum/db/commit_builder.cpp
@@ -27,6 +27,7 @@
 #include <category/execution/ethereum/core/rlp/withdrawal_rlp.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
@@ -73,7 +74,9 @@ CommitBuilder &CommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
         UpdateList storage_updates;
         std::optional<byte_string_view> value;
         auto const &account = delta.account.second;
+        proposal_post_state_.accounts[addr] = account;
         if (account.has_value()) {
+            auto const inc = account->incarnation;
             for (auto const &[key, delta] : delta.storage) {
                 if (delta.first != delta.second) {
                     storage_updates.push_front(
@@ -89,6 +92,8 @@ CommitBuilder &CommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
                             .incarnation = false,
                             .next = UpdateList{},
                             .version = static_cast<int64_t>(block_number_)}));
+                    proposal_post_state_.storage[StorageKey{addr, inc, key}] =
+                        storage_page_t{delta.second};
                 }
             }
             value = bytes_alloc_.emplace_back(

--- a/category/execution/ethereum/db/commit_builder.hpp
+++ b/category/execution/ethereum/db/commit_builder.hpp
@@ -18,6 +18,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/mpt/update.hpp>
 
@@ -34,16 +35,23 @@ struct Withdrawal;
 
 class CommitBuilder
 {
+protected:
     std::deque<mpt::Update> update_alloc_;
     std::deque<byte_string> bytes_alloc_;
     std::deque<hash256> hash_alloc_;
     mpt::UpdateList updates_;
     uint64_t block_number_;
+    // Per-block post-state assembled by `add_state_deltas`.
+    // Slot based storage fills it with single-slot storage page keyed by
+    // storage slot key, Paged based storage fills it with the actual storage
+    // page keyed by storage page key.
+    ProposalPostState proposal_post_state_;
 
 public:
     explicit CommitBuilder(uint64_t block_number);
+    virtual ~CommitBuilder() = default;
 
-    CommitBuilder &add_state_deltas(StateDeltas const &);
+    virtual CommitBuilder &add_state_deltas(StateDeltas const &);
 
     CommitBuilder &add_code(Code const &);
 
@@ -64,6 +72,14 @@ public:
     // can be added after a build() call (e.g. add_block_header between the
     // two commit stages), but previously built updates are not retained.
     mpt::UpdateList build(mpt::NibblesView);
+
+    // Move out the proposal post-state assembled by `add_state_deltas`.
+    // Must be called after `add_state_deltas`; calling it twice yields an
+    // empty struct the second time.
+    ProposalPostState take_proposal_post_state()
+    {
+        return std::move(proposal_post_state_);
+    }
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -36,13 +36,22 @@
 MONAD_NAMESPACE_BEGIN
 
 class CommitBuilder;
+struct storage_page_t;
 
 struct Db
 {
+    virtual bool is_page_encoded() const
+    {
+        return false;
+    }
+
     virtual std::optional<Account> read_account(Address const &) = 0;
 
     virtual bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) = 0;
+
+    virtual storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) = 0;
 
     virtual vm::SharedIntercode read_code(bytes32_t const &) = 0;
 

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -21,42 +21,26 @@
 #include <category/core/config.hpp>
 #include <category/core/lru/lru_cache.hpp>
 #include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
 
 #include <cstdint>
-#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
 
 MONAD_NAMESPACE_BEGIN
 
+// Encoding-agnostic LRU + proposal cache for accounts and storage leaves.
+// Storage values are held as storage_page_t, keyed by the trie key the
+// caller passes: slot_key (single slot at index 0) for slot encoding, or
+// page_key (full page) for page encoding. The caller (TrieDb) decides the
+// key and offset based on its encoding; the cache does not.
 class DbCache final
 {
-    struct StorageKey
-    {
-        static constexpr size_t k_bytes =
-            sizeof(Address) + sizeof(Incarnation) + sizeof(bytes32_t);
-
-        uint8_t bytes[k_bytes];
-
-        StorageKey() = default;
-
-        StorageKey(
-            Address const &addr, Incarnation const incarnation,
-            bytes32_t const &key)
-        {
-            memcpy(bytes, addr.bytes, sizeof(Address));
-            memcpy(&bytes[sizeof(Address)], &incarnation, sizeof(Incarnation));
-            memcpy(
-                &bytes[sizeof(Address) + sizeof(Incarnation)],
-                key.bytes,
-                sizeof(bytes32_t));
-        }
-    };
-
     using AddressHashCompare = BytesHashCompare<Address>;
     using StorageKeyHashCompare = BytesHashCompare<StorageKey>;
     using AccountsCache =
@@ -91,23 +75,43 @@ public:
         return false;
     }
 
-    bool try_read_storage(
+    bool try_read_storage_page(
         Address const &address, Incarnation const incarnation,
-        bytes32_t const &key, bytes32_t &result)
+        bytes32_t const &key, storage_page_t &result)
     {
-        storage_page_t page;
         auto const res =
-            proposals_.try_read_storage(address, incarnation, key, page);
+            proposals_.try_read_storage(address, incarnation, key, result);
         if (res.found) {
-            // Single-slot page: the value lives at index 0.
-            result = page[0];
             return true;
         }
         if (!res.truncated) {
             StorageKey const skey{address, incarnation, key};
             StorageCache::ConstAccessor acc{};
             if (storage_.find(acc, skey)) {
-                result = acc->second.value_[0];
+                result = acc->second.value_;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool try_read_storage(
+        Address const &address, Incarnation const incarnation,
+        bytes32_t const &key, uint8_t const slot_offset, bytes32_t &result)
+    {
+        storage_page_t page;
+        auto const res =
+            proposals_.try_read_storage(address, incarnation, key, page);
+        if (res.found) {
+            // slot_offset is 0 for slot encoding, the in-page offset for page.
+            result = page[slot_offset];
+            return true;
+        }
+        if (!res.truncated) {
+            StorageKey const skey{address, incarnation, key};
+            StorageCache::ConstAccessor acc{};
+            if (storage_.find(acc, skey)) {
+                result = acc->second.value_[slot_offset];
                 return true;
             }
         }
@@ -121,11 +125,10 @@ public:
     }
 
     void update_proposal_state(
-        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
+        ProposalPostState post_state, uint64_t const block_number,
         bytes32_t const &block_id)
     {
-        MONAD_ASSERT(state_deltas);
-        proposals_.commit(std::move(state_deltas), block_number, block_id);
+        proposals_.commit(std::move(post_state), block_number, block_id);
     }
 
     void on_finalize(uint64_t const block_number, bytes32_t const &block_id)
@@ -133,7 +136,7 @@ public:
         std::unique_ptr<ProposalState> const ps =
             proposals_.finalize(block_number, block_id);
         if (ps) {
-            insert_in_lru_caches(ps->state());
+            insert_in_lru_caches(ps->post_state());
         }
         else {
             // Finalizing a truncated proposal. Clear LRU caches.
@@ -153,24 +156,13 @@ public:
     }
 
 private:
-    void insert_in_lru_caches(StateDeltas const &state_deltas)
+    void insert_in_lru_caches(ProposalPostState const &post_state)
     {
-        for (auto const &[address, delta] : state_deltas) {
-            auto const &account_delta = delta.account;
-            accounts_.insert(address, account_delta.second);
-            auto const &storage = delta.storage;
-            auto const &account = account_delta.second;
-            if (account.has_value()) {
-                for (auto const &[key, storage_delta] : storage) {
-                    auto const incarnation = account->incarnation;
-                    // Single-slot page: store the value at index 0. A zero
-                    // value leaves the page empty, so a hit reads back zero.
-                    storage_page_t page;
-                    page.set(0, storage_delta.second);
-                    storage_.insert(
-                        StorageKey(address, incarnation, key), page);
-                }
-            }
+        for (auto const &[addr, acct] : post_state.accounts) {
+            accounts_.insert(addr, acct);
+        }
+        for (auto const &[sk, leaf] : post_state.storage) {
+            storage_.insert(sk, leaf);
         }
     }
 };

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -760,6 +760,12 @@ bytes32_t PartialTrieDb::read_storage(
     return !val_result ? bytes32_t{} : val_result->value;
 }
 
+storage_page_t PartialTrieDb::read_storage_page(
+    Address const &, Incarnation, bytes32_t const &)
+{
+    MONAD_ABORT("PartialTrieDb read_storage_page is currently not supported");
+}
+
 vm::SharedIntercode PartialTrieDb::read_code(bytes32_t const &code_hash)
 {
     auto it = codes_.find(code_hash);

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -167,6 +167,9 @@ public:
     bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
 
+    storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) override;
+
     vm::SharedIntercode read_code(bytes32_t const &code_hash) override;
 
     BlockHeader read_eth_header() override;

--- a/category/execution/ethereum/db/storage_key.hpp
+++ b/category/execution/ethereum/db/storage_key.hpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+
+#include <cstring>
+
+MONAD_NAMESPACE_BEGIN
+
+// Composite cache key combining account address, account incarnation, and
+// the storage trie key. The trie key is slot_key for slot-encoded storage
+// or page_key for page-encoded storage; the cache layer is encoding-agnostic.
+struct StorageKey
+{
+    static constexpr size_t k_bytes =
+        sizeof(Address) + sizeof(Incarnation) + sizeof(bytes32_t);
+
+    uint8_t bytes[k_bytes];
+
+    StorageKey() = default;
+
+    StorageKey(
+        Address const &addr, Incarnation const incarnation,
+        bytes32_t const &key)
+    {
+        memcpy(bytes, addr.bytes, sizeof(Address));
+        memcpy(&bytes[sizeof(Address)], &incarnation, sizeof(Incarnation));
+        memcpy(
+            &bytes[sizeof(Address) + sizeof(Incarnation)],
+            key.bytes,
+            sizeof(bytes32_t));
+    }
+
+    bool operator==(StorageKey const &other) const
+    {
+        return memcmp(bytes, other.bytes, k_bytes) == 0;
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -19,6 +19,7 @@
 #include <category/execution/ethereum/db/commit_builder.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 
 #include <memory>
 #include <optional>
@@ -45,18 +46,19 @@ namespace test
         std::optional<std::vector<Withdrawal>> const &withdrawals =
             std::nullopt)
     {
-        CommitBuilder builder(header.number);
-        builder.add_state_deltas(*deltas)
+        std::unique_ptr<CommitBuilder> builder =
+            make_commit_builder(header.number, db);
+        builder->add_state_deltas(*deltas)
             .add_code(code)
             .add_receipts(receipts)
             .add_transactions(txns, senders)
             .add_call_frames(call_frames)
             .add_ommers(ommers);
         if (withdrawals.has_value()) {
-            builder.add_withdrawals(withdrawals.value());
+            builder->add_withdrawals(withdrawals.value());
         }
         db.commit(
-            block_id, builder, header, std::move(deltas), [&](BlockHeader &h) {
+            block_id, *builder, header, std::move(deltas), [&](BlockHeader &h) {
                 h.receipts_root = db.receipts_root();
                 h.state_root = db.state_root();
                 h.withdrawals_root = db.withdrawals_root();

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -300,14 +300,6 @@ void TrieDb::set_block_and_prefix(
 // also changes internal state to the finalized state
 void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
 {
-    // no re-finalization
-    auto const latest_finalized = db_.get_latest_finalized_version();
-    MONAD_ASSERT_PRINTF(
-        latest_finalized == INVALID_BLOCK_NUM ||
-            block_number == latest_finalized + 1,
-        "block_number %lu is not the next finalized block after %lu",
-        block_number,
-        latest_finalized);
     MONAD_ASSERT(block_id != bytes32_t{});
     if (db_.is_on_disk()) {
         auto const src_prefix = proposal_prefix(block_id);
@@ -328,13 +320,6 @@ void TrieDb::finalize(uint64_t const block_number, bytes32_t const &block_id)
 
 void TrieDb::update_verified_block(uint64_t const block_number)
 {
-    // no re-verification
-    auto const latest_verified = db_.get_latest_verified_version();
-    MONAD_ASSERT_PRINTF(
-        latest_verified == INVALID_BLOCK_NUM || block_number > latest_verified,
-        "block_number %lu must be greater than last_verified %lu",
-        block_number,
-        latest_verified);
     db_.update_verified_version(block_number);
 }
 

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -37,15 +37,19 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/rlp/call_frame_rlp.hpp>
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/nibbles_view_fmt.hpp> // NOLINT
 #include <category/mpt/node.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/update.hpp>
 #include <category/mpt/util.hpp>
@@ -80,6 +84,7 @@ TrieDb::TrieDb(mpt::Db &db, bool const enable_multiblock_cache)
     , prefix_{finalized_nibbles}
     , curr_root_{db.load_root_for_version(block_number_)}
     , cache_{enable_multiblock_cache ? std::make_unique<DbCache>() : nullptr}
+    , page_encoded_{db_.state_machine_type() == mpt::state_machine_kind::monad}
 {
 }
 
@@ -121,8 +126,11 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
 bytes32_t TrieDb::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
+    bytes32_t const lookup_key = page_encoded_ ? compute_page_key(key) : key;
+    uint8_t const lookup_offset = page_encoded_ ? compute_slot_offset(key) : 0;
     bytes32_t result{};
-    if (cache_ && cache_->try_read_storage(addr, incarnation, key, result)) {
+    if (cache_ && cache_->try_read_storage(
+                      addr, incarnation, lookup_key, lookup_offset, result)) {
         return result;
     }
     auto const res = db_.find(
@@ -131,7 +139,8 @@ bytes32_t TrieDb::read_storage(
             prefix_,
             STATE_NIBBLE,
             NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
-            NibblesView{keccak256({key.bytes, sizeof(key.bytes)})}),
+            NibblesView{
+                keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
         block_number_);
     if (res.has_error()) {
         stats_storage_no_value();
@@ -139,9 +148,52 @@ bytes32_t TrieDb::read_storage(
     }
     stats_storage_value();
     auto encoded_storage = res.value().node->value();
-    auto const storage = decode_storage_db_ignore_key(encoded_storage);
-    MONAD_ASSERT(!storage.has_error());
-    return to_bytes(storage.value());
+    auto const value = decode_storage_db_ignore_key(encoded_storage);
+    MONAD_ASSERT(!value.has_error());
+    if (page_encoded_) {
+        auto const page = decode_storage_page(value.value());
+        MONAD_ASSERT(!page.has_error());
+        return page.value()[lookup_offset];
+    }
+    else {
+        return to_bytes(value.value());
+    }
+}
+
+storage_page_t TrieDb::read_storage_page(
+    Address const &addr, Incarnation const incarnation,
+    bytes32_t const &page_key)
+{
+    if (!page_encoded_) {
+        MONAD_ABORT("read_storage_page is only valid on a page-encoded TrieDb");
+    }
+    else {
+        storage_page_t result;
+        if (cache_ && cache_->try_read_storage_page(
+                          addr, incarnation, page_key, result)) {
+            return result;
+        }
+        auto const res = db_.find(
+            curr_root_,
+            concat(
+                prefix_,
+                STATE_NIBBLE,
+                NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
+                NibblesView{
+                    keccak256({page_key.bytes, sizeof(page_key.bytes)})}),
+            block_number_);
+        if (res.has_error()) {
+            stats_storage_no_value();
+            return {};
+        }
+        stats_storage_value();
+        auto encoded_storage = res.value().node->value();
+        auto const value = decode_storage_db_ignore_key(encoded_storage);
+        MONAD_ASSERT(!value.has_error());
+        auto const page = decode_storage_page(value.value());
+        MONAD_ASSERT(!page.has_error());
+        return page.value();
+    }
 }
 
 vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)
@@ -165,6 +217,16 @@ void TrieDb::commit(
     BlockHeader const &header, std::unique_ptr<StateDeltas> state_deltas,
     std::function<void(BlockHeader &)> const populate_header_fn)
 {
+    // The builder must be a PageCommitBuilder iff this db is page-encoded;
+    // PageCommitBuilder is the only builder that produces page-keyed updates.
+    MONAD_ASSERT_PRINTF(
+        (dynamic_cast<PageCommitBuilder const *>(&builder) != nullptr) ==
+            is_page_encoded(),
+        "encoding mismatch at block %lu: TrieDb::is_page_encoded=%d but commit "
+        "builder is of wrong type",
+        header.number,
+        is_page_encoded());
+
     auto const block_number = header.number;
     MONAD_ASSERT(block_number <= std::numeric_limits<int64_t>::max());
     MONAD_ASSERT(state_deltas);
@@ -205,7 +267,7 @@ void TrieDb::commit(
 
     if (cache_) {
         cache_->update_proposal_state(
-            std::move(state_deltas), header.number, block_id);
+            builder.take_proposal_post_state(), header.number, block_id);
     }
 }
 
@@ -445,28 +507,61 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
             MONAD_ASSERT(node.has_value());
 
             auto encoded_storage = node.value();
-
-            auto const storage = decode_storage_db(encoded_storage);
+            auto raw_res = decode_storage_db_raw(encoded_storage);
+            MONAD_ASSERT(raw_res.has_value());
 
             auto const acct_key = fmt::format(
                 "{}", NibblesView{path}.substr(0, KECCAK256_SIZE * 2));
 
-            auto const key = fmt::format(
-                "{}",
-                NibblesView{path}.substr(
-                    KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
+            if (db.is_page_encoded()) {
+                // Page-encoded leaf: first element of the RLP list is the
+                // page_key (compact), second is the encoded page bytes.
+                // Fan out one JSON entry per populated slot, keyed by
+                // keccak256(slot_key) so the output matches a slot dump.
+                bytes32_t const page_key = to_bytes(raw_res.value().first);
+                auto const page = decode_storage_page(raw_res.value().second);
+                MONAD_ASSERT(page.has_value());
+                for (uint8_t off = 0; off < storage_page_t::SLOTS; ++off) {
+                    auto const &slot_value = page.value()[off];
+                    if (slot_value == bytes32_t{}) {
+                        continue;
+                    }
+                    bytes32_t const slot_key = compute_slot_key(page_key, off);
+                    auto const hashed_slot_key = to_bytes(
+                        keccak256({slot_key.bytes, sizeof(slot_key.bytes)}));
+                    auto const key = fmt::format("{}", hashed_slot_key);
+                    auto storage_data_json = nlohmann::json::object();
+                    storage_data_json["slot"] = fmt::format(
+                        "0x{:02x}",
+                        fmt::join(
+                            std::as_bytes(std::span(slot_key.bytes)), ""));
+                    storage_data_json["value"] = fmt::format(
+                        "0x{:02x}",
+                        fmt::join(
+                            std::as_bytes(std::span(slot_value.bytes)), ""));
+                    json[acct_key]["storage"][key] = storage_data_json;
+                }
+            }
+            else {
+                // Slot-encoded leaf: trie path under the account is
+                // keccak256(slot_key); the leaf carries (slot_key,
+                // slot_value).
+                bytes32_t const slot_key = to_bytes(raw_res.value().first);
+                bytes32_t const slot_value = to_bytes(raw_res.value().second);
+                auto const key = fmt::format(
+                    "{}",
+                    NibblesView{path}.substr(
+                        KECCAK256_SIZE * 2, KECCAK256_SIZE * 2));
 
-            auto storage_data_json = nlohmann::json::object();
-            storage_data_json["slot"] = fmt::format(
-                "0x{:02x}",
-                fmt::join(
-                    std::as_bytes(std::span(storage.value().first.bytes)), ""));
-            storage_data_json["value"] = fmt::format(
-                "0x{:02x}",
-                fmt::join(
-                    std::as_bytes(std::span(storage.value().second.bytes)),
-                    ""));
-            json[acct_key]["storage"][key] = storage_data_json;
+                auto storage_data_json = nlohmann::json::object();
+                storage_data_json["slot"] = fmt::format(
+                    "0x{:02x}",
+                    fmt::join(std::as_bytes(std::span(slot_key.bytes)), ""));
+                storage_data_json["value"] = fmt::format(
+                    "0x{:02x}",
+                    fmt::join(std::as_bytes(std::span(slot_value.bytes)), ""));
+                json[acct_key]["storage"][key] = storage_data_json;
+            }
         }
 
         virtual std::unique_ptr<TraverseMachine> clone() const override

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -55,10 +55,18 @@ class TrieDb final : public ::monad::Db
     // We only want to pay that price when the cache is enabled, hence
     // the need for unique_ptr.
     std::unique_ptr<DbCache> cache_;
+    // True iff this trie reads / writes page-encoded storage (MIP-8).
+    // Set at construction; immutable. Exposed via is_page_encoded().
+    bool const page_encoded_;
 
 public:
     explicit TrieDb(mpt::Db &, bool enable_multiblock_cache = false);
     ~TrieDb();
+
+    bool is_page_encoded() const override
+    {
+        return page_encoded_;
+    }
 
     void reset_root(::monad::mpt::Node::SharedPtr root, uint64_t block_number);
     ::monad::mpt::Node::SharedPtr const &get_root() const;
@@ -66,6 +74,8 @@ public:
     virtual std::optional<Account> read_account(Address const &) override;
     virtual bytes32_t
     read_storage(Address const &, Incarnation, bytes32_t const &key) override;
+    virtual storage_page_t read_storage_page(
+        Address const &, Incarnation, bytes32_t const &page_key) override;
     virtual vm::SharedIntercode read_code(bytes32_t const &) override;
     virtual void set_block_and_prefix(
         uint64_t block_number,

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -30,6 +30,8 @@
 
 MONAD_NAMESPACE_BEGIN
 
+// TODO: add runtime page_encoded flag as well. Will need it for post fork in
+// release2
 class TrieRODb final : public ::monad::Db
 {
     ::monad::mpt::RODb &db_;
@@ -110,6 +112,12 @@ public:
         auto const storage = decode_storage_db_ignore_key(encoded_storage);
         MONAD_ASSERT(!storage.has_error());
         return to_bytes(storage.value());
+    }
+
+    virtual storage_page_t
+    read_storage_page(Address const &, Incarnation, bytes32_t const &) override
+    {
+        MONAD_ABORT("TrieRODb read_storage_page is currently not supported");
     }
 
     virtual vm::SharedIntercode read_code(bytes32_t const &code_hash) override

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -45,6 +45,7 @@
 #include <category/mpt/node.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/traverse_util.hpp>
 #include <category/mpt/update.hpp>
@@ -560,6 +561,11 @@ mpt::Compute &MachineBase::storage_root_compute() const
     return compute;
 }
 
+mpt::state_machine_kind InMemoryMachine::kind() const
+{
+    return mpt::state_machine_kind::ethereum;
+}
+
 bool InMemoryMachine::cache() const
 {
     return true;
@@ -573,6 +579,11 @@ bool InMemoryMachine::compact() const
 std::unique_ptr<StateMachine> InMemoryMachine::clone() const
 {
     return std::make_unique<InMemoryMachine>(*this);
+}
+
+mpt::state_machine_kind MonadInMemoryMachine::kind() const
+{
+    return mpt::state_machine_kind::monad;
 }
 
 std::unique_ptr<StateMachine> MonadInMemoryMachine::clone() const
@@ -590,6 +601,11 @@ mpt::Compute &MonadInMemoryMachine::storage_root_compute() const
 {
     static PagedStorageRootMerkleCompute compute;
     return compute;
+}
+
+mpt::state_machine_kind OnDiskMachine::kind() const
+{
+    return mpt::state_machine_kind::ethereum;
 }
 
 bool OnDiskMachine::cache() const
@@ -614,6 +630,11 @@ bool OnDiskMachine::auto_expire() const
 std::unique_ptr<StateMachine> OnDiskMachine::clone() const
 {
     return std::make_unique<OnDiskMachine>(*this);
+}
+
+mpt::state_machine_kind MonadOnDiskMachine::kind() const
+{
+    return mpt::state_machine_kind::monad;
 }
 
 std::unique_ptr<StateMachine> MonadOnDiskMachine::clone() const

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -96,6 +96,7 @@ static_assert(alignof(MachineBase) == 8);
 
 struct InMemoryMachine : public MachineBase
 {
+    virtual mpt::state_machine_kind kind() const override;
     virtual bool cache() const override;
     virtual bool compact() const override;
     virtual std::unique_ptr<StateMachine> clone() const override;
@@ -103,6 +104,7 @@ struct InMemoryMachine : public MachineBase
 
 struct OnDiskMachine : public MachineBase
 {
+    virtual mpt::state_machine_kind kind() const override;
     virtual bool cache() const override;
     virtual bool compact() const override;
     virtual bool auto_expire() const override;
@@ -113,6 +115,7 @@ struct OnDiskMachine : public MachineBase
 // chain is at a revision that persists storage as pages instead of slots.
 struct MonadInMemoryMachine final : public InMemoryMachine
 {
+    virtual mpt::state_machine_kind kind() const override;
     virtual std::unique_ptr<StateMachine> clone() const override;
 
 protected:
@@ -124,6 +127,7 @@ protected:
 // chain is at a revision that persists storage as pages instead of slots.
 struct MonadOnDiskMachine final : public OnDiskMachine
 {
+    virtual mpt::state_machine_kind kind() const override;
     virtual std::unique_ptr<StateMachine> clone() const override;
 
 protected:

--- a/category/execution/ethereum/state2/block_state.cpp
+++ b/category/execution/ethereum/state2/block_state.cpp
@@ -45,8 +45,9 @@
 
 MONAD_NAMESPACE_BEGIN
 
-BlockState::BlockState(Db &db, vm::VM &monad_vm)
+BlockState::BlockState(Db &db, vm::VM &monad_vm, Db *const secondary_db)
     : db_{db}
+    , secondary_db_{secondary_db}
     , vm_{monad_vm}
     , state_(std::make_unique<StateDeltas>())
 {
@@ -101,9 +102,13 @@ bytes32_t BlockState::read_storage(
     }
     // database
     {
-        auto const result = read_storage
-                                ? db_.read_storage(address, incarnation, key)
-                                : bytes32_t{};
+        bytes32_t result{};
+        if (read_storage) {
+            result = db_.read_storage(address, incarnation, key);
+            MONAD_ASSERT(
+                !secondary_db_ || secondary_db_->read_storage(
+                                      address, incarnation, key) == result);
+        }
         StateDeltas::accessor it{};
         MONAD_ASSERT(state_->find(it, address));
         auto const &account = it->second.account.second;

--- a/category/execution/ethereum/state2/block_state.hpp
+++ b/category/execution/ethereum/state2/block_state.hpp
@@ -41,6 +41,11 @@ using SelfDestructStorageReads = ankerl::unordered_dense::segmented_map<
 class BlockState final
 {
     Db &db_;
+    // Optional cross-check db: when non-null, every storage read is also
+    // performed against this db and the result asserted to match. Used by
+    // the dual-db migration path to detect divergence between the slot-
+    // encoded primary and the page-encoded secondary.
+    Db *secondary_db_;
     vm::VM &vm_;
     std::unique_ptr<StateDeltas> state_;
     Code code_;
@@ -57,7 +62,7 @@ class BlockState final
     SelfDestructStorageReads self_destruct_storage_reads_;
 
 public:
-    BlockState(Db &, vm::VM &);
+    BlockState(Db &, vm::VM &, Db *secondary_db = nullptr);
 
     vm::VM &vm()
     {

--- a/category/execution/ethereum/state2/proposal_post_state.hpp
+++ b/category/execution/ethereum/state2/proposal_post_state.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <optional>
+
+MONAD_NAMESPACE_BEGIN
+
+// Account map keyed by Address. nullopt means the account was deleted (or
+// does not exist) for the proposal at hand. Populated by
+// CommitBuilder::add_state_deltas (one entry per touched account) and drained
+// via CommitBuilder::take_proposal_post_state.
+using AccountPostState =
+    ankerl::unordered_dense::segmented_map<Address, std::optional<Account>>;
+
+// Storage leaf map keyed by StorageKey{addr, incarnation, key}. The key
+// granularity matches the trie's storage subtree: slot_key (single slot at
+// index 0) for slot mode, page_key (full page) for page mode. The
+// key being present marks "touched by this proposal"; an empty
+// storage_page_t means every slot in that entry is zero (deleted), which is
+// stored as a present entry rather than absent.
+using StoragePostState = ankerl::unordered_dense::segmented_map<
+    StorageKey, storage_page_t, BytesHashCompare<StorageKey>>;
+
+struct ProposalPostState
+{
+    AccountPostState accounts;
+    StoragePostState storage;
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -110,6 +110,29 @@ namespace
         }
     };
 
+    struct PageEncodedOnDiskStateTest : public ::testing::Test
+    {
+        mpt::Db db{/* use the page encoded state machine*/
+                   std::make_unique<MonadOnDiskMachine>(),
+                   mpt::OnDiskDbConfig{}};
+        TrieDb tdb{db};
+        vm::VM vm;
+
+        explicit PageEncodedOnDiskStateTest(bool const cache = false)
+            : tdb{db, cache}
+        {
+        }
+    };
+
+    template <typename T>
+    struct OnDiskTestSuite : public T
+    {
+    };
+
+    using OnDiskTestTypes =
+        ::testing::Types<OnDiskStateTest, PageEncodedOnDiskStateTest>;
+    TYPED_TEST_SUITE(OnDiskTestSuite, OnDiskTestTypes);
+
     struct OnDiskStateTestCached : public OnDiskStateTest
     {
         OnDiskStateTestCached()
@@ -118,6 +141,23 @@ namespace
         }
     };
 
+    struct PageEncodedOnDiskStateTestCached : public PageEncodedOnDiskStateTest
+    {
+        PageEncodedOnDiskStateTestCached()
+            : PageEncodedOnDiskStateTest(/*cache=*/true)
+        {
+        }
+    };
+
+    template <typename T>
+    struct OnDiskCachedTestSuite : public T
+    {
+    };
+
+    using OnDiskCachedTestTypes = ::testing::Types<
+        OnDiskStateTestCached, PageEncodedOnDiskStateTestCached>;
+    TYPED_TEST_SUITE(OnDiskCachedTestSuite, OnDiskCachedTestTypes);
+
     struct InMemoryStateTest
         : public InMemoryStateTestBase
         , public ::testing::Test
@@ -125,10 +165,21 @@ namespace
     };
 
     template <typename T>
-    struct InMemoryStateTraitsTest
-        : public InMemoryStateTestBase
-        , public TraitsTest<T>
+    struct InMemoryStateTraitsTest : public TraitsTest<T>
     {
+        static std::unique_ptr<mpt::StateMachine> make_machine()
+        {
+            if constexpr (TraitsTest<T>::Trait::mip_8_active()) {
+                return std::make_unique<MonadInMemoryMachine>();
+            }
+            else {
+                return std::make_unique<InMemoryMachine>();
+            }
+        }
+
+        mpt::Db db{make_machine()};
+        TrieDb tdb{db};
+        vm::VM vm;
     };
 
     struct TwoOnDisk : public ::testing::Test
@@ -667,9 +718,17 @@ TYPED_TEST(
             EXPECT_EQ(
                 this->tdb.read_storage(a, Incarnation{1, 2}, key3), value3);
 
-            EXPECT_EQ(
-                this->tdb.state_root(),
-                0x425AE06EDEDEC27A17412E8A2BC2F148A4AF94EE510FFB7AEA81E1ABF5450768_bytes32);
+            if constexpr (TestFixture::Trait::mip_8_active()) {
+                // Page-encoded storage produces a different state root.
+                EXPECT_EQ(
+                    this->tdb.state_root(),
+                    0x8249283C79A69C21B7EFAD8F4AB8904CA55FE2F5016110096F7C7624378CDBA7_bytes32);
+            }
+            else {
+                EXPECT_EQ(
+                    this->tdb.state_root(),
+                    0x425AE06EDEDEC27A17412E8A2BC2F148A4AF94EE510FFB7AEA81E1ABF5450768_bytes32);
+            }
         }
         else {
             EXPECT_EQ(this->tdb.read_storage(a, Incarnation{1, 2}, key3), null);
@@ -1594,7 +1653,7 @@ TYPED_TEST(InMemoryStateTraitsTest, commit_twice)
     }
 }
 
-TEST_F(OnDiskStateTest, commit_multiple_proposals)
+TYPED_TEST(OnDiskTestSuite, commit_multiple_proposals)
 {
     load_header({}, this->db, BlockHeader{.number = 9});
 
@@ -1720,7 +1779,7 @@ TEST_F(OnDiskStateTest, commit_multiple_proposals)
     EXPECT_EQ(state_root_round8, this->tdb.state_root());
 }
 
-TEST_F(OnDiskStateTestCached, proposal_basics)
+TYPED_TEST(OnDiskCachedTestSuite, proposal_basics)
 {
     this->tdb.reset_root(
         load_header({}, this->db, BlockHeader{.number = 9}), 9);
@@ -1778,7 +1837,7 @@ TEST_F(OnDiskStateTestCached, proposal_basics)
     EXPECT_EQ(db.read_account(a).value().balance, 30'000);
 }
 
-TEST_F(OnDiskStateTestCached, undecided_proposals)
+TYPED_TEST(OnDiskCachedTestSuite, undecided_proposals)
 {
     load_header({}, this->db, BlockHeader{.number = 9});
     Db &db = this->tdb;

--- a/category/execution/monad/db/commit_block_migration.cpp
+++ b/category/execution/monad/db/commit_block_migration.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/validate_block.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/vm/evm/explicit_traits.hpp>
+#include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/traits.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void commit_block(
+    Db &primary_db, Db *const secondary_db, bytes32_t const &block_id,
+    BlockHeader const &header, StateDeltas const &state,
+    BlockCommitAncillaries const &anc)
+{
+    auto add_common_deltas = [&](CommitBuilder &b) {
+        b.add_code(anc.code)
+            .add_receipts(anc.receipts)
+            .add_transactions(anc.transactions, anc.senders)
+            .add_call_frames(anc.call_frames)
+            .add_ommers(anc.ommers);
+        if (anc.withdrawals.has_value()) {
+            b.add_withdrawals(anc.withdrawals.value());
+        }
+    };
+
+    // `canonical_db` is the "source of truth" Db the header populator reads
+    // roots from. Both commits call populate_header via this same pointer, so
+    // both dbs end up with identical block headers. The pointer is assigned
+    // just before the commits run. Non-state roots are the same on both dbs, so
+    // the choice only really changes which state_root is stamped into the
+    // header.
+    Db *canonical_db = nullptr;
+    auto populate_header = [&](BlockHeader &h) {
+        MONAD_ASSERT(canonical_db != nullptr);
+        h.receipts_root = canonical_db->receipts_root();
+        h.state_root = canonical_db->state_root();
+        h.withdrawals_root = canonical_db->withdrawals_root();
+        h.transactions_root = canonical_db->transactions_root();
+        h.gas_used = anc.receipts.empty() ? 0 : anc.receipts.back().gas_used;
+        h.logs_bloom = compute_bloom(anc.receipts);
+        h.ommers_hash = compute_ommers_hash(anc.ommers);
+    };
+
+    // TODO: Db::commit currently takes std::unique_ptr<StateDeltas> by value,
+    // so each commit below wraps `state` in a fresh make_unique copy. Once the
+    // commit API is changed to take StateDeltas by reference, drop these copies
+    // and pass `state` directly.
+    if (secondary_db == nullptr) {
+        MONAD_ASSERT(primary_db.is_page_encoded() == traits::mip_8_active());
+        auto builder = make_commit_builder(header.number, primary_db);
+        builder->add_state_deltas(state);
+        add_common_deltas(*builder);
+        canonical_db = &primary_db;
+        primary_db.commit(
+            block_id,
+            *builder,
+            header,
+            std::make_unique<StateDeltas>(state),
+            populate_header);
+        return;
+    }
+
+    // Dual-write migration path. The primary and secondary dbs write the same
+    // data to every table; the only difference is state encoding. state_deltas
+    // is added separately to each builder so the page builder's override can
+    // kick in; everything else goes through the shared helper.
+    MONAD_ASSERT(
+        !primary_db.is_page_encoded() && secondary_db->is_page_encoded());
+    auto builder = make_commit_builder(header.number, primary_db);
+    builder->add_state_deltas(state);
+    add_common_deltas(*builder);
+
+    auto builder2 = make_commit_builder(header.number, *secondary_db);
+    builder2->add_state_deltas(state);
+    add_common_deltas(*builder2);
+
+    // The canonical db owns the state_root stamped into the header: pre-fork
+    // the slot-encoded primary, post-fork (mip-8 active) the page-encoded
+    // secondary. The canonical db commits first so its roots are live when the
+    // other db's populate_header runs.
+    bool const primary_is_canonical = !traits::mip_8_active();
+    canonical_db = primary_is_canonical ? &primary_db : secondary_db;
+    if (primary_is_canonical) {
+        primary_db.commit(
+            block_id,
+            *builder,
+            header,
+            std::make_unique<StateDeltas>(state),
+            populate_header);
+        secondary_db->commit(
+            block_id,
+            *builder2,
+            header,
+            std::make_unique<StateDeltas>(state),
+            populate_header);
+    }
+    else {
+        secondary_db->commit(
+            block_id,
+            *builder2,
+            header,
+            std::make_unique<StateDeltas>(state),
+            populate_header);
+        primary_db.commit(
+            block_id,
+            *builder,
+            header,
+            std::make_unique<StateDeltas>(state),
+            populate_header);
+    }
+}
+
+EXPLICIT_MONAD_TRAITS(commit_block);
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/commit_block_migration.hpp
+++ b/category/execution/monad/db/commit_block_migration.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/vm/evm/traits.hpp>
+
+#include <optional>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+struct BlockHeader;
+struct CallFrame;
+struct Receipt;
+struct Transaction;
+struct Withdrawal;
+struct Db;
+
+// Per-block ancillary inputs that the dual commit path forwards to the
+// shared CommitBuilder helpers. State deltas are passed separately because
+// each builder (slot for Db1, page for Db2) has its own add_state_deltas
+// override that needs the same StateDeltas instance.
+struct BlockCommitAncillaries
+{
+    Code const &code;
+    std::vector<Receipt> const &receipts;
+    std::vector<Transaction> const &transactions;
+    std::vector<Address> const &senders;
+    std::vector<std::vector<CallFrame>> const &call_frames;
+    std::vector<BlockHeader> const &ommers;
+    std::optional<std::vector<Withdrawal>> const &withdrawals;
+};
+
+template <Traits traits>
+    requires is_monad_trait_v<traits>
+void commit_block(
+    Db &primary_db, Db *secondary_db, bytes32_t const &block_id,
+    BlockHeader const &header, StateDeltas const &state,
+    BlockCommitAncillaries const &anc);
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.cpp
+++ b/category/execution/monad/db/page_commit_builder.cpp
@@ -37,6 +37,15 @@ PageCommitBuilder::PageCommitBuilder(uint64_t const block_number, monad::Db &db)
 {
 }
 
+std::unique_ptr<CommitBuilder>
+make_commit_builder(uint64_t const block_number, monad::Db &db)
+{
+    if (db.is_page_encoded()) {
+        return std::make_unique<PageCommitBuilder>(block_number, db);
+    }
+    return std::make_unique<CommitBuilder>(block_number);
+}
+
 CommitBuilder &
 PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
 {

--- a/category/execution/monad/db/page_commit_builder.cpp
+++ b/category/execution/monad/db/page_commit_builder.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/keccak.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+#include <category/mpt/update.hpp>
+#include <category/mpt/util.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+MONAD_NAMESPACE_BEGIN
+
+using namespace monad::mpt;
+
+PageCommitBuilder::PageCommitBuilder(uint64_t const block_number, monad::Db &db)
+    : CommitBuilder{block_number}
+    , db_{db}
+{
+}
+
+CommitBuilder &
+PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
+{
+    UpdateList account_updates;
+    for (auto const &[addr, delta] : state_deltas) {
+        UpdateList storage_updates;
+        std::optional<byte_string_view> value;
+        auto const &account = delta.account.second;
+        proposal_post_state_.accounts[addr] = account;
+        if (account.has_value()) {
+            Incarnation const inc = account->incarnation;
+
+            // Page granularity per account: keyed by page_key, value is the
+            // mutable storage_page_t being merged. Each first-touch of a
+            // page reads the current page from the db so subsequent slot
+            // writes at the same page_key compose into one update.
+            ankerl::unordered_dense::segmented_map<
+                bytes32_t,
+                storage_page_t,
+                BytesHashCompare<bytes32_t>>
+                pages;
+
+            for (auto const &[key, slot_delta] : delta.storage) {
+                if (slot_delta.first != slot_delta.second) {
+                    auto const pg_key = compute_page_key(key);
+                    auto const slot_off = compute_slot_offset(key);
+                    auto [it, inserted] = pages.try_emplace(pg_key);
+                    if (inserted) {
+                        it->second = db_.read_storage_page(addr, inc, pg_key);
+                    }
+                    it->second.set(slot_off, slot_delta.second);
+                }
+            }
+
+            for (auto const &[page_key, page] : pages) {
+                bool const is_empty = page.is_empty();
+                // Record the post-commit page for the proposal cache. An empty
+                // page is still stored (entry present, all slots zero); the
+                // trie gets a deletion (nullopt) since it holds no empty leaf.
+                StorageKey const sk{addr, inc, page_key};
+                proposal_post_state_.storage[sk] = page;
+                storage_updates.push_front(update_alloc_.emplace_back(Update{
+                    .key = hash_alloc_.emplace_back(
+                        keccak256({page_key.bytes, sizeof(page_key.bytes)})),
+                    .value = is_empty ? std::nullopt
+                                      : std::make_optional<byte_string_view>(
+                                            bytes_alloc_.emplace_back(
+                                                encode_storage_page_db(
+                                                    page_key, page))),
+                    .incarnation = false,
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(block_number_)}));
+            }
+            value = bytes_alloc_.emplace_back(
+                encode_account_db(addr, account.value()));
+        }
+
+        if (!storage_updates.empty() || delta.account.first != account) {
+            bool const incarnation =
+                account.has_value() && delta.account.first.has_value() &&
+                delta.account.first->incarnation != account->incarnation;
+            account_updates.push_front(update_alloc_.emplace_back(Update{
+                .key = hash_alloc_.emplace_back(
+                    keccak256({addr.bytes, sizeof(addr.bytes)})),
+                .value = value,
+                .incarnation = incarnation,
+                .next = std::move(storage_updates),
+                .version = static_cast<int64_t>(block_number_)}));
+        }
+    }
+
+    updates_.push_front(update_alloc_.emplace_back(Update{
+        .key = state_nibbles,
+        .value = byte_string_view{},
+        .incarnation = false,
+        .next = std::move(account_updates),
+        .version = static_cast<int64_t>(block_number_)}));
+
+    return *this;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.cpp
+++ b/category/execution/monad/db/page_commit_builder.cpp
@@ -55,13 +55,17 @@ PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
         std::optional<byte_string_view> value;
         auto const &account = delta.account.second;
         proposal_post_state_.accounts[addr] = account;
+        // reincarnated account starts with empty storage.
+        bool const reincarnated =
+            account.has_value() && delta.account.first.has_value() &&
+            delta.account.first->incarnation != account->incarnation;
         if (account.has_value()) {
             Incarnation const inc = account->incarnation;
-
-            // Page granularity per account: keyed by page_key, value is the
-            // mutable storage_page_t being merged. Each first-touch of a
-            // page reads the current page from the db so subsequent slot
-            // writes at the same page_key compose into one update.
+            // Storage changes in page granularity per account: keyed by
+            // page_key, value is the mutable storage_page_t being merged. Each
+            // first-touch of a page reads the current page from the db so
+            // subsequent slot writes at the same page_key compose into one
+            // update.
             ankerl::unordered_dense::segmented_map<
                 bytes32_t,
                 storage_page_t,
@@ -74,7 +78,12 @@ PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
                     auto const slot_off = compute_slot_offset(key);
                     auto [it, inserted] = pages.try_emplace(pg_key);
                     if (inserted) {
-                        it->second = db_.read_storage_page(addr, inc, pg_key);
+                        // On reincarnation, start from an empty page rather
+                        // than read_storage_page
+                        it->second =
+                            reincarnated
+                                ? storage_page_t{}
+                                : db_.read_storage_page(addr, inc, pg_key);
                     }
                     it->second.set(slot_off, slot_delta.second);
                 }
@@ -104,14 +113,11 @@ PageCommitBuilder::add_state_deltas(StateDeltas const &state_deltas)
         }
 
         if (!storage_updates.empty() || delta.account.first != account) {
-            bool const incarnation =
-                account.has_value() && delta.account.first.has_value() &&
-                delta.account.first->incarnation != account->incarnation;
             account_updates.push_front(update_alloc_.emplace_back(Update{
                 .key = hash_alloc_.emplace_back(
                     keccak256({addr.bytes, sizeof(addr.bytes)})),
                 .value = value,
-                .incarnation = incarnation,
+                .incarnation = reincarnated,
                 .next = std::move(storage_updates),
                 .version = static_cast<int64_t>(block_number_)}));
         }

--- a/category/execution/monad/db/page_commit_builder.hpp
+++ b/category/execution/monad/db/page_commit_builder.hpp
@@ -15,37 +15,26 @@
 
 #pragma once
 
-#include <category/core/config.hpp>
+#include <category/execution/ethereum/db/commit_builder.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#include <komihash.h>
-#pragma GCC diagnostic pop
+#include <memory>
 
 MONAD_NAMESPACE_BEGIN
 
-template <class Bytes>
-struct BytesHashCompare
+struct Db;
+
+class PageCommitBuilder final : public CommitBuilder
 {
-    // Ankerl-style hasher requirement.
-    using is_avalanching = void;
+    Db &db_;
 
-    // TBB concurrent_hash_map calls hash() / equal(); ankerl::unordered_dense
-    // calls operator() / equal(). Provide both from the same type.
-    size_t hash(Bytes const &a) const
-    {
-        return komihash(a.bytes, sizeof(Bytes), 0);
-    }
+public:
+    PageCommitBuilder(uint64_t block_number, Db &db);
 
-    size_t operator()(Bytes const &a) const
-    {
-        return hash(a);
-    }
-
-    bool equal(Bytes const &a, Bytes const &b) const
-    {
-        return memcmp(a.bytes, b.bytes, sizeof(Bytes)) == 0;
-    }
+    // Materializes pages from slot deltas, writes per-page updates, and
+    // populates the inherited `proposal_post_state_` with page-keyed
+    // storage_page_t entries. Use `take_proposal_post_state()` after this to
+    // consume the result.
+    CommitBuilder &add_state_deltas(StateDeltas const &) override;
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/db/page_commit_builder.hpp
+++ b/category/execution/monad/db/page_commit_builder.hpp
@@ -37,4 +37,9 @@ public:
     CommitBuilder &add_state_deltas(StateDeltas const &) override;
 };
 
+// Selects the builder matching the db encoding: PageCommitBuilder for a
+// page-encoded db, plain CommitBuilder otherwise.
+std::unique_ptr<CommitBuilder>
+make_commit_builder(uint64_t block_number, Db &db);
+
 MONAD_NAMESPACE_END

--- a/category/execution/monad/db/storage_page.hpp
+++ b/category/execution/monad/db/storage_page.hpp
@@ -43,6 +43,12 @@ struct storage_page_t
 
     storage_page_t() noexcept = default;
 
+    // Single-slot page holding `value` at offset 0 (empty if value is zero).
+    explicit storage_page_t(bytes32_t const &value)
+    {
+        set(0, value);
+    }
+
     bool operator==(storage_page_t const &other) const = default;
 
     bytes32_t operator[](uint8_t const offset) const

--- a/category/execution/monad/db/test_monad_storage_page.cpp
+++ b/category/execution/monad/db/test_monad_storage_page.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 
 #include <gtest/gtest.h>
@@ -231,4 +232,62 @@ TEST(MonadDb, page_commit_asymmetric_pair)
     EXPECT_NE(c_left, c_right);
     EXPECT_NE(c_left, bytes32_t{});
     EXPECT_NE(c_right, bytes32_t{});
+}
+
+// Slots on the same page are merged into a single page on commit.
+// Block 0 writes slots 0 and 1. Block 1 updates slot 0 only.
+// After block 1 commit, both the updated slot 0 and the untouched slot 1
+// must be present in the same page.
+TEST(MonadDb, page_write_merges_slots)
+{
+    constexpr auto slot_key_0 = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_key_1 = bytes32_t{uint64_t{0x01}};
+    constexpr auto val_0 =
+        0x000000000000000000000000000000000000000000000000000000000000aaaa_bytes32;
+    constexpr auto val_1 =
+        0x000000000000000000000000000000000000000000000000000000000000bbbb_bytes32;
+    constexpr auto val_0_updated =
+        0x000000000000000000000000000000000000000000000000000000000000dddd_bytes32;
+
+    Account const acct{.nonce = 1};
+    mpt::Db mpt_db{std::make_unique<MonadInMemoryMachine>()};
+    TrieDb tdb{mpt_db};
+    ASSERT_TRUE(tdb.is_page_encoded()) << "test requires page-encoded storage";
+
+    // Block 0: seed two slots on the same page.
+    {
+        PageCommitBuilder builder(0, tdb);
+        builder.add_state_deltas(StateDeltas{
+            {ADDR_A,
+             StateDelta{
+                 .account = {std::nullopt, acct},
+                 .storage = {
+                     {slot_key_0, {bytes32_t{}, val_0}},
+                     {slot_key_1, {bytes32_t{}, val_1}}}}}});
+        auto root = mpt_db.upsert(nullptr, builder.build(finalized_nibbles), 0);
+        tdb.reset_root(std::move(root), 0);
+    }
+
+    // Block 1: update slot 0, leave slot 1 untouched.
+    {
+        ASSERT_EQ(
+            tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_0), val_0);
+        ASSERT_EQ(
+            tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_1), val_1);
+
+        PageCommitBuilder builder(1, tdb);
+        builder.add_state_deltas(StateDeltas{
+            {ADDR_A,
+             StateDelta{
+                 .account = {acct, acct},
+                 .storage = {{slot_key_0, {val_0, val_0_updated}}}}}});
+        auto root =
+            mpt_db.upsert(tdb.get_root(), builder.build(finalized_nibbles), 1);
+        tdb.reset_root(std::move(root), 1);
+    }
+
+    // Verify: db reads back both values from the committed page.
+    EXPECT_EQ(
+        tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_0), val_0_updated);
+    EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_1), val_1);
 }

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -1,0 +1,303 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/trie_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+#include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/ondisk_db_config.hpp>
+#include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/traits.hpp>
+
+#include <gtest/gtest.h>
+
+#include <test_resource_data.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+// End to end test for the slot to page storage migration via the shared
+// monad::commit_block helper. Both Dbs get the same header; pre fork it
+// carries Db1's (slot) state_root, post fork Db2's (page) state_root.
+
+using namespace monad;
+using namespace monad::test;
+
+namespace
+{
+    // Slots 0x00 and 0x01 share one page; slot 0x80 is on a different page.
+    // This forces MonadCommitBuilder to merge two slot deltas onto the same
+    // page within a single block, exercising the page grouping path.
+    constexpr auto slot_0 = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_1 = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_far = bytes32_t{uint64_t{0x80}};
+
+    enum class Fork
+    {
+        Pre,
+        Post
+    };
+
+    // Revisions either side of the mip-8 (page-encoding) fork; keeps the
+    // MONAD_NEXT literal out of the call sites.
+    using PreMip8Fork = MonadTraits<MONAD_ZERO>;
+    using PostMip8Fork =
+        MonadTraits<MONAD_NEXT>; // TODO: replace MONAD_NEXT with the actual
+                                 // fork point constant when available
+    static_assert(
+        PostMip8Fork::mip_8_active(), "PostMip8Fork should have MIP-8 active");
+
+    // Empty ancillary buckets reused for every block: the test only cares
+    // about state_deltas, so receipts/txns/etc. stay empty across calls.
+    Code const empty_code{};
+    std::vector<Receipt> const empty_receipts{};
+    std::vector<Transaction> const empty_transactions{};
+    std::vector<Address> const empty_senders{};
+    std::vector<std::vector<CallFrame>> const empty_call_frames{};
+    std::vector<BlockHeader> const empty_ommers{};
+    std::optional<std::vector<Withdrawal>> const empty_withdrawals{};
+
+    BlockCommitAncillaries make_empty_ancillaries()
+    {
+        return BlockCommitAncillaries{
+            .code = empty_code,
+            .receipts = empty_receipts,
+            .transactions = empty_transactions,
+            .senders = empty_senders,
+            .call_frames = empty_call_frames,
+            .ommers = empty_ommers,
+            .withdrawals = empty_withdrawals};
+    }
+
+    // Drive commit_block for one block as the runloop does, with slot-encoded
+    // traits pre fork and page-encoded traits post fork.
+    void drive_commit(
+        TrieDb &tdb1, TrieDb &tdb2, Fork const fork,
+        uint64_t const block_number, bytes32_t const &block_id,
+        StateDeltas const &deltas)
+    {
+        BlockHeader const header{.number = block_number};
+        BlockCommitAncillaries const anc = make_empty_ancillaries();
+
+        if (fork == Fork::Post) {
+            commit_block<PostMip8Fork>(
+                tdb1, &tdb2, block_id, header, deltas, anc);
+        }
+        else {
+            commit_block<PreMip8Fork>(
+                tdb1, &tdb2, block_id, header, deltas, anc);
+        }
+
+        tdb1.finalize(block_number, block_id);
+        tdb2.finalize(block_number, block_id);
+    }
+
+    StateDeltas make_deltas(
+        std::optional<Account> const &prev_acct,
+        std::optional<Account> const &new_acct,
+        std::vector<std::tuple<bytes32_t, bytes32_t, bytes32_t>> const &slots)
+    {
+        StorageDeltas storage;
+        for (auto const &[k, prev, next] : slots) {
+            storage.emplace(k, StorageDelta{prev, next});
+        }
+        StateDeltas deltas;
+        deltas.emplace(
+            ADDR_A,
+            StateDelta{
+                .account = {prev_acct, new_acct},
+                .storage = std::move(storage)});
+        return deltas;
+    }
+}
+
+TEST(MigrationFork, dual_write_state_root_handoff)
+{
+    ASSERT_EQ(compute_page_key(slot_0), compute_page_key(slot_1));
+    ASSERT_NE(compute_page_key(slot_0), compute_page_key(slot_far));
+
+    mpt::Db db1{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
+    mpt::Db db2 =
+        db1.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+    TrieDb tdb1{db1};
+    TrieDb tdb2{db2};
+    ASSERT_TRUE(tdb1.is_page_encoded() == false);
+    ASSERT_TRUE(tdb2.is_page_encoded() == true);
+
+    GenesisState const GENESIS_STATE = MonadTestnet{}.get_genesis_state();
+    load_genesis_state(GENESIS_STATE, tdb1);
+    load_genesis_state(GENESIS_STATE, tdb2);
+
+    auto const make_block_id = [](uint64_t const n) { return bytes32_t{n}; };
+
+    // Three pre fork blocks, then two post fork. Acct lifetime: created at
+    // block 1, mutated each block. Slots are seeded then updated.
+    Account acct{.nonce = 1};
+    bytes32_t prev_id = {}; // genesis block_id
+
+    // Both Dbs share one canonical header, so their state_root fields match:
+    // Db1's pre fork, Db2's post fork. These helpers check that invariant.
+    auto check_pre_fork_headers = [&](char const *tag) {
+        SCOPED_TRACE(tag);
+        auto const h1 = tdb1.read_eth_header();
+        auto const h2 = tdb2.read_eth_header();
+        EXPECT_EQ(h1.state_root, h2.state_root)
+            << "Db1 and Db2 must share the same canonical header";
+        EXPECT_EQ(h1.state_root, tdb1.state_root())
+            << "pre fork header carries Db1 (slot encoded) state_root";
+        EXPECT_NE(tdb1.state_root(), tdb2.state_root())
+            << "slot and page encodings should produce different roots";
+    };
+    auto check_post_fork_headers = [&](char const *tag) {
+        SCOPED_TRACE(tag);
+        auto const h1 = tdb1.read_eth_header();
+        auto const h2 = tdb2.read_eth_header();
+        EXPECT_EQ(h1.state_root, h2.state_root)
+            << "Db1 and Db2 must share the same canonical header";
+        EXPECT_EQ(h1.state_root, tdb2.state_root())
+            << "post fork header carries Db2 (page encoded) state_root";
+        EXPECT_NE(h1.state_root, tdb1.state_root())
+            << "post fork header should not carry Db1 (slot) root";
+    };
+
+    // Block 1 (pre fork): create account, seed slot_0 and slot_1 (same page).
+    {
+        tdb1.set_block_and_prefix(0, prev_id);
+        tdb2.set_block_and_prefix(0, prev_id);
+        auto deltas = make_deltas(
+            std::nullopt,
+            acct,
+            {{slot_0, bytes32_t{}, bytes32_t{uint64_t{0xa1}}},
+             {slot_1, bytes32_t{}, bytes32_t{uint64_t{0xb1}}}});
+        drive_commit(tdb1, tdb2, Fork::Pre, 1, make_block_id(1), deltas);
+
+        check_pre_fork_headers("block 1");
+
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_0),
+            bytes32_t{uint64_t{0xa1}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_1),
+            bytes32_t{uint64_t{0xb1}});
+
+        prev_id = make_block_id(1);
+    }
+
+    // Block 2 (pre fork): touch slot_0 and seed slot_far (different page).
+    {
+        tdb1.set_block_and_prefix(1, prev_id);
+        tdb2.set_block_and_prefix(1, prev_id);
+        auto next = acct;
+        next.nonce = 2;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_0, bytes32_t{uint64_t{0xa1}}, bytes32_t{uint64_t{0xa2}}},
+             {slot_far, bytes32_t{}, bytes32_t{uint64_t{0xfa}}}});
+        drive_commit(tdb1, tdb2, Fork::Pre, 2, make_block_id(2), deltas);
+        acct = next;
+
+        check_pre_fork_headers("block 2");
+        prev_id = make_block_id(2);
+    }
+
+    // Block 3 (pre fork): account only churn (no storage writes).
+    {
+        tdb1.set_block_and_prefix(2, prev_id);
+        tdb2.set_block_and_prefix(2, prev_id);
+        auto next = acct;
+        next.nonce = 3;
+        auto deltas = make_deltas(acct, next, {});
+        drive_commit(tdb1, tdb2, Fork::Pre, 3, make_block_id(3), deltas);
+        acct = next;
+
+        check_pre_fork_headers("block 3");
+        prev_id = make_block_id(3);
+    }
+
+    // Capture pre fork Db1 root for the boundary check below.
+    bytes32_t const db1_root_pre_fork = tdb1.state_root();
+    bytes32_t const db2_root_pre_fork = tdb2.state_root();
+    ASSERT_NE(db1_root_pre_fork, bytes32_t{});
+    ASSERT_NE(db2_root_pre_fork, bytes32_t{});
+
+    // Block 4 (fork point): the canonical header now stamps Db2's page
+    // state_root. Db1 keeps advancing its own slot root, but the header
+    // points at Db2's.
+    {
+        tdb1.set_block_and_prefix(3, prev_id);
+        tdb2.set_block_and_prefix(3, prev_id);
+        auto next = acct;
+        next.nonce = 4;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_1, bytes32_t{uint64_t{0xb1}}, bytes32_t{uint64_t{0xb4}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 4, make_block_id(4), deltas);
+        acct = next;
+
+        // Db1 advanced its slot encoded state root.
+        EXPECT_NE(tdb1.state_root(), db1_root_pre_fork);
+        EXPECT_NE(tdb1.state_root(), bytes32_t{});
+        EXPECT_NE(tdb2.state_root(), db2_root_pre_fork);
+
+        // Db1's stored header carries Db2's page based state root, and
+        // Db2 sees the same header bytes.
+        check_post_fork_headers("block 4 (fork)");
+
+        prev_id = make_block_id(4);
+    }
+
+    // Block 5 (post fork): reuses the accounts with a new slot value, to
+    // verify the post fork path keeps working past the boundary.
+    {
+        tdb1.set_block_and_prefix(4, prev_id);
+        tdb2.set_block_and_prefix(4, prev_id);
+        auto next = acct;
+        next.nonce = 5;
+        auto deltas = make_deltas(
+            acct,
+            next,
+            {{slot_far, bytes32_t{uint64_t{0xfa}}, bytes32_t{uint64_t{0xf5}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 5, make_block_id(5), deltas);
+        acct = next;
+
+        check_post_fork_headers("block 5");
+
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_far),
+            bytes32_t{uint64_t{0xf5}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_1),
+            bytes32_t{uint64_t{0xb4}});
+        EXPECT_EQ(
+            tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_0),
+            bytes32_t{uint64_t{0xa2}});
+    }
+}

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -145,7 +145,7 @@ TEST(MigrationFork, dual_write_state_root_handoff)
     mpt::Db db1{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
     mpt::Db db2 =
         db1.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
-    TrieDb tdb1{db1};
+    TrieDb tdb1{db1, true /* enable_multi_block_cache */};
     TrieDb tdb2{db2};
     ASSERT_TRUE(tdb1.is_page_encoded() == false);
     ASSERT_TRUE(tdb2.is_page_encoded() == true);
@@ -300,4 +300,81 @@ TEST(MigrationFork, dual_write_state_root_handoff)
             tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot_0),
             bytes32_t{uint64_t{0xa2}});
     }
+}
+
+// The page builder must honor the storage wipe on an incarnation change:
+// when an account is destroyed and recreated (incarnation bump) and the new
+// incarnation writes only a subset of its slots, the dead incarnation's
+// untouched slots must NOT survive in the page-encoded Db2. PageCommitBuilder
+// read-modify-merges pages via read_storage_page, which is incarnation-blind
+// and runs before this block's wipe; without the empty-page-on-reincarnation
+// guard it resurrects stale slots only on the page side, diverging the
+// (post-fork canonical) page state root from the slot-encoded, EVM-correct
+// Db1.
+TEST(MigrationFork, reincarnation_does_not_resurrect_page_slots)
+{
+    mpt::Db db1{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{}};
+    mpt::Db db2 =
+        db1.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+    TrieDb tdb1{db1, true /* enable_multi_block_cache */};
+    TrieDb tdb2{db2};
+    ASSERT_FALSE(tdb1.is_page_encoded());
+    ASSERT_TRUE(tdb2.is_page_encoded());
+
+    GenesisState const GENESIS_STATE = MonadTestnet{}.get_genesis_state();
+    load_genesis_state(GENESIS_STATE, tdb1);
+    load_genesis_state(GENESIS_STATE, tdb2);
+
+    auto const make_block_id = [](uint64_t const n) { return bytes32_t{n}; };
+    bytes32_t prev_id = {};
+
+    // Block 1: create the contract at incarnation {1,0}; seed slot_0 and
+    // slot_1 (same page) plus slot_far (a different page).
+    Account const inc1{.nonce = 1, .incarnation = Incarnation{1, 0}};
+    {
+        tdb1.set_block_and_prefix(0, prev_id);
+        tdb2.set_block_and_prefix(0, prev_id);
+        auto deltas = make_deltas(
+            std::nullopt,
+            inc1,
+            {{slot_0, bytes32_t{}, bytes32_t{uint64_t{0xa1}}},
+             {slot_1, bytes32_t{}, bytes32_t{uint64_t{0xb1}}},
+             {slot_far, bytes32_t{}, bytes32_t{uint64_t{0xfa}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 1, make_block_id(1), deltas);
+        prev_id = make_block_id(1);
+    }
+
+    // Block 2: reincarnate ({1,0} -> {2,0}) and write ONLY slot_0. slot_1 and
+    // slot_far belong to the dead incarnation; the new incarnation starts with
+    // empty storage, so from its perspective slot_0 goes empty -> 0xc2.
+    Account const inc2{.nonce = 1, .incarnation = Incarnation{2, 0}};
+    {
+        tdb1.set_block_and_prefix(1, prev_id);
+        tdb2.set_block_and_prefix(1, prev_id);
+        auto deltas = make_deltas(
+            inc1, inc2, {{slot_0, bytes32_t{}, bytes32_t{uint64_t{0xc2}}}});
+        drive_commit(tdb1, tdb2, Fork::Post, 2, make_block_id(2), deltas);
+        prev_id = make_block_id(2);
+    }
+
+    // Db1 (slot) wipes exactly on the incarnation change, so it is the
+    // EVM-correct oracle. Db2 (page) must agree slot-for-slot; on-disk reads
+    // are incarnation-blind so the incarnation argument is immaterial here.
+    auto const check = [&](bytes32_t const &slot,
+                           bytes32_t const &want,
+                           char const *const tag) {
+        SCOPED_TRACE(tag);
+        auto const v1 = tdb1.read_storage(ADDR_A, Incarnation{0, 0}, slot);
+        auto const v2 = tdb2.read_storage(ADDR_A, Incarnation{0, 0}, slot);
+        EXPECT_EQ(v1, want) << "slot-encoded Db1 (EVM oracle)";
+        EXPECT_EQ(v2, want)
+            << "page-encoded Db2 must match the oracle (no resurrection)";
+    };
+    check(
+        slot_0,
+        bytes32_t{uint64_t{0xc2}},
+        "slot_0 rewritten by new incarnation");
+    check(slot_1, bytes32_t{}, "slot_1 from dead incarnation must be wiped");
+    check(
+        slot_far, bytes32_t{}, "slot_far from dead incarnation must be wiped");
 }

--- a/category/execution/monad/state2/proposal_state.hpp
+++ b/category/execution/monad/state2/proposal_state.hpp
@@ -19,29 +19,27 @@
 #include <category/core/config.hpp>
 #include <category/core/log.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
-#include <category/execution/ethereum/core/fmt/int_fmt.hpp>
-#include <category/execution/ethereum/state2/state_deltas.hpp>
-#include <category/execution/monad/db/storage_page.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
 #include <category/vm/vm.hpp>
-
-#include <category/core/hex.hpp>
 
 #include <map>
 #include <memory>
+#include <utility>
 
 MONAD_NAMESPACE_BEGIN
 
 class ProposalState
 {
-    std::unique_ptr<StateDeltas> state_;
+    ProposalPostState post_state_;
     uint64_t parent_block_;
     bytes32_t parent_id_;
 
 public:
     ProposalState(
-        std::unique_ptr<StateDeltas> state, uint64_t const parent_block_number,
+        ProposalPostState post_state, uint64_t const parent_block_number,
         bytes32_t const &parent_id)
-        : state_(std::move(state))
+        : post_state_(std::move(post_state))
         , parent_block_(parent_block_number)
         , parent_id_(parent_id)
     {
@@ -52,17 +50,17 @@ public:
         return {parent_block_, parent_id_};
     }
 
-    StateDeltas const &state() const
+    ProposalPostState const &post_state() const
     {
-        return *state_;
+        return post_state_;
     }
 
     bool try_read_account(
         Address const &address, std::optional<Account> &result) const
     {
-        StateDeltas::const_accessor it{};
-        if (state_->find(it, address)) {
-            result = it->second.account.second;
+        auto const it = post_state_.accounts.find(address);
+        if (it != post_state_.accounts.end()) {
+            result = it->second;
             return true;
         }
         return false;
@@ -72,21 +70,20 @@ public:
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, storage_page_t &result) const
     {
-        StateDeltas::const_accessor it{};
-        if (!state_->find(it, address)) {
-            return false;
+        auto const acct_it = post_state_.accounts.find(address);
+        if (acct_it != post_state_.accounts.end()) {
+            auto const &acct = acct_it->second;
+            if (!acct.has_value() || acct->incarnation != incarnation) {
+                // Account deleted or incarnation cleared in this proposal:
+                // all storage at the requested incarnation is gone.
+                result = {};
+                return true;
+            }
         }
-        auto const &account = it->second.account.second;
-        if (!account || incarnation != account->incarnation) {
-            result = storage_page_t{};
-            return true;
-        }
-        auto const &storage = it->second.storage;
-        StorageDeltas::const_accessor it2{};
-        if (storage.find(it2, key)) {
-            // Use storage_page_t for single slot storage, key is slot key,
-            // offset in a page is always 0
-            result.set(0, it2->second.second);
+        StorageKey const sk{address, incarnation, key};
+        auto const it = post_state_.storage.find(sk);
+        if (it != post_state_.storage.end()) {
+            result = it->second;
             return true;
         }
         return false;
@@ -155,7 +152,7 @@ public:
     }
 
     void commit(
-        std::unique_ptr<StateDeltas> state_deltas, uint64_t const block_number,
+        ProposalPostState post_state, uint64_t const block_number,
         bytes32_t const &block_id)
     {
         if (proposal_map_.size() >= MAX_PROPOSAL_MAP_SIZE) {
@@ -167,7 +164,7 @@ public:
                 .insert(
                     {key,
                      std::unique_ptr<ProposalState>(new ProposalState(
-                         std::move(state_deltas), block_, block_id_))})
+                         std::move(post_state), block_, block_id_))})
                 .second == true);
         block_ = block_number;
         block_id_ = block_id;

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -120,6 +120,8 @@ state_machine_kind_name(MONAD_MPT_NAMESPACE::state_machine_kind const kind)
     switch (kind) {
     case MONAD_MPT_NAMESPACE::state_machine_kind::ethereum:
         return "ethereum";
+    case MONAD_MPT_NAMESPACE::state_machine_kind::monad:
+        return "monad";
     }
     return "unknown";
 }
@@ -1607,7 +1609,9 @@ opened.
                         std::string,
                         MONAD_MPT_NAMESPACE::state_machine_kind>{
                         {"ethereum",
-                         MONAD_MPT_NAMESPACE::state_machine_kind::ethereum}},
+                         MONAD_MPT_NAMESPACE::state_machine_kind::ethereum},
+                        {"monad",
+                         MONAD_MPT_NAMESPACE::state_machine_kind::monad}},
                     CLI::ignore_case));
             cli.add_option(
                 "--compression-level",
@@ -1744,7 +1748,8 @@ opened.
         if (aux.metadata_ctx().is_new_pool()) {
             aux.metadata_ctx().set_state_machine_kind(
                 MONAD_MPT_NAMESPACE::timeline_id::primary, impl.state_machine);
-            cout << "Stamped state-machine kind on primary timeline.\n";
+            cout << "Stamped state-machine kind on primary timeline to "
+                 << state_machine_kind_name(impl.state_machine) << ".\n";
         }
 
         // Secondary timeline lifecycle. These execute against the open
@@ -1768,8 +1773,9 @@ opened.
                 MONAD_MPT_NAMESPACE::timeline_id::secondary,
                 impl.state_machine);
             aux.activate_secondary_timeline();
-            cout << "Activated secondary timeline; stamped state-machine "
-                    "kind.\n";
+            cout << "Activated secondary timeline; stamped state-machine kind "
+                    "to "
+                 << state_machine_kind_name(impl.state_machine) << ".\n";
         }
         else if (impl.deactivate_secondary) {
             if (!aux.metadata_ctx().timeline_active(

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -98,6 +98,8 @@ struct Db::Impl
     virtual void
     move_trie_version_fiber_blocking(uint64_t src, uint64_t dest) = 0;
     virtual timeline_id tid() const = 0;
+
+    virtual mpt::state_machine_kind state_machine_type() const = 0;
 };
 
 AsyncIOContext::AsyncIOContext(ReadOnlyOnDiskDbConfig const &options)
@@ -258,6 +260,11 @@ public:
     {
         return tid_;
     }
+
+    virtual mpt::state_machine_kind state_machine_type() const override
+    {
+        return aux_.metadata_ctx().get_state_machine_kind(tid_);
+    }
 };
 
 class Db::InMemory final : public Db::Impl
@@ -337,6 +344,12 @@ public:
     virtual timeline_id tid() const override
     {
         return timeline_id::primary;
+    }
+
+    virtual mpt::state_machine_kind state_machine_type() const override
+    {
+        MONAD_ASSERT(machine_);
+        return machine_->kind();
     }
 };
 
@@ -921,6 +934,12 @@ public:
     {
         return tid_;
     }
+
+    virtual mpt::state_machine_kind state_machine_type() const override
+    {
+        return worker_thread_->aux().metadata_ctx().get_state_machine_kind(
+            tid_);
+    }
 };
 
 struct RODb::Impl final
@@ -1067,9 +1086,17 @@ Db::Db(std::unique_ptr<StateMachine> machine)
 }
 
 Db::Db(std::unique_ptr<StateMachine> machine, OnDiskDbConfig const &config)
-    : impl_{std::make_unique<RWOnDisk>(
-          std::make_shared<OnDiskDbServiceThread>(config), std::move(machine),
-          timeline_id::primary, config.compaction)}
+    : impl_{[&] {
+        auto const machine_kind = machine->kind();
+        auto impl = std::make_unique<RWOnDisk>(
+            std::make_shared<OnDiskDbServiceThread>(config),
+            std::move(machine),
+            timeline_id::primary,
+            config.compaction);
+        impl->aux().metadata_ctx().set_state_machine_kind(
+            timeline_id::primary, machine_kind);
+        return impl;
+    }()}
 {
     MONAD_ASSERT(impl_->aux().is_on_disk());
 }
@@ -1323,6 +1350,12 @@ UpdateAux &Db::aux()
     return impl_->aux();
 }
 
+mpt::state_machine_kind Db::state_machine_type() const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->state_machine_type();
+}
+
 Db Db::activate_secondary_timeline(
     std::unique_ptr<StateMachine> secondary_machine)
 {
@@ -1332,7 +1365,12 @@ Db Db::activate_secondary_timeline(
     auto *const rw = static_cast<RWOnDisk *>(impl_.get());
     MONAD_ASSERT(rw->tid() == timeline_id::primary);
     MONAD_ASSERT(rw->worker_thread_use_count() == 1);
+    MONAD_ASSERT(
+        !rw->aux().metadata_ctx().timeline_active(timeline_id::secondary),
+        "secondary timeline already active, cannot activate again");
     rw->aux().activate_secondary_timeline();
+    rw->aux().metadata_ctx().set_state_machine_kind(
+        timeline_id::secondary, secondary_machine->kind());
     return Db{rw->spawn_sibling(
         std::move(secondary_machine), timeline_id::secondary)};
 }
@@ -1349,6 +1387,8 @@ Db::open_secondary_timeline(std::unique_ptr<StateMachine> secondary_machine)
     if (!rw->aux().metadata_ctx().timeline_active(timeline_id::secondary)) {
         return std::nullopt;
     }
+    rw->aux().metadata_ctx().set_state_machine_kind(
+        timeline_id::secondary, secondary_machine->kind());
     return Db{rw->spawn_sibling(
         std::move(secondary_machine), timeline_id::secondary)};
 }
@@ -1365,7 +1405,7 @@ std::optional<Db> Db::open_secondary_timeline()
     }
     auto const kind =
         rw->aux().metadata_ctx().get_state_machine_kind(timeline_id::secondary);
-    auto machine = create_state_machine(kind);
+    auto machine = create_state_machine(kind); // will assert if undefined
     return Db{rw->spawn_sibling(std::move(machine), timeline_id::secondary)};
 }
 

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -28,6 +28,7 @@
 #include <category/mpt/find_request_sender.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
 #include <category/mpt/update.hpp>
@@ -239,6 +240,12 @@ public:
     // and in-memory Dbs; secondary for Dbs returned by the activate /
     // open_secondary_timeline factories).
     timeline_id tid() const;
+
+    // Returns the state_machine_kind stamped on this Db's bound timeline
+    // in db_metadata. On-disk Dbs read it from the metadata superblock;
+    // in-memory Dbs return the kind() of the StateMachine they were
+    // constructed with.
+    state_machine_kind state_machine_type() const;
 
 private:
     friend struct test::DbAccessor;

--- a/category/mpt/state_machine.hpp
+++ b/category/mpt/state_machine.hpp
@@ -16,7 +16,9 @@
 #pragma once
 
 #include <category/mpt/config.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <stddef.h>
 
@@ -27,6 +29,16 @@ struct Compute;
 struct StateMachine
 {
     virtual ~StateMachine() = default;
+
+    // Identifies which StateMachine implementation this instance is. Used by
+    // Db to cross-check the caller's StateMachine against the on-disk
+    // metadata at open time and to stamp metadata on create / activate.
+    virtual state_machine_kind kind() const
+    {
+        // default to ethereum
+        return state_machine_kind::ethereum;
+    }
+
     virtual std::unique_ptr<StateMachine> clone() const = 0;
     virtual void down(unsigned char nibble) = 0;
     virtual void up(size_t) = 0;

--- a/category/mpt/state_machine_kind.hpp
+++ b/category/mpt/state_machine_kind.hpp
@@ -16,13 +16,14 @@
 #pragma once
 
 #include <category/mpt/config.hpp>
-#include <category/mpt/state_machine.hpp>
 
 #include <cstdint>
 #include <functional>
 #include <memory>
 
 MONAD_MPT_NAMESPACE_BEGIN
+
+struct StateMachine;
 
 // Identifies which StateMachine implementation a timeline was created with.
 // Persisted per-timeline in db_metadata::root_offsets_ring_t so that opens
@@ -33,8 +34,11 @@ enum class state_machine_kind : uint8_t
     // so a zeroed metadata byte (DBs created before the kind was persisted,
     // freshly-created pools) reads back as ethereum with no migration step.
     ethereum = 0,
-    // Future kinds (e.g. the dual-timeline hash migration target) extend here.
-    // Never reorder or reuse values: they are persisted on disk.
+    // MonadOnDiskMachine: page-encoded storage for chains at MONAD_NEXT or
+    // later. Registered alongside ethereum.
+    monad = 1,
+    // Future kinds extend here. Never reorder or reuse values: they are
+    // persisted on disk.
 };
 
 constexpr uint8_t NUM_STATE_MACHINE_KINDS = 8;

--- a/category/statesync/statesync_server_context.cpp
+++ b/category/statesync/statesync_server_context.cpp
@@ -219,6 +219,11 @@ monad_statesync_server_context::monad_statesync_server_context(TrieDb &rw)
 {
 }
 
+bool monad_statesync_server_context::is_page_encoded() const
+{
+    return rw.is_page_encoded();
+}
+
 std::optional<Account>
 monad_statesync_server_context::read_account(Address const &addr)
 {
@@ -229,6 +234,13 @@ bytes32_t monad_statesync_server_context::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
     return rw.read_storage(addr, incarnation, key);
+}
+
+storage_page_t monad_statesync_server_context::read_storage_page(
+    Address const &addr, Incarnation const incarnation,
+    bytes32_t const &page_key)
+{
+    return rw.read_storage_page(addr, incarnation, page_key);
 }
 
 monad::vm::SharedIntercode

--- a/category/statesync/statesync_server_context.hpp
+++ b/category/statesync/statesync_server_context.hpp
@@ -98,12 +98,18 @@ struct monad_statesync_server_context final : public monad::Db
 
     explicit monad_statesync_server_context(monad::TrieDb &rw);
 
+    virtual bool is_page_encoded() const override;
+
     virtual std::optional<monad::Account>
     read_account(monad::Address const &addr) override;
 
     virtual monad::bytes32_t read_storage(
         monad::Address const &addr, monad::Incarnation,
         monad::bytes32_t const &key) override;
+
+    virtual monad::storage_page_t read_storage_page(
+        monad::Address const &addr, monad::Incarnation,
+        monad::bytes32_t const &page_key) override;
 
     virtual monad::vm::SharedIntercode
     read_code(monad::bytes32_t const &hash) override;


### PR DESCRIPTION
Second PR in the storage-page series. Builds on `max/dual-timeline-state-machine`.

## Context

The storage-page work migrates account storage from one-leaf-per-slot (slot encoding) to one-leaf-per-page (page encoding, MIP-8). The first PR added the `storage_page_t` type, the page commit primitive, and dual-timeline support in the MPT layer. This PR builds the execution-layer commit path that can write either encoding, plus the dual-write machinery used to validate the migration.

## What this PR does

**Runtime page-encoding in `TrieDb`.** Learns encoding at construction from `mpt::Db::state_machine_type()` (`monad` => page), exposed via `is_page_encoded()`. Reads and commit dispatch on this flag.

**`PageCommitBuilder`.** Groups a block's slot writes into pages, reading the current page on first touch so writes compose. `commit` asserts builder encoding matches the target `TrieDb`.

**Encoding-unified proposal cache.** `DbCache` + `ProposalPostState` store storage as `storage_page_t` keyed by `StorageKey{addr, incarnation, key}` for both encodings (slot = single-slot page at offset 0). Cache state sourced from the builder's post-state.

**Dual-db migration helper (`commit_block`).** Commits to primary and dual-writes to a secondary db with the other encoding; selects builder per db via `is_page_encoded()`, picks canonical db by fork (slot pre-fork, page post-fork `mip_8_active()`), canonical commits first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)