### PR TITLE
[core] minor improvements to C keccak256 function

### DIFF
--- a/category/core/keccak.c
+++ b/category/core/keccak.c
@@ -27,8 +27,7 @@ extern void
 SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
 
 void keccak256(
-    unsigned char const *const in, unsigned long const len,
-    unsigned char out[KECCAK256_SIZE])
+    void const *const in, size_t const len, uint8_t out[KECCAK256_SIZE])
 {
     uint64_t A[5][5];
     unsigned char blk[BLOCK_SIZE];
@@ -37,7 +36,7 @@ void keccak256(
 
     size_t const rem = SHA3_absorb(A, in, len, BLOCK_SIZE);
     if (rem > 0) {
-        __builtin_memcpy(blk, &in[len - rem], rem);
+        __builtin_memcpy(blk, (uint8_t const *)in + len - rem, rem);
     }
     __builtin_memset(&blk[rem], 0, BLOCK_SIZE - rem);
     blk[rem] = 0x01;

--- a/category/core/keccak.h
+++ b/category/core/keccak.h
@@ -15,16 +15,17 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#define KECCAK256_SIZE 32
+constexpr size_t KECCAK256_SIZE = 32;
 
-void keccak256(
-    unsigned char const *in, unsigned long len,
-    unsigned char out[KECCAK256_SIZE]);
+void keccak256(void const *in, size_t len, uint8_t out[KECCAK256_SIZE]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These improvements come from trying to use keccak256 in real pure C in the Monad RISC-V platform SDK. Two header files were missing, and there is no reason to specify that the input must be `unsigned char *`, which will produce warnings when the input is something else we want to hash.

Making the input `void` is similar to memcpy(3) and memset(3), where the `size_t` parameter is always understood to be bytes because it can't reasonably be anything else, and we get natural conversion from any input type.