### PR TITLE
test/ethereum_test: add MONAD_NEXT Amsterdam spec-test job

### DIFF
--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -35,6 +35,16 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON)
 
+ExternalProject_Add(
+  MonadAmsterdamSpecTestFixtures
+  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad_amsterdam@v0.2.0/fixtures_monad_amsterdam.tar.gz"
+  URL_HASH "SHA256=20b2a55f49a4b777f1abc6c196dc0afad22475b0ac598a39cc94fc598e22619d"
+  PREFIX ${CMAKE_BINARY_DIR}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD ON)
+
 add_executable(monad-ethereum-test)
 target_link_libraries(monad-ethereum-test PRIVATE GTest::gtest monad-test-utils)
 target_sources(
@@ -100,6 +110,23 @@ endfunction()
 add_monad_test(FORK MONAD_EIGHT)
 add_monad_test(FORK MONAD_NINE)
 add_monad_test(FORK MONAD_NEXT)
+
+# MONAD_NEXT Amsterdam spec tests, from a separate fixtures release. While the
+# whole suite is excluded (see the exclusion file), the runner exits non-zero
+# via its "No tests were run" guard, so the job is marked WILL_FAIL to keep
+# ctest green. WILL_FAIL is set only while the suite is fully excluded: once
+# individual tests are re-enabled by dropping entries from the exclusion list,
+# the job runs normally so real failures (and unexpected passes) surface.
+include(${CMAKE_CURRENT_SOURCE_DIR}/exclude/MONAD_NEXT_amsterdam.cmake)
+list(JOIN MONAD_NEXT_amsterdam_excluded_tests ":" TESTS_EXCLUDED)
+add_test(NAME MONAD_NEXT_amsterdam_monad_ethereum_test
+         COMMAND monad-ethereum-test --fork MONAD_NEXT
+                 --blockchain-tests ${CMAKE_BINARY_DIR}/src/MonadAmsterdamSpecTestFixtures/blockchain_tests
+                 --gtest_filter=-:${TESTS_EXCLUDED})
+if(MONAD_NEXT_amsterdam_excluded_tests STREQUAL "BlockchainTests.*")
+  set_tests_properties(MONAD_NEXT_amsterdam_monad_ethereum_test
+                       PROPERTIES WILL_FAIL TRUE)
+endif()
 
 add_ethereum_test(FORK istanbul)
 add_ethereum_test(FORK berlin)

--- a/test/ethereum_test/exclude/MONAD_NEXT_amsterdam.cmake
+++ b/test/ethereum_test/exclude/MONAD_NEXT_amsterdam.cmake
@@ -1,0 +1,21 @@
+# Copyright (C) 2025-26 Category Labs, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# The MONAD_NEXT Amsterdam spec-test fixtures (EIP-7708, EIP-7843, EIP-8024)
+# expect a block header carrying the SLOTNUM field, which the execution layer
+# does not yet emit; every fixture therefore fails the genesis block-hash
+# check. Exclude the whole suite for now and drop entries here to re-enable
+# individual tests as support lands.
+set(MONAD_NEXT_amsterdam_excluded_tests "BlockchainTests.*")


### PR DESCRIPTION
## Summary

Adds the [`tests-monad_amsterdam@v0.2.0`](https://github.com/monad-developers/execution-specs/releases/tag/tests-monad_amsterdam%40v0.2.0) spec-test fixtures to the build and registers a `MONAD_NEXT` ctest job, mirroring the existing `add_monad_test` machinery.

Tracked by [EXE-66](https://linear.app/category-labs/issue/EXE-66).

The fixtures cover three Glamsterdam EIPs, filled for `MONAD_NEXT` (chain-id 143):
- **EIP-7708** — ETH transfers emit a log
- **EIP-7843** — SLOTNUM opcode
- **EIP-8024** — backward-compatible DUPN / SWAPN / EXCHANGE

## Current status: fully excluded (intentional)

All 98 fixtures currently fail at the genesis block-hash check (`test/utils/json_state.cpp:63`) because their block-header RLP carries the EIP-7843 `slotNumber` field (22-field header) while the execution layer still emits the 21-field Osaka header. The failure is at header encoding — before any opcode logic runs.

Until the header codec emits `slotNumber`, the whole suite is excluded via `exclude/MONAD_NEXT_amsterdam.cmake`. Excluding every test trips the runner's "No tests were run" guard (non-zero exit), so the ctest job is marked `WILL_FAIL` to stay green while fully excluded. As tests are enabled (drop entries from the exclusion file), the `WILL_FAIL` marker should be removed.

## Notes

- The fixtures do **not** include an EIP-7928 (Block-Level Access List) header field — only `slotNumber` — consistent with Monad not implementing BALs.
- Draft / scaffolding only: no execution behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMhD4GzGDvvAmLQzybR2rE