### PR TITLE
build: bump standardized Boost to 1.90 and drop legacy CMake cruft

### DIFF
--- a/category/async/concepts.hpp
+++ b/category/async/concepts.hpp
@@ -20,13 +20,7 @@
 #include <boost/outcome/experimental/status_result.hpp>
 #include <boost/outcome/try.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(                                                             \
-    <boost/outcome/experimental/status-code/system_code_from_exception.hpp>)
-    #include <boost/outcome/experimental/status-code/system_code_from_exception.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/system_code_from_exception.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/system_code_from_exception.hpp>
 
 #include <type_traits>
 

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -18,12 +18,7 @@
 #include <category/async/concepts.hpp>
 #include <category/async/erased_connected_operation.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/nested_status_code.hpp>)
-    #include <boost/outcome/experimental/status-code/nested_status_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/nested_status_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/nested_status_code.hpp>
 
 #include <variant>
 #include <vector>

--- a/category/core/rlp/decode_error.cpp
+++ b/category/core/rlp/decode_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/core/rlp/decode_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/core/rlp/decode_error.hpp
+++ b/category/core/rlp/decode_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/core/rlp/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -301,15 +301,13 @@ target_include_directories(
   monad_execution_ethereum
   PUBLIC ${CATEGORY_MAIN_DIR}
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
-  PRIVATE ${Boost_INCLUDE_DIRS}
   PUBLIC ${cthash_SOURCE_DIR}/include
   PUBLIC ${silkpre_SOURCE_DIR}/lib)
 
 target_include_directories(
   monad_execution_native
   PUBLIC ${CATEGORY_MAIN_DIR}
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test
-  PRIVATE ${Boost_INCLUDE_DIRS})
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/test)
 
 target_compile_definitions(
   monad_execution_ethereum PUBLIC MONAD_CXX_CTYPES_USE_EVMC_HPP

--- a/category/execution/ethereum/core/contract/abi_decode_error.hpp
+++ b/category/execution/ethereum/core/contract/abi_decode_error.hpp
@@ -19,14 +19,8 @@
 
 #include <initializer_list>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/core/contract/checked_math.cpp
+++ b/category/execution/ethereum/core/contract/checked_math.cpp
@@ -23,14 +23,8 @@
 #include <initializer_list>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/core/contract/checked_math.hpp
+++ b/category/execution/ethereum/core/contract/checked_math.hpp
@@ -22,14 +22,8 @@
 
 #include <initializer_list>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -34,14 +34,8 @@
 #include <evmc/evmc.h>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
 

--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -23,14 +23,8 @@
 
 #include <evmc/evmc.h>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 #include <vector>

--- a/category/execution/ethereum/validate_transaction_error.cpp
+++ b/category/execution/ethereum/validate_transaction_error.cpp
@@ -16,14 +16,8 @@
 #include <category/execution/ethereum/validate_transaction_error.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 #include <boost/outcome/success_failure.hpp>
 
 #include <initializer_list>

--- a/category/execution/ethereum/validate_transaction_error.hpp
+++ b/category/execution/ethereum/validate_transaction_error.hpp
@@ -18,14 +18,8 @@
 #include <category/core/config.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/reserve_balance/reserve_balance_error.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/execution/monad/reserve_balance/reserve_balance_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/reserve_balance/reserve_balance_error.hpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/core/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/staking/util/staking_error.cpp
+++ b/category/execution/monad/staking/util/staking_error.cpp
@@ -15,15 +15,9 @@
 
 #include <category/execution/monad/staking/util/staking_error.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/staking/util/staking_error.hpp
+++ b/category/execution/monad/staking/util/staking_error.hpp
@@ -17,14 +17,8 @@
 
 #include <category/execution/monad/staking/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 

--- a/category/execution/monad/validate_monad_block.cpp
+++ b/category/execution/monad/validate_monad_block.cpp
@@ -27,14 +27,8 @@
 #include <cstdint>
 #include <optional>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 #include <concepts>
 

--- a/category/execution/monad/validate_monad_block.hpp
+++ b/category/execution/monad/validate_monad_block.hpp
@@ -23,14 +23,8 @@
 
 #include <span>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/monad/validate_monad_transaction.hpp
+++ b/category/execution/monad/validate_monad_transaction.hpp
@@ -24,14 +24,8 @@
 
 #include <evmc/evmc.h>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/quick_status_code_from_enum.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/quick_status_code_from_enum.hpp>
 
 #include <initializer_list>
 #include <optional>

--- a/category/execution/monad/validate_system_transaction.cpp
+++ b/category/execution/monad/validate_system_transaction.cpp
@@ -23,14 +23,8 @@
 
 #include <boost/outcome/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/execution/monad/validate_system_transaction.hpp
+++ b/category/execution/monad/validate_system_transaction.hpp
@@ -19,14 +19,8 @@
 #include <category/vm/evm/traits.hpp>
 
 #include <boost/outcome/config.hpp>
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/status-code/config.hpp>)
-    #include <boost/outcome/experimental/status-code/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/config.hpp>
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/config.hpp>
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 #include <boost/outcome/success_failure.hpp>
 
 #include <initializer_list>

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -27,7 +27,7 @@ option(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # deps
 # ##############################################################################
 
-find_package(Boost 1.83 # 1.83 really is the minimum
+find_package(Boost 1.90 # standardized Boost version (Ubuntu 26.04 default)
              CONFIG REQUIRED COMPONENTS context json thread)
 find_package(GTest)
 

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -74,7 +74,7 @@ add_library(
 target_include_directories(monad_trie PUBLIC ${CATEGORY_MAIN_DIR})
 target_include_directories(monad_trie PRIVATE "third_party")
 monad_compile_options(monad_trie)
-target_link_libraries(monad_trie PRIVATE Boost::boost)
+target_link_libraries(monad_trie PRIVATE Boost::headers)
 target_link_libraries(monad_trie PUBLIC concurrentqueue)
 target_link_libraries(monad_trie PUBLIC monad_async)
 target_link_libraries(monad_trie PUBLIC quill::quill) # TODO: remove

--- a/category/mpt/db_error.hpp
+++ b/category/mpt/db_error.hpp
@@ -18,12 +18,7 @@
 #include <category/core/result.hpp>
 #include <category/mpt/config.hpp>
 
-// TODO unstable paths between versions
-#if __has_include(<boost/outcome/experimental/status-code/generic_code.hpp>)
-    #include <boost/outcome/experimental/status-code/generic_code.hpp>
-#else
-    #include <boost/outcome/experimental/status-code/status-code/generic_code.hpp>
-#endif
+#include <boost/outcome/experimental/status-code/generic_code.hpp>
 
 MONAD_MPT_NAMESPACE_BEGIN
 

--- a/scripts/ubuntu-build/install-boost.sh
+++ b/scripts/ubuntu-build/install-boost.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 packages=(
-  libboost1.83-dev
-  libboost-context1.83.0
-  libboost-context1.83-dev
-  libboost-filesystem1.83.0
-  libboost-filesystem1.83-dev
-  libboost-json1.83.0
-  libboost-json1.83-dev
-  libboost-stacktrace1.83.0
-  libboost-stacktrace1.83-dev
-  libboost-test1.83.0
-  libboost-test1.83-dev
+  libboost1.90-dev
+  libboost-context1.90.0
+  libboost-context1.90-dev
+  libboost-filesystem1.90.0
+  libboost-filesystem1.90-dev
+  libboost-json1.90.0
+  libboost-json1.90-dev
+  libboost-stacktrace1.90.0
+  libboost-stacktrace1.90-dev
+  libboost-test1.90.0
+  libboost-test1.90-dev
 )
 
 apt-get install -y --no-install-recommends "${packages[@]}"


### PR DESCRIPTION
Updates the standardized Boost version from 1.83 to 1.90 — the default shipped by Ubuntu 26.04 (`1.90.0-6ubuntu1`) — and removes legacy CMake cruft that predates CONFIG-mode Boost consumption.

## Commits

1. **`build: bump standardized Boost to 1.90`** — switch the apt package set in `scripts/ubuntu-build/install-boost.sh` (`context`, `filesystem`, `json`, `stacktrace`, `test`) from 1.83 to 1.90, and raise the `find_package` minimum in `category/mpt` to 1.90.
2. **`build: drop legacy Boost CMake cruft`** — drop the redundant explicit `${Boost_INCLUDE_DIRS}` include paths on `monad_execution_{ethereum,native}` (Boost headers reach both transitively via `Boost::fiber`), and replace the legacy `Boost::boost` all-headers alias with the modern `Boost::headers` target in `category/mpt`.

## Kept (not cruft)

The granular header-only target shim loop in the root `CMakeLists.txt` is retained: Ubuntu 1.90 still ships only `boost_headers` (no `boost_assert`/`boost_config`/etc. CMake configs), so the vendored Boost.Fiber subproject still needs the shims.

## Validation

Ran the CI-equivalent `build_and_test` Docker stage locally (`ubuntu:26.04`, gcc-15, RelWithDebInfo, `gcc-avx2`, `security.insecure`, `memlock=-1:-1`):

- Boost 1.90 packages install cleanly.
- Configure: `Found Boost ... version "1.90.0"`.
- Compile + link succeed (no `undefined reference` — confirms the transitive include paths).
- `100% tests passed, 0 tests failed out of 3612`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)