### PR TITLE
Build cleanly under clang with libstdc++-16

### DIFF
--- a/category/core/detail/start_lifetime_as_polyfill.hpp
+++ b/category/core/detail/start_lifetime_as_polyfill.hpp
@@ -18,6 +18,7 @@
 #include <category/core/config.hpp>
 
 #include <cstddef>
+#include <version>
 
 #ifndef MONAD_USE_STD_START_LIFETIME_AS
     #if __cpp_lib_start_lifetime_as >= 202207L

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -511,21 +511,21 @@ size_t DbMetadataContext::map_bytes_per_chunk_() const noexcept
 
 uint64_t DbMetadataContext::get_latest_finalized_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t const>(
+    return start_lifetime_as<std::atomic_uint64_t>(
                &copies_[0].main->latest_finalized_version)
         ->load(std::memory_order_acquire);
 }
 
 uint64_t DbMetadataContext::get_latest_verified_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t const>(
+    return start_lifetime_as<std::atomic_uint64_t>(
                &copies_[0].main->latest_verified_version)
         ->load(std::memory_order_acquire);
 }
 
 uint64_t DbMetadataContext::get_latest_voted_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t const>(
+    return start_lifetime_as<std::atomic_uint64_t>(
                &copies_[0].main->latest_voted_version)
         ->load(std::memory_order_acquire);
 }
@@ -537,7 +537,7 @@ bytes32_t DbMetadataContext::get_latest_voted_block_id() const noexcept
 
 uint64_t DbMetadataContext::get_latest_proposed_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t const>(
+    return start_lifetime_as<std::atomic_uint64_t>(
                &copies_[0].main->latest_proposed_version)
         ->load(std::memory_order_acquire);
 }
@@ -558,7 +558,7 @@ int64_t DbMetadataContext::get_auto_expire_version_metadata(
     auto const *const slot =
         (ring_idx == 0) ? &m->root_offsets_state.auto_expire_version_
                         : &m->secondary_timeline_state.auto_expire_version_;
-    return start_lifetime_as<std::atomic_int64_t const>(slot)->load(
+    return start_lifetime_as<std::atomic_int64_t>(slot)->load(
         std::memory_order_acquire);
 }
 
@@ -641,7 +641,7 @@ DbMetadataContext::get_state_machine_kind(timeline_id const tid) const noexcept
     auto const *const slot =
         (ring_idx == 0) ? &m->root_offsets_state.state_machine_kind_
                         : &m->secondary_timeline_state.state_machine_kind_;
-    auto const raw = start_lifetime_as<std::atomic_uint8_t const>(slot)->load(
+    auto const raw = start_lifetime_as<std::atomic_uint8_t>(slot)->load(
         std::memory_order_acquire);
     return static_cast<state_machine_kind>(raw);
 }
@@ -769,7 +769,7 @@ uint64_t DbMetadataContext::version_history_max_possible() const noexcept
 
 uint64_t DbMetadataContext::version_history_length() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t const>(
+    return start_lifetime_as<std::atomic_uint64_t>(
                &copies_[0].main->history_length)
         ->load(std::memory_order_relaxed);
 }
@@ -797,7 +797,7 @@ bool DbMetadataContext::timeline_active(timeline_id const tid) const noexcept
     if (tid == timeline_id::primary) {
         return true;
     }
-    return start_lifetime_as<std::atomic<uint8_t> const>(
+    return start_lifetime_as<std::atomic<uint8_t>>(
                &copies_[0].main->secondary_timeline_active_)
                ->load(std::memory_order_acquire) != 0;
 }
@@ -1205,10 +1205,10 @@ void DbMetadataContext::do_activate_secondary_body_(uint32_t const new_chunks)
         //    capacity excludes older versions (idempotent: std::max is a
         //    fixed point under repeated application).
         uint64_t const nv =
-            start_lifetime_as<std::atomic_uint64_t const>(pver_nv)->load(
+            start_lifetime_as<std::atomic_uint64_t>(pver_nv)->load(
                 std::memory_order_acquire);
         uint64_t const cur_lb =
-            start_lifetime_as<std::atomic_uint64_t const>(pver_lb)->load(
+            start_lifetime_as<std::atomic_uint64_t>(pver_lb)->load(
                 std::memory_order_acquire);
         uint64_t const new_lb =
             std::max(cur_lb, (nv >= new_cap) ? (nv - new_cap) : uint64_t{0});
@@ -1488,10 +1488,10 @@ void DbMetadataContext::do_deactivate_secondary_body_(
                 0xff,
                 tail_bytes);
             uint64_t const nv =
-                start_lifetime_as<std::atomic_uint64_t const>(pver_nv)->load(
+                start_lifetime_as<std::atomic_uint64_t>(pver_nv)->load(
                     std::memory_order_acquire);
             uint64_t const lb =
-                start_lifetime_as<std::atomic_uint64_t const>(pver_lb)->load(
+                start_lifetime_as<std::atomic_uint64_t>(pver_lb)->load(
                     std::memory_order_acquire);
             if (nv != lb) {
                 for (uint64_t v = lb; v < nv; v++) {

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -149,7 +149,7 @@ public:
         chunk_offset_t operator[](size_t const i) const noexcept
         {
             MONAD_ASSERT(capacity_ != 0);
-            return start_lifetime_as<std::atomic<chunk_offset_t> const>(
+            return start_lifetime_as<std::atomic<chunk_offset_t>>(
                        &root_offsets_chunks_[i & (capacity_ - 1)])
                 ->load(std::memory_order_acquire);
         }
@@ -242,7 +242,7 @@ public:
     // naturally with a promote flip done under release.
     uint8_t primary_ring_idx() const noexcept
     {
-        return start_lifetime_as<std::atomic<uint8_t> const>(
+        return start_lifetime_as<std::atomic<uint8_t>>(
                    &copies_[0].main->primary_ring_idx)
             ->load(std::memory_order_acquire);
     }
@@ -535,7 +535,7 @@ private:
                 m->main->root_offsets.version_lower_bound_,
                 m->main->root_offsets.next_version_,
                 m->ring_a_span,
-                start_lifetime_as<std::atomic<uint32_t> const>(
+                start_lifetime_as<std::atomic<uint32_t>>(
                     &m->main->root_offsets.storage_.cnv_chunks_len)
                         ->load(std::memory_order_acquire) *
                     entries_per_chunk};
@@ -544,7 +544,7 @@ private:
             m->main->secondary_timeline.version_lower_bound_,
             m->main->secondary_timeline.next_version_,
             m->ring_b_span,
-            start_lifetime_as<std::atomic<uint32_t> const>(
+            start_lifetime_as<std::atomic<uint32_t>>(
                 &m->main->secondary_timeline.storage_.cnv_chunks_len)
                     ->load(std::memory_order_acquire) *
                 entries_per_chunk};

--- a/category/mpt/nibbles_view.hpp
+++ b/category/mpt/nibbles_view.hpp
@@ -21,6 +21,8 @@
 #include <category/core/nibble.h>
 #include <category/mpt/config.hpp>
 
+#include <algorithm>
+#include <compare>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -34,6 +36,10 @@ MONAD_MPT_NAMESPACE_BEGIN
 
 class NibblesView;
 class Node;
+
+constexpr bool operator==(NibblesView const &a, NibblesView const &b);
+constexpr std::strong_ordering
+operator<=>(NibblesView const &a, NibblesView const &b);
 
 class Nibbles
 {
@@ -120,9 +126,6 @@ public:
     // at `pos` and up to `count` nibbles (or to the end if count == npos).
     // The returned Nibbles is always left-aligned (begin_nibble_ == 0).
     inline constexpr Nibbles substr(unsigned pos, unsigned count = npos) const;
-
-    inline constexpr bool operator==(NibblesView const &other) const;
-    inline constexpr auto operator<=>(NibblesView const &other) const;
 
     [[nodiscard]] unsigned char get(unsigned const i) const
     {
@@ -256,37 +259,6 @@ public:
         return substr(0, other.nibble_size()) == other;
     }
 
-    constexpr bool operator==(NibblesView const &other) const
-    {
-        if (this == &other) {
-            return true;
-        }
-
-        if (nibble_size() != other.nibble_size()) {
-            return false;
-        }
-
-        if (nibble_size()) {
-            for (auto i = 0u; i < nibble_size(); ++i) {
-                if (get(i) != other.get(i)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    constexpr auto operator<=>(NibblesView const &other) const
-    {
-        unsigned const min_size = std::min(nibble_size(), other.nibble_size());
-        for (unsigned i = 0; i < min_size; ++i) {
-            if (get(i) != other.get(i)) {
-                return get(i) <=> other.get(i);
-            }
-        }
-        return nibble_size() <=> other.nibble_size();
-    }
-
     [[nodiscard]] unsigned char get(unsigned const i) const
     {
         MONAD_ASSERT(i < nibble_size());
@@ -308,14 +280,32 @@ inline Nibbles::Nibbles(NibblesView const nibbles)
     }
 }
 
-inline constexpr bool Nibbles::operator==(NibblesView const &other) const
+constexpr bool operator==(NibblesView const &a, NibblesView const &b)
 {
-    return NibblesView(*this) == other;
+    if (&a == &b) {
+        return true;
+    }
+    if (a.nibble_size() != b.nibble_size()) {
+        return false;
+    }
+    for (auto i = 0u; i < a.nibble_size(); ++i) {
+        if (a.get(i) != b.get(i)) {
+            return false;
+        }
+    }
+    return true;
 }
 
-inline constexpr auto Nibbles::operator<=>(NibblesView const &other) const
+constexpr std::strong_ordering
+operator<=>(NibblesView const &a, NibblesView const &b)
 {
-    return NibblesView(*this) <=> other;
+    unsigned const min_size = std::min(a.nibble_size(), b.nibble_size());
+    for (unsigned i = 0; i < min_size; ++i) {
+        if (a.get(i) != b.get(i)) {
+            return a.get(i) <=> b.get(i);
+        }
+    }
+    return a.nibble_size() <=> b.nibble_size();
 }
 
 template <class... Args>


### PR DESCRIPTION
## Summary

Makes the C++ execution layer build cleanly under **clang against gcc-16's libstdc++**. clang (both 19 and 21) auto-selects the newest installed GCC for its standard library; once a box has gcc-16, clang compiles monad against libstdc++-16 and hits three independent incompatibilities. **gcc-15 g++ builds are unaffected** by these changes.

Motivated by dev boxes drifting onto gcc-16 (unattended `apt upgrade`), and by the question of whether clang-21 / gcc-16 can be a standard toolchain.

## The three fixes

1. **`start_lifetime_as_polyfill.hpp`** — add `#include <version>`. The polyfill queried `__cpp_lib_start_lifetime_as` without the header that defines it, so the macro read as undefined and the polyfill always defined its own `monad::start_lifetime_as`. That then collided (via ADL on `std::byte`/`std::atomic` pointer args) with libstdc++'s `std::start_lifetime_as` → ambiguous call. Including `<version>` routes to `std::` as a single entity.

2. **`db_metadata_context.{hpp,cpp}`** — drop the redundant `const` from `start_lifetime_as<std::atomic<X> const>(...)` template args (16 sites). A const `_Tp` selects libstdc++'s plain `void*` overload, whose inline-asm barrier writes to a const lvalue (`"=m" (*__q)`) — clang rejects this as *invalid lvalue in asm output* (the cv-qualified overloads guard it; the `void*` one doesn't — likely an unreported libstdc++ oversight). Every touched site immediately `->load()`, so the view is read-only either way.

3. **`nibbles_view.hpp`** — replace the member `Nibbles`/`NibblesView` comparison operators with **two namespace-scope free operators** (`==` and `<=>`) taking `NibblesView`; `Nibbles` compares via its implicit conversion to `NibblesView`. The member operators were heterogeneous (took `NibblesView`) and, combined with the bidirectional `Nibbles`↔`NibblesView` conversion, made `Nibbles`-vs-`Nibbles` comparison ambiguous under C++20's reversed-candidate rules (surfaced by libstdc++-16's `std::sort` / `std::less<void>`; clang enforces it strictly, gcc doesn't). Free functions (not members or hidden friends of `NibblesView`) so ADL finds them for `Nibbles`-vs-`Nibbles` too. Net −17 lines vs. the previous six operators.

## Verification

| | gcc-15 | clang-19 + gcc-16 |
|---|---|---|
| Full build | ✅ 0 errors | ✅ 0 errors |
| trie / nibbles / metadata tests | ✅ 268/268 | ✅ 268/268 |

The clang+gcc-16 run exercises the real `std::start_lifetime_as` path (gcc-15 uses the reinterpret_cast polyfill), so both code paths are covered. A SFINAE surface probe confirms the operator refactor does **not** widen the set of compilable cross-type comparisons (`Nibbles`/`NibblesView`/`hash256`/`byte_string`) — it's identical to the member-based design.

Rebased on current `main`.

## Draft — remaining before ready

- [ ] full `ctest` suite (only the trie/nibbles/metadata subset was run)
- [x] `clang-tidy` lint + trait-instantiation check
- [ ] decide whether to add **CI coverage for the clang + gcc-16 combo** — without it, this combination will drift back out of compatibility as libstdc++ evolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNPadqL11qvvWevL5innZw
