### PR TITLE
triedb: add page-aware storage FFI (is_page_encoded + decode_storage_page_slot)

### DIFF
--- a/rust/crates/monad-triedb/include/ffi.h
+++ b/rust/crates/monad-triedb/include/ffi.h
@@ -38,6 +38,28 @@ int triedb_read(
     TriedbRoInner *, uint8_t const *key, uint8_t key_len_nibbles,
     uint8_t const **value, uint64_t block_id);
 
+// true if the primary timeline is page-encoded (Monad state machine), in which
+// case storage is keyed by keccak(page_key) (page_key = slot >> 7) and the leaf
+// is an encoded page; otherwise storage is slot-encoded.
+bool triedb_is_page_encoded(TriedbRoInner *);
+
+// Compute the storage page key for a 32-byte slot key on a page-encoded db:
+// page_key = slot >> 7. Writes the 32-byte big-endian page key (the key the
+// storage trie is looked up by) to out_page_key.
+void triedb_compute_page_key(uint8_t const *slot_key, uint8_t *out_page_key);
+
+// Compute the slot's offset within its page for a 32-byte slot key: the low 7
+// bits of the slot key. This is the `offset` argument to
+// triedb_decode_storage_page_slot.
+uint8_t triedb_compute_slot_offset(uint8_t const *slot_key);
+
+// Decode a page-encoded storage leaf (as returned by triedb_read for a
+// page-encoded db, looked up with the page key) and write the 32-byte value of
+// the slot at `offset` (the low 7 bits of the original slot key) to out_value.
+// Returns false on decode error.
+bool triedb_decode_storage_page_slot(
+    uint8_t const *leaf, size_t leaf_len, uint8_t offset, uint8_t *out_value);
+
 typedef void (*triedb_async_read_callback_fn)(
     uint8_t const *value, int length, void *user);
 // calls (*completed) when read is

--- a/rust/crates/monad-triedb/src/ffi.cpp
+++ b/rust/crates/monad-triedb/src/ffi.cpp
@@ -18,6 +18,8 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/log.hpp>
 #include <category/core/nibble.h>
+#include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/execution/monad/staking/read_valset.hpp>
 #include <category/mpt/db.hpp>
 #include <category/mpt/ondisk_db_config.hpp>
@@ -142,6 +144,58 @@ int triedb_read(
         *value = buf;
     }
     return value_len;
+}
+
+bool triedb_is_page_encoded(TriedbRoInner *const db)
+{
+    if (db == nullptr) {
+        return false;
+    }
+    return db->db.state_machine_type() == monad::mpt::state_machine_kind::monad;
+}
+
+void triedb_compute_page_key(
+    uint8_t const *const slot_key, uint8_t *const out_page_key)
+{
+    monad::bytes32_t key;
+    memcpy(key.bytes, slot_key, sizeof(key.bytes));
+    auto const page_key = monad::compute_page_key(key);
+    memcpy(out_page_key, page_key.bytes, sizeof(page_key.bytes));
+}
+
+uint8_t triedb_compute_slot_offset(uint8_t const *const slot_key)
+{
+    monad::bytes32_t key;
+    memcpy(key.bytes, slot_key, sizeof(key.bytes));
+    return monad::compute_slot_offset(key);
+}
+
+bool triedb_decode_storage_page_slot(
+    uint8_t const *const leaf, size_t const leaf_len, uint8_t const offset,
+    uint8_t *const out_value)
+{
+    if (leaf == nullptr || out_value == nullptr) {
+        return false;
+    }
+    monad::byte_string_view enc{leaf, leaf_len};
+    auto const page_bytes = monad::decode_storage_db_ignore_key(enc);
+    if (page_bytes.has_error()) {
+        return false;
+    }
+    auto const page = monad::decode_storage_page(page_bytes.value());
+    if (page.has_error()) {
+        return false;
+    }
+    // offset is the slot key's low 7 bits (0..SLOT_OFFSET_MASK). Reject an
+    // out-of-range value rather than masking it: masking would silently read
+    // the wrong slot (e.g. 0x80 -> slot 0) and hide a caller bug, and indexing
+    // past the 128-slot page would be UB.
+    if (offset > monad::storage_page_t::SLOT_OFFSET_MASK) {
+        return false;
+    }
+    auto const slot = page.value()[offset];
+    memcpy(out_value, slot.bytes, sizeof(slot.bytes));
+    return true;
 }
 
 namespace

--- a/rust/crates/monad-triedb/src/ffi.rs
+++ b/rust/crates/monad-triedb/src/ffi.rs
@@ -19,10 +19,12 @@ pub(crate) use self::bindings::{
     triedb_async_traverse_callback_triedb_async_traverse_callback_finished_early,
     triedb_async_traverse_callback_triedb_async_traverse_callback_finished_normally,
     triedb_async_traverse_callback_triedb_async_traverse_callback_value, triedb_close,
-    triedb_earliest_version, triedb_finalize, triedb_free_valset, triedb_latest_finalized_version,
-    triedb_latest_proposed_block_id, triedb_latest_proposed_version,
-    triedb_latest_verified_version, triedb_latest_voted_block_id, triedb_latest_voted_version,
-    triedb_open, triedb_poll, triedb_read, triedb_read_valset, triedb_traverse, TriedbRoInner,
+    triedb_compute_page_key, triedb_compute_slot_offset, triedb_decode_storage_page_slot,
+    triedb_earliest_version, triedb_finalize, triedb_free_valset, triedb_is_page_encoded,
+    triedb_latest_finalized_version, triedb_latest_proposed_block_id,
+    triedb_latest_proposed_version, triedb_latest_verified_version, triedb_latest_voted_block_id,
+    triedb_latest_voted_version, triedb_open, triedb_poll, triedb_read, triedb_read_valset,
+    triedb_traverse, TriedbRoInner,
 };
 pub use self::bindings::{validator_data, validator_set};
 

--- a/rust/crates/monad-triedb/src/lib.rs
+++ b/rust/crates/monad-triedb/src/lib.rs
@@ -85,6 +85,36 @@ fn validate_nibble_key(key: &[u8], key_len_nibbles: u8, label: &str) -> Option<(
     Some(())
 }
 
+/// Compute the storage page key for a 32-byte slot `key` on a page-encoded db
+/// (`page_key = slot >> 7`). This is the key the storage trie is looked up by;
+/// the returned page leaf is then decoded with `decode_storage_page_slot` at
+/// the offset from `compute_slot_offset`. Delegates to C++ so the page geometry
+/// lives in one place.
+pub fn compute_page_key(key: [u8; 32]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    unsafe { ffi::triedb_compute_page_key(key.as_ptr(), out.as_mut_ptr()) };
+    out
+}
+
+/// Compute the slot's offset within its page for a 32-byte slot `key` (the low
+/// 7 bits). This is the `offset` argument to `decode_storage_page_slot`.
+pub fn compute_slot_offset(key: [u8; 32]) -> u8 {
+    unsafe { ffi::triedb_compute_slot_offset(key.as_ptr()) }
+}
+
+/// Decode a page-encoded storage `leaf` (the value of a storage node on a
+/// page-encoded db, looked up with the page key) and return the 32-byte value
+/// of the slot at `offset` (the low 7 bits of the original slot key). Returns
+/// `None` on decode error. Reuses the C++ page decode via FFI so the page
+/// format lives in one place.
+pub fn decode_storage_page_slot(leaf: &[u8], offset: u8) -> Option<[u8; 32]> {
+    let mut out = [0u8; 32];
+    let ok = unsafe {
+        ffi::triedb_decode_storage_page_slot(leaf.as_ptr(), leaf.len(), offset, out.as_mut_ptr())
+    };
+    ok.then_some(out)
+}
+
 /// Converts a C `u64` sentinel value (`u64::MAX` = not found) to `Option<u64>`.
 fn parse_triedb_block_num(value: u64) -> Option<u64> {
     if value == u64::MAX {
@@ -212,6 +242,13 @@ impl TriedbHandle {
         }
 
         Some(Self { db_ptr })
+    }
+
+    /// True if the primary timeline is page-encoded (Monad state machine), in
+    /// which case storage is keyed by keccak(page_key) and leaves are encoded
+    /// pages (see `decode_storage_page_slot`).
+    pub fn is_page_encoded(&self) -> bool {
+        unsafe { ffi::triedb_is_page_encoded(self.db_ptr) }
     }
 
     pub fn read(&self, key: &[u8], key_len_nibbles: u8, block_id: u64) -> Option<Vec<u8>> {


### PR DESCRIPTION
## What

Adds two read-only FFI entry points to the `monad-triedb` crate so a Rust caller can serve `eth_getStorageAt` against a **page-encoded** timeline:

- `triedb_is_page_encoded(db)` — true when the primary timeline is the Monad (page-encoded) state machine: storage is keyed by `keccak(page_key)` (`page_key = slot >> 7`) and leaves are encoded pages.
- `triedb_decode_storage_page_slot(leaf, offset)` — decode an encoded page leaf and return the 32-byte value at the slot's low-7-bit `offset`. The page wire-format decode stays in C++ (single source of truth, reuses `decode_storage_page`).

Plus the thin Rust wrappers (`ffi.rs`, `lib.rs`).

## Why

After the dual-db migration promotes the page timeline, the primary is page-encoded. A slot-only reader looks up `keccak(slot)` and finds nothing → `eth_getStorageAt` returns `0` for all real storage (a silent, customer-facing correctness hole). This FFI lets the bft RPC read page-encoded storage correctly. Consumer: companion PR in `monad-bft` (`triedb_env.rs` page-aware `get_storage_at`).

## Discussion — is this the right seam?

The split here is: **the Rust caller computes `page_key = slot >> 7` and the offset**, looks up `keccak(page_key)`, then calls this FFI to **decode only**. The main alternative is a single C++ entry point `triedb_read_storage(addr, slot)` that owns the whole page-aware read.

Trade-off as I see it:
- *Current split:* keeps the bft async/LRU cache keyed by `page_key`, so the 128 slots in a page share one disk read + cache entry; only the format-specific decode is delegated to C++ (format lives in one place). Downside: page-key derivation is duplicated outside `storage_page.hpp`.
- *C++ owns the whole read:* zero duplication, but the bft async poller + cache (keyed by nibble path) would need to either lose page-level cache sharing or be taught about pages.

Flagging for review before this lands more permanently. Happy to flip to the C++-owned approach if that's preferred.
