### PR TITLE
Support binary snapshot dump and load on secondary timeline and page-encoded db

### DIFF
--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -24,6 +24,8 @@
 #include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 
@@ -31,6 +33,8 @@
 
 #include <deque>
 #include <limits>
+#include <memory>
+#include <optional>
 
 struct monad_db_snapshot_loader
 {
@@ -40,31 +44,65 @@ struct monad_db_snapshot_loader
     std::array<monad::byte_string, 256> eth_headers;
     std::deque<monad::hash256> hash_alloc;
     std::deque<monad::mpt::Update> update_alloc;
+    std::deque<monad::byte_string> bytes_alloc;
     std::array<
         ankerl::unordered_dense::segmented_map<uint64_t, monad::mpt::Update>,
         MONAD_SNAPSHOT_SHARDS>
         account_offset_to_update;
+    // Per-shard page accumulator used only when page_encoded. Maps
+    // account_offset -> (page_key -> assembled storage_page_t).
+    std::array<
+        ankerl::unordered_dense::segmented_map<
+            uint64_t, ankerl::unordered_dense::map<
+                          monad::bytes32_t, monad::storage_page_t>>,
+        MONAD_SNAPSHOT_SHARDS>
+        page_accumulator;
     monad::mpt::UpdateList state_updates;
     monad::mpt::UpdateList code_updates;
     uint64_t bytes_read;
 
     monad_db_snapshot_loader(
         uint64_t const block, char const *const *const dbname_paths,
-        size_t const len, unsigned const sq_thread_cpu)
+        size_t const len, unsigned const sq_thread_cpu,
+        bool const load_to_secondary)
         : block{block}
-        , db{monad::mpt::OnDiskDbConfig{
-              .append = true,
-              .compaction = false,
-              .rd_buffers = 8192,
-              .wr_buffers = 32,
-              .uring_entries = 128,
-              .sq_thread_cpu =
-                  sq_thread_cpu == std::numeric_limits<unsigned>::max()
-                      ? std::nullopt
-                      : std::make_optional(sq_thread_cpu),
-              .dbname_paths = {dbname_paths, dbname_paths + len}}}
+        , db{open_target_db(
+              dbname_paths, len, sq_thread_cpu, load_to_secondary)}
         , bytes_read{0}
     {
+    }
+
+    bool page_encoded() const
+    {
+        return db.state_machine_type() == monad::mpt::state_machine_kind::monad;
+    }
+
+private:
+    static monad::mpt::Db open_target_db(
+        char const *const *const dbname_paths, size_t const len,
+        unsigned const sq_thread_cpu, bool const load_to_secondary)
+    {
+        monad::mpt::Db primary{monad::mpt::OnDiskDbConfig{
+            .append = true,
+            .compaction = false,
+            .rd_buffers = 8192,
+            .wr_buffers = 32,
+            .uring_entries = 128,
+            .sq_thread_cpu =
+                sq_thread_cpu == std::numeric_limits<unsigned>::max()
+                    ? std::nullopt
+                    : std::make_optional(sq_thread_cpu),
+            .dbname_paths = {dbname_paths, dbname_paths + len}}};
+        if (!load_to_secondary) {
+            return primary;
+        }
+        auto secondary = primary.open_secondary_timeline();
+        MONAD_ASSERT_PRINTF(
+            secondary.has_value(),
+            "secondary timeline is not active; activate it and stamp its "
+            "state_machine_kind using monad-mpt tool before loading a snapshot "
+            "into it");
+        return std::move(*secondary);
     }
 };
 
@@ -81,10 +119,55 @@ uint64_t get_shard(monad::mpt::NibblesView const path)
     return ret;
 }
 
+// When the target is page-encoded, drain the accumulator into per-account
+// `next` lists. Each page becomes one Update keyed by keccak256(page_key)
+// with value encode_storage_page_db(page_key, page) (or std::nullopt if the
+// page is empty so the entry is a deletion). The encoded byte_strings are
+// kept alive in loader->bytes_alloc until the upsert completes; the Update
+// nodes are kept in loader->update_alloc for the same reason.
+void monad_db_snapshot_loader_finalize_pages(
+    monad_db_snapshot_loader *const loader)
+{
+    using namespace monad;
+    using namespace monad::mpt;
+    if (!loader->page_encoded()) {
+        return;
+    }
+    for (size_t shard = 0; shard < MONAD_SNAPSHOT_SHARDS; ++shard) {
+        auto &shard_pages = loader->page_accumulator.at(shard);
+        if (shard_pages.empty()) {
+            continue;
+        }
+        auto &shard_accounts = loader->account_offset_to_update.at(shard);
+        for (auto &[account_offset, pages] : shard_pages) {
+            auto &account_update = shard_accounts.at(account_offset);
+            for (auto const &[page_key, page] : pages) {
+                bool const is_empty = page.is_empty();
+                std::optional<byte_string_view> value;
+                if (!is_empty) {
+                    value = byte_string_view{loader->bytes_alloc.emplace_back(
+                        encode_storage_page_db(page_key, page))};
+                }
+                account_update.next.push_front(
+                    loader->update_alloc.emplace_back(Update{
+                        .key = loader->hash_alloc.emplace_back(keccak256(
+                            {page_key.bytes, sizeof(page_key.bytes)})),
+                        .value = value,
+                        .incarnation = false,
+                        .next = UpdateList{},
+                        .version = static_cast<int64_t>(loader->block)}));
+            }
+        }
+        shard_pages.clear();
+    }
+}
+
 void monad_db_snapshot_loader_flush(monad_db_snapshot_loader *const loader)
 {
     using namespace monad;
     using namespace monad::mpt;
+
+    monad_db_snapshot_loader_finalize_pages(loader);
 
     Update state_update{
         .key = state_nibbles,
@@ -120,7 +203,11 @@ void monad_db_snapshot_loader_flush(monad_db_snapshot_loader *const loader)
         false);
     loader->hash_alloc.clear();
     loader->update_alloc.clear();
+    loader->bytes_alloc.clear();
     for (auto &map : loader->account_offset_to_update) {
+        map.clear();
+    }
+    for (auto &map : loader->page_accumulator) {
         map.clear();
     }
     loader->state_updates.clear();
@@ -216,6 +303,9 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
     void *user;
     uint64_t total_shards;
     uint64_t shard_number;
+    // Source db is page-encoded: storage leaves hold encoded pages rather than
+    // single slots, so they are expanded to slot-format entries on dump.
+    bool page_encoded;
 
     MonadSnapshotTraverseMachine(
         std::array<uint64_t, MONAD_SNAPSHOT_SHARDS> &account_bytes_written,
@@ -223,7 +313,7 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
             uint64_t shard, monad_snapshot_type, unsigned char const *bytes,
             size_t len, void *user),
         void *const user, uint64_t const total_shards,
-        uint64_t const shard_number)
+        uint64_t const shard_number, bool const page_encoded)
         : nibble{monad::mpt::INVALID_BRANCH}
         , path{}
         , account_bytes_written{account_bytes_written}
@@ -232,6 +322,7 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
         , user{user}
         , total_shards{total_shards}
         , shard_number{shard_number}
+        , page_encoded{page_encoded}
     {
     }
 
@@ -289,27 +380,62 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
         }
         else {
             MONAD_ASSERT(nibble == STATE_NIBBLE);
-            monad_snapshot_type type;
             if (path.length() == HASH_SIZE) {
-                type = MONAD_SNAPSHOT_ACCOUNT;
                 account_offset = account_bytes_written.at(shard);
                 account_bytes_written.at(shard) += val.size();
-            }
-            else {
-                MONAD_ASSERT(path.length() == (HASH_SIZE * 2));
-                type = MONAD_SNAPSHOT_STORAGE;
                 MONAD_ASSERT(
                     write(
                         shard,
-                        MONAD_SNAPSHOT_STORAGE,
-                        reinterpret_cast<unsigned char const *>(
-                            &account_offset),
-                        sizeof(account_offset),
-                        user) == sizeof(account_offset));
+                        MONAD_SNAPSHOT_ACCOUNT,
+                        val.data(),
+                        val.size(),
+                        user) == val.size());
             }
-
-            MONAD_ASSERT(
-                write(shard, type, val.data(), val.size(), user) == val.size());
+            else {
+                MONAD_ASSERT(path.length() == (HASH_SIZE * 2));
+                // Emit one slot-format storage entry, prefixed with the owning
+                // account's offset so the loader can re-link it.
+                auto const emit_slot = [&](byte_string_view const entry) {
+                    MONAD_ASSERT(
+                        write(
+                            shard,
+                            MONAD_SNAPSHOT_STORAGE,
+                            reinterpret_cast<unsigned char const *>(
+                                &account_offset),
+                            sizeof(account_offset),
+                            user) == sizeof(account_offset));
+                    MONAD_ASSERT(
+                        write(
+                            shard,
+                            MONAD_SNAPSHOT_STORAGE,
+                            entry.data(),
+                            entry.size(),
+                            user) == entry.size());
+                };
+                if (page_encoded) {
+                    // Source db is page-encoded: the storage leaf is
+                    // encode_storage_page_db(page_key, page). Expand it into
+                    // one slot-encoded entry per non-zero slot so the dumped
+                    // snapshot stays slot-granular and loads unchanged.
+                    byte_string_view enc{val};
+                    auto const raw = decode_storage_db_raw(enc);
+                    MONAD_ASSERT(raw.has_value());
+                    bytes32_t const page_key = to_bytes(raw.value().first);
+                    auto const page = decode_storage_page(raw.value().second);
+                    MONAD_ASSERT(page.has_value());
+                    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
+                        bytes32_t const slot_val = page.value()[i];
+                        if (slot_val == bytes32_t{}) {
+                            continue;
+                        }
+                        emit_slot(encode_storage_db(
+                            compute_slot_key(page_key, i), slot_val));
+                    }
+                }
+                else {
+                    emit_slot(val);
+                }
+            }
         }
 
         return true;
@@ -359,7 +485,8 @@ bool monad_db_dump_snapshot(
         uint64_t shard, monad_snapshot_type, unsigned char const *bytes,
         size_t len, void *user),
     void *const user, unsigned const dump_concurrency_limit,
-    uint64_t const total_shards, uint64_t const shard_number)
+    uint64_t const total_shards, uint64_t const shard_number,
+    bool const dump_from_secondary)
 {
     using namespace monad;
     using namespace monad::mpt;
@@ -382,7 +509,9 @@ bool monad_db_dump_snapshot(
         .dbname_paths = {dbname_paths, dbname_paths + len},
         .concurrent_read_io_limit = dump_concurrency_limit};
     AsyncIOContext io_context{config};
-    Db db{io_context};
+    Db db{
+        io_context,
+        dump_from_secondary ? timeline_id::secondary : timeline_id::primary};
 
     for (uint64_t b = block < 256 ? 0 : block - 255; b <= block; ++b) {
         uint64_t const header_shard = block - b;
@@ -429,7 +558,12 @@ bool monad_db_dump_snapshot(
 
     std::array<uint64_t, MONAD_SNAPSHOT_SHARDS> account_bytes_written{};
     MonadSnapshotTraverseMachine machine{
-        account_bytes_written, write, user, total_shards, shard_number};
+        account_bytes_written,
+        write,
+        user,
+        total_shards,
+        shard_number,
+        db.state_machine_type() == state_machine_kind::monad};
     bool const success =
         db.traverse(finalized_root, machine, block, dump_concurrency_limit);
     if (!success) {
@@ -438,18 +572,27 @@ bool monad_db_dump_snapshot(
     return success;
 }
 
+// Loads the standard slot-encoded snapshot (the format produced by
+// monad_db_dump_snapshot against a slot db) into one timeline:
+//   * load_to_secondary == false: the primary timeline.
+//   * load_to_secondary == true:  an already-activated secondary timeline.
+// The target's storage encoding is derived from its persisted
+// state_machine_kind; a page-encoded target converts slot leaves to page
+// leaves on the fly. The target's kind must already be stamped on disk.
 monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t const block, char const *const *const dbname_paths,
-    size_t const len, unsigned const sq_thread_cpu)
+    size_t const len, unsigned const sq_thread_cpu,
+    bool const load_to_secondary)
 {
-    // C ABI entry — populate the kind registry before the metadata-driven
-    // Db ctor runs inside monad_db_snapshot_loader. Idempotent.
+    // The metadata-driven Db ctor and open_secondary_timeline() resolve the
+    // persisted kind through the registry, so both factories must be present.
     monad::register_ethereum_state_machines();
-    auto *loader =
-        new monad_db_snapshot_loader(block, dbname_paths, len, sq_thread_cpu);
-    MONAD_ASSERT_PRINTF(
+    monad::register_monad_state_machines();
+    auto *loader = new monad_db_snapshot_loader(
+        block, dbname_paths, len, sq_thread_cpu, load_to_secondary);
+    MONAD_ASSERT(
         loader->db.get_latest_version() == monad::mpt::INVALID_BLOCK_NUM,
-        "database must be hard reset when loading snapshot");
+        "database must be empty when loading snapshot");
     return loader;
 }
 
@@ -489,18 +632,50 @@ void monad_db_snapshot_loader_load(
             }
             storage_view.remove_prefix(sizeof(account_offset));
             byte_string_view const before{storage_view};
-            auto const res = decode_storage_db_raw(storage_view);
-            MONAD_ASSERT(res.has_value());
-            auto &update = account_offset_to_update.at(account_offset);
-            uint64_t const consumed = before.size() - storage_view.size();
-            update.next.push_front(loader->update_alloc.emplace_back(Update{
-                .key = loader->hash_alloc.emplace_back(
-                    keccak256(to_bytes(res.value().first))),
-                .value = before.substr(0, consumed),
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(loader->block)}));
+            uint64_t consumed;
+            if (loader->page_encoded()) {
+                // The storage byte stream concatenates multiple
+                // [account_offset, leaf.value()] entries, so we use
+                // decode_storage_db_raw which advances the view in place
+                // and tolerates trailing bytes. Convert the raw views to
+                // bytes32_t (right-aligned) for the page accumulator.
+                auto const res = decode_storage_db_raw(storage_view);
+                MONAD_ASSERT(res.has_value());
+                bytes32_t const slot_key = to_bytes(res.value().first);
+                bytes32_t const slot_val = to_bytes(res.value().second);
+                consumed = before.size() - storage_view.size();
+                bytes32_t const pg_key = compute_page_key(slot_key);
+                uint8_t const slot_off = compute_slot_offset(slot_key);
+                auto &shard_pages = loader->page_accumulator.at(shard);
+                shard_pages[account_offset][pg_key].set(slot_off, slot_val);
+            }
+            else {
+                auto const res = decode_storage_db_raw(storage_view);
+                MONAD_ASSERT(res.has_value());
+                auto &update = account_offset_to_update.at(account_offset);
+                consumed = before.size() - storage_view.size();
+                update.next.push_front(loader->update_alloc.emplace_back(Update{
+                    .key = loader->hash_alloc.emplace_back(
+                        keccak256(to_bytes(res.value().first))),
+                    .value = before.substr(0, consumed),
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(loader->block)}));
+            }
             loader->bytes_read += consumed;
-            if (loader->bytes_read >= BYTES_READ_BEFORE_FLUSH) {
+            // When page-encoded, all slots that share a page_key must be in
+            // the same flush. A mid-loop flush would emit a page Update for
+            // the slots seen so far; later slots in the same page would start
+            // a fresh accumulator entry and the next flush would emit another
+            // Update for the same keccak256(page_key), causing the mpt
+            // upsert to overwrite the earlier page (set-not-merge). Defer
+            // flushing until the unconditional final flush at end of load().
+            //
+            // Consequence: the page accumulator holds a whole shard's storage
+            // in RAM before that final flush. With the current state size this
+            // is not a problem. There will be a follow up to bound the memory
+            // usage.
+            if (!loader->page_encoded() &&
+                loader->bytes_read >= BYTES_READ_BEFORE_FLUSH) {
                 monad_db_snapshot_loader_flush(loader);
             }
         }

--- a/category/execution/ethereum/db/db_snapshot.h
+++ b/category/execution/ethereum/db/db_snapshot.h
@@ -47,11 +47,11 @@ bool monad_db_dump_snapshot(
         uint64_t shard, enum monad_snapshot_type, unsigned char const *bytes,
         size_t len, void *user),
     void *user, unsigned dump_concurrency_limit, uint64_t total_shards,
-    uint64_t shard_number);
+    uint64_t shard_number, bool dump_from_secondary);
 
 struct monad_db_snapshot_loader *monad_db_snapshot_loader_create(
     uint64_t block, char const *const *dbname_paths, size_t len,
-    unsigned sq_thread_cpu);
+    unsigned sq_thread_cpu, bool load_to_secondary);
 
 void monad_db_snapshot_loader_load(
     struct monad_db_snapshot_loader *loader, uint64_t shard,

--- a/category/execution/ethereum/db/db_snapshot_filesystem.cpp
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.cpp
@@ -125,12 +125,15 @@ uint64_t monad_db_snapshot_write_filesystem(
 void monad_db_snapshot_load_filesystem(
     char const *const *const dbname_paths, size_t const len,
     unsigned const sq_thread_cpu, char const *const snapshot_dir,
-    uint64_t const block)
+    uint64_t const block, bool const load_to_secondary)
 {
     std::filesystem::path const root{std::format("{}/{}", snapshot_dir, block)};
     MONAD_ASSERT(std::filesystem::is_directory(root));
+    // The input snapshot is always slot-encoded (the standard format produced
+    // by monad_db_dump_snapshot from a slot db). If the target timeline is
+    // page-encoded, the loader converts slot leaves to page leaves on the fly.
     monad_db_snapshot_loader *const loader = monad_db_snapshot_loader_create(
-        block, dbname_paths, len, sq_thread_cpu);
+        block, dbname_paths, len, sq_thread_cpu, load_to_secondary);
 
     auto const do_mmap = [](std::filesystem::path const file) {
         using namespace monad;

--- a/category/execution/ethereum/db/db_snapshot_filesystem.h
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.h
@@ -37,7 +37,7 @@ uint64_t monad_db_snapshot_write_filesystem(
 
 void monad_db_snapshot_load_filesystem(
     char const *const *dbname_paths, size_t len, unsigned sq_thread_cpu,
-    char const *snapshot_dir, uint64_t block);
+    char const *snapshot_dir, uint64_t block, bool load_to_secondary);
 
 #ifdef __cplusplus
 }

--- a/category/execution/ethereum/test/test_db_snapshot.cpp
+++ b/category/execution/ethereum/test/test_db_snapshot.cpp
@@ -16,17 +16,22 @@
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
+#include <category/core/keccak.h>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/db_snapshot_filesystem.h>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/core/monad_block.hpp>
+#include <category/execution/monad/db/page_commit_builder.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/state_machine_kind.hpp>
+#include <category/mpt/traverse.hpp>
 #include <category/mpt/trie.hpp>
 
 #include <test_resource_data.h>
@@ -174,7 +179,8 @@ TEST(DbBinarySnapshot, Basic)
             context,
             2048, // dump_concurrency_limit
             1, // total_shards
-            0)); // shard_number
+            0, // shard_number
+            /*dump_from_secondary=*/false));
 
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
 
@@ -196,7 +202,8 @@ TEST(DbBinarySnapshot, Basic)
             1,
             static_cast<unsigned>(-1),
             snapshot_dir.path.c_str(),
-            100);
+            100,
+            /*load_to_secondary=*/false);
     }
 
     {
@@ -303,7 +310,8 @@ TEST(DbBinarySnapshot, MultipleShards)
                 context,
                 2048, // dump_concurrency_limit
                 NUM_SHARDS,
-                shard));
+                shard,
+                /*dump_from_secondary=*/false));
 
             monad_db_snapshot_filesystem_write_user_context_destroy(context);
         }
@@ -355,7 +363,8 @@ TEST(DbBinarySnapshot, MultipleShards)
             1,
             static_cast<unsigned>(-1),
             combined_root.path.c_str(),
-            100);
+            100,
+            /*load_to_secondary=*/false);
     }
     {
         AsyncIOContext io_context{
@@ -375,6 +384,373 @@ TEST(DbBinarySnapshot, MultipleShards)
             EXPECT_EQ(
                 byte_string_view(from_db->code(), from_db->size()),
                 byte_string_view(icode->code(), icode->size()));
+        }
+    }
+}
+
+namespace
+{
+    // Counts only storage leaves (entries nested under an account) under the
+    // cursor passed to Db::traverse. The cursor is expected to point at the
+    // state subtree root, so the path depth from there is:
+    //   account leaf at 64 nibbles (keccak256 addr)
+    //   storage leaf at 128 nibbles (account keccak + storage-key keccak)
+    // Anything shallower (the state-marker node, intermediate branches,
+    // account leaves) is skipped.
+    struct LeafCounter final : public monad::mpt::TraverseMachine
+    {
+        static constexpr uint8_t STORAGE_LEAF_DEPTH =
+            static_cast<uint8_t>(KECCAK256_SIZE * 2 * 2);
+        size_t count{0};
+        uint8_t depth{0};
+
+        bool
+        down(unsigned char const branch, monad::mpt::Node const &node) override
+        {
+            if (branch == monad::mpt::INVALID_BRANCH) {
+                return true;
+            }
+            depth = static_cast<uint8_t>(depth + 1 + node.path_nibbles_len());
+            if (depth == STORAGE_LEAF_DEPTH && node.has_value()) {
+                ++count;
+            }
+            return true;
+        }
+
+        void
+        up(unsigned char const branch, monad::mpt::Node const &node) override
+        {
+            if (branch == monad::mpt::INVALID_BRANCH) {
+                return;
+            }
+            depth = static_cast<uint8_t>(depth - 1 - node.path_nibbles_len());
+        }
+
+        std::unique_ptr<TraverseMachine> clone() const override
+        {
+            return std::make_unique<LeafCounter>(*this);
+        }
+    };
+}
+
+TEST(DbBinarySnapshot, LoadPageModeOnSecondaryDb)
+{
+    using namespace monad;
+    using namespace monad::mpt;
+
+    // Slots 0x00, 0x01, 0x7f share page_key 0; slots 0x80, 0x81 share page_key
+    // 1. With storage_page_t::SLOTS == 128, this exercises both grouping
+    // (multiple slots on one page) and separation (slots split across pages).
+    constexpr uint64_t BLOCK = 1;
+    constexpr std::array<uint8_t, 5> SLOT_BYTES{0x00, 0x01, 0x7f, 0x80, 0x81};
+    std::array<Address, 2> const ADDRS{Address{1}, Address{2}};
+
+    auto make_slot = [](uint8_t b) {
+        bytes32_t k{};
+        k.bytes[31] = b;
+        return k;
+    };
+    auto make_val = [](Address const &a, uint8_t b) {
+        bytes32_t v{};
+        v.bytes[30] = a.bytes[19];
+        v.bytes[31] = static_cast<uint8_t>(b ^ 0xa5);
+        return v;
+    };
+
+    ASSERT_EQ(compute_page_key(make_slot(0x00)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x01)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x7f)), bytes32_t{});
+    ASSERT_EQ(compute_page_key(make_slot(0x80)), make_slot(0x01));
+    ASSERT_EQ(compute_page_key(make_slot(0x81)), make_slot(0x01));
+
+    TempDb const dbname;
+    TempDir const snapshot_dir;
+
+    // Build slot-encoded source db with two accounts.
+    {
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.dbname_paths = {dbname.path}}};
+        load_header({}, db, BlockHeader{.number = 0});
+        db.update_finalized_version(0);
+        StateDeltas deltas;
+        for (auto const &addr : ADDRS) {
+            StorageDeltas storage;
+            for (auto const b : SLOT_BYTES) {
+                storage.emplace(
+                    make_slot(b), StorageDelta{bytes32_t{}, make_val(addr, b)});
+            }
+            deltas.emplace(
+                addr,
+                StateDelta{
+                    .account = {std::nullopt, Account{.balance = 1}},
+                    .storage = storage});
+        }
+        TrieDb tdb{db};
+        monad::test::commit_simple(
+            tdb,
+            deltas,
+            Code{},
+            bytes32_t{BLOCK},
+            BlockHeader{.number = BLOCK});
+        tdb.finalize(BLOCK, bytes32_t{BLOCK});
+    }
+
+    // Dump slot-encoded snapshot, then load it into a page-encoded secondary.
+    {
+        auto *const context =
+            monad_db_snapshot_filesystem_write_user_context_create(
+                snapshot_dir.path.c_str(), BLOCK);
+        char const *dbpath[] = {dbname.path.c_str()};
+        EXPECT_TRUE(monad_db_dump_snapshot(
+            dbpath,
+            1,
+            static_cast<unsigned>(-1),
+            BLOCK,
+            monad_db_snapshot_write_filesystem,
+            context,
+            2048,
+            1,
+            0,
+            /*dump_from_secondary=*/false));
+        monad_db_snapshot_filesystem_write_user_context_destroy(context);
+
+        // The loader opens (does not activate) the secondary, so activate it
+        // and stamp its kind (= monad) up front. Both handles are destroyed
+        // before the load so the loader holds the only timeline references.
+        {
+            mpt::Db primary{
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.append = true, .dbname_paths = {dbname.path}}};
+            [[maybe_unused]] auto const secondary =
+                primary.activate_secondary_timeline(
+                    std::make_unique<monad::MonadOnDiskMachine>());
+            MONAD_ASSERT(primary.timeline_active(timeline_id::secondary));
+        }
+
+        // Target encoding is derived from the secondary's stamped kind, so
+        // the slot snapshot is converted to page leaves on the fly.
+        monad_db_snapshot_load_filesystem(
+            dbpath,
+            1,
+            static_cast<unsigned>(-1),
+            snapshot_dir.path.c_str(),
+            BLOCK,
+            /*load_to_secondary=*/true);
+    }
+
+    // Verify secondary db is page-encoded and round-trip slot reads match.
+    {
+        mpt::Db db{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.append = true, .dbname_paths = {dbname.path}}};
+        {
+            auto db2 = db.open_secondary_timeline(
+                std::make_unique<monad::MonadOnDiskMachine>());
+            ASSERT_TRUE(db2.has_value());
+            db = std::move(db2.value());
+        }
+        TrieDb tdb{db};
+        ASSERT_TRUE(tdb.is_page_encoded());
+        tdb.set_block_and_prefix(BLOCK);
+        Incarnation const inc{0, 0};
+
+        for (auto const &addr : ADDRS) {
+            ASSERT_TRUE(tdb.read_account(addr).has_value());
+            for (auto const b : SLOT_BYTES) {
+                EXPECT_EQ(
+                    tdb.read_storage(addr, inc, make_slot(b)),
+                    make_val(addr, b))
+                    << "addr=" << static_cast<int>(addr.bytes[19]) << " slot=0x"
+                    << std::hex << static_cast<int>(b);
+            }
+
+            auto const page0 = tdb.read_storage_page(addr, inc, bytes32_t{});
+            EXPECT_EQ(page0[0], make_val(addr, 0x00));
+            EXPECT_EQ(page0[1], make_val(addr, 0x01));
+            EXPECT_EQ(page0[0x7f], make_val(addr, 0x7f));
+            for (size_t i = 2; i < 0x7f; ++i) {
+                EXPECT_EQ(page0[static_cast<uint8_t>(i)], bytes32_t{});
+            }
+
+            bytes32_t const pk1 = compute_page_key(make_slot(0x80));
+            auto const page1 = tdb.read_storage_page(addr, inc, pk1);
+            EXPECT_EQ(page1[0], make_val(addr, 0x80));
+            EXPECT_EQ(page1[1], make_val(addr, 0x81));
+            for (size_t i = 2; i < storage_page_t::SLOTS; ++i) {
+                EXPECT_EQ(page1[static_cast<uint8_t>(i)], bytes32_t{});
+            }
+
+            // Read raw leaves by hash path and decode the page.
+            auto const account_path = concat(
+                finalized_nibbles,
+                STATE_NIBBLE,
+                NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})});
+            for (bytes32_t const &page_key : {bytes32_t{}, pk1}) {
+                auto const leaf_res = db.find(
+                    concat(
+                        NibblesView{account_path},
+                        NibblesView{keccak256(
+                            {page_key.bytes, sizeof(page_key.bytes)})}),
+                    BLOCK);
+                ASSERT_TRUE(leaf_res.has_value());
+                auto enc = leaf_res.value().node->value();
+                auto const inner = decode_storage_db_ignore_key(enc);
+                ASSERT_TRUE(inner.has_value());
+                auto const decoded = decode_storage_page(inner.value());
+                ASSERT_TRUE(decoded.has_value());
+                EXPECT_EQ(
+                    decoded.value(),
+                    tdb.read_storage_page(addr, inc, page_key));
+            }
+        }
+
+        // Confirm slot grouping happened during load: each account holds
+        // exactly two storage pages (page_key 0 and page_key 1), so the
+        // state subtree should hold ADDRS.size() * 2 storage leaves total
+        // (the source had ADDRS.size() * 5 = 10 slot leaves before grouping).
+        auto const state_cursor =
+            db.find(concat(finalized_nibbles, STATE_NIBBLE), BLOCK);
+        ASSERT_TRUE(state_cursor.has_value());
+        ASSERT_TRUE(state_cursor.value().is_valid());
+        LeafCounter counter;
+        ASSERT_TRUE(db.traverse_blocking(state_cursor.value(), counter, BLOCK));
+        EXPECT_EQ(counter.count, ADDRS.size() * 2);
+    }
+}
+
+// Dump from a page-encoded secondary timeline, then load into a fresh
+// slot-encoded primary db. This is the dual-db migration path: the secondary
+// holds page-encoded state, monad_db_dump_snapshot(dump_from_secondary=true)
+// expands each page leaf into slot-format entries, and the resulting slot
+// snapshot restores into a standalone slot db. Reverse of
+// LoadPageModeOnSecondaryDb.
+TEST(DbBinarySnapshot, DumpFromSecondaryPageDb)
+{
+    using namespace monad;
+    using namespace monad::mpt;
+
+    // Slots 0x00, 0x01, 0x7f share page_key 0; slots 0x80, 0x81 share page_key
+    // 1, so the source spans two pages per account.
+    constexpr uint64_t BLOCK = 1;
+    constexpr std::array<uint8_t, 5> SLOT_BYTES{0x00, 0x01, 0x7f, 0x80, 0x81};
+    std::array<Address, 2> const ADDRS{Address{1}, Address{2}};
+
+    auto make_slot = [](uint8_t b) {
+        bytes32_t k{};
+        k.bytes[31] = b;
+        return k;
+    };
+    auto make_val = [](Address const &a, uint8_t b) {
+        bytes32_t v{};
+        v.bytes[30] = a.bytes[19];
+        v.bytes[31] = static_cast<uint8_t>(b ^ 0xa5);
+        return v;
+    };
+
+    TempDb const src_db;
+    TempDb const dest_db;
+    TempDir const snapshot_dir;
+
+    // Build a slot-encoded primary with a page-encoded secondary, and populate
+    // the secondary (MonadOnDiskMachine stamps its kind = monad).
+    {
+        mpt::Db db1{
+            std::make_unique<OnDiskMachine>(),
+            OnDiskDbConfig{.dbname_paths = {src_db.path}}};
+        // Activate before any TrieDb exists (requires worker_thread_use_count
+        // == 1). db2 is bound to the secondary timeline.
+        mpt::Db db2 = db1.activate_secondary_timeline(
+            std::make_unique<monad::MonadOnDiskMachine>());
+        load_header({}, db2, BlockHeader{.number = 0});
+        db2.update_finalized_version(0);
+        StateDeltas deltas;
+        for (auto const &addr : ADDRS) {
+            StorageDeltas storage;
+            for (auto const b : SLOT_BYTES) {
+                storage.emplace(
+                    make_slot(b), StorageDelta{bytes32_t{}, make_val(addr, b)});
+            }
+            deltas.emplace(
+                addr,
+                StateDelta{
+                    .account = {std::nullopt, Account{.balance = 1}},
+                    .storage = storage});
+        }
+        TrieDb tdb2{db2};
+        ASSERT_TRUE(tdb2.is_page_encoded());
+        // A page-encoded db must commit through PageCommitBuilder (TrieDb
+        // asserts the builder type matches the encoding).
+        PageCommitBuilder builder(BLOCK, tdb2);
+        builder.add_state_deltas(deltas).add_code(Code{});
+        BlockHeader const header{.number = BLOCK};
+        tdb2.commit(
+            bytes32_t{BLOCK}, builder, header, deltas, [&](BlockHeader &h) {
+                h.receipts_root = tdb2.receipts_root();
+                h.state_root = tdb2.state_root();
+                h.withdrawals_root = tdb2.withdrawals_root();
+                h.transactions_root = tdb2.transactions_root();
+            });
+        tdb2.finalize(BLOCK, bytes32_t{BLOCK});
+    }
+
+    // Dump from the secondary (expands page leaves to slot entries), then load
+    // into a fresh slot-encoded primary.
+    {
+        auto *const context =
+            monad_db_snapshot_filesystem_write_user_context_create(
+                snapshot_dir.path.c_str(), BLOCK);
+        char const *srcpath[] = {src_db.path.c_str()};
+        EXPECT_TRUE(monad_db_dump_snapshot(
+            srcpath,
+            1,
+            static_cast<unsigned>(-1),
+            BLOCK,
+            monad_db_snapshot_write_filesystem,
+            context,
+            2048,
+            1,
+            0,
+            /*dump_from_secondary=*/true));
+        monad_db_snapshot_filesystem_write_user_context_destroy(context);
+
+        {
+            mpt::Db dest_init{
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+            monad::mpt::test::DbAccessor::aux(dest_init)
+                .metadata_ctx()
+                .set_state_machine_kind(
+                    timeline_id::primary, state_machine_kind::ethereum);
+        }
+        char const *dest_path[] = {dest_db.path.c_str()};
+        monad_db_snapshot_load_filesystem(
+            dest_path,
+            1,
+            static_cast<unsigned>(-1),
+            snapshot_dir.path.c_str(),
+            BLOCK,
+            /*load_to_secondary=*/false);
+    }
+
+    // Verify the target is slot-encoded and every slot round-trips.
+    {
+        AsyncIOContext io_context{
+            ReadOnlyOnDiskDbConfig{.dbname_paths = {dest_db.path}}};
+        mpt::Db db{io_context};
+        TrieDb tdb{db};
+        ASSERT_FALSE(tdb.is_page_encoded());
+        tdb.set_block_and_prefix(BLOCK);
+        Incarnation const inc{0, 0};
+        for (auto const &addr : ADDRS) {
+            ASSERT_TRUE(tdb.read_account(addr).has_value());
+            for (auto const b : SLOT_BYTES) {
+                EXPECT_EQ(
+                    tdb.read_storage(addr, inc, make_slot(b)),
+                    make_val(addr, b))
+                    << "addr=" << static_cast<int>(addr.bytes[19]) << " slot=0x"
+                    << std::hex << static_cast<int>(b);
+            }
         }
     }
 }

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1122,8 +1122,8 @@ Db::Db(OnDiskDbConfig const &config)
     MONAD_ASSERT(impl_->aux().is_on_disk());
 }
 
-Db::Db(AsyncIOContext &io_ctx)
-    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, timeline_id::primary)}
+Db::Db(AsyncIOContext &io_ctx, timeline_id const tid)
+    : impl_{std::make_unique<ROOnDiskBlocking>(io_ctx, tid)}
 {
 }
 

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -118,7 +118,9 @@ public:
     // and owns the SM internally. Caller must have registered the relevant
     // kinds at process start (e.g. monad::register_ethereum_state_machines()).
     explicit Db(OnDiskDbConfig const &);
-    explicit Db(AsyncIOContext &); // on-disk RO blocking
+    explicit Db(
+        AsyncIOContext &,
+        timeline_id tid = timeline_id::primary); // on-disk RO blocking
 
     Db(Db const &) = delete;
     Db(Db &&) noexcept;

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -816,6 +816,7 @@ int main(int const argc, char *argv[])
     std::optional<std::filesystem::path> load_binary_snapshot;
     std::string version;
     unsigned dump_concurrency_limit = 2048;
+    bool use_secondary = false;
     uint64_t total_shards = 1;
     uint64_t shard_number = 0;
 
@@ -881,6 +882,14 @@ int main(int const argc, char *argv[])
             "Load a binary snapshot to db")
         ->check(CLI::ExistingDirectory)
         ->excludes(dump_binary_snapshot_option);
+    cli.add_flag(
+        "--secondary",
+        use_secondary,
+        "Operate on the secondary timeline instead of the primary: --it opens "
+        "it read-only, --dump-binary-snapshot dumps from it, and "
+        "--load-binary-snapshot loads into it. The secondary must already be "
+        "active with its state_machine_kind stamped (via monad-mpt "
+        "--activate-secondary --state-machine).");
     mode_group->require_option(0, 1);
     try {
         cli.parse(argc, argv);
@@ -902,7 +911,9 @@ int main(int const argc, char *argv[])
         ReadOnlyOnDiskDbConfig const ro_config{
             .sq_thread_cpu = sq_thread_cpu, .dbname_paths = dbname_paths};
         AsyncIOContext io_ctx{ro_config};
-        Db ro_db{io_ctx};
+        Db ro_db{
+            io_ctx,
+            use_secondary ? timeline_id::secondary : timeline_id::primary};
         fmt::println(
             "db summary: earliest_block_id={} latest_block_id={} "
             "latest_finalized_block_id={} last_verified_block_id={} "
@@ -961,12 +972,15 @@ int main(int const argc, char *argv[])
             context,
             dump_concurrency_limit,
             total_shards,
-            shard_number);
+            shard_number,
+            use_secondary);
         LOG_INFO(
-            "snapshot dump success={} version={} directory={} elapsed={}",
+            "snapshot dump success={} version={} directory={} "
+            "dump_from_secondary={} elapsed={}",
             success,
             resolved_version,
             dump_binary_snapshot.value(),
+            use_secondary,
             std::chrono::steady_clock::now() - begin);
         monad_db_snapshot_filesystem_write_user_context_destroy(context);
         return success == false;
@@ -982,11 +996,14 @@ int main(int const argc, char *argv[])
             c_dbname_paths.size(),
             sq_thread_cpu.value_or(std::numeric_limits<unsigned>::max()),
             load_binary_snapshot.value().c_str(),
-            resolved_version);
+            resolved_version,
+            use_secondary);
         LOG_INFO(
-            "snapshot version={} load_binary_snapshot={} elapsed={}",
+            "snapshot version={} load_binary_snapshot={} load_to_secondary={} "
+            "elapsed={}",
             resolved_version,
             load_binary_snapshot.value(),
+            use_secondary,
             std::chrono::steady_clock::now() - begin);
     }
     return 0;


### PR DESCRIPTION
## Summary

Lets `monad-cli` operate on the **secondary timeline** and makes snapshot dump/load **encoding-aware**, so they work against both slot-encoded and page-encoded dbs by reading the encoding from db metadata rather than assuming slot encoding.

## Changes

**`--secondary` flag (`cmd/monad_cli.cpp`)**
- New `--secondary` flag routes all three modes to the secondary timeline instead of the primary:
  - `--it` opens it read-only
  - `--dump-binary-snapshot` dumps from it
  - `--load-binary-snapshot` loads into it
- The secondary must already be active with its `state_machine_kind` stamped (via `monad-mpt --activate-secondary --state-machine`).
- Logs now report `dump_from_secondary` / `load_to_secondary`.

**Encoding-aware snapshots (`db_snapshot.{cpp,h}`, `db_snapshot_filesystem.{cpp,h}`)**
- Encoding is inferred per-db from `state_machine_type() == state_machine_kind::monad` (`page_encoded()`), no longer hard-assumed.
- **Dump** from a page-encoded source expands each page leaf back into individual storage slots.
- **Load** into a page-encoded target accumulates slots per account into pages, then finalizes each page into one Update keyed by `keccak256(page_key)` (empty pages → deletion).
- Loader/dumper signatures gain `load_to_secondary` / `dump_from_secondary`; loader opens the secondary via `open_secondary_timeline()` and asserts it's active.

**State machine registration (`monad/db/state_machine_init.{hpp,cpp}`)**
- New `register_monad_state_machines()` registers `MonadOnDiskMachine` under `state_machine_kind::monad` for the metadata-driven `Db(OnDiskDbConfig const&)` open path. Complements `register_ethereum_state_machines()`; idempotent. Wired into `cmd/monad/main.cpp` and statesync.

**`mpt::Db` RO ctor (`mpt/db.{hpp,cpp}`)**
- `Db(AsyncIOContext&, timeline_id tid = timeline_id::primary)` — RO blocking ctor can now open the secondary timeline.

## Testing
- `test_db_snapshot.cpp` extended (+384 lines) covering page-encoded dump/load round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)