### PR TITLE
[core] add missing <string.h> include to assert.h

### DIFF
--- a/category/core/assert.h
+++ b/category/core/assert.h
@@ -17,6 +17,7 @@
 
 #include <category/core/likely.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Macros defined by assert.h call `strncpy` which is in <string.h> but we were not including it