### PR TITLE
async: add MONAD_TMPDIR_FORCE override for working_temporary_directory

### DIFF
--- a/category/async/test/CMakeLists.txt
+++ b/category/async/test/CMakeLists.txt
@@ -50,3 +50,5 @@ endif()
 target_link_libraries(sender_receiver_test PRIVATE Boost::fiber)
 
 add_async_test(TARGET storage_pool_test SOURCES "storage_pool.cpp")
+
+add_async_test(TARGET util_test SOURCES "util.cpp")

--- a/category/async/test/util.cpp
+++ b/category/async/test/util.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "gtest/gtest.h"
+
+#include <category/async/config.hpp>
+#include <category/async/util.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <linux/magic.h> // for TMPFS_MAGIC
+#include <stdlib.h> // for setenv, mkdtemp, mkstemp
+#include <sys/statfs.h> // for statfs
+#include <unistd.h> // for unlink, close
+
+namespace
+{
+    namespace fs = std::filesystem;
+    using MONAD_ASYNC_NAMESPACE::detail::resolve_working_temporary_directory;
+
+    constexpr char const *ENV = "MONAD_TMPDIR_FORCE";
+
+    // Save and restore MONAD_TMPDIR_FORCE around each test so cases are
+    // independent of one another and of the ambient environment.
+    struct WorkingTempDir : public ::testing::Test
+    {
+        std::optional<std::string> saved;
+
+        void SetUp() override
+        {
+            if (char const *const v = ::getenv(ENV); v != nullptr) {
+                saved = v;
+            }
+            ::unsetenv(ENV);
+        }
+
+        void TearDown() override
+        {
+            if (saved.has_value()) {
+                ::setenv(ENV, saved->c_str(), 1);
+            }
+            else {
+                ::unsetenv(ENV);
+            }
+        }
+    };
+
+}
+
+// Deliberately not covered here: the SUID/SGID gate in
+// resolve_working_temporary_directory() (the override is honored only when
+// getuid() == geteuid() && getgid() == getegid()) cannot be exercised without
+// privileges, and an EACCES permission-denied directory is omitted because
+// root -- which CI often runs as -- bypasses permission bits and would make
+// mkstemp succeed, inverting the test.
+
+// A forced directory is returned verbatim, bypassing the O_DIRECT probe.
+TEST_F(WorkingTempDir, ForceHonoredForValidDirectory)
+{
+    std::string templ =
+        (fs::temp_directory_path() / "monad_wtd_XXXXXX").native();
+    char const *const p = ::mkdtemp(templ.data());
+    ASSERT_NE(p, nullptr);
+    fs::path const dir{p};
+    ::setenv(ENV, dir.c_str(), 1);
+    EXPECT_EQ(resolve_working_temporary_directory(), dir);
+    fs::remove_all(dir);
+}
+
+// The forced location is honored even when it is a tmpfs, which the normal
+// search deliberately rejects. This is the whole point of the override.
+TEST_F(WorkingTempDir, ForceHonoredForTmpfs)
+{
+    fs::path const shm{"/dev/shm"};
+    struct statfs s = {};
+    if (::statfs(shm.c_str(), &s) != 0 || s.f_type != TMPFS_MAGIC) {
+        GTEST_SKIP() << "/dev/shm is not a tmpfs on this host";
+    }
+    std::string templ = (shm / "monad_wtd_tmpfs_XXXXXX").native();
+    char const *const p = ::mkdtemp(templ.data());
+    ASSERT_NE(p, nullptr);
+    fs::path const dir{p};
+    ::setenv(ENV, dir.c_str(), 1);
+    EXPECT_EQ(resolve_working_temporary_directory(), dir);
+    fs::remove_all(dir);
+}
+
+// A set-but-nonexistent path throws rather than silently falling through.
+TEST_F(WorkingTempDir, ForceThrowsForNonexistentPath)
+{
+    ::setenv(ENV, "/nonexistent/monad/tmpdir", 1);
+    EXPECT_THROW(resolve_working_temporary_directory(), std::runtime_error);
+}
+
+// A path that exists but is a regular file (not a directory) throws.
+TEST_F(WorkingTempDir, ForceThrowsForRegularFile)
+{
+    std::string templ =
+        (fs::temp_directory_path() / "monad_wtd_file_XXXXXX").native();
+    int const fd = ::mkstemp(templ.data());
+    ASSERT_NE(fd, -1);
+    ::close(fd);
+    ::setenv(ENV, templ.c_str(), 1);
+    EXPECT_THROW(resolve_working_temporary_directory(), std::runtime_error);
+    ::unlink(templ.c_str());
+}
+
+// An empty value is treated as unset: the normal search runs and returns an
+// existing directory.
+TEST_F(WorkingTempDir, EmptyForceIsIgnored)
+{
+    ::setenv(ENV, "", 1);
+    fs::path result;
+    try {
+        result = resolve_working_temporary_directory();
+    }
+    catch (std::runtime_error const &) {
+        GTEST_SKIP() << "host has no O_DIRECT-capable temp dir";
+    }
+    EXPECT_TRUE(fs::is_directory(result)) << result;
+}
+
+// With the override unset, resolution still yields an existing directory.
+TEST_F(WorkingTempDir, UnsetReturnsExistingDirectory)
+{
+    fs::path result;
+    try {
+        result = resolve_working_temporary_directory();
+    }
+    catch (std::runtime_error const &) {
+        GTEST_SKIP() << "host has no O_DIRECT-capable temp dir";
+    }
+    EXPECT_TRUE(fs::is_directory(result)) << result;
+}

--- a/category/async/util.cpp
+++ b/category/async/util.cpp
@@ -40,95 +40,128 @@
 
 MONAD_ASYNC_NAMESPACE_BEGIN
 
-std::filesystem::path const &working_temporary_directory()
+std::filesystem::path detail::resolve_working_temporary_directory()
 {
-    static std::filesystem::path const v = [] {
-        std::filesystem::path ret;
-        auto test_path = [&](std::filesystem::path const &path) -> bool {
-            int fd = ::open(path.c_str(), O_RDWR | O_DIRECT | O_TMPFILE, 0600);
-            if (-1 == fd && ENOTSUP == errno) {
-                auto const path2 = path / "monad_XXXXXX";
-                std::string path2_str = path2.native();
-                fd = mkostemp(path2_str.data(), O_DIRECT);
-                if (-1 != fd) {
-                    unlink(path2_str.c_str());
-                }
-            }
+    std::filesystem::path ret;
+    auto test_path = [&](std::filesystem::path const &path) -> bool {
+        int fd = ::open(path.c_str(), O_RDWR | O_DIRECT | O_TMPFILE, 0600);
+        if (-1 == fd && ENOTSUP == errno) {
+            auto const path2 = path / "monad_XXXXXX";
+            std::string path2_str = path2.native();
+            fd = mkostemp(path2_str.data(), O_DIRECT);
             if (-1 != fd) {
-                struct statfs s = {};
-                if (-1 == fstatfs(fd, &s)) {
-                    ::close(fd);
-                    return false;
-                }
+                unlink(path2_str.c_str());
+            }
+        }
+        if (-1 != fd) {
+            struct statfs s = {};
+            if (-1 == fstatfs(fd, &s)) {
                 ::close(fd);
-                if (s.f_type == TMPFS_MAGIC) {
-                    return false;
-                }
-                ret = path;
-                return true;
+                return false;
             }
-            return false;
-        };
-        // Only observe environment variables if not a SUID or SGID situation
-        // FIXME? Is this actually enough? What about the non-standard saved
-        // uid/gid? Should I be checking if my executable is SUGID and its
-        // owning user is not mine?
-        if (getuid() == geteuid() && getgid() == getegid()) {
-            // Note that XDG_RUNTIME_DIR is the systemd runtime directory for
-            // the current user, usually mounted with tmpfs XDG_CACHE_HOME  is
-            // the systemd cache directory for the current user, usually at
-            // $HOME/.cache
-            static char const *variables[] = {
-                "TMPDIR",
-                "TMP",
-                "TEMP",
-                "TEMPDIR",
-                "XDG_RUNTIME_DIR",
-                "XDG_CACHE_HOME"};
-            for (auto const *const variable : variables) {
-                char const *const env = getenv(variable);
-                if (env != nullptr) {
-                    if (test_path(env)) {
-                        return ret;
-                    }
-                }
+            ::close(fd);
+            if (s.f_type == TMPFS_MAGIC) {
+                return false;
             }
-            // Also try $HOME/.cache
-            char const *const env = getenv("HOME");
+            ret = path;
+            return true;
+        }
+        return false;
+    };
+    // Only observe environment variables if not a SUID or SGID situation
+    // FIXME? Is this actually enough? What about the non-standard saved
+    // uid/gid? Should I be checking if my executable is SUGID and its
+    // owning user is not mine?
+    if (getuid() == geteuid() && getgid() == getegid()) {
+        // Explicit override for callers that do not require O_DIRECT
+        // (e.g. tests and fuzzers): if MONAD_TMPDIR_FORCE names a writable
+        // directory, use it verbatim, skipping the O_DIRECT probe and the
+        // tmpfs rejection that the normal search below performs. This lets
+        // such callers place their working files on a RAM-backed tmpfs (e.g.
+        // /dev/shm) to avoid SSD wear. Gated behind the same non-SUID/SGID
+        // check as the other environment variables so a setuid binary never
+        // trusts it. A value naming a directory that cannot be used throws,
+        // rather than silently falling through to a disk-backed location; an
+        // empty value is treated as unset.
+        if (char const *const forced = getenv("MONAD_TMPDIR_FORCE");
+            forced != nullptr && forced[0] != '\0') {
+            std::filesystem::path const path{forced};
+            auto const probe = path / "monad_XXXXXX";
+            std::string probe_str = probe.native();
+            int const fd = mkstemp(probe_str.data());
+            if (fd == -1) {
+                int const err = errno;
+                throw std::runtime_error(
+                    std::string{"MONAD_TMPDIR_FORCE is set to '"} + forced +
+                    "' which could not be used as a working temporary "
+                    "directory: " +
+                    strerror(err));
+            }
+            unlink(probe_str.c_str());
+            ::close(fd);
+            ret = path;
+            return ret;
+        }
+        // Note that XDG_RUNTIME_DIR is the systemd runtime directory for
+        // the current user, usually mounted with tmpfs XDG_CACHE_HOME  is
+        // the systemd cache directory for the current user, usually at
+        // $HOME/.cache
+        static char const *variables[] = {
+            "TMPDIR",
+            "TMP",
+            "TEMP",
+            "TEMPDIR",
+            "XDG_RUNTIME_DIR",
+            "XDG_CACHE_HOME"};
+        for (auto const *const variable : variables) {
+            char const *const env = getenv(variable);
             if (env != nullptr) {
-                std::filesystem::path buffer(env);
-                buffer /= ".cache";
-                if (test_path(buffer)) {
+                if (test_path(env)) {
                     return ret;
                 }
             }
         }
-        // TODO: Use getpwent_r() to extract current effective user home
-        // directory Hardcoded fallbacks in case environment is not available to
-        // us
-        if (test_path("/tmp")) {
-            return ret;
+        // Also try $HOME/.cache
+        char const *const env = getenv("HOME");
+        if (env != nullptr) {
+            std::filesystem::path buffer(env);
+            buffer /= ".cache";
+            if (test_path(buffer)) {
+                return ret;
+            }
         }
-        if (test_path("/var/tmp")) {
-            return ret;
-        }
-        if (test_path("/run/user/" + std::to_string(geteuid()))) {
-            return ret;
-        }
-        // Some systems with no writable hardcode fallbacks may have shared
-        // memory configured
-        if (test_path("/run/shm")) {
-            return ret;
-        }
-        // On some Docker images this is the only writable path anywhere
-        if (test_path("/")) {
-            return ret;
-        }
-        throw std::runtime_error(
-            "This system appears to have no writable temporary files location, "
-            "please set one using any of the usual environment variables e.g. "
-            "TMPDIR");
-    }();
+    }
+    // TODO: Use getpwent_r() to extract current effective user home
+    // directory Hardcoded fallbacks in case environment is not available to
+    // us
+    if (test_path("/tmp")) {
+        return ret;
+    }
+    if (test_path("/var/tmp")) {
+        return ret;
+    }
+    if (test_path("/run/user/" + std::to_string(geteuid()))) {
+        return ret;
+    }
+    // Some systems with no writable hardcode fallbacks may have shared
+    // memory configured
+    if (test_path("/run/shm")) {
+        return ret;
+    }
+    // On some Docker images this is the only writable path anywhere
+    if (test_path("/")) {
+        return ret;
+    }
+    throw std::runtime_error(
+        "This system appears to have no writable temporary files location, "
+        "please set one using any of the usual environment variables e.g. "
+        "TMPDIR");
+}
+
+std::filesystem::path const &working_temporary_directory()
+{
+    static std::filesystem::path const v =
+        detail::resolve_working_temporary_directory();
     return v;
 }
 

--- a/category/async/util.hpp
+++ b/category/async/util.hpp
@@ -58,7 +58,24 @@ inline constexpr chunk_offset_t round_down_align(chunk_offset_t x) noexcept
     return x;
 }
 
-//! Returns a temporary directory in which `O_DIRECT` files definitely work
+namespace detail
+{
+    //! Uncached resolution of the working temporary directory: the
+    //! implementation behind working_temporary_directory(), split out so tests
+    //! can exercise it repeatedly under different MONAD_TMPDIR_FORCE settings
+    //! (the public entry point memoises its result in a function-local static).
+    extern std::filesystem::path resolve_working_temporary_directory();
+}
+
+//! Returns a temporary directory in which `O_DIRECT` files work by default
+//! (unless overridden; see `MONAD_TMPDIR_FORCE` below).
+//!
+//! Set the `MONAD_TMPDIR_FORCE` environment variable to override the search
+//! with an explicit directory, skipping the `O_DIRECT` probe and the tmpfs
+//! rejection. Intended for callers that do not require `O_DIRECT` (e.g. tests
+//! and fuzzers) so their working files can live on a RAM-backed tmpfs such as
+//! `/dev/shm`. Ignored for setuid/setgid processes; a set-but-unusable value
+//! throws.
 extern std::filesystem::path const &working_temporary_directory();
 
 //! Creates already deleted file so no need to clean it up


### PR DESCRIPTION
working_temporary_directory() searches for a temp dir where O_DIRECT works and rejects tmpfs. Callers that do not need O_DIRECT (tests, fuzzers) sometimes want their working files on a RAM-backed tmpfs such as /dev/shm to avoid SSD wear. Add a MONAD_TMPDIR_FORCE environment variable that, when set to a writable directory, is used verbatim, skipping the O_DIRECT probe and the tmpfs rejection. A set-but-unusable value throws rather than silently falling through to a disk-backed location. Gated behind the existing non-SUID/SGID check so a setuid binary never trusts it.

Split resolution into an uncached
detail::resolve_working_temporary_directory() so it can be unit-tested under different environment settings; the public entry point keeps its function-local static cache.