### PR TITLE
[execution] Tidy up DB headers.

### DIFF
--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -22,7 +22,7 @@
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
-#include <category/mpt/db.hpp>
+#include <category/mpt/node.hpp>
 #include <category/mpt/state_machine.hpp>
 
 #include <nlohmann/json_fwd.hpp>
@@ -30,6 +30,14 @@
 #include <filesystem>
 #include <functional>
 #include <istream>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+struct Compute;
+class Db;
+class RODb;
+
+MONAD_MPT_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 

--- a/category/mpt/node.hpp
+++ b/category/mpt/node.hpp
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <category/async/storage_pool.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/endian.hpp> // NOLINT
 #include <category/core/keccak.h>
@@ -28,6 +27,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 


### PR DESCRIPTION
This patch tidies up the header for `db/util.hpp` and `mpt/node.hpp` such that they no longer pull in Linux I/O headers transitively, which are not available on bare-metal RISC-V targets.