### PR TITLE
[statesync] Re-export monad_chain_config enum constants from the FFI

### DIFF
--- a/rust/crates/monad-statesync/src/ffi.rs
+++ b/rust/crates/monad-statesync/src/ffi.rs
@@ -14,10 +14,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub use self::bindings::{
-    monad_chain_config, monad_statesync_client, monad_statesync_client_context,
-    monad_statesync_client_handle_done, monad_statesync_client_handle_target,
-    monad_statesync_client_handle_upsert, monad_sync_done, monad_sync_request,
-    monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
+    monad_chain_config, monad_chain_config_CHAIN_CONFIG_ETHEREUM_MAINNET,
+    monad_chain_config_CHAIN_CONFIG_HIVE_NET, monad_chain_config_CHAIN_CONFIG_MONAD_DEVNET,
+    monad_chain_config_CHAIN_CONFIG_MONAD_MAINNET, monad_chain_config_CHAIN_CONFIG_MONAD_TESTNET,
+    monad_statesync_client, monad_statesync_client_context, monad_statesync_client_handle_done,
+    monad_statesync_client_handle_target, monad_statesync_client_handle_upsert, monad_sync_done,
+    monad_sync_request, monad_sync_type_SYNC_TYPE_DONE, monad_sync_type_SYNC_TYPE_REQUEST,
     monad_sync_type_SYNC_TYPE_TARGET, monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT,
     monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT_DELETE, monad_sync_type_SYNC_TYPE_UPSERT_CODE,
     monad_sync_type_SYNC_TYPE_UPSERT_HEADER, monad_sync_type_SYNC_TYPE_UPSERT_STORAGE,


### PR DESCRIPTION
Re-exports the bindgen-generated `monad_chain_config_CHAIN_CONFIG_*` constants (the C `enum monad_chain_config` from `category/execution/ethereum/chain/chain_config.h`) from the `monad-statesync` `ffi` module.

These values were already generated by bindgen but lived in the private `bindings` module, so Rust consumers could only see the `monad_chain_config` *type*, not its discriminants. Exposing them lets the bft side map a chain to the statesync client (`monad_statesync_client_context_create`) using named constants sourced directly from the C header, instead of duplicating raw `0..4` discriminants.

Execution half of a 2-PR change; the bft consumer is category-labs/monad-bft#3152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
