### PR TITLE
MonadDevnet now reads MONAD_NEXT fork timestamp from env var MONAD_DEVNET_FORK_TS

### DIFF
--- a/category/execution/monad/chain/monad_devnet.cpp
+++ b/category/execution/monad/chain/monad_devnet.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/core/assert.h>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
@@ -21,13 +22,35 @@
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_devnet_alloc.hpp>
 #include <category/vm/evm/monad/revision.h>
+#include <charconv>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <system_error>
 
 MONAD_NAMESPACE_BEGIN
 
-monad_revision MonadDevnet::get_monad_revision(uint64_t /*timestamp*/) const
+monad_revision MonadDevnet::get_monad_revision(uint64_t const timestamp) const
 {
-    return MONAD_NEXT;
+    // Fork timestamp (UNIX seconds) from MONAD_DEVNET_FORK_TS; unset
+    // defaults to 0, so the chain is MONAD_NEXT from genesis as before. A
+    // set-but-unparseable value aborts rather than silently parsing as 0.
+    static auto const next_at = []() -> uint64_t {
+        char const *const env = std::getenv("MONAD_DEVNET_FORK_TS");
+        if (env == nullptr || *env == '\0') {
+            return uint64_t{0};
+        }
+        char const *const end = env + std::strlen(env);
+        uint64_t value = 0;
+        auto const [ptr, ec] = std::from_chars(env, end, value);
+        MONAD_ASSERT_PRINTF(
+            ec == std::errc{} && ptr == end,
+            "MONAD_DEVNET_FORK_TS must be a decimal UNIX timestamp, got "
+            "\"%s\"",
+            env);
+        return value;
+    }();
+    return timestamp >= next_at ? MONAD_NEXT : MONAD_NINE;
 }
 
 uint256_t MonadDevnet::get_chain_id() const


### PR DESCRIPTION
`MonadDevnet::get_monad_revision` now reads the `MONAD_NINE` -> `MONAD_NEXT` fork timestamp (UNIX seconds) from the `MONAD_DEVNET_FORK_TS` environment variable instead of returning `MONAD_NEXT` unconditionally.

- **Unset (default):** the fork point is `0`, so every block satisfies `timestamp >= 0` and the chain is `MONAD_NEXT` from genesis — byte-for-byte the same behavior as before. Production runs are unaffected.
- **Set to a future timestamp:** the chain stays at `MONAD_NINE` until that time, then crosses into `MONAD_NEXT`.
- The value is parsed strictly with `std::from_chars`; a set-but-unparseable value (typo, trailing junk, overflow) aborts rather than silently parsing as `0`, which would forfeit the pre-fork window.

This unlocks the slot -> page DB migration integration test: the harness sets `MONAD_DEVNET_FORK_TS` to "genesis + N seconds" on each run so a fresh wall-clock interval of slot-encoded pre-fork history accumulates, the activate-secondary / promote-secondary lifecycle runs offline against the node DB, and the chain then crosses into `MONAD_NEXT` on the page-encoded primary post-fork.

Supersedes the earlier approach of adding a dedicated `CHAIN_CONFIG_MONAD_DEVNET_FORK` chain type (chain_id 20144): folding the toggle into the existing devnet means no new chain config, factory wiring, CLI mapping, or statesync FFI enum value. The net change is a single file, `category/execution/monad/chain/monad_devnet.cpp`.
