### PR TITLE
statesync now works for page-encoded server and client.

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -215,6 +215,8 @@ add_library(
   "monad/db/commit_block_migration.hpp"
   "monad/db/page_commit_builder.hpp"
   "monad/db/page_commit_builder.cpp"
+  "monad/db/state_machine_init.cpp"
+  "monad/db/state_machine_init.hpp"
   "monad/db/storage_page.cpp"
   "monad/db/storage_page.hpp"
   # monad/chain

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -220,6 +220,8 @@ add_library(
   "monad/db/storage_page.cpp"
   "monad/db/storage_page.hpp"
   # monad/chain
+  "monad/chain/chain_factory.cpp"
+  "monad/chain/chain_factory.hpp"
   "monad/chain/monad_chain.cpp"
   "monad/chain/monad_chain.hpp"
   "monad/chain/monad_devnet.cpp"

--- a/category/execution/ethereum/db/test/commit_simple.hpp
+++ b/category/execution/ethereum/db/test/commit_simple.hpp
@@ -28,7 +28,6 @@ MONAD_NAMESPACE_BEGIN
 
 namespace test
 {
-
     inline void commit_simple(
         ::monad::Db &db, StateDeltas const &deltas, Code const &code,
         bytes32_t const &block_id, BlockHeader const &header,

--- a/category/execution/monad/chain/chain_factory.cpp
+++ b/category/execution/monad/chain/chain_factory.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/chain/chain.hpp>
+#include <category/execution/ethereum/chain/chain_config.h>
+#include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
+#include <category/execution/ethereum/chain/hive_net.hpp>
+#include <category/execution/monad/chain/chain_factory.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/execution/monad/chain/monad_devnet.hpp>
+#include <category/execution/monad/chain/monad_mainnet.hpp>
+#include <category/execution/monad/chain/monad_testnet.hpp>
+
+#include <memory>
+
+MONAD_NAMESPACE_BEGIN
+
+std::unique_ptr<Chain> make_chain(monad_chain_config const chain_config)
+{
+    switch (chain_config) {
+    case CHAIN_CONFIG_ETHEREUM_MAINNET:
+        return std::make_unique<EthereumMainnet>();
+    case CHAIN_CONFIG_MONAD_DEVNET:
+        return std::make_unique<MonadDevnet>();
+    case CHAIN_CONFIG_MONAD_TESTNET:
+        return std::make_unique<MonadTestnet>();
+    case CHAIN_CONFIG_MONAD_MAINNET:
+        return std::make_unique<MonadMainnet>();
+    case CHAIN_CONFIG_HIVE_NET:
+        return std::make_unique<HiveNet>();
+    }
+    MONAD_ASSERT(false);
+}
+
+std::unique_ptr<MonadChain>
+make_monad_chain(monad_chain_config const chain_config)
+{
+    switch (chain_config) {
+    case CHAIN_CONFIG_MONAD_DEVNET:
+        return std::make_unique<MonadDevnet>();
+    case CHAIN_CONFIG_MONAD_TESTNET:
+        return std::make_unique<MonadTestnet>();
+    case CHAIN_CONFIG_MONAD_MAINNET:
+        return std::make_unique<MonadMainnet>();
+    case CHAIN_CONFIG_ETHEREUM_MAINNET:
+    case CHAIN_CONFIG_HIVE_NET:
+        MONAD_ABORT_PRINTF(
+            "expected a Monad chain config, got %d", chain_config);
+    }
+    MONAD_ASSERT(false);
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/chain/chain_factory.hpp
+++ b/category/execution/monad/chain/chain_factory.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/chain/chain_config.h>
+
+#include <memory>
+
+MONAD_NAMESPACE_BEGIN
+
+struct Chain;
+struct MonadChain;
+
+// Construct the Chain implementation for a runtime chain config.
+std::unique_ptr<Chain> make_chain(monad_chain_config);
+
+std::unique_ptr<MonadChain> make_monad_chain(monad_chain_config);
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/state_machine_init.cpp
+++ b/category/execution/monad/db/state_machine_init.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/mpt/state_machine.hpp>
+#include <category/mpt/state_machine_kind.hpp>
+
+#include <memory>
+
+MONAD_NAMESPACE_BEGIN
+
+void register_monad_state_machines()
+{
+    // Only MonadOnDiskMachine participates in metadata-driven open. The
+    // in-memory production path keeps the StateMachine&-passing ctor and
+    // never reads from disk, so MonadInMemoryMachine is not registered.
+    mpt::register_state_machine(mpt::state_machine_kind::monad, [] {
+        return std::unique_ptr<mpt::StateMachine>(new MonadOnDiskMachine{});
+    });
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/state_machine_init.hpp
+++ b/category/execution/monad/db/state_machine_init.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+// Populate the mpt::state_machine_kind registry with the page-encoded Monad
+// StateMachine (state_machine_kind::monad, backed by MonadOnDiskMachine).
+// Must run once at process start before any page-encoded mpt::Db is opened
+// via the metadata-driven Db(OnDiskDbConfig const &) ctor; otherwise
+// create_state_machine() aborts at open time.
+//
+// Complements register_ethereum_state_machines() (state_machine_kind::
+// ethereum). A process that may open either encoding should call both.
+//
+// Idempotent: re-registering the same kind overwrites the prior factory.
+void register_monad_state_machines();
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -102,6 +102,7 @@ namespace
         uint64_t const block_number, bytes32_t const &block_id,
         StateDeltas const &deltas)
     {
+        MONAD_ASSERT(!tdb1.is_page_encoded() && tdb2.is_page_encoded());
         BlockHeader const header{.number = block_number};
         BlockCommitAncillaries const anc = make_empty_ancillaries();
 

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -35,8 +35,6 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
-#include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
-#include <category/execution/ethereum/chain/hive_net.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/address_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
@@ -63,10 +61,8 @@
 #include <category/execution/ethereum/validate_block.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 #include <category/execution/ethereum/validate_transaction_error.hpp>
+#include <category/execution/monad/chain/chain_factory.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
-#include <category/execution/monad/chain/monad_devnet.hpp>
-#include <category/execution/monad/chain/monad_mainnet.hpp>
-#include <category/execution/monad/chain/monad_testnet.hpp>
 #include <category/execution/monad/reserve_balance.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -1388,22 +1384,7 @@ struct monad_executor
                         transaction.gas_limit = MONAD_ETH_CALL_LOW_GAS_LIMIT;
                     }
 
-                    auto const chain =
-                        [chain_config] -> std::unique_ptr<Chain> {
-                        switch (chain_config) {
-                        case CHAIN_CONFIG_ETHEREUM_MAINNET:
-                            return std::make_unique<EthereumMainnet>();
-                        case CHAIN_CONFIG_MONAD_DEVNET:
-                            return std::make_unique<MonadDevnet>();
-                        case CHAIN_CONFIG_MONAD_TESTNET:
-                            return std::make_unique<MonadTestnet>();
-                        case CHAIN_CONFIG_MONAD_MAINNET:
-                            return std::make_unique<MonadMainnet>();
-                        case CHAIN_CONFIG_HIVE_NET:
-                            return std::make_unique<HiveNet>();
-                        }
-                        MONAD_ASSERT(false);
-                    }();
+                    auto const chain = make_chain(chain_config);
 
                     LazyBlockHash block_hash_buffer{db, block_number};
                     TrieRODb tdb{db};
@@ -1685,22 +1666,7 @@ struct monad_executor
                         1, std::memory_order_relaxed);
                 };
                 try {
-                    auto const chain =
-                        [chain_config] -> std::unique_ptr<Chain> {
-                        switch (chain_config) {
-                        case CHAIN_CONFIG_ETHEREUM_MAINNET:
-                            return std::make_unique<EthereumMainnet>();
-                        case CHAIN_CONFIG_MONAD_DEVNET:
-                            return std::make_unique<MonadDevnet>();
-                        case CHAIN_CONFIG_MONAD_TESTNET:
-                            return std::make_unique<MonadTestnet>();
-                        case CHAIN_CONFIG_MONAD_MAINNET:
-                            return std::make_unique<MonadMainnet>();
-                        case CHAIN_CONFIG_HIVE_NET:
-                            return std::make_unique<HiveNet>();
-                        }
-                        MONAD_ASSERT(false);
-                    }();
+                    auto const chain = make_chain(chain_config);
 
                     // Load transactions, senders, and authorities for
                     // `block_number`.
@@ -1952,22 +1918,7 @@ struct monad_executor
                             }
                         }
 
-                        auto const chain =
-                            [chain_config] -> std::unique_ptr<Chain> {
-                            switch (chain_config) {
-                            case CHAIN_CONFIG_ETHEREUM_MAINNET:
-                                return std::make_unique<EthereumMainnet>();
-                            case CHAIN_CONFIG_MONAD_DEVNET:
-                                return std::make_unique<MonadDevnet>();
-                            case CHAIN_CONFIG_MONAD_TESTNET:
-                                return std::make_unique<MonadTestnet>();
-                            case CHAIN_CONFIG_MONAD_MAINNET:
-                                return std::make_unique<MonadMainnet>();
-                            case CHAIN_CONFIG_HIVE_NET:
-                                return std::make_unique<HiveNet>();
-                            }
-                            MONAD_ASSERT(false);
-                        }();
+                        auto const chain = make_chain(chain_config);
 
                         if (chain_config == CHAIN_CONFIG_ETHEREUM_MAINNET ||
                             chain_config == CHAIN_CONFIG_HIVE_NET) {

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -28,6 +28,7 @@
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
 #include <category/statesync/statesync_version.h>
+#include <category/vm/evm/traits.hpp>
 
 #include <algorithm>
 #include <filesystem>
@@ -39,6 +40,7 @@ using namespace monad::mpt;
 unsigned const MONAD_SQPOLL_DISABLED = unsigned(-1);
 
 monad_statesync_client_context *monad_statesync_client_context_create(
+    monad_chain_config const chain_config,
     char const *const *const dbname_paths, size_t const len,
     unsigned const sq_thread_cpu, monad_statesync_client *const sync,
     void (*statesync_send_request)(
@@ -53,6 +55,7 @@ monad_statesync_client_context *monad_statesync_client_context_create(
     register_ethereum_state_machines();
     register_monad_state_machines();
     return new monad_statesync_client_context{
+        chain_config,
         paths,
         sq_thread_cpu == MONAD_SQPOLL_DISABLED
             ? std::nullopt
@@ -174,6 +177,13 @@ bool monad_statesync_client_finalize(monad_statesync_client_context *const ctx)
     }
 
     auto const latest_version = ctx->db.get_latest_version();
+    // The dual-write keeps both timelines in lockstep, so the secondary must be
+    // at the same version as the primary at finalize.
+    if (ctx->secondary_db) {
+        MONAD_ASSERT(
+            latest_version == ctx->secondary_db->get_latest_version(),
+            "dual-db versions should always be in sync");
+    }
 
     MONAD_ASSERT(for_each_code(
         ctx->db, latest_version, [&](bytes32_t const &hash, byte_string_view) {
@@ -184,49 +194,77 @@ bool monad_statesync_client_finalize(monad_statesync_client_context *const ctx)
         return false;
     }
 
-    if (latest_version != tgrt.number) {
-        ctx->db.move_trie_version_forward(latest_version, tgrt.number);
-        bytes32_t expected = tgrt.parent_hash;
-        for (size_t i = 0; i < std::min(tgrt.number, 256ul); ++i) {
-            auto const v = tgrt.number - i - 1;
-            auto const &hdr = ctx->hdrs[v % ctx->hdrs.size()];
-            auto const rlp = rlp::encode_block_header(hdr);
-            auto const hash = to_bytes(keccak256(rlp));
-            if (hash != expected) {
-                return false;
+    // Roll one db forward from its synced version to the target, replaying the
+    // trailing block headers, then mark the target finalized. Applied to the
+    // primary and, in dual-db mode, the page-encoded secondary, so both
+    // timelines are version- and finalize-consistent at the target.
+    auto const roll_forward_and_finalize =
+        [ctx, &tgrt, latest_version](mpt::Db &db) -> bool {
+        if (latest_version != tgrt.number) {
+            db.move_trie_version_forward(latest_version, tgrt.number);
+            bytes32_t expected = tgrt.parent_hash;
+            for (size_t i = 0; i < std::min(tgrt.number, 256ul); ++i) {
+                auto const v = tgrt.number - i - 1;
+                auto const &hdr = ctx->hdrs[v % ctx->hdrs.size()];
+                auto const rlp = rlp::encode_block_header(hdr);
+                auto const hash = to_bytes(keccak256(rlp));
+                if (hash != expected) {
+                    return false;
+                }
+                expected = hdr.parent_hash;
+
+                Update block_header_update{
+                    .key = block_header_nibbles,
+                    .value = rlp,
+                    .incarnation = true,
+                    .next = UpdateList{},
+                    .version = static_cast<int64_t>(v)};
+                UpdateList updates;
+                updates.push_front(block_header_update);
+                Update finalized{
+                    .key = finalized_nibbles,
+                    .value = byte_string_view{},
+                    .incarnation = false,
+                    .next = std::move(updates),
+                    .version = static_cast<int64_t>(v)};
+                UpdateList finalized_updates;
+                finalized_updates.push_front(finalized);
+                db.upsert(
+                    db.load_root_for_version(v),
+                    std::move(finalized_updates),
+                    v,
+                    false,
+                    false);
             }
-            expected = hdr.parent_hash;
-
-            Update block_header_update{
-                .key = block_header_nibbles,
-                .value = rlp,
-                .incarnation = true,
-                .next = UpdateList{},
-                .version = static_cast<int64_t>(v)};
-            UpdateList updates;
-            updates.push_front(block_header_update);
-            Update finalized{
-                .key = finalized_nibbles,
-                .value = byte_string_view{},
-                .incarnation = false,
-                .next = std::move(updates),
-                .version = static_cast<int64_t>(v)};
-            UpdateList finalized_updates;
-            finalized_updates.push_front(finalized);
-            ctx->db.upsert(
-                ctx->db.load_root_for_version(v),
-                std::move(finalized_updates),
-                v,
-                false,
-                false);
         }
+        db.update_finalized_version(tgrt.number);
+        return true;
+    };
+
+    if (!roll_forward_and_finalize(ctx->db)) {
+        return false;
     }
-    ctx->db.update_finalized_version(tgrt.number);
+    if (ctx->secondary_db && !roll_forward_and_finalize(*ctx->secondary_db)) {
+        return false;
+    }
 
-    TrieDb db{ctx->db};
-    MONAD_ASSERT(db.get_block_number() == tgrt.number);
-
-    return db.state_root() == tgrt.state_root;
+    // Pick the right TrieDb to read state_root from based on the target's
+    // revision.
+    auto const monad_rev = ctx->chain->get_monad_revision(tgrt.timestamp);
+    bool const page_encoded = mip_8_active(monad_rev);
+    TrieDb *db = &ctx->tdb;
+    if (page_encoded != db->is_page_encoded()) {
+        MONAD_ASSERT_PRINTF(
+            ctx->secondary_tdb &&
+                ctx->secondary_tdb->is_page_encoded() == page_encoded,
+            "No client db timeline is %s-encoded as the target revision "
+            "requires",
+            page_encoded ? "page" : "slot");
+        db = ctx->secondary_tdb.get();
+    }
+    db->set_block_and_prefix(ctx->db.get_latest_finalized_version());
+    MONAD_ASSERT(db->get_block_number() == tgrt.number);
+    return db->state_root() == tgrt.state_root;
 }
 
 void monad_statesync_client_context_destroy(

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -23,6 +23,7 @@
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
@@ -50,6 +51,7 @@ monad_statesync_client_context *monad_statesync_client_context_create(
     // factories so the kind-driven Db ctor can resolve `ethereum`.
     // Idempotent: re-registration overwrites the prior factory.
     register_ethereum_state_machines();
+    register_monad_state_machines();
     return new monad_statesync_client_context{
         paths,
         sq_thread_cpu == MONAD_SQPOLL_DISABLED

--- a/category/statesync/statesync_client.h
+++ b/category/statesync/statesync_client.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <category/execution/ethereum/chain/chain_config.h>
 #include <category/statesync/statesync_messages.h>
 
 #ifdef __cplusplus
@@ -27,9 +28,10 @@ extern unsigned const MONAD_SQPOLL_DISABLED;
 struct monad_statesync_client;
 struct monad_statesync_client_context;
 
+// chain_config must be a Monad chain
 struct monad_statesync_client_context *monad_statesync_client_context_create(
-    char const *const *dbname_paths, size_t len, unsigned sq_thread_cpu,
-    struct monad_statesync_client *,
+    enum monad_chain_config chain_config, char const *const *dbname_paths,
+    size_t len, unsigned sq_thread_cpu, struct monad_statesync_client *,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request));
 

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -13,14 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/assert.h>
+#include <category/core/bytes_hash_compare.hpp>
+#include <category/core/keccak.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/chain/chain_factory.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/update.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
+
+#include <ankerl/unordered_dense.h>
 
 #include <deque>
 #include <sys/sysinfo.h>
@@ -29,12 +36,14 @@ using namespace monad;
 using namespace monad::mpt;
 
 monad_statesync_client_context::monad_statesync_client_context(
+    monad_chain_config const chain_config,
     std::vector<std::filesystem::path> const dbname_paths,
     std::optional<unsigned> const sq_thread_cpu, unsigned const wr_buffers,
     monad_statesync_client *const sync,
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request))
-    : db{mpt::OnDiskDbConfig{
+    : chain{make_monad_chain(chain_config)}
+    , db{mpt::OnDiskDbConfig{
           .append = true,
           .compaction = false,
           .rewind_to_latest_finalized = true,
@@ -44,6 +53,19 @@ monad_statesync_client_context::monad_statesync_client_context(
           .sq_thread_cpu = sq_thread_cpu,
           .dbname_paths = dbname_paths}}
     , tdb{db} // open with latest finalized if valid, otherwise init as block 0
+    , secondary_db{[this] {
+        if (db.timeline_active(timeline_id::secondary)) {
+            MONAD_ASSERT(
+                db.state_machine_type() == state_machine_kind::ethereum);
+            auto ret = db.open_secondary_timeline();
+            MONAD_ASSERT(ret.has_value());
+            MONAD_ASSERT(
+                ret->state_machine_type() == state_machine_kind::monad);
+            return std::make_unique<mpt::Db>(std::move(ret.value()));
+        }
+        return std::unique_ptr<mpt::Db>{};
+    }()}
+    , secondary_tdb{secondary_db ? std::make_unique<TrieDb>(*secondary_db) : nullptr}
     , progress(
           monad_statesync_client_prefixes(),
           {db.get_latest_version(), db.get_latest_version()})
@@ -55,59 +77,69 @@ monad_statesync_client_context::monad_statesync_client_context(
     , statesync_send_request{statesync_send_request}
 {
     MONAD_ASSERT(db.get_latest_version() == db.get_latest_finalized_version());
+    MONAD_ASSERT((secondary_db != nullptr) == (secondary_tdb != nullptr));
+    MONAD_ASSERT(secondary_tdb == nullptr || secondary_tdb->is_page_encoded());
 }
 
 void monad_statesync_client_context::prepare_current_state()
 {
-    auto const latest_version = db.get_latest_version();
-    // First commit an empty finalized state to the current one.
-    // This requires incarnation=true so the compaction process in latest root
-    // value (`src_root->value()`) is correctly preserved.
-    UpdateList finalized_empty;
-    Update finalized{
-        .key = finalized_nibbles,
-        .value = byte_string_view{},
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(current)};
-    finalized_empty.push_front(finalized);
-    auto const src_root = db.load_root_for_version(latest_version);
-    bool write_root = false;
-    auto dest_root = db.upsert(
-        src_root,
-        std::move(finalized_empty),
-        current,
-        false,
-        false,
-        write_root);
-    MONAD_ASSERT(db.find(dest_root, finalized_nibbles, current).has_value());
+    // Roll forward `target_db`: upsert an empty finalized marker for the
+    // `current` version and carry the state + code subtries over from
+    // `latest_version`.
+    auto const roll_forward = [&](mpt::Db &target_db, auto &target_tdb) {
+        auto const latest_version = target_db.get_latest_version();
+        UpdateList finalized_empty;
+        Update finalized{
+            .key = finalized_nibbles,
+            .value = byte_string_view{},
+            .incarnation = true,
+            .next = UpdateList{},
+            .version = static_cast<int64_t>(current)};
+        finalized_empty.push_front(finalized);
+        auto const src_root = target_db.load_root_for_version(latest_version);
+        bool write_root = false;
+        auto dest_root = target_db.upsert(
+            src_root,
+            std::move(finalized_empty),
+            current,
+            false,
+            false,
+            write_root);
+        MONAD_ASSERT(
+            target_db.find(dest_root, finalized_nibbles, current).has_value());
 
-    // move state and code from latest finalized to current
-    auto const state_key = concat(FINALIZED_NIBBLE, STATE_NIBBLE);
-    auto const code_key = concat(FINALIZED_NIBBLE, CODE_NIBBLE);
-    dest_root = db.copy_trie(
-        src_root,
-        state_key,
-        std::move(dest_root),
-        state_key,
-        current,
-        write_root);
-    write_root = true;
-    dest_root = db.copy_trie(
-        src_root,
-        code_key,
-        std::move(dest_root),
-        code_key,
-        current,
-        write_root);
-    auto const finalized_res = db.find(dest_root, finalized_nibbles, current);
-    MONAD_ASSERT(finalized_res.has_value());
-    MONAD_ASSERT(finalized_res.value().node->number_of_children() == 2);
-    MONAD_ASSERT(db.find(dest_root, state_key, current).has_value());
-    MONAD_ASSERT(db.find(dest_root, code_key, current).has_value());
-    MONAD_ASSERT(dest_root->value() == src_root->value());
-    tdb.reset_root(dest_root, current);
-    MONAD_ASSERT(db.get_latest_version() == current);
+        auto const state_key = concat(FINALIZED_NIBBLE, STATE_NIBBLE);
+        auto const code_key = concat(FINALIZED_NIBBLE, CODE_NIBBLE);
+        dest_root = target_db.copy_trie(
+            src_root,
+            state_key,
+            std::move(dest_root),
+            state_key,
+            current,
+            write_root);
+        write_root = true;
+        dest_root = target_db.copy_trie(
+            src_root,
+            code_key,
+            std::move(dest_root),
+            code_key,
+            current,
+            write_root);
+        auto const finalized_res =
+            target_db.find(dest_root, finalized_nibbles, current);
+        MONAD_ASSERT(finalized_res.has_value());
+        MONAD_ASSERT(finalized_res.value().node->number_of_children() == 2);
+        MONAD_ASSERT(target_db.find(dest_root, state_key, current).has_value());
+        MONAD_ASSERT(target_db.find(dest_root, code_key, current).has_value());
+        MONAD_ASSERT(dest_root->value() == src_root->value());
+        target_tdb.reset_root(dest_root, current);
+        MONAD_ASSERT(target_db.get_latest_version() == current);
+    };
+
+    roll_forward(db, tdb);
+    if (secondary_tdb) {
+        roll_forward(*secondary_db, *secondary_tdb);
+    }
 }
 
 void monad_statesync_client_context::commit()
@@ -116,88 +148,209 @@ void monad_statesync_client_context::commit()
         db.get_latest_version() != current) {
         prepare_current_state();
     }
-    std::deque<mpt::Update> alloc;
-    std::deque<byte_string> bytes_alloc;
-    std::deque<hash256> hash_alloc;
-    UpdateList accounts;
-    for (auto const &[addr, delta] : deltas) {
+
+    // Build the encoded block header once; it's identical for both dbs.
+    auto const header_rlp = rlp::encode_block_header(tgrt);
+
+    // Build a slot-encoded storage UpdateList for an account's deltas.
+    auto build_slot_storage = [this](
+                                  StorageDeltas const &slot_deltas,
+                                  std::deque<mpt::Update> &alloc,
+                                  std::deque<byte_string> &bytes_alloc,
+                                  std::deque<hash256> &hash_alloc) {
         UpdateList storage;
-        std::optional<byte_string_view> value;
-        if (delta.has_value()) {
-            auto const &[acct, deltas] = delta.value();
-            value = bytes_alloc.emplace_back(encode_account_db(addr, acct));
-            for (auto const &[key, val] : deltas) {
-                storage.push_front(alloc.emplace_back(Update{
-                    .key = hash_alloc.emplace_back(keccak256(key.bytes)),
-                    .value = val == bytes32_t{}
-                                 ? std::nullopt
-                                 : std::make_optional<byte_string_view>(
-                                       bytes_alloc.emplace_back(
-                                           encode_storage_db(key, val))),
-                    .incarnation = false,
-                    .next = UpdateList{},
-                    .version = static_cast<int64_t>(current)}));
-            }
+        for (auto const &[key, val] : slot_deltas) {
+            storage.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(keccak256(key.bytes)),
+                .value = val == bytes32_t{}
+                             ? std::nullopt
+                             : std::make_optional<byte_string_view>(
+                                   bytes_alloc.emplace_back(
+                                       encode_storage_db(key, val))),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
         }
-        accounts.push_front(alloc.emplace_back(Update{
-            .key = hash_alloc.emplace_back(keccak256(addr.bytes)),
-            .value = value,
-            .incarnation = false,
-            .next = std::move(storage),
-            .version = static_cast<int64_t>(current)}));
-    }
-    UpdateList code_updates;
+        return storage;
+    };
 
-    for (auto const &[hash, bytes] : code) {
-        code_updates.push_front(alloc.emplace_back(Update{
-            .key = NibblesView{hash},
-            .value = bytes,
+    // Build a page-encoded storage UpdateList for Db2. Slots are grouped by
+    // page_key and merged onto any existing page contents read from the
+    // secondary trie. A page that ends up empty becomes a delete on the
+    // page entry.
+    auto build_page_storage = [this](
+                                  TrieDb &paged_db,
+                                  Address const &addr,
+                                  StorageDeltas const &slot_deltas,
+                                  std::deque<mpt::Update> &alloc,
+                                  std::deque<byte_string> &bytes_alloc,
+                                  std::deque<hash256> &hash_alloc) {
+        UpdateList storage;
+        // Per-account page granularity: keyed by page_key, value is the
+        // mutable storage_page_t being merged. Each first-touch of a page
+        // reads the current page from the secondary trie so subsequent slot
+        // writes at the same page_key compose into one update.
+        ankerl::unordered_dense::segmented_map<
+            bytes32_t,
+            storage_page_t,
+            BytesHashCompare<bytes32_t>>
+            pages;
+        for (auto const &[slot_key, slot_val] : slot_deltas) {
+            auto const pg_key = compute_page_key(slot_key);
+            auto const slot_off = compute_slot_offset(slot_key);
+            auto [it, inserted] = pages.try_emplace(pg_key);
+            if (inserted) {
+                // Incarnation isn't tracked in statesync deltas; TrieDb
+                // ignores it for storage reads, so a fixed value is fine.
+                it->second =
+                    paged_db.read_storage_page(addr, Incarnation{0, 0}, pg_key);
+            }
+            it->second.set(slot_off, slot_val);
+        }
+        for (auto const &[page_key, page] : pages) {
+            bool const is_empty = page.is_empty();
+            storage.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(
+                    keccak256({page_key.bytes, sizeof(page_key.bytes)})),
+                .value = is_empty
+                             ? std::nullopt
+                             : std::make_optional<byte_string_view>(
+                                   bytes_alloc.emplace_back(
+                                       encode_storage_page_db(page_key, page))),
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
+        }
+        return storage;
+    };
+
+    auto build_and_upsert = [this, &header_rlp](
+                                mpt::Db &target_db,
+                                auto &target_tdb,
+                                auto build_storage) {
+        std::deque<mpt::Update> alloc;
+        std::deque<byte_string> bytes_alloc;
+        std::deque<hash256> hash_alloc;
+
+        UpdateList accounts;
+        for (auto const &[addr, delta] : deltas) {
+            UpdateList storage;
+            std::optional<byte_string_view> value;
+            if (delta.has_value()) {
+                auto const &[acct, slot_deltas] = delta.value();
+                value = bytes_alloc.emplace_back(encode_account_db(addr, acct));
+                storage = build_storage(
+                    addr, slot_deltas, alloc, bytes_alloc, hash_alloc);
+            }
+            accounts.push_front(alloc.emplace_back(Update{
+                .key = hash_alloc.emplace_back(keccak256(addr.bytes)),
+                .value = value,
+                .incarnation = false,
+                .next = std::move(storage),
+                .version = static_cast<int64_t>(current)}));
+        }
+        UpdateList code_updates;
+        for (auto const &[hash, bytes] : code) {
+            code_updates.push_front(alloc.emplace_back(Update{
+                .key = NibblesView{hash},
+                .value = bytes,
+                .incarnation = false,
+                .next = UpdateList{},
+                .version = static_cast<int64_t>(current)}));
+        }
+
+        auto state_update = Update{
+            .key = state_nibbles,
+            .value = byte_string_view{},
             .incarnation = false,
+            .next = std::move(accounts),
+            .version = static_cast<int64_t>(current)};
+        auto code_update = Update{
+            .key = code_nibbles,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(code_updates),
+            .version = static_cast<int64_t>(current)};
+        auto block_header_update = Update{
+            .key = block_header_nibbles,
+            .value = header_rlp,
+            .incarnation = true,
             .next = UpdateList{},
-            .version = static_cast<int64_t>(current)}));
+            .version = static_cast<int64_t>(current)};
+        UpdateList updates;
+        updates.push_front(state_update);
+        updates.push_front(code_update);
+        updates.push_front(block_header_update);
+
+        UpdateList finalized_updates;
+        Update finalized{
+            .key = finalized_nibbles,
+            .value = byte_string_view{},
+            .incarnation = false,
+            .next = std::move(updates),
+            .version = static_cast<int64_t>(current)};
+        finalized_updates.push_front(finalized);
+
+        target_tdb.reset_root(
+            target_db.upsert(
+                target_tdb.get_root(),
+                std::move(finalized_updates),
+                current,
+                false,
+                false),
+            current);
+    };
+
+    // Primary Db
+    if (!tdb.is_page_encoded()) {
+        build_and_upsert(
+            db,
+            tdb,
+            [&](Address const &,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_slot_storage(
+                    slot_deltas, alloc, bytes_alloc, hash_alloc);
+            });
+    }
+    else {
+        build_and_upsert(
+            db,
+            tdb,
+            [&](Address const &addr,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_page_storage(
+                    tdb, addr, slot_deltas, alloc, bytes_alloc, hash_alloc);
+            });
     }
 
-    auto state_update = Update{
-        .key = state_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(accounts),
-        .version = static_cast<int64_t>(current)};
-    auto code_update = Update{
-        .key = code_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(code_updates),
-        .version = static_cast<int64_t>(current)};
-    auto const rlp = rlp::encode_block_header(tgrt);
-    auto block_header_update = Update{
-        .key = block_header_nibbles,
-        .value = rlp,
-        .incarnation = true,
-        .next = UpdateList{},
-        .version = static_cast<int64_t>(current)};
-    UpdateList updates;
-    updates.push_front(state_update);
-    updates.push_front(code_update);
-    updates.push_front(block_header_update);
+    // Secondary: page-encoded storage. Each per-account call builds its
+    // own page map; pages from one account never collide with another's,
+    // so no cross-account cache is needed.
+    if (secondary_tdb) {
+        build_and_upsert(
+            *secondary_db,
+            *secondary_tdb,
+            [&](Address const &addr,
+                StorageDeltas const &slot_deltas,
+                std::deque<mpt::Update> &alloc,
+                std::deque<byte_string> &bytes_alloc,
+                std::deque<hash256> &hash_alloc) {
+                return build_page_storage(
+                    *secondary_tdb,
+                    addr,
+                    slot_deltas,
+                    alloc,
+                    bytes_alloc,
+                    hash_alloc);
+            });
+    }
 
-    UpdateList finalized_updates;
-    Update finalized{
-        .key = finalized_nibbles,
-        .value = byte_string_view{},
-        .incarnation = false,
-        .next = std::move(updates),
-        .version = static_cast<int64_t>(current)};
-    finalized_updates.push_front(finalized);
-
-    tdb.reset_root(
-        db.upsert(
-            tdb.get_root(),
-            std::move(finalized_updates),
-            current,
-            false,
-            false),
-        current);
     code.clear();
     deltas.clear();
 }

--- a/category/statesync/statesync_client_context.hpp
+++ b/category/statesync/statesync_client_context.hpp
@@ -18,9 +18,11 @@
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
+#include <category/execution/ethereum/chain/chain_config.h>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/mpt/db.hpp>
 #include <category/statesync/statesync_protocol.hpp>
 
@@ -45,8 +47,16 @@ struct monad_statesync_client_context
 
     using StateDelta = std::pair<monad::Account, StorageDeltas>;
 
+    // Chain instance for revision lookups and determine whether the slot or
+    // page encoded db are canonical.
+    std::unique_ptr<monad::MonadChain const> chain;
+
     monad::mpt::Db db;
     monad::TrieDb tdb;
+
+    std::unique_ptr<monad::mpt::Db> secondary_db;
+    std::unique_ptr<monad::TrieDb> secondary_tdb;
+
     std::vector<std::pair<uint64_t, uint64_t>> progress;
     std::vector<std::unique_ptr<monad::StatesyncProtocol>> protocol;
     std::array<monad::BlockHeader, 256> hdrs;
@@ -62,6 +72,7 @@ struct monad_statesync_client_context
         struct monad_statesync_client *, struct monad_sync_request);
 
     monad_statesync_client_context(
+        monad_chain_config chain_config,
         std::vector<std::filesystem::path> dbname_paths,
         std::optional<unsigned> sq_thread_cpu, unsigned wr_buffers,
         monad_statesync_client *,

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
@@ -216,6 +217,14 @@ bool statesync_server_handle_request(
         {
         }
 
+        // When the server's primary is page-encoded, storage leaves hold
+        // encoded pages rather than single slots; we expand each page into
+        // slot-format upserts so v1 clients sync unchanged.
+        bool server_is_page_encoded() const
+        {
+            return sync->context->is_page_encoded();
+        }
+
         virtual bool down(unsigned char const branch, Node const &node) override
         {
             if (branch == INVALID_BRANCH) {
@@ -271,6 +280,36 @@ bool statesync_server_handle_request(
                     *upsert_bytes += size1 + size2;
                 };
 
+                // Expand a page-encoded storage leaf into one slot-format
+                // upsert per non-zero slot, so the wire stays identical to a
+                // slot-encoded server. The leaf value is
+                // encode_storage_page_db(page_key, page); compute_slot_key
+                // recovers each original storage key from (page_key, offset).
+                auto const send_storage_page = [&](byte_string_view enc) {
+                    auto const raw = decode_storage_db_raw(enc);
+                    MONAD_ASSERT(raw.has_value());
+                    auto const page_key = to_bytes(raw.value().first);
+                    auto const page = decode_storage_page(raw.value().second);
+                    MONAD_ASSERT(page.has_value());
+                    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
+                        bytes32_t const slot_val = page.value()[i];
+                        if (slot_val == bytes32_t{}) {
+                            continue;
+                        }
+                        auto const entry = encode_storage_db(
+                            compute_slot_key(page_key, i), slot_val);
+                        sync->statesync_server_send_upsert(
+                            sync->net,
+                            SYNC_TYPE_UPSERT_STORAGE,
+                            reinterpret_cast<unsigned char const *>(&addr),
+                            sizeof(addr),
+                            entry.data(),
+                            entry.size());
+                        ++(*num_upserts);
+                        *upsert_bytes += sizeof(addr) + entry.size();
+                    }
+                };
+
                 if (nibble == CODE_NIBBLE) {
                     MONAD_ASSERT(depth == HASH_SIZE);
                     send_upsert(SYNC_TYPE_UPSERT_CODE);
@@ -282,10 +321,15 @@ bool statesync_server_handle_request(
                     }
                     else {
                         MONAD_ASSERT(depth == (HASH_SIZE * 2));
-                        send_upsert(
-                            SYNC_TYPE_UPSERT_STORAGE,
-                            reinterpret_cast<unsigned char *>(&addr),
-                            sizeof(addr));
+                        if (server_is_page_encoded()) {
+                            send_storage_page(node.value());
+                        }
+                        else {
+                            send_upsert(
+                                SYNC_TYPE_UPSERT_STORAGE,
+                                reinterpret_cast<unsigned char *>(&addr),
+                                sizeof(addr));
+                        }
                     }
                 }
             }

--- a/category/statesync/test/fuzz_statesync.cpp
+++ b/category/statesync/test/fuzz_statesync.cpp
@@ -129,13 +129,13 @@ namespace
         uint64_t end{0};
     };
 
-    struct State : Range
+    struct FuzzState : Range
     {
         ankerl::unordered_dense::segmented_map<uint64_t, Range> storage;
     };
 
     void new_account(
-        StateDeltas &deltas, State &state, Incarnation const incarnation,
+        StateDeltas &deltas, FuzzState &state, Incarnation const incarnation,
         uint64_t const n)
     {
         bool const success = deltas.emplace(
@@ -149,7 +149,7 @@ namespace
     }
 
     void update_account(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n,
         Incarnation const incarnation)
     {
         if (state.begin == state.end) {
@@ -175,7 +175,7 @@ namespace
         }
     }
 
-    void remove_account(StateDeltas &deltas, State &state, TrieDb &db)
+    void remove_account(StateDeltas &deltas, FuzzState &state, TrieDb &db)
     {
         if (state.begin == state.end) {
             return;
@@ -191,8 +191,8 @@ namespace
         ++state.begin;
     }
 
-    void
-    new_storage(StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+    void new_storage(
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         if (state.begin == state.end) {
             return;
@@ -212,7 +212,7 @@ namespace
     }
 
     void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n,
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n,
         bool const erase)
     {
         if (state.storage.empty()) {
@@ -243,13 +243,13 @@ namespace
     }
 
     void update_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         update_storage(deltas, state, db, n, false);
     }
 
     void remove_storage(
-        StateDeltas &deltas, State &state, TrieDb &db, uint64_t const n)
+        StateDeltas &deltas, FuzzState &state, TrieDb &db, uint64_t const n)
     {
         update_storage(deltas, state, db, n, true);
     }
@@ -294,6 +294,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
     monad_statesync_client client;
     monad_statesync_client_context *const cctx =
         monad_statesync_client_context_create(
+            CHAIN_CONFIG_MONAD_DEVNET,
             &cdbname_str,
             1,
             static_cast<unsigned>(get_nprocs() - 1),
@@ -323,7 +324,7 @@ LLVMFuzzerTestOneInput(uint8_t const *const data, size_t const size)
         &statesync_server_send_done);
 
     std::span<uint8_t const> raw{data, size};
-    State state{};
+    FuzzState state{};
 
     bytes32_t parent_hash{};
     BlockHeader hdr{.number = 0};

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -28,6 +28,7 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -197,6 +198,7 @@ namespace
             // this; tests that bypass the C ABI and call the C++ ctor
             // directly must populate the registry themselves.
             monad::register_ethereum_state_machines();
+            monad::register_monad_state_machines();
             cctx = new monad_statesync_client_context{
                 {cdbname},
                 std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -22,13 +22,21 @@
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/chain/genesis_state.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/db/state_machine_init.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+#include <category/execution/monad/chain/chain_factory.hpp>
+#include <category/execution/monad/db/commit_block_migration.hpp>
 #include <category/execution/monad/db/state_machine_init.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -39,6 +47,9 @@
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
 #include <category/statesync/statesync_version.h>
+#include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/switch_traits.hpp>
+#include <category/vm/evm/traits.hpp>
 #include <test_resource_data.h>
 
 #include <ethash/keccak.hpp>
@@ -164,8 +175,34 @@ namespace
         }
     }
 
-    struct StateSyncFixture : public ::testing::Test
+    // single-timeline server, dual-timeline client
+    template <bool MIP_8_ACTIVE>
+    struct StateSyncFixtureT : public ::testing::Test
     {
+        static std::unique_ptr<OnDiskMachine> make_server_machine()
+        {
+            if constexpr (MIP_8_ACTIVE) { // if mip_8_is_active, we make server
+                                          // primary db page encoded
+                return std::make_unique<MonadOnDiskMachine>();
+            }
+            else {
+                return std::make_unique<OnDiskMachine>();
+            }
+        }
+
+        struct RevisionConfig
+        {
+            monad_chain_config chain_config;
+            uint64_t timestamp;
+        };
+
+        // This is THE single place to update when a chain's mip8 activation
+        // timestamp changes or MONAD_NEXT is promoted to a concrete revision.
+        // Pre-mip8: testnet at timestamp 0 maps to MONAD_ZERO (slot canonical).
+        static constexpr RevisionConfig PRE_MIP8{CHAIN_CONFIG_MONAD_TESTNET, 0};
+        // Post-mip8: devnet currently maps to MONAD_NEXT for any timestamp
+        static constexpr RevisionConfig POST_MIP8{CHAIN_CONFIG_MONAD_DEVNET, 0};
+
         std::filesystem::path cdbname;
         monad_statesync_client client;
         monad_statesync_client_context *cctx;
@@ -175,21 +212,35 @@ namespace
         monad_statesync_server_context sctx;
         mpt::AsyncIOContext io_ctx;
         mpt::Db ro;
+        RevisionConfig const revision_config;
         monad_statesync_server_network net;
         monad_statesync_server *server{};
 
-        StateSyncFixture()
+        static constexpr bool mip_8_is_active = MIP_8_ACTIVE;
+
+        StateSyncFixtureT()
             : cdbname{tmp_dbname()}
             , cctx{nullptr}
             , sdbname{tmp_dbname()}
-            , sdb{std::make_unique<OnDiskMachine>(),
+            , sdb{make_server_machine(),
                   OnDiskDbConfig{.append = true, .dbname_paths = {sdbname}}}
             , stdb{sdb}
             , sctx{stdb}
             , io_ctx{mpt::ReadOnlyOnDiskDbConfig{.dbname_paths = {sdbname}}}
             , ro{io_ctx}
+            , revision_config{MIP_8_ACTIVE ? POST_MIP8 : PRE_MIP8}
         {
+            MONAD_ASSERT(MIP_8_ACTIVE == stdb.is_page_encoded());
             sctx.ro = &ro;
+            // The client context now requires a secondary timeline to
+            // already be active on the client db.
+            mpt::Db primary{
+                std::make_unique<OnDiskMachine>(),
+                OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            [[maybe_unused]] mpt::Db secondary =
+                primary.activate_secondary_timeline(
+                    std::make_unique<MonadOnDiskMachine>());
+            MONAD_ASSERT(primary.timeline_active(mpt::timeline_id::secondary));
         }
 
         void init()
@@ -200,6 +251,7 @@ namespace
             monad::register_ethereum_state_machines();
             monad::register_monad_state_machines();
             cctx = new monad_statesync_client_context{
+                revision_config.chain_config,
                 {cdbname},
                 std::make_optional(static_cast<unsigned>(get_nprocs() - 1)),
                 4,
@@ -225,7 +277,13 @@ namespace
             }
         }
 
-        ~StateSyncFixture()
+        monad_revision get_monad_revision() const
+        {
+            return make_monad_chain(revision_config.chain_config)
+                ->get_monad_revision(revision_config.timestamp);
+        }
+
+        ~StateSyncFixtureT()
         {
             monad_statesync_client_context_destroy(cctx);
             monad_statesync_server_destroy(server);
@@ -233,49 +291,173 @@ namespace
             std::filesystem::remove(sdbname);
         }
     };
+
+    // Slot-encoded server primary for pre-mip8 fork.
+    using StateSyncFixture = StateSyncFixtureT<false>;
+    // Page-encoded server primary for post-mip8 fork
+    using PageServerStateSyncFixture = StateSyncFixtureT<true>;
+
+    template <typename TFixture>
+    struct StateSyncTestBothForks : public TFixture
+    {
+    };
+
+    using StateSyncTestTypes =
+        ::testing::Types<StateSyncFixture, PageServerStateSyncFixture>;
+    TYPED_TEST_SUITE(StateSyncTestBothForks, StateSyncTestTypes);
+
+    // Trait-aware dispatch wrapper for commit_block
+    void commit_block_dispatch(
+        monad::Db &primary, monad::Db *const secondary,
+        monad_revision const rev, bytes32_t const &block_id,
+        BlockHeader const &header, StateDeltas const &deltas,
+        BlockCommitAncillaries const &anc)
+    {
+        SWITCH_MONAD_TRAITS(
+            commit_block, primary, secondary, block_id, header, deltas, anc);
+        MONAD_ASSERT(false);
+    }
+
+    // Commit one block proposal through the production commit_block path, which
+    // stamps the canonical state_root (slot pre-mip8, page post-mip8) into the
+    // header(s)
+    bytes32_t commit_simple_revision_aware(
+        monad::Db &primary, monad::Db *const secondary,
+        monad_revision const rev, StateDeltas const &deltas, Code const &code,
+        BlockHeader const &header, std::vector<Receipt> const &receipts = {},
+        std::vector<std::vector<CallFrame>> const &call_frames = {},
+        std::vector<Address> const &senders = {},
+        std::vector<Transaction> const &txns = {},
+        std::vector<BlockHeader> const &ommers = {},
+        std::optional<std::vector<Withdrawal>> const &withdrawals =
+            std::nullopt)
+    {
+        bytes32_t const block_id =
+            header.number ? bytes32_t{header.number} : NULL_HASH_BLAKE3;
+        BlockCommitAncillaries const anc{
+            .code = code,
+            .receipts = receipts,
+            .transactions = txns,
+            .senders = senders,
+            .call_frames = call_frames,
+            .ommers = ommers,
+            .withdrawals = withdrawals};
+        commit_block_dispatch(
+            primary, secondary, rev, block_id, header, deltas, anc);
+        return block_id;
+    }
+
+    // Like commit_simple_revision_aware, then finalize and reposition both
+    // timelines (the finalized-block analogue of commit_sequential).
+    void commit_sequential_revision_aware(
+        monad::Db &primary, monad::Db *const secondary,
+        monad_revision const rev, StateDeltas const &deltas, Code const &code,
+        BlockHeader const &header, std::vector<Receipt> const &receipts = {},
+        std::vector<std::vector<CallFrame>> const &call_frames = {},
+        std::vector<Address> const &senders = {},
+        std::vector<Transaction> const &txns = {},
+        std::vector<BlockHeader> const &ommers = {},
+        std::optional<std::vector<Withdrawal>> const &withdrawals =
+            std::nullopt)
+    {
+        bytes32_t const block_id = commit_simple_revision_aware(
+            primary,
+            secondary,
+            rev,
+            deltas,
+            code,
+            header,
+            receipts,
+            call_frames,
+            senders,
+            txns,
+            ommers,
+            withdrawals);
+        primary.finalize(header.number, block_id);
+        primary.set_block_and_prefix(header.number);
+        if (secondary != nullptr) {
+            secondary->finalize(header.number, block_id);
+            secondary->set_block_and_prefix(header.number);
+        }
+    }
 }
 
-TEST_F(StateSyncFixture, sync_from_latest)
+// single timeline server -> slot and page-encoded dual db client
+TYPED_TEST(StateSyncTestBothForks, sync_from_latest)
 {
     constexpr auto N = 1'000'000;
     bytes32_t parent_hash{NULL_HASH};
     {
         mpt::Db db{
             std::make_unique<OnDiskMachine>(),
-            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            OnDiskDbConfig{.append = true, .dbname_paths = {this->cdbname}}};
         TrieDb tdb{db};
-        uint64_t const block_number = N - 257;
-        load_header(
-            db.load_root_for_version(block_number),
-            db,
-            BlockHeader{.number = block_number});
-        for (size_t i = N - 256; i < N; ++i) {
-            BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
-            tdb.set_block_and_prefix(i - 1);
-            commit_sequential(tdb, StateDeltas({}), {}, hdr);
-            parent_hash = to_bytes(
-                keccak256(rlp::encode_block_header(tdb.read_eth_header())));
+        // In dual-db set up, both primary and secondary should stay in
+        // lockstep.
+        {
+            auto db2 = db.open_secondary_timeline(
+                std::make_unique<MonadOnDiskMachine>());
+            MONAD_ASSERT(db2.has_value());
+            TrieDb tdb2{*db2};
+            ASSERT_TRUE(tdb2.is_page_encoded());
+            uint64_t const block_number = N - 257;
+            load_header(
+                db.load_root_for_version(block_number),
+                db,
+                BlockHeader{.number = block_number});
+            load_header(
+                db2->load_root_for_version(block_number),
+                *db2,
+                BlockHeader{.number = block_number});
+            for (size_t i = N - 256; i < N; ++i) {
+                BlockHeader const hdr{.parent_hash = parent_hash, .number = i};
+                tdb.set_block_and_prefix(i - 1);
+                tdb2.set_block_and_prefix(i - 1);
+                // Pre-fork (slot canonical): dual-write so both client dbs'
+                // headers carry the same slot state_root.
+                commit_sequential_revision_aware(
+                    tdb,
+                    &tdb2,
+                    this->get_monad_revision(),
+                    StateDeltas({}),
+                    {},
+                    hdr);
+                parent_hash = to_bytes(
+                    keccak256(rlp::encode_block_header(tdb.read_eth_header())));
+            }
+            // Block N: dual-write so both client dbs carry the canonical
+            // header
+            commit_sequential_revision_aware(
+                tdb,
+                &tdb2,
+                this->get_monad_revision(),
+                init_deltas(),
+                init_code(),
+                BlockHeader{.number = N});
+            // a pending proposal at N+1 (not finalized)
+            commit_simple_revision_aware(
+                tdb,
+                &tdb2,
+                this->get_monad_revision(),
+                StateDeltas({}),
+                {},
+                BlockHeader{.number = N + 1});
         }
-        load_db(tdb, N);
-        // commit some proposal to client db
-        tdb.set_block_and_prefix(N);
-        commit_simple(
-            tdb,
-            StateDeltas({}),
-            {},
-            bytes32_t{N + 1},
-            BlockHeader{.number = N + 1});
-        init();
+        this->init();
     }
+    // Canonical root of the load_db state: slot-encoded pre-mip8, page-encoded
+    // post-mip8.
     handle_target(
-        cctx,
+        this->cctx,
         BlockHeader{
             .parent_hash = parent_hash,
             .state_root =
-                0xb9eda41f4a719d9f2ae332e3954de18bceeeba2248a44110878949384b184888_bytes32,
+                this->mip_8_is_active
+                    ? 0x3438aff12a8d7d87cfae57d462e250c2dd03b5b06a5fa50a2eb3c8d397877e79_bytes32
+                    : 0xb9eda41f4a719d9f2ae332e3954de18bceeeba2248a44110878949384b184888_bytes32,
             .number = N});
-    EXPECT_TRUE(monad_statesync_client_has_reached_target(cctx));
-    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+    EXPECT_TRUE(monad_statesync_client_has_reached_target(this->cctx));
+    EXPECT_TRUE(monad_statesync_client_finalize(this->cctx));
 }
 
 TEST_F(StateSyncFixture, sync_from_empty)
@@ -342,14 +524,21 @@ TEST_F(StateSyncFixture, sync_from_empty)
     EXPECT_EQ(hdr.value(), tgrt);
 }
 
-TEST_F(StateSyncFixture, sync_from_some)
+// single timeline server -> slot and page-encoded dual db client
+TYPED_TEST(StateSyncTestBothForks, sync_from_some)
 {
     {
         mpt::Db db{
             std::make_unique<OnDiskMachine>(),
-            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            OnDiskDbConfig{.append = true, .dbname_paths = {this->cdbname}}};
         TrieDb tdb{db};
+        auto db2_opt =
+            db.open_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+        MONAD_ASSERT(db2_opt.has_value());
+        TrieDb tdb2{db2_opt.value()};
+        ASSERT_TRUE(tdb2.is_page_encoded());
         load_genesis_state(GENESIS_STATE, tdb);
+        load_genesis_state(GENESIS_STATE, tdb2);
         // commit some proposal to client db
         commit_simple(
             tdb,
@@ -357,180 +546,147 @@ TEST_F(StateSyncFixture, sync_from_some)
             {},
             NULL_HASH_BLAKE3,
             BlockHeader{.number = 1});
-        load_genesis_state(GENESIS_STATE, stdb);
-        init();
+        commit_simple(
+            tdb2,
+            StateDeltas({}),
+            {},
+            NULL_HASH_BLAKE3,
+            BlockHeader{.number = 1});
+        EXPECT_TRUE(db2_opt->load_root_for_version(0) != nullptr);
+        load_genesis_state(GENESIS_STATE, this->stdb);
+        this->init();
     }
-    ASSERT_TRUE(stdb.get_root() != nullptr);
-    auto const res = sdb.find(
-        stdb.get_root(), concat(FINALIZED_NIBBLE, BLOCKHEADER_NIBBLE), 0);
+
+    ASSERT_TRUE(this->stdb.get_root() != nullptr);
+    auto const res = this->sdb.find(
+        this->stdb.get_root(), concat(FINALIZED_NIBBLE, BLOCKHEADER_NIBBLE), 0);
     ASSERT_TRUE(res.has_value() && res.value().is_valid());
-    BlockHeader const hdr1{
-        .parent_hash = to_bytes(keccak256(res.value().node->value())),
-        .state_root =
-            0x5d651a344741e37c613b580048934ae0deb58b72b542b61416cf7d1fb81d5a79_bytes32,
-        .number = 1};
-    // delete existing account
-    {
-        constexpr auto ADDR1 =
-            0x000d836201318ec6899a67540690382780743280_address;
-        auto const acct = stdb.read_account(ADDR1);
-        MONAD_ASSERT(acct.has_value());
-        commit_sequential(
-            sctx,
-            StateDeltas({{ADDR1, {.account = {acct, std::nullopt}}}}),
-            Code{},
-            hdr1);
-        EXPECT_EQ(stdb.read_eth_header(), hdr1);
-    }
-    BlockHeader const hdr2{
-        .parent_hash = to_bytes(keccak256(rlp::encode_block_header(hdr1))),
-        .state_root =
-            0xd1afa4d8e4546cd3ca0314f2ea5ed7c2de22162b2d72b0ca3f56bcfa551e9e5f_bytes32,
-        .number = 2};
-    // new storage to existing account
-    {
-        constexpr auto ADDR1 =
-            0x02d4a30968a39e2b3498c3a6a4ed45c1c6646822_address;
-        auto const acct = stdb.read_account(ADDR1);
-        commit_sequential(
-            sctx,
-            StateDeltas(
-                {{ADDR1,
-                  {.account = {acct, acct},
-                   .storage =
-                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                         {{},
-                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
-            Code{},
-            hdr2);
-        EXPECT_EQ(stdb.read_eth_header(), hdr2);
-    }
-    BlockHeader const hdr3{
-        .parent_hash = to_bytes(keccak256(rlp::encode_block_header(hdr2))),
-        .state_root =
-            0x1922e617443693307d169df71f44688795793a91c4bf40742765c096e00413d7_bytes32,
-        .number = 3};
-    // add new smart contract
-    {
-        constexpr auto ADDR1 =
-            0x5353535353535353535353535353535353535353_address;
-        auto const code =
-            from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                     "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
-                     "ffffffffffffffffffffff0160005500")
-                .value();
-        auto const code_hash = to_bytes(keccak256(code));
-        auto const icode = vm::make_shared_intercode(code);
-        commit_sequential(
-            sctx,
-            StateDeltas(
-                {{ADDR1,
-                  {.account =
-                       {std::nullopt,
-                        Account{
-                            .balance = 1337,
-                            .code_hash = code_hash,
-                            .nonce = 1,
-                            .incarnation = Incarnation{3, 0}}},
-                   .storage =
-                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                         {{},
-                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}
+    // Commit a server block, then capture its committed header. The committed
+    // state_root is slot pre-mip8 / page post-mip8.
+    bytes32_t parent_hash = to_bytes(keccak256(res.value().node->value()));
+    auto const commit_server_block_update_parent_hash =
+        [&](StateDeltas const &deltas,
+            Code const &code,
+            uint64_t const number) {
+            commit_sequential_revision_aware(
+                this->sctx,
+                nullptr,
+                this->get_monad_revision(),
+                deltas,
+                code,
+                BlockHeader{.parent_hash = parent_hash, .number = number});
+            BlockHeader const committed = this->stdb.read_eth_header();
+            parent_hash =
+                to_bytes(keccak256(rlp::encode_block_header(committed)));
+            return committed;
+        };
 
-                }),
-            Code{{code_hash, icode}},
-            hdr3);
-        EXPECT_EQ(stdb.read_eth_header(), hdr3);
-    }
-    BlockHeader const hdr4{
-        .parent_hash = to_bytes(keccak256(rlp::encode_block_header(hdr3))),
-        .state_root =
-            0x589b5012c41144a33447c07b0cc1f3108181774b7f1eec1fa0f466ffa9bc74b3_bytes32,
-        .number = 4};
-    // delete storage
-    {
-        constexpr auto ADDR1 =
-            0x02d4a30968a39e2b3498c3a6a4ed45c1c6646822_address;
-        auto const acct = stdb.read_account(ADDR1);
-        commit_sequential(
-            sctx,
-            StateDeltas(
-                {{ADDR1,
-                  {.account = {acct, acct},
-                   .storage =
-                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                         {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
-                          {}}}}}}}),
-            Code{},
-            hdr4);
-        EXPECT_EQ(stdb.read_eth_header(), hdr4);
-    }
-    BlockHeader const hdr5{
-        .parent_hash = to_bytes(keccak256(rlp::encode_block_header(hdr4))),
-        .state_root =
-            0x1922e617443693307d169df71f44688795793a91c4bf40742765c096e00413d7_bytes32,
-        .number = 5};
-    // account incarnation
-    {
-        constexpr auto ADDR1 =
-            0x02d4a30968a39e2b3498c3a6a4ed45c1c6646822_address;
-        auto const old = stdb.read_account(ADDR1);
-        auto acct = old;
-        acct->incarnation = Incarnation{5, 0};
-        commit_sequential(
-            sctx,
-            StateDeltas(
-                {{ADDR1,
-                  {.account = {old, acct},
-                   .storage =
-                       {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
-                         {{},
-                          0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
-            Code{},
-            hdr5);
-        EXPECT_EQ(stdb.read_eth_header(), hdr5);
-    }
-    BlockHeader const hdr6{
-        .parent_hash = to_bytes(keccak256(rlp::encode_block_header(hdr5))),
-        .state_root =
-            0xd1afa4d8e4546cd3ca0314f2ea5ed7c2de22162b2d72b0ca3f56bcfa551e9e5f_bytes32,
-        .number = 6};
-    // delete smart contract
-    {
-        constexpr auto ADDR1 =
-            0x5353535353535353535353535353535353535353_address;
-        auto const acct = stdb.read_account(ADDR1);
-        MONAD_ASSERT(acct.has_value());
-        commit_sequential(
-            sctx,
-            StateDeltas({{ADDR1, {.account = {acct, std::nullopt}}}}),
-            Code{},
-            hdr6);
-        EXPECT_EQ(stdb.read_eth_header(), hdr6);
-    }
+    // existing accounts in genesis
+    constexpr auto ADDR1 = 0x000d836201318ec6899a67540690382780743280_address;
+    constexpr auto ADDR2 = 0x02d4a30968a39e2b3498c3a6a4ed45c1c6646822_address;
+    // new account address
+    constexpr auto ADDR3 = 0x5353535353535353535353535353535353535353_address;
 
-    handle_target(cctx, hdr1);
-    run();
+    // delete existing account ADDR1
+    auto const acct1 = this->stdb.read_account(ADDR1);
+    MONAD_ASSERT(acct1.has_value());
+    auto const hdr1 = commit_server_block_update_parent_hash(
+        StateDeltas({{ADDR1, {.account = {acct1, std::nullopt}}}}), Code{}, 1);
 
-    handle_target(cctx, hdr2);
-    run();
+    // new storage to existing account ADDR2
+    auto acct2 = this->stdb.read_account(ADDR2);
+    auto const hdr2 = commit_server_block_update_parent_hash(
+        StateDeltas(
+            {{ADDR2,
+              {.account = {acct2, acct2},
+               .storage =
+                   {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                     {{},
+                      0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
+        Code{},
+        2);
 
-    handle_target(cctx, hdr3);
-    run();
+    // add new smart contract ADDR3
+    auto const code =
+        from_hex("7ffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                 "fffffffffff7fffffffffffffffffffffffffffffffffffffffffff"
+                 "ffffffffffffffffffffff0160005500")
+            .value();
+    auto const code_hash = to_bytes(keccak256(code));
+    auto const icode = vm::make_shared_intercode(code);
+    auto const hdr3 = commit_server_block_update_parent_hash(
+        StateDeltas(
+            {{ADDR3,
+              {.account =
+                   {std::nullopt,
+                    Account{
+                        .balance = 1337,
+                        .code_hash = code_hash,
+                        .nonce = 1,
+                        .incarnation = Incarnation{3, 0}}},
+               .storage =
+                   {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                     {{},
+                      0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
+        Code{{code_hash, icode}},
+        3);
 
-    handle_target(cctx, hdr4);
-    run();
+    // delete storage in account ADDR2
+    acct2 = this->stdb.read_account(ADDR2);
+    auto const hdr4 = commit_server_block_update_parent_hash(
+        StateDeltas(
+            {{ADDR2,
+              {.account = {acct2, acct2},
+               .storage =
+                   {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                     {0x0000000000000013370000000000000000000000000000000000000000000003_bytes32,
+                      {}}}}}}}),
+        Code{},
+        4);
 
-    handle_target(cctx, hdr5);
-    run();
+    // account incarnation for ADDR2
+    auto const old = this->stdb.read_account(ADDR2);
+    acct2 = old;
+    acct2->incarnation = Incarnation{5, 0};
+    auto const hdr5 = commit_server_block_update_parent_hash(
+        StateDeltas(
+            {{ADDR2,
+              {.account = {old, acct2},
+               .storage =
+                   {{0x00000000000000000000000000000000000000000000000000000000cafebabe_bytes32,
+                     {{},
+                      0x0000000000000013370000000000000000000000000000000000000000000003_bytes32}}}}}}),
+        Code{},
+        5);
 
-    handle_target(cctx, hdr6);
-    run();
+    // delete smart contract at ADDR3
+    auto const acct3 = this->stdb.read_account(ADDR3);
+    MONAD_ASSERT(acct3.has_value());
+    auto const hdr6 = commit_server_block_update_parent_hash(
+        StateDeltas({{ADDR3, {.account = {acct3, std::nullopt}}}}), Code{}, 6);
 
-    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+    handle_target(this->cctx, hdr1);
+    this->run();
+
+    handle_target(this->cctx, hdr2);
+    this->run();
+
+    handle_target(this->cctx, hdr3);
+    this->run();
+
+    handle_target(this->cctx, hdr4);
+    this->run();
+
+    handle_target(this->cctx, hdr5);
+    this->run();
+
+    handle_target(this->cctx, hdr6);
+    this->run();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(this->cctx));
 
     // find transaction trie
-    mpt::RODb cdb{ReadOnlyOnDiskDbConfig{.dbname_paths = {cdbname}}};
+    mpt::RODb cdb{ReadOnlyOnDiskDbConfig{.dbname_paths = {this->cdbname}}};
     for (auto const nibble :
          {RECEIPT_NIBBLE,
           TRANSACTION_NIBBLE,
@@ -544,31 +700,38 @@ TEST_F(StateSyncFixture, sync_from_some)
     }
 }
 
-TEST_F(StateSyncFixture, deletion_proposal)
+TYPED_TEST(StateSyncTestBothForks, deletion_proposal)
 {
     {
         mpt::Db db{
             std::make_unique<OnDiskMachine>(),
-            OnDiskDbConfig{.append = true, .dbname_paths = {cdbname}}};
+            OnDiskDbConfig{.append = true, .dbname_paths = {this->cdbname}}};
         TrieDb tdb{db};
+        auto db2_opt =
+            db.open_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+        MONAD_ASSERT(db2_opt.has_value());
+        TrieDb tdb2{db2_opt.value()};
+        ASSERT_TRUE(tdb2.is_page_encoded());
         load_genesis_state(GENESIS_STATE, tdb);
-        load_genesis_state(GENESIS_STATE, stdb);
-        init();
+        load_genesis_state(GENESIS_STATE, tdb2);
+
+        load_genesis_state(GENESIS_STATE, this->stdb);
+        this->init();
     }
-    ASSERT_TRUE(stdb.get_root() != nullptr);
-    auto const res = sdb.find(
-        stdb.get_root(), concat(FINALIZED_NIBBLE, BLOCKHEADER_NIBBLE), 0);
+    ASSERT_TRUE(this->stdb.get_root() != nullptr);
+    auto const res = this->sdb.find(
+        this->stdb.get_root(), concat(FINALIZED_NIBBLE, BLOCKHEADER_NIBBLE), 0);
     ASSERT_TRUE(res.has_value() && res.value().is_valid());
     // delete ADDR1 on one fork
     {
         constexpr auto ADDR1 =
             0x000d836201318ec6899a67540690382780743280_address;
-        auto const acct = sctx.read_account(ADDR1);
+        auto const acct = this->sctx.read_account(ADDR1);
         ASSERT_TRUE(acct.has_value());
         StateDeltas deltas{{ADDR1, {.account = {acct, std::nullopt}}}};
-        sctx.set_block_and_prefix(0);
+        this->sctx.set_block_and_prefix(0);
         commit_simple(
-            sctx,
+            this->sctx,
             StateDeltas(std::move(deltas)),
             Code{},
             bytes32_t{1},
@@ -578,30 +741,30 @@ TEST_F(StateSyncFixture, deletion_proposal)
     {
         constexpr auto ADDR2 =
             0x001762430ea9c3a26e5749afdb70da5f78ddbb8c_address;
-        auto const acct = sctx.read_account(ADDR2);
+        auto const acct = this->sctx.read_account(ADDR2);
         ASSERT_TRUE(acct.has_value());
         StateDeltas deltas{{ADDR2, {.account = {acct, std::nullopt}}}};
-        sctx.set_block_and_prefix(0);
+        this->sctx.set_block_and_prefix(0);
         commit_simple(
-            sctx,
+            this->sctx,
             StateDeltas(std::move(deltas)),
             Code{},
             bytes32_t{2},
             BlockHeader{.number = 1});
     }
-    sctx.finalize(1, bytes32_t{2});
+    this->sctx.finalize(1, bytes32_t{2});
 
-    sctx.set_block_and_prefix(1, bytes32_t{1});
-    auto const bad_header = sctx.read_eth_header();
+    this->sctx.set_block_and_prefix(1, bytes32_t{1});
+    auto const bad_header = this->sctx.read_eth_header();
 
-    sctx.set_block_and_prefix(1, bytes32_t{2});
-    auto const finalized_header = sctx.read_eth_header();
+    this->sctx.set_block_and_prefix(1, bytes32_t{2});
+    auto const finalized_header = this->sctx.read_eth_header();
 
     EXPECT_NE(finalized_header.state_root, bad_header.state_root);
-    handle_target(cctx, finalized_header);
-    run();
+    handle_target(this->cctx, finalized_header);
+    this->run();
 
-    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+    EXPECT_TRUE(monad_statesync_client_finalize(this->cctx));
 }
 
 TEST_F(StateSyncFixture, sync_one_account)
@@ -640,6 +803,210 @@ TEST_F(StateSyncFixture, sync_one_account)
             .number = N});
     run();
     EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+}
+
+// Pre-fork dual-timeline server -> dual-timeline client
+TEST_F(StateSyncFixture, pre_fork_dual_timeline_server_to_dual_db_client)
+{
+    mpt::Db secondary_sdb =
+        sdb.activate_secondary_timeline(std::make_unique<MonadOnDiskMachine>());
+    TrieDb secondary_stdb{secondary_sdb};
+    ASSERT_TRUE(secondary_stdb.is_page_encoded());
+
+    init();
+    uint64_t const timestamp = revision_config.timestamp;
+    monad_revision const rev = cctx->chain->get_monad_revision(timestamp);
+
+    // ADDR_A holds five slots: three share one page_key, two share another, so
+    // the page secondary holds genuine multi-slot pages. The server dual-writes
+    // every block to both its slot primary and page secondary via commit_block;
+    // the client in turn receives slot-encoded upserts and dual-writes them to
+    // its own slot Db1 and page Db2. The test compares the two page tries at
+    // the end.
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    load_header(
+        secondary_sdb.load_root_for_version(N - 257),
+        secondary_sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        secondary_stdb.set_block_and_prefix(i - 1);
+        commit_sequential_revision_aware(
+            stdb,
+            &secondary_stdb,
+            rev,
+            {},
+            Code{},
+            BlockHeader{
+                .parent_hash = parent_hash,
+                .number = i,
+                .timestamp = timestamp});
+        EXPECT_EQ(
+            stdb.read_eth_header().state_root,
+            secondary_stdb.read_eth_header().state_root);
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    // Slots 0x00, 0x01, 0x7f all map to page_key 0 (low 7 bits are offset).
+    // Slots 0x80, 0x81 map to page_key 1.
+    constexpr auto slot_a = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_b = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_c = bytes32_t{uint64_t{0x7f}};
+    constexpr auto slot_d = bytes32_t{uint64_t{0x80}};
+    constexpr auto slot_e = bytes32_t{uint64_t{0x81}};
+    constexpr auto val_a =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto val_b =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto val_c =
+        0x00000000000000000000000000000000000000000000000000000000000000cc_bytes32;
+    constexpr auto val_d =
+        0x00000000000000000000000000000000000000000000000000000000000000dd_bytes32;
+    constexpr auto val_e =
+        0x00000000000000000000000000000000000000000000000000000000000000ee_bytes32;
+
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_b));
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_c));
+    ASSERT_EQ(compute_page_key(slot_d), compute_page_key(slot_e));
+    ASSERT_NE(compute_page_key(slot_a), compute_page_key(slot_d));
+
+    StateDeltas const storage_deltas{
+        {ADDR_A,
+         StateDelta{
+             .account = {std::nullopt, Account{.balance = 100}},
+             .storage = {
+                 {slot_a, {bytes32_t{}, val_a}},
+                 {slot_b, {bytes32_t{}, val_b}},
+                 {slot_c, {bytes32_t{}, val_c}},
+                 {slot_d, {bytes32_t{}, val_d}},
+                 {slot_e, {bytes32_t{}, val_e}}}}}};
+
+    // Dual-write the state block to both timelines
+    commit_sequential_revision_aware(
+        stdb,
+        &secondary_stdb,
+        rev,
+        storage_deltas,
+        Code{},
+        BlockHeader{.number = N, .timestamp = timestamp});
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.read_eth_header().state_root,
+            .number = N,
+            .timestamp = timestamp});
+    run();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    // both timelines db state root should match
+    cctx->tdb.set_block_and_prefix(N);
+    stdb.set_block_and_prefix(N);
+    EXPECT_EQ(stdb.state_root(), cctx->tdb.state_root());
+
+    cctx->secondary_tdb->set_block_and_prefix(N);
+    secondary_stdb.set_block_and_prefix(N);
+    EXPECT_EQ(secondary_stdb.state_root(), cctx->secondary_tdb->state_root());
+}
+
+TEST_F(
+    PageServerStateSyncFixture, post_fork_sync_page_primary_to_dual_db_client)
+{
+    ASSERT_TRUE(this->stdb.is_page_encoded());
+
+    this->init();
+    uint64_t const timestamp = this->revision_config.timestamp;
+    monad_revision const rev = this->cctx->chain->get_monad_revision(timestamp);
+    ASSERT_TRUE(mip_8_active(rev));
+
+    // ADDR_A holds five slots: 0x00/0x01/0x7f share one page, 0x80/0x81 a
+    // second page, so the server holds genuine multi-slot pages to expand.
+    constexpr auto slot_a = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_b = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_c = bytes32_t{uint64_t{0x7f}};
+    constexpr auto slot_d = bytes32_t{uint64_t{0x80}};
+    constexpr auto slot_e = bytes32_t{uint64_t{0x81}};
+    constexpr auto val_a =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto val_b =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto val_c =
+        0x00000000000000000000000000000000000000000000000000000000000000cc_bytes32;
+    constexpr auto val_d =
+        0x00000000000000000000000000000000000000000000000000000000000000dd_bytes32;
+    constexpr auto val_e =
+        0x00000000000000000000000000000000000000000000000000000000000000ee_bytes32;
+
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_b));
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_c));
+    ASSERT_EQ(compute_page_key(slot_d), compute_page_key(slot_e));
+    ASSERT_NE(compute_page_key(slot_a), compute_page_key(slot_d));
+
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        commit_sequential_revision_aware(
+            stdb,
+            nullptr,
+            rev,
+            {},
+            Code{},
+            BlockHeader{
+                .parent_hash = parent_hash,
+                .number = i,
+                .timestamp = timestamp});
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    StateDeltas const storage_deltas{
+        {ADDR_A,
+         StateDelta{
+             .account = {std::nullopt, Account{.balance = 100}},
+             .storage = {
+                 {slot_a, {bytes32_t{}, val_a}},
+                 {slot_b, {bytes32_t{}, val_b}},
+                 {slot_c, {bytes32_t{}, val_c}},
+                 {slot_d, {bytes32_t{}, val_d}},
+                 {slot_e, {bytes32_t{}, val_e}}}}}};
+
+    commit_sequential_revision_aware(
+        stdb,
+        nullptr,
+        rev,
+        storage_deltas,
+        Code{},
+        BlockHeader{.number = N, .timestamp = timestamp});
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.state_root(),
+            .number = N,
+            .timestamp = timestamp});
+    run();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    // Post-fork the client's page secondary must match the page-encoded server
+    // primary.
+    stdb.set_block_and_prefix(N);
+    cctx->secondary_tdb->set_block_and_prefix(N);
+    EXPECT_EQ(stdb.state_root(), cctx->secondary_tdb->state_root());
 }
 
 TEST_F(StateSyncFixture, sync_empty)
@@ -1459,7 +1826,12 @@ TEST(ProtocolValidation, upserts_reject_trailing_bytes)
         monad::register_ethereum_state_machines();
         monad_statesync_client client;
         monad_statesync_client_context ctx{
-            {dbname}, std::nullopt, 4, &client, &statesync_send_request};
+            CHAIN_CONFIG_MONAD_TESTNET,
+            {dbname},
+            std::nullopt,
+            4,
+            &client,
+            &statesync_send_request};
 
         Address a{0xdeadbeef};
         Account acct{.balance = 1};

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -219,6 +219,14 @@ namespace monad
     template <monad_eth_revision Rev>
     detail::TraitsKey EvmTraits<Rev>::key;
 
+    // Runtime sibling to MonadTraits::mip_8_active(), for code holding a
+    // monad_revision value rather than a trait type. Single source of the
+    // mip-8 (page-encoding) activation cutoff.
+    constexpr bool mip_8_active(monad_revision const rev) noexcept
+    {
+        return rev >= MONAD_NEXT;
+    }
+
     template <monad_revision Rev>
     struct MonadTraits
     {
@@ -311,7 +319,7 @@ namespace monad
 
         static consteval bool mip_8_active() noexcept
         {
-            return Rev >= MONAD_NEXT;
+            return ::monad::mip_8_active(Rev);
         }
 
         // Pricing version 1 activates the changes in:

--- a/cmake/test_resource_data.h.in
+++ b/cmake/test_resource_data.h.in
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <category/core/address.hpp>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/keccak.hpp>
-#include <category/core/address.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/vm/vm.hpp>
@@ -111,8 +111,18 @@ inline bytes32_t commit_sequential(
     bytes32_t const block_id =
         eth_header.number ? bytes32_t{eth_header.number} : NULL_HASH_BLAKE3;
 
-    commit_simple(db, deltas, code, block_id, eth_header,
-        receipts, call_frames, senders, txns, ommers, withdrawals);
+    commit_simple(
+        db,
+        deltas,
+        code,
+        block_id,
+        eth_header,
+        receipts,
+        call_frames,
+        senders,
+        txns,
+        ommers,
+        withdrawals);
 
     db.finalize(eth_header.number, block_id);
     db.set_block_and_prefix(eth_header.number); // set to finalized
@@ -121,72 +131,81 @@ inline bytes32_t commit_sequential(
     return block_id;
 }
 
+inline monad::StateDeltas init_deltas()
+{
+    return monad::StateDeltas(
+        {{ADDR_A,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9ce, .code_hash = A_CODE_HASH}},
+              .storage =
+                  {{bytes32_t{},
+                    {bytes32_t{},
+                     0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}}},
+         {ADDR_B,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9ce,
+                       .code_hash = B_CODE_HASH}}}},
+         {0x0000000000000000000000000000000000000102_address,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9ce,
+                       .code_hash = C_CODE_HASH}}}},
+         {0x0000000000000000000000000000000000000103_address,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9ce,
+                       .code_hash = D_CODE_HASH}}}},
+         {0x0000000000000000000000000000000000000104_address,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9ce,
+                       .code_hash = E_CODE_HASH}}}},
+         {0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address,
+          StateDelta{
+              .account = {std::nullopt, Account{.balance = 0x7024c}}}},
+         {0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}}}},
+         {0xcccccccccccccccccccccccccccccccccccccccc_address,
+          StateDelta{
+              .account =
+                  {std::nullopt,
+                   Account{
+                       .balance = 0xba1a9ce0ba1a9cf,
+                       .code_hash = H_CODE_HASH}}}}});
+}
+
+inline Code init_code()
+{
+    return Code{
+        {A_CODE_HASH, A_ICODE},
+        {B_CODE_HASH, B_ICODE},
+        {C_CODE_HASH, C_ICODE},
+        {D_CODE_HASH, D_ICODE},
+        {E_CODE_HASH, E_ICODE},
+        {H_CODE_HASH, H_ICODE}};
+}
+
 inline void load_db(TrieDb &db, uint64_t const n)
 {
     commit_sequential(
         db,
-        monad::StateDeltas({
-            {ADDR_A,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = A_CODE_HASH}},
-                 .storage =
-                     {{bytes32_t{},
-                       {bytes32_t{},
-                        0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe_bytes32}}}}},
-            {ADDR_B,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = B_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000102_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = C_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000103_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = D_CODE_HASH}}}},
-            {0x0000000000000000000000000000000000000104_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9ce,
-                          .code_hash = E_CODE_HASH}}}},
-            {0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address,
-             StateDelta{
-                 .account = {std::nullopt, Account{.balance = 0x7024c}}}},
-            {0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{.balance = 0xba1a9ce0b9aa781, .nonce = 1}}}},
-            {0xcccccccccccccccccccccccccccccccccccccccc_address,
-             StateDelta{
-                 .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = 0xba1a9ce0ba1a9cf,
-                          .code_hash = H_CODE_HASH}}}}}),
-        Code{
-            {A_CODE_HASH, A_ICODE},
-            {B_CODE_HASH, B_ICODE},
-            {C_CODE_HASH, C_ICODE},
-            {D_CODE_HASH, D_ICODE},
-            {E_CODE_HASH, E_ICODE},
-            {H_CODE_HASH, H_ICODE}},
+        init_deltas(),
+        init_code(),
         BlockHeader{.number = n}); // commit to block n, finalized
 }
 

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -30,9 +30,7 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
-#include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/chain/genesis_state.hpp>
-#include <category/execution/ethereum/chain/hive_net.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
 #include <category/execution/ethereum/core/log_level_map.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
@@ -44,9 +42,8 @@
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
 #include <category/execution/ethereum/trace/event_trace.hpp>
-#include <category/execution/monad/chain/monad_devnet.hpp>
-#include <category/execution/monad/chain/monad_mainnet.hpp>
-#include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/chain/chain_factory.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_server_network.hpp>
@@ -303,21 +300,7 @@ try {
         return mpt::Db{std::make_unique<InMemoryMachine>()};
     }();
 
-    auto chain = [chain_config] -> std::unique_ptr<Chain> {
-        switch (chain_config) {
-        case CHAIN_CONFIG_ETHEREUM_MAINNET:
-            return std::make_unique<EthereumMainnet>();
-        case CHAIN_CONFIG_MONAD_DEVNET:
-            return std::make_unique<MonadDevnet>();
-        case CHAIN_CONFIG_MONAD_TESTNET:
-            return std::make_unique<MonadTestnet>();
-        case CHAIN_CONFIG_MONAD_MAINNET:
-            return std::make_unique<MonadMainnet>();
-        case CHAIN_CONFIG_HIVE_NET:
-            return std::make_unique<HiveNet>();
-        }
-        MONAD_ASSERT(false);
-    }();
+    auto chain = make_chain(chain_config);
 
     TrieDb triedb{
         raw_db,
@@ -354,6 +337,9 @@ try {
 
     std::unique_ptr<monad::StateSyncServer> sync_server;
     if (!statesync.empty()) {
+        // Works for either encoding: a page-encoded primary expands each
+        // page leaf into slot-format upserts in the server traversal, so no
+        // protocol changes are needed.
         sync_server = monad::make_statesync_server(monad::StateSyncServerConfig{
             .triedb = &triedb,
             .network = &net.value(),

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -47,6 +47,7 @@
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
 #include <category/execution/monad/chain/monad_testnet.hpp>
+#include <category/execution/monad/db/state_machine_init.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/statesync/statesync_server_network.hpp>
 #include <category/statesync/statesync_thread.hpp>
@@ -283,6 +284,8 @@ try {
     // in-memory path has no metadata to read from and constructs the SM
     // inline.
     register_ethereum_state_machines();
+    register_monad_state_machines();
+
     mpt::Db raw_db = [&] {
         if (!db_in_memory) {
             return mpt::Db{mpt::OnDiskDbConfig{

--- a/rust/crates/monad-statesync/src/ffi.rs
+++ b/rust/crates/monad-statesync/src/ffi.rs
@@ -14,9 +14,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub use self::bindings::{
-    monad_statesync_client, monad_statesync_client_context, monad_statesync_client_handle_done,
-    monad_statesync_client_handle_target, monad_statesync_client_handle_upsert, monad_sync_done,
-    monad_sync_request, monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
+    monad_chain_config, monad_statesync_client, monad_statesync_client_context,
+    monad_statesync_client_handle_done, monad_statesync_client_handle_target,
+    monad_statesync_client_handle_upsert, monad_sync_done, monad_sync_request,
+    monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
     monad_sync_type_SYNC_TYPE_TARGET, monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT,
     monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT_DELETE, monad_sync_type_SYNC_TYPE_UPSERT_CODE,
     monad_sync_type_SYNC_TYPE_UPSERT_HEADER, monad_sync_type_SYNC_TYPE_UPSERT_STORAGE,
@@ -57,6 +58,7 @@ fn add_client_prefixes_as_new_peers(ctx: *mut monad_statesync_client_context, cl
 /// Thin unsafe wrapper around statesync_client_context that handles destruction and finalization
 /// checking
 pub struct StateSyncCtx {
+    chain_config: monad_chain_config,
     dbname_paths: *const *const ::std::os::raw::c_char,
     len: usize,
     sq_thread_cpu: Option<::std::os::raw::c_uint>,
@@ -72,6 +74,7 @@ pub struct StateSyncCtx {
 impl StateSyncCtx {
     /// Initialize StateSyncCtx. There should only ever be *one* StateSyncCtx at any given time.
     pub fn new(
+        chain_config: monad_chain_config,
         dbname_paths: *const *const ::std::os::raw::c_char,
         len: usize,
         sq_thread_cpu: Option<::std::os::raw::c_uint>,
@@ -84,6 +87,7 @@ impl StateSyncCtx {
         assert!(unsafe { bindings::monad_statesync_client_compatible(client_version) });
 
         Self {
+            chain_config,
             dbname_paths,
             len,
             sq_thread_cpu,
@@ -102,6 +106,7 @@ impl StateSyncCtx {
     pub fn get_or_create_ctx(&mut self) -> *mut monad_statesync_client_context {
         *self.ctx.get_or_insert_with(|| unsafe {
             self::bindings::monad_statesync_client_context_create(
+                self.chain_config,
                 self.dbname_paths,
                 self.len,
                 self.sq_thread_cpu
@@ -117,6 +122,7 @@ impl StateSyncCtx {
     ) -> *mut monad_statesync_client_context {
         *self.ctx.get_or_insert_with(|| unsafe {
             let ctx = self::bindings::monad_statesync_client_context_create(
+                self.chain_config,
                 self.dbname_paths,
                 self.len,
                 self.sq_thread_cpu


### PR DESCRIPTION
[Note] This includes a statesync C API changes, and need to update bft side accordingly.

Most LoC are for tests. Tests cover all cases before, during and after the migration and mip8 fork. List of cases:

**Before mip8 fork:**
Dual timeline server -> Dual timeline client
Slot encoded server -> Dual timeline client

**After mip8 fork:**
Page encoded server -> Dual timeline client