### PR TITLE
Run MIP-8 spec tests

### DIFF
--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -27,8 +27,8 @@ ExternalProject_Add(
 
 ExternalProject_Add(
   MonadSpecTestFixtures
-  URL "https://github.com/monad-developers/execution-spec-tests/releases/download/monad@v1.0.0/fixtures_monad.tar.gz"
-  URL_HASH "SHA256=94b68a8cb1eb66f03a60156ac1cc73191fc084257cf8673fb259992e44c7ed0d"
+  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad@v1.1.0/fixtures_monad.tar.gz"
+  URL_HASH "SHA256=f51ed023f0e37a5ff469677614e548509cfab55a49789049488caaafd295d0c1"
   PREFIX ${CMAKE_BINARY_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
@@ -99,6 +99,7 @@ endfunction()
 
 add_monad_test(FORK MONAD_EIGHT)
 add_monad_test(FORK MONAD_NINE)
+add_monad_test(FORK MONAD_NEXT)
 
 add_ethereum_test(FORK istanbul)
 add_ethereum_test(FORK berlin)

--- a/test/ethereum_test/exclude/MONAD_NEXT.cmake
+++ b/test/ethereum_test/exclude/MONAD_NEXT.cmake
@@ -1,0 +1,16 @@
+# Copyright (C) 2025 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set(MONAD_NEXT_excluded_tests "")


### PR DESCRIPTION
Switches to release https://github.com/monad-developers/execution-specs/releases/tag/tests-monad%40v1.1.0 with:
- MIP-8 tests
- MIP-11 compatibility fix
- upstream test additions

~PR is targeting the combined MIP-8 branch. Can either be merged if you'd like to run the MIP-8 tests in CI (preferred) or I can keep rebasing it on top from time to time. It should target `main` eventually, once that has full MIP-8 support.~ EDIT: re-targetted to main

One known issue remaining is fork naming - once MIP-8 support becomes gated on a concrete MONAD_* revision, the tests release will require updating