### PR TITLE
core: seed Address/bytes32/StorageKey hashing per process

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -110,6 +110,8 @@ add_library(
   "path_util.c"
   "path_util.h"
   "result.hpp"
+  "seeded_fast_hash.cpp"
+  "seeded_fast_hash.hpp"
   "size_of.hpp"
   "small_prng.hpp"
   "spinlock.h"

--- a/category/core/address.hpp
+++ b/category/core/address.hpp
@@ -18,6 +18,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/hex.hpp>
+#include <category/core/seeded_fast_hash.hpp>
 
 #include <evmc/evmc.h>
 
@@ -118,8 +119,7 @@ struct std::hash<monad::Address>
 {
     size_t operator()(monad::Address const &x) const noexcept
     {
-        return ankerl::unordered_dense::detail::wyhash::hash(
-            x.bytes, sizeof(x.bytes));
+        return monad::seeded_fast_hash(x.bytes, sizeof(x.bytes));
     }
 };
 

--- a/category/core/bytes.hpp
+++ b/category/core/bytes.hpp
@@ -23,6 +23,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
+#include <category/core/seeded_fast_hash.hpp>
 
 #include <evmc/evmc.hpp>
 
@@ -152,8 +153,7 @@ struct std::hash<monad::bytes32_t>
 {
     size_t operator()(monad::bytes32_t const &x) const noexcept
     {
-        return ankerl::unordered_dense::detail::wyhash::hash(
-            x.bytes, sizeof(x.bytes));
+        return monad::seeded_fast_hash(x.bytes, sizeof(x.bytes));
     }
 };
 

--- a/category/core/seeded_fast_hash.cpp
+++ b/category/core/seeded_fast_hash.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/seeded_fast_hash.hpp>
+
+#include <category/core/config.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <komihash.h>
+#pragma GCC diagnostic pop
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+uint64_t g_seed = 143;
+
+std::once_flag g_seed_once;
+
+uint64_t hash_seed() noexcept
+{
+    static uint64_t const seed = g_seed;
+    return seed;
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
+
+MONAD_NAMESPACE_BEGIN
+
+uint64_t set_hash_seed()
+{
+    std::call_once(g_seed_once, [] {
+        std::random_device rd;
+        g_seed = std::uniform_int_distribution<uint64_t>{}(rd);
+    });
+    return hash_seed();
+}
+
+uint64_t seeded_fast_hash(void const *const data, size_t const len) noexcept
+{
+    return komihash(data, len, hash_seed());
+}
+
+MONAD_NAMESPACE_END

--- a/category/core/seeded_fast_hash.hpp
+++ b/category/core/seeded_fast_hash.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,32 +16,14 @@
 #pragma once
 
 #include <category/core/config.hpp>
-#include <category/core/seeded_fast_hash.hpp>
+
+#include <cstddef>
+#include <cstdint>
 
 MONAD_NAMESPACE_BEGIN
 
-template <class Bytes>
-struct BytesHashCompare
-{
-    // Ankerl-style hasher requirement.
-    using is_avalanching = void;
+uint64_t set_hash_seed();
 
-    // TBB concurrent_hash_map calls hash() / equal(); ankerl::unordered_dense
-    // calls operator() / equal(). Provide both from the same type.
-    size_t hash(Bytes const &a) const
-    {
-        return seeded_fast_hash(a.bytes, sizeof(Bytes));
-    }
-
-    size_t operator()(Bytes const &a) const
-    {
-        return hash(a);
-    }
-
-    bool equal(Bytes const &a, Bytes const &b) const
-    {
-        return memcmp(a.bytes, b.bytes, sizeof(Bytes)) == 0;
-    }
-};
+uint64_t seeded_fast_hash(void const *data, size_t len) noexcept;
 
 MONAD_NAMESPACE_END

--- a/category/core/seeded_fast_hash_test.cpp
+++ b/category/core/seeded_fast_hash_test.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/seeded_fast_hash.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <komihash.h>
+#pragma GCC diagnostic pop
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <unistd.h>
+
+using namespace monad;
+
+// The seed is applied per process. Unfortunately this makes the test suite
+// fairly arcane, since we need to create a death test for each case and
+// communicate success via error codes.
+TEST(SeededFastHashDeathTest, unseeded_process_uses_default)
+{
+    EXPECT_EXIT(
+        ({
+            // default is 143
+            unsigned char const data[] = {1, 2, 3, 4};
+            ::_exit(
+                seeded_fast_hash(data, sizeof(data)) ==
+                        komihash(data, sizeof(data), 143)
+                    ? 0
+                    : 1);
+        }),
+        ::testing::ExitedWithCode(0),
+        "");
+}
+
+TEST(SeededFastHashDeathTest, seed_is_set_once)
+{
+    EXPECT_EXIT(
+        ({
+            unsigned char const data[] = {1, 2, 3, 4};
+            uint64_t const seed = set_hash_seed();
+            // yes, this is flaky, but would be 10^13 years to trigger, and the
+            // coverage is worth it.
+            if (seed == 143) {
+                ::_exit(1);
+            }
+            if (seeded_fast_hash(data, sizeof(data)) !=
+                komihash(data, sizeof(data), seed)) {
+                ::_exit(2);
+            }
+            // later attempts are ignored
+            if (set_hash_seed() != seed) {
+                ::_exit(3);
+            }
+            if (seeded_fast_hash(data, sizeof(data)) !=
+                komihash(data, sizeof(data), seed)) {
+                ::_exit(4);
+            }
+            ::_exit(0);
+        }),
+        ::testing::ExitedWithCode(0),
+        "");
+}
+
+TEST(SeededFastHashDeathTest, seed_after_use_is_ignored)
+{
+    EXPECT_EXIT(
+        ({
+            unsigned char const data[] = {1, 2, 3, 4};
+            if (seeded_fast_hash(data, sizeof(data)) !=
+                komihash(data, sizeof(data), 143)) {
+                ::_exit(1);
+            }
+            if (set_hash_seed() != 143) {
+                ::_exit(2);
+            }
+            if (seeded_fast_hash(data, sizeof(data)) !=
+                komihash(data, sizeof(data), 143)) {
+                ::_exit(3);
+            }
+            ::_exit(0);
+        }),
+        ::testing::ExitedWithCode(0),
+        "");
+}

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -32,6 +32,7 @@
 #include <category/core/result.hpp>
 #include <category/core/rlp/decode_error.hpp>
 #include <category/core/runtime/uint256.hpp>
+#include <category/core/seeded_fast_hash.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
@@ -2018,6 +2019,9 @@ monad_executor *monad_executor_create(
     unsigned const tx_exec_num_fibers, uint64_t const node_lru_max_mem,
     char const *const dbpath)
 {
+    uint64_t const hash_seed = set_hash_seed();
+    LOG_INFO("rpc: hashtable seed: {}", hash_seed);
+
     MONAD_ASSERT(dbpath);
     std::string const triedb_path{dbpath};
 

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -24,6 +24,7 @@
 #include <category/core/log.hpp>
 #include <category/core/monad_exception.hpp>
 #include <category/core/procfs/statm.h>
+#include <category/core/seeded_fast_hash.hpp>
 #include <category/execution/ethereum/block_hash_buffer.hpp>
 #include <category/execution/ethereum/block_hash_buffer/util.hpp>
 #include <category/execution/ethereum/chain/chain_config.h>
@@ -247,6 +248,9 @@ try {
 
     init_root_logger(log_level);
     LOG_INFO("running with commit '{}'", GIT_COMMIT_HASH);
+
+    auto const hash_seed = set_hash_seed();
+    LOG_INFO("execution: hashtable seed: {}", hash_seed);
 
     // Initialize the event system if --exec-event-ring is specified
     if (exec_event_ring_option->count() > 0) {


### PR DESCRIPTION
Address and bytes32 are hashed via a seedless wyhash, and BytesHashCompare used komihash with a fixed seed of 0. Because the hash function was fixed, worst-case colliding keys can be constructed ahead
of time, degrading the affected node-local maps (state deltas, the proposal post-state, and the DbCache LRUs) into long probe walks under adversarial input.
    
Introduce seeded_fast_hash(), a single komihash-based primitive keyed by a 64-bit seed drawn once per process from std::random_device, and route every Address/bytes32/StorageKey hasher through it.  With a per-process seed the worst-case collisions can no longer be precomputed.