### PR TITLE
Pin RISCV gcc xcompiler to 15.2

### DIFF
--- a/scripts/ubuntu-build/build-riscv-toolchain.sh
+++ b/scripts/ubuntu-build/build-riscv-toolchain.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="https://github.com/riscv-collab/riscv-gnu-toolchain"
-BRANCH="2026.06.06"
+BRANCH="2026.05.06"
 SRC="/riscv-gnu-toolchain"
 PREFIX="/root/riscv"
 
@@ -14,6 +14,17 @@ cd "${SRC}"
   --with-abi=lp64
 
 make -j"$(nproc)"
+
+# Keep the cross compiler in lockstep with the x86 host compiler.
+HOST_CC="${CC:-gcc-15}"
+HOST_VERSION="$("${HOST_CC}" -dumpfullversion)"
+CROSS_VERSION="$("${PREFIX}/bin/riscv64-unknown-elf-gcc" -dumpfullversion)"
+if [ "${CROSS_VERSION}" != "${HOST_VERSION}" ]; then
+    echo "error: cross compiler GCC ${CROSS_VERSION} does not match host" \
+        "${HOST_CC} GCC ${HOST_VERSION}; update BRANCH (currently ${BRANCH})" \
+        "to a tag whose GCC matches the host, or align the host compiler." >&2
+    exit 1
+fi
 
 # Strip debug info from the installed toolchain (kept artifacts).
 find "${PREFIX}" -type f -executable -exec strip --strip-unneeded {} + 2>/dev/null || true


### PR DESCRIPTION
The current branch points to GCC 16, but the x86 build is still on 15.2. This caused some compile issues in https://github.com/category-labs/monad/pull/2288