### PR TITLE
[vm] Make Traits::id() unique across EVM and Monad trait families

### DIFF
--- a/category/vm/evm/revision.h
+++ b/category/vm/evm/revision.h
@@ -24,9 +24,9 @@ extern "C"
 
 // Monad's in-tree EVM fork revision enum. This is a drop-in replacement for
 // evmc's `evmc_revision`: the enumerators mirror `evmc_revision` 1:1 (same
-// underlying integer values), which keeps ordering comparisons, the arithmetic
-// in previous_evm_revision(), and Traits::id() numerically unchanged. The
-// 1:1 correspondence is enforced by static_assert in revision.cpp.
+// underlying integer values), which keeps ordering comparisons and the
+// arithmetic in previous_evm_revision() unchanged. The 1:1 correspondence is
+// enforced by static_assert in revision.cpp.
 //
 // The enum itself carries no evmc dependency. The only tie to evmc is the pair
 // of conversion functions below, which are needed solely at the remaining

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -23,6 +23,7 @@
 #include <evmc/evmc.h>
 
 #include <concepts>
+#include <cstdint>
 #include <limits>
 #include <utility>
 
@@ -41,6 +42,16 @@ namespace monad
         inline constexpr size_t MAX_CODE_SIZE_MONAD_TWO = 128 * 1024;
         inline constexpr size_t MAX_INITCODE_SIZE_MONAD_FOUR =
             2 * MAX_CODE_SIZE_MONAD_TWO;
+    }
+
+    namespace detail
+    {
+        // Mirrors LLVM's AnalysisKey: a Traits specialization carries one
+        // static member of this type, and the address of that member is its
+        // opaque unique id (see the id() contract on the Traits concept).
+        struct alignas(8) TraitsKey
+        {
+        };
     }
 
     template <typename T>
@@ -172,11 +183,17 @@ namespace monad
             std::unreachable();
         }
 
-        static consteval uint64_t id() noexcept
+        static uint64_t id() noexcept
         {
-            return static_cast<uint64_t>(Rev);
+            static_assert(sizeof(uintptr_t) <= sizeof(uint64_t));
+            return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&key));
         }
+
+        static detail::TraitsKey key;
     };
+
+    template <monad_eth_revision Rev>
+    detail::TraitsKey EvmTraits<Rev>::key;
 
     template <monad_revision Rev>
     struct MonadTraits
@@ -336,16 +353,22 @@ namespace monad
             std::unreachable();
         }
 
-        static consteval uint64_t id() noexcept
+        static uint64_t id() noexcept
         {
-            return static_cast<uint64_t>(Rev);
+            static_assert(sizeof(uintptr_t) <= sizeof(uint64_t));
+            return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&key));
         }
+
+        static detail::TraitsKey key;
 
         // Temporary workaround that should be considered equivalent to calling
         // evm_rev(); remove when the refactoring to use feature flags is
         // complete.
         using evm_base = EvmTraits<MonadTraits::evm_rev()>;
     };
+
+    template <monad_revision Rev>
+    detail::TraitsKey MonadTraits<Rev>::key;
 
     template <typename T>
     inline constexpr bool is_evm_trait_v = is_specialization_of_v<EvmTraits, T>;

--- a/test/vm/unit/async_compile_tests.cpp
+++ b/test/vm/unit/async_compile_tests.cpp
@@ -29,6 +29,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -153,4 +154,42 @@ TEST(async_compile_test, disable)
         auto const entry = ncode->entrypoint();
         ASSERT_TRUE(entry == nullptr);
     }
+}
+
+// id() is the sole key distinguishing cached native code between revisions, so
+// the two trait families must never produce a colliding value across their
+// independent enums.
+TEST(async_compile_test, trait_ids_distinct)
+{
+    std::array<uint64_t, 19> const ids{
+        EvmTraits<MONAD_ETH_ISTANBUL>::id(),
+        EvmTraits<MONAD_ETH_BERLIN>::id(),
+        EvmTraits<MONAD_ETH_LONDON>::id(),
+        EvmTraits<MONAD_ETH_PARIS>::id(),
+        EvmTraits<MONAD_ETH_SHANGHAI>::id(),
+        EvmTraits<MONAD_ETH_CANCUN>::id(),
+        EvmTraits<MONAD_ETH_PRAGUE>::id(),
+        EvmTraits<MONAD_ETH_OSAKA>::id(),
+        MonadTraits<MONAD_ZERO>::id(),
+        MonadTraits<MONAD_ONE>::id(),
+        MonadTraits<MONAD_TWO>::id(),
+        MonadTraits<MONAD_THREE>::id(),
+        MonadTraits<MONAD_FOUR>::id(),
+        MonadTraits<MONAD_FIVE>::id(),
+        MonadTraits<MONAD_SIX>::id(),
+        MonadTraits<MONAD_SEVEN>::id(),
+        MonadTraits<MONAD_EIGHT>::id(),
+        MonadTraits<MONAD_NINE>::id(),
+        MonadTraits<MONAD_NEXT>::id()};
+
+    // Trip-wire: adding a revision to either family shifts these sentinels,
+    // forcing the id list above to be extended so coverage stays exhaustive.
+    static_assert(
+        MONAD_NEXT == 10, "a monad_revision was added; extend the list above");
+    static_assert(
+        MONAD_ETH_EXPERIMENTAL == 15,
+        "a monad_eth_revision was added; extend the list above");
+
+    std::unordered_set<uint64_t> const unique(ids.begin(), ids.end());
+    EXPECT_EQ(unique.size(), ids.size());
 }


### PR DESCRIPTION
EvmTraits::id() and MonadTraits::id() both returned static_cast<uint64_t>(Rev) over independent enums that each start at 0, so their id spaces overlapped (e.g. EvmTraits<MONAD_ETH_ISTANBUL> and MonadTraits<MONAD_SEVEN> both returned 7). id() is the sole key separating revisions in the native-code cache, so a cache shared across the two families would serve native code compiled for the wrong revision with no assert to catch it.

Follow LLVM's AnalysisKey pattern: each Traits specialization carries a static member whose address is its opaque id, guaranteeing uniqueness across all instantiations regardless of the underlying enums.