### PR TITLE
[staking] Downgrade priority fee distribution log level to LOG_WARNING

### DIFF
--- a/category/execution/monad/staking/priority_fee.cpp
+++ b/category/execution/monad/staking/priority_fee.cpp
@@ -47,7 +47,7 @@ void distribute_priority_fees(State &state)
     StakingContract contract(state, call_tracer);
     auto const res = contract.distribute_priority_fees(fees);
     if (res.has_error()) {
-        LOG_ERROR(
+        LOG_WARNING(
             "staking: distribute priority fee reverted: {}",
             res.error().message());
         // At the start of block execution, the proposer id is always cleared to


### PR DESCRIPTION
The flexnet tests fails upon encountering any LOG_ERROR messages emitted by execution. Flexnet is correct to fail here, because the log level is too high: the reward syscall is optionally provided by consensus. Originally, this emitted an error because, on mainnet, there is always a reward syscall present in every block, and therefore the priority fee distribution always succeeds. However, in flexnet, not all scenarios include the staking syscalls which is valid according to the spec.

Accordingly, reduce the log level from `LOG_ERROR` to `LOG_WARNING`.