### PR TITLE
mpt: reject --state-machine that conflicts with an existing pool's stamp

### DIFF
--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -425,6 +425,9 @@ struct impl_t
     bool repair_database = false;
     MONAD_MPT_NAMESPACE::state_machine_kind state_machine =
         MONAD_MPT_NAMESPACE::state_machine_kind::ethereum;
+    // Distinguishes an operator-supplied --state-machine from the ethereum
+    // default; the value alone cannot.
+    bool state_machine_explicit = false;
     std::optional<uint64_t> rewind_database_to;
     std::optional<uint64_t> reset_history_length;
     bool create_chunk_increasing = false;
@@ -1599,7 +1602,7 @@ opened.
                 "which "
                 "can be later restored with this tool (implies "
                 "--allow-dirty).");
-            cli.add_option(
+            auto *const restore_opt = cli.add_option(
                 "--restore",
                 impl.restore_database,
                 "destroy any existing database, replacing it with the archived "
@@ -1651,7 +1654,8 @@ opened.
                    "implementation via the registry. Defaults to 'ethereum'; "
                    "honored on --create, --create-empty, --truncate (stamps "
                    "the primary) and --activate-secondary (stamps the "
-                   "secondary); ignored on other subcommands.")
+                   "secondary); ignored on other subcommands. Rejected with "
+                   "--restore, which carries the kind in the archive.")
                 ->transform(CLI::CheckedTransformer(
                     std::map<
                         std::string,
@@ -1660,7 +1664,8 @@ opened.
                          MONAD_MPT_NAMESPACE::state_machine_kind::ethereum},
                         {"monad",
                          MONAD_MPT_NAMESPACE::state_machine_kind::monad}},
-                    CLI::ignore_case));
+                    CLI::ignore_case))
+                ->excludes(restore_opt);
             cli.add_option(
                 "--compression-level",
                 impl.compression_level,
@@ -1677,6 +1682,7 @@ opened.
                 std::vector<std::string> rargs(args.rbegin(), --args.rend());
                 cli.parse(std::move(rargs));
             }
+            impl.state_machine_explicit = cli.count("--state-machine") > 0;
 
             monad::start_logger_minimal();
 
@@ -1792,12 +1798,33 @@ opened.
 
         // Stamp the persisted StateMachine kind on freshly-created or
         // truncated pools. Existing pools keep whatever was previously
-        // stamped — passing --state-machine on an open here is a no-op.
+        // stamped, so an operator asking for a kind the pool does not already
+        // carry is refused rather than silently ignored.
         if (aux.metadata_ctx().is_new_pool()) {
             aux.metadata_ctx().set_state_machine_kind(
                 MONAD_MPT_NAMESPACE::timeline_id::primary, impl.state_machine);
             cout << "Stamped state-machine kind on primary timeline to "
                  << state_machine_kind_name(impl.state_machine) << ".\n";
+        }
+        // --activate-secondary stamps the secondary below, and --restore
+        // (which sets truncate_database) cannot carry an explicit kind at
+        // all; neither is a request to restamp the primary.
+        else if (
+            impl.state_machine_explicit &&
+            (impl.create_database || impl.create_empty_database ||
+             (impl.truncate_database && impl.restore_database.empty()))) {
+            auto const stamped = aux.metadata_ctx().get_state_machine_kind(
+                MONAD_MPT_NAMESPACE::timeline_id::primary);
+            if (stamped != impl.state_machine) {
+                cerr << "FATAL: cannot stamp state-machine kind '"
+                     << state_machine_kind_name(impl.state_machine)
+                     << "' on an existing database already stamped '"
+                     << state_machine_kind_name(stamped)
+                     << "'. Use --truncate --state-machine "
+                     << state_machine_kind_name(impl.state_machine)
+                     << " to discard its contents and restamp it.\n";
+                return 1;
+            }
         }
 
         // Secondary timeline lifecycle. These execute against the open

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -344,6 +344,116 @@ namespace
     }
 }
 
+// --create on an existing pool cannot restamp it: the kind is only applied
+// when the pool is newly created or truncated. An explicit --state-machine
+// that disagrees with the stamp is therefore an error, not a silent no-op.
+TEST(cli_tool, create_with_conflicting_state_machine_on_existing_pool_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--create",
+            "--state-machine",
+            "monad"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos, cerr.str().find("already stamped 'ethereum'"));
+    }
+
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::ethereum);
+}
+
+// Re-running a provisioning script must stay idempotent.
+TEST(cli_tool, create_with_matching_state_machine_on_existing_pool_accepted)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--create",
+            "--state-machine",
+            "ethereum"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--create",
+            "--state-machine",
+            "ethereum"};
+        EXPECT_EQ(0, main_impl(cout, cerr, args)) << cerr.str();
+    }
+
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::ethereum);
+}
+
+// --create with no --state-machine is create-if-needed-else-open; the
+// ethereum default must not be read as a request to restamp.
+TEST(cli_tool, create_without_state_machine_on_existing_pool_accepted)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--truncate",
+            "--state-machine",
+            "monad",
+            "--yes"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        EXPECT_EQ(0, main_impl(cout, cerr, args)) << cerr.str();
+    }
+
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::monad);
+}
+
 TEST(cli_tool, activate_secondary_stamps_secondary_kind)
 {
     char temppath[] = "cli_tool_test_XXXXXX";
@@ -382,6 +492,44 @@ TEST(cli_tool, activate_secondary_stamps_secondary_kind)
     EXPECT_EQ(
         read_kind(temppath, monad::mpt::timeline_id::secondary),
         monad::mpt::state_machine_kind::ethereum);
+}
+
+// The dual-timeline arrangement: slot primary, page secondary. Here
+// --state-machine targets the secondary, so it must not be read as a
+// conflicting request to restamp the ethereum primary.
+TEST(cli_tool, activate_secondary_with_kind_differing_from_primary_accepted)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view create_args[] = {
+            "monad-mpt", "--storage", temppath, "--create"};
+        ASSERT_EQ(0, main_impl(cout, cerr, create_args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--activate-secondary",
+            "--state-machine",
+            "monad"};
+        EXPECT_EQ(0, main_impl(cout, cerr, args)) << cerr.str();
+    }
+
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::ethereum);
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::secondary),
+        monad::mpt::state_machine_kind::monad);
 }
 
 TEST(cli_tool, activate_secondary_defaults_to_ethereum_when_flag_omitted)
@@ -916,6 +1064,50 @@ TEST_F(cli_tool_restore_preserves_kind, restore_preserves_state_machine_kind)
             return read_kind(dbpath2, monad::mpt::timeline_id::primary);
         }).get();
     EXPECT_EQ(restored_kind, synthetic_kind);
+}
+
+// The archive carries the kind, so an explicit --state-machine alongside
+// --restore can only be ignored. Rejecting the pair at parse time keeps the
+// target database intact; --restore would otherwise truncate it first.
+TEST(cli_tool, restore_with_state_machine_rejected)
+{
+    char temppath[] = "cli_tool_test_XXXXXX";
+    make_temp_pool(temppath);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(temppath); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--truncate",
+            "--state-machine",
+            "monad",
+            "--yes"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            temppath,
+            "--restore",
+            "no_such_archive",
+            "--state-machine",
+            "ethereum",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(std::string::npos, cerr.str().find("excludes"));
+    }
+
+    EXPECT_EQ(
+        read_kind(temppath, monad::mpt::timeline_id::primary),
+        monad::mpt::state_machine_kind::monad);
 }
 
 // Round-trips a Db whose secondary timeline is active and holds a key


### PR DESCRIPTION
The kind is only stamped when a pool is newly created or truncated, so monad-mpt --create --state-machine <kind> on an existing pool silently dropped the flag and exited 0. Operators provisioning page-encoded pools got slot-stamped ones instead, which surfaces much later as a wrong-encoding node rather than as a failure at provisioning time.

Refuse the operation when an explicitly passed --state-machine disagrees with the kind the pool already carries. Passing a matching kind, or omitting the flag, still succeeds, so idempotent provisioning re-runs are unaffected. Scoped to --create/--create-empty/--truncate: --restore takes its kind from the archive and --activate-secondary targets the secondary timeline, so neither is a request to restamp the primary.