### PR TITLE
Exclude .claude/worktrees from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 build
 docker
+.claude/worktrees


### PR DESCRIPTION
## Summary
- Claude Code worktrees under `.claude/worktrees/` are full repo checkouts; they were being transmitted to the docker daemon as part of the build context.
- Add `.claude/worktrees` to `.dockerignore` alongside the existing `.git`/`build`/`docker` entries.

## Test plan
- [x] Visual diff review of `.dockerignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152gDKKYN1f4U1ZX36cBoQn