### PR TITLE
[rpc] Throw on missing requests hash

### DIFF
--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -315,7 +315,6 @@ Result<std::vector<Receipt>> execute_block(
                 system_call_state_tracer,
                 chain_ctx,
                 retvals));
-        MONAD_ASSERT(block.header.requests_hash.has_value());
         if (MONAD_UNLIKELY(
                 computed_requests_hash != block.header.requests_hash.value())) {
             return BlockError::InvalidRequestsHash;


### PR DESCRIPTION
Running `eth_simulateV1` in an EIP-7685 context can trigger an assertion failure wrt to requests hash, because `eth_simulateV1` does not populate the `requests_hash` field in the `BlockHeader`. However, an EIP-7685 context requires this field to be set. EIP-7685 is not enabled on Monad, so this assertion failure should not be possible to trigger on a live simulation path. The purpose of this patch is to future-proof.