### PR TITLE
[mpt] Fix MONAD007->008 migration db_offsets overrun and root-offsets…

### DIFF
--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -1579,13 +1579,24 @@ opened.
                    "Number of chunks to allocate for storing root offsets. "
                    "Must be a positive number that is a power of 2. Default is "
                    "16. Each chunk holds approx 16.5M history entries.")
-                ->check([](std::string const &s) {
+                ->check([](std::string const &s) -> std::string {
                     auto const v = std::stoll(s);
                     if (v <= 0) {
                         return "Value must be positive";
                     }
                     if ((v & (v - 1)) != 0) {
                         return "Value must be a power of 2";
+                    }
+                    // The per-ring cnv_chunks[] list holds SIZE_ - 1 entries;
+                    // a larger count overflows the array during new-pool init.
+                    constexpr auto max_ring_chunks =
+                        monad::mpt::detail::db_metadata::root_offsets_ring_t::
+                            SIZE_ -
+                        1;
+                    if (static_cast<unsigned long long>(v) > max_ring_chunks) {
+                        return "Value must be <= " +
+                               std::to_string(max_ring_chunks) +
+                               " (root offsets ring capacity)";
                     }
                     return "";
                 });

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -64,6 +64,102 @@ static constexpr size_t MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES = 128;
 static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
 static constexpr size_t DB_METADATA_LIST_TRIPLE_BYTES = 24;
 
+namespace detail
+{
+    void migrate_monad007_to_monad008(
+        db_metadata *const m, uint32_t const chunk_count)
+    {
+        auto *const m_bytes = reinterpret_cast<std::byte *>(m);
+
+        MONAD_ASSERT(
+            m->root_offsets.cnv_chunks_len() <
+                db_metadata::root_offsets_ring_t::SIZE_,
+            "MONAD007 pool has more primary cnv chunks than MONAD008's "
+            "SIZE_ cap allows — cannot migrate");
+
+        // 1. Stash the list triple (at the tail of the MONAD007 header)
+        //    before step 2's memmove, whose destination can overlap the
+        //    triple's source for chunk_count > 65501.
+        std::array<std::byte, DB_METADATA_LIST_TRIPLE_BYTES> list_triple_buf{};
+        (void)memcpy(
+            list_triple_buf.data(),
+            m_bytes + MONAD007_LIST_TRIPLE_OFFSET,
+            DB_METADATA_LIST_TRIPLE_BYTES);
+
+        // 2. Relocate chunk_info[]. memmove because src/dst may overlap for
+        //    pathologically large chunk_count.
+        (void)memmove(
+            m_bytes + sizeof(db_metadata),
+            m_bytes + MONAD007_DB_METADATA_SIZE,
+            size_t(chunk_count) * sizeof(db_metadata::chunk_info_t));
+
+        // 3. Install the stashed list triple at its new location.
+        (void)memcpy(
+            m_bytes + offsetof(db_metadata, free_list),
+            list_triple_buf.data(),
+            DB_METADATA_LIST_TRIPLE_BYTES);
+
+        // 4. Relocate db_offsets..latest_proposed_block_id, dropping
+        //    MONAD007's global auto_expire_version (sandwiched between
+        //    latest_proposed_version and latest_voted_block_id) since
+        //    MONAD008 promotes it to a per-timeline field in
+        //    timeline_state_t. Save the value, then copy the two halves
+        //    either side of the gap into the new gap-less layout.
+        static_assert(offsetof(db_metadata, db_offsets) == 312);
+        static_assert(offsetof(db_metadata, secondary_timeline) == 432);
+        constexpr size_t MONAD007_AUTO_EXPIRE_OFFSET =
+            MONAD007_DB_OFFSETS_OFFSET + 16 + 5 * 8; // 524384
+        constexpr size_t MONAD007_PRE_AUTO_EXPIRE_BYTES =
+            MONAD007_AUTO_EXPIRE_OFFSET - MONAD007_DB_OFFSETS_OFFSET; // 56
+        constexpr size_t MONAD007_POST_AUTO_EXPIRE_BYTES =
+            MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES -
+            MONAD007_PRE_AUTO_EXPIRE_BYTES - 8; // 64
+        int64_t saved_auto_expire = 0;
+        (void)memcpy(
+            &saved_auto_expire,
+            m_bytes + MONAD007_AUTO_EXPIRE_OFFSET,
+            sizeof(saved_auto_expire));
+        (void)memcpy(
+            m_bytes + offsetof(db_metadata, db_offsets),
+            m_bytes + MONAD007_DB_OFFSETS_OFFSET,
+            MONAD007_PRE_AUTO_EXPIRE_BYTES);
+        (void)memcpy(
+            m_bytes + offsetof(db_metadata, latest_voted_block_id),
+            m_bytes + MONAD007_AUTO_EXPIRE_OFFSET + 8,
+            MONAD007_POST_AUTO_EXPIRE_BYTES);
+        // MONAD007 had no secondary, so the saved value belongs on what is now
+        // the primary.
+        m->root_offsets_state.auto_expire_version_ = saved_auto_expire;
+        // Stamp the primary timeline's state_machine_kind. The byte sat inside
+        // MONAD007's huge cnv_chunks[] (0xff for unused slots), which would
+        // trip create_state_machine()'s range check on the next open. MONAD007
+        // only supported ethereum.
+        m->root_offsets_state.state_machine_kind_ =
+            static_cast<uint8_t>(state_machine_kind::ethereum);
+        memset(
+            m->root_offsets_state.reserved_sm_,
+            0,
+            sizeof(m->root_offsets_state.reserved_sm_));
+
+        // 5. Zero the region between secondary_timeline and the live block
+        //    list (relocated in step 3). secondary_timeline_state
+        //    .state_machine_kind_ is left at zero (state_machine_kind
+        //    ::ethereum); secondary_timeline_active_ is also zero, so the byte
+        //    is unreachable until a later monad-mpt --activate-secondary
+        //    stamps the real kind.
+        auto *const new_fields_begin =
+            m_bytes + offsetof(db_metadata, secondary_timeline);
+        auto *const new_fields_end = m_bytes + offsetof(db_metadata, free_list);
+        memset(new_fields_begin, 0, size_t(new_fields_end - new_fields_begin));
+
+        // 6. Bump magic. The signal_fence keeps the preceding stores from
+        //    sinking past it under -O3 reordering; durability is enforced by
+        //    the caller's flush.
+        std::atomic_signal_fence(std::memory_order_seq_cst);
+        memcpy(m->magic, db_metadata::MAGIC, db_metadata::MAGIC_STRING_LEN);
+    }
+}
+
 DbMetadataContext::DbMetadataContext(AsyncIO &io)
     : io_(&io)
 {
@@ -195,104 +291,8 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
                 continue;
             }
             auto const g = m->hold_dirty();
-            auto *const m_bytes = reinterpret_cast<std::byte *>(m);
-
-            MONAD_ASSERT(
-                m->root_offsets.storage_.cnv_chunks_len <
-                    detail::db_metadata::root_offsets_ring_t::SIZE_,
-                "MONAD007 pool has more primary cnv chunks than MONAD008's "
-                "SIZE_ cap allows — cannot migrate");
-
-            // 1. Stash the list triple (at the tail of the MONAD007
-            //    header) before step 2's memmove, whose destination can
-            //    overlap the triple's source for chunk_count > 65501.
-            std::array<std::byte, DB_METADATA_LIST_TRIPLE_BYTES>
-                list_triple_buf{};
-            (void)memcpy(
-                list_triple_buf.data(),
-                m_bytes + MONAD007_LIST_TRIPLE_OFFSET,
-                DB_METADATA_LIST_TRIPLE_BYTES);
-
-            // 2. Relocate chunk_info[]. memmove because src/dst may
-            //    overlap for pathologically large chunk_count.
-            (void)memmove(
-                m_bytes + sizeof(detail::db_metadata),
-                m_bytes + MONAD007_DB_METADATA_SIZE,
-                size_t(chunk_count) *
-                    sizeof(detail::db_metadata::chunk_info_t));
-
-            // 3. Install the stashed list triple at its new location.
-            (void)memcpy(
-                m_bytes + offsetof(detail::db_metadata, free_list),
-                list_triple_buf.data(),
-                DB_METADATA_LIST_TRIPLE_BYTES);
-
-            // 4. Relocate db_offsets..latest_proposed_block_id, dropping
-            //    MONAD007's global auto_expire_version (sandwiched between
-            //    latest_proposed_version and latest_voted_block_id) since
-            //    MONAD008 promotes it to a per-timeline field in
-            //    timeline_state_t. Save the value, then copy the two
-            //    halves either side of the gap into the new gap-less
-            //    layout.
-            static_assert(offsetof(detail::db_metadata, db_offsets) == 312);
-            static_assert(
-                offsetof(detail::db_metadata, secondary_timeline) == 432);
-            constexpr size_t MONAD007_AUTO_EXPIRE_OFFSET =
-                MONAD007_DB_OFFSETS_OFFSET + 16 + 5 * 8; // 524384
-            constexpr size_t MONAD007_PRE_AUTO_EXPIRE_BYTES =
-                MONAD007_AUTO_EXPIRE_OFFSET - MONAD007_DB_OFFSETS_OFFSET; // 56
-            constexpr size_t MONAD007_POST_AUTO_EXPIRE_BYTES =
-                MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES -
-                MONAD007_PRE_AUTO_EXPIRE_BYTES - 8; // 64
-            int64_t saved_auto_expire = 0;
-            (void)memcpy(
-                &saved_auto_expire,
-                m_bytes + MONAD007_AUTO_EXPIRE_OFFSET,
-                sizeof(saved_auto_expire));
-            (void)memcpy(
-                m_bytes + offsetof(detail::db_metadata, db_offsets),
-                m_bytes + MONAD007_DB_OFFSETS_OFFSET,
-                MONAD007_PRE_AUTO_EXPIRE_BYTES);
-            (void)memcpy(
-                m_bytes + offsetof(detail::db_metadata, latest_voted_block_id),
-                m_bytes + MONAD007_AUTO_EXPIRE_OFFSET + 8,
-                MONAD007_POST_AUTO_EXPIRE_BYTES);
-            // MONAD007 had no secondary, so the saved value belongs on
-            // what is now the primary.
-            m->root_offsets_state.auto_expire_version_ = saved_auto_expire;
-            // Stamp the primary timeline's state_machine_kind. The byte
-            // sat inside MONAD007's huge cnv_chunks[] (0xff for unused
-            // slots), which would trip create_state_machine()'s range
-            // check on the next open. MONAD007 only supported ethereum.
-            m->root_offsets_state.state_machine_kind_ =
-                static_cast<uint8_t>(state_machine_kind::ethereum);
-            memset(
-                m->root_offsets_state.reserved_sm_,
-                0,
-                sizeof(m->root_offsets_state.reserved_sm_));
-
-            // 5. Zero the region between secondary_timeline and the live
-            //    block list (relocated in step 3).
-            //    secondary_timeline_state.state_machine_kind_ is left at
-            //    zero (state_machine_kind::ethereum);
-            //    secondary_timeline_active_ is also zero, so the byte is
-            //    unreachable until a later monad-mpt --activate-secondary
-            //    stamps the real kind.
-            auto *const new_fields_begin =
-                m_bytes + offsetof(detail::db_metadata, secondary_timeline);
-            auto *const new_fields_end =
-                m_bytes + offsetof(detail::db_metadata, free_list);
-            memset(
-                new_fields_begin, 0, size_t(new_fields_end - new_fields_begin));
-
-            // 6. Bump magic. The signal_fence keeps the preceding stores
-            //    from sinking past it under -O3 reordering; durability is
-            //    enforced by the msync after the loop.
-            std::atomic_signal_fence(std::memory_order_seq_cst);
-            memcpy(
-                m->magic,
-                detail::db_metadata::MAGIC,
-                detail::db_metadata::MAGIC_STRING_LEN);
+            detail::migrate_monad007_to_monad008(
+                m, static_cast<uint32_t>(chunk_count));
         }
         // Flush the new layout before downstream code reads at the new
         // offsets.

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -77,14 +77,24 @@ namespace detail
             "MONAD007 pool has more primary cnv chunks than MONAD008's "
             "SIZE_ cap allows — cannot migrate");
 
-        // 1. Stash the list triple (at the tail of the MONAD007 header)
-        //    before step 2's memmove, whose destination can overlap the
-        //    triple's source for chunk_count > 65501.
+        // 1. Stash the tail-of-header regions that step 2's chunk_info[]
+        //    memmove will overrun. Its destination grows up from
+        //    sizeof(db_metadata) and, for large chunk_count, runs over the
+        //    db_offsets..latest_proposed_block_id block (chunk_count > 64981)
+        //    and then the free/fast/slow list triple (chunk_count > 65501).
+        //    Both sources sit below the memmove source, so neither survives
+        //    the relocation in place — stash both before step 2.
         std::array<std::byte, DB_METADATA_LIST_TRIPLE_BYTES> list_triple_buf{};
         (void)memcpy(
             list_triple_buf.data(),
             m_bytes + MONAD007_LIST_TRIPLE_OFFSET,
             DB_METADATA_LIST_TRIPLE_BYTES);
+        std::array<std::byte, MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES>
+            db_offsets_buf{};
+        (void)memcpy(
+            db_offsets_buf.data(),
+            m_bytes + MONAD007_DB_OFFSETS_OFFSET,
+            MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES);
 
         // 2. Relocate chunk_info[]. memmove because src/dst may overlap for
         //    pathologically large chunk_count.
@@ -99,12 +109,13 @@ namespace detail
             list_triple_buf.data(),
             DB_METADATA_LIST_TRIPLE_BYTES);
 
-        // 4. Relocate db_offsets..latest_proposed_block_id, dropping
-        //    MONAD007's global auto_expire_version (sandwiched between
-        //    latest_proposed_version and latest_voted_block_id) since
+        // 4. Relocate db_offsets..latest_proposed_block_id from the stash,
+        //    dropping MONAD007's global auto_expire_version (sandwiched
+        //    between latest_proposed_version and latest_voted_block_id) since
         //    MONAD008 promotes it to a per-timeline field in
         //    timeline_state_t. Save the value, then copy the two halves
-        //    either side of the gap into the new gap-less layout.
+        //    either side of the gap into the new gap-less layout. Offsets
+        //    into db_offsets_buf are relative to MONAD007_DB_OFFSETS_OFFSET.
         static_assert(offsetof(db_metadata, db_offsets) == 312);
         static_assert(offsetof(db_metadata, secondary_timeline) == 432);
         constexpr size_t MONAD007_AUTO_EXPIRE_OFFSET =
@@ -117,15 +128,15 @@ namespace detail
         int64_t saved_auto_expire = 0;
         (void)memcpy(
             &saved_auto_expire,
-            m_bytes + MONAD007_AUTO_EXPIRE_OFFSET,
+            db_offsets_buf.data() + MONAD007_PRE_AUTO_EXPIRE_BYTES,
             sizeof(saved_auto_expire));
         (void)memcpy(
             m_bytes + offsetof(db_metadata, db_offsets),
-            m_bytes + MONAD007_DB_OFFSETS_OFFSET,
+            db_offsets_buf.data(),
             MONAD007_PRE_AUTO_EXPIRE_BYTES);
         (void)memcpy(
             m_bytes + offsetof(db_metadata, latest_voted_block_id),
-            m_bytes + MONAD007_AUTO_EXPIRE_OFFSET + 8,
+            db_offsets_buf.data() + MONAD007_PRE_AUTO_EXPIRE_BYTES + 8,
             MONAD007_POST_AUTO_EXPIRE_BYTES);
         // MONAD007 had no secondary, so the saved value belongs on what is now
         // the primary.
@@ -240,12 +251,14 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
     //   db_offsets..latest_proposed_block_id (128B)  524328 -> 312
     //
     // root_offsets and its cnv_chunks[0..30] are byte-identical between
-    // layouts. The block now holding root_offsets_state, secondary_timeline,
-    // secondary_timeline_state, identity bytes and pending_shrink_grow
-    // (offsets 296..4456) was MONAD007 padding and is
-    // zeroed so new fields start at idle defaults. Each copy migrates
-    // under hold_dirty; the memmove/memcpy/memset operations preserve
-    // their sources, so a crash-replay is idempotent.
+    // layouts and are not moved. root_offsets_state (296..312) is seeded in
+    // step 4 (auto_expire from MONAD007's global, state_machine_kind stamped
+    // ethereum). The block at [432, 4456) — secondary_timeline,
+    // secondary_timeline_state, the role/identity bytes and
+    // pending_shrink_grow — was MONAD007 padding and is zeroed so new fields
+    // start at idle defaults. Each copy migrates under hold_dirty; the
+    // memmove/memcpy/memset operations preserve their sources, so a
+    // crash-replay is idempotent.
     auto const is_previous_magic = [](detail::db_metadata const *m) {
         return 0 == memcmp(
                         m->magic,
@@ -395,6 +408,10 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
         MONAD_ASSERT(
             ring_total > 0 && (ring_total & (ring_total - 1)) == 0,
             "Number of cnv chunks for root offsets must be a power of two");
+        MONAD_ASSERT(
+            ring_total <= detail::db_metadata::root_offsets_ring_t::SIZE_ - 1,
+            "Number of cnv chunks for root offsets exceeds the per-ring "
+            "cnv_chunks[] capacity (SIZE_ - 1)");
 
         auto &a_storage = copies_[0].main->root_offsets.storage_;
         auto &b_storage = copies_[0].main->secondary_timeline.storage_;

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -65,6 +65,15 @@ namespace detail
     inline void
     db_copy(db_metadata *dest, db_metadata const *src, size_t bytes);
 
+    // In-place relocation of one metadata copy's fixed-header fields from the
+    // MONAD007 layout to MONAD008, rewriting the magic on success. chunk_count
+    // is the seq-chunk count (== chunk_info[] length). The caller is
+    // responsible for holding the copy's hold_dirty, healing dirty copies from
+    // a clean sibling beforehand, and flushing afterward. Exposed for unit
+    // tests that exercise large chunk_count layouts the constructor cannot
+    // reach without an impractically large pool.
+    void migrate_monad007_to_monad008(db_metadata *m, uint32_t chunk_count);
+
     // For the memory map of the first conventional chunk
     struct db_metadata
     {

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -169,6 +169,35 @@ TEST(cli_tool, state_machine_unknown_kind_rejected)
     EXPECT_NE(retcode, 0);
 }
 
+// 32 is a power of two but exceeds the per-ring cnv_chunks[] capacity
+// (SIZE_ - 1 = 31), so the --root-offsets-chunk-count check must reject it
+// before any pool is created.
+TEST(cli_tool, root_offsets_chunk_count_over_capacity_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    auto const fd = mkstemp(temppath);
+    if (-1 == fd) {
+        abort();
+    }
+    ::close(fd);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+    if (-1 == truncate(temppath, 6ULL * 1024 * 1024 * 1024)) {
+        abort();
+    }
+    std::stringstream cout;
+    std::stringstream cerr;
+    std::string_view args[] = {
+        "monad-mpt",
+        "--storage",
+        temppath,
+        "--create",
+        "--root-offsets-chunk-count",
+        "32"};
+    int const retcode = main_impl(cout, cerr, args);
+    EXPECT_NE(retcode, 0);
+}
+
 namespace
 {
     // Helper: open the pool RO and read back the persisted kind via

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -33,12 +33,14 @@
 
 #include <atomic>
 #include <csignal>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <memory>
 #include <span>
 #include <stop_token>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -845,6 +847,203 @@ TEST(update_aux_death_test, aborts_on_monad007_without_allow_migration)
 
     ASSERT_DEATH(
         { DbMetadataContext const ctx{testio}; }, "monad-mpt --upgrade");
+}
+
+// Regression for the MONAD007 -> MONAD008 migration on a pool large enough
+// that step 2's chunk_info[] memmove destination overruns the MONAD007
+// db_offsets + consensus block at offset 524328. The destination grows up
+// from sizeof(db_metadata) = 4480, so it reaches 524328 once
+// 4480 + 8*chunk_count > 524328, i.e. chunk_count > 64981. The constructor
+// cannot reach this regime in a unit test (it would need a >64981-seq-chunk
+// pool with >= 2 MiB cnv chunks), so drive the relocation directly on a
+// synthetic buffer. Before the fix that stashes the block, the memmove
+// zeroed db_offsets/finalized/voted/proposed before step 4 read them.
+TEST(
+    update_aux_test, migrate_monad007_preserves_db_offsets_at_large_chunk_count)
+{
+    using monad::mpt::detail::db_metadata;
+    static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+    static constexpr size_t MONAD007_DB_OFFSETS_OFFSET = 524328;
+    static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
+
+    constexpr uint32_t chunk_count = 70000;
+    static_assert(
+        4480 + 8 * size_t(chunk_count) > MONAD007_DB_OFFSETS_OFFSET,
+        "chunk_count must be large enough for the memmove to overrun "
+        "db_offsets, otherwise this test does not exercise the bug");
+
+    size_t const buf_bytes =
+        MONAD007_DB_METADATA_SIZE +
+        size_t(chunk_count) * sizeof(db_metadata::chunk_info_t);
+    // uint64_t backing gives the 8-byte alignment db_metadata requires.
+    std::vector<uint64_t> storage((buf_bytes + 7) / 8, 0);
+    auto *const buf = reinterpret_cast<uint8_t *>(storage.data());
+
+    memcpy(buf, db_metadata::PREVIOUS_MAGIC, db_metadata::MAGIC_STRING_LEN);
+    uint64_t const bitfield = static_cast<uint64_t>(chunk_count) & 0xfffffULL;
+    memcpy(buf + 8, &bitfield, 8);
+    uint64_t const test_capacity_in_free_list = 1'000'000;
+    memcpy(buf + 16, &test_capacity_in_free_list, 8);
+    // root_offsets header (offset 24) is byte-identical across layouts and
+    // is not relocated: high_bits_all_set, cnv_chunks_len, and three ids.
+    uint32_t const high_bits_all_set = uint32_t(-1);
+    uint32_t const test_cnv_chunks_len = 3;
+    uint32_t const test_ids[3] = {1, 2, 7};
+    memcpy(buf + 40, &high_bits_all_set, 4);
+    memcpy(buf + 44, &test_cnv_chunks_len, 4);
+    for (uint32_t k = 0; k < test_cnv_chunks_len; k++) {
+        memcpy(buf + 48 + k * 8, &high_bits_all_set, 4);
+        memcpy(buf + 52 + k * 8, &test_ids[k], 4);
+    }
+    memset(
+        buf + 48 + size_t(test_cnv_chunks_len) * 8,
+        0xff,
+        MONAD007_DB_OFFSETS_OFFSET - (48 + size_t(test_cnv_chunks_len) * 8));
+
+    // The 128-byte db_offsets..block_ids block. Byte indices are relative to
+    // MONAD007_DB_OFFSETS_OFFSET; a per-byte pattern makes any clobber
+    // detectable, with typed scalars overlaid at their known slots.
+    uint8_t db_block[128];
+    for (size_t i = 0; i < sizeof(db_block); i++) {
+        db_block[i] = static_cast<uint8_t>(0x80 + (i & 0x3f));
+    }
+    uint64_t const test_history_length = 12345;
+    uint64_t const test_latest_finalized = 42;
+    uint64_t const test_latest_verified = 41;
+    uint64_t const test_latest_voted = 40;
+    uint64_t const test_latest_proposed = 43;
+    int64_t const test_auto_expire = 999;
+    memcpy(db_block + 16, &test_history_length, 8); // 524344
+    memcpy(db_block + 24, &test_latest_finalized, 8); // 524352
+    memcpy(db_block + 32, &test_latest_verified, 8); // 524360
+    memcpy(db_block + 40, &test_latest_voted, 8); // 524368
+    memcpy(db_block + 48, &test_latest_proposed, 8); // 524376
+    memcpy(db_block + 56, &test_auto_expire, 8); // 524384 (dropped global)
+    memcpy(buf + MONAD007_DB_OFFSETS_OFFSET, db_block, sizeof(db_block));
+
+    memset(buf + 524456, 0xff, MONAD007_LIST_TRIPLE_OFFSET - 524456);
+    uint32_t const fl_begin = 5;
+    uint32_t const fl_end = 7;
+    uint32_t const invalid = db_metadata::NULL_CHUNK;
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET, &fl_begin, 4);
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET + 4, &fl_end, 4);
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET + 8, &invalid, 4);
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET + 12, &invalid, 4);
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET + 16, &invalid, 4);
+    memcpy(buf + MONAD007_LIST_TRIPLE_OFFSET + 20, &invalid, 4);
+
+    // Stamp recognizable chunk_info[] entries at the source so the relocation
+    // itself is checked, not just the adjacent stashed blocks. Slot 0's source
+    // (528512) is overwritten by a later destination write during the memmove,
+    // so verifying it survives at the destination exercises the forward-copy
+    // overlap handling; 35000 and the last slot cover mid/end.
+    uint32_t const ci_slots[3] = {0, 35000, chunk_count - 1};
+    uint64_t const ci_patterns[3] = {
+        0x1111222233334444ULL, 0x5555666677778888ULL, 0x9999aaaabbbbccccULL};
+    for (size_t s = 0; s < 3; s++) {
+        memcpy(
+            buf + MONAD007_DB_METADATA_SIZE +
+                size_t(ci_slots[s]) * sizeof(db_metadata::chunk_info_t),
+            &ci_patterns[s],
+            sizeof(uint64_t));
+    }
+
+    auto *const m = monad::start_lifetime_as<db_metadata>(buf);
+    monad::mpt::detail::migrate_monad007_to_monad008(m, chunk_count);
+
+    EXPECT_EQ(
+        0, memcmp(m->magic, db_metadata::MAGIC, db_metadata::MAGIC_STRING_LEN));
+    // db_offsets (16 raw bytes) relocated from 524328 to 312.
+    EXPECT_EQ(
+        0,
+        memcmp(
+            reinterpret_cast<std::byte const *>(&m->db_offsets), db_block, 16));
+    EXPECT_EQ(m->history_length, test_history_length);
+    EXPECT_EQ(m->latest_finalized_version, test_latest_finalized);
+    EXPECT_EQ(m->latest_verified_version, test_latest_verified);
+    EXPECT_EQ(m->latest_voted_version, test_latest_voted);
+    EXPECT_EQ(m->latest_proposed_version, test_latest_proposed);
+    EXPECT_EQ(m->root_offsets_state.auto_expire_version_, test_auto_expire);
+    // latest_voted_block_id + latest_proposed_block_id (64 contiguous bytes)
+    // relocated from 524392 (db_block + 64) to 368.
+    EXPECT_EQ(
+        0,
+        memcmp(
+            reinterpret_cast<std::byte const *>(&m->latest_voted_block_id),
+            db_block + 64,
+            64));
+    // root_offsets cnv list survives unrelocated.
+    EXPECT_EQ(m->root_offsets.cnv_chunks_len(), test_cnv_chunks_len);
+    for (uint32_t k = 0; k < test_cnv_chunks_len; k++) {
+        EXPECT_EQ(
+            test::DbMetadataTestAccess::storage(m->root_offsets)
+                .cnv_chunks[k]
+                .cnv_chunk_id,
+            test_ids[k]);
+    }
+    // chunk_info[] payload relocated from 528512 to sizeof(db_metadata).
+    for (size_t s = 0; s < 3; s++) {
+        uint64_t got = 0;
+        memcpy(
+            &got,
+            buf + sizeof(db_metadata) +
+                size_t(ci_slots[s]) * sizeof(db_metadata::chunk_info_t),
+            sizeof(uint64_t));
+        EXPECT_EQ(got, ci_patterns[s])
+            << "chunk_info[] slot " << ci_slots[s] << " not relocated";
+    }
+    // list triple relocated from 528488 to 4456.
+    EXPECT_EQ(m->free_list.begin, fl_begin);
+    EXPECT_EQ(m->free_list.end, fl_end);
+    EXPECT_EQ(m->fast_list.begin, db_metadata::NULL_CHUNK);
+    EXPECT_EQ(m->slow_list.begin, db_metadata::NULL_CHUNK);
+    // new-in-MONAD008 fields at idle defaults.
+    EXPECT_EQ(m->secondary_timeline.cnv_chunks_len(), 0u);
+    EXPECT_EQ(m->primary_ring_idx, 0u);
+    EXPECT_EQ(m->secondary_timeline_active_, 0u);
+    EXPECT_EQ(
+        m->root_offsets_state.state_machine_kind_,
+        static_cast<uint8_t>(state_machine_kind::ethereum));
+}
+
+// SIZE_ - 1 = 31 cnv chunks is the per-ring cnv_chunks[] cap. num_cnv_chunks
+// = SIZE_ + 1 makes ring_total = SIZE_ = 32, one past the array. New-pool
+// init must abort rather than write out of bounds into root_offsets_state.
+TEST(update_aux_death_test, aborts_when_root_offsets_ring_exceeds_capacity)
+{
+    std::string templ = (MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+                         "monad_update_aux_ring_cap_test_XXXXXX")
+                            .string();
+    int const fd = ::mkstemp(templ.data());
+    MONAD_ASSERT(fd != -1);
+    std::filesystem::path const filename{templ};
+    auto const unfilename = monad::make_scope_exit(
+        [&]() noexcept { (void)::unlink(filename.c_str()); });
+    MONAD_ASSERT(-1 != ::ftruncate(fd, 2UL << 30)); // 2GB
+
+    monad::io::Ring ring1;
+    monad::io::Ring ring2;
+    monad::io::Buffers testbuf =
+        monad::io::make_buffers_for_segregated_read_write(
+            ring1,
+            ring2,
+            2,
+            4,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+            monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+    monad::async::storage_pool::creation_flags flags;
+    flags.chunk_capacity = 24; // 16 MiB chunks keep the temp file small
+    flags.num_cnv_chunks =
+        static_cast<uint32_t>(detail::db_metadata::root_offsets_ring_t::SIZE_) +
+        1; // 33 -> ring_total 32
+    monad::async::storage_pool pool(
+        std::span{&filename, 1},
+        monad::async::storage_pool::mode::truncate,
+        flags);
+    monad::async::AsyncIO testio(pool, testbuf);
+
+    ASSERT_DEATH(
+        { DbMetadataContext const ctx{testio}; }, "exceeds the per-ring");
 }
 
 TEST(update_aux_test, activate_deactivate_secondary)


### PR DESCRIPTION
… ring bound

Two bugs in the MONAD007->MONAD008 db_metadata migration (PR #2212), found in review:

1. On a pool with > 64981 seq chunks, the chunk_info[] relocation memmove (its destination grows up from sizeof(db_metadata)) overran the MONAD007 db_offsets..latest_proposed_block_id block at offset 524328 before step 4 copied those fields to their MONAD008 locations, silently corrupting db_offsets and the consensus versions/block-ids. Stash that 128-byte block before the memmove, mirroring the existing list-triple stash.

2. New-pool init only checked the root-offsets ring chunk count was a power of two, not <= SIZE_-1 (31, the cnv_chunks[] capacity), so --root-offsets-chunk-count 32 wrote one element past the array into root_offsets_state. Add an always-on init assert and a CLI ->check reject.

The per-copy relocation is extracted into detail::migrate_monad007_to_monad008 so it can be unit-tested at large chunk_count without an impractically large pool. Adds regression tests for both bugs (the migration test is confirmed to fail without the fix) and a CLI-rejection test.