### PR TITLE
Replace silkpre's BLAKE2F precompile with vendored monad_blake2b_compress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ target_compile_options(
   ff
   PRIVATE -Wno-unused-parameter -Wno-unused-const-variable -Wno-uninitialized)
 
-# silkpre_vendor (vendored sha256 + rmd160)
+# silkpre_vendor (vendored sha256, rmd160, blake2f)
 add_subdirectory("third_party/silkpre_vendor")
 
 # tbb

--- a/category/execution/ethereum/precompiles_impl.cpp
+++ b/category/execution/ethereum/precompiles_impl.cpp
@@ -18,6 +18,7 @@
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
+#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/execution/ethereum/precompiles.hpp>
 #include <category/execution/ethereum/precompiles_bls12.hpp>
@@ -36,6 +37,7 @@
 
 #include <evmc/evmc.h>
 
+#include <silkpre_vendor/blake2b.h>
 #include <silkpre_vendor/rmd160.h>
 #include <silkpre_vendor/sha256.h>
 
@@ -46,9 +48,11 @@
 
 #include <silkpre/precompile.h>
 
+#include <bit>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <string_view>
 
@@ -184,7 +188,37 @@ PrecompileResult snarkv_execute(byte_string_view const input)
 
 PrecompileResult blake2bf_execute(byte_string_view const input)
 {
-    return silkpre_execute<silkpre_blake2_f_run>(input);
+    if (input.size() != 213) {
+        return {EVMC_PRECOMPILE_FAILURE, nullptr, 0};
+    }
+
+    uint8_t const f{input[212]};
+    if (f != 0 && f != 1) {
+        return {EVMC_PRECOMPILE_FAILURE, nullptr, 0};
+    }
+
+    MonadBlake2bState state{};
+    if (f) {
+        state.f[0] = std::numeric_limits<uint64_t>::max();
+    }
+
+    static_assert(std::endian::native == std::endian::little);
+    static_assert(sizeof(state.h) == 8 * 8);
+    std::memcpy(&state.h, input.data() + 4, 8 * 8);
+
+    uint8_t block[MONAD_BLAKE2B_BLOCKBYTES];
+    std::memcpy(block, input.data() + 68, MONAD_BLAKE2B_BLOCKBYTES);
+
+    std::memcpy(&state.t, input.data() + 196, 8 * 2);
+
+    uint32_t const r{load_be_unsafe<uint32_t>(input.data())};
+    monad_blake2b_compress(&state, block, r);
+
+    auto *const output = static_cast<uint8_t *>(std::malloc(64));
+    MONAD_ASSERT(output != nullptr);
+
+    std::memcpy(&output[0], &state.h[0], 8 * 8);
+    return {EVMC_SUCCESS, output, 64};
 }
 
 PrecompileResult point_evaluation_execute(byte_string_view const input)

--- a/category/execution/ethereum/precompiles_test.cpp
+++ b/category/execution/ethereum/precompiles_test.cpp
@@ -127,6 +127,23 @@ namespace
                                   "fffe5bfeffffffff00000001"})
             .value();
 
+    // EIP-152 test vector 8.
+    // The resulting gas cost (1 gas / round) exceeds any practical gas limit,
+    // testing the OUT_OF_GAS path in check_call_eth_precompile (without running
+    // the precompile).
+    static auto const BLAKE2F_MAX_ROUNDS_INPUT =
+        from_hex(
+            std::string_view{
+                "ffffffff" // maximum number of rounds
+                "48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54f"
+                "a5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cd"
+                "e05b6162630000000000000000000000000000000000000000000000000000"
+                "00000000000000000000000000000000000000000000000000000000000000"
+                "00000000000000000000000000000000000000000000000000000000000000"
+                "00000000000000000000000000000000000000000000000000000000000000"
+                "0000000000000300000000000000000000000000000001"})
+            .value();
+
     struct evmc_some_error
     {
     };
@@ -290,6 +307,15 @@ namespace
          .expected = evmc_status_code::EVMC_OUT_OF_GAS,
          .gas = 50'000,
          .gas_offset = -1}};
+
+    // The maximum round number 0xFFFFFFFF is impractical to actually
+    // execute, so only check that the gas cost is enforced.
+    static test_case const BLAKE2F_MAX_ROUNDS_TEST_CASES[] = {
+        {.name = "blake_2f_max_rounds_gas_cost_only",
+         .input = BLAKE2F_MAX_ROUNDS_INPUT,
+         .expected = evmc_status_code::EVMC_OUT_OF_GAS,
+         .gas = 30'000'000,
+         .gas_offset = 0}};
 
     template <Traits traits>
     void do_geth_tests(
@@ -511,6 +537,11 @@ TYPED_TEST(TraitsTest, blake2f)
 
     blake2f_test("blake_2f_valid", "blake2F.json");
     blake2f_test("blake_2f_invalid", "fail-blake2f.json");
+
+    do_geth_tests<typename TestFixture::Trait>(
+        "blake_2f_max_rounds_gas_cost_only",
+        BLAKE2F_MAX_ROUNDS_TEST_CASES,
+        0x09_address);
 }
 
 TYPED_TEST(TraitsTest, point_evaluation)

--- a/third_party/silkpre_vendor/CMakeLists.txt
+++ b/third_party/silkpre_vendor/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# SHA-256 and RIPEMD-160 implementations vendored from silkpre.
+# SHA-256, RIPEMD-160, and BLAKE2F implementations vendored from silkpre.
 # See NOTICE and LICENSE.
 
 add_library(monad_crypto STATIC)
@@ -25,6 +25,8 @@ target_sources(monad_crypto PRIVATE
   "src/silkpre_vendor/rmd160.h"
   "src/silkpre_vendor/sha256.c"
   "src/silkpre_vendor/sha256.h"
+  "src/silkpre_vendor/blake2b.c"
+  "src/silkpre_vendor/blake2b.h"
 )
 
 # Consumers include the headers via `<silkpre_vendor/sha256.h>` etc.

--- a/third_party/silkpre_vendor/NOTICE
+++ b/third_party/silkpre_vendor/NOTICE
@@ -11,6 +11,11 @@ rmd160.c / rmd160.h carry their own MIT-style permissive license,
 originally Copyright (c) 1996 Katholieke Universiteit Leuven
 (Antoon Bosselaers); the full notice is preserved in the file headers.
 
+blake2b.c / blake2b.h are derived from the reference implementation by
+Samuel Neves <sneves@dei.uc.pt>, usable under the terms of the CC0, the
+OpenSSL Licence, or the Apache Public License 2.0. The full notice is
+preserved in the file headers.
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.c
@@ -1,0 +1,99 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#include "blake2b.h"
+
+#include <stdint.h>
+#include <string.h>
+
+static const uint64_t blake2b_IV[8] = {
+    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+    0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL,
+};
+
+static const uint8_t blake2b_sigma[12][16] = {
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
+    {11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4}, {7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8},
+    {9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13}, {2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9},
+    {12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11}, {13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10},
+    {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5}, {10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0},
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
+};
+
+static inline uint64_t load64(const void* src) {
+    uint64_t w;
+    memcpy(&w, src, sizeof w);
+    return w;
+}
+
+static inline uint64_t rotr64(const uint64_t w, const unsigned c) { return (w >> c) | (w << (64 - c)); }
+
+#define G(r, i, a, b, c, d)                         \
+    do {                                            \
+        a = a + b + m[blake2b_sigma[r][2 * i + 0]]; \
+        d = rotr64(d ^ a, 32);                      \
+        c = c + d;                                  \
+        b = rotr64(b ^ c, 24);                      \
+        a = a + b + m[blake2b_sigma[r][2 * i + 1]]; \
+        d = rotr64(d ^ a, 16);                      \
+        c = c + d;                                  \
+        b = rotr64(b ^ c, 63);                      \
+    } while (0)
+
+#define ROUND(r)                           \
+    do {                                   \
+        G(r, 0, v[0], v[4], v[8], v[12]);  \
+        G(r, 1, v[1], v[5], v[9], v[13]);  \
+        G(r, 2, v[2], v[6], v[10], v[14]); \
+        G(r, 3, v[3], v[7], v[11], v[15]); \
+        G(r, 4, v[0], v[5], v[10], v[15]); \
+        G(r, 5, v[1], v[6], v[11], v[12]); \
+        G(r, 6, v[2], v[7], v[8], v[13]);  \
+        G(r, 7, v[3], v[4], v[9], v[14]);  \
+    } while (0)
+
+void silkpre_blake2b_compress(SilkpreBlake2bState* S, const uint8_t block[SILKPRE_BLAKE2B_BLOCKBYTES], size_t r) {
+    uint64_t m[16];
+    uint64_t v[16];
+    size_t i;
+
+    for (i = 0; i < 16; ++i) {
+        m[i] = load64(block + i * sizeof(m[i]));
+    }
+
+    for (i = 0; i < 8; ++i) {
+        v[i] = S->h[i];
+    }
+
+    v[8] = blake2b_IV[0];
+    v[9] = blake2b_IV[1];
+    v[10] = blake2b_IV[2];
+    v[11] = blake2b_IV[3];
+    v[12] = blake2b_IV[4] ^ S->t[0];
+    v[13] = blake2b_IV[5] ^ S->t[1];
+    v[14] = blake2b_IV[6] ^ S->f[0];
+    v[15] = blake2b_IV[7] ^ S->f[1];
+
+    for (i = 0; i < r; ++i) {
+        ROUND(i % 10);
+    }
+
+    for (i = 0; i < 8; ++i) {
+        S->h[i] = S->h[i] ^ v[i] ^ v[i + 8];
+    }
+}
+
+#undef G
+#undef ROUND

--- a/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.c
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.c
@@ -13,7 +13,9 @@
    https://blake2.net.
 */
 
-#include "blake2b.h"
+// Modified 2026 by Category Labs: renamed silkpre prefixes to monad
+
+#include <silkpre_vendor/blake2b.h>
 
 #include <stdint.h>
 #include <string.h>
@@ -64,7 +66,7 @@ static inline uint64_t rotr64(const uint64_t w, const unsigned c) { return (w >>
         G(r, 7, v[3], v[4], v[9], v[14]);  \
     } while (0)
 
-void silkpre_blake2b_compress(SilkpreBlake2bState* S, const uint8_t block[SILKPRE_BLAKE2B_BLOCKBYTES], size_t r) {
+void monad_blake2b_compress(MonadBlake2bState* S, const uint8_t block[MONAD_BLAKE2B_BLOCKBYTES], size_t r) {
     uint64_t m[16];
     uint64_t v[16];
     size_t i;

--- a/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.h
@@ -1,0 +1,43 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+
+   Modified 2022 for Silkpre by Andrew Ashikhmin.
+*/
+
+#ifndef SILKPRE_BLAKE2B_H_
+#define SILKPRE_BLAKE2B_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+enum { SILKPRE_BLAKE2B_BLOCKBYTES = 128 };
+
+typedef struct SilkpreBlake2bState {
+    uint64_t h[8];
+    uint64_t t[2];
+    uint64_t f[2];
+} SilkpreBlake2bState;
+
+// https://tools.ietf.org/html/rfc7693#section-3.2
+void silkpre_blake2b_compress(SilkpreBlake2bState* S, const uint8_t block[SILKPRE_BLAKE2B_BLOCKBYTES], size_t r);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // SILKPRE_BLAKE2B_H_

--- a/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.h
+++ b/third_party/silkpre_vendor/src/silkpre_vendor/blake2b.h
@@ -15,8 +15,10 @@
    Modified 2022 for Silkpre by Andrew Ashikhmin.
 */
 
-#ifndef SILKPRE_BLAKE2B_H_
-#define SILKPRE_BLAKE2B_H_
+// Modified 2026 by Category Labs: renamed silkpre prefixes to monad
+
+#ifndef MONAD_BLAKE2B_H_
+#define MONAD_BLAKE2B_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -25,19 +27,19 @@
 extern "C" {
 #endif
 
-enum { SILKPRE_BLAKE2B_BLOCKBYTES = 128 };
+enum { MONAD_BLAKE2B_BLOCKBYTES = 128 };
 
-typedef struct SilkpreBlake2bState {
+typedef struct MonadBlake2bState {
     uint64_t h[8];
     uint64_t t[2];
     uint64_t f[2];
-} SilkpreBlake2bState;
+} MonadBlake2bState;
 
 // https://tools.ietf.org/html/rfc7693#section-3.2
-void silkpre_blake2b_compress(SilkpreBlake2bState* S, const uint8_t block[SILKPRE_BLAKE2B_BLOCKBYTES], size_t r);
+void monad_blake2b_compress(MonadBlake2bState* S, const uint8_t block[MONAD_BLAKE2B_BLOCKBYTES], size_t r);
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif  // SILKPRE_BLAKE2B_H_
+#endif  // MONAD_BLAKE2B_H_


### PR DESCRIPTION
Vendors the BLAKE2b compression function `monad_blake2b_compress` from `third_party/silkpre` into `third_party/silkpre_vendor/src/silkpre_vendor/blake2b.{h,c}`. `blake2bf_execute` no longer dispatches through `silkpre_execute<silkpre_blake2_f_run>`, now calling `monad_blake2b_compress` with the setup done in silkpre's precompile implementation.
