### PR TITLE
[db] Dedup the storage read path across TrieDb and TrieRODb

### DIFF
--- a/category/execution/ethereum/db/trie_db.cpp
+++ b/category/execution/ethereum/db/trie_db.cpp
@@ -144,41 +144,8 @@ bytes32_t TrieDb::read_storage(
     if (status == CacheReadStatus::Hit) {
         return result;
     }
-    auto const res = db_.find(
-        curr_root_,
-        concat(
-            prefix_,
-            STATE_NIBBLE,
-            NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
-            NibblesView{
-                keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
-        block_number_);
-
-    // Decode the leaf into a page (empty if absent): a full page for page
-    // encoding, a single-slot page for slot encoding. Read-through caches it on
-    // a resolved miss.
-    storage_page_t page;
-    if (res.has_error()) {
-        stats_storage_no_value();
-    }
-    else {
-        stats_storage_value();
-        auto encoded_storage = res.value().node->value();
-        auto const value = decode_storage_db_ignore_key(encoded_storage);
-        MONAD_ASSERT(!value.has_error());
-        if (page_encoded_) {
-            auto const decoded = decode_storage_page(value.value());
-            MONAD_ASSERT(!decoded.has_error());
-            page = decoded.value();
-        }
-        else {
-            page.set(0, to_bytes(value.value()));
-        }
-    }
-    if (cache_ && status == CacheReadStatus::MissResolved) {
-        cache_->insert_storage_page(addr, incarnation, lookup_key, page);
-    }
-    return page[lookup_offset];
+    return load_storage_page(
+        addr, incarnation, lookup_key, status)[lookup_offset];
 }
 
 storage_page_t TrieDb::read_storage_page(
@@ -188,40 +155,43 @@ storage_page_t TrieDb::read_storage_page(
     if (!page_encoded_) {
         MONAD_ABORT("read_storage_page is only valid on a page-encoded TrieDb");
     }
-    else {
-        storage_page_t result;
-        auto const status = cache_ ? cache_->try_read_storage_page(
-                                         addr, incarnation, page_key, result)
-                                   : CacheReadStatus::MissTruncated;
-        if (status == CacheReadStatus::Hit) {
-            return result;
-        }
-        auto const res = db_.find(
-            curr_root_,
-            concat(
-                prefix_,
-                STATE_NIBBLE,
-                NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
-                NibblesView{
-                    keccak256({page_key.bytes, sizeof(page_key.bytes)})}),
-            block_number_);
-        if (res.has_error()) {
-            stats_storage_no_value();
-        }
-        else {
-            stats_storage_value();
-            auto encoded_storage = res.value().node->value();
-            auto const value = decode_storage_db_ignore_key(encoded_storage);
-            MONAD_ASSERT(!value.has_error());
-            auto const decoded = decode_storage_page(value.value());
-            MONAD_ASSERT(!decoded.has_error());
-            result = decoded.value();
-        }
-        if (cache_ && status == CacheReadStatus::MissResolved) {
-            cache_->insert_storage_page(addr, incarnation, page_key, result);
-        }
+    storage_page_t result;
+    auto const status =
+        cache_
+            ? cache_->try_read_storage_page(addr, incarnation, page_key, result)
+            : CacheReadStatus::MissTruncated;
+    if (status == CacheReadStatus::Hit) {
         return result;
     }
+    return load_storage_page(addr, incarnation, page_key, status);
+}
+
+storage_page_t TrieDb::load_storage_page(
+    Address const &addr, Incarnation const incarnation,
+    bytes32_t const &lookup_key, CacheReadStatus const status)
+{
+    auto const res = db_.find(
+        curr_root_,
+        concat(
+            prefix_,
+            STATE_NIBBLE,
+            NibblesView{keccak256({addr.bytes, sizeof(addr.bytes)})},
+            NibblesView{
+                keccak256({lookup_key.bytes, sizeof(lookup_key.bytes)})}),
+        block_number_);
+    storage_page_t page;
+    if (res.has_error()) {
+        stats_storage_no_value();
+    }
+    else {
+        stats_storage_value();
+        page = decode_storage_leaf_to_page(
+            res.value().node->value(), page_encoded_);
+    }
+    if (cache_ && status == CacheReadStatus::MissResolved) {
+        cache_->insert_storage_page(addr, incarnation, lookup_key, page);
+    }
+    return page;
 }
 
 vm::SharedIntercode TrieDb::read_code(bytes32_t const &code_hash)

--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -133,6 +133,12 @@ private:
     }
 
     bytes32_t merkle_root(mpt::Nibbles const &);
+
+    // read the storage page from disk, inserting into the cache on a resolved
+    // miss
+    storage_page_t load_storage_page(
+        Address const &, Incarnation, bytes32_t const &lookup_key,
+        CacheReadStatus);
 };
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/db/trie_rodb.hpp
+++ b/category/execution/ethereum/db/trie_rodb.hpp
@@ -120,17 +120,9 @@ public:
                 "Block was invalidated in db while execution was in progress");
             return {};
         }
-        auto encoded_storage = storage_leaf_res.value().node->value();
-        auto const storage = decode_storage_db_ignore_key(encoded_storage);
-        MONAD_ASSERT(!storage.has_error());
-        if (page_encoded_) {
-            auto const page = decode_storage_page(storage.value());
-            MONAD_ASSERT(!page.has_error());
-            return page.value()[compute_slot_offset(key)];
-        }
-        else {
-            return to_bytes(storage.value());
-        }
+        auto const page = decode_storage_leaf_to_page(
+            storage_leaf_res.value().node->value(), page_encoded_);
+        return page[page_encoded_ ? compute_slot_offset(key) : 0];
     }
 
     virtual storage_page_t

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -349,12 +349,8 @@ namespace
         static byte_string process(Node const &node)
         {
             MONAD_ASSERT(node.has_value());
-            auto encoded_storage = node.value();
-            auto const storage = decode_storage_db_ignore_key(encoded_storage);
-            MONAD_ASSERT(!storage.has_error());
-            auto const page = decode_storage_page(storage.value());
-            MONAD_ASSERT(page.has_value());
-            auto const commitment = page_commit(page.value());
+            auto const page = decode_storage_leaf_to_page(node.value(), true);
+            auto const commitment = page_commit(page);
             return rlp::encode_string2(
                 {commitment.bytes, sizeof(commitment.bytes)});
         }
@@ -762,6 +758,19 @@ Result<byte_string_view> decode_storage_db_ignore_key(byte_string_view &enc)
         return rlp::DecodeError::InputTooLong;
     }
     return res.second;
+}
+
+storage_page_t
+decode_storage_leaf_to_page(byte_string_view encoded, bool const page_encoded)
+{
+    auto const value = decode_storage_db_ignore_key(encoded);
+    MONAD_ASSERT(!value.has_error());
+    if (!page_encoded) {
+        return storage_page_t{to_bytes(value.value())};
+    }
+    auto const page = decode_storage_page(value.value());
+    MONAD_ASSERT(!page.has_error());
+    return page.value();
 }
 
 byte_string AccountLeafProcessor::process(mpt::Node const &node)

--- a/category/execution/ethereum/db/util.hpp
+++ b/category/execution/ethereum/db/util.hpp
@@ -199,6 +199,12 @@ decode_storage_db_raw(byte_string_view &);
 Result<std::pair<bytes32_t, bytes32_t>> decode_storage_db(byte_string_view &);
 Result<byte_string_view> decode_storage_db_ignore_key(byte_string_view &);
 
+// Decode a storage leaf value into a page: the full page for page encoding, a
+// single-slot page holding the value at offset 0 for slot encoding. Aborts on
+// a malformed leaf.
+storage_page_t
+decode_storage_leaf_to_page(byte_string_view encoded, bool page_encoded);
+
 struct AccountLeafProcessor
 {
     static byte_string process(mpt::Node const &node);


### PR DESCRIPTION
Extract decode_storage_db_to_page, the leaf-to-page decode shared by every storage reader (full page for page encoding, single-slot page for slot encoding), and fold the find + decode + read-through-insert cache-miss path common to TrieDb::read_storage and read_storage_page into a private load_storage_page helper. TrieRODb::read_storage and PagedStorageLeafProcessor reuse the decode instead of hand-rolling it.

No behavior change.