### PR TITLE
New OffsetTrie backend for PartialTrieDb - zero-copy loading from the witness binary

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(
   "ethereum/db/db_snapshot_filesystem.h"
   "ethereum/db/file_db.cpp"
   "ethereum/db/file_db.hpp"
+  "ethereum/db/offset_trie.hpp"
+  "ethereum/db/offset_trie.cpp"
   "ethereum/db/partial_trie_db.hpp"
   "ethereum/db/partial_trie_db.cpp"
   "ethereum/db/state_machine_init.cpp"

--- a/category/execution/ethereum/db/offset_trie.cpp
+++ b/category/execution/ethereum/db/offset_trie.cpp
@@ -1,0 +1,823 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/db/offset_trie.hpp>
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/cases.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/nibble.h>
+#include <category/core/rlp/encode.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/int_rlp.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <utility>
+#include <vector>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+NodeId OffsetTrie::read_root(byte_string_view const blob)
+{
+    unsigned char const *const base = blob.data();
+    size_t const len = blob.size();
+    MONAD_ASSERT(len >= HEADER_LEN);
+    MONAD_ASSERT(
+        base[0] == 'M' && base[1] == 'Z' && base[2] == 'W' && base[3] == 0x01);
+    // Keep blob offsets and overlay ids in disjoint halves of the NodeId
+    // space (blob < OVERLAY_BASE, fresh ids >= OVERLAY_BASE). Bounding the
+    // blob size bounds every offset. Real witnesses are ~MBs; this only
+    // rejects a pathological >=2 GiB blob.
+    MONAD_ASSERT(len < OVERLAY_BASE);
+    NodeId const root = read_node_id(base + 4);
+    MONAD_ASSERT(
+        root == NULL_ID || (static_cast<uint64_t>(root) >= HEADER_LEN &&
+                            static_cast<uint64_t>(root) < len));
+    return root;
+}
+
+OffsetTrie::OffsetTrie(byte_string_view const blob)
+    : blob_(blob)
+    , root{read_root(blob_)}
+{
+    unsigned char const *const base = blob_.data();
+
+    // Prime hashes bottom-up over the blob's nodes (children precede
+    // parents), rejecting any node whose extent leaves the region.
+    unsigned char const *const region_end = blob_.end();
+    uint64_t node_offset = HEADER_LEN;
+    NodeViewBase node{base + node_offset};
+    // The only node carrying the EMPTY tag is the magic header at the NULL_ID
+    // offset, which this walk starts past. checked_end has no EMPTY arm, so
+    // encountering that tag in the blob data aborts as an invalid tag. However,
+    // we have to check the very first node isn't EMPTY (provided it exists).
+    MONAD_ASSERT(node.bytes() == region_end || node.tag() != EMPTY);
+    std::vector<uint64_t> node_offsets((blob_.size() + 63) / 64, 0);
+
+    auto const is_valid_offset = [&](NodeId c) {
+        uint64_t child_offset = static_cast<uint64_t>(c);
+        MONAD_ASSERT(
+            c == NULL_ID ||
+            (child_offset < node_offset && child_offset < blob_.size() &&
+             ((node_offsets[child_offset >> 6] >> (child_offset & 63)) & 1)));
+    };
+    unsigned char rlp_buf[MAX_NODE_RLP];
+
+    while (node.bytes() < region_end) {
+        // checked_end asserts that the current node does not reach past the end
+        // of the region
+        auto next_offset =
+            static_cast<uint64_t>(node.checked_end(region_end) - base);
+
+        match(
+            node,
+            Cases{
+                [&](BranchView b) {
+                    // Validate the 16 children two at a time: a uint64_t load
+                    // spans exactly one pair, low word first.
+                    static_assert(std::endian::native == std::endian::little);
+                    static_assert(
+                        sizeof(uint64_t) == 2 * sizeof(node_id_wire_t));
+                    unsigned char const *const p = b.payload();
+                    uint64_t pair;
+                    for (unsigned i = 0; i < 8; ++i) {
+                        std::memcpy(&pair, p + i * sizeof(pair), sizeof(pair));
+                        is_valid_offset(
+                            NodeId{static_cast<node_id_wire_t>(pair)});
+                        is_valid_offset(
+                            NodeId{static_cast<node_id_wire_t>(pair >> 32)});
+                    }
+                },
+                [&](ExtView e) { is_valid_offset(e.child()); },
+                [&](AccountLeafView a) { is_valid_offset(a.storage()); },
+                [](auto) {}});
+
+        match(
+            node,
+            Cases{
+                [](NullView) {},
+                [](DigestView) {},
+                [&](auto) {
+                    node_rlp_span const rem = encode_rlp<true>(
+                        node, node_rlp_span{rlp_buf}); // priming pass
+                    // Only hash-referenced nodes (canonical RLP >= 32 B)
+                    // are cached; smaller nodes are inlined by their
+                    // parent, so caching their hash would make child_ref
+                    // emit a 32-byte ref where the trie inlines it.
+                    if (rem.rlp_size() >= 32) {
+                        bytes32_t h;
+                        keccak256(rem.rlp_data(), rem.rlp_size(), h.bytes);
+                        hashes_.emplace(NodeId{node_offset}, h);
+                    }
+                }});
+
+        node_offsets[node_offset >> 6] |= 1ull << (node_offset & 63);
+        node = NodeViewBase{base + next_offset};
+        node_offset = next_offset;
+    }
+    MONAD_ASSERT(node.bytes() == region_end); // nodes tile exactly
+    is_valid_offset(root);
+}
+
+NodeViewBase OffsetTrie::find_original(NodeId id, NibblesView key) const
+{
+    NodeViewBase found = empty();
+    while (id != NULL_ID) {
+        id = match(
+            get_original(id),
+            Cases{
+                [&](BranchView b) -> NodeId {
+                    if (key.nibble_size() == 0) { // no value at a branch
+                        return NULL_ID;
+                    }
+                    NodeId const next = b.child(key.get(0));
+                    key = key.substr(1);
+                    return next;
+                },
+                [&](ExtView e) -> NodeId {
+                    NibblesView const ep = e.path();
+                    if (!key.starts_with(ep)) {
+                        return NULL_ID;
+                    }
+                    key = key.substr(ep.nibble_size());
+                    return e.child();
+                },
+                [&](AccountLeafView l) -> NodeId {
+                    if (l.path() == key) {
+                        found = l;
+                    }
+                    return NULL_ID;
+                },
+                [&](StorageLeafView l) -> NodeId {
+                    if (l.path() == key) {
+                        found = l;
+                    }
+                    return NULL_ID;
+                },
+                [](DigestView) -> NodeId {
+                    MONAD_ABORT("incomplete witness: lookup hit a Digest");
+                },
+                [](NullView) -> NodeId {
+                    // There is only a single NullView node, namely the NULL_ID
+                    // magic header. However, since id is strictly greater than
+                    // 0 inside the loop, get_original can never reach it.
+                    std::unreachable();
+                },
+            });
+    }
+    return found;
+}
+
+bytes32_t OffsetTrie::hash(NodeId const id)
+{
+    auto const node = get_current(id);
+    return match(
+        node,
+        Cases{
+            [](NullView) { return NULL_ROOT; },
+            [](DigestView d) { return d.hash(); },
+            [&](auto) {
+                if (auto const it = hashes_.find(id); it != hashes_.end()) {
+                    return it->second;
+                }
+
+                unsigned char buf[MAX_NODE_RLP];
+                node_rlp_span const rem = encode_rlp(node, node_rlp_span{buf});
+                bytes32_t h;
+                // RLP occupies the tail: [rem.end(), buf_end).
+                keccak256(rem.rlp_data(), rem.rlp_size(), h.bytes);
+
+                hashes_.emplace(id, h);
+                return h;
+            }});
+}
+
+bytes32_t OffsetTrie::state_root()
+{
+    return hash(root);
+}
+
+template <bool priming_pass>
+OffsetTrie::node_rlp_span OffsetTrie::child_ref_compute(
+    NodeId const id, NodeViewBase const node, OffsetTrie::node_rlp_span dest)
+{
+    unsigned char buf[MAX_NODE_RLP];
+    node_rlp_span const rem =
+        encode_rlp<priming_pass>(node, node_rlp_span{buf});
+    unsigned char const *const child_rlp = rem.rlp_data();
+    size_t const child_rlp_len = rem.rlp_size();
+    if (child_rlp_len < 32) {
+        std::memcpy(dest.last(child_rlp_len).data(), child_rlp, child_rlp_len);
+        return dest.shrink(child_rlp_len);
+    }
+    // A pre-state (blob) node this large is hash-referenced, so prime()
+    // cached it bottom-up before any parent could reference it. Reaching
+    // here on a cache miss means the parent held a forward/garbage offset.
+    if constexpr (priming_pass) {
+        MONAD_ABORT("offset trie: unprimed hash-referenced node (bad offset)");
+    }
+    bytes32_t h;
+    keccak256(child_rlp, child_rlp_len, h.bytes);
+    hashes_.emplace(id, h);
+    rlp::encode_string(dest.last(33), byte_string_view{h.bytes, 32});
+    return dest.shrink(33);
+}
+
+template <bool priming_pass>
+OffsetTrie::node_rlp_span
+OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
+{
+    MONAD_DEBUG_ASSERT(node.tag() != EMPTY && node.tag() != DIGEST);
+    // Compact-encode `path` straight into d's tail as an RLP string; return
+    // d shrunk. The compact form is clen = nibble_size/2 + 1 bytes (<= 33,
+    // always a short string): write it directly, then prepend the
+    // 0x80+path_len prefix. When path_len == 1 the single byte is <= 0x3F,
+    // so it is already its own RLP and no prefix is added.
+    auto const encode_path = [](OffsetTrie::node_rlp_span d,
+                                NibblesView const path,
+                                bool const terminating) {
+        size_t const path_len = path.nibble_size() / 2 + 1;
+        compact_encode_raw(d.last(path_len).data(), path, terminating);
+        d = d.shrink(path_len);
+        if (path_len > 1) {
+            d.back() = static_cast<unsigned char>(0x80 + path_len);
+            d = d.shrink(1);
+        }
+        return d;
+    };
+    // Prepend the list header for payload [s.end(), dest.end()); return the
+    // final span. encode_list_prefix can transiently write up to 8 bytes,
+    // so build the header in a local and copy only its real length into
+    // place.
+    auto const wrap = [](OffsetTrie::node_rlp_span const s) {
+        size_t const payload_len = s.rlp_size();
+        unsigned char hdr[9];
+        auto const rest =
+            rlp::encode_list_prefix(std::span<unsigned char>{hdr}, payload_len);
+        size_t const hdr_len = sizeof(hdr) - rest.size();
+        std::memcpy(s.last(hdr_len).data(), hdr, hdr_len);
+        return s.shrink(hdr_len);
+    };
+    return node_rlp_span{match(
+        node,
+        Cases{
+            [&, wrap](BranchView b) -> std::span<unsigned char> {
+                dest.back() = 0x80; // empty branch value — last list element
+                dest = dest.shrink(1);
+                std::array<node_id_wire_t, 16> const children = b.children();
+
+                // A digest is pre-state only, put_node never shadows a digest
+                // id and its original bytes are still its current bytes which
+                // is why we can memcpy from the blob_ directly below.
+                auto const digest_at = [this](node_id_wire_t const w) {
+                    return w != 0 && w < OVERLAY_BASE &&
+                           get_original(NodeId{w}).tag() == Tag::DIGEST;
+                };
+
+                auto const consecutive_digest = [](node_id_wire_t const a,
+                                                   node_id_wire_t const b) {
+                    return uint64_t{a} + HASH_RLP_LEN == uint64_t{b};
+                };
+
+                for (int i = 15; i >= 0; --i) {
+                    if (!digest_at(children[static_cast<size_t>(i)])) {
+                        dest = child_ref<priming_pass>(
+                            NodeId{children[static_cast<size_t>(i)]}, dest);
+                        continue;
+                    }
+                    // copy any contiguous digests directly into dest, since a
+                    // digest node is already a valid RLP string
+                    static_assert(DIGEST == 0x80 + KECCAK256_SIZE);
+                    int lo = i;
+                    while (lo > 0 &&
+                           consecutive_digest(
+                               children[static_cast<size_t>(lo - 1)],
+                               children[static_cast<size_t>(lo)]) &&
+                           digest_at(children[static_cast<size_t>(lo - 1)])) {
+                        --lo;
+                    }
+                    size_t const digests_length =
+                        static_cast<size_t>(i - lo + 1) * HASH_RLP_LEN;
+
+                    unsigned char *const digests =
+                        dest.last(digests_length).data();
+                    std::memcpy(
+                        digests,
+                        blob_.data() + children[static_cast<size_t>(lo)],
+                        digests_length);
+
+                    dest = dest.shrink(digests_length);
+                    i = lo;
+                }
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](ExtView e) -> std::span<unsigned char> {
+                // child ref — last element
+                dest = child_ref<priming_pass>(e.child(), dest);
+                dest = encode_path(dest, e.path(), /*terminating=*/false);
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](
+                AccountLeafView l) -> std::span<unsigned char> {
+                // The leaf's value is the account's canonical RLP, which the
+                // node no longer holds whole: rebuild it straight into dest's
+                // tail — last field first, like everything else here —
+                // splicing the storage subtree's own hash in between the
+                // stored code_hash and nonce ‖ balance run. Reading the root
+                // through hash() is what ties the account to its storage — a
+                // leaf can only claim the root its subtree actually hashes to,
+                // and NULL_ID resolves to NULL_ROOT, i.e. no storage at all.
+                bytes32_t const storage_root = hash(l.storage());
+                byte_string_view const code_hash = l.code_hash_rlp();
+                std::memcpy(
+                    dest.last(HASH_RLP_LEN).data(),
+                    code_hash.data(),
+                    HASH_RLP_LEN);
+                dest = dest.shrink(HASH_RLP_LEN);
+                rlp::encode_string(
+                    dest.last(HASH_RLP_LEN),
+                    byte_string_view{storage_root.bytes, 32});
+                dest = dest.shrink(HASH_RLP_LEN);
+                byte_string_view const nonce_balance = l.nonce_balance_rlp();
+                std::memcpy(
+                    dest.last(nonce_balance.size()).data(),
+                    nonce_balance.data(),
+                    nonce_balance.size());
+                dest = dest.shrink(nonce_balance.size());
+                // The value is the first thing a leaf writes, so what stands
+                // in the buffer is exactly the account's payload: wrap closes
+                // it as the account list.
+                dest = wrap(dest);
+                // That list is in turn the leaf's value string. Its length is
+                // 68..108 of payload plus the 2-byte list header, so the
+                // string header is always 0xB7 + 1 followed by one length
+                // byte.
+                size_t const account_len = dest.rlp_size();
+                MONAD_DEBUG_ASSERT(account_len > 55 && account_len <= 0xFF);
+                dest.back() = static_cast<unsigned char>(account_len);
+                dest = dest.shrink(1);
+                dest.back() = 0xB8;
+                dest = dest.shrink(1);
+                dest = encode_path(dest, l.path(), /*terminating=*/true);
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](
+                StorageLeafView l) -> std::span<unsigned char> {
+                bytes32_t const v = l.value();
+                // storage value = rlp(zeroless(slot)), itself wrapped again
+                // as the leaf's value string: write the inner rlp(zl) into
+                // dest's tail, then prepend the outer string prefix in
+                // place.
+                auto const val =
+                    rlp::zeroless_view(to_byte_string_view(v.bytes));
+                size_t const val_len = rlp::string_length(val);
+                rlp::encode_string(dest.last(val_len), val);
+                dest = dest.shrink(val_len);
+                // The outer wrap collapses to no prefix only when it wraps
+                // a single byte <=0x7F, i.e. zl itself is one byte <=0x7F.
+                if (!(val.size() == 1 && val[0] <= 0x7F)) {
+                    dest.back() = static_cast<unsigned char>(0x80 + val_len);
+                    dest = dest.shrink(1);
+                }
+                dest = encode_path(dest, l.path(), /*terminating=*/true);
+                return wrap(dest);
+            },
+            [](DigestView) -> std::span<unsigned char> { std::unreachable(); },
+            [](NullView) -> std::span<unsigned char> { std::unreachable(); },
+        })};
+}
+
+namespace
+{
+    // Narrow `v` to the wire child field and append it little-endian, matching
+    // read_node_id.
+    void append_node_id(byte_string &b, NodeId const v)
+    {
+        static_assert(std::endian::native == std::endian::little);
+        auto const wire = to_node_id_wire_t(v);
+        b.append(reinterpret_cast<unsigned char const *>(&wire), sizeof(wire));
+    }
+
+    // Children already narrowed to the wire field: the array is exactly the
+    // payload, so it copies in one go rather than word by word. Only
+    // put_branch builds children in this form, so it stays local to this TU.
+    void append_branch(
+        byte_string &out, std::array<node_id_wire_t, 16> const &children)
+    {
+        static_assert(std::endian::native == std::endian::little);
+        out.reserve(out.size() + 1 + 16 * sizeof(node_id_wire_t));
+        out.push_back(BRANCH);
+        out.append(
+            reinterpret_cast<unsigned char const *>(children.data()),
+            children.size() * sizeof(node_id_wire_t));
+    }
+
+    // Append a path as nodes store it: a 1-byte nibble count then
+    // ceil(nlen/2) packed nibbles, left-aligned (nibble 0 in the high
+    // nibble of the first byte) — exactly what path_view reads back.
+    void append_path(byte_string &b, NibblesView const path)
+    {
+        unsigned const nlen = path.nibble_size();
+        MONAD_ASSERT(nlen <= std::numeric_limits<unsigned char>::max());
+        b.push_back(static_cast<unsigned char>(nlen));
+        size_t const start = b.size();
+        b.resize(start + (nlen + 1) / 2, 0);
+        for (unsigned i = 0; i < nlen; ++i) {
+            set_nibble(b.data() + start, i, path.get(i));
+        }
+    }
+
+    unsigned common_prefix_length(NibblesView const a, NibblesView const b)
+    {
+        unsigned const n = std::min(a.nibble_size(), b.nibble_size());
+        for (unsigned i = 0; i < n; ++i) {
+            if (a.get(i) != b.get(i)) {
+                return i;
+            }
+        }
+        return n;
+    }
+}
+
+void append_branch(byte_string &out, std::array<NodeId, 16> const &children)
+{
+    out.reserve(out.size() + 1 + 16 * sizeof(node_id_wire_t));
+    out.push_back(BRANCH);
+    for (NodeId const c : children) {
+        append_node_id(out, c);
+    }
+}
+
+void append_ext(byte_string &out, NibblesView const path, NodeId const child)
+{
+    out.push_back(EXT);
+    append_node_id(out, child);
+    append_path(out, path);
+}
+
+void append_storage(
+    byte_string &out, NibblesView const path, bytes32_t const &value)
+{
+    out.push_back(LEAF_STORAGE);
+    out.append(value.bytes, 32);
+    append_path(out, path);
+}
+
+void append_acct(
+    byte_string &out, NodeId const storage, Account const &acct,
+    NibblesView const path)
+{
+    out.push_back(LEAF_ACCT);
+    append_node_id(out, storage);
+    out.append(rlp::encode_bytes32(acct.code_hash));
+    // The length is only known once nonce ‖ balance are encoded, and the
+    // appends below may reallocate, so hold slot by index
+    size_t const len_index = out.size();
+    out.push_back(0);
+    out.append(rlp::encode_unsigned(acct.nonce));
+    out.append(rlp::encode_unsigned(acct.balance));
+    size_t const len = out.size() - len_index - 1;
+    MONAD_DEBUG_ASSERT(len >= 2 && len <= MAX_NONCE_BALANCE_RLP_LEN);
+    out[len_index] = static_cast<unsigned char>(len);
+    append_path(out, path);
+}
+
+void append_digest(byte_string &out, bytes32_t const &hash)
+{
+    out.push_back(DIGEST);
+    out.append(hash.bytes, 32);
+}
+
+NodeId OffsetTrie::fresh_id()
+{
+    NodeId const fresh = next_id_;
+    next_id_ = NodeId{static_cast<uint64_t>(next_id_) + 1};
+    return fresh;
+}
+
+NodeId OffsetTrie::put_node(NodeId const id, byte_string node)
+{
+    if (id == NULL_ID) {
+        NodeId const fresh = fresh_id();
+        overlay_[fresh] = std::move(node);
+        return fresh;
+    }
+    hashes_.erase(id); // bytes changed; the cached hash is stale
+    overlay_[id] = std::move(node);
+    return id;
+}
+
+NodeId OffsetTrie::put_branch(
+    NodeId const id, std::array<node_id_wire_t, 16> const &children)
+{
+    byte_string node;
+    append_branch(node, children);
+    return put_node(id, std::move(node));
+}
+
+NodeId
+OffsetTrie::put_ext(NodeId const id, NibblesView const path, NodeId const child)
+{
+    byte_string node;
+    append_ext(node, path, child);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::put_storage(
+    NodeId const id, NibblesView const path, bytes32_t const &value)
+{
+    byte_string node;
+    append_storage(node, path, value);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::clone_acct(
+    NodeId const id, AccountLeafView const acc, NibblesView const new_path)
+{
+    // Everything up to the path — tag, storage edge and both field runs — is
+    // copied verbatim, so re-pathing neither decodes nor re-encodes it.
+    byte_string node{acc.bytes(), rlp_end(child_end(acc.payload()))};
+    append_path(node, new_path);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::put_acct(
+    NodeId const id, NibblesView const path, Account const &acct,
+    NodeId const storage)
+{
+    // No storage root to pass: the leaf's hash takes it from `storage` itself.
+    byte_string node;
+    append_acct(node, storage, acct, path);
+    return put_node(id, std::move(node));
+}
+
+void OffsetTrie::fold_ext_node_path_maybe(
+    NodeId const ext_parent, NibblesView const prefix, NodeViewBase const child)
+{
+    MONAD_ASSERT(ext_parent != NULL_ID);
+    MONAD_DEBUG_ASSERT(child.tag() != EMPTY);
+
+    match(
+        child,
+        Cases{
+            // A branch can't absorb a path prefix — caller wraps it in ext.
+            [](BranchView) {},
+            [&](ExtView e) {
+                put_ext(ext_parent, concat(prefix, e.path()), e.child());
+            },
+            [&](StorageLeafView l) {
+                put_storage(ext_parent, concat(prefix, l.path()), l.value());
+            },
+            [&](AccountLeafView l) {
+                clone_acct(ext_parent, l, concat(prefix, l.path()));
+            },
+            [](DigestView) {
+                MONAD_ABORT("incomplete witness: collapse hit a Digest");
+            },
+            // Callers only fold a surviving child into its parent's path.
+            [](NullView) { std::unreachable(); },
+        });
+}
+
+std::pair<NodeId, Nibbles>
+OffsetTrie::upsert_node(NodeId const id, NibblesView const key)
+{
+    hashes_.erase(id); // dirtied along the descent
+    // Leaf split/overwrite, shared by both leaf types. Only re-emitting if the
+    // displaced old leaf differs (`reput_old`): a storage leaf keeps its
+    // value, an account leaf its fields and storage edge. `reput_old` runs
+    // ahead of every other put_* here, which is what lets it still read the
+    // displaced leaf's bytes.
+    auto const split_leaf =
+        [&](NibblesView const path,
+            auto const &reput_old) -> std::pair<NodeId, Nibbles> {
+        if (path == key) { // exact match -> overwrite (reuse id + its path)
+            return {id, Nibbles{key}};
+        }
+        // old leaf + new key meet at a fresh branch, wrapped in an
+        // extension for their shared prefix.
+        unsigned const cp = common_prefix_length(path, key);
+        MONAD_ASSERT(cp < path.nibble_size() && cp < key.nibble_size());
+        std::array<node_id_wire_t, 16> children{};
+        children[path.get(cp)] =
+            to_node_id_wire_t(reput_old(path.substr(cp + 1)));
+        NodeId const leaf = fresh_id();
+        children[key.get(cp)] = to_node_id_wire_t(leaf);
+        if (cp > 0) {
+            NodeId const branch = put_branch(NULL_ID, children);
+            put_ext(id, key.substr(0, cp), branch);
+        }
+        else {
+            put_branch(id, children);
+        }
+        return {leaf, Nibbles{key.substr(cp + 1)}};
+    };
+
+    return match(
+        get_current(id),
+        Cases{
+            [&](NullView) -> std::pair<NodeId, Nibbles> {
+                // Empty slot (or an empty trie's root): a fresh leaf
+                // holding the whole remaining key, which the caller
+                // materialises.
+                return {fresh_id(), Nibbles{key}};
+            },
+            [&](StorageLeafView l) -> std::pair<NodeId, Nibbles> {
+                bytes32_t const v = l.value();
+                return split_leaf(l.path(), [&](NibblesView const np) {
+                    return put_storage(NULL_ID, np, v);
+                });
+            },
+            [&](AccountLeafView l) -> std::pair<NodeId, Nibbles> {
+                return split_leaf(l.path(), [&, l](NibblesView const np) {
+                    return clone_acct(NULL_ID, l, np);
+                });
+            },
+            [&](ExtView e) -> std::pair<NodeId, Nibbles> {
+                Nibbles const p{e.path()};
+                NibblesView const path{p};
+                NodeId child = e.child();
+                unsigned const cp = common_prefix_length(path, key);
+                if (cp == path.nibble_size()) { // full prefix -> descend
+                    return upsert_node(child, key.substr(cp));
+                }
+                // diverge mid-extension
+                std::array<node_id_wire_t, 16> children{};
+                if (cp + 1 < path.nibble_size()) {
+                    child = put_ext(NULL_ID, path.substr(cp + 1), child);
+                }
+                children[path.get(cp)] = to_node_id_wire_t(child);
+
+                NodeId const leaf = fresh_id();
+                children[key.get(cp)] = to_node_id_wire_t(leaf);
+
+                if (cp > 0) {
+                    NodeId const branch = put_branch(NULL_ID, children);
+                    put_ext(id, key.substr(0, cp), branch);
+                }
+                else {
+                    put_branch(id, children);
+                }
+                return {leaf, Nibbles{key.substr(cp + 1)}};
+            },
+            [&](BranchView b) -> std::pair<NodeId, Nibbles> {
+                MONAD_ASSERT(key.nibble_size() > 0); // never ends at branch
+                unsigned const nib = key.get(0);
+                std::array<node_id_wire_t, 16> children = b.children();
+                NodeId const child = NodeId{children[nib]};
+                // Recurse into the slot: a NULL_ID child lets upsert_node
+                // allocate the leaf; an existing child keeps its stable id.
+                // Only rewrite the branch when a previously-empty slot
+                // fills.
+                auto const result = upsert_node(child, key.substr(1));
+                if (child == NULL_ID) {
+                    children[nib] = to_node_id_wire_t(result.first);
+                    put_branch(id, children);
+                }
+                return result;
+            },
+            [&](DigestView) -> std::pair<NodeId, Nibbles> {
+                MONAD_ABORT("incomplete witness: upsert hit a Digest");
+            },
+        });
+}
+
+OffsetTrie::EraseResult
+OffsetTrie::erase_node(NodeId const id, NibblesView const key)
+{
+    return match(
+        get_current(id),
+        Cases{
+            [&](NullView) -> OffsetTrie::EraseResult { // absent
+                return OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](StorageLeafView l) -> OffsetTrie::EraseResult {
+                return l.path() == key ? OffsetTrie::EraseResult::Erased
+                                       : OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](AccountLeafView l) -> OffsetTrie::EraseResult {
+                return l.path() == key ? OffsetTrie::EraseResult::Erased
+                                       : OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](ExtView e) -> OffsetTrie::EraseResult {
+                NodeId const child_id = e.child();
+                MONAD_ASSERT(child_id != NULL_ID);
+                Nibbles const p{e.path()};
+                NibblesView const path{p};
+                unsigned const cp = common_prefix_length(path, key);
+                if (cp < path.nibble_size()) { // key not under this ext
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                auto const erase_child = erase_node(child_id, key.substr(cp));
+                if (erase_child ==
+                    OffsetTrie::EraseResult::Erased) { // child gone -> ext
+                                                       // gone
+                    return OffsetTrie::EraseResult::Erased;
+                }
+                if (erase_child == OffsetTrie::EraseResult::Unmodified) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                // child survived; fold the ext path into it if it collapsed
+                // to a leaf/ext, but keep `id` of the ext node
+                hashes_.erase(id);
+                NodeViewBase const child = get_current(child_id);
+                return match(
+                    child,
+                    Cases{
+                        [](NullView) -> OffsetTrie::EraseResult {
+                            MONAD_ABORT("malformed trie: node not found");
+                        },
+                        [&](auto) {
+                            fold_ext_node_path_maybe(id, path, child);
+                            return OffsetTrie::EraseResult::Modified;
+                        }});
+            },
+            [&](BranchView b) -> OffsetTrie::EraseResult {
+                MONAD_ASSERT(key.nibble_size() > 0);
+                unsigned const branch = key.get(0);
+                std::array<node_id_wire_t, 16> children = b.children();
+                NodeId const child = NodeId{children[branch]};
+                if (child == NULL_ID) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                auto const erase_child = erase_node(child, key.substr(1));
+                if (erase_child == OffsetTrie::EraseResult::Unmodified) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                hashes_.erase(id);
+                if (erase_child == OffsetTrie::EraseResult::Erased) {
+                    children[branch] = to_node_id_wire_t(NULL_ID);
+                }
+                unsigned count = 0;
+                unsigned single = 0;
+                for (unsigned i = 0; i < 16 && count < 2; ++i) {
+                    if (NodeId{children[i]} != NULL_ID) {
+                        ++count;
+                        single = i;
+                    }
+                }
+                if (count == 0) {
+                    return OffsetTrie::EraseResult::Erased;
+                }
+                if (count == 1) {
+                    // collapse: fold the branch nibble into the sole child;
+                    // if that child is itself a branch, wrap it in a
+                    // one-nibble extension instead.
+                    Nibbles const child_path =
+                        concat(static_cast<unsigned char>(single));
+                    NodeId single_child = NodeId{children[single]};
+                    NodeViewBase const child = get_current(single_child);
+                    return match(
+                        child,
+                        Cases{
+                            [](NullView) -> OffsetTrie::EraseResult {
+                                MONAD_ABORT("malformed trie: node not found");
+                            },
+                            [&](BranchView) {
+                                put_ext(
+                                    id, NibblesView{child_path}, single_child);
+                                return OffsetTrie::EraseResult::Modified;
+                            },
+                            [&](auto) {
+                                fold_ext_node_path_maybe(
+                                    id, NibblesView{child_path}, child);
+                                return OffsetTrie::EraseResult::Modified;
+                            }});
+                }
+                else {
+                    put_branch(id, children); // >=2 survivors: stays
+                    return OffsetTrie::EraseResult::Modified;
+                }
+            },
+            [&](DigestView) -> OffsetTrie::EraseResult {
+                MONAD_ABORT("incomplete witness: erase hit a Digest");
+            },
+        });
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/category/execution/ethereum/db/offset_trie.cpp
+++ b/category/execution/ethereum/db/offset_trie.cpp
@@ -1,0 +1,721 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/execution/ethereum/db/offset_trie.hpp>
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/cases.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/nibble.h>
+#include <category/core/rlp/encode.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <utility>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+NodeId OffsetTrie::read_root(byte_string_view const blob)
+{
+    unsigned char const *const base = blob.data();
+    size_t const len = blob.size();
+    MONAD_ASSERT(len >= HEADER_LEN);
+    MONAD_ASSERT(
+        base[0] == 'M' && base[1] == 'Z' && base[2] == 'W' && base[3] == 0x01);
+    // Keep blob offsets and overlay ids in disjoint halves of the NodeId
+    // space (blob < OVERLAY_BASE, fresh ids >= OVERLAY_BASE). Bounding the
+    // blob size bounds every offset. Real witnesses are ~MBs; this only
+    // rejects a pathological >=2 GiB blob.
+    MONAD_ASSERT(len <= OVERLAY_BASE);
+    uint32_t const root_off = read_u32(base + 4);
+    MONAD_ASSERT(root_off == 0 || (root_off >= HEADER_LEN && root_off < len));
+    return NodeId{root_off};
+}
+
+OffsetTrie::OffsetTrie(byte_string_view const blob)
+    : root{read_root(blob)}
+    , blob_(blob)
+{
+    unsigned char const *const base = blob_.data();
+
+    // Prime hashes bottom-up over the blob's nodes (children precede
+    // parents), rejecting any node whose extent leaves the region.
+    unsigned char const *const region_end = blob_.end();
+    NodeViewBase node{base + HEADER_LEN};
+    while (node.bytes() < region_end) {
+        match(
+            node,
+            Cases{
+                [](NullView) {},
+                [](DigestView) {},
+                [&](auto) {
+                    unsigned char buf[MAX_NODE_RLP];
+                    node_rlp_span const rem = encode_rlp<true>(
+                        node, node_rlp_span{buf}); // priming pass
+                    // Only hash-referenced nodes (canonical RLP >= 32 B)
+                    // are cached; smaller nodes are inlined by their
+                    // parent, so caching their hash would make child_ref
+                    // emit a 32-byte ref where the trie inlines it.
+                    if (rem.rlp_size() >= 32) {
+                        bytes32_t h;
+                        keccak256(rem.rlp_data(), rem.rlp_size(), h.bytes);
+
+                        auto const id = static_cast<NodeId>(
+                            static_cast<uint32_t>(node.bytes() - blob_.data()));
+                        hashes_.emplace(id, h);
+                    }
+                }});
+
+        node = NodeViewBase{node.end()};
+    }
+    MONAD_ASSERT(node.bytes() == region_end); // nodes tile exactly
+}
+
+NodeViewBase OffsetTrie::find_original(NodeId id, NibblesView key) const
+{
+    NodeViewBase found = empty();
+    while (id != NULL_ID) {
+        id = match(
+            get_original(id),
+            Cases{
+                [&](BranchView b) -> NodeId {
+                    if (key.nibble_size() == 0) { // no value at a branch
+                        return NULL_ID;
+                    }
+                    NodeId const next = b.child(key.get(0));
+                    key = key.substr(1);
+                    return next;
+                },
+                [&](ExtView e) -> NodeId {
+                    NibblesView const ep = e.path();
+                    if (!key.starts_with(ep)) {
+                        return NULL_ID;
+                    }
+                    key = key.substr(ep.nibble_size());
+                    return e.child();
+                },
+                [&](AccountLeafView l) -> NodeId {
+                    if (l.path() == key) {
+                        found = l;
+                    }
+                    return NULL_ID;
+                },
+                [&](StorageLeafView l) -> NodeId {
+                    if (l.path() == key) {
+                        found = l;
+                    }
+                    return NULL_ID;
+                },
+                [](DigestView) -> NodeId {
+                    MONAD_ABORT("incomplete witness: lookup hit a Digest");
+                },
+                [](NullView) -> NodeId {
+                    MONAD_ABORT("malformed trie: node not found");
+                },
+            });
+    }
+    return found;
+}
+
+bytes32_t OffsetTrie::hash(NodeId const id)
+{
+    auto const node = get_current(id);
+    return match(
+        node,
+        Cases{
+            [](NullView) { return NULL_ROOT; },
+            [](DigestView d) { return d.hash(); },
+            [&](auto) {
+                if (auto const it = hashes_.find(id); it != hashes_.end()) {
+                    return it->second;
+                }
+
+                unsigned char buf[MAX_NODE_RLP];
+                node_rlp_span const rem = encode_rlp(node, node_rlp_span{buf});
+                bytes32_t h;
+                // RLP occupies the tail: [rem.end(), buf_end).
+                keccak256(rem.rlp_data(), rem.rlp_size(), h.bytes);
+
+                hashes_.emplace(id, h);
+                return h;
+            }});
+}
+
+bytes32_t OffsetTrie::state_root()
+{
+    return hash(root);
+}
+
+template <bool priming_pass>
+OffsetTrie::node_rlp_span
+OffsetTrie::child_ref(NodeId const id, OffsetTrie::node_rlp_span dest)
+{
+    if (id == NULL_ID) {
+        dest.back() = 0x80; // RLP empty string
+        return dest.shrink(1);
+    }
+    // A 32-byte hash reference is the RLP string of the hash (exactly 33 B:
+    // 0xa0 + 32, no length prefix) — write it straight into the tail.
+    auto const hash_ref = [&](bytes32_t const &h) {
+        rlp::encode_string(dest.last(33), byte_string_view{h.bytes, 32});
+        return dest.shrink(33);
+    };
+    if (auto const it = hashes_.find(id); it != hashes_.end()) {
+        return hash_ref(it->second);
+    }
+    // Pre-state (priming) reads bound-check and resolve against the blob;
+    // current reads consult the overlay first.
+    NodeViewBase const node = [&]() -> NodeViewBase {
+        if constexpr (priming_pass) {
+            MONAD_ASSERT(static_cast<uint32_t>(id) < blob_.size());
+            return get_original(id);
+        }
+        else {
+            return get_current(id);
+        }
+    }();
+    MONAD_ASSERT(node.tag() != EMPTY);
+    if (node.tag() == DIGEST) {
+        bytes32_t const h = DigestView{node}.hash();
+        hashes_.emplace(id, h);
+        return hash_ref(h);
+    }
+    unsigned char scratch[MAX_NODE_RLP];
+    node_rlp_span const rem =
+        encode_rlp<priming_pass>(node, node_rlp_span{scratch});
+    unsigned char const *const child_rlp = rem.rlp_data();
+    size_t const child_rlp_len = rem.rlp_size();
+    if (child_rlp_len < 32) {
+        std::memcpy(dest.last(child_rlp_len).data(), child_rlp, child_rlp_len);
+        return dest.shrink(child_rlp_len);
+    }
+    // A pre-state (blob) node this large is hash-referenced, so prime()
+    // cached it bottom-up before any parent could reference it. Reaching
+    // here on a cache miss means the parent held a forward/garbage offset.
+    if constexpr (priming_pass) {
+        MONAD_ABORT("offset trie: unprimed hash-referenced node (bad offset)");
+    }
+    bytes32_t h;
+    keccak256(child_rlp, child_rlp_len, h.bytes);
+    hashes_.emplace(id, h);
+    return hash_ref(h);
+}
+
+template <bool priming_pass>
+OffsetTrie::node_rlp_span
+OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
+{
+    MONAD_DEBUG_ASSERT(node.tag() != EMPTY && node.tag() != DIGEST);
+    // Compact-encode `path` straight into d's tail as an RLP string; return
+    // d shrunk. The compact form is clen = nibble_size/2 + 1 bytes (<= 33,
+    // always a short string): write it directly, then prepend the
+    // 0x80+path_len prefix. When path_len == 1 the single byte is <= 0x3F,
+    // so it is already its own RLP and no prefix is added.
+    auto const encode_path = [](OffsetTrie::node_rlp_span d,
+                                NibblesView const path,
+                                bool const terminating) {
+        size_t const path_len = path.nibble_size() / 2 + 1;
+        compact_encode_raw(d.last(path_len).data(), path, terminating);
+        d = d.shrink(path_len);
+        if (path_len > 1) {
+            d.back() = static_cast<unsigned char>(0x80 + path_len);
+            d = d.shrink(1);
+        }
+        return d;
+    };
+    // Prepend the list header for payload [s.end(), dest.end()); return the
+    // final span. encode_list_prefix can transiently write up to 8 bytes,
+    // so build the header in a local and copy only its real length into
+    // place.
+    auto const wrap = [](OffsetTrie::node_rlp_span const s) {
+        size_t const payload_len = s.rlp_size();
+        unsigned char hdr[9];
+        auto const rest =
+            rlp::encode_list_prefix(std::span<unsigned char>{hdr}, payload_len);
+        size_t const hdr_len = sizeof(hdr) - rest.size();
+        std::memcpy(s.last(hdr_len).data(), hdr, hdr_len);
+        return s.shrink(hdr_len);
+    };
+    return node_rlp_span{match(
+        node,
+        Cases{
+            [&, wrap](BranchView b) -> std::span<unsigned char> {
+                dest.back() = 0x80; // empty branch value — last list element
+                dest = dest.shrink(1);
+                for (int i = 15; i >= 0; --i) {
+                    dest = child_ref<priming_pass>(
+                        b.child(static_cast<unsigned>(i)), dest);
+                }
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](ExtView e) -> std::span<unsigned char> {
+                // child ref — last element
+                dest = child_ref<priming_pass>(e.child(), dest);
+                dest = encode_path(dest, e.path(), /*terminating=*/false);
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](
+                AccountLeafView l) -> std::span<unsigned char> {
+                // value = the stored account RLP, wrapped as a string
+                auto const account_rlp = l.account_rlp();
+                size_t const account_len = rlp::string_length(account_rlp);
+                rlp::encode_string(dest.last(account_len), account_rlp);
+                dest = dest.shrink(account_len);
+                dest = encode_path(dest, l.path(), /*terminating=*/true);
+                return wrap(dest);
+            },
+            [&, encode_path, wrap](
+                StorageLeafView l) -> std::span<unsigned char> {
+                bytes32_t const v = l.value();
+                // storage value = rlp(zeroless(slot)), itself wrapped again
+                // as the leaf's value string: write the inner rlp(zl) into
+                // dest's tail, then prepend the outer string prefix in
+                // place.
+                auto const val =
+                    rlp::zeroless_view(to_byte_string_view(v.bytes));
+                size_t const val_len = rlp::string_length(val);
+                rlp::encode_string(dest.last(val_len), val);
+                dest = dest.shrink(val_len);
+                // The outer wrap collapses to no prefix only when it wraps
+                // a single byte <=0x7F, i.e. zl itself is one byte <=0x7F.
+                if (!(val.size() == 1 && val[0] <= 0x7F)) {
+                    dest.back() = static_cast<unsigned char>(0x80 + val_len);
+                    dest = dest.shrink(1);
+                }
+                dest = encode_path(dest, l.path(), /*terminating=*/true);
+                return wrap(dest);
+            },
+            [](DigestView) -> std::span<unsigned char> { std::unreachable(); },
+            [](NullView) -> std::span<unsigned char> { std::unreachable(); },
+        })};
+}
+
+// ── mutation — typed byte builders (§4 layout) ───────────────────────────────
+namespace
+{
+    // Append `v` little-endian, matching read_u32/read_u16 on rv64im/x86.
+    void append_node_id(byte_string &b, NodeId const v)
+    {
+        static_assert(std::endian::native == std::endian::little);
+        b.append(reinterpret_cast<unsigned char const *>(&v), sizeof(v));
+    }
+
+    void append_rlp(byte_string &b, byte_string_view const v)
+    {
+        static_assert(std::endian::native == std::endian::little);
+        MONAD_ASSERT(v.size() <= std::numeric_limits<uint16_t>::max());
+        auto const len = static_cast<uint16_t>(v.size());
+        b.append(reinterpret_cast<unsigned char const *>(&len), sizeof(len));
+        b.append(v.data(), v.size());
+    }
+
+    // Append a path as nodes store it: a 1-byte nibble count then
+    // ceil(nlen/2) packed nibbles, left-aligned (nibble 0 in the high
+    // nibble of the first byte) — exactly what path_view reads back.
+    void append_path(byte_string &b, NibblesView const path)
+    {
+        unsigned const nlen = path.nibble_size();
+        // path_nlen reads the count back as a single byte, so a truncated
+        // one would desynchronise the node stream (as in append_rlp).
+        MONAD_ASSERT(nlen <= std::numeric_limits<unsigned char>::max());
+        b.push_back(static_cast<unsigned char>(nlen));
+        size_t const start = b.size();
+        b.resize(start + (nlen + 1) / 2, 0);
+        for (unsigned i = 0; i < nlen; ++i) {
+            set_nibble(b.data() + start, i, path.get(i));
+        }
+    }
+
+    unsigned common_prefix_length(NibblesView const a, NibblesView const b)
+    {
+        unsigned const n = std::min(a.nibble_size(), b.nibble_size());
+        for (unsigned i = 0; i < n; ++i) {
+            if (a.get(i) != b.get(i)) {
+                return i;
+            }
+        }
+        return n;
+    }
+}
+
+void append_branch(byte_string &out, std::array<NodeId, 16> const &children)
+{
+    out.reserve(out.size() + 1 + 16 * 4);
+    out.push_back(BRANCH);
+    for (NodeId const c : children) {
+        append_node_id(out, c);
+    }
+}
+
+void append_ext(byte_string &out, NibblesView const path, NodeId const child)
+{
+    out.push_back(EXT);
+    append_node_id(out, child);
+    append_path(out, path);
+}
+
+void append_storage(
+    byte_string &out, NibblesView const path, bytes32_t const &value)
+{
+    out.push_back(LEAF_STORAGE);
+    out.append(value.bytes, 32);
+    append_path(out, path);
+}
+
+void append_acct_raw(
+    byte_string &out, NibblesView const path, byte_string_view const acct_rlp,
+    NodeId const storage)
+{
+    out.push_back(LEAF_ACCT);
+    append_node_id(out, storage);
+    append_path(out, path);
+    append_rlp(out, acct_rlp);
+}
+
+void append_digest(byte_string &out, bytes32_t const &hash)
+{
+    out.push_back(DIGEST);
+    out.append(hash.bytes, 32);
+}
+
+NodeId OffsetTrie::fresh_id()
+{
+    NodeId const fresh = next_id_;
+    next_id_ = NodeId{static_cast<uint32_t>(next_id_) + 1};
+    return fresh;
+}
+
+NodeId OffsetTrie::put_node(NodeId const id, byte_string node)
+{
+    if (id == NULL_ID) {
+        NodeId const fresh = fresh_id();
+        overlay_[fresh] = std::move(node);
+        return fresh;
+    }
+    hashes_.erase(id); // bytes changed; the cached hash is stale
+    overlay_[id] = std::move(node);
+    return id;
+}
+
+NodeId
+OffsetTrie::put_branch(NodeId const id, std::array<NodeId, 16> const &children)
+{
+    byte_string node;
+    append_branch(node, children);
+    return put_node(id, std::move(node));
+}
+
+NodeId
+OffsetTrie::put_ext(NodeId const id, NibblesView const path, NodeId const child)
+{
+    byte_string node;
+    append_ext(node, path, child);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::put_storage(
+    NodeId const id, NibblesView const path, bytes32_t const &value)
+{
+    byte_string node;
+    append_storage(node, path, value);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::put_acct_raw(
+    NodeId const id, NibblesView const path, byte_string_view const acct_rlp,
+    NodeId const storage)
+{
+    byte_string node;
+    append_acct_raw(node, path, acct_rlp, storage);
+    return put_node(id, std::move(node));
+}
+
+NodeId OffsetTrie::put_acct(
+    NodeId const id, NibblesView const path, Account const &acct,
+    bytes32_t const &storage_root, NodeId const storage)
+{
+    return put_acct_raw(
+        id, path, rlp::encode_account(acct, storage_root), storage);
+}
+
+Tag OffsetTrie::fold_ext_node_path_maybe(
+    NodeId const ext_parent, NibblesView const prefix, NodeViewBase const child)
+{
+    MONAD_ASSERT(ext_parent != NULL_ID);
+    MONAD_DEBUG_ASSERT(child.tag() != EMPTY);
+
+    return match(
+        child,
+        Cases{
+            // A branch can't absorb a path prefix — caller wraps it in ext.
+            [&](BranchView) { return EXT; },
+            [&](ExtView e) {
+                put_ext(ext_parent, concat(prefix, e.path()), e.child());
+                return EXT;
+            },
+            [&](StorageLeafView l) {
+                put_storage(ext_parent, concat(prefix, l.path()), l.value());
+                return LEAF_STORAGE;
+            },
+            [&](AccountLeafView l) {
+                put_acct_raw(
+                    ext_parent,
+                    concat(prefix, l.path()),
+                    l.account_rlp(),
+                    l.storage());
+                return LEAF_ACCT;
+            },
+            [](DigestView) -> Tag {
+                MONAD_ABORT("incomplete witness: collapse hit a Digest");
+            },
+            // Callers only fold a surviving child into its parent's path.
+            [](NullView) -> Tag { std::unreachable(); },
+        });
+}
+
+std::pair<NodeId, Nibbles>
+OffsetTrie::upsert_node(NodeId const id, NibblesView const key)
+{
+    hashes_.erase(id); // dirtied along the descent
+    // Leaf split/overwrite, shared by both leaf types. Only re-emitting the
+    // displaced old leaf differs (`reput_old`): storage keeps its value, an
+    // account its acct_rlp + storage. The caller reads the old leaf's
+    // fields into reput_old's captures first, since views die at the first
+    // put_*.
+    auto const split_leaf =
+        [&](NibblesView const path,
+            auto const &reput_old) -> std::pair<NodeId, Nibbles> {
+        if (path == key) { // exact match -> overwrite (reuse id + its path)
+            return {id, Nibbles{key}};
+        }
+        // old leaf + new key meet at a fresh branch, wrapped in an
+        // extension for their shared prefix.
+        unsigned const cp = common_prefix_length(path, key);
+        MONAD_ASSERT(cp < path.nibble_size() && cp < key.nibble_size());
+        std::array<NodeId, 16> children{};
+        children[path.get(cp)] = reput_old(path.substr(cp + 1));
+        NodeId const leaf = fresh_id();
+        children[key.get(cp)] = leaf;
+        if (cp > 0) {
+            NodeId const branch = put_branch(NULL_ID, children);
+            put_ext(id, key.substr(0, cp), branch);
+        }
+        else {
+            put_branch(id, children);
+        }
+        return {leaf, Nibbles{key.substr(cp + 1)}};
+    };
+
+    return match(
+        get_current(id),
+        Cases{
+            [&](NullView) -> std::pair<NodeId, Nibbles> {
+                // Empty slot (or an empty trie's root): a fresh leaf
+                // holding the whole remaining key, which the caller
+                // materialises.
+                return {fresh_id(), Nibbles{key}};
+            },
+            [&](StorageLeafView l) -> std::pair<NodeId, Nibbles> {
+                bytes32_t const v = l.value();
+                return split_leaf(l.path(), [&](NibblesView const np) {
+                    return put_storage(NULL_ID, np, v);
+                });
+            },
+            [&](AccountLeafView l) -> std::pair<NodeId, Nibbles> {
+                byte_string const rlp{l.account_rlp()};
+                NodeId const st = l.storage();
+                return split_leaf(l.path(), [&](NibblesView const np) {
+                    return put_acct_raw(NULL_ID, np, rlp, st);
+                });
+            },
+            [&](ExtView e) -> std::pair<NodeId, Nibbles> {
+                Nibbles const p{e.path()};
+                NibblesView const path{p};
+                NodeId const child = e.child();
+                unsigned const cp = common_prefix_length(path, key);
+                if (cp == path.nibble_size()) { // full prefix -> descend
+                    return upsert_node(child, key.substr(cp));
+                }
+                // diverge mid-extension
+                std::array<NodeId, 16> children{};
+                children[path.get(cp)] =
+                    (cp + 1 < path.nibble_size())
+                        ? put_ext(NULL_ID, path.substr(cp + 1), child)
+                        : child;
+                NodeId const leaf = fresh_id();
+                children[key.get(cp)] = leaf;
+
+                if (cp > 0) {
+                    NodeId const branch = put_branch(NULL_ID, children);
+                    put_ext(id, key.substr(0, cp), branch);
+                }
+                else {
+                    put_branch(id, children);
+                }
+                return {leaf, Nibbles{key.substr(cp + 1)}};
+            },
+            [&](BranchView b) -> std::pair<NodeId, Nibbles> {
+                MONAD_ASSERT(key.nibble_size() > 0); // never ends at branch
+                unsigned const nib = key.get(0);
+                std::array<NodeId, 16> children = b.children();
+                NodeId const child = children[nib];
+                // Recurse into the slot: a NULL_ID child lets upsert_node
+                // allocate the leaf; an existing child keeps its stable id.
+                // Only rewrite the branch when a previously-empty slot
+                // fills.
+                auto const result = upsert_node(child, key.substr(1));
+                if (child == NULL_ID) {
+                    children[nib] = result.first;
+                    put_branch(id, children);
+                }
+                return result;
+            },
+            [&](DigestView) -> std::pair<NodeId, Nibbles> {
+                MONAD_ABORT("incomplete witness: upsert hit a Digest");
+            },
+        });
+}
+
+OffsetTrie::EraseResult
+OffsetTrie::erase_node(NodeId const id, NibblesView const key)
+{
+    return match(
+        get_current(id),
+        Cases{
+            [&](NullView) -> OffsetTrie::EraseResult { // absent
+                return OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](StorageLeafView l) -> OffsetTrie::EraseResult {
+                return l.path() == key ? OffsetTrie::EraseResult::Erased
+                                       : OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](AccountLeafView l) -> OffsetTrie::EraseResult {
+                return l.path() == key ? OffsetTrie::EraseResult::Erased
+                                       : OffsetTrie::EraseResult::Unmodified;
+            },
+            [&](ExtView e) -> OffsetTrie::EraseResult {
+                NodeId const child_id = e.child();
+                MONAD_ASSERT(child_id != NULL_ID);
+                Nibbles const p{e.path()};
+                NibblesView const path{p};
+                unsigned const cp = common_prefix_length(path, key);
+                if (cp < path.nibble_size()) { // key not under this ext
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                auto const erase_child = erase_node(child_id, key.substr(cp));
+                if (erase_child ==
+                    OffsetTrie::EraseResult::Erased) { // child gone -> ext
+                                                       // gone
+                    return OffsetTrie::EraseResult::Erased;
+                }
+                if (erase_child == OffsetTrie::EraseResult::Unmodified) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                // child survived; fold the ext path into it if it collapsed
+                // to a leaf/ext, but keep `id` of the ext node
+                hashes_.erase(id);
+                NodeViewBase const child = get_current(child_id);
+                return match(
+                    child,
+                    Cases{
+                        [](NullView) -> OffsetTrie::EraseResult {
+                            MONAD_ABORT("malformed trie: node not found");
+                        },
+                        [&](auto) {
+                            return fold_ext_node_path_maybe(id, path, child) ==
+                                           EXT
+                                       ? OffsetTrie::EraseResult::SameShape
+                                       : OffsetTrie::EraseResult::NewShape;
+                        }});
+            },
+            [&](BranchView b) -> OffsetTrie::EraseResult {
+                MONAD_ASSERT(key.nibble_size() > 0);
+                unsigned const branch = key.get(0);
+                std::array<NodeId, 16> children = b.children();
+                NodeId const child = children[branch];
+                if (child == NULL_ID) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                auto const erase_child =
+                    erase_node(children[branch], key.substr(1));
+                if (erase_child == OffsetTrie::EraseResult::Unmodified) {
+                    return OffsetTrie::EraseResult::Unmodified;
+                }
+                hashes_.erase(id);
+                if (erase_child == OffsetTrie::EraseResult::Erased) {
+                    children[branch] = NULL_ID;
+                }
+                unsigned count = 0;
+                unsigned single = 0;
+                for (unsigned i = 0; i < 16 && count < 2; ++i) {
+                    if (children[i] != NULL_ID) {
+                        ++count;
+                        single = i;
+                    }
+                }
+                if (count == 0) {
+                    return OffsetTrie::EraseResult::Erased;
+                }
+                if (count == 1) {
+                    // collapse: fold the branch nibble into the sole child;
+                    // if that child is itself a branch, wrap it in a
+                    // one-nibble extension instead.
+                    Nibbles const child_path =
+                        concat(static_cast<unsigned char>(single));
+                    NodeViewBase const child = get_current(children[single]);
+                    return match(
+                        child,
+                        Cases{
+                            [](NullView) -> OffsetTrie::EraseResult {
+                                MONAD_ABORT("malformed trie: node not found");
+                            },
+                            [&](BranchView) {
+                                put_ext(
+                                    id,
+                                    NibblesView{child_path},
+                                    children[single]);
+                                return OffsetTrie::EraseResult::NewShape;
+                            },
+                            [&](auto) {
+                                fold_ext_node_path_maybe(
+                                    id, NibblesView{child_path}, child);
+                                return OffsetTrie::EraseResult::NewShape;
+                            }});
+                }
+                else {
+                    put_branch(id, children); // >=2 survivors: stays
+                    return OffsetTrie::EraseResult::SameShape;
+                }
+            },
+            [&](DigestView) -> OffsetTrie::EraseResult {
+                MONAD_ABORT("incomplete witness: erase hit a Digest");
+            },
+        });
+}
+
+MONAD_MPT_NAMESPACE_END

--- a/category/execution/ethereum/db/offset_trie.hpp
+++ b/category/execution/ethereum/db/offset_trie.hpp
@@ -1,0 +1,622 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// Offset-based, zero-copy witness trie for the zkVM guest.
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/cases.hpp>
+#include <category/core/config.hpp>
+#include <category/core/rlp/encode.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
+#include <category/execution/ethereum/core/rlp/int_rlp.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <utility>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+enum Tag : uint8_t
+{
+    BRANCH = 0,
+    EXT = 1,
+    LEAF_ACCT = 2,
+    LEAF_STORAGE = 3,
+    // By using 0xa0 as the digest tag, the digest aligns with its RLP encoding
+    DIGEST = 0xa0,
+    // NULL_ID addresses the blob's first magic byte, so the magic's leading
+    // 'M' doubles as the null node's tag: a null child dereferences to a
+    // real view instead of needing a null pre-check at every call site.
+    // read_root asserts the magic, which is what guarantees the byte is
+    // there.
+    EMPTY = 'M',
+};
+
+inline constexpr uint32_t HEADER_LEN = 8; // magic(4) root_offset(4)
+
+// Upper bound on a single node's canonical RLP: 16 child refs (<=33 B each)
+// + value slot + list header. 700 leaves margin.
+inline constexpr size_t MAX_NODE_RLP = 700;
+
+// A node's stable id. 0 = null; `n` in the [HEADER_LEN, blob_len) range is
+// a blob offset (unless shadowed by an overlay); n >= OVERLAY_BASE is a
+// fresh overlay node.
+//
+// The id is register-width, independent of the 32-bit child field the wire
+// format stores it in (node_id_wire_t below)
+enum class NodeId : uint64_t
+{
+};
+inline constexpr NodeId NULL_ID{0};
+
+// Width of a child/root field in the node encoding
+using node_id_wire_t = uint32_t;
+
+inline constexpr size_t HASH_RLP_LEN = 33; // 0xa0 ‖ 32 B
+// Widest that run can get: 1 + 8 for the nonce, 1 + 32 for the balance. Both
+// are RLP-zeroless, so real accounts sit far below this.
+inline constexpr size_t MAX_NONCE_BALANCE_RLP_LEN = 42;
+
+// Splits the NodeId space by the wire field's high bit: blob offsets live
+// below it, fresh overlay ids at/above it. The OffsetTrie constructor rejects
+// blobs larger than this, so a blob offset can never reach the overlay half
+// (no collision). Real witnesses are ~MBs, far under 2 GiB.
+inline constexpr uint64_t OVERLAY_BASE = uint64_t{1} << 31;
+
+inline bool is_overlay_id(NodeId id)
+{
+    return static_cast<uint64_t>(id) >= OVERLAY_BASE;
+}
+
+struct NodeIdHash
+{
+    using is_avalanching = void;
+
+    uint64_t operator()(NodeId const id) const noexcept
+    {
+        return ankerl::unordered_dense::hash<uint64_t>{}(
+            static_cast<uint64_t>(id));
+    }
+};
+
+// Widen a wire child field to an id. The one place the two representations
+// meet on the read side (append_node_id is its write-side counterpart).
+inline NodeId read_node_id(unsigned char const *const p)
+{
+    static_assert(std::endian::native == std::endian::little);
+    node_id_wire_t v;
+    std::memcpy(&v, p, sizeof(v));
+    return NodeId{v};
+}
+
+inline node_id_wire_t to_node_id_wire_t(NodeId v)
+{
+    auto const wire = static_cast<node_id_wire_t>(v);
+    MONAD_ASSERT(static_cast<uint64_t>(v) == wire);
+    return wire;
+}
+
+// ── node writers ─────────────────────────────────────────────────────────────
+void append_branch(byte_string &out, std::array<NodeId, 16> const &children);
+void append_ext(byte_string &out, NibblesView path, NodeId child);
+void append_storage(byte_string &out, NibblesView path, bytes32_t const &);
+void append_acct(
+    byte_string &out, NodeId storage, Account const &, NibblesView path);
+// No put_digest counterpart: mutation never creates a Digest, they only
+// ever arrive in the pre-state blob from the producer.
+void append_digest(byte_string &out, bytes32_t const &hash);
+
+// ── views ────────────────────────────────────────────────────────────────────
+// NodeViewBase is the untyped view (a pointer at the node's tag byte).
+// Typed views derive from it and add only their tag's getters.
+class NodeViewBase
+{
+    unsigned char const *p_;
+
+public:
+    explicit NodeViewBase(unsigned char const *const p)
+        : p_(p)
+    {
+    }
+
+    Tag tag() const
+    {
+        return Tag(*p_);
+    }
+
+    inline unsigned char const *bytes() const
+    {
+        return p_;
+    }
+
+    inline unsigned char const *payload() const
+    {
+        return p_ + 1;
+    }
+
+    // One past the last byte of this node, from its tag's fixed layout.
+    // Aborts if the tag is invalid or the pointer reaches beyond the end of the
+    // region.
+    unsigned char const *
+    checked_end(unsigned char const *const region_end) const;
+};
+
+// Nibble count
+inline unsigned path_length(unsigned char const *const p)
+{
+    return p[0];
+}
+
+// Packed size of the path in bytes — half the nibble count, rounded up.
+inline unsigned path_byte_length(unsigned char const *const p)
+{
+    return (path_length(p) + 1) / 2;
+}
+
+inline NibblesView path_view(unsigned char const *const p)
+{
+    return NibblesView{0u, path_length(p), p + 1};
+}
+
+inline unsigned char const *path_view_end(unsigned char const *const p)
+{
+    return p + 1 + path_byte_length(p);
+}
+
+// LEAF_ACCT and EXT keep their child id at a fixed position right after the
+// tag, so storage()/child() is a constant-offset read instead of a walk
+// over a path or account RLP. The rest of the node follows that field.
+inline unsigned char const *child_end(unsigned char const *const p)
+{
+    return p + sizeof(node_id_wire_t);
+}
+
+// One past a LEAF_ACCT's field runs, from the start of its code hash: the
+// fixed-width hash, then the length byte and the nonce ‖ balance run it
+// counts.
+inline unsigned char const *rlp_end(unsigned char const *const p)
+{
+    return p + HASH_RLP_LEN + 1 + p[HASH_RLP_LEN];
+}
+
+inline unsigned char const *
+NodeViewBase::checked_end(unsigned char const *const region_end) const
+{
+    MONAD_DEBUG_ASSERT(bytes() < region_end);
+
+    auto const path_view_end_checked =
+        [region_end](unsigned char const *const p) {
+            MONAD_ASSERT(p < region_end);
+            return path_view_end(p);
+        };
+
+    auto const rlp_end_checked = [region_end](unsigned char const *const p) {
+        MONAD_ASSERT(static_cast<size_t>(region_end - p) > HASH_RLP_LEN);
+        return rlp_end(p);
+    };
+
+    unsigned char const *end_ptr{nullptr};
+
+    switch (tag()) {
+    case BRANCH: // 16 child offsets
+        end_ptr = payload() + 16 * sizeof(node_id_wire_t);
+        break;
+    case EXT: // child offset + path
+        end_ptr = path_view_end_checked(child_end(payload()));
+        break;
+    case LEAF_ACCT: // storage offset + code hash + nonce & balance length +
+                    // nonce & balance + path
+        end_ptr = path_view_end_checked(rlp_end_checked(child_end(payload())));
+        break;
+    case LEAF_STORAGE: // 32-byte value + path
+        end_ptr = path_view_end_checked(payload() + 32);
+        break;
+    case DIGEST: // 32-byte hash
+        end_ptr = payload() + 32;
+        break;
+    default:
+        MONAD_ABORT("offset trie: invalid node tag");
+    }
+    MONAD_ASSERT(end_ptr <= region_end);
+    return end_ptr;
+}
+
+class NullView : public NodeViewBase
+{
+public:
+    explicit NullView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+};
+
+class BranchView : public NodeViewBase
+{
+public:
+    explicit BranchView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NodeId child(unsigned const i) const // NULL_ID if empty
+    {
+        return read_node_id(payload() + sizeof(node_id_wire_t) * i);
+    }
+
+    std::array<node_id_wire_t, 16> children() const
+    {
+        static_assert(std::endian::native == std::endian::little);
+        std::array<node_id_wire_t, 16> ids;
+        std::memcpy(ids.data(), payload(), sizeof(ids));
+        return ids;
+    }
+};
+
+class ExtView : public NodeViewBase
+{
+public:
+    explicit ExtView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NibblesView path() const
+    {
+        return path_view(child_end(payload()));
+    }
+
+    NodeId child() const
+    {
+        return read_node_id(payload());
+    }
+};
+
+// An account leaf stores the account's fields in the following order:
+// - storage node id
+// - code hash RLP
+// - nonce ‖ balance RLP
+// - nibble path length
+// - nibble path
+class AccountLeafView : public NodeViewBase
+{
+public:
+    explicit AccountLeafView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    // NULL_ID if no storage subtree materialized.
+    NodeId storage() const
+    {
+        return read_node_id(payload());
+    }
+
+    // code_hash as an RLP string
+    byte_string_view code_hash_rlp() const
+    {
+        return byte_string_view{child_end(payload()), HASH_RLP_LEN};
+    }
+
+    // nonce ‖ balance as RLP strings
+    byte_string_view nonce_balance_rlp() const
+    {
+        unsigned char const *const len_p = child_end(payload()) + HASH_RLP_LEN;
+        size_t const len = len_p[0];
+        MONAD_ASSERT(len >= 2 && len <= MAX_NONCE_BALANCE_RLP_LEN);
+        return byte_string_view{len_p + 1, len};
+    }
+
+    NibblesView path() const
+    {
+        return path_view(rlp_end(child_end(payload())));
+    }
+
+    // lazily RLP-decode the account (fields for read_account)
+    Account account() const
+    {
+        Account acct;
+        // Decoded through the accessors, so the stored length is bounded here
+        // as well and not only on the extent walk.
+        byte_string_view code_hash = code_hash_rlp();
+        auto const hash = rlp::decode_bytes32(code_hash);
+        MONAD_ASSERT(hash.has_value());
+        acct.code_hash = hash.value();
+        byte_string_view nonce_balance = nonce_balance_rlp();
+        auto const nonce = rlp::decode_unsigned<uint64_t>(nonce_balance);
+        MONAD_ASSERT(nonce.has_value());
+        acct.nonce = nonce.value();
+        auto const balance = rlp::decode_unsigned<uint256_t>(nonce_balance);
+        MONAD_ASSERT(balance.has_value());
+        acct.balance = balance.value();
+        MONAD_ASSERT(nonce_balance.empty());
+        return acct;
+    }
+};
+
+class StorageLeafView : public NodeViewBase
+{
+public:
+    explicit StorageLeafView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NibblesView path() const
+    {
+        return path_view(payload() + 32);
+    }
+
+    bytes32_t value() const
+    {
+        bytes32_t v;
+        std::memcpy(v.bytes, payload(), 32);
+        return v;
+    }
+};
+
+class DigestView : public NodeViewBase
+{
+public:
+    explicit DigestView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    bytes32_t hash() const
+    {
+        bytes32_t h;
+        std::memcpy(h.bytes, payload(), 32);
+        return h;
+    }
+};
+
+template <class... Fs>
+decltype(auto) match(NodeViewBase n, Fs &&...fs)
+{
+    Cases const v{std::forward<Fs>(fs)...};
+    switch (n.tag()) {
+    case BRANCH:
+        return v(BranchView{n});
+    case EXT:
+        return v(ExtView{n});
+    case LEAF_ACCT:
+        return v(AccountLeafView{n});
+    case LEAF_STORAGE:
+        return v(StorageLeafView{n});
+    case DIGEST:
+        return v(DigestView{n});
+    case EMPTY:
+        return v(NullView{n});
+    default:
+        MONAD_ABORT("bad node tag");
+    }
+}
+
+// ── OffsetTrie — immutable blob + stable-id overlay ──────────────────────────
+class OffsetTrie
+{
+    byte_string_view blob_;
+    ankerl::unordered_dense::map<NodeId, byte_string, NodeIdHash> overlay_{};
+    ankerl::unordered_dense::map<NodeId, bytes32_t, NodeIdHash> hashes_{};
+    NodeId next_id_{OVERLAY_BASE}; // fresh-id counter (>= OVERLAY_BASE)
+public:
+    // Wrap the read-only node blob, structurally validate it, and prime the
+    // hash cache (see prime()). Aborts if the blob is malformed.
+    explicit OffsetTrie(byte_string_view blob);
+
+    // Account-trie root, NULL_ID while the trie is empty. upsert_node and
+    // erase_node keep a materialised root's id stable, so a caller only
+    // reassigns it across the empty/non-empty transitions — exactly as
+    // PartialTrieDb::commit already threads a storage sub-root.
+    NodeId root;
+
+    NodeViewBase empty() const
+    {
+        // The blob is a node region, not text: NodeViewBase reads the tag
+        // at this byte and takes every extent from the node layout, so
+        // there is nothing to NUL-terminate.
+        // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+        return NodeViewBase{blob_.data()};
+    }
+
+    NodeViewBase get_original(NodeId const id) const
+    {
+        // NULL_ID resolves to the blob's first magic byte, i.e. the EMPTY
+        // tag
+        MONAD_ASSERT(
+            id == NULL_ID || (static_cast<uint64_t>(id) >= HEADER_LEN &&
+                              static_cast<uint64_t>(id) < blob_.size()));
+        return NodeViewBase{blob_.data() + static_cast<uint64_t>(id)};
+    }
+
+    // Current bytes for `id` — overlay entry if present, else the blob.
+    // put_node shadows a rewritten blob node under its own blob id, so the
+    // overlay has to be consulted for every id, not just fresh ones. A
+    // fresh id with no entry yet is a node upsert allocated but no put_*
+    // has materialised: it reads as empty.
+    NodeViewBase get_current(NodeId const id) const
+    {
+        auto const it = overlay_.find(id);
+        if (it != overlay_.end()) {
+            return NodeViewBase{it->second.data()};
+        }
+        return is_overlay_id(id) ? empty() : get_original(id);
+    }
+
+    // Walk the (pre-state) trie rooted at `id` following `key`; return the
+    // leaf view if the key is present, else `NullView`. Aborts on a Digest
+    // (incomplete witness). Traverses through the view accessors via match.
+    NodeViewBase find_original(NodeId id, NibblesView key) const;
+
+    NodeId put_branch(NodeId, std::array<node_id_wire_t, 16> const &);
+    NodeId put_ext(NodeId, NibblesView, NodeId);
+    NodeId put_storage(NodeId, NibblesView, bytes32_t const &);
+    NodeId put_acct(NodeId, NibblesView, Account const &, NodeId);
+    // Copies account data verbatim but appends a new path
+    NodeId clone_acct(NodeId id, AccountLeafView acc, NibblesView new_path);
+    std::pair<NodeId, Nibbles>
+    upsert_node(NodeId const id, NibblesView const key);
+
+    // What the node at the erased key's ancestor has to do about it. There is
+    // no shape dimension here on purpose: an id outlives a re-encode, so a
+    // parent never learns (or needs to learn) whether a surviving child stayed
+    // an extension or collapsed into a leaf — that stability is what keeps the
+    // rewrite from bubbling up.
+    enum class EraseResult
+    {
+        Erased,
+        Unmodified,
+        Modified
+    };
+    EraseResult erase_node(NodeId, NibblesView);
+
+    // keccak of the (current) trie rooted at `id`; NULL_ID -> NULL_ROOT.
+    // Serves the account root and the storage sub-root an account leaf spans.
+    // Consults hashes_; recomputes + caches a missing id.
+    //
+    // `id` must be a trie root. Unlike the priming pass this caches whatever
+    // it is given, and child_ref consults hashes_ before deciding whether to
+    // inline, so a cached id whose canonical RLP is under 32 B would be
+    // hash-referenced by its parent where the trie inlines it. Roots are
+    // exempt because they are never inlined — and both call sites hand over a
+    // node that spells a whole 64-nibble key, or a branch, so is over 32 B
+    // anyway.
+    bytes32_t hash(NodeId id);
+    bytes32_t state_root();
+
+private:
+    // A thin view over an RLP scratch buffer of fixed capacity
+    // MAX_NODE_RLP. Encoding writes the payload into the *tail* of the
+    // buffer, so `data()` always stays at the buffer start and `size()`
+    // shrinks as bytes are written. The live RLP region is therefore
+    // [data() + size(), buf_end):
+    //   rlp_data() = data() + size(),  rlp_size() = MAX_NODE_RLP - size().
+    struct node_rlp_span : std::span<unsigned char>
+    {
+        explicit node_rlp_span(std::span<unsigned char> const s)
+            : std::span<unsigned char>(s)
+        {
+        }
+
+        // The written RLP is the tail past size(), not a subspan of *this,
+        // so rlp_data() needs the raw base pointer. Everyone else must
+        // reach bytes through last(): hide the front pointer to stop
+        // accidental writes to the unwritten head being mistaken for the
+        // payload.
+        unsigned char *data() const = delete;
+
+        unsigned char const *rlp_data() const
+        {
+            return std::span<unsigned char>::data() + size();
+        }
+
+        size_t rlp_size() const
+        {
+            return MAX_NODE_RLP - size();
+        }
+
+        node_rlp_span shrink(size_t const n) const
+        {
+            return node_rlp_span{first(size() - n)};
+        }
+    };
+
+    template <bool priming_pass>
+    node_rlp_span child_ref_compute(
+        NodeId const id, NodeViewBase const node, node_rlp_span dest);
+
+    template <bool priming_pass>
+    inline node_rlp_span child_ref(NodeId const id, node_rlp_span dest)
+    {
+        if (id == NULL_ID) {
+            dest.back() = 0x80; // RLP empty string
+            return dest.shrink(1);
+        }
+        // Pre-state (priming) reads bound-check and resolve against the blob;
+        // current reads consult the overlay first.
+        NodeViewBase const node = [&]() -> NodeViewBase {
+            if constexpr (priming_pass) {
+                return get_original(id);
+            }
+            else {
+                return get_current(id);
+            }
+        }();
+        return match(
+            node,
+            Cases{
+                [](NullView) -> node_rlp_span {
+                    MONAD_ABORT("malformed trie: node not found");
+                },
+                [&](DigestView d) {
+                    static_assert(DIGEST == 0x80 + KECCAK256_SIZE);
+                    std::memcpy(
+                        dest.last(HASH_RLP_LEN).data(),
+                        d.bytes(),
+                        HASH_RLP_LEN);
+                    return dest.shrink(HASH_RLP_LEN);
+                },
+                [&](auto) {
+                    if (auto const it = hashes_.find(id); it != hashes_.end()) {
+                        bytes32_t const &hash = it->second;
+                        rlp::encode_string(
+                            dest.last(33), byte_string_view{hash.bytes, 32});
+                        return dest.shrink(33);
+                    }
+                    return child_ref_compute<priming_pass>(id, node, dest);
+                }});
+    }
+
+    // The node's full canonical Ethereum RLP. Reads `node`'s fields and
+    // resolves its children through child_ref.
+    template <bool priming_pass = false>
+    node_rlp_span encode_rlp(NodeViewBase node, node_rlp_span dest);
+
+    NodeId fresh_id();
+
+    // Commit `node` bytes to the overlay under `id`, returning `id`. If
+    // `id == NULL_ID` a fresh overlay id is allocated; otherwise the node's
+    // bytes are replaced (shadowing the blob) and its stale hash dropped.
+    // This is the single allocation/rewrite point behind every put_*.
+    NodeId put_node(NodeId id, byte_string node);
+
+    // Fold `prefix` onto `child`'s path when `child` is a leaf/ext, committing
+    // the merged node under `parent`'s id so nothing above is repointed. The
+    // trie's collapse/merge primitive. A branch `child` is left alone — a path
+    // can't fold into one — and neither caller needs it to be: the extension
+    // caller's node already spells `prefix`, and the branch-collapse caller
+    // wraps a branch child in a one-nibble extension itself.
+    void fold_ext_node_path_maybe(
+        NodeId const parent, NibblesView const prefix,
+        NodeViewBase const child);
+
+    // Initial root id from the blob header (root_offset, or an overlay-id
+    // sentinel for an empty trie); also validates the header.
+    static NodeId read_root(byte_string_view blob);
+};
+
+MONAD_MPT_NAMESPACE_END

--- a/category/execution/ethereum/db/offset_trie.hpp
+++ b/category/execution/ethereum/db/offset_trie.hpp
@@ -1,0 +1,518 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+// Offset-based, zero-copy witness trie for the zkVM guest.
+
+#include <category/core/assert.h>
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/cases.hpp>
+#include <category/core/config.hpp>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/mpt/config.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <utility>
+
+MONAD_MPT_NAMESPACE_BEGIN
+
+enum Tag : uint8_t
+{
+    BRANCH = 0,
+    EXT = 1,
+    LEAF_ACCT = 2,
+    LEAF_STORAGE = 3,
+    DIGEST = 4,
+    // NULL_ID addresses the blob's first magic byte, so the magic's leading
+    // 'M' doubles as the null node's tag: a null child dereferences to a
+    // real view instead of needing a null pre-check at every call site.
+    // read_root asserts the magic, which is what guarantees the byte is
+    // there.
+    EMPTY = 'M',
+};
+
+inline constexpr uint32_t HEADER_LEN = 8; // magic(4) root_offset(4)
+// Splits the NodeId space by the high bit: blob offsets live below it,
+// fresh overlay ids at/above it. The OffsetTrie constructor rejects blobs
+// larger than this, so a blob offset can never reach the overlay half (no
+// collision). Real witnesses are ~MBs, far under 2 GiB.
+inline constexpr uint32_t OVERLAY_BASE = 1u << 31;
+
+// Upper bound on a single node's canonical RLP: 16 child refs (<=33 B each)
+// + value slot + list header. 700 leaves margin.
+inline constexpr size_t MAX_NODE_RLP = 700;
+
+// A node's stable id. 0 = null; `n` in the [HEADER_LEN, blob_len) range is
+// a blob offset (unless shadowed by an overlay); n >= OVERLAY_BASE is a
+// fresh overlay node.
+enum class NodeId : uint32_t
+{
+};
+inline constexpr NodeId NULL_ID{0};
+
+inline bool is_overlay_id(NodeId id)
+{
+    return static_cast<uint32_t>(id) >= OVERLAY_BASE;
+}
+
+struct NodeIdHash
+{
+    using is_avalanching = void;
+
+    uint64_t operator()(NodeId const id) const noexcept
+    {
+        return ankerl::unordered_dense::hash<uint32_t>{}(
+            static_cast<uint32_t>(id));
+    }
+};
+
+// ── little-endian unaligned scalar reads ─────────────────────────────────────
+inline uint32_t read_u32(unsigned char const *const p)
+{
+    static_assert(std::endian::native == std::endian::little);
+    uint32_t v;
+    std::memcpy(&v, p, 4);
+    return v;
+}
+
+inline uint16_t read_u16(unsigned char const *const p)
+{
+    static_assert(std::endian::native == std::endian::little);
+    uint16_t v;
+    std::memcpy(&v, p, 2);
+    return v;
+}
+
+// ── node writers ─────────────────────────────────────────────────────────────
+void append_branch(byte_string &out, std::array<NodeId, 16> const &children);
+void append_ext(byte_string &out, NibblesView path, NodeId child);
+void append_storage(byte_string &out, NibblesView path, bytes32_t const &);
+void append_acct_raw(
+    byte_string &out, NibblesView path, byte_string_view acct_rlp,
+    NodeId storage);
+// No put_digest counterpart: mutation never creates a Digest, they only
+// ever arrive in the pre-state blob from the producer.
+void append_digest(byte_string &out, bytes32_t const &hash);
+
+// ── views ────────────────────────────────────────────────────────────────────
+// NodeViewBase is the untyped view (a pointer at the node's tag byte).
+// Typed views derive from it and add only their tag's getters.
+class NodeViewBase
+{
+    unsigned char const *p_;
+
+public:
+    explicit NodeViewBase(unsigned char const *const p)
+        : p_(p)
+    {
+    }
+
+    Tag tag() const
+    {
+        return Tag(*p_);
+    }
+
+    inline unsigned char const *bytes() const
+    {
+        return p_;
+    }
+
+    inline unsigned char const *payload() const
+    {
+        return p_ + 1;
+    }
+
+    // One past the last byte of this node, from its tag's fixed layout.
+    // Aborts if the tag is invalid. Reads the node's length fields, so the
+    // caller must bound the returned pointer against the region end (a
+    // malformed blob can make it point past the buffer).
+    unsigned char const *end() const;
+};
+
+// Nibble count
+inline unsigned path_length(unsigned char const *const p)
+{
+    return p[0];
+}
+
+// Packed size of the path in bytes — half the nibble count, rounded up.
+inline unsigned path_byte_length(unsigned char const *const p)
+{
+    return (path_length(p) + 1) / 2;
+}
+
+inline NibblesView path_view(unsigned char const *const p)
+{
+    return NibblesView{0u, path_length(p), p + 1};
+}
+
+inline unsigned char const *path_view_end(unsigned char const *const p)
+{
+    return p + 1 + path_byte_length(p);
+}
+
+// LEAF_ACCT and EXT keep their child id at a fixed position right after the
+// tag, so storage()/child() is a constant-offset read instead of a walk
+// over a path or account RLP. The rest of the node follows that field.
+inline unsigned char const *child_end(unsigned char const *const p)
+{
+    return p + sizeof(NodeId);
+}
+
+inline unsigned char const *account_rlp_end(unsigned char const *const p)
+{
+    uint16_t const rlp_len = read_u16(p);
+    return p + sizeof(rlp_len) + rlp_len;
+}
+
+inline unsigned char const *NodeViewBase::end() const
+{
+    switch (tag()) {
+    case BRANCH: // 16 child offsets
+        return payload() + 16 * sizeof(NodeId);
+    case EXT: // child offset + path
+        return path_view_end(child_end(payload()));
+    case LEAF_ACCT: // storage offset + path + acc length + acc rlp
+        return account_rlp_end(path_view_end(child_end(payload())));
+    case LEAF_STORAGE: // 32-byte value + path
+        return path_view_end(payload() + 32);
+    case DIGEST: // 32-byte hash
+        return payload() + 32;
+    case EMPTY: // pointing at the header
+        return bytes() + HEADER_LEN;
+    }
+    MONAD_ABORT("offset trie: invalid node tag");
+}
+
+class NullView : public NodeViewBase
+{
+public:
+    explicit NullView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+};
+
+class BranchView : public NodeViewBase
+{
+public:
+    explicit BranchView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NodeId child(unsigned const i) const // NULL_ID if empty
+    {
+        return NodeId{read_u32(payload() + 4 * i)};
+    }
+
+    std::array<NodeId, 16> children() const
+    {
+        std::array<NodeId, 16> out{};
+        for (unsigned i = 0; i < 16; ++i) {
+            out[i] = child(i);
+        }
+        return out;
+    }
+};
+
+class ExtView : public NodeViewBase
+{
+public:
+    explicit ExtView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NibblesView path() const
+    {
+        return path_view(child_end(payload()));
+    }
+
+    NodeId child() const
+    {
+        return NodeId{read_u32(payload())};
+    }
+};
+
+class AccountLeafView : public NodeViewBase
+{
+public:
+    explicit AccountLeafView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NibblesView path() const
+    {
+        return path_view(child_end(payload()));
+    }
+
+    // stored Ethereum account RLP (for hashing / decode)
+    byte_string_view account_rlp() const
+    {
+        unsigned char const *const acc_len_p =
+            path_view_end(child_end(payload()));
+        unsigned const acc_len = read_u16(acc_len_p);
+        return byte_string_view{acc_len_p + 2, acc_len};
+    }
+
+    // lazily RLP-decode the account (fields for read_account)
+    Account account() const
+    {
+        byte_string_view enc = account_rlp();
+        bytes32_t storage_root; // discarded; storage is traversed via storage()
+        auto res = rlp::decode_account(storage_root, enc);
+        MONAD_ASSERT(res.has_value());
+        return res.value();
+    }
+
+    // NULL_ID if no storage subtree materialized. Fixed offset — the whole
+    // point of storing it ahead of the path and account RLP.
+    NodeId storage() const
+    {
+        return NodeId{read_u32(payload())};
+    }
+};
+
+class StorageLeafView : public NodeViewBase
+{
+public:
+    explicit StorageLeafView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    NibblesView path() const
+    {
+        return path_view(payload() + 32);
+    }
+
+    bytes32_t value() const
+    {
+        bytes32_t v;
+        std::memcpy(v.bytes, payload(), 32);
+        return v;
+    }
+};
+
+class DigestView : public NodeViewBase
+{
+public:
+    explicit DigestView(NodeViewBase b)
+        : NodeViewBase(b)
+    {
+    }
+
+    bytes32_t hash() const
+    {
+        bytes32_t h;
+        std::memcpy(h.bytes, payload(), 32);
+        return h;
+    }
+};
+
+template <class... Fs>
+decltype(auto) match(NodeViewBase n, Fs &&...fs)
+{
+    Cases const v{std::forward<Fs>(fs)...};
+    switch (n.tag()) {
+    case BRANCH:
+        return v(BranchView{n});
+    case EXT:
+        return v(ExtView{n});
+    case LEAF_ACCT:
+        return v(AccountLeafView{n});
+    case LEAF_STORAGE:
+        return v(StorageLeafView{n});
+    case DIGEST:
+        return v(DigestView{n});
+    case EMPTY:
+        return v(NullView{n});
+    }
+    MONAD_ABORT("bad node tag");
+}
+
+// ── OffsetTrie — immutable blob + stable-id overlay ──────────────────────────
+class OffsetTrie
+{
+public:
+    // Wrap the read-only node blob, structurally validate it, and prime the
+    // hash cache (see prime()). Aborts if the blob is malformed.
+    explicit OffsetTrie(byte_string_view blob);
+
+    // Account-trie root, NULL_ID while the trie is empty. upsert_node and
+    // erase_node keep a materialised root's id stable, so a caller only
+    // reassigns it across the empty/non-empty transitions — exactly as
+    // PartialTrieDb::commit already threads a storage sub-root.
+    NodeId root;
+
+    NodeViewBase empty() const
+    {
+        // The blob is a node region, not text: NodeViewBase reads the tag
+        // at this byte and takes every extent from the node layout, so
+        // there is nothing to NUL-terminate.
+        // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+        return NodeViewBase{blob_.data()};
+    }
+
+    NodeViewBase get_original(NodeId const id) const
+    {
+        // NULL_ID resolves to the blob's first magic byte, i.e. the EMPTY
+        // tag
+        MONAD_ASSERT(
+            id == NULL_ID || (static_cast<uint32_t>(id) >= HEADER_LEN &&
+                              static_cast<uint32_t>(id) < blob_.size()));
+        return NodeViewBase{blob_.data() + static_cast<uint32_t>(id)};
+    }
+
+    // Current bytes for `id` — overlay entry if present, else the blob.
+    // put_node shadows a rewritten blob node under its own blob id, so the
+    // overlay has to be consulted for every id, not just fresh ones. A
+    // fresh id with no entry yet is a node upsert allocated but no put_*
+    // has materialised: it reads as empty.
+    NodeViewBase get_current(NodeId const id) const
+    {
+        auto const it = overlay_.find(id);
+        if (it != overlay_.end()) {
+            return NodeViewBase{it->second.data()};
+        }
+        return is_overlay_id(id) ? empty() : get_original(id);
+    }
+
+    // Walk the (pre-state) trie rooted at `id` following `key`; return the
+    // leaf view if the key is present, else `NullView`. Aborts on a Digest
+    // (incomplete witness). Traverses through the view accessors via match.
+    NodeViewBase find_original(NodeId id, NibblesView key) const;
+
+    NodeId put_branch(NodeId, std::array<NodeId, 16> const &);
+    NodeId put_ext(NodeId, NibblesView, NodeId);
+    NodeId put_storage(NodeId, NibblesView, bytes32_t const &);
+    NodeId
+    put_acct(NodeId, NibblesView, Account const &, bytes32_t const &, NodeId);
+    std::pair<NodeId, Nibbles>
+    upsert_node(NodeId const id, NibblesView const key);
+
+    enum class EraseResult
+    {
+        Erased,
+        Unmodified,
+        SameShape,
+        NewShape
+    };
+    EraseResult erase_node(NodeId, NibblesView);
+
+    // keccak of the (current) trie rooted at `id`; NULL_ID -> NULL_ROOT.
+    // Serves the account root and, at commit, freshly built storage
+    // sub-roots. Consults hashes_; recomputes + caches a missing id.
+    bytes32_t hash(NodeId id);
+    bytes32_t state_root();
+
+private:
+    // A thin view over an RLP scratch buffer of fixed capacity
+    // MAX_NODE_RLP. Encoding writes the payload into the *tail* of the
+    // buffer, so `data()` always stays at the buffer start and `size()`
+    // shrinks as bytes are written. The live RLP region is therefore
+    // [data() + size(), buf_end):
+    //   rlp_data() = data() + size(),  rlp_size() = MAX_NODE_RLP - size().
+    struct node_rlp_span : std::span<unsigned char>
+    {
+        explicit node_rlp_span(std::span<unsigned char> const s)
+            : std::span<unsigned char>(s)
+        {
+        }
+
+        // The written RLP is the tail past size(), not a subspan of *this,
+        // so rlp_data() needs the raw base pointer. Everyone else must
+        // reach bytes through last(): hide the front pointer to stop
+        // accidental writes to the unwritten head being mistaken for the
+        // payload.
+        unsigned char *data() const = delete;
+
+        unsigned char const *rlp_data() const
+        {
+            return std::span<unsigned char>::data() + size();
+        }
+
+        size_t rlp_size() const
+        {
+            return MAX_NODE_RLP - size();
+        }
+
+        node_rlp_span shrink(size_t const n) const
+        {
+            return node_rlp_span{first(size() - n)};
+        }
+    };
+
+    template <bool priming_pass>
+    node_rlp_span child_ref(NodeId id, node_rlp_span dest);
+
+    // The node's full canonical Ethereum RLP. Reads `node`'s fields and
+    // resolves its children through child_ref.
+    template <bool priming_pass = false>
+    node_rlp_span encode_rlp(NodeViewBase node, node_rlp_span dest);
+
+    NodeId fresh_id();
+
+    // Commit `node` bytes to the overlay under `id`, returning `id`. If
+    // `id == NULL_ID` a fresh overlay id is allocated; otherwise the node's
+    // bytes are replaced (shadowing the blob) and its stale hash dropped.
+    // This is the single allocation/rewrite point behind every put_*.
+    NodeId put_node(NodeId id, byte_string node);
+
+    // Fold `prefix` onto `child`'s path when `child` is a leaf/ext,
+    // committing the merged node under `child` (returned). Returns nullopt
+    // when `child` is a branch — a path can't fold into one, so the caller
+    // wraps it in an extension instead. The trie's collapse/merge
+    // primitive.
+    Tag fold_ext_node_path_maybe(
+        NodeId const parent, NibblesView const prefix,
+        NodeViewBase const child);
+
+    // Like put_acct but takes the account's already-encoded RLP verbatim,
+    // preserving the stored storage_root exactly (used when re-pathing an
+    // account leaf on collapse/merge, where re-deriving it is impossible).
+    NodeId put_acct_raw(
+        NodeId id, NibblesView path, byte_string_view acct_rlp, NodeId storage);
+
+    // Account-trie recursion behind upsert_account / erase_account —
+    // mirrors upsert_storage / erase_storage but over account leaves.
+    // upsert reports the found/created leaf id via `leaf` so commit can
+    // fill in its fields.
+    NodeId upsert_account_node(NodeId id, NibblesView key, NodeId &leaf);
+    NodeId erase_account_node(NodeId id, NibblesView key);
+
+    // Initial root id from the blob header (root_offset, or an overlay-id
+    // sentinel for an empty trie); also validates the header.
+    static NodeId read_root(byte_string_view blob);
+
+    byte_string_view blob_;
+    ankerl::unordered_dense::map<NodeId, byte_string, NodeIdHash> overlay_;
+    ankerl::unordered_dense::map<NodeId, bytes32_t, NodeIdHash> hashes_;
+    NodeId next_id_{OVERLAY_BASE}; // fresh-id counter (>= OVERLAY_BASE)
+};
+
+MONAD_MPT_NAMESPACE_END

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -13,810 +13,98 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/db/partial_trie_db.hpp>
+
+#include <category/core/address.hpp>
+#include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/cases.hpp>
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
-#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
-#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
-#include <category/execution/ethereum/db/partial_trie_db.hpp>
-#include <category/execution/ethereum/rlp/decode.hpp>
-#include <category/execution/monad/db/storage_page.hpp>
-#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/core/likely.h>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/mpt/nibbles_view.hpp>
-#include <category/vm/code.hpp>
 
-#include <ankerl/unordered_dense.h>
+#include <functional>
+#include <optional>
 
-#include <array>
-#include <cstdint>
-#include <cstring>
-#include <memory>
-#include <span>
-#include <utility>
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+// Deltas cover the whole *touched* set, not the changed set: a read lands as
+// `first == second` (BlockState::read_storage). An unchanged entry contributes
+// nothing to the trie, but committing it anyway costs a full root-to-leaf
+// descent and invalidates the cached hash of every node along it — so filter
+// them out before touching the trie at all.
+bool is_changed(StorageDelta const &d)
+{
+    return d.first != d.second;
+}
+
+bool is_changed(StateDelta const &d)
+{
+    if (d.account.first != d.account.second) {
+        return true;
+    }
+    for (auto const &kv : d.storage) {
+        if (is_changed(kv.second)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
-namespace
-{
-
-    // Forward declaration for mutual recursion.
-    template <typename T>
-    Result<ChildRef<T>> decode_child_ref(
-        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
-        NodeIndex const &nodes);
-
-    template <typename T>
-    byte_string encode_child_ref(ChildRef<T> const &child);
-
-    // ensures enc.empty() if successful
-    template <typename T>
-    Result<PartialNode<T>> decode_partial_node(
-        byte_string_view &enc, mpt::NibblesView curr_path,
-        NodeIndex const &nodes)
-    {
-        if (MONAD_UNLIKELY(enc.empty())) {
-            return rlp::DecodeError::InputTooShort;
-        }
-
-        {
-            // Make a copy of enc in case we need to backtrack in the branch
-            // case below
-            byte_string_view short_node_enc{enc};
-            BOOST_OUTCOME_TRY(
-                auto key_enc, rlp::parse_metadata(short_node_enc));
-            BOOST_OUTCOME_TRY(
-                auto val_enc, rlp::parse_metadata(short_node_enc));
-
-            if (short_node_enc.empty()) {
-                enc = short_node_enc;
-                // Extension/Leaf node
-                if (MONAD_UNLIKELY(key_enc.first != rlp::RlpType::String)) {
-                    return rlp::DecodeError::TypeUnexpected;
-                }
-
-                BOOST_OUTCOME_TRY(
-                    auto decoded_pair, mpt::compact_decode(key_enc.second));
-                auto const &[decoded_path, is_leaf] = decoded_pair;
-                mpt::Nibbles full_path =
-                    mpt::concat(curr_path, mpt::NibblesView{decoded_path});
-
-                if (MONAD_UNLIKELY(full_path.nibble_size() > 64)) {
-                    return rlp::DecodeError::PathTooLong;
-                }
-
-                if (is_leaf) {
-                    if (MONAD_UNLIKELY(val_enc.first != rlp::RlpType::String)) {
-                        return rlp::DecodeError::TypeUnexpected;
-                    }
-                    BOOST_OUTCOME_TRY(
-                        auto value, T::decode(val_enc.second, nodes));
-                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
-                    return PartialNode<T>{
-                        LeafData<T>{std::move(decoded_path), std::move(value)}};
-                }
-                else {
-                    BOOST_OUTCOME_TRY(
-                        auto child,
-                        decode_child_ref<T>(
-                            val_enc.first,
-                            val_enc.second,
-                            mpt::NibblesView{full_path},
-                            nodes));
-                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
-                    return PartialNode<T>{ExtensionData<T>{
-                        std::move(decoded_path), std::move(child)}};
-                }
-            }
-        }
-
-        // Branch node: re-parse from the beginning since we consumed k and v
-        // above
-        BranchData<T> branch{};
-
-        if (MONAD_UNLIKELY(curr_path.nibble_size() + 1 > 64)) {
-            return rlp::DecodeError::PathTooLong;
-        }
-
-        for (unsigned i = 0; i < 16; ++i) {
-            BOOST_OUTCOME_TRY(auto child_enc, rlp::parse_metadata(enc));
-            mpt::Nibbles child_path =
-                mpt::concat(curr_path, static_cast<unsigned char>(i));
-            BOOST_OUTCOME_TRY(
-                auto child,
-                decode_child_ref<T>(
-                    child_enc.first,
-                    child_enc.second,
-                    mpt::NibblesView{child_path},
-                    nodes));
-            branch.children[i] = std::move(child);
-        }
-        BOOST_OUTCOME_TRY(auto v_enc, rlp::decode_string(enc));
-        if (!v_enc.empty()) {
-            BOOST_OUTCOME_TRY(auto value, T::decode(v_enc, nodes));
-            MONAD_DEBUG_ASSERT(v_enc.empty());
-            branch.value = std::move(value);
-        }
-        if (MONAD_UNLIKELY(!enc.empty())) {
-            return rlp::DecodeError::InputTooLong;
-        }
-        return PartialNode<T>{std::move(branch)};
-    }
-
-    // ensures enc.empty() if successful
-    template <typename T>
-    Result<ChildRef<T>> decode_child_ref(
-        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
-        NodeIndex const &nodes)
-    {
-        if (ty == rlp::RlpType::List) {
-            // Embedded node (inline RLP list). Ethereum requires the *full* RLP
-            // encoding of an inline node to be < 32 bytes; since `enc` is the
-            // list payload (header already stripped), its size must be <= 30.
-            if (MONAD_UNLIKELY(enc.size() > 30)) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            // Manual expansion of BOOST_OUTCOME_TRY to avoid a named
-            // PartialNode<T> local that triggers a GCC false-positive
-            // -Wmaybe-uninitialized on the unique_ptr inside AccountLeafValue.
-            auto node_result_ = decode_partial_node<T>(enc, path, nodes);
-            if (MONAD_UNLIKELY(node_result_.has_failure())) {
-                return std::move(node_result_).as_failure();
-            }
-            MONAD_DEBUG_ASSERT(enc.empty());
-            return std::make_unique<PartialNode<T>>(
-                std::move(node_result_).assume_value());
-        }
-        else {
-            // String: either empty (null slot) or 32-byte hash reference
-            if (enc.empty()) {
-                return nullptr;
-            }
-            if (MONAD_UNLIKELY(enc.size() < 32)) {
-                return rlp::DecodeError::InputTooShort;
-            }
-            if (MONAD_UNLIKELY(enc.size() > 32)) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            bytes32_t hash{};
-            std::memcpy(hash.bytes, enc.data(), 32);
-            enc = enc.substr(32);
-            MONAD_DEBUG_ASSERT(enc.empty());
-            // NULL_ROOT is the canonical empty-trie hash; represent it as a
-            // null pointer so encode/decode are symmetric with
-            // AccountLeafValue.
-            if (hash == NULL_ROOT) {
-                return nullptr;
-            }
-            auto it = nodes.find(hash);
-            if (it == nodes.end()) {
-                return std::make_unique<PartialNode<T>>(HashStub{hash});
-            }
-            // The NodeIndex stores the raw RLP item (list). Strip the list
-            // header before passing the payload to decode_partial_node.
-            byte_string_view node_enc{it->second};
-            BOOST_OUTCOME_TRY(auto payload, rlp::parse_list_metadata(node_enc));
-            if (MONAD_UNLIKELY(!node_enc.empty())) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            BOOST_OUTCOME_TRY(
-                auto v, decode_partial_node<T>(payload, path, nodes));
-            MONAD_DEBUG_ASSERT(payload.empty());
-            return std::make_unique<PartialNode<T>>(std::move(v));
-        }
-    }
-
-    template <typename T>
-    byte_string encode_partial_node(PartialNode<T> const &node)
-    {
-        return std::visit(
-            Cases{
-                [](LeafData<T> const &leaf) {
-                    MONAD_ASSERT(leaf.path.nibble_size() <= 64);
-                    unsigned char compact_buf[33];
-                    auto compact_sv = mpt::compact_encode(
-                        compact_buf,
-                        mpt::NibblesView{leaf.path},
-                        /*terminating=*/true);
-                    return rlp::encode_list2(
-                        rlp::encode_string2(compact_sv),
-                        rlp::encode_string2(T::encode(leaf.value)));
-                },
-                [](ExtensionData<T> const &ext) {
-                    MONAD_ASSERT(ext.path.nibble_size() <= 64);
-                    unsigned char compact_buf[33];
-                    auto compact_sv = mpt::compact_encode(
-                        compact_buf,
-                        mpt::NibblesView{ext.path},
-                        /*terminating=*/false);
-                    return rlp::encode_list2(
-                        rlp::encode_string2(compact_sv),
-                        encode_child_ref(ext.child));
-                },
-                [](BranchData<T> const &branch) {
-                    byte_string body;
-                    for (unsigned i = 0; i < 16; ++i) {
-                        body += encode_child_ref(branch.children[i]);
-                    }
-                    body += branch.value ? T::encode(*branch.value)
-                                         : rlp::EMPTY_STRING;
-                    return rlp::encode_list2(body);
-                },
-                [](HashStub const &) -> byte_string {
-                    MONAD_ABORT("Incomplete witness");
-                },
-            },
-            node.v);
-    }
-
-    template <typename T>
-    byte_string encode_child_ref(ChildRef<T> const &child)
-    {
-        if (!child) {
-            return rlp::EMPTY_STRING;
-        }
-        if (auto const *stub = std::get_if<HashStub>(&child->v)) {
-            return rlp::encode_string2(byte_string_view{stub->hash.bytes, 32});
-        }
-        byte_string rlp_bytes = encode_partial_node(*child);
-        if (rlp_bytes.size() < 32) {
-            return rlp_bytes; // embedded inline
-        }
-        unsigned char hash[32];
-        keccak256(rlp_bytes.data(), rlp_bytes.size(), hash);
-        return rlp::encode_string2(byte_string_view{hash, 32});
-    }
-
-    /// Walk the trie rooted at `root` following the given nibble key.
-    /// Aborts if the lookup hits an unresolved HashStub, and returns
-    /// a pointer to the leaf value on success, or nullptr if the key is absent.
-    template <typename T>
-    T *trie_lookup(ChildRef<T> const &root, mpt::NibblesView remaining)
-    {
-        PartialNode<T> *node = root.get();
-        while (node != nullptr) {
-            if (auto *leaf = std::get_if<LeafData<T>>(&node->v)) {
-                return (mpt::NibblesView{leaf->path} == remaining)
-                           ? &leaf->value
-                           : nullptr;
-            }
-            else if (auto *ext = std::get_if<ExtensionData<T>>(&node->v)) {
-                mpt::NibblesView const ext_path{ext->path};
-                if (!remaining.starts_with(ext_path)) {
-                    return nullptr;
-                }
-                remaining = remaining.substr(ext_path.nibble_size());
-                node = ext->child.get();
-            }
-            else if (auto *branch = std::get_if<BranchData<T>>(&node->v)) {
-                if (remaining.empty()) {
-                    return branch->value ? &*branch->value : nullptr;
-                }
-                unsigned const nibble = remaining.get(0);
-                remaining = remaining.substr(1);
-                node = branch->children[nibble].get();
-            }
-            else {
-                MONAD_ABORT("Incomplete witness");
-            }
-        }
-        return nullptr; // null child — key absent
-    }
-
-    unsigned
-    common_prefix_length(mpt::NibblesView const a, mpt::NibblesView const b)
-    {
-        unsigned const n = std::min(a.nibble_size(), b.nibble_size());
-        for (unsigned i = 0; i < n; ++i) {
-            if (a.get(i) != b.get(i)) {
-                return i;
-            }
-        }
-        return n;
-    }
-
-    // Insert or update a leaf in the trie when override = true.
-    // Get or insert when override = false.
-    template <bool override = true, typename T>
-    T &trie_get_or_upsert(ChildRef<T> &root, mpt::NibblesView key, T value);
-
-    template <bool override, typename T>
-    [[gnu::always_inline]] inline T &trie_get_or_upsert_at_new_branch(
-        ChildRef<T> &root, BranchData<T> &&branch, unsigned const common_prefix,
-        mpt::NibblesView key, T value)
-    {
-        MONAD_DEBUG_ASSERT(common_prefix <= key.nibble_size());
-
-        T *ret_val{};
-
-        if (common_prefix < key.nibble_size()) {
-            ret_val = &trie_get_or_upsert<override>(
-                branch.children[key.get(common_prefix)],
-                key.substr(common_prefix + 1),
-                std::move(value));
-        }
-        else {
-            if constexpr (override) {
-                branch.value = std::move(value);
-            }
-            else {
-                if (!branch.value) {
-                    branch.value = std::move(value);
-                }
-            }
-        }
-
-        if (common_prefix > 0) {
-            root = std::make_unique<PartialNode<T>>(ExtensionData<T>{
-                mpt::Nibbles{key.substr(0, common_prefix)},
-                std::make_unique<PartialNode<T>>(std::move(branch))});
-            // if the value was stored in branch.value, we need to fetch
-            // value's pointer after the move
-            if (!ret_val) {
-                return *(std::get<BranchData<T>>(
-                             std::get<ExtensionData<T>>(root->v).child->v)
-                             .value);
-            }
-        }
-        else {
-            root = std::make_unique<PartialNode<T>>(std::move(branch));
-            // if the value was stored in branch.value, we need to fetch
-            // value's pointer after the move
-            if (!ret_val) {
-                return *std::get<BranchData<T>>(root->v).value;
-            }
-        }
-        return *ret_val;
-    }
-
-    template <bool override, typename T>
-    [[gnu::always_inline]] inline T &trie_get_or_upsert_at_branch(
-        BranchData<T> &branch, mpt::NibblesView key, T value)
-    {
-        if (key.empty()) {
-            if constexpr (override) {
-                branch.value = std::move(value);
-            }
-            else {
-                if (!branch.value) {
-                    branch.value = std::move(value);
-                }
-            }
-            return *branch.value;
-        }
-        return trie_get_or_upsert<override>(
-            branch.children[key.get(0)], key.substr(1), std::move(value));
-    }
-
-    template <bool override, typename T>
-    T &trie_get_or_upsert(ChildRef<T> &root, mpt::NibblesView key, T value)
-    {
-        if (!root) {
-            root = std::make_unique<PartialNode<T>>(
-                LeafData<T>{mpt::Nibbles{key}, std::move(value)});
-            return std::get<LeafData<T>>(root->v).value;
-        }
-
-        return std::visit(
-            Cases{
-                [&](LeafData<T> &leaf) -> T & {
-                    mpt::NibblesView const leaf_path{leaf.path};
-                    if (leaf_path == key) {
-                        if constexpr (override) {
-                            leaf.value = std::move(value);
-                        }
-                        return leaf.value;
-                    }
-
-                    unsigned const cp = common_prefix_length(leaf_path, key);
-                    MONAD_DEBUG_ASSERT(
-                        cp < leaf_path.nibble_size() || cp < key.nibble_size());
-
-                    BranchData<T> branch{};
-
-                    if (cp < leaf_path.nibble_size()) {
-                        branch.children[leaf_path.get(cp)] =
-                            std::make_unique<PartialNode<T>>(LeafData<T>{
-                                mpt::Nibbles{leaf_path.substr(cp + 1)},
-                                std::move(leaf.value)});
-                    }
-                    else {
-                        branch.value = std::move(leaf.value);
-                    }
-
-                    return trie_get_or_upsert_at_new_branch<override>(
-                        root, std::move(branch), cp, key, std::move(value));
-                },
-                [&](ExtensionData<T> &ext) -> T & {
-                    mpt::NibblesView const ext_path{ext.path};
-
-                    unsigned const cp = common_prefix_length(ext_path, key);
-                    if (cp == ext_path.nibble_size()) {
-                        return trie_get_or_upsert<override>(
-                            ext.child, key.substr(cp), std::move(value));
-                    }
-
-                    BranchData<T> branch{};
-
-                    branch.children[ext_path.get(cp)] =
-                        (cp + 1 < ext_path.nibble_size())
-                            ? std::make_unique<PartialNode<T>>(ExtensionData<T>{
-                                  mpt::Nibbles{ext_path.substr(cp + 1)},
-                                  std::move(ext.child)})
-                            : std::move(ext.child);
-
-                    return trie_get_or_upsert_at_new_branch<override>(
-                        root, std::move(branch), cp, key, std::move(value));
-                },
-                [&](BranchData<T> &branch) -> T & {
-                    return trie_get_or_upsert_at_branch<override>(
-                        branch, key, std::move(value));
-                },
-                [](HashStub &) -> T & { MONAD_ABORT("Incomplete witness"); },
-            },
-            root->v);
-    }
-
-    template <typename Prefix, typename T>
-        requires(
-            std::same_as<Prefix, unsigned char> ||
-            std::same_as<Prefix, mpt::NibblesView>)
-    [[gnu::always_inline]] inline std::optional<ChildRef<T>>
-    concat_path_maybe(Prefix const prefix, ChildRef<T> &node)
-    {
-        if (auto *child_leaf = std::get_if<LeafData<T>>(&node->v)) {
-            child_leaf->path =
-                mpt::concat(prefix, mpt::NibblesView{child_leaf->path});
-            return std::move(node);
-        }
-        else if (auto *child_ext = std::get_if<ExtensionData<T>>(&node->v)) {
-            child_ext->path =
-                mpt::concat(prefix, mpt::NibblesView{child_ext->path});
-            return std::move(node);
-        }
-        return std::nullopt;
-    }
-
-    enum class DeleteResult
-    {
-        Reset,
-        Compressed,
-        Unchanged
-    };
-
-    /// Delete a leaf from the trie at the given nibble key, applying branch
-    /// compression as needed. Returns:
-    ///   - Reset:      `root` was reset to null (the node went away).
-    ///   - Compressed: `root` was reassigned (path-merge or branch collapsed
-    ///                 to a leaf/ext); the node still exists but has changed
-    ///                 identity.
-    ///   - Unchanged:  no structural change at this level (either the key
-    ///                 was absent, or a delete happened deeper but did not
-    ///                 propagate a shape change here).
-    template <typename T>
-    DeleteResult trie_delete(ChildRef<T> &root, mpt::NibblesView key)
-    {
-        if (!root) {
-            return DeleteResult::Unchanged;
-        }
-
-        return std::visit(
-            Cases{
-                [&](LeafData<T> &leaf) -> DeleteResult {
-                    if (mpt::NibblesView{leaf.path} == key) {
-                        root.reset();
-                        return DeleteResult::Reset;
-                    }
-                    return DeleteResult::Unchanged;
-                },
-                [&](ExtensionData<T> &ext) -> DeleteResult {
-                    mpt::NibblesView const ext_path{ext.path};
-                    unsigned const cp = common_prefix_length(ext_path, key);
-                    if (cp < ext_path.nibble_size()) {
-                        return DeleteResult::Unchanged;
-                    }
-                    switch (trie_delete(ext.child, key.substr(cp))) {
-                    case DeleteResult::Unchanged:
-                        return DeleteResult::Unchanged;
-                    case DeleteResult::Reset:
-                        root.reset();
-                        return DeleteResult::Reset;
-                    case DeleteResult::Compressed: {
-                        // Merge paths if child is now a leaf or
-                        // extension
-                        auto maybe_compressed = concat_path_maybe(
-                            mpt::NibblesView{ext.path}, ext.child);
-                        if (maybe_compressed) {
-                            root = std::move(*maybe_compressed);
-                            return DeleteResult::Compressed;
-                        }
-                        return DeleteResult::Unchanged;
-                    }
-                    }
-                    std::unreachable();
-                },
-                [&](BranchData<T> &branch) -> DeleteResult {
-                    if (key.empty()) {
-                        if (!branch.value) {
-                            return DeleteResult::Unchanged;
-                        }
-                        branch.value.reset();
-                    }
-                    else if (
-                        trie_delete(
-                            branch.children[key.get(0)], key.substr(1)) !=
-                        DeleteResult::Reset) {
-                        // we can exit early as long as we know that the call to
-                        // trie_delete didn't result in a reset.
-                        // Even if compression occured, the child is still
-                        // non-null, hence no compaction will occur
-                        return DeleteResult::Unchanged;
-                    }
-
-                    unsigned child_count = 0;
-                    unsigned single_idx = 0;
-                    for (unsigned i = 0; i < 16 && child_count < 2; ++i) {
-                        if (branch.children[i]) {
-                            ++child_count;
-                            single_idx = i;
-                        }
-                    }
-                    bool const has_value = branch.value.has_value();
-
-                    if (child_count == 0 && !has_value) {
-                        root.reset();
-                        return DeleteResult::Reset;
-                    }
-                    if (child_count == 0 && has_value) {
-                        root = std::make_unique<PartialNode<T>>(LeafData<T>{
-                            mpt::Nibbles{}, std::move(*branch.value)});
-                        return DeleteResult::Compressed;
-                    }
-                    if (child_count == 1 && !has_value) {
-                        auto &child = branch.children[single_idx];
-                        // We unconditionally require the inclusion of the
-                        // sole surviving child on a branch in the witness.
-                        // This is strictly not necessary when the child is a
-                        // branch node, as we can just wrap the HashStub
-                        // opaquely in an extension, maintaining a canonical
-                        // Ethereum MPT. However, if the child is an extension
-                        // or a leaf, having only a HashStub would lead to a
-                        // non-canoncial extension->extension or extension->leaf
-                        // tries, which would produce an incorrect state root.
-                        // In the latter two cases, branch compression merges
-                        // the child's path with the branch nibble.
-                        // Requring the emission of the sole surviving child in
-                        // all cases makes debugging easier with minimal
-                        // overheads to the witness size, although this means
-                        // the witness is not minimal (there is currently no
-                        // formal definition of what constitutes a minimal
-                        // witness).
-                        MONAD_ASSERT(
-                            !std::holds_alternative<HashStub>(child->v));
-                        auto const nibble =
-                            static_cast<unsigned char>(single_idx);
-                        auto maybe_compressed =
-                            concat_path_maybe(nibble, child);
-                        if (maybe_compressed) {
-                            root = std::move(*maybe_compressed);
-                        }
-                        else {
-                            MONAD_DEBUG_ASSERT(
-                                std::holds_alternative<BranchData<T>>(
-                                    child->v));
-                            mpt::Nibbles nibble_path{1};
-                            nibble_path.set(0, nibble);
-                            root = std::make_unique<PartialNode<T>>(
-                                ExtensionData<T>{
-                                    std::move(nibble_path), std::move(child)});
-                        }
-
-                        return DeleteResult::Compressed;
-                    }
-                    return DeleteResult::Unchanged;
-                },
-                [](HashStub &) -> DeleteResult {
-                    MONAD_ABORT("Incomplete witness");
-                },
-            },
-            root->v);
-    }
-
-} // anonymous namespace
-
-// ensures enc.empty() if successful
-Result<AccountLeafValue>
-AccountLeafValue::decode(byte_string_view &enc, NodeIndex const &nodes)
-{
-    bytes32_t storage_root{};
-    BOOST_OUTCOME_TRY(Account acct, rlp::decode_account(storage_root, enc));
-    if (MONAD_UNLIKELY(!enc.empty())) {
-        return rlp::DecodeError::InputTooLong;
-    }
-    StorageTrie strie;
-    if (storage_root != NULL_ROOT) {
-        mpt::Nibbles empty_path{};
-        byte_string_view storage_root_enc{
-            storage_root.bytes, sizeof(storage_root.bytes)};
-        BOOST_OUTCOME_TRY(
-            strie,
-            decode_child_ref<StorageLeafValue>(
-                rlp::RlpType::String,
-                storage_root_enc,
-                mpt::NibblesView{empty_path},
-                nodes));
-        MONAD_DEBUG_ASSERT(storage_root_enc.empty());
-    }
-
-    return AccountLeafValue{.account = acct, .storage = std::move(strie)};
-}
-
-byte_string AccountLeafValue::encode(AccountLeafValue const &v)
-{
-    bytes32_t storage_root;
-    if (!v.storage) {
-        storage_root = NULL_ROOT;
-    }
-    else {
-        auto const &storage_node = *v.storage;
-        if (auto const *stub = std::get_if<HashStub>(&storage_node.v)) {
-            storage_root = stub->hash;
-        }
-        else {
-            byte_string rlp_bytes = encode_partial_node(storage_node);
-            storage_root = to_bytes(keccak256(
-                byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
-        }
-    }
-
-    return rlp::encode_account(v.account, storage_root);
-}
-
-// ensures enc.empty() if successful
-Result<StorageLeafValue>
-StorageLeafValue::decode(byte_string_view &enc, NodeIndex const & /*nodes*/)
-{
-    BOOST_OUTCOME_TRY(auto const raw, rlp::decode_bytes32_compact(enc));
-    if (MONAD_UNLIKELY(!enc.empty())) {
-        return rlp::DecodeError::InputTooLong;
-    }
-    return StorageLeafValue{raw};
-}
-
-byte_string StorageLeafValue::encode(StorageLeafValue const &v)
-{
-    return rlp::encode_bytes32_compact(v.value);
-}
-
-Result<PartialTrieDb> PartialTrieDb::from_witness(
-    bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
-    byte_string_view encoded_codes)
-{
-    NodeIndex node_index;
-    {
-        while (!encoded_nodes.empty()) {
-            BOOST_OUTCOME_TRY(
-                auto const node_bytes,
-                rlp::parse_list_metadata_raw(encoded_nodes));
-            bytes32_t const key = to_bytes(keccak256(node_bytes));
-            node_index.emplace(
-                key, byte_string{node_bytes.data(), node_bytes.size()});
-        }
-    }
-
-    CodeIndex code_index;
-    {
-        while (!encoded_codes.empty()) {
-            BOOST_OUTCOME_TRY(
-                auto bytes, rlp::parse_string_metadata(encoded_codes));
-            bytes32_t key = to_bytes(keccak256(bytes));
-            code_index.emplace(
-                key,
-                vm::make_shared_intercode(
-                    std::span<uint8_t const>{bytes.data(), bytes.size()}));
-        }
-    }
-
-    AccountTrie root_node;
-    {
-        mpt::Nibbles empty_path{};
-        byte_string_view pre_state_root_enc{
-            pre_state_root.bytes, sizeof(pre_state_root.bytes)};
-        BOOST_OUTCOME_TRY(
-            root_node,
-            decode_child_ref<AccountLeafValue>(
-                rlp::RlpType::String,
-                pre_state_root_enc,
-                mpt::NibblesView{empty_path},
-                node_index));
-        MONAD_DEBUG_ASSERT(pre_state_root_enc.empty());
-    }
-
-    return PartialTrieDb{std::move(root_node), std::move(code_index)};
-}
-
 std::optional<Account> PartialTrieDb::read_account(Address const &addr)
 {
-    auto const key_hash = keccak256(addr.bytes);
-    auto const result = trie_lookup(root_, mpt::NibblesView{key_hash});
-    if (!result) {
-        return std::nullopt;
-    }
-    return result->account;
+    auto const key = keccak256(addr.bytes);
+    return match(
+        trie_.find_original(trie_.root, mpt::NibblesView{key}),
+        Cases{
+            [](mpt::NullView) -> std::optional<Account> {
+                return std::nullopt;
+            },
+            [](mpt::AccountLeafView l) -> std::optional<Account> {
+                return l.account();
+            },
+            [](auto) -> std::optional<Account> {
+                MONAD_ABORT("incorrect node type returned in read_account");
+            }});
 }
 
 bytes32_t PartialTrieDb::read_storage(
     Address const &addr, Incarnation, bytes32_t const &slot)
 {
-    auto const acct_hash = keccak256(addr.bytes);
-    auto const acct_result = trie_lookup(root_, mpt::NibblesView{acct_hash});
-    if (!acct_result || !acct_result->storage) {
-        return {};
+    auto const akey = keccak256(addr.bytes);
+    auto const sroot = match(
+        trie_.find_original(trie_.root, mpt::NibblesView{akey}),
+        Cases{
+            [](mpt::NullView) { return mpt::NULL_ID; },
+            [](mpt::AccountLeafView l) { return l.storage(); },
+            [](auto) -> mpt::NodeId {
+                MONAD_ABORT("incorrect node type returned in read_storage");
+            }});
+
+    if (sroot == mpt::NULL_ID) {
+        return bytes32_t{};
     }
-    auto const slot_hash = keccak256(slot.bytes);
-    auto const val_result =
-        trie_lookup(acct_result->storage, mpt::NibblesView{slot_hash});
-    return !val_result ? bytes32_t{} : val_result->value;
-}
+    auto const skey = keccak256(slot.bytes);
 
-storage_page_t PartialTrieDb::read_storage_page(
-    Address const &, Incarnation, bytes32_t const &)
-{
-    MONAD_ABORT("PartialTrieDb read_storage_page is currently not supported");
-}
-
-vm::SharedIntercode PartialTrieDb::read_code(bytes32_t const &code_hash)
-{
-    auto it = codes_.find(code_hash);
-    if (it == codes_.end()) {
-        return vm::make_shared_intercode({});
-    }
-    return it->second;
-}
-
-BlockHeader PartialTrieDb::read_eth_header()
-{
-    return last_committed_header_;
-}
-
-bytes32_t PartialTrieDb::state_root()
-{
-    if (!root_) {
-        return NULL_ROOT;
-    }
-    if (auto const *stub = std::get_if<HashStub>(&root_->v)) {
-        return stub->hash;
-    }
-    byte_string rlp_bytes = encode_partial_node(*root_);
-    return to_bytes(
-        keccak256(byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
-}
-
-bytes32_t PartialTrieDb::receipts_root()
-{
-    return last_committed_header_.receipts_root;
-}
-
-bytes32_t PartialTrieDb::transactions_root()
-{
-    return last_committed_header_.transactions_root;
-}
-
-std::optional<bytes32_t> PartialTrieDb::withdrawals_root()
-{
-    return last_committed_header_.withdrawals_root;
-}
-
-uint64_t PartialTrieDb::get_block_number() const
-{
-    return block_number_;
-}
-
-void PartialTrieDb::set_block_and_prefix(
-    uint64_t block_number, bytes32_t const &)
-{
-    block_number_ = block_number;
+    return match(
+        trie_.find_original(sroot, mpt::NibblesView{skey}),
+        Cases{
+            [](mpt::NullView) { return bytes32_t{}; },
+            [](mpt::StorageLeafView l) { return l.value(); },
+            [](auto) -> bytes32_t {
+                MONAD_ABORT("incorrect node type returned in read_storage");
+            }});
 }
 
 void PartialTrieDb::commit(
@@ -824,60 +112,84 @@ void PartialTrieDb::commit(
     StateDeltas const &deltas,
     std::function<void(BlockHeader &)> populate_header_fn)
 {
+    using mpt::NodeId;
+    using mpt::NULL_ID;
+    using mpt::OffsetTrie;
+
     block_number_ = header.number;
 
-    // Pass 1: inserts and updates (accounts that exist in post-state)
+    // Pass 1: inserts and updates — accounts present in the post-state. The
+    // storage sub-root is threaded through the put_* builders rather than held
+    // as a live leaf reference.
     for (auto const &[addr, delta] : deltas) {
         auto const &new_account = delta.account.second;
-        if (!new_account) {
+        if (!new_account || !is_changed(delta)) {
             continue;
         }
-
         auto const acct_key = keccak256(addr.bytes);
+        auto const [leaf, leaf_path] =
+            trie_.upsert_node(trie_.root, mpt::NibblesView{acct_key});
+        if (MONAD_UNLIKELY(trie_.root == NULL_ID)) {
+            // First account into an empty trie: the leaf becomes the root.
+            trie_.root = leaf;
+        }
+        NodeId storage = match(
+            trie_.get_current(leaf),
+            Cases{
+                [](mpt::NullView) { return NULL_ID; },
+                [](mpt::AccountLeafView a) { return a.storage(); },
+                [](auto) -> NodeId {
+                    MONAD_ABORT("incorrect node type returned in commit");
+                }});
 
-        auto &existing = trie_get_or_upsert<false>(
-            root_, mpt::NibblesView{acct_key}, AccountLeafValue{});
-
-        // Incarnation bump: the account was destroyed and recreated in
-        // this block (CREATE2/SELFDESTRUCT/CREATE2 patterns). The old
-        // storage trie must be wiped before the new slot deltas apply
+        // Incarnation bump (destroy + recreate in-block): wipe old storage.
         if (delta.account.first.has_value() &&
             delta.account.first->incarnation != new_account->incarnation) {
-            existing.storage.reset();
+            storage = NULL_ID;
         }
 
-        existing.account = *new_account;
-
-        auto &storage = existing.storage;
-
-        // Apply storage deltas: upserts first, then deletions
+        // All upserts must happen before the deletes, otherwise branch
+        // compression could and hit a digest
         for (auto const &[slot, sdelta] : delta.storage) {
-            if (sdelta.second != bytes32_t{}) {
+            if (is_changed(sdelta) && sdelta.second != bytes32_t{}) {
                 auto const slot_key = keccak256(slot.bytes);
-                trie_get_or_upsert(
-                    storage,
-                    mpt::NibblesView{slot_key},
-                    StorageLeafValue{sdelta.second});
+                auto const [sleaf, sleaf_path] =
+                    trie_.upsert_node(storage, mpt::NibblesView{slot_key});
+                if (storage == NULL_ID) {
+                    storage = sleaf; // first slot into empty storage: the leaf
+                                     // is the sub-root
+                }
+                trie_.put_storage(sleaf, sleaf_path, sdelta.second);
             }
         }
         for (auto const &[slot, sdelta] : delta.storage) {
-            if (sdelta.second == bytes32_t{} && sdelta.first != bytes32_t{}) {
+            if (is_changed(sdelta) && sdelta.second == bytes32_t{}) {
                 auto const slot_key = keccak256(slot.bytes);
-                trie_delete(storage, mpt::NibblesView{slot_key});
+                if (trie_.erase_node(storage, mpt::NibblesView{slot_key}) ==
+                    OffsetTrie::EraseResult::Erased) {
+                    storage = NULL_ID;
+                };
             }
         }
+
+        // The leaf records only the storage edge; state_root() derives the
+        // root from the subtree itself, so there is nothing to bake in and no
+        // reason to hash the subtree before it is asked for.
+        trie_.put_acct(
+            leaf, mpt::NibblesView{leaf_path}, *new_account, storage);
     }
 
-    // Pass 2: deletions (accounts removed in post-state)
+    // Pass 2: deletions — accounts absent in the post-state but present before.
     for (auto const &[addr, delta] : deltas) {
-        if (delta.account.second) {
-            continue;
-        }
-        if (!delta.account.first) {
+        if (delta.account.second || !delta.account.first) {
             continue;
         }
         auto const acct_key = keccak256(addr.bytes);
-        trie_delete(root_, mpt::NibblesView{acct_key});
+        if (MONAD_UNLIKELY(
+                trie_.erase_node(trie_.root, mpt::NibblesView{acct_key}) ==
+                OffsetTrie::EraseResult::Erased)) {
+            trie_.root = NULL_ID;
+        }
     }
 
     last_committed_header_ = header;

--- a/category/execution/ethereum/db/partial_trie_db.cpp
+++ b/category/execution/ethereum/db/partial_trie_db.cpp
@@ -13,810 +13,98 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/db/partial_trie_db.hpp>
+
+#include <category/core/address.hpp>
+#include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/cases.hpp>
 #include <category/core/config.hpp>
 #include <category/core/keccak.hpp>
-#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
-#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
-#include <category/execution/ethereum/db/partial_trie_db.hpp>
-#include <category/execution/ethereum/rlp/decode.hpp>
-#include <category/execution/monad/db/storage_page.hpp>
-#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/core/likely.h>
+#include <category/execution/ethereum/core/account.hpp>
+#include <category/execution/ethereum/core/block.hpp>
+#include <category/execution/ethereum/db/db.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
+#include <category/execution/ethereum/state2/state_deltas.hpp>
+#include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/mpt/nibbles_view.hpp>
-#include <category/vm/code.hpp>
 
-#include <ankerl/unordered_dense.h>
+#include <functional>
+#include <optional>
 
-#include <array>
-#include <cstdint>
-#include <cstring>
-#include <memory>
-#include <span>
-#include <utility>
+MONAD_ANONYMOUS_NAMESPACE_BEGIN
+
+// Deltas cover the whole *touched* set, not the changed set: a read lands as
+// `first == second` (BlockState::read_storage). An unchanged entry contributes
+// nothing to the trie, but committing it anyway costs a full root-to-leaf
+// descent and invalidates the cached hash of every node along it — so filter
+// them out before touching the trie at all.
+bool is_changed(StorageDelta const &d)
+{
+    return d.first != d.second;
+}
+
+bool is_changed(StateDelta const &d)
+{
+    if (d.account.first != d.account.second) {
+        return true;
+    }
+    for (auto const &kv : d.storage) {
+        if (is_changed(kv.second)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
-namespace
-{
-
-    // Forward declaration for mutual recursion.
-    template <typename T>
-    Result<ChildRef<T>> decode_child_ref(
-        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
-        NodeIndex const &nodes);
-
-    template <typename T>
-    byte_string encode_child_ref(ChildRef<T> const &child);
-
-    // ensures enc.empty() if successful
-    template <typename T>
-    Result<PartialNode<T>> decode_partial_node(
-        byte_string_view &enc, mpt::NibblesView curr_path,
-        NodeIndex const &nodes)
-    {
-        if (MONAD_UNLIKELY(enc.empty())) {
-            return rlp::DecodeError::InputTooShort;
-        }
-
-        {
-            // Make a copy of enc in case we need to backtrack in the branch
-            // case below
-            byte_string_view short_node_enc{enc};
-            BOOST_OUTCOME_TRY(
-                auto key_enc, rlp::parse_metadata(short_node_enc));
-            BOOST_OUTCOME_TRY(
-                auto val_enc, rlp::parse_metadata(short_node_enc));
-
-            if (short_node_enc.empty()) {
-                enc = short_node_enc;
-                // Extension/Leaf node
-                if (MONAD_UNLIKELY(key_enc.first != rlp::RlpType::String)) {
-                    return rlp::DecodeError::TypeUnexpected;
-                }
-
-                BOOST_OUTCOME_TRY(
-                    auto decoded_pair, mpt::compact_decode(key_enc.second));
-                auto const &[decoded_path, is_leaf] = decoded_pair;
-                mpt::Nibbles full_path =
-                    mpt::concat(curr_path, mpt::NibblesView{decoded_path});
-
-                if (MONAD_UNLIKELY(full_path.nibble_size() > 64)) {
-                    return rlp::DecodeError::PathTooLong;
-                }
-
-                if (is_leaf) {
-                    if (MONAD_UNLIKELY(val_enc.first != rlp::RlpType::String)) {
-                        return rlp::DecodeError::TypeUnexpected;
-                    }
-                    BOOST_OUTCOME_TRY(
-                        auto value, T::decode(val_enc.second, nodes));
-                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
-                    return PartialNode<T>{
-                        LeafData<T>{std::move(decoded_path), std::move(value)}};
-                }
-                else {
-                    BOOST_OUTCOME_TRY(
-                        auto child,
-                        decode_child_ref<T>(
-                            val_enc.first,
-                            val_enc.second,
-                            mpt::NibblesView{full_path},
-                            nodes));
-                    MONAD_DEBUG_ASSERT(val_enc.second.empty());
-                    return PartialNode<T>{ExtensionData<T>{
-                        std::move(decoded_path), std::move(child)}};
-                }
-            }
-        }
-
-        // Branch node: re-parse from the beginning since we consumed k and v
-        // above
-        BranchData<T> branch{};
-
-        if (MONAD_UNLIKELY(curr_path.nibble_size() + 1 > 64)) {
-            return rlp::DecodeError::PathTooLong;
-        }
-
-        for (unsigned i = 0; i < 16; ++i) {
-            BOOST_OUTCOME_TRY(auto child_enc, rlp::parse_metadata(enc));
-            mpt::Nibbles child_path =
-                mpt::concat(curr_path, static_cast<unsigned char>(i));
-            BOOST_OUTCOME_TRY(
-                auto child,
-                decode_child_ref<T>(
-                    child_enc.first,
-                    child_enc.second,
-                    mpt::NibblesView{child_path},
-                    nodes));
-            branch.children[i] = std::move(child);
-        }
-        BOOST_OUTCOME_TRY(auto v_enc, rlp::decode_string(enc));
-        if (!v_enc.empty()) {
-            BOOST_OUTCOME_TRY(auto value, T::decode(v_enc, nodes));
-            MONAD_DEBUG_ASSERT(v_enc.empty());
-            branch.value = std::move(value);
-        }
-        if (MONAD_UNLIKELY(!enc.empty())) {
-            return rlp::DecodeError::InputTooLong;
-        }
-        return PartialNode<T>{std::move(branch)};
-    }
-
-    // ensures enc.empty() if successful
-    template <typename T>
-    Result<ChildRef<T>> decode_child_ref(
-        rlp::RlpType ty, byte_string_view &enc, mpt::NibblesView path,
-        NodeIndex const &nodes)
-    {
-        if (ty == rlp::RlpType::List) {
-            // Embedded node (inline RLP list). Ethereum requires the *full* RLP
-            // encoding of an inline node to be < 32 bytes; since `enc` is the
-            // list payload (header already stripped), its size must be <= 30.
-            if (MONAD_UNLIKELY(enc.size() > 30)) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            // Manual expansion of BOOST_OUTCOME_TRY to avoid a named
-            // PartialNode<T> local that triggers a GCC false-positive
-            // -Wmaybe-uninitialized on the unique_ptr inside AccountLeafValue.
-            auto node_result_ = decode_partial_node<T>(enc, path, nodes);
-            if (MONAD_UNLIKELY(node_result_.has_failure())) {
-                return std::move(node_result_).as_failure();
-            }
-            MONAD_DEBUG_ASSERT(enc.empty());
-            return std::make_unique<PartialNode<T>>(
-                std::move(node_result_).assume_value());
-        }
-        else {
-            // String: either empty (null slot) or 32-byte hash reference
-            if (enc.empty()) {
-                return nullptr;
-            }
-            if (MONAD_UNLIKELY(enc.size() < 32)) {
-                return rlp::DecodeError::InputTooShort;
-            }
-            if (MONAD_UNLIKELY(enc.size() > 32)) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            bytes32_t hash{};
-            std::memcpy(hash.bytes, enc.data(), 32);
-            enc = enc.substr(32);
-            MONAD_DEBUG_ASSERT(enc.empty());
-            // NULL_ROOT is the canonical empty-trie hash; represent it as a
-            // null pointer so encode/decode are symmetric with
-            // AccountLeafValue.
-            if (hash == NULL_ROOT) {
-                return nullptr;
-            }
-            auto it = nodes.find(hash);
-            if (it == nodes.end()) {
-                return std::make_unique<PartialNode<T>>(HashStub{hash});
-            }
-            // The NodeIndex stores the raw RLP item (list). Strip the list
-            // header before passing the payload to decode_partial_node.
-            byte_string_view node_enc{it->second};
-            BOOST_OUTCOME_TRY(auto payload, rlp::parse_list_metadata(node_enc));
-            if (MONAD_UNLIKELY(!node_enc.empty())) {
-                return rlp::DecodeError::InputTooLong;
-            }
-            BOOST_OUTCOME_TRY(
-                auto v, decode_partial_node<T>(payload, path, nodes));
-            MONAD_DEBUG_ASSERT(payload.empty());
-            return std::make_unique<PartialNode<T>>(std::move(v));
-        }
-    }
-
-    template <typename T>
-    byte_string encode_partial_node(PartialNode<T> const &node)
-    {
-        return std::visit(
-            Cases{
-                [](LeafData<T> const &leaf) {
-                    MONAD_ASSERT(leaf.path.nibble_size() <= 64);
-                    unsigned char compact_buf[33];
-                    auto compact_sv = mpt::compact_encode(
-                        compact_buf,
-                        mpt::NibblesView{leaf.path},
-                        /*terminating=*/true);
-                    return rlp::encode_list2(
-                        rlp::encode_string2(compact_sv),
-                        rlp::encode_string2(T::encode(leaf.value)));
-                },
-                [](ExtensionData<T> const &ext) {
-                    MONAD_ASSERT(ext.path.nibble_size() <= 64);
-                    unsigned char compact_buf[33];
-                    auto compact_sv = mpt::compact_encode(
-                        compact_buf,
-                        mpt::NibblesView{ext.path},
-                        /*terminating=*/false);
-                    return rlp::encode_list2(
-                        rlp::encode_string2(compact_sv),
-                        encode_child_ref(ext.child));
-                },
-                [](BranchData<T> const &branch) {
-                    byte_string body;
-                    for (unsigned i = 0; i < 16; ++i) {
-                        body += encode_child_ref(branch.children[i]);
-                    }
-                    body += branch.value ? T::encode(*branch.value)
-                                         : rlp::EMPTY_STRING;
-                    return rlp::encode_list2(body);
-                },
-                [](HashStub const &) -> byte_string {
-                    MONAD_ABORT("Incomplete witness");
-                },
-            },
-            node.v);
-    }
-
-    template <typename T>
-    byte_string encode_child_ref(ChildRef<T> const &child)
-    {
-        if (!child) {
-            return rlp::EMPTY_STRING;
-        }
-        if (auto const *stub = std::get_if<HashStub>(&child->v)) {
-            return rlp::encode_string2(byte_string_view{stub->hash.bytes, 32});
-        }
-        byte_string rlp_bytes = encode_partial_node(*child);
-        if (rlp_bytes.size() < 32) {
-            return rlp_bytes; // embedded inline
-        }
-        unsigned char hash[32];
-        keccak256(rlp_bytes.data(), rlp_bytes.size(), hash);
-        return rlp::encode_string2(byte_string_view{hash, 32});
-    }
-
-    /// Walk the trie rooted at `root` following the given nibble key.
-    /// Aborts if the lookup hits an unresolved HashStub, and returns
-    /// a pointer to the leaf value on success, or nullptr if the key is absent.
-    template <typename T>
-    T *trie_lookup(ChildRef<T> const &root, mpt::NibblesView remaining)
-    {
-        PartialNode<T> *node = root.get();
-        while (node != nullptr) {
-            if (auto *leaf = std::get_if<LeafData<T>>(&node->v)) {
-                return (mpt::NibblesView{leaf->path} == remaining)
-                           ? &leaf->value
-                           : nullptr;
-            }
-            else if (auto *ext = std::get_if<ExtensionData<T>>(&node->v)) {
-                mpt::NibblesView const ext_path{ext->path};
-                if (!remaining.starts_with(ext_path)) {
-                    return nullptr;
-                }
-                remaining = remaining.substr(ext_path.nibble_size());
-                node = ext->child.get();
-            }
-            else if (auto *branch = std::get_if<BranchData<T>>(&node->v)) {
-                if (remaining.empty()) {
-                    return branch->value ? &*branch->value : nullptr;
-                }
-                unsigned const nibble = remaining.get(0);
-                remaining = remaining.substr(1);
-                node = branch->children[nibble].get();
-            }
-            else {
-                MONAD_ABORT("Incomplete witness");
-            }
-        }
-        return nullptr; // null child — key absent
-    }
-
-    unsigned
-    common_prefix_length(mpt::NibblesView const a, mpt::NibblesView const b)
-    {
-        unsigned const n = std::min(a.nibble_size(), b.nibble_size());
-        for (unsigned i = 0; i < n; ++i) {
-            if (a.get(i) != b.get(i)) {
-                return i;
-            }
-        }
-        return n;
-    }
-
-    // Insert or update a leaf in the trie when override = true.
-    // Get or insert when override = false.
-    template <bool override = true, typename T>
-    T &trie_get_or_upsert(ChildRef<T> &root, mpt::NibblesView key, T value);
-
-    template <bool override, typename T>
-    [[gnu::always_inline]] inline T &trie_get_or_upsert_at_new_branch(
-        ChildRef<T> &root, BranchData<T> &&branch, unsigned const common_prefix,
-        mpt::NibblesView key, T value)
-    {
-        MONAD_DEBUG_ASSERT(common_prefix <= key.nibble_size());
-
-        T *ret_val{};
-
-        if (common_prefix < key.nibble_size()) {
-            ret_val = &trie_get_or_upsert<override>(
-                branch.children[key.get(common_prefix)],
-                key.substr(common_prefix + 1),
-                std::move(value));
-        }
-        else {
-            if constexpr (override) {
-                branch.value = std::move(value);
-            }
-            else {
-                if (!branch.value) {
-                    branch.value = std::move(value);
-                }
-            }
-        }
-
-        if (common_prefix > 0) {
-            root = std::make_unique<PartialNode<T>>(ExtensionData<T>{
-                mpt::Nibbles{key.substr(0, common_prefix)},
-                std::make_unique<PartialNode<T>>(std::move(branch))});
-            // if the value was stored in branch.value, we need to fetch
-            // value's pointer after the move
-            if (!ret_val) {
-                return *(std::get<BranchData<T>>(
-                             std::get<ExtensionData<T>>(root->v).child->v)
-                             .value);
-            }
-        }
-        else {
-            root = std::make_unique<PartialNode<T>>(std::move(branch));
-            // if the value was stored in branch.value, we need to fetch
-            // value's pointer after the move
-            if (!ret_val) {
-                return *std::get<BranchData<T>>(root->v).value;
-            }
-        }
-        return *ret_val;
-    }
-
-    template <bool override, typename T>
-    [[gnu::always_inline]] inline T &trie_get_or_upsert_at_branch(
-        BranchData<T> &branch, mpt::NibblesView key, T value)
-    {
-        if (key.empty()) {
-            if constexpr (override) {
-                branch.value = std::move(value);
-            }
-            else {
-                if (!branch.value) {
-                    branch.value = std::move(value);
-                }
-            }
-            return *branch.value;
-        }
-        return trie_get_or_upsert<override>(
-            branch.children[key.get(0)], key.substr(1), std::move(value));
-    }
-
-    template <bool override, typename T>
-    T &trie_get_or_upsert(ChildRef<T> &root, mpt::NibblesView key, T value)
-    {
-        if (!root) {
-            root = std::make_unique<PartialNode<T>>(
-                LeafData<T>{mpt::Nibbles{key}, std::move(value)});
-            return std::get<LeafData<T>>(root->v).value;
-        }
-
-        return std::visit(
-            Cases{
-                [&](LeafData<T> &leaf) -> T & {
-                    mpt::NibblesView const leaf_path{leaf.path};
-                    if (leaf_path == key) {
-                        if constexpr (override) {
-                            leaf.value = std::move(value);
-                        }
-                        return leaf.value;
-                    }
-
-                    unsigned const cp = common_prefix_length(leaf_path, key);
-                    MONAD_DEBUG_ASSERT(
-                        cp < leaf_path.nibble_size() || cp < key.nibble_size());
-
-                    BranchData<T> branch{};
-
-                    if (cp < leaf_path.nibble_size()) {
-                        branch.children[leaf_path.get(cp)] =
-                            std::make_unique<PartialNode<T>>(LeafData<T>{
-                                mpt::Nibbles{leaf_path.substr(cp + 1)},
-                                std::move(leaf.value)});
-                    }
-                    else {
-                        branch.value = std::move(leaf.value);
-                    }
-
-                    return trie_get_or_upsert_at_new_branch<override>(
-                        root, std::move(branch), cp, key, std::move(value));
-                },
-                [&](ExtensionData<T> &ext) -> T & {
-                    mpt::NibblesView const ext_path{ext.path};
-
-                    unsigned const cp = common_prefix_length(ext_path, key);
-                    if (cp == ext_path.nibble_size()) {
-                        return trie_get_or_upsert<override>(
-                            ext.child, key.substr(cp), std::move(value));
-                    }
-
-                    BranchData<T> branch{};
-
-                    branch.children[ext_path.get(cp)] =
-                        (cp + 1 < ext_path.nibble_size())
-                            ? std::make_unique<PartialNode<T>>(ExtensionData<T>{
-                                  mpt::Nibbles{ext_path.substr(cp + 1)},
-                                  std::move(ext.child)})
-                            : std::move(ext.child);
-
-                    return trie_get_or_upsert_at_new_branch<override>(
-                        root, std::move(branch), cp, key, std::move(value));
-                },
-                [&](BranchData<T> &branch) -> T & {
-                    return trie_get_or_upsert_at_branch<override>(
-                        branch, key, std::move(value));
-                },
-                [](HashStub &) -> T & { MONAD_ABORT("Incomplete witness"); },
-            },
-            root->v);
-    }
-
-    template <typename Prefix, typename T>
-        requires(
-            std::same_as<Prefix, unsigned char> ||
-            std::same_as<Prefix, mpt::NibblesView>)
-    [[gnu::always_inline]] inline std::optional<ChildRef<T>>
-    concat_path_maybe(Prefix const prefix, ChildRef<T> &node)
-    {
-        if (auto *child_leaf = std::get_if<LeafData<T>>(&node->v)) {
-            child_leaf->path =
-                mpt::concat(prefix, mpt::NibblesView{child_leaf->path});
-            return std::move(node);
-        }
-        else if (auto *child_ext = std::get_if<ExtensionData<T>>(&node->v)) {
-            child_ext->path =
-                mpt::concat(prefix, mpt::NibblesView{child_ext->path});
-            return std::move(node);
-        }
-        return std::nullopt;
-    }
-
-    enum class DeleteResult
-    {
-        Reset,
-        Compressed,
-        Unchanged
-    };
-
-    /// Delete a leaf from the trie at the given nibble key, applying branch
-    /// compression as needed. Returns:
-    ///   - Reset:      `root` was reset to null (the node went away).
-    ///   - Compressed: `root` was reassigned (path-merge or branch collapsed
-    ///                 to a leaf/ext); the node still exists but has changed
-    ///                 identity.
-    ///   - Unchanged:  no structural change at this level (either the key
-    ///                 was absent, or a delete happened deeper but did not
-    ///                 propagate a shape change here).
-    template <typename T>
-    DeleteResult trie_delete(ChildRef<T> &root, mpt::NibblesView key)
-    {
-        if (!root) {
-            return DeleteResult::Unchanged;
-        }
-
-        return std::visit(
-            Cases{
-                [&](LeafData<T> &leaf) -> DeleteResult {
-                    if (mpt::NibblesView{leaf.path} == key) {
-                        root.reset();
-                        return DeleteResult::Reset;
-                    }
-                    return DeleteResult::Unchanged;
-                },
-                [&](ExtensionData<T> &ext) -> DeleteResult {
-                    mpt::NibblesView const ext_path{ext.path};
-                    unsigned const cp = common_prefix_length(ext_path, key);
-                    if (cp < ext_path.nibble_size()) {
-                        return DeleteResult::Unchanged;
-                    }
-                    switch (trie_delete(ext.child, key.substr(cp))) {
-                    case DeleteResult::Unchanged:
-                        return DeleteResult::Unchanged;
-                    case DeleteResult::Reset:
-                        root.reset();
-                        return DeleteResult::Reset;
-                    case DeleteResult::Compressed: {
-                        // Merge paths if child is now a leaf or
-                        // extension
-                        auto maybe_compressed = concat_path_maybe(
-                            mpt::NibblesView{ext.path}, ext.child);
-                        if (maybe_compressed) {
-                            root = std::move(*maybe_compressed);
-                            return DeleteResult::Compressed;
-                        }
-                        return DeleteResult::Unchanged;
-                    }
-                    }
-                    std::unreachable();
-                },
-                [&](BranchData<T> &branch) -> DeleteResult {
-                    if (key.empty()) {
-                        if (!branch.value) {
-                            return DeleteResult::Unchanged;
-                        }
-                        branch.value.reset();
-                    }
-                    else if (
-                        trie_delete(
-                            branch.children[key.get(0)], key.substr(1)) !=
-                        DeleteResult::Reset) {
-                        // we can exit early as long as we know that the call to
-                        // trie_delete didn't result in a reset.
-                        // Even if compression occured, the child is still
-                        // non-null, hence no compaction will occur
-                        return DeleteResult::Unchanged;
-                    }
-
-                    unsigned child_count = 0;
-                    unsigned single_idx = 0;
-                    for (unsigned i = 0; i < 16 && child_count < 2; ++i) {
-                        if (branch.children[i]) {
-                            ++child_count;
-                            single_idx = i;
-                        }
-                    }
-                    bool const has_value = branch.value.has_value();
-
-                    if (child_count == 0 && !has_value) {
-                        root.reset();
-                        return DeleteResult::Reset;
-                    }
-                    if (child_count == 0 && has_value) {
-                        root = std::make_unique<PartialNode<T>>(LeafData<T>{
-                            mpt::Nibbles{}, std::move(*branch.value)});
-                        return DeleteResult::Compressed;
-                    }
-                    if (child_count == 1 && !has_value) {
-                        auto &child = branch.children[single_idx];
-                        // We unconditionally require the inclusion of the
-                        // sole surviving child on a branch in the witness.
-                        // This is strictly not necessary when the child is a
-                        // branch node, as we can just wrap the HashStub
-                        // opaquely in an extension, maintaining a canonical
-                        // Ethereum MPT. However, if the child is an extension
-                        // or a leaf, having only a HashStub would lead to a
-                        // non-canoncial extension->extension or extension->leaf
-                        // tries, which would produce an incorrect state root.
-                        // In the latter two cases, branch compression merges
-                        // the child's path with the branch nibble.
-                        // Requring the emission of the sole surviving child in
-                        // all cases makes debugging easier with minimal
-                        // overheads to the witness size, although this means
-                        // the witness is not minimal (there is currently no
-                        // formal definition of what constitutes a minimal
-                        // witness).
-                        MONAD_ASSERT(
-                            !std::holds_alternative<HashStub>(child->v));
-                        auto const nibble =
-                            static_cast<unsigned char>(single_idx);
-                        auto maybe_compressed =
-                            concat_path_maybe(nibble, child);
-                        if (maybe_compressed) {
-                            root = std::move(*maybe_compressed);
-                        }
-                        else {
-                            MONAD_DEBUG_ASSERT(
-                                std::holds_alternative<BranchData<T>>(
-                                    child->v));
-                            mpt::Nibbles nibble_path{1};
-                            nibble_path.set(0, nibble);
-                            root = std::make_unique<PartialNode<T>>(
-                                ExtensionData<T>{
-                                    std::move(nibble_path), std::move(child)});
-                        }
-
-                        return DeleteResult::Compressed;
-                    }
-                    return DeleteResult::Unchanged;
-                },
-                [](HashStub &) -> DeleteResult {
-                    MONAD_ABORT("Incomplete witness");
-                },
-            },
-            root->v);
-    }
-
-} // anonymous namespace
-
-// ensures enc.empty() if successful
-Result<AccountLeafValue>
-AccountLeafValue::decode(byte_string_view &enc, NodeIndex const &nodes)
-{
-    bytes32_t storage_root{};
-    BOOST_OUTCOME_TRY(Account acct, rlp::decode_account(storage_root, enc));
-    if (MONAD_UNLIKELY(!enc.empty())) {
-        return rlp::DecodeError::InputTooLong;
-    }
-    StorageTrie strie;
-    if (storage_root != NULL_ROOT) {
-        mpt::Nibbles empty_path{};
-        byte_string_view storage_root_enc{
-            storage_root.bytes, sizeof(storage_root.bytes)};
-        BOOST_OUTCOME_TRY(
-            strie,
-            decode_child_ref<StorageLeafValue>(
-                rlp::RlpType::String,
-                storage_root_enc,
-                mpt::NibblesView{empty_path},
-                nodes));
-        MONAD_DEBUG_ASSERT(storage_root_enc.empty());
-    }
-
-    return AccountLeafValue{.account = acct, .storage = std::move(strie)};
-}
-
-byte_string AccountLeafValue::encode(AccountLeafValue const &v)
-{
-    bytes32_t storage_root;
-    if (!v.storage) {
-        storage_root = NULL_ROOT;
-    }
-    else {
-        auto const &storage_node = *v.storage;
-        if (auto const *stub = std::get_if<HashStub>(&storage_node.v)) {
-            storage_root = stub->hash;
-        }
-        else {
-            byte_string rlp_bytes = encode_partial_node(storage_node);
-            storage_root = to_bytes(keccak256(
-                byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
-        }
-    }
-
-    return rlp::encode_account(v.account, storage_root);
-}
-
-// ensures enc.empty() if successful
-Result<StorageLeafValue>
-StorageLeafValue::decode(byte_string_view &enc, NodeIndex const & /*nodes*/)
-{
-    BOOST_OUTCOME_TRY(auto const raw, rlp::decode_bytes32_compact(enc));
-    if (MONAD_UNLIKELY(!enc.empty())) {
-        return rlp::DecodeError::InputTooLong;
-    }
-    return StorageLeafValue{raw};
-}
-
-byte_string StorageLeafValue::encode(StorageLeafValue const &v)
-{
-    return rlp::encode_bytes32_compact(v.value);
-}
-
-Result<PartialTrieDb> PartialTrieDb::from_witness(
-    bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
-    byte_string_view encoded_codes)
-{
-    NodeIndex node_index;
-    {
-        while (!encoded_nodes.empty()) {
-            BOOST_OUTCOME_TRY(
-                auto const node_bytes,
-                rlp::parse_list_metadata_raw(encoded_nodes));
-            bytes32_t const key = to_bytes(keccak256(node_bytes));
-            node_index.emplace(
-                key, byte_string{node_bytes.data(), node_bytes.size()});
-        }
-    }
-
-    CodeIndex code_index;
-    {
-        while (!encoded_codes.empty()) {
-            BOOST_OUTCOME_TRY(
-                auto bytes, rlp::parse_string_metadata(encoded_codes));
-            bytes32_t key = to_bytes(keccak256(bytes));
-            code_index.emplace(
-                key,
-                vm::make_shared_intercode(
-                    std::span<uint8_t const>{bytes.data(), bytes.size()}));
-        }
-    }
-
-    AccountTrie root_node;
-    {
-        mpt::Nibbles empty_path{};
-        byte_string_view pre_state_root_enc{
-            pre_state_root.bytes, sizeof(pre_state_root.bytes)};
-        BOOST_OUTCOME_TRY(
-            root_node,
-            decode_child_ref<AccountLeafValue>(
-                rlp::RlpType::String,
-                pre_state_root_enc,
-                mpt::NibblesView{empty_path},
-                node_index));
-        MONAD_DEBUG_ASSERT(pre_state_root_enc.empty());
-    }
-
-    return PartialTrieDb{std::move(root_node), std::move(code_index)};
-}
-
 std::optional<Account> PartialTrieDb::read_account(Address const &addr)
 {
-    auto const key_hash = keccak256(addr.bytes);
-    auto const result = trie_lookup(root_, mpt::NibblesView{key_hash});
-    if (!result) {
-        return std::nullopt;
-    }
-    return result->account;
+    auto const key = keccak256(addr.bytes);
+    return match(
+        trie_.find_original(trie_.root, mpt::NibblesView{key}),
+        Cases{
+            [](mpt::NullView) -> std::optional<Account> {
+                return std::nullopt;
+            },
+            [](mpt::AccountLeafView l) -> std::optional<Account> {
+                return l.account();
+            },
+            [](auto) -> std::optional<Account> {
+                MONAD_ABORT("incorrect node type returned in read_account");
+            }});
 }
 
 bytes32_t PartialTrieDb::read_storage(
     Address const &addr, Incarnation, bytes32_t const &slot)
 {
-    auto const acct_hash = keccak256(addr.bytes);
-    auto const acct_result = trie_lookup(root_, mpt::NibblesView{acct_hash});
-    if (!acct_result || !acct_result->storage) {
-        return {};
+    auto const akey = keccak256(addr.bytes);
+    auto const sroot = match(
+        trie_.find_original(trie_.root, mpt::NibblesView{akey}),
+        Cases{
+            [](mpt::NullView) { return mpt::NULL_ID; },
+            [](mpt::AccountLeafView l) { return l.storage(); },
+            [](auto) -> mpt::NodeId {
+                MONAD_ABORT("incorrect node type returned in read_storage");
+            }});
+
+    if (sroot == mpt::NULL_ID) {
+        return bytes32_t{};
     }
-    auto const slot_hash = keccak256(slot.bytes);
-    auto const val_result =
-        trie_lookup(acct_result->storage, mpt::NibblesView{slot_hash});
-    return !val_result ? bytes32_t{} : val_result->value;
-}
+    auto const skey = keccak256(slot.bytes);
 
-storage_page_t PartialTrieDb::read_storage_page(
-    Address const &, Incarnation, bytes32_t const &)
-{
-    MONAD_ABORT("PartialTrieDb read_storage_page is currently not supported");
-}
-
-vm::SharedIntercode PartialTrieDb::read_code(bytes32_t const &code_hash)
-{
-    auto it = codes_.find(code_hash);
-    if (it == codes_.end()) {
-        return vm::make_shared_intercode({});
-    }
-    return it->second;
-}
-
-BlockHeader PartialTrieDb::read_eth_header()
-{
-    return last_committed_header_;
-}
-
-bytes32_t PartialTrieDb::state_root()
-{
-    if (!root_) {
-        return NULL_ROOT;
-    }
-    if (auto const *stub = std::get_if<HashStub>(&root_->v)) {
-        return stub->hash;
-    }
-    byte_string rlp_bytes = encode_partial_node(*root_);
-    return to_bytes(
-        keccak256(byte_string_view{rlp_bytes.data(), rlp_bytes.size()}));
-}
-
-bytes32_t PartialTrieDb::receipts_root()
-{
-    return last_committed_header_.receipts_root;
-}
-
-bytes32_t PartialTrieDb::transactions_root()
-{
-    return last_committed_header_.transactions_root;
-}
-
-std::optional<bytes32_t> PartialTrieDb::withdrawals_root()
-{
-    return last_committed_header_.withdrawals_root;
-}
-
-uint64_t PartialTrieDb::get_block_number() const
-{
-    return block_number_;
-}
-
-void PartialTrieDb::set_block_and_prefix(
-    uint64_t block_number, bytes32_t const &)
-{
-    block_number_ = block_number;
+    return match(
+        trie_.find_original(sroot, mpt::NibblesView{skey}),
+        Cases{
+            [](mpt::NullView) { return bytes32_t{}; },
+            [](mpt::StorageLeafView l) { return l.value(); },
+            [](auto) -> bytes32_t {
+                MONAD_ABORT("incorrect node type returned in read_storage");
+            }});
 }
 
 void PartialTrieDb::commit(
@@ -824,60 +112,86 @@ void PartialTrieDb::commit(
     StateDeltas const &deltas,
     std::function<void(BlockHeader &)> populate_header_fn)
 {
+    using mpt::NodeId;
+    using mpt::NULL_ID;
+    using mpt::OffsetTrie;
+
     block_number_ = header.number;
 
-    // Pass 1: inserts and updates (accounts that exist in post-state)
+    // Pass 1: inserts and updates — accounts present in the post-state. The
+    // storage sub-root is threaded through the put_* builders rather than held
+    // as a live leaf reference.
     for (auto const &[addr, delta] : deltas) {
         auto const &new_account = delta.account.second;
-        if (!new_account) {
+        if (!new_account || !is_changed(delta)) {
             continue;
         }
-
         auto const acct_key = keccak256(addr.bytes);
+        auto const [leaf, leaf_path] =
+            trie_.upsert_node(trie_.root, mpt::NibblesView{acct_key});
+        if (MONAD_UNLIKELY(trie_.root == NULL_ID)) {
+            // First account into an empty trie: the leaf becomes the root.
+            trie_.root = leaf;
+        }
+        NodeId storage = match(
+            trie_.get_current(leaf),
+            Cases{
+                [](mpt::NullView) { return NULL_ID; },
+                [](mpt::AccountLeafView a) { return a.storage(); },
+                [](auto) -> NodeId {
+                    MONAD_ABORT("incorrect node type returned in commit");
+                }});
 
-        auto &existing = trie_get_or_upsert<false>(
-            root_, mpt::NibblesView{acct_key}, AccountLeafValue{});
-
-        // Incarnation bump: the account was destroyed and recreated in
-        // this block (CREATE2/SELFDESTRUCT/CREATE2 patterns). The old
-        // storage trie must be wiped before the new slot deltas apply
+        // Incarnation bump (destroy + recreate in-block): wipe old storage.
         if (delta.account.first.has_value() &&
             delta.account.first->incarnation != new_account->incarnation) {
-            existing.storage.reset();
+            storage = NULL_ID;
         }
 
-        existing.account = *new_account;
-
-        auto &storage = existing.storage;
-
-        // Apply storage deltas: upserts first, then deletions
+        // Storage deltas: upserts first, then deletions (as in the reference).
         for (auto const &[slot, sdelta] : delta.storage) {
-            if (sdelta.second != bytes32_t{}) {
+            if (is_changed(sdelta) && sdelta.second != bytes32_t{}) {
                 auto const slot_key = keccak256(slot.bytes);
-                trie_get_or_upsert(
-                    storage,
-                    mpt::NibblesView{slot_key},
-                    StorageLeafValue{sdelta.second});
+                auto const [sleaf, sleaf_path] =
+                    trie_.upsert_node(storage, mpt::NibblesView{slot_key});
+                if (storage == NULL_ID) {
+                    storage = sleaf; // first slot into empty storage: the leaf
+                                     // is the sub-root
+                }
+                trie_.put_storage(sleaf, sleaf_path, sdelta.second);
             }
         }
         for (auto const &[slot, sdelta] : delta.storage) {
-            if (sdelta.second == bytes32_t{} && sdelta.first != bytes32_t{}) {
+            if (is_changed(sdelta) && sdelta.second == bytes32_t{}) {
                 auto const slot_key = keccak256(slot.bytes);
-                trie_delete(storage, mpt::NibblesView{slot_key});
+                if (trie_.erase_node(storage, mpt::NibblesView{slot_key}) ==
+                    OffsetTrie::EraseResult::Erased) {
+                    storage = NULL_ID;
+                };
             }
         }
+
+        // Bake the freshly computed storage root into the account leaf.
+        bytes32_t const storage_root = trie_.hash(storage);
+        trie_.put_acct(
+            leaf,
+            mpt::NibblesView{leaf_path},
+            *new_account,
+            storage_root,
+            storage);
     }
 
-    // Pass 2: deletions (accounts removed in post-state)
+    // Pass 2: deletions — accounts absent in the post-state but present before.
     for (auto const &[addr, delta] : deltas) {
-        if (delta.account.second) {
-            continue;
-        }
-        if (!delta.account.first) {
+        if (delta.account.second || !delta.account.first) {
             continue;
         }
         auto const acct_key = keccak256(addr.bytes);
-        trie_delete(root_, mpt::NibblesView{acct_key});
+        if (MONAD_UNLIKELY(
+                trie_.erase_node(trie_.root, mpt::NibblesView{acct_key}) ==
+                OffsetTrie::EraseResult::Erased)) {
+            trie_.root = NULL_ID;
+        }
     }
 
     last_committed_header_ = header;

--- a/category/execution/ethereum/db/partial_trie_db.hpp
+++ b/category/execution/ethereum/db/partial_trie_db.hpp
@@ -15,143 +15,39 @@
 
 #pragma once
 
-#include <category/core/address.hpp>
-#include <category/core/byte_string.hpp>
+// Db backed by a witness-derived partial trie (see offset_trie.hpp).
+
+#include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
-#include <category/core/int.hpp>
-#include <category/core/result.hpp>
 #include <category/execution/ethereum/core/account.hpp>
 #include <category/execution/ethereum/core/block.hpp>
-#include <category/execution/ethereum/core/receipt.hpp>
-#include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/db/db.hpp>
-#include <category/execution/ethereum/state2/state_deltas.hpp>
-#include <category/execution/ethereum/trace/call_frame.hpp>
-#include <category/mpt/nibbles_view.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
 #include <category/vm/code.hpp>
 
 #include <ankerl/unordered_dense.h>
 
-#include <array>
 #include <cstdint>
-#include <memory>
+#include <functional>
 #include <optional>
-#include <span>
-#include <variant>
-#include <vector>
+#include <utility>
 
 MONAD_NAMESPACE_BEGIN
 
-/// An unresolved subtree whose contents are absent from the witness.
-struct HashStub
-{
-    bytes32_t hash;
-};
-
-using NodeIndex = ankerl::unordered_dense::map<bytes32_t, byte_string>;
-
-template <typename T>
-concept LeafValue =
-    requires(byte_string_view &enc, NodeIndex const &nodes, T const &v) {
-        { T::decode(enc, nodes) } -> std::same_as<Result<T>>;
-        { T::encode(v) } -> std::same_as<byte_string>;
-    };
-
-template <LeafValue V>
-struct PartialNode;
-
-/// Owning pointer to a child node. A null pointer represents an empty branch
-/// slot (analogous to an absent nibble in a standard Ethereum branch node).
-template <LeafValue V>
-using ChildRef = std::unique_ptr<PartialNode<V>>;
-
-template <LeafValue V>
-struct BranchData
-{
-    std::array<ChildRef<V>, 16> children;
-    std::optional<V> value;
-};
-
-template <LeafValue V>
-struct ExtensionData
-{
-    mpt::Nibbles path;
-    ChildRef<V> child;
-};
-
-template <LeafValue V>
-struct LeafData
-{
-    mpt::Nibbles path;
-    V value;
-};
-
-/// Four-way variant: branch, extension, leaf, or opaque hash stub.
-template <LeafValue V>
-struct PartialNode
-{
-    using Variant =
-        std::variant<BranchData<V>, ExtensionData<V>, LeafData<V>, HashStub>;
-
-    Variant v;
-
-    PartialNode() = default;
-
-    template <class T>
-        requires std::constructible_from<Variant, T>
-    explicit PartialNode(T &&x)
-        : v(std::forward<T>(x))
-    {
-    }
-};
-
-struct StorageLeafValue
-{
-    bytes32_t value;
-
-    static Result<StorageLeafValue>
-    decode(byte_string_view &enc, NodeIndex const & /*nodes*/);
-
-    static byte_string encode(StorageLeafValue const &v);
-};
-
-using StorageTrie = ChildRef<StorageLeafValue>;
-
-struct AccountLeafValue
-{
-    Account account;
-    StorageTrie
-        storage{}; ///< per-account storage MPT, embedded directly in the leaf
-
-    static Result<AccountLeafValue>
-    decode(byte_string_view &enc, NodeIndex const &nodes);
-
-    static byte_string encode(AccountLeafValue const &v);
-};
-
-using AccountTrie = ChildRef<AccountLeafValue>;
-
 using CodeIndex = ankerl::unordered_dense::map<bytes32_t, vm::SharedIntercode>;
 
-// ---------------------------------------------------------------------------
-// PartialTrieDb
-// ---------------------------------------------------------------------------
-
-/// A sparse Ethereum account + storage MPT that implements the Db interface.
-///
-/// Built from an execution witness bundle; serves as a drop-in replacement
-/// for TrieDb during zkVM STF proving.
 class PartialTrieDb final : public Db
 {
-    AccountTrie root_;
+    mpt::OffsetTrie trie_;
     CodeIndex codes_;
     uint64_t block_number_{0};
     BlockHeader last_committed_header_{};
 
-    PartialTrieDb(AccountTrie root, CodeIndex codes)
-        : root_{std::move(root)}
-        , codes_{std::move(codes)}
+public:
+    PartialTrieDb(mpt::OffsetTrie trie, CodeIndex codes)
+        : trie_(std::move(trie))
+        , codes_(std::move(codes))
     {
     }
 
@@ -164,32 +60,58 @@ public:
         return false;
     }
 
-    static Result<PartialTrieDb> from_witness(
-        bytes32_t const &pre_state_root, byte_string_view encoded_nodes,
-        byte_string_view encoded_codes);
-
     std::optional<Account> read_account(Address const &) override;
 
     bytes32_t
-    read_storage(Address const &, Incarnation, bytes32_t const &key) override;
+    read_storage(Address const &, Incarnation, bytes32_t const &) override;
 
-    storage_page_t read_storage_page(
-        Address const &, Incarnation, bytes32_t const &page_key) override;
+    storage_page_t
+    read_storage_page(Address const &, Incarnation, bytes32_t const &) override
+    {
+        MONAD_ABORT("PartialTrieDb: read_storage_page unsupported");
+    }
 
-    vm::SharedIntercode read_code(bytes32_t const &code_hash) override;
+    vm::SharedIntercode read_code(bytes32_t const &code_hash) override
+    {
+        auto const it = codes_.find(code_hash);
+        return it == codes_.end() ? vm::make_shared_intercode({}) : it->second;
+    }
 
-    BlockHeader read_eth_header() override;
+    BlockHeader read_eth_header() override
+    {
+        return last_committed_header_;
+    }
 
-    bytes32_t state_root() override;
-    bytes32_t receipts_root() override;
-    bytes32_t transactions_root() override;
-    std::optional<bytes32_t> withdrawals_root() override;
+    bytes32_t state_root() override
+    {
+        return trie_.state_root();
+    }
 
-    uint64_t get_block_number() const override;
+    bytes32_t receipts_root() override
+    {
+        return last_committed_header_.receipts_root;
+    }
+
+    bytes32_t transactions_root() override
+    {
+        return last_committed_header_.transactions_root;
+    }
+
+    std::optional<bytes32_t> withdrawals_root() override
+    {
+        return last_committed_header_.withdrawals_root;
+    }
+
+    uint64_t get_block_number() const override
+    {
+        return block_number_;
+    }
 
     void set_block_and_prefix(
-        uint64_t block_number,
-        bytes32_t const &block_id = bytes32_t{}) override;
+        uint64_t const block_number, bytes32_t const &) override
+    {
+        block_number_ = block_number;
+    }
 
     void commit(
         bytes32_t const &block_id, CommitBuilder &, BlockHeader const &,

--- a/category/execution/ethereum/db/test/test_offset_trie.cpp
+++ b/category/execution/ethereum/db/test/test_offset_trie.cpp
@@ -1,0 +1,411 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Offset-format trie (wip_WITNESS_OFFSET_FORMAT.md): verify + views + open +
+// lookup. Builds a small blob by hand (no encoder yet) and reads it back.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/nibble.h>
+#include <category/execution/ethereum/db/offset_trie.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace monad;
+using namespace monad::mpt;
+
+namespace
+{
+    mpt::Nibbles nibs_to_path(std::vector<uint8_t> const &nibs)
+    {
+        mpt::Nibbles p{(size_t)nibs.size()};
+        for (size_t i = 0; i < nibs.size(); ++i) {
+            p.set((unsigned)i, nibs[i]);
+        }
+        return p;
+    }
+
+    // Builds an offset-format blob (§3/§4) for tests, post-order so every child
+    // offset precedes its parent. Node bytes come from the production append_*
+    // writers, so the node layout has a single source of truth; only the header
+    // and the offset bookkeeping live here.
+    struct BlobBuilder
+    {
+        byte_string buf;
+
+        BlobBuilder()
+        {
+            unsigned char const magic[4] = {'M', 'Z', 'W', 0x01};
+            buf.append(magic, 4);
+            buf.append(4, (unsigned char)0); // root_off placeholder
+        }
+
+        uint32_t here() const
+        {
+            return (uint32_t)buf.size();
+        }
+
+        uint32_t storage_leaf(std::vector<uint8_t> const &nibs, bytes32_t val)
+        {
+            uint32_t const off = here();
+            mpt::Nibbles const path = nibs_to_path(nibs);
+            append_storage(buf, mpt::NibblesView{path}, val);
+            return off;
+        }
+
+        uint32_t digest(bytes32_t h)
+        {
+            uint32_t const off = here();
+            append_digest(buf, h);
+            return off;
+        }
+
+        uint32_t branch(std::array<uint32_t, 16> const &ch)
+        {
+            uint32_t const off = here();
+            std::array<NodeId, 16> children{};
+            for (unsigned i = 0; i < 16; ++i) {
+                children[i] = NodeId{ch[i]};
+            }
+            append_branch(buf, children);
+            return off;
+        }
+
+        byte_string finalize(uint32_t const root_off)
+        {
+            // LE, matching read_u32 (both sides assert a little-endian host)
+            std::memcpy(buf.data() + 4, &root_off, sizeof(root_off));
+            return buf;
+        }
+    };
+
+    // ── independent RLP oracle (allocating encode2 path) ────────────────────
+    bytes32_t oracle_hash(byte_string const &rlp)
+    {
+        return to_bytes(keccak256(byte_string_view{rlp}));
+    }
+
+    // canonical RLP of a storage leaf: list[ compact(path,leaf), string(rlp(v))
+    // ]
+    byte_string
+    oracle_storage_leaf(std::vector<uint8_t> const &nibs, bytes32_t v)
+    {
+        mpt::Nibbles const p = nibs_to_path(nibs);
+        unsigned char cbuf[33];
+        auto const compact =
+            mpt::compact_encode(cbuf, mpt::NibblesView{p}, /*term=*/true);
+        byte_string const trie_val = rlp::encode_string2(
+            rlp::zeroless_view(to_byte_string_view(v.bytes)));
+        return rlp::encode_list2(
+            rlp::encode_string2(compact),
+            rlp::encode_string2(byte_string_view{trie_val}));
+    }
+
+    // parent-facing reference of a child node's RLP
+    byte_string oracle_ref(byte_string const &node_rlp)
+    {
+        if (node_rlp.size() < 32) {
+            return node_rlp; // inline
+        }
+        return rlp::encode_string2(
+            byte_string_view{oracle_hash(node_rlp).bytes, 32});
+    }
+
+    // canonical RLP of an account leaf: list[ compact(path,leaf), string(acct)
+    // ]
+    byte_string oracle_account_leaf(
+        mpt::NibblesView const path, byte_string const &acct_rlp)
+    {
+        unsigned char cbuf[33];
+        auto const compact = mpt::compact_encode(cbuf, path, /*term=*/true);
+        return rlp::encode_list2(
+            rlp::encode_string2(compact),
+            rlp::encode_string2(byte_string_view{acct_rlp}));
+    }
+
+    // ── helpers for building a trie from scratch via OffsetTrie mutation
+    // ────── NibblesView over a 32-byte key (64 nibbles, MSB-first).
+    mpt::NibblesView key_view(bytes32_t const &k)
+    {
+        return mpt::NibblesView{byte_string_view{k.bytes, sizeof(k.bytes)}};
+    }
+
+    // The 64 nibbles of a 32-byte key, as the oracle helpers expect them.
+    std::vector<uint8_t> key_nibbles(bytes32_t const &k)
+    {
+        std::vector<uint8_t> n(64);
+        for (unsigned i = 0; i < 64; ++i) {
+            n[i] = get_nibble(k.bytes, i);
+        }
+        return n;
+    }
+
+    // A 32-byte key from two marker bytes (first/last), so two keys can be made
+    // to diverge at nibble 0 by choosing different high nibbles of byte 0.
+    bytes32_t make_key(uint8_t const first, uint8_t const last)
+    {
+        bytes32_t k{};
+        k.bytes[0] = first;
+        k.bytes[31] = last;
+        return k;
+    }
+
+    // An empty (root_off == 0) offset-trie blob to build onto.
+    byte_string empty_blob()
+    {
+        BlobBuilder bb;
+        return bb.finalize(0);
+    }
+
+    // Insert into the account trie, as PartialTrieDb::commit does: an empty
+    // trie's root is NULL_ID, so the first leaf becomes the new root. Returns
+    // the leaf id + path for the caller to put_acct.
+    std::pair<NodeId, mpt::Nibbles>
+    upsert_account(OffsetTrie &store, mpt::NibblesView const key)
+    {
+        auto const res = store.upsert_node(store.root, key);
+        if (store.root == NULL_ID) {
+            store.root = res.first;
+        }
+        return res;
+    }
+}
+
+TEST(OffsetTrie, VerifyOpenViewsFind)
+{
+    bytes32_t v1{};
+    v1.bytes[31] = 0x11;
+    bytes32_t hdig{};
+    for (auto &b : hdig.bytes) {
+        b = 0xab;
+    }
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, v1); // key tail = [a]
+    uint32_t const dig = bb.digest(hdig);
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = dig;
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+
+    OffsetTrie const store{blob};
+    EXPECT_EQ((uint32_t)store.root, br);
+
+    // match the root branch through the view accessors
+    bool const matched = match(
+        store.get_current(store.root),
+        Cases{
+            [&](BranchView b) -> bool {
+                EXPECT_EQ((uint32_t)b.child(3), leaf);
+                EXPECT_EQ((uint32_t)b.child(7), dig);
+                EXPECT_EQ((uint32_t)b.child(0), 0u);
+                return true;
+            },
+            [&](auto) -> bool { return false; }});
+    EXPECT_TRUE(matched);
+
+    EXPECT_EQ(StorageLeafView{store.get_current(NodeId{leaf})}.value(), v1);
+    EXPECT_EQ(DigestView{store.get_current(NodeId{dig})}.hash(), hdig);
+
+    // find the storage leaf by full key [3, a]
+    mpt::Nibbles key{(size_t)2};
+    key.set(0, 3);
+    key.set(1, 0xa);
+    auto const found = store.find_original(store.root, mpt::NibblesView{key});
+    EXPECT_EQ(found.tag(), LEAF_STORAGE);
+    EXPECT_EQ(StorageLeafView{found}.value(), v1);
+
+    // absent key
+    mpt::Nibbles absent{(size_t)2};
+    absent.set(0, 4);
+    absent.set(1, 0x0);
+    EXPECT_EQ(
+        store.find_original(store.root, mpt::NibblesView{absent}).tag(), EMPTY);
+}
+
+TEST(OffsetTrieDeathTest, OutOfRangeChildAborts)
+{
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, bytes32_t{});
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = 999999; // out-of-range child offset
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+    // priming follows the bad edge into get_original, which aborts.
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
+TEST(OffsetTrie, HashSingleStorageLeaf)
+{
+    bytes32_t v{};
+    v.bytes[31] = 0x11;
+    std::vector<uint8_t> const nibs = {1, 2, 3};
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf(nibs, v);
+    byte_string const blob = bb.finalize(leaf);
+
+    OffsetTrie store{blob};
+    EXPECT_EQ(store.state_root(), oracle_hash(oracle_storage_leaf(nibs, v)));
+}
+
+TEST(OffsetTrie, HashBranchWithDigest)
+{
+    bytes32_t v1{};
+    v1.bytes[31] = 0x11;
+    bytes32_t hdig{};
+    for (auto &b : hdig.bytes) {
+        b = 0xab;
+    }
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, v1);
+    uint32_t const dig = bb.digest(hdig);
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = dig;
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+
+    OffsetTrie store{blob};
+
+    // oracle: 16 child refs + empty value, wrapped as a list, then keccak
+    byte_string body;
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i == 3) {
+            body += oracle_ref(oracle_storage_leaf({0xa}, v1));
+        }
+        else if (i == 7) {
+            body += rlp::encode_string2(byte_string_view{hdig.bytes, 32});
+        }
+        else {
+            body += rlp::EMPTY_STRING; // 0x80
+        }
+    }
+    body += rlp::EMPTY_STRING; // empty branch value
+    bytes32_t const want = oracle_hash(rlp::encode_list2(body));
+
+    EXPECT_EQ(store.state_root(), want);
+}
+
+// ── mutation: build the trie from scratch via upsert/erase, check state_root
+// against the independent RLP oracle ────────────────────────────────────────
+
+TEST(OffsetTrie, UpsertSingleAccount)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const key = make_key(0x12, 0x34);
+    Account acct{};
+    acct.balance = 5;
+    acct.nonce = 7;
+
+    auto const [leaf, path] = upsert_account(store, key_view(key));
+    store.put_acct(leaf, mpt::NibblesView{path}, acct, NULL_ROOT, NULL_ID);
+
+    // sole node: a leaf holding the full key
+    byte_string const arlp = rlp::encode_account(acct, NULL_ROOT);
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(key), arlp)));
+}
+
+TEST(OffsetTrie, UpsertTwoAccountsThenErase)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const ka = make_key(0x0a, 0x11); // nibble 0 = 0x0
+    bytes32_t const kb = make_key(0xb0, 0x22); // nibble 0 = 0xb (diverge at 0)
+    Account aa{};
+    aa.balance = 1;
+    Account ab{};
+    ab.balance = 2;
+
+    auto const insert = [&](bytes32_t const &k, Account const &a) {
+        auto const [leaf, path] = upsert_account(store, key_view(k));
+        store.put_acct(leaf, mpt::NibblesView{path}, a, NULL_ROOT, NULL_ID);
+    };
+    insert(ka, aa);
+    insert(kb, ab);
+
+    // oracle: a branch with the two accounts as children (each a leaf over the
+    // remaining 63 nibbles), no branch value.
+    byte_string const arlp = rlp::encode_account(aa, NULL_ROOT);
+    byte_string const brlp = rlp::encode_account(ab, NULL_ROOT);
+    byte_string body;
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i == 0x0) {
+            body +=
+                oracle_ref(oracle_account_leaf(key_view(ka).substr(1), arlp));
+        }
+        else if (i == 0xb) {
+            body +=
+                oracle_ref(oracle_account_leaf(key_view(kb).substr(1), brlp));
+        }
+        else {
+            body += rlp::EMPTY_STRING;
+        }
+    }
+    body += rlp::EMPTY_STRING; // empty branch value
+    EXPECT_EQ(store.state_root(), oracle_hash(rlp::encode_list2(body)));
+
+    // erase ka -> the branch collapses back to a single leaf over the full kb
+    store.erase_node(store.root, key_view(ka));
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(kb), brlp)));
+}
+
+TEST(OffsetTrie, UpsertAccountWithStorage)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const akey = make_key(0x12, 0x34);
+    bytes32_t const skey = make_key(0x56, 0x78);
+    bytes32_t sval{};
+    sval.bytes[31] = 0x99;
+    Account acct{};
+    acct.balance = 3;
+
+    auto const [leaf, apath] = upsert_account(store, key_view(akey));
+    auto const [storage, spath] = store.upsert_node(NULL_ID, key_view(skey));
+    store.put_storage(storage, mpt::NibblesView{spath}, sval);
+    bytes32_t const sroot = store.hash(storage);
+    store.put_acct(leaf, mpt::NibblesView{apath}, acct, sroot, storage);
+
+    // storage sub-root is a single storage leaf over the full slot key
+    bytes32_t const oracle_sroot =
+        oracle_hash(oracle_storage_leaf(key_nibbles(skey), sval));
+    EXPECT_EQ(sroot, oracle_sroot);
+
+    byte_string const arlp = rlp::encode_account(acct, oracle_sroot);
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(akey), arlp)));
+}

--- a/category/execution/ethereum/db/test/test_offset_trie.cpp
+++ b/category/execution/ethereum/db/test/test_offset_trie.cpp
@@ -1,0 +1,459 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Offset-format trie (wip_WITNESS_OFFSET_FORMAT.md): verify + views + open +
+// lookup. Builds a small blob by hand (no encoder yet) and reads it back.
+
+#include <category/core/byte_string.hpp>
+#include <category/core/bytes.hpp>
+#include <category/core/keccak.hpp>
+#include <category/core/nibble.h>
+#include <category/execution/ethereum/core/rlp/account_rlp.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/mpt/merkle/compact_encode.hpp>
+#include <category/mpt/nibbles_view.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace monad;
+using namespace monad::mpt;
+
+namespace
+{
+    mpt::Nibbles nibs_to_path(std::vector<uint8_t> const &nibs)
+    {
+        mpt::Nibbles p{nibs.size()};
+        for (unsigned i = 0; i < nibs.size(); ++i) {
+            p.set(i, nibs[i]);
+        }
+        return p;
+    }
+
+    // Builds an offset-format blob (§3/§4) for tests, post-order so every child
+    // offset precedes its parent. Node bytes come from the production append_*
+    // writers, so the node layout has a single source of truth; only the header
+    // and the offset bookkeeping live here.
+    struct BlobBuilder
+    {
+        byte_string buf;
+
+        BlobBuilder()
+            : buf{'M', 'Z', 'W', 0x01, 0, 0, 0, 0}
+        {
+        }
+
+        uint32_t here() const
+        {
+            return static_cast<uint32_t>(buf.size());
+        }
+
+        uint32_t storage_leaf(std::vector<uint8_t> const &nibs, bytes32_t val)
+        {
+            uint32_t const off = here();
+            mpt::Nibbles const path = nibs_to_path(nibs);
+            append_storage(buf, mpt::NibblesView{path}, val);
+            return off;
+        }
+
+        uint32_t digest(bytes32_t h)
+        {
+            uint32_t const off = here();
+            append_digest(buf, h);
+            return off;
+        }
+
+        uint32_t branch(std::array<uint32_t, 16> const &ch)
+        {
+            uint32_t const off = here();
+            std::array<NodeId, 16> children{};
+            for (unsigned i = 0; i < 16; ++i) {
+                children[i] = NodeId{ch[i]};
+            }
+            append_branch(buf, children);
+            return off;
+        }
+
+        byte_string finalize(uint32_t const root_off)
+        {
+            // LE, matching read_node_id (both sides assert a little-endian
+            // host)
+            std::memcpy(buf.data() + 4, &root_off, sizeof(root_off));
+            return buf;
+        }
+    };
+
+    // ── independent RLP oracle (allocating encode2 path) ────────────────────
+    bytes32_t oracle_hash(byte_string const &rlp)
+    {
+        return to_bytes(keccak256(byte_string_view{rlp}));
+    }
+
+    // canonical RLP of a storage leaf: list[ compact(path,leaf), string(rlp(v))
+    // ]
+    byte_string
+    oracle_storage_leaf(std::vector<uint8_t> const &nibs, bytes32_t v)
+    {
+        mpt::Nibbles const p = nibs_to_path(nibs);
+        unsigned char cbuf[33];
+        auto const compact =
+            mpt::compact_encode(cbuf, mpt::NibblesView{p}, /*term=*/true);
+        byte_string const trie_val = rlp::encode_string2(
+            rlp::zeroless_view(to_byte_string_view(v.bytes)));
+        return rlp::encode_list2(
+            rlp::encode_string2(compact),
+            rlp::encode_string2(byte_string_view{trie_val}));
+    }
+
+    // parent-facing reference of a child node's RLP
+    byte_string oracle_ref(byte_string const &node_rlp)
+    {
+        if (node_rlp.size() < 32) {
+            return node_rlp; // inline
+        }
+        return rlp::encode_string2(
+            byte_string_view{oracle_hash(node_rlp).bytes, 32});
+    }
+
+    // canonical RLP of an account leaf:
+    // list[ compact(path,leaf), string(acct) ]
+    byte_string oracle_account_leaf(
+        mpt::NibblesView const path, byte_string const &acct_rlp)
+    {
+        unsigned char cbuf[33];
+        auto const compact = mpt::compact_encode(cbuf, path, /*term=*/true);
+        return rlp::encode_list2(
+            rlp::encode_string2(compact),
+            rlp::encode_string2(byte_string_view{acct_rlp}));
+    }
+
+    // ── helpers for building a trie from scratch via OffsetTrie mutation
+    // ────── NibblesView over a 32-byte key (64 nibbles, MSB-first).
+    mpt::NibblesView key_view(bytes32_t const &k)
+    {
+        return mpt::NibblesView{byte_string_view{k.bytes, sizeof(k.bytes)}};
+    }
+
+    // The 64 nibbles of a 32-byte key, as the oracle helpers expect them.
+    std::vector<uint8_t> key_nibbles(bytes32_t const &k)
+    {
+        std::vector<uint8_t> n(64);
+        for (unsigned i = 0; i < 64; ++i) {
+            n[i] = get_nibble(k.bytes, i);
+        }
+        return n;
+    }
+
+    // A 32-byte key from two marker bytes (first/last), so two keys can be made
+    // to diverge at nibble 0 by choosing different high nibbles of byte 0.
+    bytes32_t make_key(uint8_t const first, uint8_t const last)
+    {
+        bytes32_t k{};
+        k.bytes[0] = first;
+        k.bytes[31] = last;
+        return k;
+    }
+
+    // An empty (root_off == 0) offset-trie blob to build onto.
+    byte_string empty_blob()
+    {
+        BlobBuilder bb;
+        return bb.finalize(0);
+    }
+
+    // Insert into the account trie, as PartialTrieDb::commit does: an empty
+    // trie's root is NULL_ID, so the first leaf becomes the new root. Returns
+    // the leaf id + path for the caller to put_acct.
+    std::pair<NodeId, mpt::Nibbles>
+    upsert_account(OffsetTrie &store, mpt::NibblesView const key)
+    {
+        auto const res = store.upsert_node(store.root, key);
+        if (store.root == NULL_ID) {
+            store.root = res.first;
+        }
+        return res;
+    }
+}
+
+TEST(OffsetTrie, VerifyOpenViewsFind)
+{
+    bytes32_t v1{};
+    v1.bytes[31] = 0x11;
+    bytes32_t hdig{};
+    for (auto &b : hdig.bytes) {
+        b = 0xab;
+    }
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, v1); // key tail = [a]
+    uint32_t const dig = bb.digest(hdig);
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = dig;
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+
+    OffsetTrie const store{blob};
+    EXPECT_EQ(static_cast<uint64_t>(store.root), br);
+
+    // match the root branch through the view accessors
+    bool const matched = match(
+        store.get_current(store.root),
+        Cases{
+            [&](BranchView b) -> bool {
+                EXPECT_EQ(static_cast<uint64_t>(b.child(3)), leaf);
+                EXPECT_EQ(static_cast<uint64_t>(b.child(7)), dig);
+                EXPECT_EQ(b.child(0), NULL_ID);
+                return true;
+            },
+            [&](auto) -> bool { return false; }});
+    EXPECT_TRUE(matched);
+
+    EXPECT_EQ(StorageLeafView{store.get_current(NodeId{leaf})}.value(), v1);
+    EXPECT_EQ(DigestView{store.get_current(NodeId{dig})}.hash(), hdig);
+
+    // find the storage leaf by full key [3, a]
+    mpt::Nibbles key{2};
+    key.set(0, 3);
+    key.set(1, 0xa);
+    auto const found = store.find_original(store.root, mpt::NibblesView{key});
+    EXPECT_EQ(found.tag(), LEAF_STORAGE);
+    EXPECT_EQ(StorageLeafView{found}.value(), v1);
+
+    // absent key
+    mpt::Nibbles absent{2};
+    absent.set(0, 4);
+    absent.set(1, 0x0);
+    EXPECT_EQ(
+        store.find_original(store.root, mpt::NibblesView{absent}).tag(), EMPTY);
+}
+
+TEST(OffsetTrieDeathTest, OutOfRangeChildAborts)
+{
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, bytes32_t{});
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = 999999; // out-of-range child offset
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+    // priming follows the bad edge into get_original, which aborts.
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
+TEST(OffsetTrie, HashSingleStorageLeaf)
+{
+    bytes32_t v{};
+    v.bytes[31] = 0x11;
+    std::vector<uint8_t> const nibs = {1, 2, 3};
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf(nibs, v);
+    byte_string const blob = bb.finalize(leaf);
+
+    OffsetTrie store{blob};
+    EXPECT_EQ(store.state_root(), oracle_hash(oracle_storage_leaf(nibs, v)));
+}
+
+TEST(OffsetTrie, HashBranchWithDigest)
+{
+    bytes32_t v1{};
+    v1.bytes[31] = 0x11;
+    bytes32_t hdig{};
+    for (auto &b : hdig.bytes) {
+        b = 0xab;
+    }
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, v1);
+    uint32_t const dig = bb.digest(hdig);
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = dig;
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+
+    OffsetTrie store{blob};
+
+    // oracle: 16 child refs + empty value, wrapped as a list, then keccak
+    byte_string body;
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i == 3) {
+            body += oracle_ref(oracle_storage_leaf({0xa}, v1));
+        }
+        else if (i == 7) {
+            body += rlp::encode_string2(byte_string_view{hdig.bytes, 32});
+        }
+        else {
+            body += rlp::EMPTY_STRING; // 0x80
+        }
+    }
+    body += rlp::EMPTY_STRING; // empty branch value
+    bytes32_t const want = oracle_hash(rlp::encode_list2(body));
+
+    EXPECT_EQ(store.state_root(), want);
+}
+
+// Digests the producer emits back to back land at consecutive offsets, so
+// encode_rlp copies the whole run into the parent's RLP in one go rather than
+// one child_ref at a time. The three hashes differ, so a run copied in the
+// wrong order cannot pass.
+TEST(OffsetTrie, HashBranchWithAdjacentDigests)
+{
+    bytes32_t v1{};
+    v1.bytes[31] = 0x11;
+    std::array<bytes32_t, 3> hdig{};
+    for (unsigned k = 0; k < 3; ++k) {
+        for (auto &b : hdig[k].bytes) {
+            b = static_cast<unsigned char>(0xa0 + k);
+        }
+    }
+
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, v1);
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    for (unsigned k = 0; k < 3; ++k) {
+        ch[5 + k] = bb.digest(hdig[k]);
+    }
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+
+    OffsetTrie store{blob};
+
+    // oracle: 16 child refs + empty value, wrapped as a list, then keccak
+    byte_string body;
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i == 3) {
+            body += oracle_ref(oracle_storage_leaf({0xa}, v1));
+        }
+        else if (i >= 5 && i <= 7) {
+            body +=
+                rlp::encode_string2(byte_string_view{hdig[i - 5].bytes, 32});
+        }
+        else {
+            body += rlp::EMPTY_STRING; // 0x80
+        }
+    }
+    body += rlp::EMPTY_STRING; // empty branch value
+    bytes32_t const want = oracle_hash(rlp::encode_list2(body));
+
+    EXPECT_EQ(store.state_root(), want);
+}
+
+// ── mutation: build the trie from scratch via upsert/erase, check state_root
+// against the independent RLP oracle ────────────────────────────────────────
+
+TEST(OffsetTrie, UpsertSingleAccount)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const key = make_key(0x12, 0x34);
+    Account acct{};
+    acct.balance = 5;
+    acct.nonce = 7;
+
+    auto const [leaf, path] = upsert_account(store, key_view(key));
+    store.put_acct(leaf, mpt::NibblesView{path}, acct, NULL_ID);
+
+    // sole node: a leaf holding the full key
+    byte_string const arlp = rlp::encode_account(acct, NULL_ROOT);
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(key), arlp)));
+}
+
+TEST(OffsetTrie, UpsertTwoAccountsThenErase)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const ka = make_key(0x0a, 0x11); // nibble 0 = 0x0
+    bytes32_t const kb = make_key(0xb0, 0x22); // nibble 0 = 0xb (diverge at 0)
+    Account aa{};
+    aa.balance = 1;
+    Account ab{};
+    ab.balance = 2;
+
+    auto const insert = [&](bytes32_t const &k, Account const &a) {
+        auto const [leaf, path] = upsert_account(store, key_view(k));
+        store.put_acct(leaf, mpt::NibblesView{path}, a, NULL_ID);
+    };
+    insert(ka, aa);
+    insert(kb, ab);
+
+    // oracle: a branch with the two accounts as children (each a leaf over the
+    // remaining 63 nibbles), no branch value.
+    byte_string const arlp = rlp::encode_account(aa, NULL_ROOT);
+    byte_string const brlp = rlp::encode_account(ab, NULL_ROOT);
+    byte_string body;
+    for (unsigned i = 0; i < 16; ++i) {
+        if (i == 0x0) {
+            body +=
+                oracle_ref(oracle_account_leaf(key_view(ka).substr(1), arlp));
+        }
+        else if (i == 0xb) {
+            body +=
+                oracle_ref(oracle_account_leaf(key_view(kb).substr(1), brlp));
+        }
+        else {
+            body += rlp::EMPTY_STRING;
+        }
+    }
+    body += rlp::EMPTY_STRING; // empty branch value
+    EXPECT_EQ(store.state_root(), oracle_hash(rlp::encode_list2(body)));
+
+    // erase ka -> the branch collapses back to a single leaf over the full kb
+    store.erase_node(store.root, key_view(ka));
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(kb), brlp)));
+}
+
+TEST(OffsetTrie, UpsertAccountWithStorage)
+{
+    byte_string const blob = empty_blob();
+    OffsetTrie store{blob};
+
+    bytes32_t const akey = make_key(0x12, 0x34);
+    bytes32_t const skey = make_key(0x56, 0x78);
+    bytes32_t sval{};
+    sval.bytes[31] = 0x99;
+    Account acct{};
+    acct.balance = 3;
+
+    auto const [leaf, apath] = upsert_account(store, key_view(akey));
+    auto const [storage, spath] = store.upsert_node(NULL_ID, key_view(skey));
+    store.put_storage(storage, mpt::NibblesView{spath}, sval);
+    bytes32_t const sroot = store.hash(storage);
+    // No root is handed over: the leaf must derive `sroot` from `storage`.
+    store.put_acct(leaf, mpt::NibblesView{apath}, acct, storage);
+
+    // storage sub-root is a single storage leaf over the full slot key
+    bytes32_t const oracle_sroot =
+        oracle_hash(oracle_storage_leaf(key_nibbles(skey), sval));
+    EXPECT_EQ(sroot, oracle_sroot);
+
+    byte_string const arlp = rlp::encode_account(acct, oracle_sroot);
+    EXPECT_EQ(
+        store.state_root(),
+        oracle_hash(oracle_account_leaf(key_view(akey), arlp)));
+}

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -13,96 +13,97 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// The Db interface over an offset-format witness trie. Node-layout and
+// mutation-primitive coverage lives in test_offset_trie.cpp; this file
+// exercises what PartialTrieDb adds on top — reads, commit, and the header
+// accessors.
+
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/keccak.hpp>
-#include <category/core/rlp/decode_error.hpp>
 #include <category/execution/ethereum/core/rlp/account_rlp.hpp>
-#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
 #include <category/execution/ethereum/db/partial_trie_db.hpp>
-#include <category/execution/ethereum/rlp/decode.hpp>
-#include <category/execution/ethereum/rlp/encode2.hpp>
-#include <category/mpt/merkle/compact_encode.hpp>
 #include <category/mpt/nibbles_view.hpp>
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
-#include <random>
-#include <variant>
+#include <utility>
 
 using namespace monad;
 
 namespace
 {
-    void storage_leaf_roundtrip(
-        bytes32_t const &val, NodeIndex &nodes, std::string_view label = {})
+    // An offset-format blob with the 8-byte header and no nodes (root_off 0).
+    byte_string empty_blob()
     {
-        byte_string const enc = StorageLeafValue::encode(StorageLeafValue{val});
-
-        byte_string_view view{enc};
-        auto const decoded = StorageLeafValue::decode(view, nodes);
-        ASSERT_FALSE(decoded.has_error()) << label;
-        EXPECT_EQ(decoded.value().value, val) << label;
-        ASSERT_TRUE(view.empty()) << label;
+        byte_string buf;
+        unsigned char const magic[4] = {'M', 'Z', 'W', 0x01};
+        buf.append(magic, 4);
+        buf.append(4, static_cast<unsigned char>(0)); // root_off == 0
+        return buf;
     }
 
-    byte_string
-    make_branch_with_child(unsigned slot, byte_string const &child_rlp)
+    /// A blob whose only node is an account leaf for `addr` with an empty
+    /// storage trie. Node bytes come from the production writer, so the layout
+    /// has a single source of truth here as in test_offset_trie.cpp.
+    byte_string account_blob(Address const &addr, Account const &acct)
     {
-        byte_string body;
-        for (unsigned i = 0; i < 16; ++i) {
-            body += (i == slot) ? child_rlp : rlp::EMPTY_STRING;
+        byte_string buf = empty_blob();
+        uint32_t const root_off = static_cast<uint32_t>(buf.size());
+
+        auto const key = keccak256(addr.bytes);
+        byte_string const acct_rlp = rlp::encode_account(acct, NULL_ROOT);
+        mpt::append_acct_raw(
+            buf, mpt::NibblesView{key}, acct_rlp, mpt::NULL_ID);
+
+        // LE, matching read_u32 (both sides assert a little-endian host)
+        std::memcpy(buf.data() + 4, &root_off, sizeof(root_off));
+        return buf;
+    }
+
+    /// PartialTrieDb holds a *view* over the node blob, so the bytes have to
+    /// outlive it. Bundling the two keeps that contract local to the test.
+    class TestDb
+    {
+        byte_string blob_;
+        PartialTrieDb db_;
+
+    public:
+        explicit TestDb(byte_string blob, CodeIndex codes = {})
+            : blob_(std::move(blob))
+            , db_(mpt::OffsetTrie{blob_}, std::move(codes))
+        {
         }
-        body += rlp::EMPTY_STRING; // value slot
-        return rlp::encode_list2(body);
-    }
 
-    Result<PartialTrieDb> db_from_rlp_node(byte_string const &node_rlp)
-    {
-        bytes32_t const root = to_bytes(
-            keccak256(byte_string_view{node_rlp.data(), node_rlp.size()}));
-        return PartialTrieDb::from_witness(
-            root, byte_string_view{node_rlp.data(), node_rlp.size()}, {});
-    }
+        TestDb(TestDb const &) = delete;
+        TestDb &operator=(TestDb const &) = delete;
 
-    PartialTrieDb make_empty_db()
-    {
-        auto result = PartialTrieDb::from_witness(NULL_ROOT, {}, {});
-        MONAD_ASSERT(!result.has_error());
-        return std::move(result.value());
-    }
+        PartialTrieDb *operator->()
+        {
+            return &db_;
+        }
+    };
 
     void commit_with(
-        PartialTrieDb &db, BlockHeader const &header, StateDeltas deltas,
+        TestDb &db, BlockHeader const &header, StateDeltas deltas,
         std::function<void(BlockHeader &)> populate = [](BlockHeader &) {})
     {
         CommitBuilder builder(header.number);
-        db.commit(bytes32_t{}, builder, header, deltas, std::move(populate));
+        db->commit(bytes32_t{}, builder, header, deltas, std::move(populate));
     }
 
-    /// Build a witness whose only node is a leaf for `addr` with the given
-    /// account and an empty storage trie.
-    Result<PartialTrieDb>
-    db_from_account(Address const &addr, Account const &acct)
+    /// state_root of a trie holding exactly one account, built from a blob
+    /// rather than by committing — the independent oracle for commit results.
+    bytes32_t single_account_root(Address const &addr, Account const &acct)
     {
-        auto const path_bytes = keccak256(addr.bytes);
-        mpt::Nibbles leaf_path{mpt::NibblesView{path_bytes}};
-
-        unsigned char compact_buf[33];
-        auto const compact_sv = mpt::compact_encode(
-            compact_buf, mpt::NibblesView{leaf_path}, /*terminating=*/true);
-
-        byte_string const encoded_acct = rlp::encode_account(acct, NULL_ROOT);
-        byte_string const leaf_rlp = rlp::encode_list2(
-            rlp::encode_string2(compact_sv),
-            rlp::encode_string2(
-                byte_string_view{encoded_acct.data(), encoded_acct.size()}));
-
-        return db_from_rlp_node(leaf_rlp);
+        TestDb db{account_blob(addr, acct)};
+        return db->state_root();
     }
 
     constexpr auto ADDR_X = 0x00000000000000000000000000000000deadbeef_address;
@@ -119,262 +120,34 @@ namespace
         0x000000000000000000000000000000000000000000000000000000000000beef_bytes32;
 } // namespace
 
-TEST(StorageLeafValue, DecodeZeroValue)
-{
-    // rlp(uint256(0)) = 0x80 (empty string), representing the zero storage
-    // value.
-    NodeIndex nodes{};
-    byte_string const zero_rlp{static_cast<unsigned char>(0x80)};
-    byte_string_view enc{zero_rlp.data(), zero_rlp.size()};
-    auto const result = StorageLeafValue::decode(enc, nodes);
-    ASSERT_FALSE(result.has_error());
-    EXPECT_EQ(result.value().value, bytes32_t{});
-}
-
-TEST(StorageLeafValue, DecodeEncodeRoundtrip)
-{
-    // Seed with a fixed value so the test is deterministic.
-    std::mt19937_64 rng{0xc0ffee'dead'beef'13ULL};
-    std::uniform_int_distribution<unsigned int> byte_dist{0, 255};
-
-    NodeIndex nodes{};
-
-    for (int i = 0; i < 10000; ++i) {
-        bytes32_t val{};
-        std::generate(std::begin(val.bytes), std::end(val.bytes), [&] {
-            return static_cast<uint8_t>(byte_dist(rng));
-        });
-        storage_leaf_roundtrip(val, nodes, "iteration " + std::to_string(i));
-    }
-}
-
-TEST(StorageLeafValue, DecodeEncodeRoundtrip_ExtremeValues)
-{
-    NodeIndex nodes{};
-
-    bytes32_t all_zeros{};
-    storage_leaf_roundtrip(all_zeros, nodes, "all zeros");
-
-    bytes32_t all_ffs{};
-    std::fill(
-        std::begin(all_ffs.bytes), std::end(all_ffs.bytes), uint8_t{0xff});
-    storage_leaf_roundtrip(all_ffs, nodes, "all 0xFF");
-}
-
-TEST(StorageLeafValue, DecodeTooLong)
-{
-    // rlp(33 bytes) is a string with a 33-byte payload — one byte over
-    // bytes32_t capacity.
-    byte_string const overlong =
-        rlp::encode_string2(byte_string(33, static_cast<unsigned char>(0xff)));
-    NodeIndex nodes{};
-    byte_string_view enc{overlong.data(), overlong.size()};
-    auto const result = StorageLeafValue::decode(enc, nodes);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(AccountLeafValue, DecodeEncodeRoundtrip_EmptyStorage)
-{
-    constexpr auto code_hash =
-        0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890_bytes32;
-    Account const acct{.balance = 99999, .code_hash = code_hash, .nonce = 7};
-    byte_string const encoded_acct = rlp::encode_account(acct, NULL_ROOT);
-
-    NodeIndex nodes{};
-    byte_string_view enc{encoded_acct};
-    auto const decoded = AccountLeafValue::decode(enc, nodes);
-    ASSERT_FALSE(decoded.has_error());
-
-    auto const &decoded_acct = decoded.value();
-    EXPECT_EQ(decoded_acct.account.nonce, acct.nonce);
-    EXPECT_EQ(decoded_acct.account.balance, acct.balance);
-    EXPECT_EQ(decoded_acct.account.code_hash, code_hash);
-
-    // NULL_ROOT storage is represented as nullptr (empty trie), not HashStub.
-    EXPECT_EQ(decoded_acct.storage, nullptr);
-
-    EXPECT_EQ(AccountLeafValue::encode(decoded_acct), encoded_acct);
-}
-
-TEST(PartialTrieDb, StateRoot_HashStubWhenRootAbsentFromNodeIndex)
-{
-    // When pre_state_root is not present in the node index the root remains a
-    // HashStub, and state_root() must return the original hash unchanged.
-    constexpr auto sentinel =
-        0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef_bytes32;
-
-    auto result = PartialTrieDb::from_witness(sentinel, {}, {});
-    ASSERT_FALSE(result.has_error());
-    EXPECT_EQ(result.value().state_root(), sentinel);
-}
-
-TEST(PartialTrieDb, StateRoot_SingleLeafRoundtrip)
-{
-    // Build a single-account leaf node manually, then verify that
-    // state_root() re-encodes and re-hashes it to the same value.
-
-    // Dummy leaf path: two nibbles [0xA, 0xB] (even length, so compact prefix =
-    // 0x20).
-    mpt::Nibbles path{2};
-    path.set(0, 0xA);
-    path.set(1, 0xB);
-
-    unsigned char compact_buf[33];
-    auto const compact_sv = mpt::compact_encode(
-        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
-    // compact_sv == { 0x20, 0xAB }
-
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(compact_sv),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_FALSE(result.has_error());
-
-    bytes32_t const expected_root =
-        to_bytes(keccak256(byte_string_view{leaf_rlp.data(), leaf_rlp.size()}));
-    EXPECT_EQ(result.value().state_root(), expected_root);
-}
-
-TEST(PartialTrieDb, ShortHashReference)
-{
-    // A branch child that is a 20-byte string (too short for a hash
-    // reference, too long for an empty slot) must fail with InputTooShort.
-    byte_string const short_hash(20, static_cast<unsigned char>(0xAA));
-    byte_string const child_rlp = rlp::encode_string2(
-        byte_string_view{short_hash.data(), short_hash.size()});
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, ShortHashReference_OneByte)
-{
-    // A single non-zero byte (self-encodes for [0x01..0x7f]) is a 1-byte
-    // string — too short for a hash reference.
-    byte_string const child_rlp{static_cast<unsigned char>(0x42)};
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, LongHashReference)
-{
-    // A branch child that is a 33-byte string (one byte over the expected
-    // 32) must fail with InputTooLong.
-    byte_string const long_hash(33, static_cast<unsigned char>(0xBB));
-    byte_string const child_rlp = rlp::encode_string2(
-        byte_string_view{long_hash.data(), long_hash.size()});
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(PartialTrieDb, OversizedInlineNode)
-{
-    // An inline (embedded) node must have full RLP encoding < 32 bytes.
-    // Build a list whose payload is 31 bytes to trigger InputTooLong.
-    byte_string const payload(31, static_cast<unsigned char>(0x00));
-    byte_string const child_rlp = rlp::encode_list2(payload);
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(PartialTrieDb, EmptyInlineNode)
-{
-    // An empty list (0xc0) has zero-length payload.
-    // Decoding should fail with InputTooShort.
-    byte_string const child_rlp{static_cast<unsigned char>(0xc0)};
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, PathTooLong)
-{
-    // A leaf whose compact-encoded path decodes to 65 nibbles exceeds the
-    // 64-nibble MPT key limit and must fail with PathTooLong.
-    mpt::Nibbles path{65};
-    for (unsigned i = 0; i < 65; ++i) {
-        path.set(i, static_cast<unsigned char>(i % 16));
-    }
-
-    unsigned char compact_buf[34];
-    auto const compact_sv = mpt::compact_encode(
-        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
-
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(compact_sv),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
-}
-
-TEST(PartialTrieDb, PathTooLongOver255CompactPath)
-{
-    byte_string compact_key(129, 0x00);
-    compact_key[0] = 0x20; // leaf node, even path length
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(
-            byte_string_view{compact_key.data(), compact_key.size()}),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
-}
-
 // ---------------------------------------------------------------------------
 // Read tests
+//
+// Reads are served from the witness pre-state (OffsetTrie::find_original), so
+// they see the blob the db was opened with, not anything a later commit built.
 // ---------------------------------------------------------------------------
 
 TEST(PartialTrieDb, Read_EmptyTrie)
 {
-    auto db = make_empty_db();
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    TestDb db{empty_blob()};
+    EXPECT_EQ(db->read_account(ADDR_X), std::nullopt);
+    EXPECT_EQ(db->read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
 }
 
 TEST(PartialTrieDb, Read_LeafWitness_FoundAndAbsent)
 {
     Account const acct{.balance = 1234, .nonce = 7};
-    auto result = db_from_account(ADDR_X, acct);
-    ASSERT_FALSE(result.has_error());
-    auto db = std::move(result.value());
+    TestDb db{account_blob(ADDR_X, acct)};
 
-    auto const found = db.read_account(ADDR_X);
+    auto const found = db->read_account(ADDR_X);
     ASSERT_TRUE(found.has_value());
     EXPECT_EQ(found->balance, acct.balance);
     EXPECT_EQ(found->nonce, acct.nonce);
 
-    // Different address misses the single leaf — the trie is fully resolved
-    // so the lookup terminates with absent (no HashStub on the path).
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    // A different address misses the single leaf — the trie is fully resolved,
+    // so the lookup terminates as absent rather than hitting a Digest.
+    EXPECT_EQ(db->read_account(ADDR_Y), std::nullopt);
+    EXPECT_EQ(db->read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
 }
 
 TEST(PartialTrieDb, ReadCode_PresentAndMissing)
@@ -385,39 +158,36 @@ TEST(PartialTrieDb, ReadCode_PresentAndMissing)
     bytes32_t const hash1 = to_bytes(keccak256(code1));
     bytes32_t const hash2 = to_bytes(keccak256(code2));
 
-    byte_string const encoded_codes =
-        rlp::encode_string2(byte_string_view{code1.data(), code1.size()}) +
-        rlp::encode_string2(byte_string_view{code2.data(), code2.size()});
+    CodeIndex codes;
+    codes.emplace(hash1, vm::make_shared_intercode(code1));
+    codes.emplace(hash2, vm::make_shared_intercode(code2));
+    TestDb db{empty_blob(), std::move(codes)};
 
-    auto result = PartialTrieDb::from_witness(
-        NULL_ROOT,
-        {},
-        byte_string_view{encoded_codes.data(), encoded_codes.size()});
-    ASSERT_FALSE(result.has_error());
-    auto db = std::move(result.value());
-
-    auto const ic1 = db.read_code(hash1);
+    auto const ic1 = db->read_code(hash1);
     EXPECT_EQ(
         byte_string_view(ic1->code(), ic1->size()), byte_string_view{code1});
 
-    auto const ic2 = db.read_code(hash2);
+    auto const ic2 = db->read_code(hash2);
     EXPECT_EQ(
         byte_string_view(ic2->code(), ic2->size()), byte_string_view{code2});
 
     // Missing hash returns an empty intercode rather than asserting.
     constexpr auto missing =
         0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface_bytes32;
-    auto const ic_missing = db.read_code(missing);
+    auto const ic_missing = db->read_code(missing);
     EXPECT_EQ(ic_missing->size(), 0u);
 }
 
 // ---------------------------------------------------------------------------
 // Commit tests
+//
+// commit builds the post-state in the overlay; state_root() is the observable
+// result, since reads stay on the pre-state blob.
 // ---------------------------------------------------------------------------
 
 TEST(PartialTrieDb, Commit_InsertSingleAccount)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1'000, .nonce = 3};
 
     commit_with(
@@ -425,57 +195,44 @@ TEST(PartialTrieDb, Commit_InsertSingleAccount)
         BlockHeader{.number = 1},
         StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_NE(db.state_root(), NULL_ROOT);
-    EXPECT_EQ(db.get_block_number(), 1u);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
+    EXPECT_EQ(db->get_block_number(), 1u);
 }
 
 TEST(PartialTrieDb, Commit_UpdateExistingAccount)
 {
-    auto db = make_empty_db();
     Account const acct1{.balance = 100, .nonce = 1};
     Account const acct2{.balance = 200, .nonce = 2};
 
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct1}}}});
-    bytes32_t const root_after_insert = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct1)};
+    bytes32_t const root_before = db->state_root();
 
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct1, acct2}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct2);
-    EXPECT_NE(db.state_root(), root_after_insert);
-    EXPECT_NE(db.state_root(), NULL_ROOT);
+    EXPECT_NE(db->state_root(), root_before);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct2));
 }
 
 TEST(PartialTrieDb, Commit_DeleteAccount_LeavesEmptyTrie)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 999, .nonce = 5};
-
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    ASSERT_NE(db.state_root(), NULL_ROOT);
+    TestDb db{account_blob(ADDR_X, acct)};
+    ASSERT_NE(db->state_root(), NULL_ROOT);
 
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.state_root(), NULL_ROOT);
+    EXPECT_EQ(db->state_root(), NULL_ROOT);
 }
 
 TEST(PartialTrieDb, Commit_TwoAccountsThenDeleteOne_BranchCompresses)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct_x{.balance = 1, .nonce = 1};
     Account const acct_y{.balance = 2, .nonce = 2};
 
@@ -485,37 +242,23 @@ TEST(PartialTrieDb, Commit_TwoAccountsThenDeleteOne_BranchCompresses)
         StateDeltas{
             {ADDR_X, StateDelta{.account = {std::nullopt, acct_x}}},
             {ADDR_Y, StateDelta{.account = {std::nullopt, acct_y}}}});
+    ASSERT_NE(db->state_root(), NULL_ROOT);
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct_x);
-    EXPECT_EQ(db.read_account(ADDR_Y), acct_y);
-    ASSERT_NE(db.state_root(), NULL_ROOT);
-
-    // Build a fresh single-leaf trie containing only ADDR_Y → acct_y. After
-    // deleting ADDR_X from `db`, branch compression must produce the same trie
-    // (and therefore the same state_root).
-    auto only_y_result = db_from_account(ADDR_Y, acct_y);
-    ASSERT_FALSE(only_y_result.has_error());
-    bytes32_t const root_only_y = only_y_result.value().state_root();
-
+    // Deleting ADDR_X must collapse the branch back to a single leaf, i.e. to
+    // the same trie a witness holding only ADDR_Y would produce.
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct_x, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.read_account(ADDR_Y), acct_y);
-    EXPECT_EQ(db.state_root(), root_only_y);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_Y, acct_y));
 }
 
 TEST(PartialTrieDb, Commit_TouchOnlyIsNoOp)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 7, .nonce = 1};
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    bytes32_t const root_before = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct)};
+    bytes32_t const root_before = db->state_root();
 
     // {nullopt, nullopt} hits neither the upsert nor the deletion pass — a
     // pure no-op, even for entries that name a present account.
@@ -526,39 +269,32 @@ TEST(PartialTrieDb, Commit_TouchOnlyIsNoOp)
             {ADDR_X, StateDelta{.account = {std::nullopt, std::nullopt}}},
             {ADDR_Y, StateDelta{.account = {std::nullopt, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.state_root(), root_before);
+    EXPECT_EQ(db->state_root(), root_before);
 }
 
 TEST(PartialTrieDb, Commit_DeleteAbsentAccountIsNoOp)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 7, .nonce = 1};
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    bytes32_t const root_before = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct)};
+    bytes32_t const root_before = db->state_root();
 
-    // ADDR_Y is not in the trie. The pass-2 branch runs trie_delete which
-    // returns false for missing keys; state must be unchanged.
+    // ADDR_Y is not in the trie, so the deletion pass finds nothing to erase
+    // and the root must be unchanged.
     Account const stale{.balance = 99};
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_Y, StateDelta{.account = {stale, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_EQ(db.state_root(), root_before);
+    EXPECT_EQ(db->state_root(), root_before);
 }
 
 TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1, .nonce = 1};
 
-    // Insert account with two storage slots.
+    // Insert the account with two storage slots.
     commit_with(
         db,
         BlockHeader{.number = 1},
@@ -569,11 +305,10 @@ TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
                  .storage = {
                      {SLOT_1, {bytes32_t{}, VAL_1}},
                      {SLOT_2, {bytes32_t{}, VAL_2}}}}}});
+    bytes32_t const root_two_slots = db->state_root();
+    EXPECT_NE(root_two_slots, single_account_root(ADDR_X, acct));
 
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), VAL_1);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_2), VAL_2);
-
-    // Update SLOT_1, delete SLOT_2 in a second commit.
+    // Update SLOT_1 and delete SLOT_2 in a second commit.
     commit_with(
         db,
         BlockHeader{.number = 2},
@@ -584,23 +319,29 @@ TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
                  .storage = {
                      {SLOT_1, {VAL_1, VAL_2}},
                      {SLOT_2, {VAL_2, bytes32_t{}}}}}}});
+    EXPECT_NE(db->state_root(), root_two_slots);
 
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), VAL_2);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_2), bytes32_t{});
-
-    // Slot that was never set returns zero (account exists, slot absent).
-    constexpr auto SLOT_3 =
-        0x0000000000000000000000000000000000000000000000000000000000000003_bytes32;
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_3), bytes32_t{});
+    // Deleting the surviving slot too must return the account to an empty
+    // storage trie, i.e. the storage_root it had before any slot was set.
+    commit_with(
+        db,
+        BlockHeader{.number = 3},
+        StateDeltas{
+            {ADDR_X,
+             StateDelta{
+                 .account = {acct, acct},
+                 .storage = {{SLOT_1, {VAL_2, bytes32_t{}}}}}}});
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
 }
 
 TEST(PartialTrieDb, Commit_StorageZeroToZeroIsNoOp)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1, .nonce = 1};
 
     // {0, 0} storage delta hits neither the upsert pass (sdelta.second is
-    // zero) nor the delete pass (sdelta.first is zero) — pure no-op.
+    // zero) nor the delete pass (sdelta.first is zero) — pure no-op, so the
+    // account lands with an empty storage trie.
     commit_with(
         db,
         BlockHeader{.number = 1},
@@ -610,13 +351,12 @@ TEST(PartialTrieDb, Commit_StorageZeroToZeroIsNoOp)
                  .account = {std::nullopt, acct},
                  .storage = {{SLOT_1, {bytes32_t{}, bytes32_t{}}}}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
 }
 
 TEST(PartialTrieDb, Commit_PopulatesHeaderRoots)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
 
     constexpr auto receipts =
         0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bytes32;
@@ -632,44 +372,41 @@ TEST(PartialTrieDb, Commit_PopulatesHeaderRoots)
             h.withdrawals_root = withdrawals;
         });
 
-    EXPECT_EQ(db.receipts_root(), receipts);
-    EXPECT_EQ(db.transactions_root(), txns);
-    ASSERT_TRUE(db.withdrawals_root().has_value());
-    EXPECT_EQ(*db.withdrawals_root(), withdrawals);
+    EXPECT_EQ(db->receipts_root(), receipts);
+    EXPECT_EQ(db->transactions_root(), txns);
+    ASSERT_TRUE(db->withdrawals_root().has_value());
+    EXPECT_EQ(*db->withdrawals_root(), withdrawals);
 
     // commit_simple-style consumers expect the populated header to be readable
     // back through read_eth_header.
-    auto const stored = db.read_eth_header();
+    auto const stored = db->read_eth_header();
     EXPECT_EQ(stored.number, 42u);
     EXPECT_EQ(stored.receipts_root, receipts);
     EXPECT_EQ(stored.transactions_root, txns);
     ASSERT_TRUE(stored.withdrawals_root.has_value());
     EXPECT_EQ(*stored.withdrawals_root, withdrawals);
 
-    EXPECT_EQ(db.get_block_number(), 42u);
+    EXPECT_EQ(db->get_block_number(), 42u);
 }
 
 TEST(PartialTrieDb, SetBlockAndPrefix_UpdatesBlockNumber)
 {
-    auto db = make_empty_db();
-    EXPECT_EQ(db.get_block_number(), 0u);
-    db.set_block_and_prefix(99);
-    EXPECT_EQ(db.get_block_number(), 99u);
+    TestDb db{empty_blob()};
+    EXPECT_EQ(db->get_block_number(), 0u);
+    db->set_block_and_prefix(99, bytes32_t{});
+    EXPECT_EQ(db->get_block_number(), 99u);
 }
 
 TEST(PartialTrieDb, Commit_StateRootMatchesIndependentlyEncodedTrie)
 {
-    // Round-trip check: committing one account into an empty trie should yield
-    // the same state_root as building a single-leaf trie directly from a
-    // synthetic witness.
-    auto live = make_empty_db();
+    // Round-trip check: committing one account into an empty trie yields the
+    // same state_root as opening a single-leaf blob directly.
+    TestDb live{empty_blob()};
     Account const acct{.balance = 0xdeadbeef, .nonce = 12};
     commit_with(
         live,
         BlockHeader{.number = 1},
         StateDeltas{{ADDR_Z, StateDelta{.account = {std::nullopt, acct}}}});
 
-    auto reference_result = db_from_account(ADDR_Z, acct);
-    ASSERT_FALSE(reference_result.has_error());
-    EXPECT_EQ(live.state_root(), reference_result.value().state_root());
+    EXPECT_EQ(live->state_root(), single_account_root(ADDR_Z, acct));
 }

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -13,96 +13,95 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// The Db interface over an offset-format witness trie. Node-layout and
+// mutation-primitive coverage lives in test_offset_trie.cpp; this file
+// exercises what PartialTrieDb adds on top — reads, commit, and the header
+// accessors.
+
 #include <category/core/address.hpp>
 #include <category/core/byte_string.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/keccak.hpp>
-#include <category/core/rlp/decode_error.hpp>
 #include <category/execution/ethereum/core/rlp/account_rlp.hpp>
-#include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/commit_builder.hpp>
+#include <category/execution/ethereum/db/offset_trie.hpp>
 #include <category/execution/ethereum/db/partial_trie_db.hpp>
-#include <category/execution/ethereum/rlp/decode.hpp>
-#include <category/execution/ethereum/rlp/encode2.hpp>
-#include <category/mpt/merkle/compact_encode.hpp>
 #include <category/mpt/nibbles_view.hpp>
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
-#include <random>
-#include <variant>
+#include <utility>
 
 using namespace monad;
 
 namespace
 {
-    void storage_leaf_roundtrip(
-        bytes32_t const &val, NodeIndex &nodes, std::string_view label = {})
+    // An offset-format blob with the 8-byte header and no nodes (root_off 0).
+    byte_string empty_blob()
     {
-        byte_string const enc = StorageLeafValue::encode(StorageLeafValue{val});
-
-        byte_string_view view{enc};
-        auto const decoded = StorageLeafValue::decode(view, nodes);
-        ASSERT_FALSE(decoded.has_error()) << label;
-        EXPECT_EQ(decoded.value().value, val) << label;
-        ASSERT_TRUE(view.empty()) << label;
+        byte_string buf;
+        unsigned char const magic[4] = {'M', 'Z', 'W', 0x01};
+        buf.append(magic, 4);
+        buf.append(4, static_cast<unsigned char>(0)); // root_off == 0
+        return buf;
     }
 
-    byte_string
-    make_branch_with_child(unsigned slot, byte_string const &child_rlp)
+    /// A blob whose only node is an account leaf for `addr` with an empty
+    /// storage trie. Node bytes come from the production writer, so the layout
+    /// has a single source of truth here as in test_offset_trie.cpp.
+    byte_string account_blob(Address const &addr, Account const &acct)
     {
-        byte_string body;
-        for (unsigned i = 0; i < 16; ++i) {
-            body += (i == slot) ? child_rlp : rlp::EMPTY_STRING;
+        byte_string buf = empty_blob();
+        uint32_t const root_off = static_cast<uint32_t>(buf.size());
+
+        auto const key = keccak256(addr.bytes);
+        mpt::append_acct(buf, mpt::NULL_ID, acct, mpt::NibblesView{key});
+
+        // LE, matching read_node_id (both sides assert a little-endian host)
+        std::memcpy(buf.data() + 4, &root_off, sizeof(root_off));
+        return buf;
+    }
+
+    /// PartialTrieDb holds a *view* over the node blob, so the bytes have to
+    /// outlive it. Bundling the two keeps that contract local to the test.
+    class TestDb
+    {
+        byte_string blob_;
+        PartialTrieDb db_;
+
+    public:
+        explicit TestDb(byte_string blob, CodeIndex codes = {})
+            : blob_(std::move(blob))
+            , db_(mpt::OffsetTrie{blob_}, std::move(codes))
+        {
         }
-        body += rlp::EMPTY_STRING; // value slot
-        return rlp::encode_list2(body);
-    }
 
-    Result<PartialTrieDb> db_from_rlp_node(byte_string const &node_rlp)
-    {
-        bytes32_t const root = to_bytes(
-            keccak256(byte_string_view{node_rlp.data(), node_rlp.size()}));
-        return PartialTrieDb::from_witness(
-            root, byte_string_view{node_rlp.data(), node_rlp.size()}, {});
-    }
+        TestDb(TestDb const &) = delete;
+        TestDb &operator=(TestDb const &) = delete;
 
-    PartialTrieDb make_empty_db()
-    {
-        auto result = PartialTrieDb::from_witness(NULL_ROOT, {}, {});
-        MONAD_ASSERT(!result.has_error());
-        return std::move(result.value());
-    }
+        PartialTrieDb *operator->()
+        {
+            return &db_;
+        }
+    };
 
     void commit_with(
-        PartialTrieDb &db, BlockHeader const &header, StateDeltas deltas,
+        TestDb &db, BlockHeader const &header, StateDeltas deltas,
         std::function<void(BlockHeader &)> populate = [](BlockHeader &) {})
     {
         CommitBuilder builder(header.number);
-        db.commit(bytes32_t{}, builder, header, deltas, std::move(populate));
+        db->commit(bytes32_t{}, builder, header, deltas, std::move(populate));
     }
 
-    /// Build a witness whose only node is a leaf for `addr` with the given
-    /// account and an empty storage trie.
-    Result<PartialTrieDb>
-    db_from_account(Address const &addr, Account const &acct)
+    /// state_root of a trie holding exactly one account, built from a blob
+    /// rather than by committing — the independent oracle for commit results.
+    bytes32_t single_account_root(Address const &addr, Account const &acct)
     {
-        auto const path_bytes = keccak256(addr.bytes);
-        mpt::Nibbles leaf_path{mpt::NibblesView{path_bytes}};
-
-        unsigned char compact_buf[33];
-        auto const compact_sv = mpt::compact_encode(
-            compact_buf, mpt::NibblesView{leaf_path}, /*terminating=*/true);
-
-        byte_string const encoded_acct = rlp::encode_account(acct, NULL_ROOT);
-        byte_string const leaf_rlp = rlp::encode_list2(
-            rlp::encode_string2(compact_sv),
-            rlp::encode_string2(
-                byte_string_view{encoded_acct.data(), encoded_acct.size()}));
-
-        return db_from_rlp_node(leaf_rlp);
+        TestDb db{account_blob(addr, acct)};
+        return db->state_root();
     }
 
     constexpr auto ADDR_X = 0x00000000000000000000000000000000deadbeef_address;
@@ -119,262 +118,34 @@ namespace
         0x000000000000000000000000000000000000000000000000000000000000beef_bytes32;
 } // namespace
 
-TEST(StorageLeafValue, DecodeZeroValue)
-{
-    // rlp(uint256(0)) = 0x80 (empty string), representing the zero storage
-    // value.
-    NodeIndex nodes{};
-    byte_string const zero_rlp{static_cast<unsigned char>(0x80)};
-    byte_string_view enc{zero_rlp.data(), zero_rlp.size()};
-    auto const result = StorageLeafValue::decode(enc, nodes);
-    ASSERT_FALSE(result.has_error());
-    EXPECT_EQ(result.value().value, bytes32_t{});
-}
-
-TEST(StorageLeafValue, DecodeEncodeRoundtrip)
-{
-    // Seed with a fixed value so the test is deterministic.
-    std::mt19937_64 rng{0xc0ffee'dead'beef'13ULL};
-    std::uniform_int_distribution<unsigned int> byte_dist{0, 255};
-
-    NodeIndex nodes{};
-
-    for (int i = 0; i < 10000; ++i) {
-        bytes32_t val{};
-        std::generate(std::begin(val.bytes), std::end(val.bytes), [&] {
-            return static_cast<uint8_t>(byte_dist(rng));
-        });
-        storage_leaf_roundtrip(val, nodes, "iteration " + std::to_string(i));
-    }
-}
-
-TEST(StorageLeafValue, DecodeEncodeRoundtrip_ExtremeValues)
-{
-    NodeIndex nodes{};
-
-    bytes32_t all_zeros{};
-    storage_leaf_roundtrip(all_zeros, nodes, "all zeros");
-
-    bytes32_t all_ffs{};
-    std::fill(
-        std::begin(all_ffs.bytes), std::end(all_ffs.bytes), uint8_t{0xff});
-    storage_leaf_roundtrip(all_ffs, nodes, "all 0xFF");
-}
-
-TEST(StorageLeafValue, DecodeTooLong)
-{
-    // rlp(33 bytes) is a string with a 33-byte payload — one byte over
-    // bytes32_t capacity.
-    byte_string const overlong =
-        rlp::encode_string2(byte_string(33, static_cast<unsigned char>(0xff)));
-    NodeIndex nodes{};
-    byte_string_view enc{overlong.data(), overlong.size()};
-    auto const result = StorageLeafValue::decode(enc, nodes);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(AccountLeafValue, DecodeEncodeRoundtrip_EmptyStorage)
-{
-    constexpr auto code_hash =
-        0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890_bytes32;
-    Account const acct{.balance = 99999, .code_hash = code_hash, .nonce = 7};
-    byte_string const encoded_acct = rlp::encode_account(acct, NULL_ROOT);
-
-    NodeIndex nodes{};
-    byte_string_view enc{encoded_acct};
-    auto const decoded = AccountLeafValue::decode(enc, nodes);
-    ASSERT_FALSE(decoded.has_error());
-
-    auto const &decoded_acct = decoded.value();
-    EXPECT_EQ(decoded_acct.account.nonce, acct.nonce);
-    EXPECT_EQ(decoded_acct.account.balance, acct.balance);
-    EXPECT_EQ(decoded_acct.account.code_hash, code_hash);
-
-    // NULL_ROOT storage is represented as nullptr (empty trie), not HashStub.
-    EXPECT_EQ(decoded_acct.storage, nullptr);
-
-    EXPECT_EQ(AccountLeafValue::encode(decoded_acct), encoded_acct);
-}
-
-TEST(PartialTrieDb, StateRoot_HashStubWhenRootAbsentFromNodeIndex)
-{
-    // When pre_state_root is not present in the node index the root remains a
-    // HashStub, and state_root() must return the original hash unchanged.
-    constexpr auto sentinel =
-        0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef_bytes32;
-
-    auto result = PartialTrieDb::from_witness(sentinel, {}, {});
-    ASSERT_FALSE(result.has_error());
-    EXPECT_EQ(result.value().state_root(), sentinel);
-}
-
-TEST(PartialTrieDb, StateRoot_SingleLeafRoundtrip)
-{
-    // Build a single-account leaf node manually, then verify that
-    // state_root() re-encodes and re-hashes it to the same value.
-
-    // Dummy leaf path: two nibbles [0xA, 0xB] (even length, so compact prefix =
-    // 0x20).
-    mpt::Nibbles path{2};
-    path.set(0, 0xA);
-    path.set(1, 0xB);
-
-    unsigned char compact_buf[33];
-    auto const compact_sv = mpt::compact_encode(
-        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
-    // compact_sv == { 0x20, 0xAB }
-
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(compact_sv),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_FALSE(result.has_error());
-
-    bytes32_t const expected_root =
-        to_bytes(keccak256(byte_string_view{leaf_rlp.data(), leaf_rlp.size()}));
-    EXPECT_EQ(result.value().state_root(), expected_root);
-}
-
-TEST(PartialTrieDb, ShortHashReference)
-{
-    // A branch child that is a 20-byte string (too short for a hash
-    // reference, too long for an empty slot) must fail with InputTooShort.
-    byte_string const short_hash(20, static_cast<unsigned char>(0xAA));
-    byte_string const child_rlp = rlp::encode_string2(
-        byte_string_view{short_hash.data(), short_hash.size()});
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, ShortHashReference_OneByte)
-{
-    // A single non-zero byte (self-encodes for [0x01..0x7f]) is a 1-byte
-    // string — too short for a hash reference.
-    byte_string const child_rlp{static_cast<unsigned char>(0x42)};
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, LongHashReference)
-{
-    // A branch child that is a 33-byte string (one byte over the expected
-    // 32) must fail with InputTooLong.
-    byte_string const long_hash(33, static_cast<unsigned char>(0xBB));
-    byte_string const child_rlp = rlp::encode_string2(
-        byte_string_view{long_hash.data(), long_hash.size()});
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(PartialTrieDb, OversizedInlineNode)
-{
-    // An inline (embedded) node must have full RLP encoding < 32 bytes.
-    // Build a list whose payload is 31 bytes to trigger InputTooLong.
-    byte_string const payload(31, static_cast<unsigned char>(0x00));
-    byte_string const child_rlp = rlp::encode_list2(payload);
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooLong);
-}
-
-TEST(PartialTrieDb, EmptyInlineNode)
-{
-    // An empty list (0xc0) has zero-length payload.
-    // Decoding should fail with InputTooShort.
-    byte_string const child_rlp{static_cast<unsigned char>(0xc0)};
-
-    byte_string const branch = make_branch_with_child(0, child_rlp);
-    auto result = db_from_rlp_node(branch);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::InputTooShort);
-}
-
-TEST(PartialTrieDb, PathTooLong)
-{
-    // A leaf whose compact-encoded path decodes to 65 nibbles exceeds the
-    // 64-nibble MPT key limit and must fail with PathTooLong.
-    mpt::Nibbles path{65};
-    for (unsigned i = 0; i < 65; ++i) {
-        path.set(i, static_cast<unsigned char>(i % 16));
-    }
-
-    unsigned char compact_buf[34];
-    auto const compact_sv = mpt::compact_encode(
-        compact_buf, mpt::NibblesView{path}, /*terminating=*/true);
-
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(compact_sv),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
-}
-
-TEST(PartialTrieDb, PathTooLongOver255CompactPath)
-{
-    byte_string compact_key(129, 0x00);
-    compact_key[0] = 0x20; // leaf node, even path length
-    AccountLeafValue const val{.account = {.nonce = 1}};
-    byte_string const encoded_val = AccountLeafValue::encode(val);
-    byte_string const leaf_rlp = rlp::encode_list2(
-        rlp::encode_string2(
-            byte_string_view{compact_key.data(), compact_key.size()}),
-        rlp::encode_string2(
-            byte_string_view{encoded_val.data(), encoded_val.size()}));
-    auto result = db_from_rlp_node(leaf_rlp);
-    ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.error(), rlp::DecodeError::PathTooLong);
-}
-
 // ---------------------------------------------------------------------------
 // Read tests
+//
+// Reads are served from the witness pre-state (OffsetTrie::find_original), so
+// they see the blob the db was opened with, not anything a later commit built.
 // ---------------------------------------------------------------------------
 
 TEST(PartialTrieDb, Read_EmptyTrie)
 {
-    auto db = make_empty_db();
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    TestDb db{empty_blob()};
+    EXPECT_EQ(db->read_account(ADDR_X), std::nullopt);
+    EXPECT_EQ(db->read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
 }
 
 TEST(PartialTrieDb, Read_LeafWitness_FoundAndAbsent)
 {
     Account const acct{.balance = 1234, .nonce = 7};
-    auto result = db_from_account(ADDR_X, acct);
-    ASSERT_FALSE(result.has_error());
-    auto db = std::move(result.value());
+    TestDb db{account_blob(ADDR_X, acct)};
 
-    auto const found = db.read_account(ADDR_X);
+    auto const found = db->read_account(ADDR_X);
     ASSERT_TRUE(found.has_value());
     EXPECT_EQ(found->balance, acct.balance);
     EXPECT_EQ(found->nonce, acct.nonce);
 
-    // Different address misses the single leaf — the trie is fully resolved
-    // so the lookup terminates with absent (no HashStub on the path).
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    // A different address misses the single leaf — the trie is fully resolved,
+    // so the lookup terminates as absent rather than hitting a Digest.
+    EXPECT_EQ(db->read_account(ADDR_Y), std::nullopt);
+    EXPECT_EQ(db->read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
 }
 
 TEST(PartialTrieDb, ReadCode_PresentAndMissing)
@@ -385,39 +156,36 @@ TEST(PartialTrieDb, ReadCode_PresentAndMissing)
     bytes32_t const hash1 = to_bytes(keccak256(code1));
     bytes32_t const hash2 = to_bytes(keccak256(code2));
 
-    byte_string const encoded_codes =
-        rlp::encode_string2(byte_string_view{code1.data(), code1.size()}) +
-        rlp::encode_string2(byte_string_view{code2.data(), code2.size()});
+    CodeIndex codes;
+    codes.emplace(hash1, vm::make_shared_intercode(code1));
+    codes.emplace(hash2, vm::make_shared_intercode(code2));
+    TestDb db{empty_blob(), std::move(codes)};
 
-    auto result = PartialTrieDb::from_witness(
-        NULL_ROOT,
-        {},
-        byte_string_view{encoded_codes.data(), encoded_codes.size()});
-    ASSERT_FALSE(result.has_error());
-    auto db = std::move(result.value());
-
-    auto const ic1 = db.read_code(hash1);
+    auto const ic1 = db->read_code(hash1);
     EXPECT_EQ(
         byte_string_view(ic1->code(), ic1->size()), byte_string_view{code1});
 
-    auto const ic2 = db.read_code(hash2);
+    auto const ic2 = db->read_code(hash2);
     EXPECT_EQ(
         byte_string_view(ic2->code(), ic2->size()), byte_string_view{code2});
 
     // Missing hash returns an empty intercode rather than asserting.
     constexpr auto missing =
         0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface_bytes32;
-    auto const ic_missing = db.read_code(missing);
+    auto const ic_missing = db->read_code(missing);
     EXPECT_EQ(ic_missing->size(), 0u);
 }
 
 // ---------------------------------------------------------------------------
 // Commit tests
+//
+// commit builds the post-state in the overlay; state_root() is the observable
+// result, since reads stay on the pre-state blob.
 // ---------------------------------------------------------------------------
 
 TEST(PartialTrieDb, Commit_InsertSingleAccount)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1'000, .nonce = 3};
 
     commit_with(
@@ -425,57 +193,44 @@ TEST(PartialTrieDb, Commit_InsertSingleAccount)
         BlockHeader{.number = 1},
         StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_NE(db.state_root(), NULL_ROOT);
-    EXPECT_EQ(db.get_block_number(), 1u);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
+    EXPECT_EQ(db->get_block_number(), 1u);
 }
 
 TEST(PartialTrieDb, Commit_UpdateExistingAccount)
 {
-    auto db = make_empty_db();
     Account const acct1{.balance = 100, .nonce = 1};
     Account const acct2{.balance = 200, .nonce = 2};
 
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct1}}}});
-    bytes32_t const root_after_insert = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct1)};
+    bytes32_t const root_before = db->state_root();
 
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct1, acct2}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct2);
-    EXPECT_NE(db.state_root(), root_after_insert);
-    EXPECT_NE(db.state_root(), NULL_ROOT);
+    EXPECT_NE(db->state_root(), root_before);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct2));
 }
 
 TEST(PartialTrieDb, Commit_DeleteAccount_LeavesEmptyTrie)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 999, .nonce = 5};
-
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    ASSERT_NE(db.state_root(), NULL_ROOT);
+    TestDb db{account_blob(ADDR_X, acct)};
+    ASSERT_NE(db->state_root(), NULL_ROOT);
 
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.state_root(), NULL_ROOT);
+    EXPECT_EQ(db->state_root(), NULL_ROOT);
 }
 
 TEST(PartialTrieDb, Commit_TwoAccountsThenDeleteOne_BranchCompresses)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct_x{.balance = 1, .nonce = 1};
     Account const acct_y{.balance = 2, .nonce = 2};
 
@@ -485,37 +240,23 @@ TEST(PartialTrieDb, Commit_TwoAccountsThenDeleteOne_BranchCompresses)
         StateDeltas{
             {ADDR_X, StateDelta{.account = {std::nullopt, acct_x}}},
             {ADDR_Y, StateDelta{.account = {std::nullopt, acct_y}}}});
+    ASSERT_NE(db->state_root(), NULL_ROOT);
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct_x);
-    EXPECT_EQ(db.read_account(ADDR_Y), acct_y);
-    ASSERT_NE(db.state_root(), NULL_ROOT);
-
-    // Build a fresh single-leaf trie containing only ADDR_Y → acct_y. After
-    // deleting ADDR_X from `db`, branch compression must produce the same trie
-    // (and therefore the same state_root).
-    auto only_y_result = db_from_account(ADDR_Y, acct_y);
-    ASSERT_FALSE(only_y_result.has_error());
-    bytes32_t const root_only_y = only_y_result.value().state_root();
-
+    // Deleting ADDR_X must collapse the branch back to a single leaf, i.e. to
+    // the same trie a witness holding only ADDR_Y would produce.
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_X, StateDelta{.account = {acct_x, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), std::nullopt);
-    EXPECT_EQ(db.read_account(ADDR_Y), acct_y);
-    EXPECT_EQ(db.state_root(), root_only_y);
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_Y, acct_y));
 }
 
 TEST(PartialTrieDb, Commit_TouchOnlyIsNoOp)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 7, .nonce = 1};
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    bytes32_t const root_before = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct)};
+    bytes32_t const root_before = db->state_root();
 
     // {nullopt, nullopt} hits neither the upsert nor the deletion pass — a
     // pure no-op, even for entries that name a present account.
@@ -526,39 +267,32 @@ TEST(PartialTrieDb, Commit_TouchOnlyIsNoOp)
             {ADDR_X, StateDelta{.account = {std::nullopt, std::nullopt}}},
             {ADDR_Y, StateDelta{.account = {std::nullopt, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.state_root(), root_before);
+    EXPECT_EQ(db->state_root(), root_before);
 }
 
 TEST(PartialTrieDb, Commit_DeleteAbsentAccountIsNoOp)
 {
-    auto db = make_empty_db();
     Account const acct{.balance = 7, .nonce = 1};
-    commit_with(
-        db,
-        BlockHeader{.number = 1},
-        StateDeltas{{ADDR_X, StateDelta{.account = {std::nullopt, acct}}}});
-    bytes32_t const root_before = db.state_root();
+    TestDb db{account_blob(ADDR_X, acct)};
+    bytes32_t const root_before = db->state_root();
 
-    // ADDR_Y is not in the trie. The pass-2 branch runs trie_delete which
-    // returns false for missing keys; state must be unchanged.
+    // ADDR_Y is not in the trie, so the deletion pass finds nothing to erase
+    // and the root must be unchanged.
     Account const stale{.balance = 99};
     commit_with(
         db,
         BlockHeader{.number = 2},
         StateDeltas{{ADDR_Y, StateDelta{.account = {stale, std::nullopt}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_account(ADDR_Y), std::nullopt);
-    EXPECT_EQ(db.state_root(), root_before);
+    EXPECT_EQ(db->state_root(), root_before);
 }
 
 TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1, .nonce = 1};
 
-    // Insert account with two storage slots.
+    // Insert the account with two storage slots.
     commit_with(
         db,
         BlockHeader{.number = 1},
@@ -569,11 +303,10 @@ TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
                  .storage = {
                      {SLOT_1, {bytes32_t{}, VAL_1}},
                      {SLOT_2, {bytes32_t{}, VAL_2}}}}}});
+    bytes32_t const root_two_slots = db->state_root();
+    EXPECT_NE(root_two_slots, single_account_root(ADDR_X, acct));
 
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), VAL_1);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_2), VAL_2);
-
-    // Update SLOT_1, delete SLOT_2 in a second commit.
+    // Update SLOT_1 and delete SLOT_2 in a second commit.
     commit_with(
         db,
         BlockHeader{.number = 2},
@@ -584,23 +317,29 @@ TEST(PartialTrieDb, Commit_StorageInsertReadDelete)
                  .storage = {
                      {SLOT_1, {VAL_1, VAL_2}},
                      {SLOT_2, {VAL_2, bytes32_t{}}}}}}});
+    EXPECT_NE(db->state_root(), root_two_slots);
 
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), VAL_2);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_2), bytes32_t{});
-
-    // Slot that was never set returns zero (account exists, slot absent).
-    constexpr auto SLOT_3 =
-        0x0000000000000000000000000000000000000000000000000000000000000003_bytes32;
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_3), bytes32_t{});
+    // Deleting the surviving slot too must return the account to an empty
+    // storage trie, i.e. the storage_root it had before any slot was set.
+    commit_with(
+        db,
+        BlockHeader{.number = 3},
+        StateDeltas{
+            {ADDR_X,
+             StateDelta{
+                 .account = {acct, acct},
+                 .storage = {{SLOT_1, {VAL_2, bytes32_t{}}}}}}});
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
 }
 
 TEST(PartialTrieDb, Commit_StorageZeroToZeroIsNoOp)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
     Account const acct{.balance = 1, .nonce = 1};
 
     // {0, 0} storage delta hits neither the upsert pass (sdelta.second is
-    // zero) nor the delete pass (sdelta.first is zero) — pure no-op.
+    // zero) nor the delete pass (sdelta.first is zero) — pure no-op, so the
+    // account lands with an empty storage trie.
     commit_with(
         db,
         BlockHeader{.number = 1},
@@ -610,13 +349,12 @@ TEST(PartialTrieDb, Commit_StorageZeroToZeroIsNoOp)
                  .account = {std::nullopt, acct},
                  .storage = {{SLOT_1, {bytes32_t{}, bytes32_t{}}}}}}});
 
-    EXPECT_EQ(db.read_account(ADDR_X), acct);
-    EXPECT_EQ(db.read_storage(ADDR_X, Incarnation{0, 0}, SLOT_1), bytes32_t{});
+    EXPECT_EQ(db->state_root(), single_account_root(ADDR_X, acct));
 }
 
 TEST(PartialTrieDb, Commit_PopulatesHeaderRoots)
 {
-    auto db = make_empty_db();
+    TestDb db{empty_blob()};
 
     constexpr auto receipts =
         0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bytes32;
@@ -632,44 +370,41 @@ TEST(PartialTrieDb, Commit_PopulatesHeaderRoots)
             h.withdrawals_root = withdrawals;
         });
 
-    EXPECT_EQ(db.receipts_root(), receipts);
-    EXPECT_EQ(db.transactions_root(), txns);
-    ASSERT_TRUE(db.withdrawals_root().has_value());
-    EXPECT_EQ(*db.withdrawals_root(), withdrawals);
+    EXPECT_EQ(db->receipts_root(), receipts);
+    EXPECT_EQ(db->transactions_root(), txns);
+    ASSERT_TRUE(db->withdrawals_root().has_value());
+    EXPECT_EQ(*db->withdrawals_root(), withdrawals);
 
     // commit_simple-style consumers expect the populated header to be readable
     // back through read_eth_header.
-    auto const stored = db.read_eth_header();
+    auto const stored = db->read_eth_header();
     EXPECT_EQ(stored.number, 42u);
     EXPECT_EQ(stored.receipts_root, receipts);
     EXPECT_EQ(stored.transactions_root, txns);
     ASSERT_TRUE(stored.withdrawals_root.has_value());
     EXPECT_EQ(*stored.withdrawals_root, withdrawals);
 
-    EXPECT_EQ(db.get_block_number(), 42u);
+    EXPECT_EQ(db->get_block_number(), 42u);
 }
 
 TEST(PartialTrieDb, SetBlockAndPrefix_UpdatesBlockNumber)
 {
-    auto db = make_empty_db();
-    EXPECT_EQ(db.get_block_number(), 0u);
-    db.set_block_and_prefix(99);
-    EXPECT_EQ(db.get_block_number(), 99u);
+    TestDb db{empty_blob()};
+    EXPECT_EQ(db->get_block_number(), 0u);
+    db->set_block_and_prefix(99, bytes32_t{});
+    EXPECT_EQ(db->get_block_number(), 99u);
 }
 
 TEST(PartialTrieDb, Commit_StateRootMatchesIndependentlyEncodedTrie)
 {
-    // Round-trip check: committing one account into an empty trie should yield
-    // the same state_root as building a single-leaf trie directly from a
-    // synthetic witness.
-    auto live = make_empty_db();
+    // Round-trip check: committing one account into an empty trie yields the
+    // same state_root as opening a single-leaf blob directly.
+    TestDb live{empty_blob()};
     Account const acct{.balance = 0xdeadbeef, .nonce = 12};
     commit_with(
         live,
         BlockHeader{.number = 1},
         StateDeltas{{ADDR_Z, StateDelta{.account = {std::nullopt, acct}}}});
 
-    auto reference_result = db_from_account(ADDR_Z, acct);
-    ASSERT_FALSE(reference_result.has_error());
-    EXPECT_EQ(live.state_root(), reference_result.value().state_root());
+    EXPECT_EQ(live->state_root(), single_account_root(ADDR_Z, acct));
 }

--- a/category/execution/ethereum/db/test/test_partial_trie_db.cpp
+++ b/category/execution/ethereum/db/test/test_partial_trie_db.cpp
@@ -24,13 +24,11 @@
 #include <category/execution/ethereum/db/partial_trie_db.hpp>
 #include <category/execution/ethereum/rlp/decode.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
-#include <category/execution/ethereum/rlp/execution_witness.hpp>
 #include <category/mpt/merkle/compact_encode.hpp>
 #include <category/mpt/nibbles_view.hpp>
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <random>
@@ -40,11 +38,6 @@ using namespace monad;
 
 namespace
 {
-    byte_string make_minimal_witness()
-    {
-        return encode_execution_witness({}, {}, {}, {});
-    }
-
     void storage_leaf_roundtrip(
         bytes32_t const &val, NodeIndex &nodes, std::string_view label = {})
     {
@@ -125,105 +118,6 @@ namespace
     constexpr auto VAL_2 =
         0x000000000000000000000000000000000000000000000000000000000000beef_bytes32;
 } // namespace
-
-TEST(ParseExecutionWitness, ValidMinimalWitness)
-{
-    auto const w = make_minimal_witness();
-    auto const result = parse_execution_witness(w);
-    ASSERT_FALSE(result.has_error());
-    EXPECT_TRUE(result.value().block_rlp.empty());
-    EXPECT_TRUE(result.value().encoded_nodes.empty());
-    EXPECT_TRUE(result.value().encoded_codes.empty());
-    EXPECT_TRUE(result.value().encoded_headers.empty());
-    EXPECT_TRUE(result.value().encoded_parent_senders_and_authorities.empty());
-    EXPECT_TRUE(
-        result.value().encoded_grandparent_senders_and_authorities.empty());
-}
-
-TEST(ParseExecutionWitness, EmptyInput)
-{
-    auto const result = parse_execution_witness({});
-    EXPECT_TRUE(result.has_error());
-}
-
-TEST(ParseExecutionWitness, OuterTypeNotList)
-{
-    // A single empty-string byte (0x80) is not a list.
-    byte_string const bad{static_cast<unsigned char>(0x80)};
-    auto const result = parse_execution_witness(bad);
-    EXPECT_TRUE(result.has_error());
-}
-
-TEST(ParseExecutionWitness, Truncated)
-{
-    auto w = make_minimal_witness();
-    w.resize(w.size() - 1);
-    auto const result = parse_execution_witness(w);
-    EXPECT_TRUE(result.has_error());
-}
-
-TEST(EncodeExecutionWitness, AllFieldsRoundtrip)
-{
-    // block_rlp is wrapped by the encoder as an RLP string; the parser hands
-    // back the unwrapped payload.
-    byte_string const block_rlp{0x01, 0x02, 0x03, 0x04};
-
-    // Nodes are already complete RLP items and are emitted raw, so the parsed
-    // [1] payload is their straight concatenation.
-    std::vector<byte_string> const nodes{
-        rlp::encode_list2(rlp::encode_string2(byte_string{0xaa})),
-        rlp::encode_string2(byte_string{0xbb, 0xcc})};
-
-    // Codes and headers are each wrapped as RLP strings by the encoder.
-    std::vector<byte_string> const codes{
-        byte_string{0x60, 0x00, 0x60, 0x00}, byte_string{0x00}};
-    std::vector<byte_string> const headers{
-        byte_string{0xde, 0xad}, byte_string{0xbe, 0xef, 0xfe}};
-
-    ankerl::unordered_dense::segmented_set<Address> parents;
-    parents.insert(ADDR_X);
-    parents.insert(ADDR_Y);
-    ankerl::unordered_dense::segmented_set<Address> grandparents;
-    grandparents.insert(ADDR_Z);
-
-    byte_string const encoded = encode_execution_witness(
-        block_rlp, nodes, codes, headers, &parents, &grandparents);
-
-    auto const result = parse_execution_witness(encoded);
-    ASSERT_FALSE(result.has_error());
-    auto const &w = result.value();
-
-    EXPECT_EQ(w.block_rlp, byte_string_view{block_rlp});
-
-    // [1] nodes: raw concatenation.
-    EXPECT_EQ(w.encoded_nodes, byte_string_view{nodes[0] + nodes[1]});
-
-    // [2] codes / [3] headers: each entry wrapped as an RLP string.
-    EXPECT_EQ(
-        w.encoded_codes,
-        byte_string_view{
-            rlp::encode_string2(codes[0]) + rlp::encode_string2(codes[1])});
-    EXPECT_EQ(
-        w.encoded_headers,
-        byte_string_view{
-            rlp::encode_string2(headers[0]) + rlp::encode_string2(headers[1])});
-
-    // [4]/[5] addresses: emitted in sorted order, each wrapped as an RLP
-    // string.
-    std::vector<Address> sorted_parents{ADDR_X, ADDR_Y};
-    std::sort(sorted_parents.begin(), sorted_parents.end());
-    byte_string expected_parents;
-    for (auto const &a : sorted_parents) {
-        expected_parents += rlp::encode_string2(to_byte_string_view(a.bytes));
-    }
-    EXPECT_EQ(
-        w.encoded_parent_senders_and_authorities,
-        byte_string_view{expected_parents});
-    EXPECT_EQ(
-        w.encoded_grandparent_senders_and_authorities,
-        byte_string_view{
-            rlp::encode_string2(to_byte_string_view(ADDR_Z.bytes))});
-}
 
 TEST(StorageLeafValue, DecodeZeroValue)
 {

--- a/category/execution/ethereum/rlp/execution_witness.cpp
+++ b/category/execution/ethereum/rlp/execution_witness.cpp
@@ -59,7 +59,7 @@ Result<ExecutionWitness> parse_execution_witness(byte_string_view witness_bytes)
 }
 
 byte_string encode_execution_witness(
-    byte_string_view const block_rlp, std::span<byte_string const> const nodes,
+    byte_string_view const block_rlp, byte_string_view const nodes,
     std::span<byte_string const> const codes,
     std::span<byte_string const> const headers,
     ankerl::unordered_dense::segmented_set<Address> const
@@ -72,10 +72,7 @@ byte_string encode_execution_witness(
     constexpr size_t addr_string_size = 1 + sizeof(Address);
 
     // Pre-calc: payload size of every nested list, then total output size.
-    size_t nodes_payload = 0;
-    for (auto const &n : nodes) {
-        nodes_payload += n.size();
-    }
+    size_t const nodes_payload = nodes.size();
     size_t codes_payload = 0;
     for (auto const &c : codes) {
         codes_payload += rlp::string_length(c);
@@ -111,11 +108,11 @@ byte_string encode_execution_witness(
     // [0] block_rlp wrapped as RLP string
     d = rlp::encode_string(d, block_rlp);
 
-    // [1] nodes — each entry is itself a complete RLP list, concatenated raw
+    // [1] nodes — the offset-format blob emitted raw inside a list envelope
     d = rlp::encode_list_prefix(d, nodes_payload);
-    for (auto const &n : nodes) {
-        std::memcpy(d.data(), n.data(), n.size());
-        d = d.subspan(n.size());
+    if (!nodes.empty()) {
+        std::memcpy(d.data(), nodes.data(), nodes.size());
+        d = d.subspan(nodes.size());
     }
 
     // [2] codes — each raw bytecode wrapped as RLP string

--- a/category/execution/ethereum/rlp/execution_witness.hpp
+++ b/category/execution/ethereum/rlp/execution_witness.hpp
@@ -34,7 +34,8 @@ MONAD_NAMESPACE_BEGIN
 ///
 /// Wire format (6-field RLP list):
 ///   [0] block_rlp                     RLP-encoded block
-///   [1] [node...]                     RLP list of MPT node preimages
+///   [1] nodes                         offset-format node blob (see
+///                                     offset_trie.hpp) in a list envelope
 ///   [2] [code...]                     RLP list of contract bytecodes
 ///   [3] [header...]                   RLP list of ancestor block headers
 ///   [4] [address...]                  Parent sender+authority set
@@ -56,7 +57,7 @@ Result<ExecutionWitness>
 parse_execution_witness(byte_string_view witness_bytes);
 
 byte_string encode_execution_witness(
-    byte_string_view block_rlp, std::span<byte_string const> nodes,
+    byte_string_view block_rlp, byte_string_view nodes,
     std::span<byte_string const> codes, std::span<byte_string const> headers,
     ankerl::unordered_dense::segmented_set<Address> const
         *const parent_senders_and_authorities = nullptr,

--- a/category/execution/ethereum/rlp/test/test_execution_witness.cpp
+++ b/category/execution/ethereum/rlp/test/test_execution_witness.cpp
@@ -1,0 +1,139 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/address.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/execution/ethereum/rlp/encode2.hpp>
+#include <category/execution/ethereum/rlp/execution_witness.hpp>
+
+#include <ankerl/unordered_dense.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+using namespace monad;
+
+namespace
+{
+    byte_string make_minimal_witness()
+    {
+        return encode_execution_witness({}, {}, {}, {});
+    }
+
+    constexpr auto ADDR_X = 0x00000000000000000000000000000000deadbeef_address;
+    constexpr auto ADDR_Y = 0x000000000000000000000000000000000baddcaf_address;
+    constexpr auto ADDR_Z = 0xcafef00dcafef00dcafef00dcafef00dcafef00d_address;
+}
+
+TEST(ParseExecutionWitness, ValidMinimalWitness)
+{
+    auto const w = make_minimal_witness();
+    auto const result = parse_execution_witness(w);
+    ASSERT_FALSE(result.has_error());
+    EXPECT_TRUE(result.value().block_rlp.empty());
+    EXPECT_TRUE(result.value().encoded_nodes.empty());
+    EXPECT_TRUE(result.value().encoded_codes.empty());
+    EXPECT_TRUE(result.value().encoded_headers.empty());
+    EXPECT_TRUE(result.value().encoded_parent_senders_and_authorities.empty());
+    EXPECT_TRUE(
+        result.value().encoded_grandparent_senders_and_authorities.empty());
+}
+
+TEST(ParseExecutionWitness, EmptyInput)
+{
+    auto const result = parse_execution_witness({});
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(ParseExecutionWitness, OuterTypeNotList)
+{
+    // A single empty-string byte (0x80) is not a list.
+    byte_string const bad{static_cast<unsigned char>(0x80)};
+    auto const result = parse_execution_witness(bad);
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(ParseExecutionWitness, Truncated)
+{
+    auto w = make_minimal_witness();
+    w.resize(w.size() - 1);
+    auto const result = parse_execution_witness(w);
+    EXPECT_TRUE(result.has_error());
+}
+
+TEST(EncodeExecutionWitness, AllFieldsRoundtrip)
+{
+    // block_rlp is wrapped by the encoder as an RLP string; the parser hands
+    // back the unwrapped payload.
+    byte_string const block_rlp{0x01, 0x02, 0x03, 0x04};
+
+    // Nodes are already complete RLP items and are emitted raw, so the parsed
+    // [1] payload is their straight concatenation.
+    std::vector<byte_string> const nodes{
+        rlp::encode_list2(rlp::encode_string2(byte_string{0xaa})),
+        rlp::encode_string2(byte_string{0xbb, 0xcc})};
+
+    // Codes and headers are each wrapped as RLP strings by the encoder.
+    std::vector<byte_string> const codes{
+        byte_string{0x60, 0x00, 0x60, 0x00}, byte_string{0x00}};
+    std::vector<byte_string> const headers{
+        byte_string{0xde, 0xad}, byte_string{0xbe, 0xef, 0xfe}};
+
+    ankerl::unordered_dense::segmented_set<Address> parents;
+    parents.insert(ADDR_X);
+    parents.insert(ADDR_Y);
+    ankerl::unordered_dense::segmented_set<Address> grandparents;
+    grandparents.insert(ADDR_Z);
+
+    byte_string const encoded = encode_execution_witness(
+        block_rlp, nodes, codes, headers, &parents, &grandparents);
+
+    auto const result = parse_execution_witness(encoded);
+    ASSERT_FALSE(result.has_error());
+    auto const &w = result.value();
+
+    EXPECT_EQ(w.block_rlp, byte_string_view{block_rlp});
+
+    // [1] nodes: raw concatenation.
+    EXPECT_EQ(w.encoded_nodes, byte_string_view{nodes[0] + nodes[1]});
+
+    // [2] codes / [3] headers: each entry wrapped as an RLP string.
+    EXPECT_EQ(
+        w.encoded_codes,
+        byte_string_view{
+            rlp::encode_string2(codes[0]) + rlp::encode_string2(codes[1])});
+    EXPECT_EQ(
+        w.encoded_headers,
+        byte_string_view{
+            rlp::encode_string2(headers[0]) + rlp::encode_string2(headers[1])});
+
+    // [4]/[5] addresses: emitted in sorted order, each wrapped as an RLP
+    // string.
+    std::vector<Address> sorted_parents{ADDR_X, ADDR_Y};
+    std::sort(sorted_parents.begin(), sorted_parents.end());
+    byte_string expected_parents;
+    for (auto const &a : sorted_parents) {
+        expected_parents += rlp::encode_string2(to_byte_string_view(a.bytes));
+    }
+    EXPECT_EQ(
+        w.encoded_parent_senders_and_authorities,
+        byte_string_view{expected_parents});
+    EXPECT_EQ(
+        w.encoded_grandparent_senders_and_authorities,
+        byte_string_view{
+            rlp::encode_string2(to_byte_string_view(ADDR_Z.bytes))});
+}

--- a/category/execution/ethereum/rlp/test/test_execution_witness.cpp
+++ b/category/execution/ethereum/rlp/test/test_execution_witness.cpp
@@ -81,11 +81,9 @@ TEST(EncodeExecutionWitness, AllFieldsRoundtrip)
     // back the unwrapped payload.
     byte_string const block_rlp{0x01, 0x02, 0x03, 0x04};
 
-    // Nodes are already complete RLP items and are emitted raw, so the parsed
-    // [1] payload is their straight concatenation.
-    std::vector<byte_string> const nodes{
-        rlp::encode_list2(rlp::encode_string2(byte_string{0xaa})),
-        rlp::encode_string2(byte_string{0xbb, 0xcc})};
+    // The node blob is opaque to the encoder and emitted raw, so the parsed
+    // [1] payload is exactly the input bytes.
+    byte_string const nodes{0xaa, 0xbb, 0xcc, 0xdd, 0xee};
 
     // Codes and headers are each wrapped as RLP strings by the encoder.
     std::vector<byte_string> const codes{
@@ -108,8 +106,8 @@ TEST(EncodeExecutionWitness, AllFieldsRoundtrip)
 
     EXPECT_EQ(w.block_rlp, byte_string_view{block_rlp});
 
-    // [1] nodes: raw concatenation.
-    EXPECT_EQ(w.encoded_nodes, byte_string_view{nodes[0] + nodes[1]});
+    // [1] nodes: the blob emitted raw.
+    EXPECT_EQ(w.encoded_nodes, byte_string_view{nodes});
 
     // [2] codes / [3] headers: each entry wrapped as an RLP string.
     EXPECT_EQ(

--- a/category/mpt/merkle/compact_encode.hpp
+++ b/category/mpt/merkle/compact_encode.hpp
@@ -37,7 +37,7 @@ compact_encode_len(unsigned const si, unsigned const ei)
 
 // Transform the nibbles to its compact encoding
 // https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/
-[[nodiscard]] constexpr byte_string_view compact_encode(
+constexpr void compact_encode_raw(
     unsigned char *const res, NibblesView const nibbles, bool const terminating)
 {
     unsigned i = 0;
@@ -57,7 +57,12 @@ compact_encode_len(unsigned const si, unsigned const ei)
         set_nibble(res, res_ci, nibbles.get(i));
         ++res_ci;
     }
+}
 
+[[nodiscard]] constexpr byte_string_view compact_encode(
+    unsigned char *const res, NibblesView const nibbles, bool const terminating)
+{
+    compact_encode_raw(res, nibbles, terminating);
     return byte_string_view{
         res, nibbles.nibble_size() ? (nibbles.nibble_size() / 2 + 1) : 1u};
 }


### PR DESCRIPTION
**Goal:** replace the flat, hash-keyed RLP node list in the witness with a **pre-resolved, offset-linked 
node graph** the ZK guest reads **in place** — no in-guest hash indexing, no per-node RLP decode, 
no per-node allocation, except for writes on commit, which use a copy on write hash map overlay. When
calculating the state root and walking the trie, we check the overlay first.

The nodes are indexed via a `uint32_t` `NodeId` offset. The `NodeId` space is partitioned by the high bit: 
blob offsets live below it, fresh overlay ids at/above it. Real witnesses are ~MBs, far under 2 GiB imposed by
the partition.

## Conventions

- **Little-endian** for all *structural* integers (offsets, lengths, counts, tags).
- **Offsets** are **absolute, from byte 0 of the node region**, stored as
  `uint_32t`. Witnesses are ~10 MB, so `uint_32t` (4 GiB) is ample. `0` = **null / empty** (byte 0
  is `magic`, never a node, so `0` is a safe sentinel).
- **Account values** (`nonce`, `balance`) are stored **big-endian, full width** so the RLP
  encoder (`encode_to`) can `zeroless_view` them directly — no `bswap`. Slot values
  likewise. **Hashes** (`code_hash`, digest) are raw 32-byte arrays.
- **Paths** (nibbles) are packed 2/byte, **first nibble in the high 4 bits** — the
  `get_nibble`/`set_nibble` convention (`category/core/nibble.h`: nibble `n` is the high
  half of byte `n/2` when `n` is even). The guest builds a zero-copy view straight over the
  buffer with `mpt::NibblesView{/*begin=*/0, /*end=*/path_nlen, path_ptr}`
- **Statically sized fields come first**. Fields such as `child`/`value`/`storage` are fixed size
  and therefore come first, as decoding them does not require reading the value under the pointer

## Header (node region, bytes `[0, 8)`)

```
off  size  field        meaning
0    4     magic        'M','Z','W', 0x01   (0x01 = format version)
4    4     root_off     u32  offset of the ACCOUNT-TRIE root node (0 = empty trie)
```
---

## Node encodings

Every node begins with a 1-byte `tag`. Nodes are **tightly packed** (no padding /
alignment). There are six tags:

### Empty — `tag = 'M'`

pointer at the header, which starts with an 'M'. This keeps the invariant that a `NULL_ID` 
points to a "null"/empty node, so we can have a total `get_current` function and pattern 
match on the result, where a possible option is a null/empty value.

### Branch — `tag = 0x00`
```
u8      tag = 0x00
u32[16] children_offs        16 child offsets; 0 = absent slot
```
Branches carry **no value** — valid for the account and storage
tries (fixed 64-nibble hashed keys never terminate at a branch).

### Extension — `tag = 0x01`
```
u8    tag = 0x01
u32   child_off         child node offset (MUST be non-null)
u8    path_len         
...   path              ceil(path_len/2) bytes
```

### Leaf, account value — `tag = 0x02`
```
u8    tag = 0x02
u32   storage_off       storage-trie root id; 0 = no storage subtree present
b264  code_hash_rlp
u8    acct_rlp_len      length of the account-RLP blob
...   acct_rlp          rlp(nonce) || rlp(balance)
u8    path_len
...   path              ceil(path_len/2) bytes

```

The account code hash, nonce and balance are RLP encoded, Since the code hash is always a fixed 33B
RLP string, it is stored before the variable length nonce and balance. These are prepended with a single byte indicating their length.

### Leaf, storage value — `tag = 0x03`
```
u8    tag = 0x03
u256  value             big-endian (32 bytes, the slot value)
u8    path_len
...   path              ceil(path_len/2) bytes
```

### Digest (unresolved subtree) — `tag = 0xa0`
```
u8    tag = 0xa0
b256  hash              32 raw bytes — keccak of the omitted subtree's RLP
```

We use the tag `0xa0` because it is the RLP string length encoding for the hash `0x80 + 32 (KECCAK256_SIZE)`, hence digest is a valid RLP string we can memcpy when comping the state root hash without re-encoding.