### PR TITLE
[cmd] monad-cli: accept "latest_finalized" for --version

### DIFF
--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -786,6 +786,24 @@ int interactive_impl(Db &db)
     return 0;
 }
 
+// Resolve a --version spec to a concrete block version. The spec is either a
+// decimal block number or the literal "latest_finalized". Returns nullopt on a
+// malformed spec.
+std::optional<uint64_t> resolve_snapshot_version(
+    std::string const &spec, uint64_t const latest_finalized)
+{
+    if (spec == "latest_finalized") {
+        return latest_finalized;
+    }
+    uint64_t value;
+    auto const [ptr, ec] =
+        std::from_chars(spec.data(), spec.data() + spec.size(), value);
+    if (ec != std::errc{} || ptr != spec.data() + spec.size()) {
+        return std::nullopt;
+    }
+    return value;
+}
+
 MONAD_ANONYMOUS_NAMESPACE_END
 
 int main(int const argc, char *argv[])
@@ -796,7 +814,7 @@ int main(int const argc, char *argv[])
     bool interactive = false;
     std::optional<std::filesystem::path> dump_binary_snapshot;
     std::optional<std::filesystem::path> load_binary_snapshot;
-    uint64_t version;
+    std::string version;
     unsigned dump_concurrency_limit = 2048;
     uint64_t total_shards = 1;
     uint64_t shard_number = 0;
@@ -824,7 +842,14 @@ int main(int const argc, char *argv[])
         "--it,--interactive", interactive, "set to run in interactive mode");
     auto *const cli_group =
         mode_group->add_option_group("cli", "options for non-interactive mode");
-    cli_group->add_option("--version", version)->required();
+    cli_group
+        ->add_option(
+            "--version",
+            version,
+            "Block version to operate on: a block number, or "
+            "\"latest_finalized\" to use the database's latest finalized "
+            "version")
+        ->required();
     auto *const dump_binary_snapshot_option = cli_group->add_option(
         "--dump-binary-snapshot,--dump_binary_snapshot",
         dump_binary_snapshot,
@@ -871,6 +896,7 @@ int main(int const argc, char *argv[])
     LOG_INFO("running with commit '{}'", GIT_COMMIT_HASH);
     flush_logger();
 
+    uint64_t resolved_version = 0;
     {
         fmt::println("Opening read only database {}.", dbname_paths);
         ReadOnlyOnDiskDbConfig const ro_config{
@@ -889,6 +915,25 @@ int main(int const argc, char *argv[])
         if (interactive) {
             return interactive_impl(ro_db);
         }
+        if (dump_binary_snapshot.has_value() ||
+            load_binary_snapshot.has_value()) {
+            auto const v = resolve_snapshot_version(
+                version, ro_db.get_latest_finalized_version());
+            if (!v.has_value()) {
+                LOG_ERROR(
+                    "invalid --version \"{}\": expected a block number or "
+                    "\"latest_finalized\"",
+                    version);
+                return 1;
+            }
+            if (*v == INVALID_BLOCK_NUM) {
+                LOG_ERROR(
+                    "no finalized version available to snapshot (the database "
+                    "has no finalized blocks)");
+                return 1;
+            }
+            resolved_version = *v;
+        }
     }
     if (dump_binary_snapshot.has_value()) {
         if (shard_number >= total_shards) {
@@ -901,7 +946,7 @@ int main(int const argc, char *argv[])
 
         auto *const context =
             monad_db_snapshot_filesystem_write_user_context_create(
-                dump_binary_snapshot.value().c_str(), version);
+                dump_binary_snapshot.value().c_str(), resolved_version);
         std::vector<char const *> c_dbname_paths;
         for (auto const &path : dbname_paths) {
             c_dbname_paths.emplace_back(path.c_str());
@@ -911,7 +956,7 @@ int main(int const argc, char *argv[])
             c_dbname_paths.data(),
             c_dbname_paths.size(),
             sq_thread_cpu.value_or(std::numeric_limits<unsigned>::max()),
-            version,
+            resolved_version,
             monad_db_snapshot_write_filesystem,
             context,
             dump_concurrency_limit,
@@ -920,7 +965,7 @@ int main(int const argc, char *argv[])
         LOG_INFO(
             "snapshot dump success={} version={} directory={} elapsed={}",
             success,
-            version,
+            resolved_version,
             dump_binary_snapshot.value(),
             std::chrono::steady_clock::now() - begin);
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
@@ -937,10 +982,10 @@ int main(int const argc, char *argv[])
             c_dbname_paths.size(),
             sq_thread_cpu.value_or(std::numeric_limits<unsigned>::max()),
             load_binary_snapshot.value().c_str(),
-            version);
+            resolved_version);
         LOG_INFO(
             "snapshot version={} load_binary_snapshot={} elapsed={}",
-            version,
+            resolved_version,
             load_binary_snapshot.value(),
             std::chrono::steady_clock::now() - begin);
     }


### PR DESCRIPTION
## Summary

`monad-cli --version` still requires an explicit value, but now accepts either a block number or the literal `latest_finalized`, which resolves to the database's latest finalized version at open time.

This lets snapshot dump/load run without the operator first looking up and passing an explicit finalized block number, while keeping the version choice explicit (no silent default). A malformed `--version` is rejected with a clear error rather than silently parsed.

- `--version 12345` → block 12345 (unchanged)
- `--version latest_finalized` → the DB's latest finalized version
- `--version` omitted → still an error (required)

Motivated by review feedback on the page-store migration runbook (operators were told to grep the activate output for the version number).

## Test plan

- `monad-cli` builds clean (GCC RelWithDebInfo).
- `--help` shows the new `--version` semantics and `[required]`; omitting it errors with `--version is required`.
- The version-spec parser was verified standalone across edge cases: `latest_finalized`, `0`, normal, `UINT64_MAX`, and rejection of empty/garbage/partial/whitespace/negative inputs.
- Full DB-backed dump/load is exercised by the page-store migration integration tests; `monad-mpt --create` can't run in this sandbox (no hugepages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
