### PR TITLE
MIP-12: Validate maximum block reward

### DIFF
--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -107,6 +107,17 @@ namespace limits
         return 50;
     };
 
+    template <Traits traits>
+    constexpr uint256_t maximum_block_reward()
+    {
+        if constexpr (traits::mip_12_active()) {
+            return 18 * MON;
+        }
+        else {
+            return 25 * MON;
+        }
+    }
+
     constexpr uint64_t withdrawal_delay()
     {
         return 1;

--- a/category/execution/monad/validate_monad_block.cpp
+++ b/category/execution/monad/validate_monad_block.cpp
@@ -118,8 +118,6 @@ Result<void> static_validate_monad_body(
         return SyscallKind::Other;
     };
 
-    constexpr uint256_t MAXIMUM_BLOCK_REWARD = 25 * staking::MON;
-
     std::array<bool, 3> seen{};
     std::optional<SyscallKind> last_kind;
     for (auto it = txns.begin(); it != end_system_txn; ++it) {
@@ -139,7 +137,8 @@ Result<void> static_validate_monad_body(
         last_kind = kind;
 
         if (kind == SyscallKind::Reward &&
-            MONAD_UNLIKELY(it->value > MAXIMUM_BLOCK_REWARD)) {
+            MONAD_UNLIKELY(
+                it->value > staking::limits::maximum_block_reward<traits>())) {
             return MonadBlockError::InvalidRewardValue;
         }
     }

--- a/category/execution/monad/validate_monad_block_test.cpp
+++ b/category/execution/monad/validate_monad_block_test.cpp
@@ -22,6 +22,7 @@
 #include <category/execution/monad/validate_monad_block.hpp>
 #include <monad/test/traits_test.hpp>
 
+#include <string_view>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -65,8 +66,7 @@ TYPED_TEST(MonadTraitsTest, system_txn_comes_after_user_txn)
         0xcccc_address,
     };
     std::vector<Transaction> txns(senders.size());
-    auto const res =
-        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    auto const res = static_validate_monad_body<Trait>(senders, txns);
     if constexpr (Trait::monad_rev() < MONAD_FOUR) {
         EXPECT_FALSE(res.has_error());
     }
@@ -210,13 +210,86 @@ TYPED_TEST(MonadTraitsTest, reward_txn_exceeds_maximum)
     std::vector<Transaction> txns(senders.size());
     txns[0].data = syscall_calldata(REWARD);
     txns[0].value = 26 * staking::MON;
-    auto const res =
-        static_validate_monad_body<typename TestFixture::Trait>(senders, txns);
+    auto const res = static_validate_monad_body<Trait>(senders, txns);
     if constexpr (Trait::monad_rev() < MONAD_FOUR) {
         EXPECT_FALSE(res.has_error());
     }
     else {
         ASSERT_TRUE(res.has_error());
         EXPECT_EQ(res.error(), MonadBlockError::InvalidRewardValue);
+    }
+}
+
+TYPED_TEST(MonadTraitsTest, mip12_migration)
+{
+    using Trait = typename TestFixture::Trait;
+
+    std::vector<Address> senders{
+        SYSTEM_SENDER,
+    };
+    std::vector<Transaction> txns(senders.size());
+    // 25 MON is staking reward before MIP-12
+    txns[0].data = syscall_calldata(REWARD);
+    txns[0].value = 25 * staking::MON;
+    auto const res = static_validate_monad_body<Trait>(senders, txns);
+    if constexpr (Trait::mip_12_active()) {
+        ASSERT_TRUE(res.has_error());
+        EXPECT_EQ(res.error(), MonadBlockError::InvalidRewardValue);
+    }
+    else {
+        EXPECT_FALSE(res.has_error());
+    }
+}
+
+// Fork-independent tests pinned to the latest revision.
+using ValidateMonadBlockLatest =
+    MonadTraitsTest<::detail::MonadRevisionConstant<MONAD_NEXT>>;
+
+struct RewardCase
+{
+    uint256_t value;
+    bool expect_error;
+    std::string_view name;
+};
+
+class BlockRewardLatest
+    : public ValidateMonadBlockLatest
+    , public ::testing::WithParamInterface<RewardCase>
+{
+};
+
+// maximum_block_reward is 18 MON once MIP-12 is active (latest revision).
+INSTANTIATE_TEST_SUITE_P(
+    Mip12, BlockRewardLatest,
+    ::testing::Values(
+        RewardCase{0, false, "zero"},
+        RewardCase{1 * staking::MON, false, "one_mon"},
+        RewardCase{18 * staking::MON, false, "at_maximum"},
+        RewardCase{18 * staking::MON + 1, true, "one_wei_over"},
+        RewardCase{25 * staking::MON, true, "pre_mip_12_maximum"},
+        RewardCase{26 * staking::MON, true, "exceeds_one"},
+        RewardCase{100 * staking::MON, true, "well_over"}),
+    [](::testing::TestParamInfo<RewardCase> const &info) {
+        return std::string{info.param.name};
+    });
+
+TEST_P(BlockRewardLatest, reward_against_maximum)
+{
+    auto const &param = GetParam();
+
+    std::vector<Address> senders{
+        SYSTEM_SENDER,
+    };
+    std::vector<Transaction> txns(senders.size());
+    txns[0].data = syscall_calldata(REWARD);
+    txns[0].value = param.value;
+
+    auto const res = static_validate_monad_body<Trait>(senders, txns);
+    if (param.expect_error) {
+        ASSERT_TRUE(res.has_error());
+        EXPECT_EQ(res.error(), MonadBlockError::InvalidRewardValue);
+    }
+    else {
+        EXPECT_FALSE(res.has_error());
     }
 }

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -84,6 +84,7 @@ namespace monad
         { T::mip_8_active() } -> std::same_as<bool>;
         { T::mip_9_active() } -> std::same_as<bool>;
         { T::mip_11_active() } -> std::same_as<bool>;
+        { T::mip_12_active() } -> std::same_as<bool>;
         { T::can_create_inside_delegated() } -> std::same_as<bool>;
 
         // Constants
@@ -150,12 +151,17 @@ namespace monad
             return Rev >= MONAD_ETH_OSAKA;
         }
 
+        static consteval bool mip_3_active() noexcept
+        {
+            return false;
+        }
+
         static consteval bool mip_8_active() noexcept
         {
             return false;
         }
 
-        static consteval bool mip_3_active() noexcept
+        static consteval bool mip_12_active() noexcept
         {
             return false;
         }
@@ -310,6 +316,11 @@ namespace monad
         }
 
         static consteval bool mip_8_active() noexcept
+        {
+            return Rev >= MONAD_NEXT;
+        }
+
+        static consteval bool mip_12_active() noexcept
         {
             return Rev >= MONAD_NEXT;
         }


### PR DESCRIPTION
MIP-12 is a consensus only fork. That will go live _before_ `MONAD_TEN`, so execution can start validating the lowered block reward after `MONAD_TEN` activates. This is validation hygiene rather than a correctness. Although there will be a small gap in which execution is not validating the 18 MON max, this is fine, because execution validation not be stricter than consensus validation.