### PR TITLE
[zkvm] add MONAD_STATIC_ASSERT macro

### DIFF
--- a/category/core/assert.h
+++ b/category/core/assert.h
@@ -125,6 +125,12 @@ extern "C"
         while (0)
 #endif
 
+// Type-layout / compile-time invariant assertion, on by default. The zkVM
+// guest shadows this header (zkvm/category/core/assert.h) to erase the
+// check, because backing-type substitutions (e.g. immutable::map switching
+// from immer to ankerl) change sizeof for affected classes.
+#define MONAD_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
+
 #ifdef __cplusplus
 }
 #endif

--- a/category/execution/ethereum/state3/account_state.hpp
+++ b/category/execution/ethereum/state3/account_state.hpp
@@ -155,7 +155,7 @@ public:
     }
 };
 
-static_assert(sizeof(AccountState) == 160);
+MONAD_STATIC_ASSERT(sizeof(AccountState) == 160);
 
 // RELAXED MERGE
 // track the min original balance needed at start of transaction and if the

--- a/category/execution/ethereum/state3/account_substate.hpp
+++ b/category/execution/ethereum/state3/account_substate.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 
@@ -100,6 +101,6 @@ public:
     }
 };
 
-static_assert(sizeof(AccountSubstate) == 24);
+MONAD_STATIC_ASSERT(sizeof(AccountSubstate) == 24);
 
 MONAD_NAMESPACE_END

--- a/zkvm/category/core/assert.h
+++ b/zkvm/category/core/assert.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include_next <category/core/assert.h>
+
+// Layout invariants from the host build which don't hold in zkVM get erased
+#undef MONAD_STATIC_ASSERT
+#define MONAD_STATIC_ASSERT(...)


### PR DESCRIPTION
Will be shadowed for properties which change in zkvm build e.g. struct/class size due to different backing data structures (immer vs ankerl etc).