### PR TITLE
[docs] Add comment-hygiene sweeps to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,15 @@ Carve-outs where the parameter stays non-const:
 - Typedefs that hide pointers, notably `va_list` — adding `const` breaks `va_arg`/`va_copy` on implementations where `va_list` is an array type (see `category/core/format_err.c:33`).
 - Lambda parameters.
 
+### Comment hygiene after rebase, squash, or rename/removal
+
+Stale comments are invisible to the author (you read your intent, not the text) and to diff-scoped reviewers and PR bots (they can't grep the whole tree or read unchanged files). After squashing history, rebasing onto a new base, or renaming/removing any function, type, or field, run two sweeps before finalizing:
+
+1. **Temporal-language sweep.** Grep changed comments (extended regex) for the temporal markers: `grep -nE 'Previously|Originally|No longer|The old|Now uses|Used to|previous (commit|version|approach)|initially was'`. Every hit must describe a *durable* contrast (e.g. this-branch-vs-`main` behavior) — not an intermediate state of your own branch, which doesn't exist in the final history and is meaningless to a future reader. Reword or delete.
+2. **Dead-identifier sweep.** For every function/type/field named in a changed comment, confirm it still exists: `grep -rnw 'identifier' category/ test/`. Renames and removals leave stale references that the temporal-word grep won't catch. A comment naming a planned-but-unwired caller (`used by propose_block`) is the same defect — verify the caller actually exists and calls the code, or drop the claim.
+
+Apply both sweeps proactively whenever history is rewritten or a symbol changes name — not only when asked.
+
 ## Adding Tests
 
 Tests use Google Test. CMake helper functions are defined in root `CMakeLists.txt`:


### PR DESCRIPTION
Adds a short `### Comment hygiene` subsection to the checked-in `CLAUDE.md` under Code Conventions.

## Why

The repo's shared `CLAUDE.md` currently carries no comment guidance, so every contributor's Claude session (and PR bots like Copilot) is blind to comment rot. A recent review surfaced the failure mode concretely: a stacked PR carried a dead-identifier comment (a class name that never existed in the tree) and an aspirational caller-reference (`used by propose_block`, a caller that doesn't call it). Both survived author self-review and the Copilot reviewer — the author reads their intent, and a diff-scoped bot can neither grep the whole tree nor read unchanged files.

## What

Two mechanical, non-stylistic checks to run after a rebase, squash, or any rename/removal:

1. **Temporal-language sweep** — drop comments describing a vanished intermediate state of your own branch (they mean nothing in the final history).
2. **Dead-identifier sweep** — every function/type/field named in a changed comment must still exist (`grep -rn '\<identifier\>' category/ test/`); a comment naming a planned-but-unwired caller is the same defect.

Scoped deliberately to the verifiable sweeps — no opinionated "what makes a good comment" discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)