### PR TITLE
Add MONAD_TRY / MONAD_CATCH_ALL macros

### DIFF
--- a/category/core/throw.hpp
+++ b/category/core/throw.hpp
@@ -17,3 +17,9 @@
 
 // Throw a C++ exception
 #define MONAD_THROW(exc, ...) throw exc(__VA_ARGS__)
+
+// Wrap a try/catch pair. On platforms with exceptions disabled, these are
+// redefined to erase the `try` keyword and reduce the `catch` to a dead
+// `if constexpr (false)`, so the catch body still type-checks but never runs.
+#define MONAD_TRY try
+#define MONAD_CATCH(...) catch (__VA_ARGS__)

--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -19,6 +19,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
+#include <category/core/throw.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_history.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
@@ -51,10 +52,12 @@ EvmcHostBase::EvmcHostBase(
 evmc::bytes32 EvmcHostBase::get_storage(
     evmc::address const &address, evmc::bytes32 const &key) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return state_.get_storage(address, key);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -64,10 +67,12 @@ evmc_storage_status EvmcHostBase::set_storage(
     evmc::address const &address, evmc::bytes32 const &key,
     evmc::bytes32 const &value) noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return state_.set_storage(address, key, value);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -76,10 +81,12 @@ evmc_storage_status EvmcHostBase::set_storage(
 evmc::uint256be
 EvmcHostBase::get_balance(evmc::address const &address) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return store_be_as<evmc::uint256be>(state_.get_balance(address));
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -87,7 +94,8 @@ EvmcHostBase::get_balance(evmc::address const &address) const noexcept
 
 size_t EvmcHostBase::get_code_size(evmc::address const &address) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         if (MONAD_UNLIKELY(
                 std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
             bytes32_t const hash = state_.get_code_hash(address);
@@ -101,7 +109,8 @@ size_t EvmcHostBase::get_code_size(evmc::address const &address) const noexcept
         }
         return state_.get_code_size(address);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -110,13 +119,15 @@ size_t EvmcHostBase::get_code_size(evmc::address const &address) const noexcept
 evmc::bytes32
 EvmcHostBase::get_code_hash(evmc::address const &address) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         if (state_.account_is_dead(address)) {
             return bytes32_t{};
         }
         return state_.get_code_hash(address);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -126,7 +137,8 @@ size_t EvmcHostBase::copy_code(
     evmc::address const &address, size_t const offset, uint8_t *const data,
     size_t const size) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         if (MONAD_UNLIKELY(
                 std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
             bytes32_t const hash = state_.get_code_hash(address);
@@ -140,7 +152,8 @@ size_t EvmcHostBase::copy_code(
         }
         return state_.copy_code(address, offset, data, size);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -157,7 +170,8 @@ evmc_tx_context const *EvmcHostBase::get_tx_context() const noexcept
 evmc::bytes32
 EvmcHostBase::get_block_hash(int64_t const block_number) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         MONAD_ASSERT(block_number >= 0);
         if (bytes32_t const block_hash = get_block_hash_history(
                 state_, static_cast<uint64_t>(block_number));
@@ -169,7 +183,8 @@ EvmcHostBase::get_block_hash(int64_t const block_number) const noexcept
         MONAD_ASSERT(block_hash != bytes32_t{});
         return block_hash;
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -180,7 +195,8 @@ void EvmcHostBase::emit_log(
     size_t const data_size, evmc::bytes32 const topics[],
     size_t const num_topics) noexcept
 {
-    try {
+    MONAD_TRY
+    {
         Receipt::Log log{.data = {data, data_size}, .address = address};
         for (auto i = 0u; i < num_topics; ++i) {
             log.topics.push_back({topics[i]});
@@ -189,7 +205,8 @@ void EvmcHostBase::emit_log(
         call_tracer_.on_log(std::move(log));
         return;
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -198,10 +215,12 @@ void EvmcHostBase::emit_log(
 evmc::bytes32 EvmcHostBase::get_transient_storage(
     evmc::address const &address, evmc::bytes32 const &key) const noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return state_.get_transient_storage(address, key);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -211,10 +230,12 @@ void EvmcHostBase::set_transient_storage(
     evmc::address const &address, evmc::bytes32 const &key,
     evmc::bytes32 const &value) noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return state_.set_transient_storage(address, key, value);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();
@@ -224,10 +245,12 @@ EvmcHostBase::PageStorageStatus EvmcHostBase::update_page(
     evmc::address const &address, evmc::bytes32 const &page_key,
     evmc_storage_status const status) noexcept
 {
-    try {
+    MONAD_TRY
+    {
         return state_.update_page(address, page_key, status);
     }
-    catch (...) {
+    MONAD_CATCH(...)
+    {
         capture_current_exception();
     }
     stack_unwind();

--- a/category/execution/ethereum/evmc_host.hpp
+++ b/category/execution/ethereum/evmc_host.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/core/throw.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/contract/abi_encode.hpp>
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
@@ -137,10 +138,12 @@ struct EvmcHost final : public EvmcHostBase
     {
         static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
 
-        try {
+        MONAD_TRY
+        {
             return !state_.account_is_dead(address);
         }
-        catch (...) {
+        MONAD_CATCH(...)
+        {
             capture_current_exception();
         }
         stack_unwind();
@@ -150,7 +153,8 @@ struct EvmcHost final : public EvmcHostBase
         evmc::address const &address,
         evmc::address const &beneficiary) noexcept override
     {
-        try {
+        MONAD_TRY
+        {
             auto const [result, transferred_balance] =
                 state_.selfdestruct<traits>(address, beneficiary);
 
@@ -162,7 +166,8 @@ struct EvmcHost final : public EvmcHostBase
 
             return result;
         }
-        catch (...) {
+        MONAD_CATCH(...)
+        {
             capture_current_exception();
         }
         stack_unwind();
@@ -170,7 +175,8 @@ struct EvmcHost final : public EvmcHostBase
 
     virtual evmc::Result call(evmc_message const &msg) noexcept override
     {
-        try {
+        MONAD_TRY
+        {
             if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2) {
                 auto result =
                     ::monad::execute_create_message<traits>(this, state_, msg);
@@ -189,7 +195,8 @@ struct EvmcHost final : public EvmcHostBase
                 return ::monad::execute_call_message<traits>(this, state_, msg);
             }
         }
-        catch (...) {
+        MONAD_CATCH(...)
+        {
             capture_current_exception();
         }
         stack_unwind();
@@ -198,13 +205,15 @@ struct EvmcHost final : public EvmcHostBase
     virtual evmc_access_status
     access_account(evmc::address const &address) noexcept override
     {
-        try {
+        MONAD_TRY
+        {
             if (is_precompile<traits>(address)) {
                 return EVMC_ACCESS_WARM;
             }
             return state_.access_account(address);
         }
-        catch (...) {
+        MONAD_CATCH(...)
+        {
             capture_current_exception();
         }
         stack_unwind();
@@ -214,10 +223,12 @@ struct EvmcHost final : public EvmcHostBase
         evmc::address const &address,
         evmc::bytes32 const &key) noexcept override
     {
-        try {
+        MONAD_TRY
+        {
             return state_.access_storage<traits>(address, key);
         }
-        catch (...) {
+        MONAD_CATCH(...)
+        {
             capture_current_exception();
         }
         stack_unwind();

--- a/zkvm/category/core/throw.hpp
+++ b/zkvm/category/core/throw.hpp
@@ -21,3 +21,5 @@
 #include <zkvm/core/zkvm_halt.h>
 
 #define MONAD_THROW(exc, ...) zkvm_halt(1)
+#define MONAD_TRY
+#define MONAD_CATCH(...) if constexpr (false)


### PR DESCRIPTION
`EvmcHost` wraps each callback in `try/catch (...)`, but the zkVM builds with `-fno-exceptions`, so the keywords are a hard compile error. `MONAD_TRY` / `MONAD_CATCH_ALL` hide them behind macros.