### PR TITLE
Add `is_code_tracer` to `StateTracer`

### DIFF
--- a/category/execution/ethereum/evmc_host.cpp
+++ b/category/execution/ethereum/evmc_host.cpp
@@ -26,6 +26,7 @@
 #include <category/execution/ethereum/evmc_host.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/execution/ethereum/trace/state_tracer.hpp>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -96,8 +97,7 @@ size_t EvmcHostBase::get_code_size(evmc::address const &address) const noexcept
 {
     MONAD_TRY
     {
-        if (MONAD_UNLIKELY(
-                std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
+        if (MONAD_UNLIKELY(trace::is_code_tracer(state_tracer_))) {
             bytes32_t const hash = state_.get_code_hash(address);
             if (hash == NULL_HASH) {
                 return 0;
@@ -139,8 +139,7 @@ size_t EvmcHostBase::copy_code(
 {
     MONAD_TRY
     {
-        if (MONAD_UNLIKELY(
-                std::holds_alternative<trace::CodeTracer>(state_tracer_))) {
+        if (MONAD_UNLIKELY(trace::is_code_tracer(state_tracer_))) {
             bytes32_t const hash = state_.get_code_hash(address);
             if (hash != NULL_HASH) {
                 auto const vcode = state_.read_code(hash);

--- a/category/execution/ethereum/trace/state_tracer.hpp
+++ b/category/execution/ethereum/trace/state_tracer.hpp
@@ -138,6 +138,11 @@ namespace trace
         std::monostate, PrestateTracer, StateDiffTracer, AccessListTracer,
         CodeTracer>;
 
+    [[gnu::always_inline]] inline bool is_code_tracer(StateTracer const &tracer)
+    {
+        return std::holds_alternative<CodeTracer>(tracer);
+    }
+
     inline void on_read_code(
         StateTracer &tracer, bytes32_t const &code_hash,
         vm::SharedIntercode const &intercode)

--- a/zkvm/category/execution/ethereum/trace/state_tracer.hpp
+++ b/zkvm/category/execution/ethereum/trace/state_tracer.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/bytes.hpp>
+#include <category/core/config.hpp>
+#include <category/vm/code.hpp>
+#include <category/vm/evm/traits.hpp>
+
+#include <variant>
+
+MONAD_NAMESPACE_BEGIN
+
+class State;
+
+namespace trace
+{
+    using StateTracer = std::monostate;
+
+    [[gnu::always_inline]] inline bool is_code_tracer(StateTracer const &)
+    {
+        return false;
+    }
+
+    [[gnu::always_inline]] inline void
+    on_read_code(StateTracer &, bytes32_t const &, vm::SharedIntercode const &)
+    {
+    }
+
+    [[gnu::always_inline]] inline void on_frame_reject(StateTracer &, State &)
+    {
+    }
+
+    [[gnu::always_inline]] inline void reset(StateTracer &) {}
+
+    template <Traits>
+    [[gnu::always_inline]] inline void run_tracer(StateTracer &, State &)
+    {
+    }
+}
+
+MONAD_NAMESPACE_END


### PR DESCRIPTION
`StateTracer` is defined as `monostate` instead of a `variant` for zkvm, so a bare `std::holds_alternative<trace::CodeTracer>` would not compile in zkvm