### PR TITLE
Use Azure Ubuntu mirrors in CI docker builds

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -74,5 +74,7 @@ jobs:
           with:
             context: .
             file: docker/Dockerfile
+            build-args: |-
+              UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
             target: code_quality
             cache-from: type=gha,scope=base

--- a/.github/workflows/docker-base-riscv.yaml
+++ b/.github/workflows/docker-base-riscv.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           ulimit: "memlock=-1:-1"
           target: base_riscv_toolchain
           cache-from: |

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           ulimit: "memlock=-1:-1"
           target: base
           cache-to: type=gha,scope=base
@@ -38,6 +40,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           ulimit: "memlock=-1:-1"
           target: base_rust
           cache-from: type=gha,scope=base

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,6 +59,7 @@ jobs:
             CXX=${{ matrix.compiler.CXX }}
             CMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }}
             TOOLCHAIN=gcc-avx2
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           allow: security.insecure # for tests which use io_uring
           ulimit: "memlock=-1:-1"
           target: build_and_test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,7 @@ jobs:
           build-args: |-
             CC=gcc-15
             CXX=g++-15
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           target: build_and_test_rust
           cache-from: type=gha,scope=base_rust
 
@@ -53,6 +54,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           target: code_quality_rust
           cache-from: type=gha,scope=base_rust
 

--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -79,6 +79,7 @@ jobs:
                   CXX=${{ matrix.compiler.CXX }}
                   CMAKE_BUILD_TYPE=${{ matrix.build.CMAKE_BUILD_TYPE }}
                   TOOLCHAIN=${{ matrix.build.TOOLCHAIN }}
+                  UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
                 target: build_and_test_vm
                 cache-from: type=gha,scope=base
 
@@ -102,6 +103,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           target: vm_fuzz
           cache-from: type=gha,scope=base
 

--- a/.github/workflows/test-zk.yml
+++ b/.github/workflows/test-zk.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          build-args: |-
+            UBUNTU_MIRROR=http://azure.archive.ubuntu.com/ubuntu/
           target: build_zk
           cache-from: |
             type=gha,scope=riscv-toolchain

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,13 @@
 
 FROM ubuntu:26.04 AS base
 
+# Optional mirror to use instead of the default Ubuntu archive.
+ARG UBUNTU_MIRROR
+RUN if [ -n "${UBUNTU_MIRROR}" ]; then \
+        sed -Ei "s,http://(archive|security)\.ubuntu\.com/ubuntu/?,${UBUNTU_MIRROR},g" \
+            /etc/apt/sources.list.d/ubuntu.sources; \
+    fi
+
 COPY scripts/ubuntu-build/ /opt
 
 RUN apt-get update && \


### PR DESCRIPTION
Adds an `UBUNTU_MIRROR` build arg to `docker/Dockerfile` that rewrites the APT sources when set, and sets it to the Azure Ubuntu mirror in all CI workflows that build the image. GitHub-hosted runners run in Azure, so this avoids depending on `archive.ubuntu.com` from CI.