### PR TITLE
[build] Normalize Boost.Outcome status-code includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,10 @@ endif()
 # libs
 # ##############################################################################
 
+include(cmake/boost_outcome_status_code_overlay.cmake)
+monad_configure_boost_outcome_status_code_overlay(
+  MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+
 add_subdirectory("category/async")
 add_subdirectory("category/core")
 add_subdirectory("category/mpt")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,10 @@ endif()
 # libs
 # ##############################################################################
 
+include(cmake/boost_outcome_status_code_overlay.cmake)
+monad_configure_boost_outcome_status_code_overlay(
+  MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+
 add_subdirectory("category/async")
 # crypto before core: monad_core links monad_crypto for keccak256()
 add_subdirectory("category/crypto")

--- a/category/async/CMakeLists.txt
+++ b/category/async/CMakeLists.txt
@@ -42,6 +42,9 @@ add_library(
   "util.hpp")
 
 target_include_directories(monad_async PUBLIC ${CATEGORY_MAIN_DIR})
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(monad_async)
+endif()
 monad_compile_options(monad_async)
 target_link_libraries(monad_async PUBLIC monad_core Boost::fiber)
 

--- a/category/async/concepts.hpp
+++ b/category/async/concepts.hpp
@@ -20,13 +20,7 @@
 #include <boost/outcome/experimental/status_result.hpp>
 #include <boost/outcome/try.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(                                                             \
-    <boost/outcome/experimental/status-code/system_code_from_exception.hpp>)
-    #include <boost/outcome/experimental/status-code/system_code_from_exception.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/system_code_from_exception.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/system_code_from_exception.hpp>
 
 #include <type_traits>
 

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -18,12 +18,7 @@
 #include <category/async/concepts.hpp>
 #include <category/async/erased_connected_operation.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/nested_status_code.hpp>)
-    #include <boost/outcome/experimental/status-code/nested_status_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/nested_status_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/nested_status_code.hpp>
 
 #include <variant>
 #include <vector>

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -207,6 +207,9 @@ endif()
 
 monad_compile_options(monad_core)
 target_include_directories(monad_core PUBLIC ${CATEGORY_MAIN_DIR})
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(monad_core)
+endif()
 
 if(MONAD_CORE_FORCE_DEBUG_ASSERT)
   target_compile_definitions(monad_core PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT")

--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -205,6 +205,11 @@ endif()
 
 monad_compile_options(monad_core)
 target_include_directories(monad_core PUBLIC ${CATEGORY_MAIN_DIR})
+target_include_directories(monad_core SYSTEM BEFORE
+                           PUBLIC "${THIRD_PARTY_DIR}/fiber/include")
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(monad_core)
+endif()
 
 if(MONAD_CORE_FORCE_DEBUG_ASSERT)
   target_compile_definitions(monad_core PUBLIC "MONAD_CORE_FORCE_DEBUG_ASSERT")

--- a/category/core/checked_math.cpp
+++ b/category/core/checked_math.cpp
@@ -25,14 +25,8 @@
 #include <initializer_list>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/core/checked_math.hpp
+++ b/category/core/checked_math.hpp
@@ -21,14 +21,8 @@
 
 #include <initializer_list>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/core/rlp/decode_error.cpp
+++ b/category/core/rlp/decode_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/core/rlp/decode_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/core/rlp/decode_error.hpp
+++ b/category/core/rlp/decode_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/core/rlp/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -304,12 +304,20 @@ target_include_directories(
   PRIVATE ${Boost_INCLUDE_DIRS}
   PUBLIC ${cthash_SOURCE_DIR}/include
   PUBLIC ${silkpre_SOURCE_DIR}/lib)
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(
+    monad_execution_ethereum)
+endif()
 
 target_include_directories(
   monad_execution_native
   PUBLIC ${CATEGORY_MAIN_DIR}
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
   PRIVATE ${Boost_INCLUDE_DIRS})
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(
+    monad_execution_native)
+endif()
 
 target_compile_definitions(
   monad_execution_ethereum PUBLIC MONAD_CXX_CTYPES_USE_EVMC_HPP

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -328,12 +328,20 @@ target_include_directories(
   PRIVATE ${Boost_INCLUDE_DIRS}
   PUBLIC ${cthash_SOURCE_DIR}/include
   PRIVATE ${silkpre_SOURCE_DIR}/lib)
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(
+    monad_execution_ethereum)
+endif()
 
 target_include_directories(
   monad_execution_native
   PUBLIC ${CATEGORY_MAIN_DIR}
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
   PRIVATE ${Boost_INCLUDE_DIRS})
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(
+    monad_execution_native)
+endif()
 
 target_compile_definitions(
   monad_execution_ethereum PUBLIC MONAD_CXX_CTYPES_USE_EVMC_HPP

--- a/category/execution/ethereum/core/contract/abi_decode_error.hpp
+++ b/category/execution/ethereum/core/contract/abi_decode_error.hpp
@@ -19,14 +19,8 @@
 
 #include <initializer_list>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/core/contract/checked_math.cpp
+++ b/category/execution/ethereum/core/contract/checked_math.cpp
@@ -23,14 +23,8 @@
 #include <initializer_list>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/core/contract/checked_math.hpp
+++ b/category/execution/ethereum/core/contract/checked_math.hpp
@@ -22,14 +22,8 @@
 
 #include <initializer_list>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -34,14 +34,8 @@
 #include <evmc/evmc.h>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
 

--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -23,14 +23,8 @@
 
 #include <evmc/evmc.h>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 #include <vector>

--- a/category/execution/ethereum/validate_transaction_error.cpp
+++ b/category/execution/ethereum/validate_transaction_error.cpp
@@ -16,14 +16,9 @@
 #include <category/execution/ethereum/validate_transaction_error.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 #include <boost/outcome/success_failure.hpp>
 
 #include <initializer_list>

--- a/category/execution/ethereum/validate_transaction_error.hpp
+++ b/category/execution/ethereum/validate_transaction_error.hpp
@@ -18,14 +18,8 @@
 #include <category/core/config.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/reserve_balance/reserve_balance_error.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/execution/monad/reserve_balance/reserve_balance_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/reserve_balance/reserve_balance_error.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/core/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/staking/util/staking_error.cpp
+++ b/category/execution/monad/staking/util/staking_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/execution/monad/staking/util/staking_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/staking/util/staking_error.hpp
+++ b/category/execution/monad/staking/util/staking_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/execution/monad/staking/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/validate_monad_block.cpp
+++ b/category/execution/monad/validate_monad_block.cpp
@@ -27,14 +27,8 @@
 #include <cstdint>
 #include <optional>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 #include <concepts>
 

--- a/category/execution/monad/validate_monad_block.hpp
+++ b/category/execution/monad/validate_monad_block.hpp
@@ -23,14 +23,8 @@
 
 #include <span>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/monad/validate_monad_transaction.hpp
+++ b/category/execution/monad/validate_monad_transaction.hpp
@@ -24,14 +24,8 @@
 
 #include <evmc/evmc.h>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 #include <optional>

--- a/category/execution/monad/validate_system_transaction.cpp
+++ b/category/execution/monad/validate_system_transaction.cpp
@@ -22,15 +22,8 @@
 #include <category/vm/evm/explicit_traits.hpp>
 
 #include <boost/outcome/config.hpp>
-
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/monad/validate_system_transaction.hpp
+++ b/category/execution/monad/validate_system_transaction.hpp
@@ -19,14 +19,8 @@
 #include <category/vm/evm/traits.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 #include <boost/outcome/success_failure.hpp>
 
 #include <initializer_list>

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -72,6 +72,9 @@ add_library(
   "update_aux.cpp"
   "util.hpp")
 target_include_directories(monad_trie PUBLIC ${CATEGORY_MAIN_DIR})
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(monad_trie)
+endif()
 target_include_directories(monad_trie PRIVATE "third_party")
 monad_compile_options(monad_trie)
 target_link_libraries(monad_trie PRIVATE Boost::boost)

--- a/category/mpt/db_error.hpp
+++ b/category/mpt/db_error.hpp
@@ -18,12 +18,7 @@
 #include <category/core/result.hpp>
 #include <category/mpt/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/generic_code.hpp>)
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_MPT_NAMESPACE_BEGIN
 

--- a/cmake/boost_outcome_status_code_overlay.cmake
+++ b/cmake/boost_outcome_status_code_overlay.cmake
@@ -1,0 +1,164 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function(monad_configure_boost_outcome_status_code_overlay out_var)
+  set(_flat_base "boost/outcome/experimental/status-code")
+  set(_nested_base "boost/outcome/experimental/status-code/status-code")
+
+  set(_boost_include_dirs ${Boost_INCLUDE_DIRS})
+  if(NOT _boost_include_dirs AND TARGET Boost::headers)
+    get_target_property(_boost_include_dirs Boost::headers
+                        INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+
+  if(NOT _boost_include_dirs)
+    message(
+      FATAL_ERROR
+        "Boost include directories are unknown; cannot configure Boost.Outcome status-code overlay"
+    )
+  endif()
+
+  set(_flat_root)
+  set(_nested_root)
+  foreach(_include_dir IN LISTS _boost_include_dirs)
+    if(NOT _flat_root
+       AND EXISTS "${_include_dir}/${_flat_base}/config.hpp")
+      set(_flat_root "${_include_dir}")
+    endif()
+    if(NOT _nested_root
+       AND EXISTS "${_include_dir}/${_nested_base}/config.hpp")
+      set(_nested_root "${_include_dir}")
+    endif()
+  endforeach()
+
+  set(_overlay_dir
+      "${CMAKE_BINARY_DIR}/generated/boost-outcome-status-code-overlay")
+  set_property(GLOBAL PROPERTY MONAD_BOOST_INCLUDE_DIRS
+                               "${_boost_include_dirs}")
+
+  if(_flat_root)
+    if(_nested_root AND NOT _nested_root STREQUAL _flat_root)
+      message(
+        WARNING
+          "Selected Boost include directories expose both flat and nested "
+          "Boost.Outcome status-code layouts from different roots; using "
+          "flat layout from ${_flat_root}; nested layout was found at "
+          "${_nested_root}"
+      )
+    else()
+      message(
+        STATUS
+          "Using Boost.Outcome status-code flat include layout from ${_flat_root}"
+      )
+    endif()
+
+    # The source tree uses the flat include spelling, so no overlay is needed.
+    file(REMOVE_RECURSE "${_overlay_dir}")
+    set_property(GLOBAL PROPERTY MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR "")
+    set(${out_var}
+        ""
+        PARENT_SCOPE)
+    return()
+  elseif(_nested_root)
+    set(_source_root "${_nested_root}")
+    set(_source_base "${_nested_base}")
+    set(_wrapper_base "${_flat_base}")
+  else()
+    list(JOIN _boost_include_dirs "\n  " _boost_include_dirs_pretty)
+    message(
+      FATAL_ERROR
+        "Could not find Boost.Outcome status-code headers under selected Boost include directories:\n  ${_boost_include_dirs_pretty}"
+    )
+  endif()
+
+  # Monad only includes top-level status-code headers directly. Forwarded
+  # nested headers resolve their own detail/ siblings relative to themselves.
+  file(GLOB _status_code_headers CONFIGURE_DEPENDS
+       "${_source_root}/${_source_base}/*.hpp")
+  if(NOT _status_code_headers)
+    message(
+      FATAL_ERROR
+        "No Boost.Outcome status-code headers found under ${_source_root}/${_source_base}"
+    )
+  endif()
+
+  file(MAKE_DIRECTORY "${_overlay_dir}/${_wrapper_base}")
+  file(REMOVE_RECURSE "${_overlay_dir}/${_nested_base}")
+  set(_generated_headers)
+  foreach(_header IN LISTS _status_code_headers)
+    get_filename_component(_header_name "${_header}" NAME)
+    set(_header_path "${_overlay_dir}/${_wrapper_base}/${_header_name}")
+    set(_header_content
+        "#pragma once\n#include <${_source_base}/${_header_name}>\n")
+    list(APPEND _generated_headers "${_header_path}")
+
+    if(EXISTS "${_header_path}")
+      file(READ "${_header_path}" _existing_header_content)
+    else()
+      set(_existing_header_content)
+    endif()
+
+    if(NOT _existing_header_content STREQUAL _header_content)
+      file(WRITE "${_header_path}" "${_header_content}")
+    endif()
+  endforeach()
+
+  file(GLOB _existing_headers CONFIGURE_DEPENDS
+       "${_overlay_dir}/${_wrapper_base}/*.hpp")
+  foreach(_header IN LISTS _existing_headers)
+    if(NOT _header IN_LIST _generated_headers)
+      file(REMOVE "${_header}")
+    endif()
+  endforeach()
+
+  message(
+    STATUS
+      "Generated Boost.Outcome status-code include overlay for ${_wrapper_base} from ${_source_root}/${_source_base}"
+  )
+  set_property(GLOBAL PROPERTY MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR
+                               "${_overlay_dir}")
+  set(${out_var}
+      "${_overlay_dir}"
+      PARENT_SCOPE)
+endfunction()
+
+function(monad_target_include_boost_outcome_status_code_overlay target)
+  if(NOT TARGET "${target}")
+    message(FATAL_ERROR "Unknown target: ${target}")
+  endif()
+
+  get_property(_overlay_dir GLOBAL PROPERTY
+               MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+  if(NOT _overlay_dir AND MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+    set(_overlay_dir "${MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR}")
+  endif()
+
+  get_property(_boost_include_dirs GLOBAL PROPERTY MONAD_BOOST_INCLUDE_DIRS)
+  if(NOT _boost_include_dirs AND Boost_INCLUDE_DIRS)
+    set(_boost_include_dirs ${Boost_INCLUDE_DIRS})
+  endif()
+
+  set(_include_dirs)
+  if(_overlay_dir)
+    list(APPEND _include_dirs "$<BUILD_INTERFACE:${_overlay_dir}>")
+  endif()
+  foreach(_include_dir IN LISTS _boost_include_dirs)
+    list(APPEND _include_dirs "$<BUILD_INTERFACE:${_include_dir}>")
+  endforeach()
+
+  if(_include_dirs)
+    target_include_directories("${target}" BEFORE PUBLIC ${_include_dirs})
+  endif()
+endfunction()

--- a/cmake/boost_outcome_status_code_overlay.cmake
+++ b/cmake/boost_outcome_status_code_overlay.cmake
@@ -1,0 +1,156 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function(monad_configure_boost_outcome_status_code_overlay out_var)
+  set(_flat_base "boost/outcome/experimental/status-code")
+  set(_nested_base "boost/outcome/experimental/status-code/status-code")
+
+  set(_boost_include_dirs ${Boost_INCLUDE_DIRS})
+  if(NOT _boost_include_dirs AND TARGET Boost::headers)
+    get_target_property(_boost_include_dirs Boost::headers
+                        INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+
+  if(NOT _boost_include_dirs)
+    message(
+      FATAL_ERROR
+        "Boost include directories are unknown; cannot configure Boost.Outcome status-code overlay"
+    )
+  endif()
+
+  set(_flat_root)
+  set(_nested_root)
+  foreach(_include_dir IN LISTS _boost_include_dirs)
+    if(NOT _flat_root
+       AND EXISTS "${_include_dir}/${_flat_base}/config.hpp")
+      set(_flat_root "${_include_dir}")
+    endif()
+    if(NOT _nested_root
+       AND EXISTS "${_include_dir}/${_nested_base}/config.hpp")
+      set(_nested_root "${_include_dir}")
+    endif()
+  endforeach()
+
+  set(_overlay_dir
+      "${CMAKE_BINARY_DIR}/generated/boost-outcome-status-code-overlay")
+  set_property(GLOBAL PROPERTY MONAD_BOOST_INCLUDE_DIRS
+                               "${_boost_include_dirs}")
+
+  if(_flat_root)
+    if(_nested_root AND NOT _nested_root STREQUAL _flat_root)
+      message(
+        WARNING
+          "Selected Boost include directories expose both flat and nested "
+          "Boost.Outcome status-code layouts from different roots; using "
+          "flat layout from ${_flat_root}; nested layout was found at "
+          "${_nested_root}"
+      )
+    else()
+      message(
+        STATUS
+          "Using Boost.Outcome status-code flat include layout from ${_flat_root}"
+      )
+    endif()
+
+    # The source tree uses the flat include spelling, so no overlay is needed.
+    file(REMOVE_RECURSE "${_overlay_dir}")
+    set_property(GLOBAL PROPERTY MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR "")
+    set(${out_var}
+        ""
+        PARENT_SCOPE)
+    return()
+  elseif(_nested_root)
+    set(_source_root "${_nested_root}")
+    set(_source_base "${_nested_base}")
+    set(_wrapper_base "${_flat_base}")
+  else()
+    list(JOIN _boost_include_dirs "\n  " _boost_include_dirs_pretty)
+    message(
+      FATAL_ERROR
+        "Could not find Boost.Outcome status-code headers under selected Boost include directories:\n  ${_boost_include_dirs_pretty}"
+    )
+  endif()
+
+  # Monad only includes top-level status-code headers directly. Forwarded
+  # nested headers resolve their own detail/ siblings relative to themselves.
+  file(GLOB _status_code_headers CONFIGURE_DEPENDS
+       "${_source_root}/${_source_base}/*.hpp")
+  if(NOT _status_code_headers)
+    message(
+      FATAL_ERROR
+        "No Boost.Outcome status-code headers found under ${_source_root}/${_source_base}"
+    )
+  endif()
+
+  file(MAKE_DIRECTORY "${_overlay_dir}/${_wrapper_base}")
+  file(REMOVE_RECURSE "${_overlay_dir}/${_nested_base}")
+  set(_generated_headers)
+  foreach(_header IN LISTS _status_code_headers)
+    get_filename_component(_header_name "${_header}" NAME)
+    set(_header_path "${_overlay_dir}/${_wrapper_base}/${_header_name}")
+    set(_header_content
+        "#pragma once\n#include <${_source_base}/${_header_name}>\n")
+    list(APPEND _generated_headers "${_header_path}")
+
+    if(EXISTS "${_header_path}")
+      file(READ "${_header_path}" _existing_header_content)
+    else()
+      set(_existing_header_content)
+    endif()
+
+    if(NOT _existing_header_content STREQUAL _header_content)
+      file(WRITE "${_header_path}" "${_header_content}")
+    endif()
+  endforeach()
+
+  file(GLOB _existing_headers CONFIGURE_DEPENDS
+       "${_overlay_dir}/${_wrapper_base}/*.hpp")
+  foreach(_header IN LISTS _existing_headers)
+    if(NOT _header IN_LIST _generated_headers)
+      file(REMOVE "${_header}")
+    endif()
+  endforeach()
+
+  message(
+    STATUS
+      "Generated Boost.Outcome status-code include overlay for ${_wrapper_base} from ${_source_root}/${_source_base}"
+  )
+  set_property(GLOBAL PROPERTY MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR
+                               "${_overlay_dir}")
+  set(${out_var}
+      "${_overlay_dir}"
+      PARENT_SCOPE)
+endfunction()
+
+function(monad_target_include_boost_outcome_status_code_overlay target)
+  if(NOT TARGET "${target}")
+    message(FATAL_ERROR "Unknown target: ${target}")
+  endif()
+
+  get_property(_overlay_dir GLOBAL PROPERTY
+               MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+  if(NOT _overlay_dir AND MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR)
+    set(_overlay_dir "${MONAD_BOOST_OUTCOME_STATUS_CODE_OVERLAY_DIR}")
+  endif()
+
+  set(_include_dirs)
+  if(_overlay_dir)
+    list(APPEND _include_dirs "$<BUILD_INTERFACE:${_overlay_dir}>")
+  endif()
+
+  if(_include_dirs)
+    target_include_directories("${target}" BEFORE PUBLIC ${_include_dirs})
+  endif()
+endfunction()

--- a/rust/crates/monad-triedb/CMakeLists.txt
+++ b/rust/crates/monad-triedb/CMakeLists.txt
@@ -38,6 +38,9 @@ add_library(triedb_driver SHARED "${PROJECT_SOURCE_DIR}/include/ffi.h"
                                  "${PROJECT_SOURCE_DIR}/src/ffi.cpp")
 
 target_include_directories(triedb_driver PUBLIC ${PROJECT_SOURCE_DIR}/include)
+if(COMMAND monad_target_include_boost_outcome_status_code_overlay)
+  monad_target_include_boost_outcome_status_code_overlay(triedb_driver)
+endif()
 
 # Interface link monad_execution so that we'll take any configuration we need,
 # but we won't build it


### PR DESCRIPTION
Normalize Monad sources on the flattened Boost.Outcome status-code include layout used by newer Boost releases, and remove the per-file `__has_include` forks for the older nested layout.

Add a CMake overlay that inspects the selected Boost include directories and, when building against older Boost releases with the nested `status-code/status-code` layout, generates flat forwarding headers. The overlay is added to Monad targets whose public headers use these includes so `Boost_DIR` selection remains authoritative instead of falling through to compiler include paths.

This PR also makes the status-code dependency on `generic_code.hpp` explicit. Some of the old nested-layout include branches included `generic_code.hpp` directly while the flat-layout branches relied on it transitively; after normalizing on the flat Boost.Outcome include spelling, the affected files now include `generic_code.hpp` directly so flat and nested Boost layouts have the same declared dependencies.

Co-Authored-By: Codex GPT-5.5 <codex@openai.com>