### PR TITLE
Add `MONAD_TEN`; activate MIP-8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All execution code is templated on a `Traits` parameter that encodes the chain r
 There are two trait families, defined in `category/vm/evm/traits.hpp`:
 
 - **`EvmTraits<evmc_revision>`** — one per EVM fork (HOMESTEAD through OSAKA, 14 total)
-- **`MonadTraits<monad_revision>`** — one per Monad revision (MONAD_ZERO through MONAD_NEXT, 11 total)
+- **`MonadTraits<monad_revision>`** — one per Monad revision (MONAD_ZERO through MONAD_NEXT, 12 total)
 
 Both satisfy the `Traits` concept, which exposes `consteval` methods for:
 - `evm_rev()` — the underlying EVM revision (MonadTraits maps to an EVM rev, e.g. MONAD_FOUR+ maps to EVMC_PRAGUE)
@@ -85,15 +85,15 @@ Templates must be explicitly instantiated in `.cpp` files using macros from `cat
 | Macro | What it instantiates | Revisions |
 |-------|---------------------|-----------|
 | `EXPLICIT_EVM_TRAITS(f)` | Free function `f` | 14 EVM revisions |
-| `EXPLICIT_MONAD_TRAITS(f)` | Free function `f` | 11 Monad revisions |
-| `EXPLICIT_TRAITS(f)` | Free function `f` | All 25 |
+| `EXPLICIT_MONAD_TRAITS(f)` | Free function `f` | 12 Monad revisions |
+| `EXPLICIT_TRAITS(f)` | Free function `f` | All 26 |
 | `EXPLICIT_EVM_TRAITS_CLASS(c)` | Class template `c` | 14 EVM revisions |
-| `EXPLICIT_MONAD_TRAITS_CLASS(c)` | Class template `c` | 11 Monad revisions |
-| `EXPLICIT_MONAD_TRAITS_STRUCT(c)` | Struct template `c` | 11 Monad revisions |
-| `EXPLICIT_TRAITS_CLASS(c)` | Class template `c` | All 25 |
+| `EXPLICIT_MONAD_TRAITS_CLASS(c)` | Class template `c` | 12 Monad revisions |
+| `EXPLICIT_MONAD_TRAITS_STRUCT(c)` | Struct template `c` | 12 Monad revisions |
+| `EXPLICIT_TRAITS_CLASS(c)` | Class template `c` | All 26 |
 | `EXPLICIT_EVM_TRAITS_MEMBER(f)` | Member function `f` | 14 EVM revisions |
-| `EXPLICIT_MONAD_TRAITS_MEMBER(f)` | Member function `f` | 11 Monad revisions |
-| `EXPLICIT_TRAITS_MEMBER(f)` | Member function `f` | All 25 |
+| `EXPLICIT_MONAD_TRAITS_MEMBER(f)` | Member function `f` | 12 Monad revisions |
+| `EXPLICIT_TRAITS_MEMBER(f)` | Member function `f` | All 26 |
 
 **Rules:**
 - Instantiation macros go in `.cpp` files only, never in headers.
@@ -156,7 +156,8 @@ Defined in `category/vm/evm/monad/revision.h`:
 |----------|---------------|-----------------|
 | MONAD_ZERO–THREE | EVMC_CANCUN | Base Monad; MONAD_TWO raises max code size to 128KB |
 | MONAD_FOUR–EIGHT | EVMC_PRAGUE | EIP-7951 active; larger initcode; Monad pricing v1 at MONAD_SEVEN |
-| MONAD_NINE+ | EVMC_OSAKA | MIP-3 active |
+| MONAD_NINE | EVMC_OSAKA | MIP-3 active |
+| MONAD_TEN | EVMC_OSAKA | MIP-8 (page-encoded storage) active |
 | MONAD_NEXT | EVMC_OSAKA | Future/development |
 
 Key differences from EVM traits: EIP-4844 (blob gas) is always disabled, cold account/storage costs are higher (Monad pricing), and code size limits are larger (128KB code, 256KB initcode). See the [Monad changelog](https://docs.monad.xyz/developer-essentials/changelog) for user-facing details of each revision.

--- a/category/execution/monad/chain/monad_testnet.cpp
+++ b/category/execution/monad/chain/monad_testnet.cpp
@@ -25,7 +25,10 @@ MONAD_NAMESPACE_BEGIN
 
 monad_revision MonadTestnet::get_monad_revision(uint64_t const timestamp) const
 {
-    if (MONAD_LIKELY(timestamp >= 1773153000)) { // 2026-03-10T14:30:00.000Z
+    if (MONAD_LIKELY(timestamp >= 1786545000)) { // 2026-08-12T14:30:00.000Z
+        return MONAD_TEN;
+    }
+    else if (timestamp >= 1773153000) { // 2026-03-10T14:30:00.000Z
         return MONAD_NINE;
     }
     else if (timestamp >= 1763562600) { // 2025-11-19T14:30:00.000Z

--- a/category/execution/monad/db/test_page_storage_migration.cpp
+++ b/category/execution/monad/db/test_page_storage_migration.cpp
@@ -65,11 +65,9 @@ namespace
     };
 
     // Revisions either side of the mip-8 (page-encoding) fork; keeps the
-    // MONAD_NEXT literal out of the call sites.
+    // MONAD_TEN literal out of the call sites.
     using PreMip8Fork = MonadTraits<MONAD_ZERO>;
-    using PostMip8Fork =
-        MonadTraits<MONAD_NEXT>; // TODO: replace MONAD_NEXT with the actual
-                                 // fork point constant when available
+    using PostMip8Fork = MonadTraits<MONAD_TEN>;
     static_assert(
         PostMip8Fork::mip_8_active(), "PostMip8Fork should have MIP-8 active");
 

--- a/category/mpt/state_machine_kind.hpp
+++ b/category/mpt/state_machine_kind.hpp
@@ -34,7 +34,7 @@ enum class state_machine_kind : uint8_t
     // so a zeroed metadata byte (DBs created before the kind was persisted,
     // freshly-created pools) reads back as ethereum with no migration step.
     ethereum = 0,
-    // MonadOnDiskMachine: page-encoded storage for chains at MONAD_NEXT or
+    // MonadOnDiskMachine: page-encoded storage for chains at MONAD_TEN or
     // later. Registered alongside ethereum.
     monad = 1,
     // Future kinds extend here. Never reorder or reuse values: they are

--- a/category/vm/evm/explicit_traits.hpp
+++ b/category/vm/evm/explicit_traits.hpp
@@ -63,6 +63,8 @@
         f<::monad::MonadTraits<MONAD_EIGHT>>;                                  \
     template decltype(f<::monad::MonadTraits<MONAD_NINE>>)                     \
         f<::monad::MonadTraits<MONAD_NINE>>;                                   \
+    template decltype(f<::monad::MonadTraits<MONAD_TEN>>)                      \
+        f<::monad::MonadTraits<MONAD_TEN>>;                                    \
     template decltype(f<::monad::MonadTraits<MONAD_NEXT>>)                     \
         f<::monad::MonadTraits<MONAD_NEXT>>;
 
@@ -93,6 +95,7 @@
     template class c<::monad::MonadTraits<MONAD_SEVEN>>;                       \
     template class c<::monad::MonadTraits<MONAD_EIGHT>>;                       \
     template class c<::monad::MonadTraits<MONAD_NINE>>;                        \
+    template class c<::monad::MonadTraits<MONAD_TEN>>;                         \
     template class c<::monad::MonadTraits<MONAD_NEXT>>;
 
 #define EXPLICIT_TRAITS_CLASS(c)                                               \
@@ -110,6 +113,7 @@
     template struct c<::monad::MonadTraits<MONAD_SEVEN>>;                      \
     template struct c<::monad::MonadTraits<MONAD_EIGHT>>;                      \
     template struct c<::monad::MonadTraits<MONAD_NINE>>;                       \
+    template struct c<::monad::MonadTraits<MONAD_TEN>>;                        \
     template struct c<::monad::MonadTraits<MONAD_NEXT>>;
 
 // Template member functions
@@ -162,6 +166,7 @@
     template void id<&f<::monad::MonadTraits<MONAD_SEVEN>>>();                 \
     template void id<&f<::monad::MonadTraits<MONAD_EIGHT>>>();                 \
     template void id<&f<::monad::MonadTraits<MONAD_NINE>>>();                  \
+    template void id<&f<::monad::MonadTraits<MONAD_TEN>>>();                   \
     template void id<&f<::monad::MonadTraits<MONAD_NEXT>>>();
 
 #define EXPLICIT_MONAD_TRAITS_MEMBER_HELPER(f, id)                             \

--- a/category/vm/evm/monad/revision.h
+++ b/category/vm/evm/monad/revision.h
@@ -32,7 +32,8 @@ enum monad_revision
     MONAD_SEVEN = 7,
     MONAD_EIGHT = 8,
     MONAD_NINE = 9,
-    MONAD_NEXT = 10
+    MONAD_TEN = 10,
+    MONAD_NEXT = 11,
 };
 
 inline char const *monad_revision_to_string(enum monad_revision const rev)
@@ -58,6 +59,8 @@ inline char const *monad_revision_to_string(enum monad_revision const rev)
         return "MONAD_EIGHT";
     case MONAD_NINE:
         return "MONAD_NINE";
+    case MONAD_TEN:
+        return "MONAD_TEN";
     case MONAD_NEXT:
         return "MONAD_NEXT";
     }

--- a/category/vm/evm/switch_traits.hpp
+++ b/category/vm/evm/switch_traits.hpp
@@ -65,6 +65,8 @@
         return f<::monad::MonadTraits<MONAD_EIGHT>>(__VA_ARGS__);              \
     case MONAD_NINE:                                                           \
         return f<::monad::MonadTraits<MONAD_NINE>>(__VA_ARGS__);               \
+    case MONAD_TEN:                                                            \
+        return f<::monad::MonadTraits<MONAD_TEN>>(__VA_ARGS__);                \
     case MONAD_NEXT:                                                           \
         return f<::monad::MonadTraits<MONAD_NEXT>>(__VA_ARGS__);               \
     }

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -258,7 +258,7 @@ namespace monad
     // mip-8 (page-encoding) activation cutoff.
     constexpr bool mip_8_active(monad_revision const rev) noexcept
     {
-        return rev >= MONAD_NEXT;
+        return rev >= MONAD_TEN;
     }
 
     template <monad_revision Rev>

--- a/category/vm/runtime/storage_costs.hpp
+++ b/category/vm/runtime/storage_costs.hpp
@@ -236,6 +236,12 @@ namespace monad::vm::runtime
     };
 
     template <>
+    struct StorageCostTable<MonadTraits<MONAD_TEN>>
+        : StorageCostTable<MonadTraits<MONAD_TEN>::evm_base>
+    {
+    };
+
+    template <>
     struct StorageCostTable<MonadTraits<MONAD_NEXT>>
         : StorageCostTable<MonadTraits<MONAD_NEXT>::evm_base>
     {

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -470,13 +470,11 @@ try {
                     block_db_timeout);
             }
             else {
-#if 0
-                // TODO: Enable this check when we announce the migration; 
-                // remove once dual-db is deprecated.
-                // Live monad must be dual db mode: slot-encoded primary + 
+                // TODO: Remove this check once dual-db is deprecated.
+                // Live monad must be dual db mode: slot-encoded primary +
                 // page-encoded secondary.
-                if (chain_config == CHAIN_CONFIG_MONAD_TESTNET ||
-                    chain_config == CHAIN_CONFIG_MONAD_MAINNET) {
+                // TODO: Enable assertion for mainnet when dual-db is enabled
+                if (chain_config == CHAIN_CONFIG_MONAD_TESTNET) {
                     MONAD_ASSERT_PRINTF(
                         raw_db.timeline_active(
                             monad::mpt::timeline_id::secondary),
@@ -487,7 +485,7 @@ try {
                             ? "monad_testnet"
                             : "monad_mainnet"); // TODO: remove at release2
                 }
-#endif
+
                 std::optional<mpt::Db> secondary_db;
                 std::optional<TrieDb> secondary_triedb;
                 if (raw_db.timeline_active(

--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -27,8 +27,8 @@ ExternalProject_Add(
 
 ExternalProject_Add(
   MonadSpecTestFixtures
-  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad@v1.1.1/fixtures_monad.tar.gz"
-  URL_HASH "SHA256=1837b6bbbb51bd956623c5efc92f0c6123be7ea7563492703ff085d7c31876f2"
+  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad@v1.2.0/fixtures_monad.tar.gz"
+  URL_HASH "SHA256=d0210111e5902d375b9b428824df820f1e2ce8aa79c645445f862a22a364cc87"
   PREFIX ${CMAKE_BINARY_DIR}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
@@ -109,7 +109,7 @@ endfunction()
 
 add_monad_test(FORK MONAD_EIGHT)
 add_monad_test(FORK MONAD_NINE)
-add_monad_test(FORK MONAD_NEXT)
+add_monad_test(FORK MONAD_TEN)
 
 # MONAD_NEXT Amsterdam spec tests, from a separate fixtures release. While the
 # whole suite is excluded (see the exclusion file), the runner exits non-zero

--- a/test/ethereum_test/exclude/MONAD_TEN.cmake
+++ b/test/ethereum_test/exclude/MONAD_TEN.cmake
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-set(MONAD_NEXT_excluded_tests "")
+set(MONAD_TEN_excluded_tests "")

--- a/test/ethereum_test/include/revision_map.hpp
+++ b/test/ethereum_test/include/revision_map.hpp
@@ -53,6 +53,7 @@ inline std::unordered_map<
         {"MONAD_SEVEN", MONAD_SEVEN},
         {"MONAD_EIGHT", MONAD_EIGHT},
         {"MONAD_NINE", MONAD_NINE},
+        {"MONAD_TEN", MONAD_TEN},
         {"MONAD_NEXT", MONAD_NEXT}};
 
 MONAD_TEST_NAMESPACE_END

--- a/test/vm/unit/async_compile_tests.cpp
+++ b/test/vm/unit/async_compile_tests.cpp
@@ -163,7 +163,7 @@ TEST(async_compile_test, trait_ids_distinct)
 {
     // One revision per line so the roster stays readable and diffs cleanly.
     // clang-format off
-    std::array<uint64_t, 19> const ids{
+    std::array<uint64_t, 20> const ids{
         EvmTraits<MONAD_ETH_BERLIN>::id(),
         EvmTraits<MONAD_ETH_LONDON>::id(),
         EvmTraits<MONAD_ETH_PARIS>::id(),
@@ -182,13 +182,14 @@ TEST(async_compile_test, trait_ids_distinct)
         MonadTraits<MONAD_SEVEN>::id(),
         MonadTraits<MONAD_EIGHT>::id(),
         MonadTraits<MONAD_NINE>::id(),
+        MonadTraits<MONAD_TEN>::id(),
         MonadTraits<MONAD_NEXT>::id()};
     // clang-format on
 
     // Trip-wire: adding a revision to either family shifts these sentinels,
     // forcing the id list above to be extended so coverage stays exhaustive.
     static_assert(
-        MONAD_NEXT == 10, "a monad_revision was added; extend the list above");
+        MONAD_NEXT == 11, "a monad_revision was added; extend the list above");
     static_assert(
         MONAD_ETH_EXPERIMENTAL == 16,
         "a monad_eth_revision was added; extend the list above");


### PR DESCRIPTION
This PR adds a new Monad revision (`MONAD_TEN`) and specifies that MIP-8 is the only feature activated in that revision.