### PR TITLE
[mpt] Fix leaf-on-branch hex-prefix in VarLen merkle compute

### DIFF
--- a/category/mpt/compute.cpp
+++ b/category/mpt/compute.cpp
@@ -31,19 +31,18 @@
 MONAD_MPT_NAMESPACE_BEGIN
 
 byte_string encode_two_pieces(
-    NibblesView const path, byte_string_view const second, bool const has_value)
+    NibblesView const path, byte_string_view const second, bool const is_leaf)
 {
     constexpr size_t max_compact_encode_size = KECCAK256_SIZE + 1;
 
     MONAD_ASSERT(path.data_size() <= KECCAK256_SIZE);
 
     unsigned char path_arr[max_compact_encode_size] = {0};
-    auto const first = compact_encode(path_arr, path, has_value);
+    auto const first = compact_encode(path_arr, path, is_leaf);
     MONAD_ASSERT(first.size() <= max_compact_encode_size);
     // leaf and hashed node ref requires rlp encoding,
     // rlp encoded but unhashed branch node ref doesn't
-    bool const need_encode_second =
-        has_value || second.size() >= KECCAK256_SIZE;
+    bool const need_encode_second = is_leaf || second.size() >= KECCAK256_SIZE;
     auto const concat_len =
         rlp::string_length(first) +
         (need_encode_second ? rlp::string_length(second) : second.size());

--- a/category/mpt/compute.hpp
+++ b/category/mpt/compute.hpp
@@ -65,13 +65,13 @@ std::span<unsigned char>
 encode_16_children(Node const &, std::span<unsigned char> result);
 
 byte_string encode_two_pieces(
-    NibblesView path, byte_string_view second, bool has_value = false);
+    NibblesView path, byte_string_view second, bool is_leaf = false);
 
 [[gnu::always_inline]] inline unsigned encode_two_pieces_reference(
     unsigned char *const dest, NibblesView const path,
-    byte_string_view const second, bool const has_value = false)
+    byte_string_view const second, bool const is_leaf = false)
 {
-    auto const rlp = encode_two_pieces(path, second, has_value);
+    auto const rlp = encode_two_pieces(path, second, is_leaf);
     return to_node_reference({rlp.data(), rlp.size()}, dest);
 }
 
@@ -342,8 +342,12 @@ struct VarLenMerkleCompute : Compute
         // rlp(encoded path, inline branch hash)
         if (node.has_path()) { // extension node, rlp encode with path too
             MONAD_ASSERT(node.bitpacked.data_len);
+            // A node with children is always an extension, even when it also
+            // carries a value: the value is already encoded in the 17th slot
+            // of the inline branch data, so the hex-prefix must be the
+            // non-terminating (extension) one.
             return encode_two_pieces_reference(
-                buffer, node.path_nibble_view(), node.data(), node.has_value());
+                buffer, node.path_nibble_view(), node.data(), false);
         }
         // Ethereum branch
         return compute_branch_reference_(buffer, node);
@@ -443,7 +447,11 @@ private:
                            compute_branch_reference_(branch_hash, *node)};
                    }())
                               : LeafValueProcessor::process(*node),
-                   node->has_value());
+                   // A node with children is an extension based on ethereum MPT
+                   // definition even if it also has a value; the value is
+                   // already inside the branch encoding. Only a childless node
+                   // takes the terminating leaf prefix.
+                   node->mask == 0);
     }
 };
 

--- a/category/mpt/test/encode_two_pieces_test.cpp
+++ b/category/mpt/test/encode_two_pieces_test.cpp
@@ -37,7 +37,7 @@ TEST(EncodeTwoPieces, Leaf)
 
     byte_string const value = {'h', 'e', 'l', 'l', 'o'};
     auto const encoded = encode_two_pieces(
-        NibblesView{path}, byte_string_view{value}, /*has_value=*/true);
+        NibblesView{path}, byte_string_view{value}, /*is_leaf=*/true);
 
     byte_string const expected = {
         0xc9, 0x82, 0x31, 0x23, 0x85, 'h', 'e', 'l', 'l', 'o'};
@@ -57,7 +57,7 @@ TEST(EncodeTwoPieces, ExtensionShortChildRef)
 
     byte_string const second = {0xc3, 0x01, 0x02, 0x03};
     auto const encoded = encode_two_pieces(
-        NibblesView{path}, byte_string_view{second}, /*has_value=*/false);
+        NibblesView{path}, byte_string_view{second}, /*is_leaf=*/false);
 
     byte_string const expected = {
         0xc7, 0x82, 0x00, 0xab, 0xc3, 0x01, 0x02, 0x03};

--- a/category/mpt/test/merkle_trie_test.cpp
+++ b/category/mpt/test/merkle_trie_test.cpp
@@ -698,6 +698,31 @@ TYPED_TEST(TrieTest, variable_length_trie)
     }
 }
 
+// A node with both children and a value (one key a proper prefix of another)
+// must be encoded as an extension, not a leaf. Expected root is the Ethereum
+// canonical MPT vector "branch-value-update" from
+// third_party/ethereum-tests/TrieTests/trietest.json. Not reachable in
+// production state roots: variable-length trie in production is keyed by
+// a prefix-free set (self-delimiting RLP indices).
+TYPED_TEST(TrieTest, leaf_on_branch_canonical_root)
+{
+    this->sm = std::make_unique<StateMachineAlwaysVarLen>();
+
+    auto const abc = 0x616263_bytes; // "abc"
+    auto const abcd = 0x61626364_bytes; // "abcd"
+
+    this->root = upsert_updates(
+        this->aux,
+        *this->sm,
+        std::move(this->root),
+        make_update(abc, abc),
+        make_update(abcd, abcd));
+
+    EXPECT_EQ(
+        this->root_hash(),
+        0x7a320748f780ad9ad5b0837302075ce0eeba6c26e3d8562c67ccc0f1b273298a_bytes);
+}
+
 TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
 {
     constexpr uint64_t version = 0;

--- a/category/mpt/test/merkle_trie_test.cpp
+++ b/category/mpt/test/merkle_trie_test.cpp
@@ -698,6 +698,66 @@ TYPED_TEST(TrieTest, variable_length_trie)
     }
 }
 
+// A node with both children and a value (one key a proper prefix of another)
+// must be encoded as an extension, not a leaf. Expected root is the Ethereum
+// canonical MPT vector "branch-value-update" from
+// third_party/ethereum-tests/TrieTests/trietest.json. Not reachable in
+// production state roots: variable-length trie in production is keyed by
+// a prefix-free set (self-delimiting RLP indices).
+TYPED_TEST(TrieTest, leaf_on_branch_canonical_root)
+{
+    this->sm = std::make_unique<StateMachineAlwaysVarLen>();
+
+    auto const abc = 0x616263_bytes; // "abc"
+    auto const abcd = 0x61626364_bytes; // "abcd"
+
+    this->root = upsert_updates(
+        this->aux,
+        *this->sm,
+        std::move(this->root),
+        make_update(abc, abc),
+        make_update(abcd, abcd));
+
+    EXPECT_EQ(
+        this->root_hash(),
+        0x7a320748f780ad9ad5b0837302075ce0eeba6c26e3d8562c67ccc0f1b273298a_bytes);
+}
+
+// Same as leaf_on_branch_canonical_root, but under a key prefix so the
+// leaf-on-branch node goes through the single-child case code path in
+// RootVarLenMerkleCompute::compute_node_data_len.
+TYPED_TEST(TrieTest, leaf_on_branch_canonical_root_with_prefix)
+{
+    auto const prefix = 0x00_bytes;
+    this->sm = std::make_unique<StateMachineVarLenTrieWithPrefix<2>>();
+
+    auto const abc = 0x616263_bytes; // "abc"
+    auto const abcd = 0x61626364_bytes; // "abcd"
+
+    UpdateList updates;
+    Update u1 = make_update(abc, abc);
+    Update u2 = make_update(abcd, abcd);
+    updates.push_front(u1);
+    updates.push_front(u2);
+
+    auto u_prefix = make_update(prefix, monad::byte_string_view{});
+    u_prefix.next = std::move(updates);
+    UpdateList ul_prefix;
+    ul_prefix.push_front(u_prefix);
+    this->root = upsert(
+        this->aux,
+        0,
+        *this->sm,
+        {},
+        std::move(ul_prefix),
+        /*write_root=*/true,
+        timeline_id::primary);
+
+    EXPECT_EQ(
+        this->root->data(),
+        0x7a320748f780ad9ad5b0837302075ce0eeba6c26e3d8562c67ccc0f1b273298a_bytes);
+}
+
 TYPED_TEST(TrieTest, variable_length_trie_with_prefix)
 {
     constexpr uint64_t version = 0;


### PR DESCRIPTION
A node with both children and a value (a branch node that ends a key) was compact-encoded with terminating = true whenever its path was hex-prefix encoded. Per the Ethereum MPT definition such a node is an extension followed by a branch, so the prefix must be non-terminating; the value is carried in the 17th slot of the branch encoding, not on the extension. As a result VarLenMerkleCompute and RootVarLenMerkleCompute diverged from the canonical Ethereum root.

**Unreachable in production**: every production variable-length trie is keyed by a prefix-free set (self-delimiting RLP indices), so no committed root is affected.

Add regression test against the ethereum-tests "branch-value-update" vector.