### PR TITLE
Make DbCache a read-through cache 

### DIFF
--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -36,6 +36,16 @@
 
 MONAD_NAMESPACE_BEGIN
 
+// Outcome of a cache read.
+enum class CacheReadStatus
+{
+    Hit, // served from proposal map or LRU
+    MissResolved, // both missed, proposal chain walked to the finalized base
+                  // -> disk value == finalized value -> safe to cache this miss
+    MissTruncated, // proposal chain truncated before the finalized base
+                   // -> can't prove finalized-consistent -> don't cache miss
+};
+
 // Encoding-agnostic LRU + proposal cache for accounts and storage leaves.
 // Storage values are held as storage_page_t, keyed by the trie key the
 // caller passes: slot_key (single slot at index 0) for slot encoding, or
@@ -62,44 +72,55 @@ class DbCache final
 public:
     DbCache() = default;
 
-    bool
+    CacheReadStatus
     try_read_account(Address const &address, std::optional<Account> &result)
     {
         auto const res = proposals_.try_read_account(address, result);
         if (res.found) {
-            return true;
+            return CacheReadStatus::Hit;
         }
-        if (!res.truncated) {
-            AccountsCache::ConstAccessor acc{};
-            if (accounts_.find(acc, address)) {
-                result = acc->second.value_;
-                return true;
-            }
+        if (res.truncated) {
+            return CacheReadStatus::MissTruncated;
         }
-        return false;
+        AccountsCache::ConstAccessor acc{};
+        if (accounts_.find(acc, address)) {
+            result = acc->second.value_;
+            return CacheReadStatus::Hit;
+        }
+        return CacheReadStatus::MissResolved;
     }
 
-    bool try_read_storage_page(
+    // Read-through: cache a finalized-consistent account fetched from disk
+    // after a `MissResolved` read. A nullopt is a valid (negative) entry: it
+    // records that the account is absent at the finalized baseline.
+    void insert_account(
+        Address const &address, std::optional<Account> const &account)
+    {
+        accounts_.insert(address, account);
+    }
+
+    CacheReadStatus try_read_storage_page(
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, storage_page_t &result)
     {
         auto const res =
             proposals_.try_read_storage(address, incarnation, key, result);
         if (res.found) {
-            return true;
+            return CacheReadStatus::Hit;
         }
-        if (!res.truncated) {
-            StorageKey const skey{address, incarnation, key};
-            StorageCache::ConstAccessor acc{};
-            if (storage_.find(acc, skey)) {
-                result = acc->second.value_;
-                return true;
-            }
+        if (res.truncated) {
+            return CacheReadStatus::MissTruncated;
         }
-        return false;
+        StorageKey const skey{address, incarnation, key};
+        StorageCache::ConstAccessor acc{};
+        if (storage_.find(acc, skey)) {
+            result = acc->second.value_;
+            return CacheReadStatus::Hit;
+        }
+        return CacheReadStatus::MissResolved;
     }
 
-    bool try_read_storage(
+    CacheReadStatus try_read_storage(
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, uint8_t const slot_offset, bytes32_t &result)
     {
@@ -109,17 +130,33 @@ public:
         if (res.found) {
             // slot_offset is 0 for slot encoding, the in-page offset for page.
             result = page[slot_offset];
-            return true;
+            return CacheReadStatus::Hit;
         }
-        if (!res.truncated) {
-            StorageKey const skey{address, incarnation, key};
-            StorageCache::ConstAccessor acc{};
-            if (storage_.find(acc, skey)) {
-                result = acc->second.value_[slot_offset];
-                return true;
-            }
+        if (res.truncated) {
+            return CacheReadStatus::MissTruncated;
         }
-        return false;
+        StorageKey const skey{address, incarnation, key};
+        StorageCache::ConstAccessor acc{};
+        if (storage_.find(acc, skey)) {
+            result = acc->second.value_[slot_offset];
+            return CacheReadStatus::Hit;
+        }
+        return CacheReadStatus::MissResolved;
+    }
+
+    // Read-through: insert a finalized-consistent storage page fetched from
+    // disk after a `MissResolved` read. Uses try_insert so a sibling read is
+    // never overwritten. An empty page is a valid (negative) entry: it records
+    // that the page is absent at the finalized baseline, so a follow-up
+    // read-modify-write in commit stage need not re-read from disk.
+    void insert_storage_page(
+        Address const &address, Incarnation const incarnation,
+        bytes32_t const &key, storage_page_t const &page)
+    {
+        StorageKey const skey{address, incarnation, key};
+        storage_page_t value = page;
+        storage_.try_insert(
+            skey, value, static_cast<uint32_t>(page.byte_size()));
     }
 
     void

--- a/category/execution/ethereum/db/db_cache.hpp
+++ b/category/execution/ethereum/db/db_cache.hpp
@@ -145,18 +145,17 @@ public:
     }
 
     // Read-through: insert a finalized-consistent storage page fetched from
-    // disk after a `MissResolved` read. Uses try_insert so a sibling read is
-    // never overwritten. An empty page is a valid (negative) entry: it records
-    // that the page is absent at the finalized baseline, so a follow-up
-    // read-modify-write in commit stage need not re-read from disk.
+    // disk after a `MissResolved` read. try_insert_no_overwrite leaves an
+    // entry a concurrent sibling read already cached untouched (all concurrent
+    // read-throughs resolve against the same finalized baseline, so a colliding
+    // entry holds the same page anyway).
     void insert_storage_page(
         Address const &address, Incarnation const incarnation,
         bytes32_t const &key, storage_page_t const &page)
     {
         StorageKey const skey{address, incarnation, key};
-        storage_page_t value = page;
-        storage_.try_insert(
-            skey, value, static_cast<uint32_t>(page.byte_size()));
+        storage_.try_insert_no_overwrite(
+            skey, page, static_cast<uint32_t>(page.byte_size()));
     }
 
     void

--- a/category/execution/ethereum/db/db_cache_test.cpp
+++ b/category/execution/ethereum/db/db_cache_test.cpp
@@ -1,0 +1,173 @@
+// Copyright (C) 2025 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/bytes.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/db/db_cache.hpp>
+#include <category/execution/ethereum/db/storage_key.hpp>
+#include <category/execution/ethereum/state2/proposal_post_state.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+
+using namespace monad;
+using namespace monad::literals;
+
+namespace
+{
+    constexpr auto ADDR = 0x00000000000000000000000000000000000000aa_address;
+    constexpr auto OTHER_ADDR =
+        0x00000000000000000000000000000000000000bb_address;
+    constexpr auto KEY =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto OTHER_KEY =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto VALUE1 =
+        0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+    constexpr auto VALUE2 =
+        0x0000000000000000000000000000000000000000000000000000000000000002_bytes32;
+
+    Incarnation const INC{0, 0};
+
+    ProposalPostState make_post_state(
+        Address const &addr, bytes32_t const &key, bytes32_t const &value)
+    {
+        ProposalPostState post;
+        post.accounts[addr] = Account{.nonce = 1};
+        post.storage[StorageKey{addr, INC, key}] = storage_page_t{value};
+        return post;
+    }
+}
+
+TEST(DbCacheTest, unknown_proposal_cursor_is_miss_truncated)
+{
+    DbCache cache;
+    cache.set_block_and_prefix(3, bytes32_t{9});
+
+    // proposal id has nothing.
+    storage_page_t page;
+    EXPECT_EQ(
+        cache.try_read_storage_page(ADDR, INC, KEY, page),
+        CacheReadStatus::MissTruncated);
+}
+
+TEST(DbCacheTest, write_beyond_depth_limit_is_miss_truncated)
+{
+
+    DbCache cache;
+    cache.update_proposal_state(
+        make_post_state(ADDR, KEY, VALUE2), 1, bytes32_t{1});
+
+    // proposals 2..6 are padding that only touch OTHER_ADDR/OTHER_KEY. the
+    // walk in Proposals::try_read checks at most DEPTH_LIMIT = 5 entries, so
+    // from the tip it visits 6, 5, 4, 3, 2 and gives up before reaching
+    // proposal 1's write.
+    for (uint64_t n = 2; n <= 6; ++n) {
+        cache.update_proposal_state(
+            make_post_state(OTHER_ADDR, OTHER_KEY, VALUE1), n, bytes32_t{n});
+    }
+
+    // point reads at the branch tip.
+    cache.set_block_and_prefix(6, bytes32_t{6});
+
+    // truncates before reaching proposal 1
+    storage_page_t page;
+    EXPECT_EQ(
+        cache.try_read_storage_page(ADDR, INC, KEY, page),
+        CacheReadStatus::MissTruncated);
+
+    // same for the account map.
+    std::optional<Account> acct;
+    EXPECT_EQ(
+        cache.try_read_account(ADDR, acct), CacheReadStatus::MissTruncated);
+}
+
+TEST(DbCacheTest, proposal_write_shadows_readthrough_entry)
+{
+    DbCache cache;
+    cache.update_proposal_state(
+        make_post_state(OTHER_ADDR, OTHER_KEY, VALUE2), 1, bytes32_t{1});
+    cache.set_block_and_prefix(1, bytes32_t{1});
+
+    // populate the read-through entry. the walk from proposal 1 reaches the
+    // finalized base without finding KEY, so db will fetch VALUE1 from
+    // disk and cache it.
+    bytes32_t slot;
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot),
+        CacheReadStatus::MissResolved);
+    cache.insert_storage_page(ADDR, INC, KEY, storage_page_t{VALUE1});
+
+    // verify read through entry is populated
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot), CacheReadStatus::Hit);
+    EXPECT_EQ(slot, VALUE1);
+
+    // proposal 2 writes KEY = VALUE2: the LRU entry is now stale relative
+    // to this branch.
+    cache.update_proposal_state(
+        make_post_state(ADDR, KEY, VALUE2), 2, bytes32_t{2});
+    cache.set_block_and_prefix(2, bytes32_t{2});
+
+    // The overlay walk must serve proposal 2's write
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot), CacheReadStatus::Hit);
+    EXPECT_EQ(slot, VALUE2);
+}
+
+TEST(DbCacheTest, finalization_write_overwrites_readthrough_entry)
+{
+    DbCache cache;
+    cache.update_proposal_state(
+        make_post_state(OTHER_ADDR, OTHER_KEY, VALUE2), 1, bytes32_t{1});
+    cache.set_block_and_prefix(1, bytes32_t{1});
+
+    // populate the read-through entry. the walk from proposal 1 reaches the
+    // finalized base without finding KEY, so db will fetch VALUE1 from
+    // disk and cache it.
+    bytes32_t slot;
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot),
+        CacheReadStatus::MissResolved);
+    cache.insert_storage_page(ADDR, INC, KEY, storage_page_t{VALUE1});
+
+    // verify readthrough entry is populated
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot), CacheReadStatus::Hit);
+    EXPECT_EQ(slot, VALUE1);
+
+    // proposal 2 writes KEY = VALUE2; proposal 3 builds on top of it without
+    // touching KEY, so its reads must come from the LRU.
+    cache.update_proposal_state(
+        make_post_state(ADDR, KEY, VALUE2), 2, bytes32_t{2});
+    cache.update_proposal_state(
+        make_post_state(OTHER_ADDR, OTHER_KEY, VALUE1), 3, bytes32_t{3});
+
+    // readthrough VALUE1 is replaced by VALUE2.
+    cache.on_finalize(1, bytes32_t{1});
+    cache.on_finalize(2, bytes32_t{2});
+
+    // clean walk from proposal 3 to finalized 2 finds no writer of KEY, so
+    // the LRU answers — it must serve the finalized VALUE2, not the stale
+    // read-through VALUE1.
+    cache.set_block_and_prefix(3, bytes32_t{3});
+    EXPECT_EQ(
+        cache.try_read_storage(ADDR, INC, KEY, 0, slot), CacheReadStatus::Hit);
+    EXPECT_EQ(slot, VALUE2);
+}

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -104,7 +104,9 @@ Node::SharedPtr const &TrieDb::get_root() const
 std::optional<Account> TrieDb::read_account(Address const &addr)
 {
     std::optional<Account> result;
-    if (cache_ && cache_->try_read_account(addr, result)) {
+    auto const status = cache_ ? cache_->try_read_account(addr, result)
+                               : CacheReadStatus::MissTruncated;
+    if (status == CacheReadStatus::Hit) {
         return result;
     }
     auto const res = db_.find(
@@ -114,13 +116,19 @@ std::optional<Account> TrieDb::read_account(Address const &addr)
             STATE_NIBBLE,
             NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})}),
         block_number_);
+    // result stays nullopt if absent at the finalized baseline.
     if (res.has_error()) {
         stats_account_no_value();
-        return std::nullopt;
     }
-    stats_account_value();
-    auto encoded_account = res.value().node->value();
-    return decode_account_db_ignore_address(encoded_account).value();
+    else {
+        stats_account_value();
+        auto encoded_account = res.value().node->value();
+        result = decode_account_db_ignore_address(encoded_account).value();
+    }
+    if (cache_ && status == CacheReadStatus::MissResolved) {
+        cache_->insert_account(addr, result);
+    }
+    return result;
 }
 
 bytes32_t TrieDb::read_storage(
@@ -129,8 +137,11 @@ bytes32_t TrieDb::read_storage(
     bytes32_t const lookup_key = storage_lookup_key(key);
     uint8_t const lookup_offset = page_encoded_ ? compute_slot_offset(key) : 0;
     bytes32_t result{};
-    if (cache_ && cache_->try_read_storage(
-                      addr, incarnation, lookup_key, lookup_offset, result)) {
+    auto const status =
+        cache_ ? cache_->try_read_storage(
+                     addr, incarnation, lookup_key, lookup_offset, result)
+               : CacheReadStatus::MissTruncated;
+    if (status == CacheReadStatus::Hit) {
         return result;
     }
     auto const res = db_.find(
@@ -142,22 +153,32 @@ bytes32_t TrieDb::read_storage(
             NibblesView{
                 keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
         block_number_);
+
+    // Decode the leaf into a page (empty if absent): a full page for page
+    // encoding, a single-slot page for slot encoding. Read-through caches it on
+    // a resolved miss.
+    storage_page_t page;
     if (res.has_error()) {
         stats_storage_no_value();
-        return {};
-    }
-    stats_storage_value();
-    auto encoded_storage = res.value().node->value();
-    auto const value = decode_storage_db_ignore_key(encoded_storage);
-    MONAD_ASSERT(!value.has_error());
-    if (page_encoded_) {
-        auto const page = decode_storage_page(value.value());
-        MONAD_ASSERT(!page.has_error());
-        return page.value()[lookup_offset];
     }
     else {
-        return to_bytes(value.value());
+        stats_storage_value();
+        auto encoded_storage = res.value().node->value();
+        auto const value = decode_storage_db_ignore_key(encoded_storage);
+        MONAD_ASSERT(!value.has_error());
+        if (page_encoded_) {
+            auto const decoded = decode_storage_page(value.value());
+            MONAD_ASSERT(!decoded.has_error());
+            page = decoded.value();
+        }
+        else {
+            page.set(0, to_bytes(value.value()));
+        }
     }
+    if (cache_ && status == CacheReadStatus::MissResolved) {
+        cache_->insert_storage_page(addr, incarnation, lookup_key, page);
+    }
+    return page[lookup_offset];
 }
 
 storage_page_t TrieDb::read_storage_page(
@@ -169,8 +190,10 @@ storage_page_t TrieDb::read_storage_page(
     }
     else {
         storage_page_t result;
-        if (cache_ && cache_->try_read_storage_page(
-                          addr, incarnation, page_key, result)) {
+        auto const status = cache_ ? cache_->try_read_storage_page(
+                                         addr, incarnation, page_key, result)
+                                   : CacheReadStatus::MissTruncated;
+        if (status == CacheReadStatus::Hit) {
             return result;
         }
         auto const res = db_.find(
@@ -184,15 +207,20 @@ storage_page_t TrieDb::read_storage_page(
             block_number_);
         if (res.has_error()) {
             stats_storage_no_value();
-            return {};
         }
-        stats_storage_value();
-        auto encoded_storage = res.value().node->value();
-        auto const value = decode_storage_db_ignore_key(encoded_storage);
-        MONAD_ASSERT(!value.has_error());
-        auto const page = decode_storage_page(value.value());
-        MONAD_ASSERT(!page.has_error());
-        return page.value();
+        else {
+            stats_storage_value();
+            auto encoded_storage = res.value().node->value();
+            auto const value = decode_storage_db_ignore_key(encoded_storage);
+            MONAD_ASSERT(!value.has_error());
+            auto const decoded = decode_storage_page(value.value());
+            MONAD_ASSERT(!decoded.has_error());
+            result = decoded.value();
+        }
+        if (cache_ && status == CacheReadStatus::MissResolved) {
+            cache_->insert_storage_page(addr, incarnation, page_key, result);
+        }
+        return result;
     }
 }
 

--- a/category/execution/ethereum/state2/test/test_state.cpp
+++ b/category/execution/ethereum/state2/test/test_state.cpp
@@ -182,19 +182,30 @@ namespace
         vm::VM vm;
     };
 
+    template <bool page_encoded>
     struct TwoOnDisk : public ::testing::Test
     {
         mpt::Db db1{
-            std::make_unique<OnDiskMachine>(),
+            page_encoded ? std::make_unique<MonadOnDiskMachine>()
+                         : std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.file_size_db = 8}};
         mpt::Db db2{
-            std::make_unique<OnDiskMachine>(),
+            page_encoded ? std::make_unique<MonadOnDiskMachine>()
+                         : std::make_unique<OnDiskMachine>(),
             mpt::OnDiskDbConfig{.file_size_db = 8}};
         // baseline noncaching db for tdb1
         TrieDb tdb1{db1};
         TrieDb tdb2{db2, /*enable_multiblock_cache=*/true};
         vm::VM vm;
     };
+
+    template <typename T>
+    struct TwoOnDiskSuite : public T
+    {
+    };
+
+    using TwoOnDiskTypes = ::testing::Types<TwoOnDisk<false>, TwoOnDisk<true>>;
+    TYPED_TEST_SUITE(TwoOnDiskSuite, TwoOnDiskTypes);
 }
 
 DEFINE_TRAITS_FIXTURE(InMemoryStateTraitsTest);
@@ -2482,7 +2493,7 @@ namespace
     };
 }
 
-TEST_F(TwoOnDisk, random_proposals)
+TYPED_TEST(TwoOnDiskSuite, random_proposals)
 {
     this->tdb1.reset_root(
         load_header({}, this->db1, BlockHeader{.number = 0}), 0);

--- a/category/vm/utils/lru_weight_cache.hpp
+++ b/category/vm/utils/lru_weight_cache.hpp
@@ -128,6 +128,24 @@ namespace monad::vm::utils
             return true;
         }
 
+        /// Like try_insert, but takes `value` by const reference and never
+        /// mutates it or overwrites an existing entry. Returns true iff a new
+        /// entry was inserted.
+        bool try_insert_no_overwrite(
+            Key const &key, Value const &value, uint32_t const weight)
+        {
+            ConstAccessor acc;
+            if (!hmap_.insert(acc, {key, HashMapValue{value, weight}})) {
+                try_update_lru(&*acc);
+                return false;
+            }
+            ListNode const *const node = &*acc;
+            acc.release();
+            lru_.push_front(node);
+            adjust_by_delta_weight(weight);
+            return true;
+        }
+
         /// Get approximate total weight of the cached elements.
         uint64_t approx_weight() const
         {


### PR DESCRIPTION
## Problem

DbCache is populated only by committed state: the LRU caches are filled at finalization (`on_finalize` -> `insert_in_lru_caches`) and the proposal map at commit (update_proposal_state). A read that misses both fetches the value from the trie and discards it. Nothing that is only read is ever cached.

This has performance impact for the page-encoded (MIP-8) commit path. `PageCommitBuilder` performs a read-modify-write: for every touched page it reads the current page from the db to merge the changed slots before writing. Because those reads aren't cached, the commit-time RMW re-reads pages from disk that execution already read in the same block, the commit phase re-does the read execution just did. On a fresh-storage workload this dominates block time.

## Change

Add read-through: on a storage/account read-miss, insert the value fetched from disk into the LRU so a subsequent read hits.

- `try_read_account` / `try_read_storage` / `try_read_storage_page` now return a `CacheReadStatus` (`Hit` / `MissResolved` / `MissTruncated`) instead of `bool`.
- New `insert_account` / `insert_storage_page` populate the LRU, guarded by the status.
- `TrieDb::read_account` / `read_storage` / `read_storage_page` insert the disk value on `MissResolved`, including empty/absent entries (negative caching).

🤖  Generated with Claude Opus 4.8