### PR TITLE
Pin CI base image by digest and rebuild weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker-base.yaml
+++ b/.github/workflows/docker-base.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docker/Dockerfile'
       - 'scripts/ubuntu-build/**'
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1-labs
 
-FROM ubuntu:26.04 AS base
+FROM ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03 AS base
 
 COPY scripts/ubuntu-build/ /opt
 


### PR DESCRIPTION
Pins `ubuntu:26.04` by digest so upstream tag pushes don't silently invalidate the shared build cache, adds a dependabot config to open a PR when a new image is published, and rebuilds the cached base image weekly so apt packages don't go stale between Dockerfile changes.