### PR TITLE
gcc-16 build fixes: <unistd.h> for close(), gate preserve_none to Clang

### DIFF
--- a/category/execution/ethereum/db/db_snapshot_filesystem.cpp
+++ b/category/execution/ethereum/db/db_snapshot_filesystem.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <linux/mman.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 MONAD_ANONYMOUS_NAMESPACE_BEGIN
 

--- a/category/vm/interpreter/types.hpp
+++ b/category/vm/interpreter/types.hpp
@@ -31,9 +31,15 @@
  * preserve the registers used for argument threading.
  *
  * See https://blog.reverberate.org/2025/02/10/tail-call-updates.html for a good
- * reference to this technique. It is not supported by GCC as of version 15.
+ * reference to this technique.
+ *
+ * Restricted to Clang: gcc-15 does not support preserve_none, and g++-16 (which
+ * does) miscompiles it together with the musttail dispatch below at -Og,
+ * corrupting gas accounting (wrong gas_used / state root in ethereum_test). It
+ * is only a marginal register-allocation optimisation, so gating it to Clang
+ * costs nothing on GCC.
  */
-#if defined(__has_attribute)
+#if defined(__has_attribute) && defined(__clang__)
     #if __has_attribute(preserve_none)
         #define MONAD_VM_INSTRUCTION_CALL __attribute__((preserve_none))
     #else


### PR DESCRIPTION
Draft — two low-risk fixes toward building under **gcc-16 / libstdc++-16**. Both are no-ops under gcc-15 (the standard toolchain) and Clang; they only change g++-16 behavior.

This does **not** by itself produce a working gcc-16 build — the `start_lifetime_as<std::atomic<…>>` → `std::atomic_ref` changes needed to *compile* the mpt/async code under libstdc++-16 are intentionally split into a separate PR that needs more detailed review.

### Commits

1. **db: include `<unistd.h>` for `close()`** — libstdc++-16 no longer pulls `<unistd.h>` in transitively via `<fcntl.h>`/`<sys/mman.h>`, so `close()` in `monad_db_snapshot_load_filesystem` is undeclared. Explicit include; no-op on gcc-15.

2. **vm/interpreter: gate `preserve_none` to Clang** — g++-16 newly supports `__attribute__((preserve_none))` (gcc-15 did not, so it was a no-op there). Enabling it on the interpreter's `musttail` dispatch **miscompiles** under g++-16 at `-Og`: the dispatch threads `gas_remaining` while also taking its address for the inlined `call_runtime()` gas sync, and `preserve_none` + `musttail` + address-taken-local corrupts the threaded gas → `ethereum_test` fails with `invalid gas used` / `wrong merkle root` across forks. g++-16's own new `-Wmaybe-musttail-local-addr` flags the same construct at `-O0`.

   Confirmed by A/B under g++-16 `-Og`: preserve_none ON fails, OFF passes (full cancun + MONAD_NINE fork runs). gcc-15 and Clang unaffected. **Only Debug/`-Og` is affected — `-O2`/RelWithDebInfo (production) is not.** The attribute is only a marginal register-allocation optimisation, so restricting it to Clang is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014prCgjeEdXrcbPewLpwst3
