### PR TITLE
Accept page-encoded primary in MIP-8 migration assertion

### DIFF
--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -471,19 +471,23 @@ try {
             }
             else {
                 // TODO: Remove this check once dual-db is deprecated.
-                // Live monad must be dual db mode: slot-encoded primary +
-                // page-encoded secondary.
+                // Live monad requires a page-encoded timeline, either as
+                // primary (Phase C) or secondary (Phase A/B dual-db).
                 // TODO: Enable assertion for mainnet when dual-db is enabled
                 if (chain_config == CHAIN_CONFIG_MONAD_TESTNET) {
+                    bool const primary_is_page = db.is_page_encoded();
+                    bool const secondary_active = raw_db.timeline_active(
+                        monad::mpt::timeline_id::secondary);
                     MONAD_ASSERT_PRINTF(
-                        raw_db.timeline_active(
-                            monad::mpt::timeline_id::secondary),
-                        "live monad requires a page-encoded secondary during "
-                        "the migration release, but secondary timeline is not "
-                        "active on %s",
+                        primary_is_page || secondary_active,
+                        "live monad requires a page-encoded timeline "
+                        "(as primary or secondary) on %s; "
+                        "primary_is_page=%d secondary_active=%d",
                         chain_config == CHAIN_CONFIG_MONAD_TESTNET
                             ? "monad_testnet"
-                            : "monad_mainnet"); // TODO: remove at release2
+                            : "monad_mainnet", // TODO: remove at release2
+                        primary_is_page,
+                        secondary_active);
                 }
 
                 std::optional<mpt::Db> secondary_db;


### PR DESCRIPTION
## Summary

- Broaden the testnet dual-db assertion to accept a page-encoded primary timeline (Phase C) in addition to a page-encoded secondary (Phase A/B)
- Without this, nodes that have promoted page to primary after MIP-8 activation will fail to start
- Restore scripts correctly create page-only DBs after the hardfork, but the current assertion rejects them

## Context

MF flagged that after Phase C (promote page timeline to primary, deactivate legacy), the current assertion — which only checks for a secondary timeline — causes node startup failure. The fix checks if a page-encoded timeline exists as either primary or secondary.

## Test plan

- [ ] Build and verify node starts in dual-db mode (Phase A/B)
- [ ] Build and verify node starts in page-only mode (Phase C)
- [ ] Verify slot-only mode (no page timeline) still fails the assertion