### PR TITLE
[page_store] Make TrieRODb storage reads encoding-aware

### DIFF
--- a/category/execution/ethereum/db/db.hpp
+++ b/category/execution/ethereum/db/db.hpp
@@ -26,6 +26,7 @@
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/state2/state_deltas.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/vm/vm.hpp>
 
 #include <cstdint>
@@ -36,15 +37,10 @@
 MONAD_NAMESPACE_BEGIN
 
 class CommitBuilder;
-struct storage_page_t;
 
 struct Db
 {
-    virtual bool is_page_encoded() const
-    {
-        return false;
-    }
-
+    virtual bool is_page_encoded() const = 0;
     virtual std::optional<Account> read_account(Address const &) = 0;
 
     virtual bytes32_t
@@ -82,6 +78,12 @@ struct Db
     virtual std::string print_stats()
     {
         return {};
+    }
+
+protected:
+    bytes32_t storage_lookup_key(bytes32_t const &key) const
+    {
+        return is_page_encoded() ? compute_page_key(key) : key;
     }
 };
 

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -158,6 +158,12 @@ class PartialTrieDb final : public Db
 public:
     PartialTrieDb() = delete;
 
+    // TODO: update impl to make it work with page-encoded storage
+    bool is_page_encoded() const override
+    {
+        return false;
+    }
+
     static Result<PartialTrieDb> from_witness(
         bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
         byte_string_view encoded_codes);

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -126,7 +126,7 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
 bytes32_t TrieDb::read_storage(
     Address const &addr, Incarnation const incarnation, bytes32_t const &key)
 {
-    bytes32_t const lookup_key = page_encoded_ ? compute_page_key(key) : key;
+    bytes32_t const lookup_key = storage_lookup_key(key);
     uint8_t const lookup_offset = page_encoded_ ? compute_slot_offset(key) : 0;
     bytes32_t result{};
     if (cache_ && cache_->try_read_storage(

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -19,8 +19,10 @@
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/db/db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/db_error.hpp>
+#include <category/mpt/state_machine_kind.hpp>
 #include <category/vm/vm.hpp>
 
 #include <category/core/hex.hpp>
@@ -30,23 +32,29 @@
 
 MONAD_NAMESPACE_BEGIN
 
-// TODO: add runtime page_encoded flag as well. Will need it for post fork in
-// release2
 class TrieRODb final : public ::monad::Db
 {
     ::monad::mpt::RODb &db_;
     uint64_t block_number_;
     ::monad::mpt::NodeCursor prefix_cursor_;
+    bool const page_encoded_;
 
 public:
     explicit TrieRODb(mpt::RODb &db)
         : db_(db)
         , block_number_(mpt::INVALID_BLOCK_NUM)
         , prefix_cursor_()
+        , page_encoded_(
+              db_.state_machine_type() == mpt::state_machine_kind::monad)
     {
     }
 
     ~TrieRODb() = default;
+
+    virtual bool is_page_encoded() const override
+    {
+        return page_encoded_;
+    }
 
     virtual void set_block_and_prefix(
         uint64_t const block_number,
@@ -94,12 +102,16 @@ public:
     virtual bytes32_t read_storage(
         Address const &addr, Incarnation, bytes32_t const &key) override
     {
+        // On a page-encoded db the storage leaf is the page that contains the
+        // slot, keyed by page_key; the slot value lives at its offset within.
+        bytes32_t const lookup_key = storage_lookup_key(key);
         auto storage_leaf_res = db_.find(
             prefix_cursor_,
             mpt::concat(
                 STATE_NIBBLE,
                 mpt::NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
-                mpt::NibblesView{keccak256({key.bytes, sizeof(key.bytes)})}),
+                mpt::NibblesView{
+                    keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
             block_number_);
         if (!storage_leaf_res.has_value()) {
             MONAD_ASSERT_THROW(
@@ -111,7 +123,14 @@ public:
         auto encoded_storage = storage_leaf_res.value().node->value();
         auto const storage = decode_storage_db_ignore_key(encoded_storage);
         MONAD_ASSERT(!storage.has_error());
-        return to_bytes(storage.value());
+        if (page_encoded_) {
+            auto const page = decode_storage_page(storage.value());
+            MONAD_ASSERT(!page.has_error());
+            return page.value()[compute_slot_offset(key)];
+        }
+        else {
+            return to_bytes(storage.value());
+        }
     }
 
     virtual storage_page_t

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1022,6 +1022,13 @@ uint64_t RODb::get_earliest_version() const
     return impl_->aux().metadata_ctx().db_history_min_valid_version();
 }
 
+state_machine_kind RODb::state_machine_type() const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux().metadata_ctx().get_state_machine_kind(
+        timeline_id::primary);
+}
+
 DbError find_result_to_db_error(find_result const result) noexcept
 {
     switch (result) {

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -61,6 +61,8 @@ struct AsyncIOContext
     explicit AsyncIOContext(OnDiskDbConfig const &options);
 };
 
+// Hardcode it to open the primary timeline. All timelines are always in sync
+// and store the canonical state.
 class RODb
 {
     struct Impl;
@@ -84,6 +86,8 @@ public:
     bool traverse(
         NodeCursor const &, TraverseMachine &, uint64_t block_id,
         size_t concurrency_limit = 4096);
+
+    state_machine_kind state_machine_type() const;
 };
 
 // A Db is bound to one timeline. The constructors below produce a primary

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -129,40 +129,48 @@ namespace
         return v;
     }
 
-    struct EthCallFixture : public ::testing::Test
+    // Machine selects the db state machine: OnDiskMachine = slot-encoded,
+    // MonadOnDiskMachine = page-encoded. The executor opens its own RODb on
+    // dbname, so the on-disk encoding drives TrieRODb's read path.
+    template <class Machine>
+    struct EthCallEncodingFixture : public ::testing::Test
     {
         std::filesystem::path dbname;
         mpt::Db db;
         TrieDb tdb;
         vm::VM vm;
 
-        EthCallFixture()
+        EthCallEncodingFixture()
             : dbname{[] {
-                std::filesystem::path dbname(
-                    MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
-                    "monad_eth_call_test1_XXXXXX");
-                int const fd = ::mkstemp((char *)dbname.native().data());
+                std::string dbpath =
+                    (MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+                     "monad_eth_call_test1_XXXXXX")
+                        .string();
+                int const fd = ::mkstemp(dbpath.data());
                 MONAD_ASSERT(fd != -1);
                 MONAD_ASSERT(
                     -1 !=
                     ::ftruncate(
                         fd, static_cast<off_t>(8ULL * 1024 * 1024 * 1024)));
                 ::close(fd);
-                return dbname;
+                return std::filesystem::path{dbpath};
             }()}
-            , db{std::make_unique<OnDiskMachine>(),
+            , db{std::make_unique<Machine>(),
                  mpt::OnDiskDbConfig{.append = false, .dbname_paths = {dbname}}}
             , tdb{db}
         {
         }
 
-        ~EthCallFixture()
+        ~EthCallEncodingFixture()
         {
             std::filesystem::remove(dbname);
         }
 
         void test_transfer_call_with_trace(bool gas_specified);
     };
+
+    // Slot-encoded db (the common case) for the bulk of TEST_F tests.
+    using EthCallFixture = EthCallEncodingFixture<OnDiskMachine>;
 
     struct callback_context
     {
@@ -184,7 +192,9 @@ namespace
         c->promise.set_value();
     }
 
-    void EthCallFixture::test_transfer_call_with_trace(bool const gas_specified)
+    template <class Machine>
+    void EthCallEncodingFixture<Machine>::test_transfer_call_with_trace(
+        bool const gas_specified)
     {
         for (uint64_t i = 0; i < 256; ++i) {
             commit_sequential(
@@ -289,6 +299,11 @@ namespace
         monad_executor_destroy(executor);
     }
 }
+
+// Storage-reading tests run on both encodings: slot (pre-mip8) and page
+// (post-mip8).
+using EthCallMachines = ::testing::Types<OnDiskMachine, MonadOnDiskMachine>;
+TYPED_TEST_SUITE(EthCallEncodingFixture, EthCallMachines);
 
 TEST_F(EthCallFixture, simple_success_call)
 {
@@ -3616,7 +3631,7 @@ TEST_F(EthCallFixture, prestate_state_overrides)
     monad_executor_destroy(executor);
 }
 
-TEST_F(EthCallFixture, prestate_override_state)
+TYPED_TEST(EthCallEncodingFixture, prestate_override_state)
 {
     static constexpr Address CONTRACT_ADDR =
         0xcccccccccccccccccccccccccccccccccccccccc_address;
@@ -3668,17 +3683,18 @@ TEST_F(EthCallFixture, prestate_override_state)
                  StorageDeltas{{storage_key, {bytes32_t{}, storage_value}}}}}};
 
     commit_sequential(
-        tdb,
+        this->tdb,
         StateDeltas(std::move(deltas)),
         {{code_hash, compiled_code}},
         BlockHeader{.number = 0});
 
-    auto const storage = tdb.read_storage(
+    auto const storage = this->tdb.read_storage(
         CONTRACT_ADDR, Incarnation{0, 0}, store_be_as<bytes32_t>(uint256_t{0}));
     ASSERT_EQ(storage, store_be_as<bytes32_t>(uint256_t{uint64_t{64}}));
 
     for (uint64_t i = 1; i < 256; ++i) {
-        commit_sequential(tdb, StateDeltas({}), {}, BlockHeader{.number = i});
+        commit_sequential(
+            this->tdb, StateDeltas({}), {}, BlockHeader{.number = i});
     }
 
     static constexpr auto from = Address{};
@@ -3686,7 +3702,7 @@ TEST_F(EthCallFixture, prestate_override_state)
     Transaction const tx{.gas_limit = 200000u, .to = CONTRACT_ADDR};
     BlockHeader const header{.number = 256};
 
-    commit_sequential(tdb, StateDeltas({}), {}, header);
+    commit_sequential(this->tdb, StateDeltas({}), {}, header);
 
     auto const rlp_tx = to_vec(rlp::encode_transaction(tx));
     auto const rlp_header = to_vec(rlp::encode_block_header(header));
@@ -3694,7 +3710,7 @@ TEST_F(EthCallFixture, prestate_override_state)
         to_vec(rlp::encode_address(std::make_optional(from)));
     auto const rlp_block_id = to_vec(rlp_finalized_id);
 
-    auto *executor = create_executor(dbname.string());
+    auto *executor = create_executor(this->dbname.string());
 
     // Test 'state' override option. It should wipe the existing and update the
     // given slots.
@@ -6763,7 +6779,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
 }
 
 // Test time travelling
-TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
+TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
 {
     using namespace monad::vm::utils;
 
@@ -6787,7 +6803,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
     bytes32_t const unlock_time = store_be_as<bytes32_t>(uint256_t{512});
 
     commit_sequential(
-        tdb,
+        this->tdb,
         StateDeltas{
             {sender,
              StateDelta{
@@ -6810,10 +6826,10 @@ TEST_F(EthCallFixture, eth_simulate_v1_time_travel)
 
     for (uint64_t i = 1; i < 256; ++i) {
         commit_sequential(
-            tdb, {}, {}, BlockHeader{.number = i, .timestamp = i});
+            this->tdb, {}, {}, BlockHeader{.number = i, .timestamp = i});
     }
 
-    auto *executor = create_executor(dbname.string());
+    auto *executor = create_executor(this->dbname.string());
 
     Transaction const tx{
         .gas_limit = 200'000'000,


### PR DESCRIPTION
## What

`monad_executor` reads state through `TrieRODb`, which always decoded
slot-format storage leaves. Against a page-encoded (post-mip8) db this returns
wrong/empty values for any `SLOAD`. This PR makes `TrieRODb::read_storage` follow
the db's actual encoding.

## Changes

- **`TrieRODb` encoding-aware**: `read_storage` now looks up the `page_key`
  leaf and extracts the slot at its offset when the db is page-encoded,
  mirroring the writable `TrieDb`. Slot-encoded path is unchanged.
- **`mpt::RODb::state_machine_type()`**: reads the (primary) timeline's
  `state_machine_kind` from `db_metadata`, so `TrieRODb` can detect its
  encoding at construction.
- **`Db::is_page_encoded()` is now pure virtual**, forcing every `Db` to
  declare its encoding. `TrieRODb` overrides it; `PartialTrieDb` returns
  `false` (page support left as a TODO).

## Testing

`monad_executor_test`: the storage-reading tests (`prestate_override_state`,
`eth_simulate_v1_time_travel`) now run as `TYPED_TEST` over both slot- and
page-encoded dbs via `EthCallEncodingFixture`, exercising the page read path
through both the eth_call and eth_simulate executor paths. Storage-agnostic
tests stay slot-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)