### PR TITLE
Use availability predicates in opcode/instruction tables

### DIFF
--- a/category/vm/evm/opcodes.hpp
+++ b/category/vm/evm/opcodes.hpp
@@ -21,9 +21,7 @@
 #include <evmc/evmc.hpp>
 
 #include <array>
-#include <cstddef>
 #include <cstdint>
-#include <exception>
 #include <string_view>
 #include <tuple>
 
@@ -252,13 +250,6 @@ namespace monad::vm::compiler
         SELFDESTRUCT = 0xFF
     };
 
-    consteval monad_eth_revision
-    previous_evm_revision(monad_eth_revision const rev)
-    {
-        MONAD_DEBUG_ASSERT(std::to_underlying(rev) > 0);
-        return monad_eth_revision(std::to_underlying(rev) - 1);
-    }
-
     /**
      * Placeholder value representing an opcode value not currently used by the
      * EVM specification. The value of `unknown_opcode_info` is significant, so
@@ -266,6 +257,17 @@ namespace monad::vm::compiler
      */
     constexpr auto unknown_opcode_info =
         OpCodeInfo{"UNKNOWN", 0, 0, false, false, 0, 0};
+
+    template <Traits traits>
+    consteval std::string_view eip_4399_name()
+    {
+        return traits::eip_4399_active() ? "PREVRANDAO" : "DIFFICULTY";
+    }
+
+    consteval OpCodeInfo when(bool const available, OpCodeInfo const info)
+    {
+        return available ? info : unknown_opcode_info;
+    }
 
     /**
      * Lookup table of opcode info for each possible 1-byte opcode value.
@@ -276,24 +278,11 @@ namespace monad::vm::compiler
      * revisions and become valid in later ones).
      */
     template <Traits traits>
-    consteval std::array<OpCodeInfo, 256> make_opcode_table() = delete;
-
-    template <Traits traits>
-    constexpr std::array<OpCodeInfo, 256> opcode_table =
-        make_opcode_table<traits>();
-
-    consteval inline void add_opcode(
-        uint8_t const opcode, std::array<OpCodeInfo, 256> &table,
-        OpCodeInfo const info)
+    consteval std::array<OpCodeInfo, 256> make_opcode_table()
     {
-        MONAD_DEBUG_ASSERT(table[opcode] == unknown_opcode_info);
-        table[opcode] = info;
-    }
+        static_assert(traits::evm_rev() >= MONAD_ETH_BERLIN);
 
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_BERLIN>>()
-    {
+        // clang-format off
         return {
             OpCodeInfo{"STOP", 0, 0, 0, false, 0, 0}, // 0x00
             OpCodeInfo{"ADD", 0, 2, 1, false, 3, 0}, // 0x01
@@ -326,7 +315,7 @@ namespace monad::vm::compiler
             OpCodeInfo{"SHL", 0, 2, 1, false, 3, 0}, // 0x1B,
             OpCodeInfo{"SHR", 0, 2, 1, false, 3, 0}, // 0x1C,
             OpCodeInfo{"SAR", 0, 2, 1, false, 3, 0}, // 0x1D,
-            unknown_opcode_info,
+            when(traits::eip_7939_active(), {"CLZ", 0, 1, 1, false, 5, 0}), // 0x1E,
             unknown_opcode_info,
 
             OpCodeInfo{"SHA3", 0, 2, 1, true, 30, 0}, // 0x20,
@@ -367,13 +356,13 @@ namespace monad::vm::compiler
             OpCodeInfo{"COINBASE", 0, 0, 1, false, 2, 0}, // 0x41,
             OpCodeInfo{"TIMESTAMP", 0, 0, 1, false, 2, 0}, // 0x42,
             OpCodeInfo{"NUMBER", 0, 0, 1, false, 2, 0}, // 0x43,
-            OpCodeInfo{"DIFFICULTY", 0, 0, 1, false, 2, 0}, // 0x44,
+            OpCodeInfo{eip_4399_name<traits>(), 0, 0, 1, false, 2, 0}, // 0x44,
             OpCodeInfo{"GASLIMIT", 0, 0, 1, false, 2, 0}, // 0x45,
             OpCodeInfo{"CHAINID", 0, 0, 1, false, 2, 0}, // 0x46,
             OpCodeInfo{"SELFBALANCE", 0, 0, 1, false, 5, 0}, // 0x47,
-            unknown_opcode_info,
-            unknown_opcode_info,
-            unknown_opcode_info,
+            when(traits::eip_3198_active(), {"BASEFEE", 0, 0, 1, false, 2, 0}), // 0x48,
+            when(traits::has_blob_opcodes(), {"BLOBHASH", 0, 1, 1, false, 3, 0}), // 0x49,
+            when(traits::has_blob_opcodes(), {"BLOBBASEFEE", 0, 0, 1, false, 2, 0}), // 0x4A,
             unknown_opcode_info,
             unknown_opcode_info,
             unknown_opcode_info,
@@ -385,17 +374,17 @@ namespace monad::vm::compiler
             OpCodeInfo{"MSTORE", 0, 2, 0, true, 3, 0}, // 0x52,
             OpCodeInfo{"MSTORE8", 0, 2, 0, true, 3, 0}, // 0x53,
             OpCodeInfo{"SLOAD", 0, 1, 1, true, 100, 0}, // 0x54,
-            OpCodeInfo{"SSTORE", 0, 2, 0, true, 100, 0}, // 0x55,
+            OpCodeInfo{"SSTORE", 0, 2, 0, true, traits::base_sstore_cost(), 0}, // 0x55,
             OpCodeInfo{"JUMP", 0, 1, 0, false, 8, 0}, // 0x56,
             OpCodeInfo{"JUMPI", 0, 2, 0, false, 10, 0}, // 0x57,
             OpCodeInfo{"PC", 0, 0, 1, false, 2, 0}, // 0x58,
             OpCodeInfo{"MSIZE", 0, 0, 1, false, 2, 0}, // 0x59,
             OpCodeInfo{"GAS", 0, 0, 1, false, 2, 0}, // 0x5A,
             OpCodeInfo{"JUMPDEST", 0, 0, 0, false, 1, 0}, // 0x5B,
-            unknown_opcode_info,
-            unknown_opcode_info,
-            unknown_opcode_info,
-            unknown_opcode_info,
+            when(traits::eip_1153_active(), {"TLOAD", 0, 1, 1, false, 100, 0}), // 0x5C,
+            when(traits::eip_1153_active(), {"TSTORE", 0, 2, 0, false, 100, 0}), // 0x5D,
+            when(traits::eip_5656_active(), {"MCOPY", 0, 3, 0, true, 3, 0}), // 0x5E,
+            when(traits::eip_3855_active(), {"PUSH0", 0, 0, 1, false, 2, 0}), // 0x5F,
 
             OpCodeInfo{"PUSH1", 1, 0, 1, false, 3, 1}, // 0x60,
             OpCodeInfo{"PUSH2", 2, 0, 1, false, 3, 2}, // 0x61,
@@ -567,166 +556,12 @@ namespace monad::vm::compiler
             unknown_opcode_info,
             OpCodeInfo{"SELFDESTRUCT", 0, 1, 0, true, 5000, 0} // 0xFF,
         };
+        // clang-format on
     }
 
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_LONDON>>()
-    {
-        auto table = make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_LONDON)>>();
-
-        add_opcode(0x48, table, {"BASEFEE", 0, 0, 1, false, 2, 0});
-
-        return table;
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_PARIS>>()
-    {
-        auto table = make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_PARIS)>>();
-
-        table[0x44].name = "PREVRANDAO";
-
-        return table;
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_SHANGHAI>>()
-    {
-        auto table = make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_SHANGHAI)>>();
-
-        add_opcode(0x5F, table, {"PUSH0", 0, 0, 1, false, 2, 0});
-
-        return table;
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_CANCUN>>()
-    {
-        auto table = make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_CANCUN)>>();
-
-        add_opcode(0x49, table, {"BLOBHASH", 0, 1, 1, false, 3, 0});
-        add_opcode(0x4A, table, {"BLOBBASEFEE", 0, 0, 1, false, 2, 0});
-        add_opcode(0x5C, table, {"TLOAD", 0, 1, 1, false, 100, 0});
-        add_opcode(0x5D, table, {"TSTORE", 0, 2, 0, false, 100, 0});
-        add_opcode(0x5E, table, {"MCOPY", 0, 3, 0, true, 3, 0});
-
-        return table;
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_PRAGUE>>()
-    {
-        return make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_PRAGUE)>>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_OSAKA>>()
-    {
-        auto table = make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_OSAKA)>>();
-
-        // https://eips.ethereum.org/EIPS/eip-7939
-        add_opcode(0x1E, table, {"CLZ", 0, 1, 1, false, 5, 0});
-        return table;
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<EvmTraits<MONAD_ETH_AMSTERDAM>>()
-    {
-        return make_opcode_table<
-            EvmTraits<previous_evm_revision(MONAD_ETH_AMSTERDAM)>>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_ZERO>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_ZERO>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_ONE>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_ONE>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_TWO>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_TWO>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_THREE>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_THREE>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_FOUR>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_FOUR>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_FIVE>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_FIVE>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_SIX>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_SIX>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_SEVEN>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_SEVEN>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_EIGHT>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_EIGHT>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_NINE>>()
-    {
-        return make_opcode_table<MonadTraits<MONAD_NINE>::evm_base>();
-    }
-
-    template <>
-    consteval std::array<OpCodeInfo, 256>
-    make_opcode_table<MonadTraits<MONAD_NEXT>>()
-    {
-        auto table = make_opcode_table<MonadTraits<MONAD_NEXT>::evm_base>();
-        table[SSTORE].min_gas = MonadTraits<MONAD_NEXT>::base_sstore_cost();
-        return table;
-    }
+    template <Traits traits>
+    constexpr std::array<OpCodeInfo, 256> opcode_table =
+        make_opcode_table<traits>();
 
     /**
      * Returns `true` if `opcode` is an invalid opcode at this revision.

--- a/category/vm/evm/revision.h
+++ b/category/vm/evm/revision.h
@@ -25,8 +25,8 @@ extern "C"
 // Monad's in-tree EVM fork revision enum. This is a drop-in replacement for
 // evmc's `evmc_revision`: the enumerators through MONAD_ETH_OSAKA mirror
 // `evmc_revision` 1:1 (same underlying integer values), which keeps ordering
-// comparisons and the arithmetic in previous_evm_revision() unchanged. That
-// 1:1 correspondence is enforced by static_assert in revision.cpp.
+// comparisons between revisions unchanged. That 1:1 correspondence is
+// enforced by static_assert in revision.cpp.
 //
 // MONAD_ETH_AMSTERDAM and above have no `evmc_revision` counterpart in the
 // bundled evmc — they are the first future forks grown on this side of the

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -20,12 +20,12 @@
 #include <category/vm/evm/monad/revision.h>
 #include <category/vm/evm/revision.h>
 
+#include <cstddef>
 #include <evmc/evmc.h>
 
 #include <concepts>
 #include <cstdint>
 #include <limits>
-#include <utility>
 
 namespace monad
 {
@@ -70,23 +70,34 @@ namespace monad
         { T::evm_rev() } -> std::same_as<monad_eth_revision>;
 
         // Feature flags
+
+        { T::eip_1153_active() } -> std::same_as<bool>;
+        { T::eip_3198_active() } -> std::same_as<bool>;
+        { T::eip_3855_active() } -> std::same_as<bool>;
+        { T::eip_4399_active() } -> std::same_as<bool>;
         { T::eip_4844_active() } -> std::same_as<bool>;
+        { T::eip_5656_active() } -> std::same_as<bool>;
         { T::eip_7685_active() } -> std::same_as<bool>;
         { T::eip_7691_active() } -> std::same_as<bool>;
         { T::eip_7823_active() } -> std::same_as<bool>;
         { T::eip_7883_active() } -> std::same_as<bool>;
+        { T::eip_7939_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
         { T::mip_8_active() } -> std::same_as<bool>;
         { T::mip_11_active() } -> std::same_as<bool>;
         { T::mip_12_active() } -> std::same_as<bool>;
         { T::can_create_inside_delegated() } -> std::same_as<bool>;
+        // If true, BLOBHASH/BLOBBASEFEE exist and return
+        // stub data. Separate from eip_4844_active.
+        { T::has_blob_opcodes() } -> std::same_as<bool>;
 
         // Constants
         { T::max_code_size() } -> std::same_as<size_t>;
         { T::max_initcode_size() } -> std::same_as<size_t>;
         { T::cold_account_cost() } -> std::same_as<int64_t>;
         { T::cold_storage_cost() } -> std::same_as<int64_t>;
+        { T::base_sstore_cost() } -> std::same_as<int64_t>;
 
         // Instead of storing a revision, caches should identify revision
         // changes by storing the opaque value returned by this method. No
@@ -105,7 +116,32 @@ namespace monad
             return Rev;
         }
 
+        static consteval bool eip_1153_active() noexcept
+        {
+            return Rev >= MONAD_ETH_CANCUN;
+        }
+
+        static consteval bool eip_3198_active() noexcept
+        {
+            return Rev >= MONAD_ETH_LONDON;
+        }
+
+        static consteval bool eip_3855_active() noexcept
+        {
+            return Rev >= MONAD_ETH_SHANGHAI;
+        }
+
+        static consteval bool eip_4399_active() noexcept
+        {
+            return Rev >= MONAD_ETH_PARIS;
+        }
+
         static consteval bool eip_4844_active() noexcept
+        {
+            return Rev >= MONAD_ETH_CANCUN;
+        }
+
+        static consteval bool eip_5656_active() noexcept
         {
             return Rev >= MONAD_ETH_CANCUN;
         }
@@ -126,6 +162,11 @@ namespace monad
         }
 
         static consteval bool eip_7883_active() noexcept
+        {
+            return Rev >= MONAD_ETH_OSAKA;
+        }
+
+        static consteval bool eip_7939_active() noexcept
         {
             return Rev >= MONAD_ETH_OSAKA;
         }
@@ -160,6 +201,11 @@ namespace monad
             return true;
         }
 
+        static consteval bool has_blob_opcodes() noexcept
+        {
+            return Rev >= MONAD_ETH_CANCUN;
+        }
+
         static consteval size_t max_code_size() noexcept
         {
             return constants::MAX_CODE_SIZE_EIP170;
@@ -182,6 +228,11 @@ namespace monad
         static consteval int64_t cold_storage_cost() noexcept
         {
             return 2000;
+        }
+
+        static consteval int64_t base_sstore_cost() noexcept
+        {
+            return 100;
         }
 
         static uint64_t id() noexcept
@@ -224,12 +275,37 @@ namespace monad
             return Rev;
         }
 
+        static consteval bool eip_1153_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_CANCUN;
+        }
+
+        static consteval bool eip_3198_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_LONDON;
+        }
+
+        static consteval bool eip_3855_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_SHANGHAI;
+        }
+
+        static consteval bool eip_4399_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_PARIS;
+        }
+
         static consteval bool eip_4844_active() noexcept
         {
             // if this EIP is ever enabled, reserve balance must be modified
             // such that execution (and consensus) is accounting for the blob
             // gas used (irrevocable) in the reserve balance calculation
             return false;
+        }
+
+        static consteval bool eip_5656_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_CANCUN;
         }
 
         static consteval bool eip_7685_active() noexcept
@@ -256,6 +332,11 @@ namespace monad
             return evm_rev() >= MONAD_ETH_OSAKA;
         }
 
+        static consteval bool eip_7939_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_OSAKA;
+        }
+
         static consteval bool eip_7951_active() noexcept
         {
             return Rev >= MONAD_FOUR;
@@ -277,6 +358,11 @@ namespace monad
         static consteval bool can_create_inside_delegated() noexcept
         {
             return false;
+        }
+
+        static consteval bool has_blob_opcodes() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_CANCUN;
         }
 
         static consteval bool mip_8_active() noexcept

--- a/category/vm/interpreter/instruction_table.hpp
+++ b/category/vm/interpreter/instruction_table.hpp
@@ -95,8 +95,10 @@ namespace monad::vm::interpreter
     {
         static_assert(traits::evm_rev() >= MONAD_ETH_ISTANBUL);
 
-        constexpr auto since = [](monad_eth_revision first, InstrEval impl) {
-            return (traits::evm_rev() >= first) ? impl : invalid;
+        constexpr auto avail = [](compiler::EvmOpCode const opcode,
+                                  InstrEval impl) {
+            return !compiler::is_unknown_opcode_info<traits>(opcode) ? impl
+                                                                     : invalid;
         };
 
         return {
@@ -131,7 +133,7 @@ namespace monad::vm::interpreter
             shl<traits>, // 0x1B,
             shr<traits>, // 0x1C,
             sar<traits>, // 0x1D,
-            since(MONAD_ETH_OSAKA, clz<traits>), // 0x1E,
+            avail(CLZ, clz<traits>), // 0x1E,
             invalid, //
 
             sha3<traits>, // 0x20,
@@ -177,9 +179,9 @@ namespace monad::vm::interpreter
             gaslimit<traits>, // 0x45,
             chainid<traits>, // 0x46,
             selfbalance<traits>, // 0x47,
-            since(MONAD_ETH_LONDON, basefee<traits>), // 0x48,
-            since(MONAD_ETH_CANCUN, blobhash<traits>), // 0x49,
-            since(MONAD_ETH_CANCUN, blobbasefee<traits>), // 0x4A,
+            avail(BASEFEE, basefee<traits>), // 0x48,
+            avail(BLOBHASH, blobhash<traits>), // 0x49,
+            avail(BLOBBASEFEE, blobbasefee<traits>), // 0x4A,
             invalid, //
             invalid, //
             invalid, //
@@ -198,10 +200,10 @@ namespace monad::vm::interpreter
             msize<traits>, // 0x59,
             gas<traits>, // 0x5A,
             jumpdest<traits>, // 0x5B,
-            since(MONAD_ETH_CANCUN, tload<traits>), // 0x5C,
-            since(MONAD_ETH_CANCUN, tstore<traits>), // 0x5D,
-            since(MONAD_ETH_CANCUN, mcopy<traits>), // 0x5E,
-            since(MONAD_ETH_SHANGHAI, push<0, traits>), // 0x5F,
+            avail(TLOAD, tload<traits>), // 0x5C,
+            avail(TSTORE, tstore<traits>), // 0x5D,
+            avail(MCOPY, mcopy<traits>), // 0x5E,
+            avail(PUSH0, push<0, traits>), // 0x5F,
 
             push<1, traits>, // 0x60,
             push<2, traits>, // 0x61,


### PR DESCRIPTION
Instead of using revision-chaining with `make_opcode_table` and successively building up newer tables with `add_opcode`, have one table that checks feature-flag availability predicates (e.g. `when(traits::eip_7939_active(), {"CLZ", ...})` for including the opcode `CLZ` if EIP-7939 is in the current fork).

Additionally, `instruction_table` now derives opcode availabilityfrom `opcode_table`, using `!is_unknown_opcode_info<traits>(op)` (through the `avail` helper lambda), keeping the tables in sync.
