### PR TITLE
[statesync/db] Dedup page→slot fan-out behind StoragePageSlots

### DIFF
--- a/category/execution/ethereum/db/db_snapshot.cpp
+++ b/category/execution/ethereum/db/db_snapshot.cpp
@@ -413,23 +413,15 @@ struct MonadSnapshotTraverseMachine : public monad::mpt::TraverseMachine
                             user) == entry.size());
                 };
                 if (page_encoded) {
-                    // Source db is page-encoded: the storage leaf is
-                    // encode_storage_page_db(page_key, page). Expand it into
+                    // Source db is page-encoded: expand the storage leaf into
                     // one slot-encoded entry per non-zero slot so the dumped
                     // snapshot stays slot-granular and loads unchanged.
-                    byte_string_view enc{val};
-                    auto const raw = decode_storage_db_raw(enc);
-                    MONAD_ASSERT(raw.has_value());
-                    bytes32_t const page_key = to_bytes(raw.value().first);
-                    auto const page = decode_storage_page(raw.value().second);
-                    MONAD_ASSERT(page.has_value());
-                    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
-                        bytes32_t const slot_val = page.value()[i];
-                        if (slot_val == bytes32_t{}) {
-                            continue;
-                        }
-                        emit_slot(encode_storage_db(
-                            compute_slot_key(page_key, i), slot_val));
+                    auto const decoded =
+                        decode_storage_page_leaf(byte_string_view{val});
+                    MONAD_ASSERT(decoded.has_value());
+                    for (auto const [slot_key, slot_val] :
+                         decoded.value().slots()) {
+                        emit_slot(encode_storage_db(slot_key, slot_val));
                     }
                 }
                 else {

--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -504,27 +504,17 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
         {
             MONAD_ASSERT(node.has_value());
 
-            auto encoded_storage = node.value();
-            auto raw_res = decode_storage_db_raw(encoded_storage);
-            MONAD_ASSERT(raw_res.has_value());
-
             auto const acct_key = fmt::format(
                 "{}", NibblesView{path}.substr(0, KECCAK256_SIZE * 2));
 
             if (db.is_page_encoded()) {
-                // Page-encoded leaf: first element of the RLP list is the
-                // page_key (compact), second is the encoded page bytes.
-                // Fan out one JSON entry per populated slot, keyed by
-                // keccak256(slot_key) so the output matches a slot dump.
-                bytes32_t const page_key = to_bytes(raw_res.value().first);
-                auto const page = decode_storage_page(raw_res.value().second);
-                MONAD_ASSERT(page.has_value());
-                for (uint8_t off = 0; off < storage_page_t::SLOTS; ++off) {
-                    auto const &slot_value = page.value()[off];
-                    if (slot_value == bytes32_t{}) {
-                        continue;
-                    }
-                    bytes32_t const slot_key = compute_slot_key(page_key, off);
+                // Page-encoded leaf: fan out one JSON entry per populated slot,
+                // keyed by keccak256(slot_key) so the output matches a slot
+                // dump.
+                auto const decoded = decode_storage_page_leaf(node.value());
+                MONAD_ASSERT(decoded.has_value());
+                for (auto const [slot_key, slot_value] :
+                     decoded.value().slots()) {
                     auto const hashed_slot_key = to_bytes(
                         keccak256({slot_key.bytes, sizeof(slot_key.bytes)}));
                     auto const key = fmt::format("{}", hashed_slot_key);
@@ -544,6 +534,9 @@ nlohmann::json TrieDb::to_json(size_t const concurrency_limit)
                 // Slot-encoded leaf: trie path under the account is
                 // keccak256(slot_key); the leaf carries (slot_key,
                 // slot_value).
+                auto encoded_storage = node.value();
+                auto const raw_res = decode_storage_db_raw(encoded_storage);
+                MONAD_ASSERT(raw_res.has_value());
                 bytes32_t const slot_key = to_bytes(raw_res.value().first);
                 bytes32_t const slot_value = to_bytes(raw_res.value().second);
                 auto const key = fmt::format(

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -773,6 +773,16 @@ decode_storage_leaf_to_page(byte_string_view encoded, bool const page_encoded)
     return page.value();
 }
 
+Result<DecodedStoragePage> decode_storage_page_leaf(byte_string_view leaf)
+{
+    BOOST_OUTCOME_TRY(auto const raw, decode_storage_db_raw(leaf));
+    if (!leaf.empty()) {
+        return rlp::DecodeError::InputTooLong;
+    }
+    BOOST_OUTCOME_TRY(auto page, decode_storage_page(raw.second));
+    return DecodedStoragePage{to_bytes(raw.first), std::move(page)};
+}
+
 byte_string AccountLeafProcessor::process(mpt::Node const &node)
 {
     MONAD_ASSERT(node.has_value());

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -205,6 +205,10 @@ Result<byte_string_view> decode_storage_db_ignore_key(byte_string_view &);
 storage_page_t
 decode_storage_leaf_to_page(byte_string_view encoded, bool page_encoded);
 
+// Decode a page-encoded storage leaf (an encode_storage_page_db value) into its
+// page key and page; fails on a malformed leaf (including trailing bytes).
+Result<DecodedStoragePage> decode_storage_page_leaf(byte_string_view leaf);
+
 struct AccountLeafProcessor
 {
     static byte_string process(mpt::Node const &node);

--- a/category/execution/monad/db/storage_page.cpp
+++ b/category/execution/monad/db/storage_page.cpp
@@ -284,13 +284,12 @@ byte_string encode_storage_page(storage_page_t const &page)
 {
     byte_string encoded;
     encoded.reserve(page.size() * 34);
-    constexpr uint8_t SLOTS = static_cast<uint8_t>(storage_page_t::SLOTS);
-    for (uint8_t i = 0; i < SLOTS; ++i) {
-        bytes32_t const &value = page[i];
-        if (value != bytes32_t{}) {
-            encoded.push_back(i);
-            encoded += rlp::encode_bytes32_compact(value);
-        }
+    auto const values = page.values();
+    size_t dense = 0;
+    for (auto bits = page.bitmap(); bits != 0; bits &= bits - 1) {
+        encoded.push_back(lowest_offset(bits));
+        encoded += rlp::encode_bytes32_compact(values[dense]);
+        ++dense;
     }
     return encoded;
 }

--- a/category/execution/monad/db/storage_page.hpp
+++ b/category/execution/monad/db/storage_page.hpp
@@ -26,8 +26,12 @@
 #include <evmc/evmc.hpp>
 
 #include <bit>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
+#include <span>
+#include <utility>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -99,6 +103,15 @@ struct storage_page_t
     bitmap_t bitmap() const
     {
         return bitmap_;
+    }
+
+    // The non-zero values in ascending slot order: values()[k] is the value of
+    // the k-th set bit in bitmap(). Exposed so callers can walk bitmap() set
+    // bits in lockstep (O(popcount)) rather than probing all SLOTS via
+    // operator[].
+    std::span<bytes32_t const> values() const
+    {
+        return {values_.data(), values_.size()};
     }
 
     // Number of non-zero slots.
@@ -177,6 +190,107 @@ compute_slot_key(bytes32_t const &page_key, uint8_t const slot_offset)
         (page_int << storage_page_t::PAGE_KEY_SHIFT) | slot_offset;
     return store_be_as<bytes32_t>(slot_int);
 }
+
+// Slot offset of the lowest set bit in a non-empty bitmap. Split into two
+// 64-bit halves because std::countr_zero has no 128-bit overload.
+inline uint8_t lowest_offset(storage_page_t::bitmap_t const bitmap)
+{
+    auto const lo = static_cast<uint64_t>(bitmap);
+    return lo != 0 ? static_cast<uint8_t>(std::countr_zero(lo))
+                   : static_cast<uint8_t>(
+                         64 +
+                         std::countr_zero(static_cast<uint64_t>(bitmap >> 64)));
+}
+
+// A non-owning view over the populated (non-zero) slots of a decoded storage
+// page, yielding (slot_key, slot_value) in ascending offset order.
+class StoragePageSlots
+{
+public:
+    struct Sentinel
+    {
+    };
+
+    class iterator
+    {
+    public:
+        using value_type = std::pair<bytes32_t, bytes32_t>;
+        using difference_type = ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+        using pointer = void;
+        using reference = value_type;
+
+        iterator(bytes32_t const &page_key, storage_page_t const &page)
+            : page_key_(page_key)
+            , values_(page.values())
+            , remaining_(page.bitmap())
+            , dense_index_(0)
+        {
+        }
+
+        value_type operator*() const
+        {
+            return {
+                compute_slot_key(page_key_, lowest_offset(remaining_)),
+                values_[dense_index_]};
+        }
+
+        iterator &operator++()
+        {
+            remaining_ &= remaining_ - 1; // clear lowest set bit
+            ++dense_index_;
+            return *this;
+        }
+
+        bool operator!=(Sentinel const &) const
+        {
+            return remaining_ != 0;
+        }
+
+    private:
+        bytes32_t page_key_;
+        std::span<bytes32_t const> values_;
+        storage_page_t::bitmap_t remaining_;
+        size_t dense_index_;
+    };
+
+    StoragePageSlots(bytes32_t const &page_key, storage_page_t const &page)
+        : page_key_(page_key)
+        , page_(&page)
+    {
+    }
+
+    iterator begin() const
+    {
+        return iterator(page_key_, *page_);
+    }
+
+    Sentinel end() const
+    {
+        return Sentinel{};
+    }
+
+private:
+    bytes32_t page_key_;
+    storage_page_t const *page_;
+};
+
+// Owning result of decoding a page-encoded storage leaf: its page key and page.
+struct DecodedStoragePage
+{
+    bytes32_t page_key;
+    storage_page_t page;
+
+    // The returned view borrows this object's page, so it is only valid while
+    // this object lives; deleted on rvalues to prevent iterating a view into a
+    // destroyed temporary.
+    StoragePageSlots slots() const &
+    {
+        return StoragePageSlots{page_key, page};
+    }
+
+    StoragePageSlots slots() const && = delete;
+};
 
 bytes32_t page_commit(storage_page_t const &page);
 

--- a/category/execution/monad/db/test_page_encoding.cpp
+++ b/category/execution/monad/db/test_page_encoding.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/core/rlp/decode_error.hpp>
+#include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/monad/db/storage_page.hpp>
 
 #include <gtest/gtest.h>
@@ -133,4 +134,32 @@ TEST(PageEncoding, decode_rejects_truncated_pair)
     auto const result = decode_storage_page(enc);
     ASSERT_TRUE(result.has_error());
     EXPECT_EQ(result.assume_error(), rlp::DecodeError::InputTooShort);
+}
+
+TEST(PageEncoding, decode_storage_page_leaf_roundtrip)
+{
+    constexpr bytes32_t page_key{uint64_t{0xabcd}};
+    storage_page_t page{};
+    page.set(0, bytes32_t{uint64_t{0x11}});
+    page.set(64, bytes32_t{uint64_t{0x22}});
+    page.set(127, bytes32_t{uint64_t{0x33}});
+
+    auto const leaf = encode_storage_page_db(page_key, page);
+    auto const decoded = decode_storage_page_leaf(byte_string_view{leaf});
+    ASSERT_TRUE(decoded.has_value());
+    EXPECT_EQ(decoded.value().page_key, page_key);
+    EXPECT_EQ(decoded.value().page, page);
+}
+
+TEST(PageEncoding, decode_storage_page_leaf_rejects_trailing_bytes)
+{
+    constexpr bytes32_t page_key{uint64_t{0xabcd}};
+    storage_page_t page{};
+    page.set(3, bytes32_t{uint64_t{0x44}});
+
+    auto leaf = encode_storage_page_db(page_key, page);
+    leaf.push_back(0x00); // trailing byte after the RLP list
+    auto const decoded = decode_storage_page_leaf(byte_string_view{leaf});
+    ASSERT_TRUE(decoded.has_error());
+    EXPECT_EQ(decoded.assume_error(), rlp::DecodeError::InputTooLong);
 }

--- a/category/execution/monad/db/test_storage_page.cpp
+++ b/category/execution/monad/db/test_storage_page.cpp
@@ -321,3 +321,77 @@ TEST(MonadDb, byte_size_spill)
     // plus the live elements.
     EXPECT_GE(page.byte_size(), sizeof(storage_page_t) + 5 * sizeof(bytes32_t));
 }
+
+TEST(MonadDb, storage_page_slots_iterates_populated_in_ascending_order)
+{
+    // Offsets 63 and 64 straddle the two 64-bit halves of the 128-bit bitmap,
+    // exercising the lowest_offset() split and the dense-index lockstep across
+    // the boundary.
+    constexpr bytes32_t page_key{uint64_t{0x1234}};
+    constexpr uint8_t offsets[] = {0, 1, 63, 64, 126, 127};
+    constexpr size_t num_offsets = sizeof(offsets) / sizeof(offsets[0]);
+
+    storage_page_t page{};
+    for (uint8_t const off : offsets) {
+        page.set(off, bytes32_t{static_cast<uint64_t>(off + 1)});
+    }
+    DecodedStoragePage const decoded{page_key, page};
+
+    size_t i = 0;
+    for (auto const [slot_key, val] : decoded.slots()) {
+        ASSERT_LT(i, num_offsets);
+        uint8_t const off = offsets[i];
+        EXPECT_EQ(slot_key, compute_slot_key(page_key, off));
+        EXPECT_EQ(val, bytes32_t{static_cast<uint64_t>(off + 1)});
+        ++i;
+    }
+    EXPECT_EQ(i, num_offsets);
+}
+
+TEST(MonadDb, storage_page_slots_empty_page_yields_nothing)
+{
+    DecodedStoragePage const decoded{
+        bytes32_t{uint64_t{0xab}}, storage_page_t{}};
+    size_t count = 0;
+    for (auto const [slot_key, val] : decoded.slots()) {
+        (void)slot_key;
+        (void)val;
+        ++count;
+    }
+    EXPECT_EQ(count, 0u);
+}
+
+TEST(MonadDb, storage_page_slots_full_page)
+{
+    constexpr bytes32_t page_key{uint64_t{0x9999}};
+    storage_page_t page{};
+    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
+        page.set(i, bytes32_t{static_cast<uint64_t>(i + 1)});
+    }
+    DecodedStoragePage const decoded{page_key, page};
+
+    size_t expected_off = 0;
+    for (auto const [slot_key, val] : decoded.slots()) {
+        EXPECT_EQ(
+            slot_key,
+            compute_slot_key(page_key, static_cast<uint8_t>(expected_off)));
+        EXPECT_EQ(val, bytes32_t{static_cast<uint64_t>(expected_off + 1)});
+        ++expected_off;
+    }
+    EXPECT_EQ(expected_off, storage_page_t::SLOTS);
+}
+
+TEST(MonadDb, lowest_offset_across_bitmap_halves)
+{
+    using bitmap_t = storage_page_t::bitmap_t;
+    EXPECT_EQ(lowest_offset(bitmap_t{1}), 0);
+    EXPECT_EQ(lowest_offset(bitmap_t{1} << 63), 63);
+    EXPECT_EQ(lowest_offset(bitmap_t{1} << 64), 64);
+    EXPECT_EQ(lowest_offset(bitmap_t{1} << 127), 127);
+    // With multiple bits set it returns the lowest; the 63/64 pair straddles
+    // the two 64-bit halves the split walks.
+    EXPECT_EQ(lowest_offset((bitmap_t{1} << 64) | (bitmap_t{1} << 63)), 63);
+    // Multiple bits, all in the high half: exercises the else-branch returning
+    // the lowest high-half bit rather than the highest.
+    EXPECT_EQ(lowest_offset((bitmap_t{1} << 100) | (bitmap_t{1} << 70)), 70);
+}

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -24,7 +24,6 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
-#include <category/execution/monad/db/storage_page.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
@@ -282,36 +281,6 @@ bool statesync_server_handle_request(
                     *upsert_bytes += size1 + size2;
                 };
 
-                // Expand a page-encoded storage leaf into one slot-format
-                // upsert per non-zero slot, so the wire stays identical to a
-                // slot-encoded server. The leaf value is
-                // encode_storage_page_db(page_key, page); compute_slot_key
-                // recovers each original storage key from (page_key, offset).
-                auto const send_storage_page = [&](byte_string_view enc) {
-                    auto const raw = decode_storage_db_raw(enc);
-                    MONAD_ASSERT(raw.has_value());
-                    auto const page_key = to_bytes(raw.value().first);
-                    auto const page = decode_storage_page(raw.value().second);
-                    MONAD_ASSERT(page.has_value());
-                    for (uint8_t i = 0; i < storage_page_t::SLOTS; ++i) {
-                        bytes32_t const slot_val = page.value()[i];
-                        if (slot_val == bytes32_t{}) {
-                            continue;
-                        }
-                        auto const entry = encode_storage_db(
-                            compute_slot_key(page_key, i), slot_val);
-                        sync->statesync_server_send_upsert(
-                            sync->net,
-                            SYNC_TYPE_UPSERT_STORAGE,
-                            reinterpret_cast<unsigned char const *>(&addr),
-                            sizeof(addr),
-                            entry.data(),
-                            entry.size());
-                        ++(*num_upserts);
-                        *upsert_bytes += sizeof(addr) + entry.size();
-                    }
-                };
-
                 if (nibble == CODE_NIBBLE) {
                     MONAD_ASSERT(depth == HASH_SIZE);
                     send_upsert(SYNC_TYPE_UPSERT_CODE);
@@ -324,7 +293,27 @@ bool statesync_server_handle_request(
                     else {
                         MONAD_ASSERT(depth == (HASH_SIZE * 2));
                         if (server_is_page_encoded()) {
-                            send_storage_page(node.value());
+                            // Expand the page-encoded leaf into one slot-format
+                            // upsert per non-zero slot, so the wire stays
+                            // identical to a slot-encoded server.
+                            auto const decoded =
+                                decode_storage_page_leaf(node.value());
+                            MONAD_ASSERT(decoded.has_value());
+                            for (auto const [slot_key, slot_val] :
+                                 decoded.value().slots()) {
+                                auto const entry =
+                                    encode_storage_db(slot_key, slot_val);
+                                sync->statesync_server_send_upsert(
+                                    sync->net,
+                                    SYNC_TYPE_UPSERT_STORAGE,
+                                    reinterpret_cast<unsigned char const *>(
+                                        &addr),
+                                    sizeof(addr),
+                                    entry.data(),
+                                    entry.size());
+                                ++(*num_upserts);
+                                *upsert_bytes += sizeof(addr) + entry.size();
+                            }
                         }
                         else {
                             send_upsert(


### PR DESCRIPTION
The page→slot fan-out — expanding a page-encoded storage leaf into one slot-encoded entry per non-zero slot — was implemented three times: in the statesync server, TrieDb::to_json, and the snapshot dumper. Each re-derived the same decode + storage_page_t::SLOTS loop + compute_slot_key.

Introduce decode_storage_page_leaf(), a named Result-returning free function that RLP-decodes a leaf into a DecodedStoragePage (its key plus page), so the non-trivial, fallible decode is explicit at the call site. Iterating DecodedStoragePage::slots() yields a StoragePageSlots — a lightweight, non-owning input-iterator view over the page's populated slots (modeled on mpt::NodeChildrenRange). The three consumers now share this.

The shared iterator also drops the O(SLOTS) probing the fan-outs previously did: they looped offset 0..128 calling storage_page_t::operator[], which for each slot tests the bitmap and recomputes a dense index via popcount. StoragePageSlots instead walks the bitmap directly — countr_zero to find each populated slot and a lockstep dense index into the values span — so cost is O(popcount) in the number of non-zero slots, with no per-slot recompute.

No behavior change.