### PR TITLE
[execution]: Memory Bound LRU Cache

### DIFF
--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -26,8 +26,10 @@
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 #include <category/execution/monad/state2/proposal_state.hpp>
+#include <category/vm/utils/lru_weight_cache.hpp>
 
 #include <cstdint>
+#include <format>
 #include <memory>
 #include <optional>
 #include <string>
@@ -48,11 +50,13 @@ class DbCache final
     // The cache is slot-granular: keyed by slot_key, the value is a
     // storage_page_t used as a single-slot container holding the value at
     // index 0 only. This will be compatible for future page-granular reads.
-    using StorageCache =
-        LruCache<StorageKey, storage_page_t, StorageKeyHashCompare>;
+    using StorageCache = vm::utils::LruWeightCache<
+        StorageKey, storage_page_t, StorageKeyHashCompare>;
+
+    static constexpr uint32_t STORAGE_CACHE_MAX_BYTES = 256u * 1024 * 1024;
 
     AccountsCache accounts_{10'000'000};
-    StorageCache storage_{10'000'000};
+    StorageCache storage_{STORAGE_CACHE_MAX_BYTES};
     Proposals proposals_;
 
 public:
@@ -139,7 +143,9 @@ public:
             insert_in_lru_caches(ps->post_state());
         }
         else {
-            // Finalizing a truncated proposal. Clear LRU caches.
+            // Finalizing a truncated proposal. Clear LRU caches.  This is an
+            // expensive operation. However, with 100 unfinalized proposals,
+            // cache speed is the least of our problems.
             accounts_.clear();
             storage_.clear();
         }
@@ -152,7 +158,8 @@ public:
 
     std::string storage_stats()
     {
-        return storage_.print_stats();
+        return std::format(
+            "{:8} / {:10}", storage_.size(), storage_.approx_weight());
     }
 
 private:
@@ -162,7 +169,7 @@ private:
             accounts_.insert(addr, acct);
         }
         for (auto const &[sk, leaf] : post_state.storage) {
-            storage_.insert(sk, leaf);
+            storage_.insert(sk, leaf, static_cast<uint32_t>(leaf.byte_size()));
         }
     }
 };

--- a/category/execution/monad/db/storage_page.hpp
+++ b/category/execution/monad/db/storage_page.hpp
@@ -107,6 +107,15 @@ struct storage_page_t
         return values_.size();
     }
 
+    // Approximate in-memory footprint in bytes, used as the LRU cache weight.
+    size_t byte_size() const
+    {
+        size_t const heap = values_.capacity() > INLINE_VALUES
+                                ? values_.capacity() * sizeof(bytes32_t)
+                                : 0;
+        return sizeof(storage_page_t) + heap;
+    }
+
     // Bit i of the result is set iff at least one of slots 2i, 2i+1 is
     // non-zero. Used by page_commit to walk only the active pair-leaves.
     // Defined in storage_page.cpp to keep the BMI2 (_pext_u64) dependency

--- a/category/execution/monad/db/test_monad_storage_page.cpp
+++ b/category/execution/monad/db/test_monad_storage_page.cpp
@@ -291,3 +291,33 @@ TEST(MonadDb, page_write_merges_slots)
         tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_0), val_0_updated);
     EXPECT_EQ(tdb.read_storage(ADDR_A, Incarnation{0, 0}, slot_key_1), val_1);
 }
+
+TEST(MonadDb, byte_size_inline)
+{
+    constexpr bytes32_t val{uint64_t{0xabcd}};
+
+    storage_page_t page;
+    EXPECT_EQ(page.byte_size(), sizeof(storage_page_t));
+
+    // Up to the inline capacity (4 values) nothing is heap-allocated, so the
+    // footprint stays at the base object size.
+    for (uint8_t i = 0; i < 4; ++i) {
+        page.set(i, val);
+        EXPECT_EQ(page.byte_size(), sizeof(storage_page_t));
+    }
+}
+
+TEST(MonadDb, byte_size_spill)
+{
+    constexpr bytes32_t val{uint64_t{0xabcd}};
+
+    storage_page_t page;
+    for (uint8_t i = 0; i < 5; ++i) {
+        page.set(i, val);
+    }
+
+    // The 5th value spills values_ to a heap buffer. Growth is
+    // implementation-defined, so the footprint is at least the base object
+    // plus the live elements.
+    EXPECT_GE(page.byte_size(), sizeof(storage_page_t) + 5 * sizeof(bytes32_t));
+}

--- a/category/vm/utils/lru_weight_cache.hpp
+++ b/category/vm/utils/lru_weight_cache.hpp
@@ -99,6 +99,14 @@ namespace monad::vm::utils
             return is_new_key;
         }
 
+        // Not thread-safe with other cache operations.
+        void clear()
+        {
+            hmap_.clear();
+            lru_.clear();
+            weight_.store(0, std::memory_order_release);
+        }
+
         /// Like insert, but does not overwrite an existing value in the cache.
         /// Instead if a value already exists under `key` then it will
         /// overwrite the `value` argument with the existing value.
@@ -234,6 +242,12 @@ namespace monad::vm::utils
         public:
             explicit LruList(int64_t const lru_update_period)
                 : lru_update_period_{lru_update_period}
+            {
+                clear();
+            }
+
+            // Not thread-safe with other LruList operations.
+            void clear()
             {
                 base_.second.next_ = &base_;
                 base_.second.prev_ = &base_;

--- a/test/vm/unit/lru_weight_cache_tests.cpp
+++ b/test/vm/unit/lru_weight_cache_tests.cpp
@@ -251,6 +251,25 @@ TEST_F(LruWeightCacheTest, reread_evict)
     ASSERT_FALSE(weight_cache_find(base_key).has_value());
 }
 
+TEST_F(LruWeightCacheTest, clear)
+{
+    uint32_t total_weight = 0;
+    for (size_t i = 0; i < 3; ++i) {
+        Value const v = default_values(elems[i]);
+        weight_cache_.insert(elems[i], v, v);
+        total_weight += v;
+    }
+    ASSERT_EQ(weight_cache_.size(), 3u);
+    ASSERT_EQ(weight_cache_.approx_weight(), total_weight);
+
+    weight_cache_.clear();
+    ASSERT_EQ(weight_cache_.size(), 0u);
+    ASSERT_EQ(weight_cache_.approx_weight(), 0u);
+    for (size_t i = 0; i < 3; ++i) {
+        ASSERT_FALSE(weight_cache_find(elems[i]).has_value());
+    }
+}
+
 TEST_F(LruWeightCacheTest, is_consistent)
 {
     for (uint32_t i = 0; i < 20; ++i) {


### PR DESCRIPTION
Introduces a memory bound LRU cache for variable length storage slots. Under page storage, the cache will hold which have different sizes if the inline storage is exceeded.