### PR TITLE
mpt: max version should return INVALID_BLOCK_NUM when rewind below its valid range

### DIFF
--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -707,7 +707,7 @@ void DbMetadataContext::update_root_offset(
         ro.assign(i, root_offset);
         if (root_offset == INVALID_OFFSET && i == db_history_max_version(tid) &&
             i == db_history_min_valid_version(tid)) {
-            ro.reset_all(0);
+            ro.reset_all();
             MONAD_ASSERT(ro.max_version() == INVALID_BLOCK_NUM);
         }
     };
@@ -720,21 +720,7 @@ void DbMetadataContext::fast_forward_next_version(
 {
     auto do_ = [&](unsigned const which) {
         auto const g = copies_[which].main->hold_dirty();
-        auto ro = root_offsets(tid, which);
-        uint64_t curr_version = ro.max_version();
-        MONAD_ASSERT(
-            curr_version == INVALID_BLOCK_NUM || new_version > curr_version);
-
-        if (curr_version == INVALID_BLOCK_NUM ||
-            new_version - curr_version >= ro.capacity()) {
-            ro.reset_all(new_version);
-        }
-        else {
-            while (curr_version + 1 < new_version) {
-                ro.push(INVALID_OFFSET);
-                curr_version = ro.max_version();
-            }
-        }
+        root_offsets(tid, which).advance_next_version(new_version);
     };
     do_(0);
     do_(1);

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -166,7 +166,9 @@ public:
             return version_lower_bound_.load(std::memory_order_acquire);
         }
 
-        void reset_all(uint64_t const version)
+        // Reset to the empty state: no valid slot, max_version() returns
+        // INVALID_BLOCK_NUM, and the next push() lands at version 0.
+        void reset_all()
         {
             MONAD_ASSERT(capacity_ != 0);
             version_lower_bound_.store(0, std::memory_order_release);
@@ -175,23 +177,49 @@ public:
                 (void *)root_offsets_chunks_.data(),
                 0xff,
                 capacity_ * sizeof(chunk_offset_t));
-            version_lower_bound_.store(version, std::memory_order_release);
-            next_version_.store(version, std::memory_order_release);
+        }
+
+        // Position the write cursor so the next push() lands at `version`,
+        // invalidating any slots skipped over. The ring must be empty or
+        // strictly behind `version`.
+        void advance_next_version(uint64_t const version)
+        {
+            auto const curr_max = max_version();
+            MONAD_ASSERT(curr_max == INVALID_BLOCK_NUM || curr_max < version);
+            if (curr_max == INVALID_BLOCK_NUM ||
+                version - curr_max >= capacity_) {
+                reset_all();
+                version_lower_bound_.store(version, std::memory_order_release);
+                next_version_.store(version, std::memory_order_release);
+            }
+            else {
+                for (uint64_t v = curr_max + 1; v < version; ++v) {
+                    push(async::INVALID_OFFSET);
+                }
+            }
         }
 
         void rewind_to_version(uint64_t const version)
         {
             MONAD_ASSERT(version < max_version());
+            // A target below the ring's entire valid range empties it
+            auto const lower_bound =
+                version_lower_bound_.load(std::memory_order_acquire);
+            if (version < lower_bound) {
+                reset_all();
+                return;
+            }
+            // Otherwise the target must hold a root (rewinding into a
+            // gap between valid roots is refused), so a non-empty ring
+            // always has a valid root at max_version().
+            MONAD_ASSERT(
+                (*this)[version] != INVALID_OFFSET,
+                "rewind_to_version target has no root");
             MONAD_ASSERT(max_version() - version <= capacity_);
             for (uint64_t i = version + 1; i <= max_version(); i++) {
                 assign(i, async::INVALID_OFFSET);
             }
-            if (version <
-                version_lower_bound_.load(std::memory_order_acquire)) {
-                version_lower_bound_.store(version, std::memory_order_release);
-            }
             next_version_.store(version + 1, std::memory_order_release);
-            update_version_lower_bound_();
         }
     };
 

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -2332,6 +2332,85 @@ TEST(update_aux_test, rewind_discards_speculative_on_both_timelines)
     aux.deactivate_secondary_timeline();
 }
 
+namespace
+{
+    // Shared setup for the rewind tests below: anonymous on-disk pool,
+    // io rings, and buffers.
+    struct RewindTestPool
+    {
+        monad::async::storage_pool pool{
+            monad::async::use_anonymous_inode_tag{}};
+        monad::io::Ring ring1;
+        monad::io::Ring ring2;
+        monad::io::Buffers testbuf =
+            monad::io::make_buffers_for_segregated_read_write(
+                ring1, ring2, 2, 4,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE,
+                monad::async::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE);
+        monad::async::AsyncIO io{pool, testbuf};
+    };
+
+    // Seed primary versions 0..primary_max and activate the secondary.
+    void seed_primary_and_activate_secondary(
+        monad::async::storage_pool &pool, UpdateAux &aux,
+        uint64_t const primary_max)
+    {
+        for (uint64_t v = 0; v <= primary_max; ++v) {
+            primary_write(pool, aux, v);
+        }
+        aux.activate_secondary_timeline();
+    }
+}
+
+// Rewinding to a version before the secondary's first valid version leaves
+// nothing on the secondary timeline: its ring must report empty
+// (INVALID_BLOCK_NUM) rather than a max_version with no root.
+TEST(update_aux_test, rewind_below_secondary_range_empties_secondary)
+{
+    RewindTestPool t;
+    UpdateAux aux{t.io, AUX_TEST_HISTORY_LENGTH};
+    auto const &mctx = aux.metadata_ctx();
+    // Secondary activates late: its first root lands at version 8.
+    seed_primary_and_activate_secondary(t.pool, aux, 9);
+    secondary_write(t.pool, aux, 8);
+    secondary_write(t.pool, aux, 9);
+
+    aux.rewind_to_version(5);
+
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::primary), 5u);
+    // Secondary had no version <= 5, so its timeline is now empty.
+    EXPECT_TRUE(mctx.timeline_active(timeline_id::secondary));
+    EXPECT_EQ(
+        mctx.db_history_max_version(timeline_id::secondary), INVALID_BLOCK_NUM);
+    EXPECT_EQ(
+        mctx.db_history_min_valid_version(timeline_id::secondary),
+        INVALID_BLOCK_NUM);
+    EXPECT_FALSE(mctx.version_is_valid_ondisk(5, timeline_id::secondary));
+}
+
+// Rewinding into a gap in the secondary's history (versions with no root
+// between valid ones) is refused: it would leave the secondary reporting
+// a max_version whose slot holds no root.
+TEST(update_aux_test, rewind_into_secondary_gap_aborts)
+{
+    RewindTestPool t;
+    UpdateAux aux{t.io, AUX_TEST_HISTORY_LENGTH};
+    auto &mctx = aux.metadata_ctx();
+    seed_primary_and_activate_secondary(t.pool, aux, 9);
+    secondary_write(t.pool, aux, 0);
+    secondary_write(t.pool, aux, 1);
+    // Manufacture a gap: secondary skips versions 2..7, next root lands
+    // at version 8 (as move_trie_version_forward would leave behind).
+    auto const off = fake_root_write(t.pool, aux);
+    mctx.fast_forward_next_version(8, timeline_id::secondary);
+    mctx.append_root_offset(off, timeline_id::secondary);
+    EXPECT_EQ(mctx.db_history_max_version(timeline_id::secondary), 8u);
+    mctx.set_latest_finalized_version(5);
+
+    ASSERT_DEATH(
+        aux.rewind_to_version(5), "rewind_to_version target has no root");
+}
+
 // Both timelines must persist across an UpdateAux re-init (simulates a
 // node restart that triggers rewind_to_latest_finalized internally).
 TEST(update_aux_test, rewind_state_survives_reopen)

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -239,10 +239,10 @@ void UpdateAux::clear_ondisk_db()
         metadata_ctx_->timeline_active(timeline_id::secondary);
     auto do_ = [&](unsigned const which) {
         auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
-        metadata_ctx_->root_offsets(timeline_id::primary, which).reset_all(0);
+        metadata_ctx_->root_offsets(timeline_id::primary, which).reset_all();
         if (secondary_active) {
             metadata_ctx_->root_offsets(timeline_id::secondary, which)
-                .reset_all(0);
+                .reset_all();
         }
     };
     do_(0);

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -253,10 +253,10 @@ void UpdateAux::clear_ondisk_db()
         metadata_ctx_->timeline_active(timeline_id::secondary);
     auto do_ = [&](unsigned const which) {
         auto const g = metadata_ctx_->main_mutable(which)->hold_dirty();
-        metadata_ctx_->root_offsets(timeline_id::primary, which).reset_all(0);
+        metadata_ctx_->root_offsets(timeline_id::primary, which).reset_all();
         if (secondary_active) {
             metadata_ctx_->root_offsets(timeline_id::secondary, which)
-                .reset_all(0);
+                .reset_all();
         }
     };
     do_(0);


### PR DESCRIPTION
## Problem

Rewinding to a version before a ring's first valid root (e.g. a secondary
timeline activated after the rewind target) left `next_version` at
`target + 1`. The ring then reported a `max_version()` whose slot held no
root: `get_latest_version()` named a version that could not be loaded, and
readers of the latest root got null.

## Change

* `rewind_to_version` on the root offsets ring now resets the ring to the
  empty state when the target predates its entire valid range, so
  `max_version()` reports `INVALID_BLOCK_NUM`, identical to a freshly
  activated secondary. The next commit reseeds it through the existing
  fast forward path.
* Rewinding into a gap between valid roots is refused with an assert.
  Together these restore the invariant that a non-empty ring always has a
  valid root at `max_version()`, and the `sec_root != INVALID_OFFSET`
  assert in `UpdateAux::rewind_to_version` stays as a corruption tripwire.
* Refactor: `reset_all(version)` is split into `reset_all()` (empty state)
  and `advance_next_version(version)` (write cursor positioning used by
  `fast_forward_next_version`). No behavior change.