### PR TITLE
[mpt] Trim both timelines in tandem in dynamic history length adjustment

### DIFF
--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <category/async/util.hpp>
+#include <category/core/assert.h>
 
 #include <category/core/detail/start_lifetime_as_polyfill.hpp>
 
@@ -312,6 +313,8 @@ public:
     //! \brief Flags for storage pool creation
     struct creation_flags
     {
+        static constexpr uint32_t MAX_CHUNK_CAPACITY_BITS = (1 << 5) - 1;
+
         //! How much to shift left a bit to set chunk capacity during creation.
         //! The maximum is 32 (4Gb).
         uint32_t chunk_capacity : 5;
@@ -345,6 +348,14 @@ public:
             , allow_migration(false)
             , num_cnv_chunks(3)
         {
+        }
+
+        //! Set chunk_capacity with range validation; direct assignment to
+        //! the 5-bit field would silently truncate an oversized value.
+        constexpr void set_chunk_capacity(uint32_t const bits)
+        {
+            MONAD_ASSERT(bits <= MAX_CHUNK_CAPACITY_BITS);
+            chunk_capacity = bits & MAX_CHUNK_CAPACITY_BITS;
         }
     };
 

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -1682,7 +1682,7 @@ opened.
 
             auto mode =
                 MONAD_ASYNC_NAMESPACE::storage_pool::mode::open_existing;
-            impl.flags.chunk_capacity = impl.chunk_capacity & 31;
+            impl.flags.set_chunk_capacity(impl.chunk_capacity);
             if (impl.create_chunk_increasing) {
                 impl.flags.interleave_chunks_evenly = true;
             }

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -130,6 +130,7 @@ AsyncIOContext::AsyncIOContext(OnDiskDbConfig const &options)
     : pool{[&] -> async::storage_pool {
         async::storage_pool::creation_flags pool_options;
         pool_options.num_cnv_chunks = options.root_offsets_chunk_count + 1;
+        pool_options.set_chunk_capacity(options.chunk_capacity);
         auto const len = options.file_size_db * 1024 * 1024 * 1024 + 24576;
         if (options.dbname_paths.empty()) {
             return async::storage_pool{

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -672,6 +672,16 @@ void DbMetadataContext::update_history_length_metadata(
         auto const g = m->hold_dirty();
         auto const ro = root_offsets(which);
         MONAD_ASSERT(history_len > 0 && history_len <= ro.capacity());
+        // history_length is a single parameter governing both timelines.
+        // Checking against the primary ring's capacity suffices because
+        // activation splits the cnv chunks evenly, giving both rings the
+        // same capacity; assert that invariant so a future uneven split
+        // cannot silently let history_len exceed the secondary's capacity.
+        if (timeline_active(timeline_id::secondary)) {
+            MONAD_ASSERT(
+                root_offsets(timeline_id::secondary, which).capacity() ==
+                ro.capacity());
+        }
         reinterpret_cast<std::atomic_uint64_t *>(&m->history_length)
             ->store(history_len, std::memory_order_relaxed);
     };

--- a/category/mpt/ondisk_db_config.hpp
+++ b/category/mpt/ondisk_db_config.hpp
@@ -49,6 +49,10 @@ struct OnDiskDbConfig
     // deactivation the chunks are returned to the primary. Must be a power
     // of 2. Each chunk can hold 1 << 24 = 16777216 historical entries.
     uint32_t root_offsets_chunk_count{2};
+    // Storage chunk capacity as a power of two (1 << n bytes). Only applied
+    // when the pool is created. Smaller chunks give tests finer disk-usage
+    // granularity on small db files.
+    uint32_t chunk_capacity{28};
 };
 
 struct ReadOnlyOnDiskDbConfig

--- a/category/mpt/test/db_test.cpp
+++ b/category/mpt/test/db_test.cpp
@@ -946,6 +946,92 @@ TEST(DbTest, history_length_adjustment_reclaims_with_active_secondary)
     remove(dbname);
 }
 
+TEST(DbTest, history_length_adjustment_trims_both_timelines)
+{
+    // The secondary dual-writes every version the primary writes, as in
+    // production. Under disk pressure the controller must trim both
+    // timelines in tandem: trimming only the primary frees nothing (the
+    // secondary pins the GC boundary) and history collapses to
+    // MIN_HISTORY_LENGTH.
+    //
+    // Sizing: small chunks give fine disk-usage granularity, and small
+    // writes on a 2 GB file put the 0.8 trigger past the ~5000 versions
+    // fast compaction needs before it starts advancing the roots' compact
+    // offsets, without which erased versions reclaim nothing.
+    auto const dbname = create_temp_file(1);
+    OnDiskDbConfig const config{
+        .compaction = true,
+        .sq_thread_cpu{std::nullopt},
+        .dbname_paths = {dbname},
+        .chunk_capacity = 23}; // 8 MiB chunks, the smallest AsyncIO accepts
+    Db db{std::make_unique<StateMachineAlwaysEmpty>(), config};
+
+    constexpr unsigned nkeys = 25;
+    monad::byte_string const value(2 * 1024, 0xf);
+
+    auto batch_upsert = [&](Db &target,
+                            Node::SharedPtr &root,
+                            uint64_t const version,
+                            size_t const salt) {
+        UpdateList ls;
+        std::deque<monad::byte_string> bytes_alloc;
+        std::deque<Update> updates_alloc;
+        for (size_t i = 0; i < nkeys; ++i) {
+            ls.push_front(updates_alloc.emplace_back(Update{
+                .key = bytes_alloc.emplace_back(keccak_int_to_string(salt + i)),
+                .value = value,
+                .incarnation = false,
+                .next = UpdateList{}}));
+        }
+        root = target.upsert(std::move(root), std::move(ls), version);
+    };
+
+    Node::SharedPtr primary_root{};
+    uint64_t version = 0;
+    for (; version < 5; ++version) {
+        batch_upsert(db, primary_root, version, 0);
+    }
+
+    uint64_t const activation_version = version;
+    uint64_t const version_cap = version + 100000;
+    {
+        Db secondary_db = db.activate_secondary_timeline(
+            std::make_unique<StateMachineAlwaysEmpty>());
+        Node::SharedPtr secondary_root{};
+
+        uint64_t const start_history = db.get_history_length();
+        while (db.get_history_length() == start_history &&
+               version < version_cap) {
+            batch_upsert(secondary_db, secondary_root, version, 0xD00D0000);
+            batch_upsert(db, primary_root, version, 0);
+            ++version;
+        }
+        ASSERT_LT(db.get_history_length(), start_history)
+            << "controller never shrank history under disk pressure";
+        // Both timelines were trimmed, so the minimal cut relieves pressure
+        // without collapsing to the floor. The one-sided trim made every
+        // candidate look unreclaimable and slammed history to
+        // MIN_HISTORY_LENGTH here.
+        EXPECT_GT(db.get_history_length(), MIN_HISTORY_LENGTH);
+        // The secondary was trimmed in tandem with the primary; a one-sided
+        // trim leaves its min valid version pinned at activation.
+        auto const &meta = test::DbAccessor::aux(db).metadata_ctx();
+        EXPECT_GT(
+            meta.db_history_min_valid_version(timeline_id::secondary),
+            activation_version);
+        // Auto-expire advances up to 2 versions per upsert and the primary
+        // upserts last in the loop, so the two can skew by an expire step.
+        auto const primary_min =
+            meta.db_history_min_valid_version(timeline_id::primary);
+        auto const secondary_min =
+            meta.db_history_min_valid_version(timeline_id::secondary);
+        EXPECT_GE(primary_min, secondary_min);
+        EXPECT_LE(primary_min - secondary_min, 2);
+    }
+    db.deactivate_secondary_timeline();
+    remove(dbname);
+}
+
 TEST_F(OnDiskDbWithFileFixture, read_only_db_traverse_as_version_expire)
 {
     struct TraverseMachinePruneHistory final : public TraverseMachine

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -190,6 +190,11 @@ class UpdateAux
     double
     calculate_disk_usage_if_erased_up_to_and_including(uint64_t version) const;
 
+    // Version up to which timeline tid is erased when history is trimmed to
+    // version_to_erase, clamped to keep the timeline's newest version.
+    // Returns INVALID_BLOCK_NUM when the timeline holds nothing to trim.
+    uint64_t erase_boundary(uint64_t version_to_erase, timeline_id tid) const;
+
     /* Calculate the version up to which the database will automatically expire
     entries (referred to as "auto_expire" in code names).
 

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -669,43 +669,58 @@ void UpdateAux::erase_versions_up_to_and_including(
     release_unreferenced_chunks();
 }
 
+uint64_t UpdateAux::erase_boundary(
+    uint64_t const version_to_erase, timeline_id const tid) const
+{
+    // Clamp so a timeline's newest version is never erased (a wipe would
+    // break promotion/deactivation). For the primary the clamp is inert:
+    // the caller bounds version_to_erase at MIN_HISTORY_LENGTH below the
+    // primary max. For the secondary it only bites if the timeline lags
+    // behind version_to_erase.
+    if (!metadata_ctx_->timeline_active(tid)) {
+        return INVALID_BLOCK_NUM;
+    }
+    auto const tl_max = metadata_ctx_->db_history_max_version(tid);
+    if (tl_max == INVALID_BLOCK_NUM || tl_max == 0) {
+        return INVALID_BLOCK_NUM;
+    }
+    return std::min(version_to_erase, tl_max - 1);
+}
+
 double UpdateAux::calculate_disk_usage_if_erased_up_to_and_including(
     uint64_t const version_to_erase) const
 {
     MONAD_ASSERT(is_on_disk());
     MONAD_ASSERT(metadata_ctx_->db_history_max_version() != INVALID_BLOCK_NUM);
-    uint64_t min_version_post_erase = version_to_erase + 1;
-    MONAD_ASSERT(
-        min_version_post_erase < metadata_ctx_->db_history_max_version(),
-        "Must have at least one valid version left after erase.");
-    while (!metadata_ctx_->version_is_valid_ondisk(min_version_post_erase)) {
-        min_version_post_erase++;
-    }
-    auto const min_valid_root_post_erase = read_node_blocking(
-        *this,
-        metadata_ctx_->get_root_offset_at_version(min_version_post_erase),
-        min_version_post_erase,
-        timeline_id::primary);
-    auto min_offsets =
-        compact_offset_pair::deserialize(min_valid_root_post_erase->value());
-    // Controller trims only the primary, but an active secondary still pins its
-    // oldest root; fold it in or the prediction over-estimates reclaim.
-    if (metadata_ctx_->timeline_active(timeline_id::secondary)) {
-        auto const sec_min =
-            metadata_ctx_->db_history_min_valid_version(timeline_id::secondary);
-        if (sec_min != INVALID_BLOCK_NUM) {
-            auto const sec_root = read_node_blocking(
-                *this,
-                metadata_ctx_->get_root_offset_at_version(
-                    sec_min, timeline_id::secondary),
-                sec_min,
-                timeline_id::secondary);
-            auto const sec_offsets =
-                compact_offset_pair::deserialize(sec_root->value());
-            min_offsets.fast = std::min(min_offsets.fast, sec_offsets.fast);
-            min_offsets.slow = std::min(min_offsets.slow, sec_offsets.slow);
+
+    // The controller erases both timelines in tandem to the same boundary,
+    // so the predicted GC boundary is the component-wise min over all
+    // active timelines of the oldest root surviving that timeline's erase.
+    compact_offset_pair min_offsets{
+        INVALID_COMPACT_VIRTUAL_OFFSET, INVALID_COMPACT_VIRTUAL_OFFSET};
+    for (auto const tid : {timeline_id::primary, timeline_id::secondary}) {
+        auto const erase_up_to = erase_boundary(version_to_erase, tid);
+        if (erase_up_to == INVALID_BLOCK_NUM) {
+            // timeline inactive or holds no version
+            continue;
         }
+        auto const tl_max = metadata_ctx_->db_history_max_version(tid);
+        uint64_t v = erase_up_to + 1;
+        while (v <= tl_max && !metadata_ctx_->version_is_valid_ondisk(v, tid)) {
+            v++;
+        }
+        if (v > tl_max) {
+            continue;
+        }
+        auto const root = read_node_blocking(
+            *this, metadata_ctx_->get_root_offset_at_version(v, tid), v, tid);
+        MONAD_ASSERT(root && root->has_value());
+        auto const offsets = compact_offset_pair::deserialize(root->value());
+        min_offsets.fast = std::min(min_offsets.fast, offsets.fast);
+        min_offsets.slow = std::min(min_offsets.slow, offsets.slow);
     }
+    // The primary always contributes: the caller bounds version_to_erase by
+    // MIN_HISTORY_LENGTH below the primary max, so a valid version survives.
     MONAD_ASSERT(
         min_offsets.fast != INVALID_COMPACT_VIRTUAL_OFFSET &&
         min_offsets.slow != INVALID_COMPACT_VIRTUAL_OFFSET);
@@ -761,8 +776,14 @@ void UpdateAux::adjust_history_length_based_on_disk_usage()
                 best_version_to_erase = *it;
             }
         }
-        erase_versions_up_to_and_including(
-            best_version_to_erase, timeline_id::primary);
+        // Trim both timelines in tandem so the reclaim matches the
+        // prediction; per-timeline boundaries keep each newest version.
+        for (auto const tid : {timeline_id::primary, timeline_id::secondary}) {
+            auto const erase_up_to = erase_boundary(best_version_to_erase, tid);
+            if (erase_up_to != INVALID_BLOCK_NUM) {
+                erase_versions_up_to_and_including(erase_up_to, tid);
+            }
+        }
         metadata_ctx_->update_history_length_metadata(
             std::max(max_version - best_version_to_erase, MIN_HISTORY_LENGTH));
         MONAD_ASSERT(


### PR DESCRIPTION
## Problem

With a secondary timeline active, `adjust_history_length_based_on_disk_usage()` always collapsed history to `MIN_HISTORY_LENGTH` (300) once disk usage hit 0.8, while reclaiming almost nothing. 

The reclaim prediction folded in the secondary's oldest pinned root, but the controller only erased primary versions. Every candidate erase point therefore predicted usage above the threshold, the search for a gentle cut was skipped, and the maximum trim was taken. Since chunk GC is gated on the combined boundary across both timelines, the trim also freed no disk.

## Fix

Disk pressure and `history_length` are shared across both timelines, so trim them in tandem:

- `erase_boundary(version, tid)` computes each timeline's erase point, clamped so a timeline's newest version is never erased (inert for the primary, which is already bounded by `MIN_HISTORY_LENGTH`).
- `calculate_disk_usage_if_erased_up_to_and_including()` predicts the GC boundary as the component-wise min over both timelines after each is erased to its own boundary, matching what the controller then does.
- `update_history_length_metadata()` asserts both rings share capacity, documenting the even chunk split that lets one `history_length` parameter govern both.

## Testing

New regression test `history_length_adjustment_trims_both_timelines`: an in-sync dual-writing secondary under disk pressure must get a gentle trim, not a collapse to `MIN_HISTORY_LENGTH`, with both timelines' min valid versions advancing together. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)