### PR TITLE
[execution/ethereum] Activate Osaka on mainnet

### DIFF
--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -36,17 +36,9 @@
 
 using BOOST_OUTCOME_V2_NAMESPACE::success;
 
-MONAD_ANONYMOUS_NAMESPACE_BEGIN
-
-// Mainnet BPO activation times and blob parameters are canonicalized in
-// EIP-8134 and EIP-8135. BPO scheduling itself is defined by EIP-7892.
-constexpr uint64_t PRAGUE_ACTIVATION_TIMESTAMP = 1746612311;
-constexpr uint64_t BPO1_ACTIVATION_TIMESTAMP = 1765290071;
-constexpr uint64_t BPO2_ACTIVATION_TIMESTAMP = 1767747671;
-
-MONAD_ANONYMOUS_NAMESPACE_END
-
 MONAD_NAMESPACE_BEGIN
+
+using namespace eth_forks;
 
 uint256_t EthereumMainnet::get_chain_id() const
 {
@@ -59,22 +51,22 @@ monad_eth_revision EthereumMainnet::get_revision(
     if (MONAD_LIKELY(timestamp >= PRAGUE_ACTIVATION_TIMESTAMP)) {
         return MONAD_ETH_PRAGUE;
     }
-    else if (timestamp >= 1710338135) {
+    else if (timestamp >= CANCUN_ACTIVATION_TIMESTAMP) {
         return MONAD_ETH_CANCUN;
     }
-    else if (timestamp >= 1681338455) {
+    else if (timestamp >= SHANGHAI_ACTIVATION_TIMESTAMP) {
         return MONAD_ETH_SHANGHAI;
     }
-    else if (block_number >= 15537394) {
+    else if (block_number >= PARIS_ACTIVATION_BLOCK_NUMBER) {
         return MONAD_ETH_PARIS;
     }
-    else if (block_number >= 12965000) {
+    else if (block_number >= LONDON_ACTIVATION_BLOCK_NUMBER) {
         return MONAD_ETH_LONDON;
     }
-    else if (block_number >= 12244000) {
+    else if (block_number >= BERLIN_ACTIVATION_BLOCK_NUMBER) {
         return MONAD_ETH_BERLIN;
     }
-    else if (block_number >= 9069000) {
+    else if (block_number >= ISTANBUL_ACTIVATION_BLOCK_NUMBER) {
         return MONAD_ETH_ISTANBUL;
     }
     MONAD_ASSERT(false, "unsupported fork");

--- a/category/execution/ethereum/chain/ethereum_mainnet.cpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.cpp
@@ -48,7 +48,10 @@ uint256_t EthereumMainnet::get_chain_id() const
 monad_eth_revision EthereumMainnet::get_revision(
     uint64_t const block_number, uint64_t const timestamp) const
 {
-    if (MONAD_LIKELY(timestamp >= PRAGUE_ACTIVATION_TIMESTAMP)) {
+    if (MONAD_LIKELY(timestamp >= OSAKA_ACTIVATION_TIMESTAMP)) {
+        return MONAD_ETH_OSAKA;
+    }
+    else if (timestamp >= PRAGUE_ACTIVATION_TIMESTAMP) {
         return MONAD_ETH_PRAGUE;
     }
     else if (timestamp >= CANCUN_ACTIVATION_TIMESTAMP) {
@@ -74,8 +77,7 @@ monad_eth_revision EthereumMainnet::get_revision(
 
 BlobSchedule EthereumMainnet::get_blob_schedule(uint64_t const timestamp) const
 {
-    if (timestamp >= BPO1_ACTIVATION_TIMESTAMP &&
-        get_revision(0, timestamp) >= MONAD_ETH_OSAKA) {
+    if (timestamp >= BPO1_ACTIVATION_TIMESTAMP) {
         if (MONAD_LIKELY(timestamp >= BPO2_ACTIVATION_TIMESTAMP)) {
             return BPO2_BLOB_SCHEDULE;
         }

--- a/category/execution/ethereum/chain/ethereum_mainnet.hpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.hpp
@@ -24,6 +24,7 @@
 
 #include <evmc/evmc.h>
 
+#include <cstdint>
 #include <span>
 
 MONAD_NAMESPACE_BEGIN
@@ -31,6 +32,32 @@ MONAD_NAMESPACE_BEGIN
 struct BlockHeader;
 struct Receipt;
 struct Transaction;
+
+namespace eth_forks
+{
+    inline constexpr uint64_t PRAGUE_ACTIVATION_TIMESTAMP = 1746612311;
+    inline constexpr uint64_t CANCUN_ACTIVATION_TIMESTAMP = 1710338135;
+    inline constexpr uint64_t SHANGHAI_ACTIVATION_TIMESTAMP = 1681338455;
+
+    inline constexpr uint64_t PARIS_ACTIVATION_BLOCK_NUMBER = 15537394;
+    inline constexpr uint64_t LONDON_ACTIVATION_BLOCK_NUMBER = 12965000;
+    inline constexpr uint64_t BERLIN_ACTIVATION_BLOCK_NUMBER = 12244000;
+    inline constexpr uint64_t ISTANBUL_ACTIVATION_BLOCK_NUMBER = 9069000;
+
+    // Mainnet BPO activation times and blob parameters are canonicalized in
+    // EIP-8134 and EIP-8135. BPO scheduling itself is defined by EIP-7892.
+    inline constexpr uint64_t BPO1_ACTIVATION_TIMESTAMP = 1765290071;
+    inline constexpr uint64_t BPO2_ACTIVATION_TIMESTAMP = 1767747671;
+}
+
+namespace constants
+{
+    // Replay support policy: the earliest supported fork is Istanbul, so
+    // blocks before its activation cannot be executed. The revision-valued
+    // counterpart, EARLIEST_SUPPORTED_EVM_FORK, lives in vm/evm/traits.hpp.
+    inline constexpr uint64_t EARLIEST_SUPPORTED_ETH_BLOCK_NUMBER =
+        eth_forks::ISTANBUL_ACTIVATION_BLOCK_NUMBER;
+}
 
 inline constexpr size_t MAX_CODE_SIZE_EIP170 = 24 * 1024; // 0x6000
 inline constexpr size_t MAX_INITCODE_SIZE_EIP3860 =

--- a/category/execution/ethereum/chain/ethereum_mainnet.hpp
+++ b/category/execution/ethereum/chain/ethereum_mainnet.hpp
@@ -35,6 +35,7 @@ struct Transaction;
 
 namespace eth_forks
 {
+    inline constexpr uint64_t OSAKA_ACTIVATION_TIMESTAMP = 1764798551;
     inline constexpr uint64_t PRAGUE_ACTIVATION_TIMESTAMP = 1746612311;
     inline constexpr uint64_t CANCUN_ACTIVATION_TIMESTAMP = 1710338135;
     inline constexpr uint64_t SHANGHAI_ACTIVATION_TIMESTAMP = 1681338455;

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -45,8 +45,6 @@ namespace monad
         inline constexpr monad_eth_revision LATEST_SUPPORTED_EVM_FORK =
             MONAD_ETH_OSAKA;
 
-        inline constexpr uint64_t EARLIEST_SUPPORTED_ETH_BLOCK_NUMBER = 9069000;
-
         inline constexpr size_t MAX_CODE_SIZE_EIP170 = 24 * 1024; // 0x6000
         inline constexpr size_t MAX_INITCODE_SIZE_EIP3860 =
             2 * MAX_CODE_SIZE_EIP170; // 0xC000


### PR DESCRIPTION
Return MONAD_ETH_OSAKA for Ethereum mainnet blocks at or after the Fusaka/Osaka activation timestamp.

With the BPO schedule support from #2331, current Osaka execution support is sufficient for canonical historical replay of Osaka-era blocks across the BPO1 and BPO2 transitions.

The remaining Osaka-era gaps are validation-only and tracked separately:
- [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) validates the maximum gas limit for individual transactions;
- [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918) validates the parent-derived excess blob gas value in block headers; 
- [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934) validates the maximum RLP-encoded execution block size.

Edit: first commit in this PR creates constants for block number and timestamps of network revisions