### PR TITLE
[execution/ethereum] Add EIP-4844/7918 blob gas validation

### DIFF
--- a/category/execution/ethereum/test/test_validation.cpp
+++ b/category/execution/ethereum/test/test_validation.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/test/test_traits_state.hpp>
+#include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/execution/ethereum/validate_block.hpp>
 #include <category/execution/ethereum/validate_transaction.hpp>
 #include <monad/test/traits_test.hpp>
@@ -431,6 +432,106 @@ TYPED_TEST(TraitsTest, optional_fields_existence)
 }
 
 #undef TEST_OPTIONAL_FIELD
+
+TYPED_TEST(TraitsTest, calc_excess_blob_gas)
+{
+    auto const target_blob_gas =
+        target_blob_gas_per_block(CANCUN_BLOB_SCHEDULE);
+
+    BlockHeader parent{
+        .blob_gas_used = target_blob_gas + GAS_PER_BLOB,
+        .excess_blob_gas = target_blob_gas};
+
+    EXPECT_EQ(
+        calc_excess_blob_gas<typename TestFixture::Trait>(
+            parent, CANCUN_BLOB_SCHEDULE),
+        target_blob_gas + GAS_PER_BLOB);
+
+    parent.blob_gas_used = 0;
+    parent.excess_blob_gas = target_blob_gas - 1;
+    EXPECT_EQ(
+        calc_excess_blob_gas<typename TestFixture::Trait>(
+            parent, CANCUN_BLOB_SCHEDULE),
+        0);
+}
+
+TYPED_TEST(TraitsTest, calc_excess_blob_gas_uses_reserve_price_when_active)
+{
+    BlobSchedule const blob_schedule = PRAGUE_BLOB_SCHEDULE;
+    auto const target_blob_gas = target_blob_gas_per_block(blob_schedule);
+
+    BlockHeader parent{
+        .base_fee_per_gas = uint256_t{1'000'000},
+        .blob_gas_used = target_blob_gas,
+        .excess_blob_gas = target_blob_gas};
+
+    uint64_t const expected_excess_blob_gas = [&] {
+        if constexpr (TestFixture::Trait::eip_7918_active()) {
+            return target_blob_gas +
+                   target_blob_gas *
+                       (blob_schedule.max_blobs_per_block -
+                        blob_schedule.target_blobs_per_block) /
+                       blob_schedule.max_blobs_per_block;
+        }
+        else {
+            return target_blob_gas;
+        }
+    }();
+
+    EXPECT_EQ(
+        calc_excess_blob_gas<typename TestFixture::Trait>(
+            parent, blob_schedule),
+        expected_excess_blob_gas);
+}
+
+TYPED_TEST(TraitsTest, validate_excess_blob_gas_against_parent)
+{
+    if constexpr (!TestFixture::Trait::eip_4844_active()) {
+        GTEST_SKIP() << "EIP-4844 is not active";
+    }
+    else {
+        static constexpr uint64_t timestamp =
+            TestFixture::Trait::evm_rev() >= MONAD_ETH_PRAGUE
+                ? uint64_t{1746612311}
+                : uint64_t{1710338135};
+
+        EthereumMainnet const chain;
+        auto const blob_schedule = chain.get_blob_schedule(timestamp);
+        auto const target_blob_gas = target_blob_gas_per_block(blob_schedule);
+
+        BlockHeader parent{
+            .blob_gas_used = target_blob_gas + GAS_PER_BLOB,
+            .excess_blob_gas = target_blob_gas};
+        uint64_t const expected_excess_blob_gas =
+            calc_excess_blob_gas<typename TestFixture::Trait>(
+                parent, blob_schedule);
+
+        BlockHeader header{
+            .number = 1,
+            .gas_limit = 10000,
+            .timestamp = timestamp,
+            .base_fee_per_gas = uint256_t{},
+            .withdrawals_root = bytes32_t{},
+            .blob_gas_used = uint64_t{0},
+            .excess_blob_gas = expected_excess_blob_gas,
+            .parent_beacon_block_root = bytes32_t{}};
+        if constexpr (TestFixture::Trait::evm_rev() >= MONAD_ETH_PRAGUE) {
+            header.requests_hash = bytes32_t{};
+        }
+        Block block{.header = header, .withdrawals = std::vector<Withdrawal>{}};
+
+        auto result =
+            static_validate_block_with_parent<typename TestFixture::Trait>(
+                chain, block, parent);
+        EXPECT_TRUE(result.has_value());
+
+        block.header.excess_blob_gas = expected_excess_blob_gas + 1;
+        result = static_validate_block_with_parent<typename TestFixture::Trait>(
+            chain, block, parent);
+        ASSERT_TRUE(result.has_error());
+        EXPECT_EQ(result.error(), BlockError::InvalidExcessBlobGas);
+    }
+}
 
 TYPED_TEST(TraitsTest, invalid_nonce)
 {

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -16,6 +16,7 @@
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
+#include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
@@ -222,6 +223,46 @@ uint256_t get_base_fee_per_blob_gas(
         uint256_t{excess_blob_gas},
         uint256_t{blob_schedule.blob_base_fee_update_fraction});
 }
+
+template <Traits traits>
+uint64_t calc_excess_blob_gas(
+    BlockHeader const &parent_header,
+    BlobSchedule const &current_blob_schedule) noexcept
+{
+    uint64_t const total_blob_gas = parent_header.excess_blob_gas.value_or(0) +
+                                    parent_header.blob_gas_used.value_or(0);
+    uint64_t const target_blob_gas =
+        target_blob_gas_per_block(current_blob_schedule);
+
+    if (total_blob_gas < target_blob_gas) {
+        return 0;
+    }
+
+    if constexpr (traits::eip_7918_active()) {
+        constexpr uint256_t PRICE_RATIO = GAS_PER_BLOB / BLOB_BASE_COST;
+
+        auto const threshold = checked_mul(
+            PRICE_RATIO,
+            get_base_fee_per_blob_gas(
+                parent_header.excess_blob_gas.value_or(0),
+                current_blob_schedule));
+
+        uint256_t const execution_base_fee =
+            parent_header.base_fee_per_gas.value_or(uint256_t{});
+
+        if (threshold && execution_base_fee > threshold.assume_value()) {
+            return parent_header.excess_blob_gas.value_or(0) +
+                   parent_header.blob_gas_used.value_or(0) *
+                       (current_blob_schedule.max_blobs_per_block -
+                        current_blob_schedule.target_blobs_per_block) /
+                       current_blob_schedule.max_blobs_per_block;
+        }
+    }
+
+    return total_blob_gas - target_blob_gas;
+}
+
+EXPLICIT_TRAITS(calc_excess_blob_gas);
 
 uint64_t get_total_blob_gas(Transaction const &tx) noexcept
 {

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -64,6 +64,9 @@ max_gas_cost(uint64_t const gas_limit, uint256_t const max_fee_per_gas) noexcept
 // EIP-4844
 inline constexpr uint64_t GAS_PER_BLOB = 131'072;
 
+// EIP-7918
+inline constexpr uint64_t BLOB_BASE_COST = 8192;
+
 template <Traits traits>
 inline constexpr BlobSchedule default_blob_schedule() noexcept
 {
@@ -82,10 +85,21 @@ max_blob_gas_per_block(BlobSchedule const &blob_schedule) noexcept
     return blob_schedule.max_blobs_per_block * GAS_PER_BLOB;
 }
 
+inline constexpr uint64_t
+target_blob_gas_per_block(BlobSchedule const &blob_schedule) noexcept
+{
+    return blob_schedule.target_blobs_per_block * GAS_PER_BLOB;
+}
+
 uint256_t
 calc_blob_fee(Transaction const &, uint64_t, BlobSchedule const &) noexcept;
 
 uint256_t get_base_fee_per_blob_gas(uint64_t, BlobSchedule const &) noexcept;
+
+template <Traits traits>
+uint64_t calc_excess_blob_gas(
+    BlockHeader const &parent_header,
+    BlobSchedule const &current_blob_schedule) noexcept;
 
 uint64_t get_total_blob_gas(Transaction const &) noexcept;
 

--- a/category/execution/ethereum/validate_block.cpp
+++ b/category/execution/ethereum/validate_block.cpp
@@ -226,6 +226,24 @@ Result<void> static_validate_4844(Chain const &chain, Block const &block)
 }
 
 template <Traits traits>
+Result<void> static_validate_4844_parent(
+    Chain const &chain, Block const &block, BlockHeader const &parent_header)
+{
+    if constexpr (traits::eip_4844_active()) {
+        auto const blob_schedule =
+            chain.get_blob_schedule(block.header.timestamp);
+        uint64_t const expected_excess_blob_gas =
+            calc_excess_blob_gas<traits>(parent_header, blob_schedule);
+        if (MONAD_UNLIKELY(
+                block.header.excess_blob_gas.value() !=
+                expected_excess_blob_gas)) {
+            return BlockError::InvalidExcessBlobGas;
+        }
+    }
+    return success();
+}
+
+template <Traits traits>
 Result<void> static_validate_body(Chain const &chain, Block const &block)
 {
     // EIP-4895
@@ -257,6 +275,19 @@ Result<void> static_validate_block(Chain const &chain, Block const &block)
 }
 
 EXPLICIT_TRAITS(static_validate_block);
+
+template <Traits traits>
+Result<void> static_validate_block_with_parent(
+    Chain const &chain, Block const &block, BlockHeader const &parent_header)
+{
+    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
+    BOOST_OUTCOME_TRY(
+        static_validate_4844_parent<traits>(chain, block, parent_header));
+
+    return success();
+}
+
+EXPLICIT_TRAITS(static_validate_block_with_parent);
 
 Result<void>
 validate_output_header(BlockHeader const &input, BlockHeader const &output)
@@ -330,6 +361,7 @@ quick_status_code_from_enum<monad::BlockError>::value_mappings()
         {BlockError::InvalidOmmerHeader, "invalid ommer header", {}},
         {BlockError::WrongLogsBloom, "wrong logs bloom", {}},
         {BlockError::InvalidGasUsed, "invalid gas used", {}},
+        {BlockError::InvalidExcessBlobGas, "invalid excess blob gas", {}},
         {BlockError::WrongMerkleRoot, "wrong merkle root", {}},
         {BlockError::SystemCallMissingCode,
          "system call target has no code",

--- a/category/execution/ethereum/validate_block.hpp
+++ b/category/execution/ethereum/validate_block.hpp
@@ -54,6 +54,7 @@ enum class BlockError
     InvalidOmmerHeader,
     WrongLogsBloom,
     InvalidGasUsed,
+    InvalidExcessBlobGas,
     WrongMerkleRoot,
     SystemCallMissingCode,
     SystemCallFailed,
@@ -74,6 +75,10 @@ Result<void> static_validate_header(BlockHeader const &);
 
 template <Traits traits>
 Result<void> static_validate_block(Chain const &chain, Block const &);
+
+template <Traits traits>
+Result<void> static_validate_block_with_parent(
+    Chain const &chain, Block const &, BlockHeader const &parent_header);
 
 Result<void>
 validate_output_header(BlockHeader const &input, BlockHeader const &output);

--- a/category/execution/runloop/runloop_ethereum.cpp
+++ b/category/execution/runloop/runloop_ethereum.cpp
@@ -90,7 +90,8 @@ template <Traits traits>
 Result<void> process_ethereum_block(
     Chain const &chain, Db &db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
-    fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
+    fiber::PriorityPool &priority_pool, Block &block,
+    BlockHeader const &parent_header, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing)
 {
     static_assert(traits::evm_rev() >= MONAD_ETH_CONSTANTINOPLE);
@@ -111,7 +112,8 @@ Result<void> process_ethereum_block(
         std::nullopt);
 
     // Block input validation
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
+    BOOST_OUTCOME_TRY(
+        static_validate_block_with_parent<traits>(chain, block, parent_header));
 
     // Sender and authority recovery
     auto const sender_recovery_begin = std::chrono::steady_clock::now();
@@ -297,6 +299,13 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
             "Could not query %lu from blockdb",
             block_num);
 
+        BlockHeader const parent_header = db.read_eth_header();
+        MONAD_ASSERT_PRINTF(
+            parent_header.number + 1 == block.header.number,
+            "parent header number %lu does not precede block %lu",
+            parent_header.number,
+            block.header.number);
+
         bytes32_t const block_id = bytes32_t{block.header.number};
         monad_eth_revision const rev =
             chain.get_revision(block.header.number, block.header.timestamp);
@@ -310,6 +319,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_ethereum(
                 block_hash_buffer,
                 priority_pool,
                 block,
+                parent_header,
                 block_id,
                 parent_block_id,
                 enable_tracing);

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -81,6 +81,7 @@ namespace monad
         { T::eip_7691_active() } -> std::same_as<bool>;
         { T::eip_7823_active() } -> std::same_as<bool>;
         { T::eip_7883_active() } -> std::same_as<bool>;
+        { T::eip_7918_active() } -> std::same_as<bool>;
         { T::eip_7939_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
@@ -162,6 +163,11 @@ namespace monad
         }
 
         static consteval bool eip_7883_active() noexcept
+        {
+            return Rev >= MONAD_ETH_OSAKA;
+        }
+
+        static consteval bool eip_7918_active() noexcept
         {
             return Rev >= MONAD_ETH_OSAKA;
         }
@@ -330,6 +336,11 @@ namespace monad
         static consteval bool eip_7883_active() noexcept
         {
             return evm_rev() >= MONAD_ETH_OSAKA;
+        }
+
+        static consteval bool eip_7918_active() noexcept
+        {
+            return false;
         }
 
         static consteval bool eip_7939_active() noexcept

--- a/test/ethereum_test/exclude/cancun.cmake
+++ b/test/ethereum_test/exclude/cancun.cmake
@@ -14,24 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set(cancun_excluded_tests
-    # Blobs (EIP-4844)
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_above_target_change.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_change.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_negative_excess_blob_gas.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_non_multiple_excess_blob_gas.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_static_excess_blob_gas.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
-    "BlockchainTests.GeneralStateTests/Pyspecs/cancun/eip4844_blobs/invalid_zero_excess_blob_gas_in_header.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
-
     # withdrawals root
     "BlockchainTests.InvalidBlocks/bc4895_withdrawals/incorrectWithdrawalsRoot.json"
 

--- a/test/ethereum_test/exclude/osaka.cmake
+++ b/test/ethereum_test/exclude/osaka.cmake
@@ -14,17 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set(osaka_excluded_tests
-    # Blobs (EIP-4844, EIP-7918)
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
-    "BlockchainTests.osaka/eip7918_blob_reserve_price/test_reserve_price_boundary.json"
-
     # Unimplemented Prague EIPs
     "BlockchainTests.prague/eip6110_deposits/*"
     "BlockchainTests.prague/eip7685_general_purpose_el_requests/*"

--- a/test/ethereum_test/exclude/prague.cmake
+++ b/test/ethereum_test/exclude/prague.cmake
@@ -14,17 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set(prague_excluded_tests
-    # Blobs (EIP-4844)
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_above_target_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_change.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_excess_blob_gas_target_blobs_increase_from_zero.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_negative_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_non_multiple_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target.json"
-    "BlockchainTests.cancun/eip4844_blobs/test_invalid_zero_excess_blob_gas_in_header.json"
-
-
     # Long-running tests
     "BlockchainTests.prague/eip2935_historical_block_hashes_from_state/block_hashes/block_hashes_history.json"
 

--- a/test/ethereum_test/src/blockchain_test.cpp
+++ b/test/ethereum_test/src/blockchain_test.cpp
@@ -322,8 +322,8 @@ void validate_post_state(nlohmann::json const &json, nlohmann::json const &db)
 
 template <Traits traits>
 Result<BlockExecOutput> execute(
-    Chain const &chain, Block &block, monad::Db &db, vm::VM &vm,
-    BlockHashBuffer const &block_hash_buffer,
+    Chain const &chain, Block &block, BlockHeader const &parent_header,
+    monad::Db &db, vm::VM &vm, BlockHashBuffer const &block_hash_buffer,
     std::map<uint64_t, ankerl::unordered_dense::segmented_set<Address>>
         &senders_and_authorities_map,
     bool enable_tracing, std::vector<Receipt> &receipts,
@@ -333,7 +333,8 @@ Result<BlockExecOutput> execute(
 
     using namespace monad::test;
 
-    BOOST_OUTCOME_TRY(static_validate_block<traits>(chain, block));
+    BOOST_OUTCOME_TRY(
+        static_validate_block_with_parent<traits>(chain, block, parent_header));
 
     BlockState block_state(db, vm);
     BlockMetrics metrics;
@@ -451,8 +452,8 @@ Result<BlockExecOutput> execute(
 
 template <Traits traits>
 Result<std::vector<Receipt>> execute_and_record(
-    Chain const &chain, Block &block, monad::Db &db, vm::VM &vm,
-    BlockHashBuffer const &block_hash_buffer,
+    Chain const &chain, Block &block, BlockHeader const &parent_header,
+    monad::Db &db, vm::VM &vm, BlockHashBuffer const &block_hash_buffer,
     std::map<uint64_t, ankerl::unordered_dense::segmented_set<Address>>
         &senders_and_authorities_map,
     bool enable_tracing)
@@ -475,6 +476,7 @@ Result<std::vector<Receipt>> execute_and_record(
     auto result = record_block_result(execute<traits>(
         chain,
         block,
+        parent_header,
         db,
         vm,
         block_hash_buffer,
@@ -520,6 +522,7 @@ void process_test(
     // genesis block has no senders or authorities
     senders_and_authorities_map[0] =
         ankerl::unordered_dense::segmented_set<Address>{};
+    BlockHeader parent_header = json_state.header;
 
     for (auto const &j_block : j_contents.at("blocks")) {
 
@@ -549,6 +552,7 @@ void process_test(
         auto const result = execute_and_record<traits>(
             chain,
             block.value(),
+            parent_header,
             tdb,
             vm,
             block_hash_buffer,
@@ -578,6 +582,7 @@ void process_test(
 
         if (!result.has_error()) {
             db_post_state = tdb.to_json();
+            parent_header = block.value().header;
             EXPECT_FALSE(j_block.contains("expectException")) << name;
             EXPECT_EQ(tdb.get_block_number(), curr_block_number) << name;
             auto const root = tdb.get_root();


### PR DESCRIPTION
Validates each block’s excess blob gas against its parent header, using the [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) update rule and [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918) reserve-price adjustment.

Enable the corresponding EIP-4844 and EIP-7918 tests.

## Checklist

- [x] Update internal tracker for EIP-7918 (EXE-45)