### PR TITLE
[core] Move checked math helpers into core

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -82,6 +82,8 @@ add_library(
   "bytes.hpp"
   "bytes_hash_compare.hpp"
   "cases.hpp"
+  "checked_math.cpp"
+  "checked_math.hpp"
   "cleanup.h"
   "cleanup.c"
   "cpu_relax.h"

--- a/category/core/checked_math.cpp
+++ b/category/core/checked_math.cpp
@@ -13,13 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/execution/ethereum/core/contract/checked_math.hpp>
+#include <category/core/checked_math.hpp>
 
 #include <category/core/config.hpp>
-#include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/runtime/uint256.hpp>
 
+#include <array>
+#include <cstdint>
 #include <initializer_list>
 
 #include <boost/outcome/config.hpp>

--- a/category/core/checked_math.hpp
+++ b/category/core/checked_math.hpp
@@ -16,9 +16,8 @@
 #pragma once
 
 #include <category/core/config.hpp>
-#include <category/core/int.hpp>
-#include <category/core/likely.h>
 #include <category/core/result.hpp>
+#include <category/core/runtime/uint256.hpp>
 
 #include <initializer_list>
 

--- a/category/core/checked_math_test.cpp
+++ b/category/core/checked_math_test.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/checked_math.hpp>
+#include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace monad;
+
+TEST(CheckedMath, Add)
+{
+    auto const sum = checked_add(uint256_t{1}, uint256_t{2});
+    ASSERT_TRUE(sum);
+    EXPECT_EQ(sum.assume_value(), uint256_t{3});
+
+    auto const overflow =
+        checked_add(std::numeric_limits<uint256_t>::max(), uint256_t{1});
+    ASSERT_TRUE(overflow.has_error());
+    EXPECT_EQ(overflow.error(), MathError::Overflow);
+}
+
+TEST(CheckedMath, Subtract)
+{
+    auto const difference = checked_sub(uint256_t{3}, uint256_t{2});
+    ASSERT_TRUE(difference);
+    EXPECT_EQ(difference.assume_value(), uint256_t{1});
+
+    auto const underflow = checked_sub(uint256_t{0}, uint256_t{1});
+    ASSERT_TRUE(underflow.has_error());
+    EXPECT_EQ(underflow.error(), MathError::Underflow);
+}
+
+TEST(CheckedMath, Multiply)
+{
+    constexpr uint256_t TWO_TO_128 = uint256_t{1} << 128;
+
+    auto const product = checked_mul(TWO_TO_128 - 1, TWO_TO_128 + 1);
+    ASSERT_TRUE(product);
+    EXPECT_EQ(product.assume_value(), std::numeric_limits<uint256_t>::max());
+
+    auto const overflow = checked_mul(TWO_TO_128, TWO_TO_128);
+    ASSERT_TRUE(overflow.has_error());
+    EXPECT_EQ(overflow.error(), MathError::Overflow);
+}
+
+TEST(CheckedMath, Divide)
+{
+    auto const quotient = checked_div(uint256_t{7}, uint256_t{2});
+    ASSERT_TRUE(quotient);
+    EXPECT_EQ(quotient.assume_value(), uint256_t{3});
+
+    auto const division_by_zero = checked_div(uint256_t{1}, uint256_t{0});
+    ASSERT_TRUE(division_by_zero.has_error());
+    EXPECT_EQ(division_by_zero.error(), MathError::DivisionByZero);
+}

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -51,8 +51,6 @@ add_library(
   "ethereum/core/contract/abi_encode.hpp"
   "ethereum/core/contract/abi_signatures.hpp"
   "ethereum/core/contract/big_endian.hpp"
-  "ethereum/core/contract/checked_math.cpp"
-  "ethereum/core/contract/checked_math.hpp"
   "ethereum/core/contract/events.hpp"
   "ethereum/core/contract/storage_array.hpp"
   "ethereum/core/contract/storage_variable.hpp"

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -15,11 +15,11 @@
 
 #pragma once
 
+#include <category/core/checked_math.hpp>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/core/result.hpp>
 #include <category/execution/ethereum/chain/blob_schedule.hpp>
-#include <category/execution/ethereum/core/contract/checked_math.hpp>
 #include <category/vm/evm/traits.hpp>
 
 #include <evmc/evmc.h>

--- a/category/execution/ethereum/validate_transaction.cpp
+++ b/category/execution/ethereum/validate_transaction.cpp
@@ -20,9 +20,9 @@
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/result.hpp>
-#include <category/execution/ethereum/core/contract/checked_math.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
+#include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -160,8 +160,7 @@ Result<void> static_validate_transaction(
     }
 
     // EIP-1559: check gas_limit * max_fee_per_gas doesn't overflow uint256
-    if (MONAD_UNLIKELY(
-            !checked_mul(uint256_t{tx.gas_limit}, tx.max_fee_per_gas))) {
+    if (MONAD_UNLIKELY(!max_gas_cost(tx.gas_limit, tx.max_fee_per_gas))) {
         return TransactionError::GasLimitOverflow;
     }
 

--- a/category/execution/ethereum/validate_transaction.hpp
+++ b/category/execution/ethereum/validate_transaction.hpp
@@ -16,10 +16,10 @@
 #pragma once
 
 #include <category/core/address.hpp>
+#include <category/core/checked_math.hpp>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/core/result.hpp>
-#include <category/execution/ethereum/core/contract/checked_math.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/state_tracer.hpp>

--- a/category/execution/monad/staking/staking_contract.cpp
+++ b/category/execution/monad/staking/staking_contract.cpp
@@ -15,6 +15,7 @@
 
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
+#include <category/core/checked_math.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
 #include <category/core/log.hpp>
@@ -23,7 +24,6 @@
 #include <category/execution/ethereum/core/contract/abi_decode.hpp>
 #include <category/execution/ethereum/core/contract/abi_encode.hpp>
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
-#include <category/execution/ethereum/core/contract/checked_math.hpp>
 #include <category/execution/ethereum/core/contract/events.hpp>
 #include <category/execution/ethereum/core/contract/storage_array.hpp>
 #include <category/execution/ethereum/core/contract/storage_variable.hpp>


### PR DESCRIPTION
This library is being used in a few different places which made its location in a sub-directory of `execution/ethereum` a bit awkward, e.g. Monad staking and header files higher up the Ethereum tree depend on it.

Reuse max_gas_cost in static transaction validation rather than duplicating the checked multiplication.

Add small focused unit tests for sanity checking successful arithmetic and overflow, underflow, and division-by-zero results.