### PR TITLE
feat: Enable spec test execution using runloop

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -220,6 +220,8 @@ add_library(
   # monad/chain
   "monad/chain/chain_factory.cpp"
   "monad/chain/chain_factory.hpp"
+  "monad/chain/eest_net.cpp"
+  "monad/chain/eest_net.hpp"
   "monad/chain/monad_chain.cpp"
   "monad/chain/monad_chain.hpp"
   "monad/chain/monad_devnet.cpp"

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -221,6 +221,8 @@ add_library(
   # monad/chain
   "monad/chain/chain_factory.cpp"
   "monad/chain/chain_factory.hpp"
+  "monad/chain/eest_net.cpp"
+  "monad/chain/eest_net.hpp"
   "monad/chain/monad_chain.cpp"
   "monad/chain/monad_chain.hpp"
   "monad/chain/monad_devnet.cpp"

--- a/category/execution/ethereum/chain/genesis_state.cpp
+++ b/category/execution/ethereum/chain/genesis_state.cpp
@@ -40,7 +40,8 @@
 
 MONAD_NAMESPACE_BEGIN
 
-void load_genesis_state(GenesisState const &genesis, TrieDb &db)
+void load_genesis_state(
+    GenesisState const &genesis, TrieDb &db, bool const verbatim_header)
 {
     MONAD_ASSERT(genesis.alloc);
     MONAD_ASSERT(
@@ -106,6 +107,9 @@ void load_genesis_state(GenesisState const &genesis, TrieDb &db)
         genesis.header,
         deltas,
         [&](BlockHeader &h) {
+            if (verbatim_header) {
+                return;
+            }
             h.receipts_root = db.receipts_root();
             h.state_root = db.state_root();
             h.withdrawals_root = db.withdrawals_root();

--- a/category/execution/ethereum/chain/genesis_state.hpp
+++ b/category/execution/ethereum/chain/genesis_state.hpp
@@ -28,6 +28,11 @@ struct GenesisState
     char const *const alloc{nullptr};
 };
 
-void load_genesis_state(GenesisState const &, TrieDb &);
+// With verbatim_header, store the supplied genesis header as-is
+// instead of re-stamping its roots from the db; use when the header's
+// hash must be preserved although the db computes its state root in a
+// different encoding.
+void load_genesis_state(
+    GenesisState const &, TrieDb &, bool verbatim_header = false);
 
 MONAD_NAMESPACE_END

--- a/category/execution/monad/chain/eest_net.cpp
+++ b/category/execution/monad/chain/eest_net.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/monad/chain/eest_net.hpp>
+#include <category/vm/evm/monad/revision.h>
+
+#include <utility>
+
+MONAD_NAMESPACE_BEGIN
+
+EestNet::EestNet(
+    std::string genesis_alloc, BlockHeader genesis_header,
+    EestNetRevisionSchedule schedule)
+    : genesis_alloc_{std::move(genesis_alloc)}
+    , genesis_header_{std::move(genesis_header)}
+    , schedule_{std::move(schedule)}
+{
+    MONAD_ASSERT(!schedule_.empty());
+    MONAD_ASSERT(schedule_.front().first == 0);
+}
+
+monad_revision EestNet::get_monad_revision(uint64_t const timestamp) const
+{
+    monad_revision revision = schedule_.front().second;
+    for (auto const &[from_timestamp, rev] : schedule_) {
+        if (timestamp >= from_timestamp) {
+            revision = rev;
+        }
+    }
+    return revision;
+}
+
+uint256_t EestNet::get_chain_id() const
+{
+    return EEST_NET_CHAIN_ID;
+}
+
+GenesisState EestNet::get_genesis_state() const
+{
+    return {genesis_header_, genesis_alloc_.c_str()};
+}
+
+MONAD_NAMESPACE_END

--- a/category/execution/monad/chain/eest_net.hpp
+++ b/category/execution/monad/chain/eest_net.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+#include <category/execution/ethereum/chain/genesis_state.hpp>
+#include <category/execution/monad/chain/monad_chain.hpp>
+#include <category/vm/evm/monad/revision.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+MONAD_NAMESPACE_BEGIN
+
+inline constexpr uint64_t EEST_NET_CHAIN_ID = 30143;
+
+// Revision activations by block timestamp, ascending; the first entry
+// must activate at timestamp 0.
+using EestNetRevisionSchedule =
+    std::vector<std::pair<uint64_t, monad_revision>>;
+
+// Chain for executing EEST (execution-spec-tests) blockchain fixtures
+// against the production runloop. The genesis allocation (the fixture's
+// `pre` state), the genesis block header (the fixture's genesis, so
+// that the parent hash of block 1 matches the fixture's) and the
+// revision schedule (derived from the fixture's `network`; a single
+// entry for non-transition fixtures) are supplied at runtime instead
+// of being compiled in.
+struct EestNet : MonadChain
+{
+    EestNet(
+        std::string genesis_alloc, BlockHeader genesis_header,
+        EestNetRevisionSchedule schedule);
+
+    virtual monad_revision
+    get_monad_revision(uint64_t timestamp) const override;
+
+    virtual uint256_t get_chain_id() const override;
+
+    virtual GenesisState get_genesis_state() const override;
+
+private:
+    std::string genesis_alloc_;
+    BlockHeader genesis_header_;
+    EestNetRevisionSchedule schedule_;
+};
+
+MONAD_NAMESPACE_END

--- a/category/execution/runloop/runloop_interface_monad.cpp
+++ b/category/execution/runloop/runloop_interface_monad.cpp
@@ -19,10 +19,12 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/monad/chain/eest_net.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
@@ -32,8 +34,16 @@
 #include <category/mpt/db.hpp>
 #include <category/vm/vm.hpp>
 
+#include <evmc/hex.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
@@ -43,7 +53,11 @@ namespace fs = std::filesystem;
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
-unsigned const sq_thread_cpu = 7;
+// Pin the io_uring SQPOLL thread outside the worker CPUs where it
+// can; fall back to the highest available CPU on smaller hosts
+// (IORING_SETUP_SQ_AFF rejects an out-of-range CPU with EINVAL).
+unsigned const sq_thread_cpu =
+    std::min(7u, std::max(1u, std::thread::hardware_concurrency()) - 1u);
 quill::LogLevel const log_level = quill::LogLevel::Info;
 unsigned const nthreads = 4;
 unsigned const nfibers = 256;
@@ -223,7 +237,8 @@ struct MonadRunloopImpl
     bool is_first_run;
 
     MonadRunloopImpl(
-        uint64_t chain_id, char const *ledger_path, char const *db_path);
+        std::unique_ptr<MonadChain> chain, char const *ledger_path,
+        char const *db_path, bool verbatim_genesis_header = false);
 };
 
 mpt::Db get_secondary_raw_db(mpt::Db &db)
@@ -239,9 +254,9 @@ mpt::Db get_secondary_raw_db(mpt::Db &db)
 }
 
 MonadRunloopImpl::MonadRunloopImpl(
-    uint64_t const chain_id, char const *const ledger_path,
-    char const *const db_path)
-    : chain{monad_chain_from_chain_id(chain_id)}
+    std::unique_ptr<MonadChain> chain_arg, char const *const ledger_path,
+    char const *const db_path, bool const verbatim_genesis_header)
+    : chain{std::move(chain_arg)}
     , ledger_dir{ledger_path}
     , raw_db{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{.append = true, .compaction = true, .rewind_to_latest_finalized = true, .rd_buffers = 8192, .wr_buffers = 32, .uring_entries = 128, .sq_thread_cpu = sq_thread_cpu, .dbname_paths = {fs::path{db_path}}}}
     , secondary_raw_db{get_secondary_raw_db(raw_db)}
@@ -259,8 +274,9 @@ MonadRunloopImpl::MonadRunloopImpl(
     if (triedb.get_root() == nullptr) {
         LOG_INFO("loading from genesis");
         GenesisState const genesis_state = chain->get_genesis_state();
-        load_genesis_state(genesis_state, triedb);
-        load_genesis_state(genesis_state, secondary_triedb);
+        load_genesis_state(genesis_state, triedb, verbatim_genesis_header);
+        load_genesis_state(
+            genesis_state, secondary_triedb, verbatim_genesis_header);
     }
     else {
         LOG_INFO("loading from previous DB state");
@@ -278,7 +294,7 @@ MonadRunloopImpl::MonadRunloopImpl(
         init_block_hash_buffer_from_triedb(rodb, block_num, block_hash_buffer);
     if (!have_headers) {
         BlockDb block_db{ledger_path};
-        MONAD_ASSERT(chain_id == mainnet_chain_id);
+        MONAD_ASSERT(chain->get_chain_id() == mainnet_chain_id);
         MONAD_ASSERT(init_block_hash_buffer_from_blockdb(
             block_db, block_num, block_hash_buffer));
     }
@@ -370,16 +386,74 @@ public:
 
 MONAD_ANONYMOUS_NAMESPACE_END
 
-extern "C" MonadRunloop *monad_runloop_new(
-    uint64_t const chain_id, char const *const ledger_path,
-    char const *const db_path)
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+void monad_runloop_init_logging()
 {
     static bool is_quill_running;
     if (!is_quill_running) {
         init_root_logger(log_level);
         is_quill_running = true;
     }
-    return from_impl(new MonadRunloopImpl{chain_id, ledger_path, db_path});
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+extern "C" MonadRunloop *monad_runloop_new(
+    uint64_t const chain_id, char const *const ledger_path,
+    char const *const db_path)
+{
+    monad_runloop_init_logging();
+    return from_impl(new MonadRunloopImpl{
+        monad_chain_from_chain_id(chain_id), ledger_path, db_path});
+}
+
+extern "C" MonadRunloop *monad_runloop_new_eest(
+    char const *const ledger_path, char const *const db_path,
+    char const *const genesis_alloc_json,
+    char const *const genesis_block_rlp_hex,
+    char const *const revision_schedule)
+{
+    monad_runloop_init_logging();
+    MONAD_ASSERT(genesis_alloc_json != nullptr);
+    MONAD_ASSERT(genesis_block_rlp_hex != nullptr);
+    MONAD_ASSERT(revision_schedule != nullptr);
+    auto const genesis_block_rlp =
+        evmc::from_hex(std::string_view{genesis_block_rlp_hex});
+    MONAD_ASSERT(genesis_block_rlp.has_value());
+    byte_string_view genesis_block_rlp_view{
+        genesis_block_rlp->data(), genesis_block_rlp->size()};
+    auto const genesis_block = rlp::decode_block(genesis_block_rlp_view);
+    MONAD_ASSERT(!genesis_block.has_error());
+
+    // Parse "<revision>:<from timestamp>,..." into the schedule.
+    EestNetRevisionSchedule schedule;
+    std::istringstream stream{revision_schedule};
+    std::string entry;
+    while (std::getline(stream, entry, ',')) {
+        auto const sep = entry.find(':');
+        MONAD_ASSERT(sep != std::string::npos);
+        auto const revision = std::stoul(entry.substr(0, sep));
+        MONAD_ASSERT(revision <= MONAD_NEXT);
+        auto const from_timestamp = std::stoull(entry.substr(sep + 1));
+        schedule.emplace_back(
+            from_timestamp, static_cast<monad_revision>(revision));
+    }
+
+    // The fixture's genesis header must be stored verbatim: its
+    // stateRoot is computed in the fixture fork's canonical encoding
+    // (page for MIP-8 fixtures), while the primary here is always
+    // slot-encoded. Re-stamping would change the stored genesis header
+    // hash, which BLOCKHASH, EIP-2935 and block 1's parent hash all
+    // derive from.
+    return from_impl(new MonadRunloopImpl{
+        std::make_unique<EestNet>(
+            std::string{genesis_alloc_json},
+            genesis_block.assume_value().header,
+            std::move(schedule)),
+        ledger_path,
+        db_path,
+        /* verbatim_genesis_header = */ true});
 }
 
 extern "C" void monad_runloop_delete(MonadRunloop *const runloop)
@@ -482,4 +556,16 @@ extern "C" void monad_runloop_dump(MonadRunloop *const pre_runloop)
 {
     MonadRunloopImpl *const runloop = to_impl(pre_runloop);
     std::cout << runloop->triedb.to_json().dump(4) << std::endl;
+}
+
+extern "C" char *monad_runloop_dump_json(MonadRunloop *const pre_runloop)
+{
+    MonadRunloopImpl *const runloop = to_impl(pre_runloop);
+    auto const json = runloop->triedb.to_json().dump();
+    return strdup(json.c_str());
+}
+
+extern "C" void monad_runloop_free_string(char *const str)
+{
+    free(str);
 }

--- a/category/execution/runloop/runloop_interface_monad.cpp
+++ b/category/execution/runloop/runloop_interface_monad.cpp
@@ -19,10 +19,12 @@
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/db/block_db.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/monad/chain/eest_net.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/execution/monad/chain/monad_devnet.hpp>
 #include <category/execution/monad/chain/monad_mainnet.hpp>
@@ -32,8 +34,16 @@
 #include <category/mpt/db.hpp>
 #include <category/vm/vm.hpp>
 
+#include <evmc/hex.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
 
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
@@ -43,7 +53,11 @@ namespace fs = std::filesystem;
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
 
-unsigned const sq_thread_cpu = 7;
+// Pin the io_uring SQPOLL thread outside the worker CPUs where it
+// can; fall back to the highest available CPU on smaller hosts
+// (IORING_SETUP_SQ_AFF rejects an out-of-range CPU with EINVAL).
+unsigned const sq_thread_cpu =
+    std::min(7u, std::max(1u, std::thread::hardware_concurrency()) - 1u);
 quill::LogLevel const log_level = quill::LogLevel::Info;
 unsigned const nthreads = 4;
 unsigned const nfibers = 256;
@@ -223,7 +237,8 @@ struct MonadRunloopImpl
     uint64_t start_block_num;
 
     MonadRunloopImpl(
-        uint64_t chain_id, char const *ledger_path, char const *db_path);
+        std::unique_ptr<MonadChain> chain, char const *ledger_path,
+        char const *db_path, bool verbatim_genesis_header = false);
 };
 
 mpt::Db get_secondary_raw_db(mpt::Db &db)
@@ -239,9 +254,9 @@ mpt::Db get_secondary_raw_db(mpt::Db &db)
 }
 
 MonadRunloopImpl::MonadRunloopImpl(
-    uint64_t const chain_id, char const *const ledger_path,
-    char const *const db_path)
-    : chain{monad_chain_from_chain_id(chain_id)}
+    std::unique_ptr<MonadChain> chain_arg, char const *const ledger_path,
+    char const *const db_path, bool const verbatim_genesis_header)
+    : chain{std::move(chain_arg)}
     , ledger_dir{ledger_path}
     , raw_db{std::make_unique<OnDiskMachine>(), mpt::OnDiskDbConfig{.append = true, .compaction = true, .rewind_to_latest_finalized = true, .rd_buffers = 8192, .wr_buffers = 32, .uring_entries = 128, .sq_thread_cpu = sq_thread_cpu, .dbname_paths = {fs::path{db_path}}}}
     , secondary_raw_db{get_secondary_raw_db(raw_db)}
@@ -258,8 +273,9 @@ MonadRunloopImpl::MonadRunloopImpl(
     if (triedb.get_root() == nullptr) {
         LOG_INFO("loading from genesis");
         GenesisState const genesis_state = chain->get_genesis_state();
-        load_genesis_state(genesis_state, triedb);
-        load_genesis_state(genesis_state, secondary_triedb);
+        load_genesis_state(genesis_state, triedb, verbatim_genesis_header);
+        load_genesis_state(
+            genesis_state, secondary_triedb, verbatim_genesis_header);
     }
     else {
         LOG_INFO("loading from previous DB state");
@@ -278,7 +294,7 @@ MonadRunloopImpl::MonadRunloopImpl(
         init_block_hash_buffer_from_triedb(rodb, block_num, block_hash_buffer);
     if (!have_headers) {
         BlockDb block_db{ledger_path};
-        MONAD_ASSERT(chain_id == mainnet_chain_id);
+        MONAD_ASSERT(chain->get_chain_id() == mainnet_chain_id);
         MONAD_ASSERT(init_block_hash_buffer_from_blockdb(
             block_db, block_num, block_hash_buffer));
     }
@@ -370,16 +386,74 @@ public:
 
 MONAD_ANONYMOUS_NAMESPACE_END
 
-extern "C" MonadRunloop *monad_runloop_new(
-    uint64_t const chain_id, char const *const ledger_path,
-    char const *const db_path)
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+void monad_runloop_init_logging()
 {
     static bool is_quill_running;
     if (!is_quill_running) {
         init_root_logger(log_level);
         is_quill_running = true;
     }
-    return from_impl(new MonadRunloopImpl{chain_id, ledger_path, db_path});
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+extern "C" MonadRunloop *monad_runloop_new(
+    uint64_t const chain_id, char const *const ledger_path,
+    char const *const db_path)
+{
+    monad_runloop_init_logging();
+    return from_impl(new MonadRunloopImpl{
+        monad_chain_from_chain_id(chain_id), ledger_path, db_path});
+}
+
+extern "C" MonadRunloop *monad_runloop_new_eest(
+    char const *const ledger_path, char const *const db_path,
+    char const *const genesis_alloc_json,
+    char const *const genesis_block_rlp_hex,
+    char const *const revision_schedule)
+{
+    monad_runloop_init_logging();
+    MONAD_ASSERT(genesis_alloc_json != nullptr);
+    MONAD_ASSERT(genesis_block_rlp_hex != nullptr);
+    MONAD_ASSERT(revision_schedule != nullptr);
+    auto const genesis_block_rlp =
+        evmc::from_hex(std::string_view{genesis_block_rlp_hex});
+    MONAD_ASSERT(genesis_block_rlp.has_value());
+    byte_string_view genesis_block_rlp_view{
+        genesis_block_rlp->data(), genesis_block_rlp->size()};
+    auto const genesis_block = rlp::decode_block(genesis_block_rlp_view);
+    MONAD_ASSERT(!genesis_block.has_error());
+
+    // Parse "<revision>:<from timestamp>,..." into the schedule.
+    EestNetRevisionSchedule schedule;
+    std::istringstream stream{revision_schedule};
+    std::string entry;
+    while (std::getline(stream, entry, ',')) {
+        auto const sep = entry.find(':');
+        MONAD_ASSERT(sep != std::string::npos);
+        auto const revision = std::stoul(entry.substr(0, sep));
+        MONAD_ASSERT(revision <= MONAD_NEXT);
+        auto const from_timestamp = std::stoull(entry.substr(sep + 1));
+        schedule.emplace_back(
+            from_timestamp, static_cast<monad_revision>(revision));
+    }
+
+    // The fixture's genesis header must be stored verbatim: its
+    // stateRoot is computed in the fixture fork's canonical encoding
+    // (page for MIP-8 fixtures), while the primary here is always
+    // slot-encoded. Re-stamping would change the stored genesis header
+    // hash, which BLOCKHASH, EIP-2935 and block 1's parent hash all
+    // derive from.
+    return from_impl(new MonadRunloopImpl{
+        std::make_unique<EestNet>(
+            std::string{genesis_alloc_json},
+            genesis_block.assume_value().header,
+            std::move(schedule)),
+        ledger_path,
+        db_path,
+        /* verbatim_genesis_header = */ true});
 }
 
 extern "C" void monad_runloop_delete(MonadRunloop *const runloop)
@@ -483,4 +557,16 @@ extern "C" void monad_runloop_dump(MonadRunloop *const pre_runloop)
 {
     MonadRunloopImpl *const runloop = to_impl(pre_runloop);
     std::cout << runloop->triedb.to_json().dump(4) << std::endl;
+}
+
+extern "C" char *monad_runloop_dump_json(MonadRunloop *const pre_runloop)
+{
+    MonadRunloopImpl *const runloop = to_impl(pre_runloop);
+    auto const json = runloop->triedb.to_json().dump();
+    return strdup(json.c_str());
+}
+
+extern "C" void monad_runloop_free_string(char *const str)
+{
+    free(str);
 }

--- a/category/execution/runloop/runloop_interface_monad.h
+++ b/category/execution/runloop/runloop_interface_monad.h
@@ -39,6 +39,22 @@ typedef void MonadRunloop;
 MonadRunloop *monad_runloop_new(
     uint64_t chain_id, char const *ledger_path, char const *db_path);
 
+// Make a new runloop client on the EEST chain (EestNet). The genesis
+// allocation (the EEST fixture's `pre` state) is supplied as a JSON
+// document: {"<hex address>": {"wei_balance": "<dec|hex>",
+// "nonce": "<hex>", "code": "0x..", "storage": {"0x..": "0x.."}}, ...}.
+// The genesis block (the fixture's `genesisRLP`) is supplied as a hex
+// encoded RLP block, so block 1's parent hash matches the fixture.
+// Both are loaded only when the database is freshly created.
+// The revision schedule (derived from the fixture's `network`) is a
+// comma separated list of "<monad_revision number>:<from timestamp>"
+// entries in ascending timestamp order, e.g. "9:0" for a plain
+// MONAD_NINE fixture or "8:0,9:15000" for a transition fixture.
+MonadRunloop *monad_runloop_new_eest(
+    char const *ledger_path, char const *db_path,
+    char const *genesis_alloc_json, char const *genesis_block_rlp_hex,
+    char const *revision_schedule);
+
 // Deallocate a runloop client
 void monad_runloop_delete(MonadRunloop *);
 
@@ -65,6 +81,13 @@ void monad_runloop_get_secondary_state_root(
 
 // Dump the current state of the database to stdout
 void monad_runloop_dump(MonadRunloop *);
+
+// Dump the current state of the database as a JSON string. The result
+// must be released with monad_runloop_free_string.
+char *monad_runloop_dump_json(MonadRunloop *);
+
+// Free a string returned by this interface.
+void monad_runloop_free_string(char *);
 
 #ifdef __cplusplus
 }

--- a/rust/crates/monad-cxx/build.rs
+++ b/rust/crates/monad-cxx/build.rs
@@ -14,6 +14,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 fn main() {
+    // The eest-runner FFI lives in the C++ tree; without this, cargo's
+    // build-script caching skips recompiles when only this file changes.
+    println!(
+        "cargo:rerun-if-changed=../../../category/execution/runloop/\
+runloop_interface_monad.cpp"
+    );
+
     if monad_build::should_build_execution() {
         monad_build::MonadCMake::new(
             monad_build::repository_root(),


### PR DESCRIPTION
Adds a `monad_execution_runloop` lib which is used by a test harness for executing github.com/monad-developers/execution-specs against a runloop-based execution client code.

From description in EEST repo ([PR-ed here](https://github.com/monad-developers/execution-specs/pull/32)), a runloop based test harness:

> Executes blockchain fixtures (including those generated from state
tests) against the production monad execution client, via its
`runloop` and the consensus ledger directory. The oracle is the
fixture's `postState`, compared account by account
(balance/nonce/code/storage).

The PR uses commits from `andreaslyn` and `m-alvarez` prior branches.

Currently there are 3 main use cases for this setup:
1. Run all spec tests in a slower but more production-like environment (than `monad-ethereum-test` executable)
2. Enable running fork transition tests (for MIP-8 specifically, but generally too)
3. Enable running preliminary performance regression tests for MIP-8