### PR TITLE
[evm/traits]: Disable MIP-11 on MONAD_NEXT

### DIFF
--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -2049,9 +2049,6 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                     "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                         "balance": "0x1",
                         "nonce": 1
-                    },
-                    "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                        "balance": "0x0"
                     }
                 },
                 "txHash": "0x659b50d5b5c543fb681ace210eb175938d5b829297bcf579bc186ac0ea0874dd"
@@ -2065,9 +2062,6 @@ TEST_F(EthCallFixture, trace_block_with_prestate)
                     "0xc48513273d60b70ee2f25d5c4256612a91573e1e": {
                         "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                         "nonce": 2
-                    },
-                    "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                        "balance": "0x0"
                     }
                 },
                 "txHash": "0x0b391cd83e5ebd2a5d5c0223c4258eaa364737cc6cb9f88c83eced5eb2543e8b"
@@ -2296,9 +2290,6 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                 "balance": "0x1",
                 "nonce": 1
-            },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x0"
             }
         })";
 
@@ -2341,9 +2332,6 @@ TEST_F(EthCallFixture, trace_transaction_with_prestate)
                 "balance":
                 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce": 2
-            },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x0"
             }
         })";
         EXPECT_EQ(
@@ -2860,9 +2848,6 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
             "0xbedcab535cc48a9bd659ac448f092d02ba23a05a": {
                 "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce":1
-            },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x0"
             }
         })";
         EXPECT_EQ(
@@ -2926,9 +2911,6 @@ TEST_F(EthCallFixture, prestate_trace_near_genesis)
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                 "balance": "0x1",
                 "nonce":1
-            },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x0"
             }
         })";
 
@@ -4442,8 +4424,9 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "balance": "0x1",
                 "nonce": 1
             },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x0"
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                "balance": "0x0",
+                "nonce": 1
             }
         })";
 
@@ -4482,13 +4465,14 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "balance": "0xabbb",
                 "nonce": 1
             },
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                "balance": "0x1b7740",
+                "nonce": 1
+            },
             "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                 "balance":
                 "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 "nonce": 2
-            },
-            "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                "balance": "0x1b7740"
             }
         })";
         EXPECT_EQ(
@@ -4534,7 +4518,7 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0xabbb"
                 },
-                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
                     "balance": "0x1b7740"
                 }
             },
@@ -4546,6 +4530,10 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 },
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0x1",
+                    "nonce": 1
+                },
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                    "balance": "0x0",
                     "nonce": 1
                 }
             }
@@ -4586,13 +4574,13 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
                     "balance": "0x15775"
                 },
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                    "balance": "0x36ee80"
+                },
                 "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                     "balance":
                     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0cfc5",
                     "nonce": 3
-                },
-                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                    "balance": "0x36ee80"
                 }
             },
             "pre": {
@@ -4600,13 +4588,14 @@ TEST_F(EthCallFixture, trace_transaction_with_rewards_prestate)
                     "balance": "0xabbb",
                     "nonce": 1
                 },
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                    "balance": "0x1b7740",
+                    "nonce": 1
+                },
                 "0xea4f2322426da1c68b6b7b8cc244c4fa0f14b7d3": {
                     "balance":
                     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                     "nonce": 2
-                },
-                "0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5": {
-                    "balance": "0x1b7740"
                 }
             }
         })";

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -302,7 +302,7 @@ namespace monad
 
         static consteval bool mip_11_active() noexcept
         {
-            return Rev >= MONAD_NEXT;
+            return false;
         }
 
         static consteval bool can_create_inside_delegated() noexcept

--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -27,8 +27,8 @@ ExternalProject_Add(
 
 ExternalProject_Add(
   MonadSpecTestFixtures
-  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad@v1.1.0/fixtures_monad.tar.gz"
-  URL_HASH "SHA256=f51ed023f0e37a5ff469677614e548509cfab55a49789049488caaafd295d0c1"
+  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad@v1.1.1/fixtures_monad.tar.gz"
+  URL_HASH "SHA256=1837b6bbbb51bd956623c5efc92f0c6123be7ea7563492703ff085d7c31876f2"
   PREFIX ${CMAKE_BINARY_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
The approach is being rethought w.r.t. and event being emitted on fee distribution.