### PR TITLE
[execution] Hoist block hash utils to their own TU.

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -127,6 +127,8 @@ add_library(
   # ethereum/execution
   "ethereum/block_hash_buffer.cpp"
   "ethereum/block_hash_buffer.hpp"
+  "ethereum/block_hash_buffer/util.cpp"
+  "ethereum/block_hash_buffer/util.hpp"
   "ethereum/block_hash_history.cpp"
   "ethereum/block_hash_history.hpp"
   "ethereum/block_reward.cpp"

--- a/category/execution/ethereum/block_hash_buffer.cpp
+++ b/category/execution/ethereum/block_hash_buffer.cpp
@@ -16,15 +16,8 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
-#include <category/core/keccak.hpp>
 #include <category/core/likely.h>
-#include <category/core/log.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
-#include <category/execution/ethereum/core/block.hpp>
-#include <category/execution/ethereum/db/block_db.hpp>
-#include <category/execution/ethereum/db/util.hpp>
-#include <category/mpt/db.hpp>
-#include <category/mpt/nibbles_view.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -155,50 +148,6 @@ BlockHashChain::find_chain(bytes32_t const &block_id) const
         return buf_;
     }
     return it->buf;
-}
-
-bool init_block_hash_buffer_from_triedb(
-    mpt::Db &rodb, uint64_t const block_number,
-    BlockHashBufferFinalized &block_hash_buffer)
-{
-    for (uint64_t b = block_number < 256 ? 0 : block_number - 256;
-         b < block_number;
-         ++b) {
-        auto const header = rodb.find(
-            mpt::concat(
-                FINALIZED_NIBBLE, mpt::NibblesView{block_header_nibbles}),
-            b);
-        if (!header.has_value()) {
-            LOG_WARNING(
-                "Could not query block header {} from TrieDb -- {}",
-                b,
-                header.error().message().c_str());
-            return false;
-        }
-        auto const h = to_bytes(keccak256(header.value().node->value()));
-        block_hash_buffer.set(b, h);
-    }
-
-    return true;
-}
-
-bool init_block_hash_buffer_from_blockdb(
-    BlockDb &block_db, uint64_t const block_number,
-    BlockHashBufferFinalized &block_hash_buffer)
-{
-    for (uint64_t b = block_number < 256 ? 1 : block_number - 255;
-         b <= block_number;
-         ++b) {
-        Block block;
-        auto const ok = block_db.get(b, block);
-        if (!ok) {
-            LOG_WARNING("Could not query block {} from blockdb.", b);
-            return false;
-        }
-        block_hash_buffer.set(b - 1, block.header.parent_hash);
-    }
-
-    return true;
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/block_hash_buffer.hpp
+++ b/category/execution/ethereum/block_hash_buffer.hpp
@@ -24,13 +24,6 @@
 
 MONAD_NAMESPACE_BEGIN
 
-class BlockDb;
-
-namespace mpt
-{
-    class Db;
-}
-
 class BlockHashBuffer
 {
 public:
@@ -93,11 +86,5 @@ public:
     void finalize(bytes32_t const &block_id);
     BlockHashBuffer const &find_chain(bytes32_t const &block_id) const;
 };
-
-bool init_block_hash_buffer_from_triedb(
-    mpt::Db &, uint64_t, BlockHashBufferFinalized &);
-
-bool init_block_hash_buffer_from_blockdb(
-    BlockDb &, uint64_t block_number, BlockHashBufferFinalized &);
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/block_hash_buffer/util.cpp
+++ b/category/execution/ethereum/block_hash_buffer/util.cpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/log.hpp>
+#include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/execution/ethereum/block_hash_buffer/util.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/db/block_db.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/mpt/db.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+bool init_block_hash_buffer_from_triedb(
+    mpt::Db const &rodb, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer)
+{
+    for (uint64_t b = block_number < 256 ? 0 : block_number - 256;
+         b < block_number;
+         ++b) {
+        auto const header = rodb.find(
+            mpt::concat(
+                FINALIZED_NIBBLE, mpt::NibblesView{block_header_nibbles}),
+            b);
+        if (!header.has_value()) {
+            LOG_WARNING(
+                "Could not query block header {} from TrieDb -- {}",
+                b,
+                header.error().message().c_str());
+            return false;
+        }
+        auto const h = to_bytes(keccak256(header.value().node->value()));
+        block_hash_buffer.set(b, h);
+    }
+
+    return true;
+}
+
+bool init_block_hash_buffer_from_blockdb(
+    BlockDb const &block_db, uint64_t const block_number,
+    BlockHashBufferFinalized &block_hash_buffer)
+{
+    for (uint64_t b = block_number < 256 ? 1 : block_number - 255;
+         b <= block_number;
+         ++b) {
+        Block block;
+        auto const ok = block_db.get(b, block);
+        if (!ok) {
+            LOG_WARNING("Could not query block {} from blockdb.", b);
+            return false;
+        }
+        block_hash_buffer.set(b - 1, block.header.parent_hash);
+    }
+
+    return true;
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/block_hash_buffer/util.hpp
+++ b/category/execution/ethereum/block_hash_buffer/util.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+class BlockDb;
+class BlockHashBufferFinalized;
+
+namespace mpt
+{
+    class Db;
+}
+
+// Populate `block_hash_buffer` with up to 256 ancestor hashes preceding
+// `block_number` sourced from a TrieDb instance.
+bool init_block_hash_buffer_from_triedb(
+    mpt::Db const &, uint64_t, BlockHashBufferFinalized &);
+
+// Populate `block_hash_buffer` with up to 256 ancestor hashes preceding
+// `block_number` sourced from a BlockDb instance.
+bool init_block_hash_buffer_from_blockdb(
+    BlockDb const &, uint64_t block_number, BlockHashBufferFinalized &);
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/block_hash_buffer_test.cpp
+++ b/category/execution/ethereum/block_hash_buffer_test.cpp
@@ -18,6 +18,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -23,7 +23,6 @@
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/core/runtime/uint256.hpp>
-#include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/block.hpp>

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -28,6 +28,7 @@
 #include <category/core/monad_exception.hpp>
 #include <category/core/procfs/statm.h>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
+#include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/chain/genesis_state.hpp>


### PR DESCRIPTION
This patch pulls the utility functions from `category/execution/ethereum/block_hash_buffer.hpp`. The reason for this change is to be able to compile the block hash buffer translation unit for the zkVM target. The utility functions depend on `mpt` and `async` which we cannot build on zkVM.