### PR TITLE
mpt/async: use std::atomic_ref instead of start_lifetime_as<std::atomic<T>>

### DIFF
--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <atomic>
-#include <bit>
 #include <cassert>
 #include <compare>
 #include <cstdint>
@@ -205,63 +204,10 @@ inline size_t iov_length(std::span<const struct iovec> const iovecs)
 
 MONAD_ASYNC_NAMESPACE_END
 
-namespace std
-{
-    template <>
-    class atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>
-    {
-        atomic<uint64_t> v_;
-
-    public:
-        using value_type = MONAD_ASYNC_NAMESPACE::chunk_offset_t;
-
-        constexpr bool is_lock_free() const noexcept
-        {
-            return v_.is_lock_free();
-        }
-
-        constexpr explicit atomic(value_type const v) noexcept
-            : v_(std::bit_cast<uint64_t>(v))
-        {
-        }
-
-        atomic(atomic const &) = delete;
-        atomic(atomic &&) = delete;
-        atomic &operator=(atomic const &) = delete;
-        atomic &operator=(atomic &&) = delete;
-
-        void store(
-            value_type const v,
-            std::memory_order const ord = std::memory_order_seq_cst) noexcept
-        {
-            v_.store(std::bit_cast<uint64_t>(v), ord);
-        }
-
-        value_type load(std::memory_order const ord = std::memory_order_seq_cst)
-            const noexcept
-        {
-            return std::bit_cast<value_type>(v_.load(ord));
-        }
-
-        value_type exchange(
-            value_type const desired,
-            std::memory_order const ord = std::memory_order_seq_cst) noexcept
-        {
-            return std::bit_cast<value_type>(
-                v_.exchange(std::bit_cast<uint64_t>(desired), ord));
-        }
-    };
-}
-
-static_assert(sizeof(std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>) == 8);
-static_assert(alignof(std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>) == 8);
-static_assert(std::is_trivially_copyable_v<
-              std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>>);
-
-// The db metadata code views raw chunk_offset_t storage through
-// std::atomic_ref (the primary template, not the specialization above).
-// Require that view to be lock-free -- matching the uint64_t-backed
-// std::atomic<chunk_offset_t> -- so both use direct atomic instructions
-// rather than a per-process (hence non-shareable) lock table.
+// chunk_offset_t storage in the db metadata is accessed through
+// std::atomic_ref (see db_metadata_context). It lives in cross-process
+// shared memory, so require that view to be lock-free: a lock-based
+// fallback would use a per-process (hence non-shareable) lock table and
+// break cross-process atomicity.
 static_assert(std::atomic_ref<
               MONAD_ASYNC_NAMESPACE::chunk_offset_t>::is_always_lock_free);

--- a/category/async/config.hpp
+++ b/category/async/config.hpp
@@ -257,3 +257,11 @@ static_assert(sizeof(std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>) == 8);
 static_assert(alignof(std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>) == 8);
 static_assert(std::is_trivially_copyable_v<
               std::atomic<MONAD_ASYNC_NAMESPACE::chunk_offset_t>>);
+
+// The db metadata code views raw chunk_offset_t storage through
+// std::atomic_ref (the primary template, not the specialization above).
+// Require that view to be lock-free -- matching the uint64_t-backed
+// std::atomic<chunk_offset_t> -- so both use direct atomic instructions
+// rather than a per-process (hence non-shareable) lock table.
+static_assert(std::atomic_ref<
+              MONAD_ASYNC_NAMESPACE::chunk_offset_t>::is_always_lock_free);

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -121,7 +121,8 @@ std::pair<file_offset_t, file_offset_t> storage_pool::device_t::capacity() const
         auto const chunks = this->chunks();
         auto const useds = metadata_->chunk_bytes_used(size_of_file_);
         for (size_t n = 0; n < chunks; n++) {
-            used += useds[n].load(std::memory_order_acquire);
+            used += std::atomic_ref<uint32_t>(useds[n]).load(
+                std::memory_order_acquire);
         }
         return {capacity, used};
     }
@@ -166,11 +167,14 @@ std::pair<int, file_offset_t> storage_pool::chunk_t::write_fd(
             std::numeric_limits<uint32_t>::max());
         auto const size =
             (bytes_which_shall_be_written > 0)
-                ? chunk_bytes_used[chunkid_within_device_].fetch_add(
-                      static_cast<uint32_t>(bytes_which_shall_be_written),
-                      std::memory_order_acq_rel)
-                : chunk_bytes_used[chunkid_within_device_].load(
-                      std::memory_order_acquire);
+                ? std::atomic_ref<uint32_t>(
+                      chunk_bytes_used[chunkid_within_device_])
+                      .fetch_add(
+                          static_cast<uint32_t>(bytes_which_shall_be_written),
+                          std::memory_order_acq_rel)
+                : std::atomic_ref<uint32_t>(
+                      chunk_bytes_used[chunkid_within_device_])
+                      .load(std::memory_order_acquire);
         MONAD_ASSERT_PRINTF(
             size + bytes_which_shall_be_written <= metadata->chunk_capacity,
             "size %u bytes which shall be written %zu chunk capacity %u",
@@ -192,8 +196,9 @@ file_offset_t storage_pool::chunk_t::size() const
         }
         auto const chunk_bytes_used =
             metadata->chunk_bytes_used(device().size_of_file_);
-        return chunk_bytes_used[chunkid_within_device_].load(
-            std::memory_order_acquire);
+        return std::atomic_ref<uint32_t>(
+                   chunk_bytes_used[chunkid_within_device_])
+            .load(std::memory_order_acquire);
     }
     MONAD_ABORT("zonefs support isn't implemented yet");
 }
@@ -258,8 +263,8 @@ bool storage_pool::chunk_t::try_trim_contents(uint32_t bytes)
             auto const *metadata = device().metadata_;
             auto const chunk_bytes_used =
                 metadata->chunk_bytes_used(device().size_of_file_);
-            chunk_bytes_used[chunkid_within_device_].store(
-                bytes, std::memory_order_release);
+            std::atomic_ref<uint32_t>(chunk_bytes_used[chunkid_within_device_])
+                .store(bytes, std::memory_order_release);
         }
         return true;
     }
@@ -321,8 +326,8 @@ bool storage_pool::chunk_t::try_trim_contents(uint32_t bytes)
             auto const *metadata = device().metadata_;
             auto const chunk_bytes_used =
                 metadata->chunk_bytes_used(device().size_of_file_);
-            chunk_bytes_used[chunkid_within_device_].store(
-                bytes, std::memory_order_release);
+            std::atomic_ref<uint32_t>(chunk_bytes_used[chunkid_within_device_])
+                .store(bytes, std::memory_order_release);
         }
         return true;
     }

--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -119,10 +119,9 @@ std::pair<file_offset_t, file_offset_t> storage_pool::device_t::capacity() const
             "failed due to %s",
             std::strerror(errno));
         auto const chunks = this->chunks();
-        auto const useds = metadata_->chunk_bytes_used(size_of_file_);
         for (size_t n = 0; n < chunks; n++) {
-            used += std::atomic_ref<uint32_t>(useds[n]).load(
-                std::memory_order_acquire);
+            used += metadata_->chunk_bytes_used_at(size_of_file_, n)
+                        .load(std::memory_order_acquire);
         }
         return {capacity, used};
     }
@@ -160,21 +159,17 @@ std::pair<int, file_offset_t> storage_pool::chunk_t::write_fd(
             return std::pair<int, file_offset_t>{write_fd_, offset_};
         }
         auto const *const metadata = device().metadata_;
-        auto const chunk_bytes_used =
-            metadata->chunk_bytes_used(device().size_of_file_);
         MONAD_ASSERT(
             bytes_which_shall_be_written <=
             std::numeric_limits<uint32_t>::max());
+        auto const cbu = metadata->chunk_bytes_used_at(
+            device().size_of_file_, chunkid_within_device_);
         auto const size =
             (bytes_which_shall_be_written > 0)
-                ? std::atomic_ref<uint32_t>(
-                      chunk_bytes_used[chunkid_within_device_])
-                      .fetch_add(
-                          static_cast<uint32_t>(bytes_which_shall_be_written),
-                          std::memory_order_acq_rel)
-                : std::atomic_ref<uint32_t>(
-                      chunk_bytes_used[chunkid_within_device_])
-                      .load(std::memory_order_acquire);
+                ? cbu.fetch_add(
+                      static_cast<uint32_t>(bytes_which_shall_be_written),
+                      std::memory_order_acq_rel)
+                : cbu.load(std::memory_order_acquire);
         MONAD_ASSERT_PRINTF(
             size + bytes_which_shall_be_written <= metadata->chunk_capacity,
             "size %u bytes which shall be written %zu chunk capacity %u",
@@ -194,10 +189,9 @@ file_offset_t storage_pool::chunk_t::size() const
             // Conventional chunks are always full
             return metadata->chunk_capacity;
         }
-        auto const chunk_bytes_used =
-            metadata->chunk_bytes_used(device().size_of_file_);
-        return std::atomic_ref<uint32_t>(
-                   chunk_bytes_used[chunkid_within_device_])
+        return metadata
+            ->chunk_bytes_used_at(
+                device().size_of_file_, chunkid_within_device_)
             .load(std::memory_order_acquire);
     }
     MONAD_ABORT("zonefs support isn't implemented yet");
@@ -261,9 +255,9 @@ bool storage_pool::chunk_t::try_trim_contents(uint32_t bytes)
             std::strerror(errno));
         if (append_only_) {
             auto const *metadata = device().metadata_;
-            auto const chunk_bytes_used =
-                metadata->chunk_bytes_used(device().size_of_file_);
-            std::atomic_ref<uint32_t>(chunk_bytes_used[chunkid_within_device_])
+            metadata
+                ->chunk_bytes_used_at(
+                    device().size_of_file_, chunkid_within_device_)
                 .store(bytes, std::memory_order_release);
         }
         return true;
@@ -324,9 +318,9 @@ bool storage_pool::chunk_t::try_trim_contents(uint32_t bytes)
         }
         if (append_only_) {
             auto const *metadata = device().metadata_;
-            auto const chunk_bytes_used =
-                metadata->chunk_bytes_used(device().size_of_file_);
-            std::atomic_ref<uint32_t>(chunk_bytes_used[chunkid_within_device_])
+            metadata
+                ->chunk_bytes_used_at(
+                    device().size_of_file_, chunkid_within_device_)
                 .store(bytes, std::memory_order_release);
         }
         return true;

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -119,21 +119,22 @@ public:
                 return ret;
             }
 
-            // Only used for seq chunks. The elements alias shared on-disk
-            // storage; access each via std::atomic_ref<uint32_t>.
-            std::span<uint32_t> chunk_bytes_used(
-                file_offset_t const end_of_this_offset) const noexcept
+            // Only used for seq chunks. Returns an atomic view of the
+            // per-chunk bytes-used counter at `index`; the underlying uint32_t
+            // aliases shared on-disk storage, so access is always atomic.
+            std::atomic_ref<uint32_t> chunk_bytes_used_at(
+                file_offset_t const end_of_this_offset,
+                size_t const index) const noexcept
             {
                 static_assert(
                     sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));
                 auto const count = chunks(end_of_this_offset);
-                return {
-                    start_lifetime_as_array<uint32_t>(
-                        const_cast<std::byte *>(
-                            reinterpret_cast<std::byte const *>(this)) -
-                            count * sizeof(uint32_t),
-                        count),
-                    count};
+                auto *const base = start_lifetime_as_array<uint32_t>(
+                    const_cast<std::byte *>(
+                        reinterpret_cast<std::byte const *>(this)) -
+                        count * sizeof(uint32_t),
+                    count);
+                return std::atomic_ref<uint32_t>(base[index]);
             }
 
             // Bytes used by the pool metadata on this device

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -119,15 +119,16 @@ public:
                 return ret;
             }
 
-            // Only used for seq chunks
-            std::span<std::atomic<uint32_t>> chunk_bytes_used(
+            // Only used for seq chunks. The elements alias shared on-disk
+            // storage; access each via std::atomic_ref<uint32_t>.
+            std::span<uint32_t> chunk_bytes_used(
                 file_offset_t const end_of_this_offset) const noexcept
             {
                 static_assert(
                     sizeof(uint32_t) == sizeof(std::atomic<uint32_t>));
                 auto const count = chunks(end_of_this_offset);
                 return {
-                    start_lifetime_as_array<std::atomic<uint32_t>>(
+                    start_lifetime_as_array<uint32_t>(
                         const_cast<std::byte *>(
                             reinterpret_cast<std::byte const *>(this)) -
                             count * sizeof(uint32_t),

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -511,23 +511,20 @@ size_t DbMetadataContext::map_bytes_per_chunk_() const noexcept
 
 uint64_t DbMetadataContext::get_latest_finalized_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t>(
-               &copies_[0].main->latest_finalized_version)
-        ->load(std::memory_order_acquire);
+    return std::atomic_ref<uint64_t>(copies_[0].main->latest_finalized_version)
+        .load(std::memory_order_acquire);
 }
 
 uint64_t DbMetadataContext::get_latest_verified_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t>(
-               &copies_[0].main->latest_verified_version)
-        ->load(std::memory_order_acquire);
+    return std::atomic_ref<uint64_t>(copies_[0].main->latest_verified_version)
+        .load(std::memory_order_acquire);
 }
 
 uint64_t DbMetadataContext::get_latest_voted_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t>(
-               &copies_[0].main->latest_voted_version)
-        ->load(std::memory_order_acquire);
+    return std::atomic_ref<uint64_t>(copies_[0].main->latest_voted_version)
+        .load(std::memory_order_acquire);
 }
 
 bytes32_t DbMetadataContext::get_latest_voted_block_id() const noexcept
@@ -537,9 +534,8 @@ bytes32_t DbMetadataContext::get_latest_voted_block_id() const noexcept
 
 uint64_t DbMetadataContext::get_latest_proposed_version() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t>(
-               &copies_[0].main->latest_proposed_version)
-        ->load(std::memory_order_acquire);
+    return std::atomic_ref<uint64_t>(copies_[0].main->latest_proposed_version)
+        .load(std::memory_order_acquire);
 }
 
 bytes32_t DbMetadataContext::get_latest_proposed_block_id() const noexcept
@@ -550,16 +546,15 @@ bytes32_t DbMetadataContext::get_latest_proposed_block_id() const noexcept
 int64_t DbMetadataContext::get_auto_expire_version_metadata(
     timeline_id const tid) const noexcept
 {
-    auto const *const m = copies_[0].main;
+    auto *const m = copies_[0].main;
     uint8_t const primary_idx = primary_ring_idx();
     uint8_t const ring_idx = (tid == timeline_id::primary)
                                  ? primary_idx
                                  : static_cast<uint8_t>(primary_idx ^ 1u);
-    auto const *const slot =
-        (ring_idx == 0) ? &m->root_offsets_state.auto_expire_version_
-                        : &m->secondary_timeline_state.auto_expire_version_;
-    return start_lifetime_as<std::atomic_int64_t>(slot)->load(
-        std::memory_order_acquire);
+    auto *const slot = (ring_idx == 0)
+                           ? &m->root_offsets_state.auto_expire_version_
+                           : &m->secondary_timeline_state.auto_expire_version_;
+    return std::atomic_ref<int64_t>(*slot).load(std::memory_order_acquire);
 }
 
 // Version metadata setters
@@ -624,7 +619,7 @@ void DbMetadataContext::set_auto_expire_version_metadata(
         auto *const slot =
             (ring_idx == 0) ? &m->root_offsets_state.auto_expire_version_
                             : &m->secondary_timeline_state.auto_expire_version_;
-        start_lifetime_as<std::atomic_int64_t>(slot)->store(
+        std::atomic_ref<int64_t>(*slot).store(
             version, std::memory_order_release);
     };
     do_(copies_[0].main);
@@ -634,15 +629,15 @@ void DbMetadataContext::set_auto_expire_version_metadata(
 state_machine_kind
 DbMetadataContext::get_state_machine_kind(timeline_id const tid) const noexcept
 {
-    auto const *const m = copies_[0].main;
+    auto *const m = copies_[0].main;
     uint8_t const ring_idx = (tid == timeline_id::primary)
                                  ? primary_ring_idx()
                                  : (primary_ring_idx() ^ 1u);
-    auto const *const slot =
-        (ring_idx == 0) ? &m->root_offsets_state.state_machine_kind_
-                        : &m->secondary_timeline_state.state_machine_kind_;
-    auto const raw = start_lifetime_as<std::atomic_uint8_t>(slot)->load(
-        std::memory_order_acquire);
+    auto *const slot = (ring_idx == 0)
+                           ? &m->root_offsets_state.state_machine_kind_
+                           : &m->secondary_timeline_state.state_machine_kind_;
+    auto const raw =
+        std::atomic_ref<uint8_t>(*slot).load(std::memory_order_acquire);
     return static_cast<state_machine_kind>(raw);
 }
 
@@ -657,7 +652,7 @@ void DbMetadataContext::set_state_machine_kind(
         auto *const slot =
             (ring_idx == 0) ? &m->root_offsets_state.state_machine_kind_
                             : &m->secondary_timeline_state.state_machine_kind_;
-        start_lifetime_as<std::atomic_uint8_t>(slot)->store(
+        std::atomic_ref<uint8_t>(*slot).store(
             static_cast<uint8_t>(kind), std::memory_order_release);
     };
     do_(copies_[0].main);
@@ -769,9 +764,8 @@ uint64_t DbMetadataContext::version_history_max_possible() const noexcept
 
 uint64_t DbMetadataContext::version_history_length() const noexcept
 {
-    return start_lifetime_as<std::atomic_uint64_t>(
-               &copies_[0].main->history_length)
-        ->load(std::memory_order_relaxed);
+    return std::atomic_ref<uint64_t>(copies_[0].main->history_length)
+        .load(std::memory_order_relaxed);
 }
 
 uint64_t DbMetadataContext::db_history_range_lower_bound(
@@ -797,9 +791,8 @@ bool DbMetadataContext::timeline_active(timeline_id const tid) const noexcept
     if (tid == timeline_id::primary) {
         return true;
     }
-    return start_lifetime_as<std::atomic<uint8_t>>(
-               &copies_[0].main->secondary_timeline_active_)
-               ->load(std::memory_order_acquire) != 0;
+    return std::atomic_ref<uint8_t>(copies_[0].main->secondary_timeline_active_)
+               .load(std::memory_order_acquire) != 0;
 }
 
 void DbMetadataContext::reset_secondary_ring_storage_(
@@ -1205,15 +1198,13 @@ void DbMetadataContext::do_activate_secondary_body_(uint32_t const new_chunks)
         //    capacity excludes older versions (idempotent: std::max is a
         //    fixed point under repeated application).
         uint64_t const nv =
-            start_lifetime_as<std::atomic_uint64_t>(pver_nv)->load(
-                std::memory_order_acquire);
+            std::atomic_ref<uint64_t>(*pver_nv).load(std::memory_order_acquire);
         uint64_t const cur_lb =
-            start_lifetime_as<std::atomic_uint64_t>(pver_lb)->load(
-                std::memory_order_acquire);
+            std::atomic_ref<uint64_t>(*pver_lb).load(std::memory_order_acquire);
         uint64_t const new_lb =
             std::max(cur_lb, (nv >= new_cap) ? (nv - new_cap) : uint64_t{0});
         if (new_lb > cur_lb) {
-            start_lifetime_as<std::atomic_uint64_t>(pver_lb)->store(
+            std::atomic_ref<uint64_t>(*pver_lb).store(
                 new_lb, std::memory_order_release);
         }
         // 2. Under replay, the primary's tail slots [new_chunks, old_chunks)
@@ -1255,12 +1246,12 @@ void DbMetadataContext::do_activate_secondary_body_(uint32_t const new_chunks)
                 if (old_pos == new_pos) {
                     continue;
                 }
-                auto *src = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &primary_span[old_pos]);
-                auto *dst = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                    &primary_span[new_pos]);
-                dst->store(
-                    src->load(std::memory_order_acquire),
+                std::atomic_ref<chunk_offset_t> const src(
+                    primary_span[old_pos]);
+                std::atomic_ref<chunk_offset_t> const dst(
+                    primary_span[new_pos]);
+                dst.store(
+                    src.load(std::memory_order_acquire),
                     std::memory_order_release);
             }
         }
@@ -1317,18 +1308,16 @@ void DbMetadataContext::do_activate_secondary_body_(uint32_t const new_chunks)
         auto const secondary_live_bytes =
             uint64_t(new_chunks) * map_bytes_per_chunk_();
         memset((void *)secondary_span.data(), 0xff, secondary_live_bytes);
-        start_lifetime_as<std::atomic_uint64_t>(sver_lb)->store(
-            0, std::memory_order_release);
-        start_lifetime_as<std::atomic_uint64_t>(sver_nv)->store(
-            0, std::memory_order_release);
+        std::atomic_ref<uint64_t>(*sver_lb).store(0, std::memory_order_release);
+        std::atomic_ref<uint64_t>(*sver_nv).store(0, std::memory_order_release);
         // 7. Commit cnv_chunks_len (idempotent store of the same value).
-        start_lifetime_as<std::atomic<uint32_t>>(&pstore.cnv_chunks_len)
-            ->store(new_chunks, std::memory_order_release);
-        start_lifetime_as<std::atomic<uint32_t>>(&sstore.cnv_chunks_len)
-            ->store(new_chunks, std::memory_order_release);
+        std::atomic_ref<uint32_t>(pstore.cnv_chunks_len)
+            .store(new_chunks, std::memory_order_release);
+        std::atomic_ref<uint32_t>(sstore.cnv_chunks_len)
+            .store(new_chunks, std::memory_order_release);
         // 8. Flip secondary_timeline_active_ (idempotent).
-        start_lifetime_as<std::atomic<uint8_t>>(&m->secondary_timeline_active_)
-            ->store(1, std::memory_order_release);
+        std::atomic_ref<uint8_t>(m->secondary_timeline_active_)
+            .store(1, std::memory_order_release);
     }
 
     if (version_history_length() > new_cap) {
@@ -1487,12 +1476,10 @@ void DbMetadataContext::do_deactivate_secondary_body_(
                          old_cap * sizeof(chunk_offset_t)),
                 0xff,
                 tail_bytes);
-            uint64_t const nv =
-                start_lifetime_as<std::atomic_uint64_t>(pver_nv)->load(
-                    std::memory_order_acquire);
-            uint64_t const lb =
-                start_lifetime_as<std::atomic_uint64_t>(pver_lb)->load(
-                    std::memory_order_acquire);
+            uint64_t const nv = std::atomic_ref<uint64_t>(*pver_nv).load(
+                std::memory_order_acquire);
+            uint64_t const lb = std::atomic_ref<uint64_t>(*pver_lb).load(
+                std::memory_order_acquire);
             if (nv != lb) {
                 for (uint64_t v = lb; v < nv; v++) {
                     uint64_t const old_pos = v & (old_cap - 1);
@@ -1500,25 +1487,25 @@ void DbMetadataContext::do_deactivate_secondary_body_(
                     if (old_pos == new_pos) {
                         continue;
                     }
-                    auto *src = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                        &primary_span[old_pos]);
-                    auto *dst = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                        &primary_span[new_pos]);
-                    dst->store(
-                        src->load(std::memory_order_acquire),
+                    std::atomic_ref<chunk_offset_t> const src(
+                        primary_span[old_pos]);
+                    std::atomic_ref<chunk_offset_t> const dst(
+                        primary_span[new_pos]);
+                    dst.store(
+                        src.load(std::memory_order_acquire),
                         std::memory_order_release);
                 }
             }
         }
         // 4. Commit the grow / shrink (primary grows, secondary shrinks
         //    to 0). Idempotent stores.
-        start_lifetime_as<std::atomic<uint32_t>>(&pstore.cnv_chunks_len)
-            ->store(primary_new_chunks, std::memory_order_release);
-        start_lifetime_as<std::atomic<uint32_t>>(&sstore.cnv_chunks_len)
-            ->store(0, std::memory_order_release);
+        std::atomic_ref<uint32_t>(pstore.cnv_chunks_len)
+            .store(primary_new_chunks, std::memory_order_release);
+        std::atomic_ref<uint32_t>(sstore.cnv_chunks_len)
+            .store(0, std::memory_order_release);
         // 5. Mark secondary inactive (idempotent).
-        start_lifetime_as<std::atomic<uint8_t>>(&m->secondary_timeline_active_)
-            ->store(0, std::memory_order_release);
+        std::atomic_ref<uint8_t>(m->secondary_timeline_active_)
+            .store(0, std::memory_order_release);
     }
 }
 
@@ -1580,8 +1567,8 @@ void DbMetadataContext::do_promote_secondary_to_primary_body_(
     for (auto const &copy : copies_) {
         auto *const m = copy.main;
         auto const g = m->hold_dirty();
-        start_lifetime_as<std::atomic<uint8_t>>(&m->primary_ring_idx)
-            ->store(target_ring_idx, std::memory_order_release);
+        std::atomic_ref<uint8_t>(m->primary_ring_idx)
+            .store(target_ring_idx, std::memory_order_release);
     }
 }
 

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -564,8 +564,8 @@ void DbMetadataContext::set_latest_finalized_version(
 {
     auto do_ = [&](detail::db_metadata *m) {
         auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_finalized_version)
-            ->store(version, std::memory_order_release);
+        std::atomic_ref<uint64_t>(m->latest_finalized_version)
+            .store(version, std::memory_order_release);
     };
     do_(copies_[0].main);
     do_(copies_[1].main);
@@ -576,8 +576,8 @@ void DbMetadataContext::set_latest_verified_version(
 {
     auto do_ = [&](detail::db_metadata *m) {
         auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_verified_version)
-            ->store(version, std::memory_order_release);
+        std::atomic_ref<uint64_t>(m->latest_verified_version)
+            .store(version, std::memory_order_release);
     };
     do_(copies_[0].main);
     do_(copies_[1].main);
@@ -589,8 +589,8 @@ void DbMetadataContext::set_latest_voted(
     for (auto const i : {0, 1}) {
         auto *const m = copies_[i].main;
         auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_voted_version)
-            ->store(version, std::memory_order_release);
+        std::atomic_ref<uint64_t>(m->latest_voted_version)
+            .store(version, std::memory_order_release);
         m->latest_voted_block_id = block_id;
     }
 }
@@ -601,8 +601,8 @@ void DbMetadataContext::set_latest_proposed(
     for (auto const i : {0, 1}) {
         auto *const m = copies_[i].main;
         auto const g = m->hold_dirty();
-        reinterpret_cast<std::atomic_uint64_t *>(&m->latest_proposed_version)
-            ->store(version, std::memory_order_release);
+        std::atomic_ref<uint64_t>(m->latest_proposed_version)
+            .store(version, std::memory_order_release);
         m->latest_proposed_block_id = block_id;
     }
 }
@@ -677,8 +677,8 @@ void DbMetadataContext::update_history_length_metadata(
                 root_offsets(timeline_id::secondary, which).capacity() ==
                 ro.capacity());
         }
-        reinterpret_cast<std::atomic_uint64_t *>(&m->history_length)
-            ->store(history_len, std::memory_order_relaxed);
+        std::atomic_ref<uint64_t>(m->history_length)
+            .store(history_len, std::memory_order_relaxed);
     };
     do_(0);
     do_(1);

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -127,9 +127,9 @@ public:
             auto const wp = next_version_.load(std::memory_order_relaxed);
             auto const next_wp = wp + 1;
             MONAD_ASSERT(next_wp != 0);
-            auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                &root_offsets_chunks_[wp & (capacity_ - 1)]);
-            p->store(o, std::memory_order_release);
+            std::atomic_ref<chunk_offset_t> const p(
+                root_offsets_chunks_[wp & (capacity_ - 1)]);
+            p.store(o, std::memory_order_release);
             next_version_.store(next_wp, std::memory_order_release);
             if (o != INVALID_OFFSET) {
                 update_version_lower_bound_();
@@ -139,9 +139,9 @@ public:
         void assign(size_t const i, chunk_offset_t const o) noexcept
         {
             MONAD_ASSERT(capacity_ != 0);
-            auto *p = start_lifetime_as<std::atomic<chunk_offset_t>>(
-                &root_offsets_chunks_[i & (capacity_ - 1)]);
-            p->store(o, std::memory_order_release);
+            std::atomic_ref<chunk_offset_t> const p(
+                root_offsets_chunks_[i & (capacity_ - 1)]);
+            p.store(o, std::memory_order_release);
             update_version_lower_bound_(
                 (o != INVALID_OFFSET) ? i : uint64_t(-1));
         }
@@ -149,9 +149,9 @@ public:
         chunk_offset_t operator[](size_t const i) const noexcept
         {
             MONAD_ASSERT(capacity_ != 0);
-            return start_lifetime_as<std::atomic<chunk_offset_t>>(
-                       &root_offsets_chunks_[i & (capacity_ - 1)])
-                ->load(std::memory_order_acquire);
+            return std::atomic_ref<chunk_offset_t>(
+                       root_offsets_chunks_[i & (capacity_ - 1)])
+                .load(std::memory_order_acquire);
         }
 
         // return INVALID_BLOCK_NUM indicates that db is empty
@@ -242,9 +242,8 @@ public:
     // naturally with a promote flip done under release.
     uint8_t primary_ring_idx() const noexcept
     {
-        return start_lifetime_as<std::atomic<uint8_t>>(
-                   &copies_[0].main->primary_ring_idx)
-            ->load(std::memory_order_acquire);
+        return std::atomic_ref<uint8_t>(copies_[0].main->primary_ring_idx)
+            .load(std::memory_order_acquire);
     }
 
     root_offsets_delegator
@@ -535,18 +534,18 @@ private:
                 m->main->root_offsets.version_lower_bound_,
                 m->main->root_offsets.next_version_,
                 m->ring_a_span,
-                start_lifetime_as<std::atomic<uint32_t>>(
-                    &m->main->root_offsets.storage_.cnv_chunks_len)
-                        ->load(std::memory_order_acquire) *
+                std::atomic_ref<uint32_t>(
+                    m->main->root_offsets.storage_.cnv_chunks_len)
+                        .load(std::memory_order_acquire) *
                     entries_per_chunk};
         }
         return root_offsets_delegator{
             m->main->secondary_timeline.version_lower_bound_,
             m->main->secondary_timeline.next_version_,
             m->ring_b_span,
-            start_lifetime_as<std::atomic<uint32_t>>(
-                &m->main->secondary_timeline.storage_.cnv_chunks_len)
-                    ->load(std::memory_order_acquire) *
+            std::atomic_ref<uint32_t>(
+                m->main->secondary_timeline.storage_.cnv_chunks_len)
+                    .load(std::memory_order_acquire) *
                 entries_per_chunk};
     }
 

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -361,6 +361,10 @@ namespace detail
 #endif
         static_assert(sizeof(chunk_info_t) == 8);
         static_assert(std::is_trivially_copyable_v<chunk_info_t>);
+        // chunk_info[] lives in cross-process shared memory and is accessed
+        // via std::atomic_ref<chunk_info_t>; require lock-free so it uses
+        // direct atomic instructions rather than a per-process lock table.
+        static_assert(std::atomic_ref<chunk_info_t>::is_always_lock_free);
 
         auto hold_dirty() noexcept
         {
@@ -405,8 +409,14 @@ namespace detail
             uint32_t const idx, std::memory_order const load_ord =
                                     std::memory_order_seq_cst) const noexcept
         {
-            return reinterpret_cast<std::atomic<chunk_info_t> const *>(at(idx))
-                ->load(load_ord);
+            // at() is const-qualified, but chunk_info[] is mutable shared
+            // memory; std::atomic_ref gains a const-qualified form only in
+            // C++26 (P3323R1), so a const_cast is required here for now.
+            // TODO(C++26/P3323): use std::atomic_ref<chunk_info_t const> and
+            // drop the const_cast.
+            return std::atomic_ref<chunk_info_t>(
+                       *const_cast<chunk_info_t *>(at(idx)))
+                .load(load_ord);
         }
 
         chunk_info_t const *free_list_begin() const noexcept
@@ -499,7 +509,7 @@ namespace detail
                     tail->next_chunk_id == chunk_info_t::INVALID_CHUNK_ID);
                 list.end = tail->next_chunk_id = i->index(this) & 0xfffffU;
             }
-            reinterpret_cast<std::atomic<chunk_info_t> *>(i)->store(
+            std::atomic_ref<chunk_info_t>(*i).store(
                 info, std::memory_order_release);
         }
 
@@ -604,29 +614,34 @@ namespace detail
         MONAD_ASSERT((((uintptr_t)dest_) & 7) == 0);
         MONAD_ASSERT((((uintptr_t)src_) & 7) == 0);
         MONAD_ASSERT((((uintptr_t)bytes) & 7) == 0);
-        auto *dest = reinterpret_cast<std::atomic<uint64_t> *>(dest_);
-        auto const *src = reinterpret_cast<std::atomic<uint64_t> const *>(src_);
+        auto *dest = reinterpret_cast<uint64_t *>(dest_);
+        // src_ is const but aliases mutable shared memory; std::atomic_ref
+        // gains a const-qualified form only in C++26 (P3323R1), so cast the
+        // const away for now.
+        // TODO(C++26/P3323): use std::atomic_ref<uint64_t const>, drop cast.
+        auto *src = reinterpret_cast<uint64_t *>(const_cast<void *>(src_));
         while (bytes >= 64) {
-            auto const a0 = (src++)->load(load_ord);
-            auto const a1 = (src++)->load(load_ord);
-            auto const a2 = (src++)->load(load_ord);
-            auto const a3 = (src++)->load(load_ord);
-            auto const a4 = (src++)->load(load_ord);
-            auto const a5 = (src++)->load(load_ord);
-            auto const a6 = (src++)->load(load_ord);
-            auto const a7 = (src++)->load(load_ord);
-            (dest++)->store(a0, store_ord);
-            (dest++)->store(a1, store_ord);
-            (dest++)->store(a2, store_ord);
-            (dest++)->store(a3, store_ord);
-            (dest++)->store(a4, store_ord);
-            (dest++)->store(a5, store_ord);
-            (dest++)->store(a6, store_ord);
-            (dest++)->store(a7, store_ord);
+            auto const a0 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a1 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a2 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a3 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a4 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a5 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a6 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            auto const a7 = std::atomic_ref<uint64_t>(*src++).load(load_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a0, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a1, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a2, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a3, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a4, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a5, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a6, store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(a7, store_ord);
             bytes -= 64;
         }
         for (size_t n = 0; n < bytes; n += 8) {
-            (dest++)->store((src++)->load(load_ord), store_ord);
+            std::atomic_ref<uint64_t>(*dest++).store(
+                std::atomic_ref<uint64_t>(*src++).load(load_ord), store_ord);
         }
     }
 

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -169,7 +169,7 @@ namespace detail
         struct timeline_state_t
         {
             // Last upsert's auto-expire version threshold for this timeline.
-            // Accessed via start_lifetime_as<std::atomic_int64_t>.
+            // Accessed atomically via std::atomic_ref<int64_t>.
             int64_t auto_expire_version_;
             // mpt::state_machine_kind for the timeline currently bound to
             // this physical ring. Stamped at pool create time by monad-mpt
@@ -279,14 +279,14 @@ namespace detail
 
         // used to know if the metadata was being
         // updated when the process suddenly exited
-        std::atomic<uint8_t> &is_dirty() noexcept
+        std::atomic_ref<uint8_t> is_dirty() noexcept
         {
             static_assert(sizeof(std::atomic<uint8_t>) == sizeof(uint8_t));
 #ifndef __clang__
             static_assert(bitfield_layout_check());
 #endif
-            return *start_lifetime_as<std::atomic<uint8_t>>(
-                (std::byte *)&capacity_in_free_list - 1);
+            return std::atomic_ref<uint8_t>(*start_lifetime_as<uint8_t>(
+                (std::byte *)&capacity_in_free_list - 1));
         }
 
         struct id_pair

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -1499,9 +1499,8 @@ TEST(update_aux_test, replay_completes_pending_promote_after_crash)
         {
             auto *const m0 = const_cast<db_metadata *>(ctx.main(0));
             auto const g = m0->hold_dirty();
-            monad::start_lifetime_as<std::atomic<uint8_t>>(
-                &m0->primary_ring_idx)
-                ->store(1, std::memory_order_release);
+            std::atomic_ref<uint8_t>(m0->primary_ring_idx)
+                .store(1, std::memory_order_release);
         }
         ASSERT_EQ(ctx.main(0)->primary_ring_idx, 1u);
         ASSERT_EQ(ctx.main(1)->primary_ring_idx, 0u);


### PR DESCRIPTION
## Problem

libstdc++-16 made `std::start_lifetime_as<T>` hard-require `is_implicit_lifetime_v<T>`. `std::atomic<T>` is not an implicit-lifetime type, so the long-standing pattern of viewing raw bytes in the memory-mapped TrieDB metadata as a `std::atomic` — `start_lifetime_as<std::atomic<T>>(ptr)->load()/->store()` — no longer compiles under gcc-16 / libstdc++-16:

```
error: static assertion failed
  static_assert(is_implicit_lifetime_v<_Tp>);
  • 'std::atomic<unsigned char>' is not an implicit-lifetime type
```

## Fix

Those sites (and their `reinterpret_cast<std::atomic<T>*>` siblings) perform atomic loads / stores / `fetch_add` on plain, non-atomic fields that live in shared, memory-mapped metadata. There was never a real `std::atomic` object at those addresses, so the pattern was always technically UB — libstdc++-16 just began enforcing it. `std::atomic_ref<T>` is the C++20 facility for exactly this: atomic operations on a pre-existing non-atomic object. This PR migrates every such site to `std::atomic_ref<T>`, **preserving each memory order verbatim**.

## Commits (kept split for review)

1. **use std::atomic_ref instead of start_lifetime_as<std::atomic<T>>** — the core fix; converts the 38 `start_lifetime_as<std::atomic<…>>` sites. `detail::db_metadata::is_dirty()` now returns `std::atomic_ref<uint8_t>` by value (callers use `.load()`/`.store()`/the implicit conversion, unchanged). `std::atomic_ref<chunk_offset_t>` resolves to the primary template rather than the custom `std::atomic<chunk_offset_t>` specialisation; a `static_assert(std::atomic_ref<chunk_offset_t>::is_always_lock_free)` pins that both lower to the same lock-free 8-byte atomics — required for the cross-process mmap.

2. **hand out atomic_ref via chunk_bytes_used_at accessor** — replaces `device_t::metadata_t::chunk_bytes_used()`, which returned a `std::span<uint32_t>` that each caller wrapped in `atomic_ref` per access, with `chunk_bytes_used_at(offset, index)` returning the `std::atomic_ref<uint32_t>` directly. Removes the footgun of a plain span whose elements could be accessed non-atomically by accident.

3. **drop the now-unused std::atomic<chunk_offset_t> specialisation** — with all access going through `atomic_ref`, the custom specialisation has no users anywhere in the tree; remove it, its layout static_asserts, and the `<bit>` include it needed for `bit_cast`.

4. **replace reinterpret_cast<std::atomic<T>*> with std::atomic_ref** — the sibling cast pattern that still compiled but expressed the same fake-atomic-object UB: the five `uint64_t` version setters, the `chunk_info_t` load/store, and the word-by-word `atomic_memcpy` loop. Two of these read through a const-qualified path (a const method / a `void const*` source) over genuinely-mutable shared memory; since `std::atomic_ref` gains a const-qualified form only in **C++26 (P3323R1)**, those two keep a documented `const_cast` + `TODO`. `chunk_info_t` has no custom specialisation, so `atomic_ref` uses the primary template exactly as the cast did; a matching lock-free `static_assert` is added.

## What is intentionally *not* changed

Behaviour. Every conversion is a 1:1 swap at the same address, width, and memory order; an independent detailed review of the diff (byte representation of the `chunk_offset_t` primary-vs-custom-atomic path, `atomic_ref::required_alignment` vs the `db_metadata` field layout, and site-by-site memory orders) concluded it is behaviour-preserving.

## Validation

- **Full build green under clang-19 + gcc-16 libstdc++** (the config this gcc-16 port is validated on). No `start_lifetime_as<atomic>` or `reinterpret_cast<atomic>` remain.
- **g++-16 directly:** the previously-failing TUs now compile. A full g++-16 `-O2` build still can't complete, but only because of pre-existing, unrelated `-Werror` false positives in Boost.Outcome headers — nothing in this diff.
- **Tests (clang + libstdc++-16), all green:** `storage_pool_test`, `db_metadata_test`, `db_state_machine_kind_open_test`, `update_aux_test`, and the `db_test` copy / dirty / secondary / auto_expire / version_history subset — covering every changed path, including the two `const` getters, the secondary-timeline migrate/promote logic, `db_copy`/`atomic_memcpy`, and chunk-info add/remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
