### PR TITLE
mpt: bound promote target primary_ring_idx to a valid ring selector

### DIFF
--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -989,6 +989,11 @@ void DbMetadataContext::replay_pending_shrink_grow_()
         do_deactivate_secondary_body_(op_param);
     }
     else if (op_kind == detail::db_metadata::PENDING_OP_PROMOTE) {
+        MONAD_ASSERT_PRINTF(
+            op_param == 0 || op_param == 1,
+            "corrupt db_metadata: pending promote op_param=%u out of range "
+            "(must be 0 or 1)",
+            op_param);
         LOG_INFO(
             "Replaying in-flight promote_secondary_to_primary_header (target "
             "primary_ring_idx = {}) after unclean shutdown",
@@ -1558,6 +1563,10 @@ void DbMetadataContext::deactivate_secondary_header()
 void DbMetadataContext::do_promote_secondary_to_primary_body_(
     uint8_t const target_ring_idx)
 {
+    MONAD_ASSERT_PRINTF(
+        target_ring_idx == 0 || target_ring_idx == 1,
+        "promote target primary_ring_idx=%u must be 0 or 1",
+        static_cast<unsigned>(target_ring_idx));
     for (auto const &copy : copies_) {
         auto *const m = copy.main;
         auto const g = m->hold_dirty();


### PR DESCRIPTION
primary_ring_idx is a binary ring selector (0 = ring_a, 1 = ring_b). Assert it in the two paths that set it from on-disk state:

- do_promote_secondary_to_primary_body_(), the single choke point for both the live promote and crash replay, guards the value it stores.
- the crash-replay PROMOTE branch checks pending op_param before the static_cast<uint8_t> that would otherwise truncate a corrupt value (e.g. 256 -> 0) into a valid-looking selector.

A corrupt/out-of-range value now aborts cleanly instead of silently selecting the wrong ring.