### PR TITLE
snapshot: raise fd limit, fail fast, and report open errors on dump

### DIFF
--- a/category/async/io.cpp
+++ b/category/async/io.cpp
@@ -132,17 +132,44 @@ namespace detail
     {
         AsyncIO_rlimit_raiser_impl()
         {
+            constexpr rlim_t target = 16384;
             struct rlimit r = {0, 0};
-            getrlimit(RLIMIT_NOFILE, &r);
-            if (r.rlim_cur < 4096) {
-                std::cerr << "WARNING: maximum file descriptor limit is "
-                          << r.rlim_cur
-                          << " which is less than 4096. 'Too many open files' "
-                             "errors may result. You can increase the hard "
-                             "file descriptor limit for a given user by adding "
-                             "to '/etc/security/limits.conf' '<username> hard "
-                             "nofile 16384'."
+            if (getrlimit(RLIMIT_NOFILE, &r) != 0) {
+                std::cerr << "WARNING: getrlimit(RLIMIT_NOFILE) failed: "
+                          << std::strerror(errno)
+                          << "; cannot check or raise the open file limit."
                           << std::endl;
+                return;
+            }
+            // Raise the soft limit toward target, capped at the hard limit
+            // (RLIM_INFINITY means the hard limit imposes no cap). The guard
+            // skips the call when the soft limit already meets the target.
+            rlim_t desired = target;
+            if (r.rlim_max != RLIM_INFINITY && r.rlim_max < desired) {
+                desired = r.rlim_max;
+            }
+            if (desired > r.rlim_cur) {
+                struct rlimit const want = {desired, r.rlim_max};
+                if (setrlimit(RLIMIT_NOFILE, &want) == 0) {
+                    r.rlim_cur = desired;
+                }
+                else {
+                    std::cerr << "WARNING: setrlimit(RLIMIT_NOFILE) to "
+                              << desired << " failed: " << std::strerror(errno)
+                              << "; proceeding with a soft limit of "
+                              << r.rlim_cur << "." << std::endl;
+                }
+            }
+            if (r.rlim_cur < 4096) {
+                std::cerr
+                    << "WARNING: maximum file descriptor limit is "
+                    << r.rlim_cur
+                    << " which is less than 4096. 'Too many open files' "
+                       "errors may result. Raise the hard file descriptor "
+                       "limit for this user (e.g. in "
+                       "'/etc/security/limits.conf': '<username> hard "
+                       "nofile 16384')."
+                    << std::endl;
             }
         }
     } AsyncIO_rlimit_raiser;

--- a/category/execution/ethereum/db/db_snapshot.h
+++ b/category/execution/ethereum/db/db_snapshot.h
@@ -26,6 +26,12 @@ inline constexpr unsigned MONAD_SNAPSHOT_SHARDS =
     1 << (MONAD_SNAPSHOT_SHARD_NIBBLES * 4);
 static_assert(MONAD_SNAPSHOT_SHARDS == 256);
 
+// Number of files written per shard, one per monad_snapshot_type (eth_header,
+// account, storage, code). The filesystem dumper holds this many file
+// descriptors open per active shard for the whole dump, so a run needs roughly
+// (active shards) * MONAD_SNAPSHOT_FILES_PER_SHARD descriptors at its peak.
+inline constexpr unsigned MONAD_SNAPSHOT_FILES_PER_SHARD = 4;
+
 extern "C"
 {
 #endif

--- a/category/execution/ethereum/db/db_snapshot_filesystem.cpp
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.cpp
@@ -20,11 +20,14 @@
 #include <category/core/hex.hpp>
 #include <category/core/likely.h>
 #include <category/execution/ethereum/core/fmt/bytes_fmt.hpp>
+#include <category/execution/ethereum/db/db_snapshot.h>
 #include <category/execution/ethereum/db/db_snapshot_filesystem.h>
 
 #include <ankerl/unordered_dense.h>
 #include <blake3.h>
 
+#include <cerrno>
+#include <cstring>
 #include <fcntl.h>
 #include <filesystem>
 #include <format>
@@ -37,11 +40,17 @@ MONAD_ANONYMOUS_NAMESPACE_BEGIN
 struct SnapshotShardStream
 {
     std::ofstream foutput;
-    std::ofstream fchecksum;
+    // The checksum is written once, at destroy time, so only its path is kept
+    // here and the stream is opened lazily rather than held open for the whole
+    // dump. The data stream (foutput) is already held open per shard across all
+    // 256 shards; keeping the checksum stream open too would double that fd
+    // footprint, so deferring it halves the descriptors the dump holds at once.
+    std::filesystem::path checksum_path;
     blake3_hasher hasher;
 };
 
-using SnapshotShard = std::array<SnapshotShardStream, 4>;
+using SnapshotShard =
+    std::array<SnapshotShardStream, MONAD_SNAPSHOT_FILES_PER_SHARD>;
 
 MONAD_ANONYMOUS_NAMESPACE_END
 
@@ -75,9 +84,39 @@ void monad_db_snapshot_filesystem_write_user_context_destroy(
 {
     for (auto &[_, stream] : context->shard) {
         for (auto &shard : stream) {
+            // Flush and close the data file now, rather than letting the
+            // ofstream destructor do it (where the result would be discarded),
+            // so a write/flush/close failure -- e.g. ENOSPC on the final
+            // buffer, or a deferred write-back error surfaced only at close()
+            // -- aborts here at dump time with the right cause instead of
+            // surfacing later as a load-time checksum mismatch on a truncated
+            // file.
+            errno = 0;
+            shard.foutput.close();
+            MONAD_ASSERT_PRINTF(
+                shard.foutput.good(),
+                "failed to write snapshot data file %s: %s",
+                std::filesystem::path{shard.checksum_path}
+                    .replace_extension()
+                    .c_str(),
+                std::strerror(errno));
+
             monad::bytes32_t hash;
             blake3_hasher_finalize(&shard.hasher, hash.bytes, BLAKE3_OUT_LEN);
-            shard.fchecksum << fmt::format("{}", hash);
+            errno = 0;
+            std::ofstream fchecksum{shard.checksum_path, std::ios::out};
+            MONAD_ASSERT_PRINTF(
+                fchecksum.is_open(),
+                "failed to open %s: %s",
+                shard.checksum_path.c_str(),
+                std::strerror(errno));
+            fchecksum << fmt::format("{}", hash);
+            fchecksum.close();
+            MONAD_ASSERT_PRINTF(
+                fchecksum.good(),
+                "failed to write checksum %s: %s",
+                shard.checksum_path.c_str(),
+                std::strerror(errno));
         }
     }
     delete context;
@@ -98,17 +137,18 @@ uint64_t monad_db_snapshot_write_filesystem(
         MONAD_ASSERT(success);
         constexpr std::array files = {
             "eth_header", "account", "storage", "code"};
+        static_assert(files.size() == MONAD_SNAPSHOT_FILES_PER_SHARD);
         for (size_t i = 0; i < it->second.size(); ++i) {
-            auto &[foutput, fchecksum, hasher] = it->second.at(i);
+            auto &[foutput, checksum_path, hasher] = it->second.at(i);
             std::filesystem::path const output = shard_dir / files[i];
+            errno = 0;
             foutput.open(output, std::ios::binary | std::ios::out);
-            std::filesystem::path const checksum{
-                std::format("{}.blake3", output.c_str())};
-            fchecksum.open(checksum, std::ios::out);
             MONAD_ASSERT_PRINTF(
-                foutput.is_open(), "failed to open %s", output.c_str());
-            MONAD_ASSERT_PRINTF(
-                fchecksum.is_open(), "failed to open %s", checksum.c_str());
+                foutput.is_open(),
+                "failed to open %s: %s",
+                output.c_str(),
+                std::strerror(errno));
+            checksum_path = std::format("{}.blake3", output.c_str());
             blake3_hasher_init(&hasher);
         }
     }
@@ -137,17 +177,33 @@ void monad_db_snapshot_load_filesystem(
 
     auto const do_mmap = [](std::filesystem::path const file) {
         using namespace monad;
-        MONAD_ASSERT(std::filesystem::is_regular_file(file));
-        int fd = open(file.c_str(), O_RDONLY);
-        MONAD_ASSERT(fd != -1);
+        MONAD_ASSERT_PRINTF(
+            std::filesystem::is_regular_file(file),
+            "snapshot input file missing or not a regular file: %s",
+            file.c_str());
+        errno = 0;
+        int const fd = open(file.c_str(), O_RDONLY);
+        MONAD_ASSERT_PRINTF(
+            fd != -1,
+            "failed to open %s: %s",
+            file.c_str(),
+            std::strerror(errno));
 
         unsigned long const size = std::filesystem::file_size(file);
         void *data = nullptr;
         if (size) {
             data = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
-            MONAD_ASSERT(data != MAP_FAILED);
+            MONAD_ASSERT_PRINTF(
+                data != MAP_FAILED,
+                "failed to mmap %s: %s",
+                file.c_str(),
+                std::strerror(errno));
             // optimize for sequential accesses
-            MONAD_ASSERT(madvise(data, size, MADV_SEQUENTIAL) == 0);
+            MONAD_ASSERT_PRINTF(
+                madvise(data, size, MADV_SEQUENTIAL) == 0,
+                "madvise failed for %s: %s",
+                file.c_str(),
+                std::strerror(errno));
 
             std::filesystem::path const checksum{
                 std::format("{}.blake3", file.c_str())};
@@ -155,7 +211,13 @@ void monad_db_snapshot_load_filesystem(
                 std::filesystem::is_regular_file(checksum),
                 "missing checksum file %s",
                 checksum.c_str());
+            errno = 0;
             std::ifstream t(checksum);
+            MONAD_ASSERT_PRINTF(
+                t.is_open(),
+                "failed to open checksum file %s: %s",
+                checksum.c_str(),
+                std::strerror(errno));
             std::stringstream buffer;
             buffer << t.rdbuf();
             auto const stored_hash = from_hex<bytes32_t>(buffer.str());

--- a/cmd/monad_cli.cpp
+++ b/cmd/monad_cli.cpp
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <charconv>
 #include <chrono>
 #include <cmath>
@@ -55,6 +56,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -73,6 +75,7 @@
 #include <vector>
 
 #include <stdio.h>
+#include <sys/resource.h>
 #include <unistd.h>
 
 using namespace monad;
@@ -905,6 +908,70 @@ int main(int const argc, char *argv[])
     LOG_INFO("running with commit '{}'", GIT_COMMIT_HASH);
     flush_logger();
 
+    // Validate snapshot-dump preconditions before opening the database or
+    // starting any work, so a misconfigured environment fails immediately with
+    // a non-zero exit code rather than part-way through (which would leave a
+    // partial snapshot behind).
+    if (dump_binary_snapshot.has_value()) {
+        if (shard_number >= total_shards) {
+            LOG_ERROR(
+                "shard_number ({}) must be < total_shards ({})",
+                shard_number,
+                total_shards);
+            return 1;
+        }
+        // The dumper processes the shard indices s in [0,
+        // MONAD_SNAPSHOT_SHARDS) with s % total_shards == shard_number (see
+        // db_snapshot.cpp), so this run handles ceil((SHARDS - shard_number) /
+        // total_shards) shards. The ternary guards the unsigned subtraction
+        // against shard_number >= SHARDS (no shards match, count is 0).
+        uint64_t const shards_this_run =
+            shard_number < MONAD_SNAPSHOT_SHARDS
+                ? (MONAD_SNAPSHOT_SHARDS - shard_number + total_shards - 1) /
+                      total_shards
+                : 0;
+        // The dumper holds one fd open per (shard, data file) for the whole
+        // run; add headroom for the triedb device(s), io_uring rings, logger,
+        // and std streams.
+        constexpr uint64_t fd_headroom = 256;
+        uint64_t const required_fds =
+            shards_this_run * MONAD_SNAPSHOT_FILES_PER_SHARD + fd_headroom;
+        struct rlimit limit{};
+        if (getrlimit(RLIMIT_NOFILE, &limit) != 0) {
+            // getrlimit essentially never fails for RLIMIT_NOFILE; if it
+            // somehow does we cannot verify the limit, so warn and proceed
+            // rather than block a dump that may well succeed. The dumper's
+            // open() asserts remain the backstop.
+            LOG_WARNING(
+                "could not read the open file descriptor limit (getrlimit "
+                "failed: {}); proceeding without the snapshot fd pre-flight "
+                "check",
+                std::strerror(errno));
+        }
+        else if (limit.rlim_cur < required_fds) {
+            // The soft limit was already raised toward the hard limit at
+            // startup (AsyncIO_rlimit_raiser in category/async/io.cpp), so
+            // reaching here means the hard limit itself is too low and must be
+            // raised (limits.conf / systemd LimitNOFILE).
+            auto const hard_limit = limit.rlim_max == RLIM_INFINITY
+                                        ? std::string{"unlimited"}
+                                        : std::to_string(limit.rlim_max);
+            LOG_ERROR(
+                "open file descriptor limit (soft {}, hard {}) is too low to "
+                "dump this snapshot, which needs about {} descriptors ({} "
+                "shards x {} files plus headroom). Raise the hard limit for "
+                "this user (e.g. add '<user> hard nofile 16384' to "
+                "/etc/security/limits.conf, or set LimitNOFILE in the systemd "
+                "unit) and retry.",
+                limit.rlim_cur,
+                hard_limit,
+                required_fds,
+                shards_this_run,
+                MONAD_SNAPSHOT_FILES_PER_SHARD);
+            return 1;
+        }
+    }
+
     uint64_t resolved_version = 0;
     {
         fmt::println("Opening read only database {}.", dbname_paths);
@@ -947,14 +1014,6 @@ int main(int const argc, char *argv[])
         }
     }
     if (dump_binary_snapshot.has_value()) {
-        if (shard_number >= total_shards) {
-            LOG_ERROR(
-                "shard_number ({}) must be < total_shards ({})",
-                shard_number,
-                total_shards);
-            return 1;
-        }
-
         auto *const context =
             monad_db_snapshot_filesystem_write_user_context_create(
                 dump_binary_snapshot.value().c_str(), resolved_version);
@@ -974,6 +1033,11 @@ int main(int const argc, char *argv[])
             total_shards,
             shard_number,
             use_secondary);
+        // Finalize (flush/close the data files and write the checksums) before
+        // logging success: destroy asserts on a write/checksum failure, so
+        // doing it first keeps a late failure from being preceded by a
+        // success=true log line.
+        monad_db_snapshot_filesystem_write_user_context_destroy(context);
         LOG_INFO(
             "snapshot dump success={} version={} directory={} "
             "dump_from_secondary={} elapsed={}",
@@ -982,7 +1046,6 @@ int main(int const argc, char *argv[])
             dump_binary_snapshot.value(),
             use_secondary,
             std::chrono::steady_clock::now() - begin);
-        monad_db_snapshot_filesystem_write_user_context_destroy(context);
         return success == false;
     }
     else if (load_binary_snapshot.has_value()) {


### PR DESCRIPTION
The filesystem snapshot dumper held one std::ofstream per shard/file open for the whole dump (256 shards x 4 files), overrunning the common 1024 soft RLIMIT_NOFILE part-way through and aborting on a failed ofstream::open with only "failed to open <path>".

- io.cpp: AsyncIO_rlimit_raiser now raises the soft RLIMIT_NOFILE to the hard limit (up to 16384) instead of only warning, and warns with errno on getrlimit/setrlimit failure or when the hard limit is itself too low.
- db_snapshot_filesystem.cpp: open the .blake3 checksum streams lazily at destroy time (halving peak fds); flush and check the data and checksum streams so a truncated dump fails at dump time instead of as a later load-time checksum mismatch; and append strerror(errno) to every open-failure assert (including a previously-unchecked ifstream).
- monad_cli.cpp: pre-flight the open-file limit before opening the db and exit non-zero with a clear message when it cannot fit the dump, deriving the requirement per invocation from --total-shards/--shard-number.

Reported by operators dumping snapshots for the v0.16.0 migration.