### PR TITLE
statesync: send page-encoded storage leaves verbatim (protocol 1.3)

### DIFF
--- a/category/execution/ethereum/db/trie_db.hpp
+++ b/category/execution/ethereum/db/trie_db.hpp
@@ -102,6 +102,14 @@ public:
     virtual std::string print_stats() override;
     virtual uint64_t get_block_number() const override;
 
+    // Storage-trie leaf lookups resolved from disk, hits and misses both,
+    // accumulated since the last print_stats() reset it.
+    uint64_t storage_read_count() const
+    {
+        return n_storage_no_value_.load(std::memory_order_acquire) +
+               n_storage_value_.load(std::memory_order_acquire);
+    }
+
     nlohmann::json to_json(size_t concurrency_limit = 4096);
     uint64_t get_history_length() const;
 

--- a/category/execution/ethereum/db/util.cpp
+++ b/category/execution/ethereum/db/util.cpp
@@ -738,6 +738,12 @@ decode_storage_db_raw(byte_string_view &enc)
 {
     BOOST_OUTCOME_TRY(auto payload, rlp::parse_list_metadata(enc));
     BOOST_OUTCOME_TRY(byte_string_view const slot, rlp::decode_string(payload));
+    if (MONAD_UNLIKELY(slot.size() > sizeof(bytes32_t))) {
+        return rlp::DecodeError::InputTooLong;
+    }
+    // The value is left unbounded: it is a bytes32 on the slot-encoded path but
+    // a whole encoded page on the page-encoded one, so only the caller knows
+    // its bound.
     BOOST_OUTCOME_TRY(byte_string_view const val, rlp::decode_string(payload));
     return {slot, val};
 }
@@ -746,6 +752,9 @@ Result<std::pair<bytes32_t, bytes32_t>> decode_storage_db(byte_string_view &enc)
 {
     BOOST_OUTCOME_TRY(auto res, decode_storage_db_raw(enc));
     if (!enc.empty()) {
+        return rlp::DecodeError::InputTooLong;
+    }
+    if (MONAD_UNLIKELY(res.second.size() > sizeof(bytes32_t))) {
         return rlp::DecodeError::InputTooLong;
     }
     return {to_bytes(res.first), to_bytes(res.second)};

--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -91,6 +91,11 @@ bool monad_statesync_client_has_reached_target(
     return true;
 }
 
+// `version` is what the caller declares this client can decode, not the result
+// of a handshake: production passes monad_statesync_version(), this build's own
+// newest, so the page-record branch is the only one taken there. Peer version
+// negotiation lives in bft and gates what a *server* sends; it does not reach
+// here. Tests pass a lower value to exercise the older branch.
 void monad_statesync_client_handle_new_peer(
     monad_statesync_client_context *const ctx, uint64_t const prefix,
     uint32_t const version)
@@ -99,7 +104,12 @@ void monad_statesync_client_handle_new_peer(
     auto &ptr = ctx->protocol.at(prefix);
     // TODO: handle switching peers
     MONAD_ASSERT(!ptr);
-    ptr = std::make_unique<StatesyncProtocolV1_2>();
+    if (version >= MONAD_STATESYNC_VERSION_1_3) {
+        ptr = std::make_unique<StatesyncProtocolV1_3>(version);
+    }
+    else {
+        ptr = std::make_unique<StatesyncProtocolV1_2>(version);
+    }
 }
 
 void monad_statesync_client_handle_target(

--- a/category/statesync/statesync_client_context.cpp
+++ b/category/statesync/statesync_client_context.cpp
@@ -174,10 +174,12 @@ void monad_statesync_client_context::commit()
         return storage;
     };
 
-    // Build a page-encoded storage UpdateList for Db2. Slots are grouped by
-    // page_key and merged onto any existing page contents read from the
-    // secondary trie. A page that ends up empty becomes a delete on the
-    // page entry.
+    // Build a page-encoded storage UpdateList for paged_db (the primary
+    // trie when it is page-encoded, or the page-encoded secondary). Slots
+    // are grouped by page_key; a page starts from paged_db's existing
+    // contents and is merged into, unless the whole page arrived on the
+    // wire, in which case it is built from scratch. A page that ends up
+    // empty becomes a delete on the page entry.
     auto build_page_storage = [this](
                                   TrieDb &paged_db,
                                   Address const &addr,
@@ -187,23 +189,31 @@ void monad_statesync_client_context::commit()
                                   std::deque<monad_hash256> &hash_alloc) {
         UpdateList storage;
         // Per-account page granularity: keyed by page_key, value is the
-        // mutable storage_page_t being merged. Each first-touch of a page
-        // reads the current page from the secondary trie so subsequent slot
-        // writes at the same page_key compose into one update.
+        // mutable storage_page_t being composed. Each first-touch of a page
+        // establishes its starting point -- read-and-merge from paged_db,
+        // or empty when the page is covered -- so subsequent slot writes at
+        // the same page_key compose into one update.
         ankerl::unordered_dense::segmented_map<
             bytes32_t,
             storage_page_t,
             BytesHashCompare<bytes32_t>>
             pages;
+        auto const cov = covered_pages.find(addr);
+        auto const *const covered =
+            cov == covered_pages.end() ? nullptr : &cov->second;
         for (auto const &[slot_key, slot_val] : slot_deltas) {
             auto const pg_key = compute_page_key(slot_key);
             auto const slot_off = compute_slot_offset(slot_key);
             auto [it, inserted] = pages.try_emplace(pg_key);
             if (inserted) {
-                // Incarnation isn't tracked in statesync deltas; TrieDb
-                // ignores it for storage reads, so a fixed value is fine.
-                it->second =
-                    paged_db.read_storage_page(addr, Incarnation{0, 0}, pg_key);
+                // A covered page arrived complete, so there is nothing to
+                // merge into. Incarnation isn't tracked in statesync deltas;
+                // TrieDb ignores it for storage reads, so a fixed value is
+                // fine.
+                it->second = covered != nullptr && covered->contains(pg_key)
+                                 ? storage_page_t{}
+                                 : paged_db.read_storage_page(
+                                       addr, Incarnation{0, 0}, pg_key);
             }
             it->second.set(slot_off, slot_val);
         }
@@ -353,4 +363,6 @@ void monad_statesync_client_context::commit()
 
     code.clear();
     deltas.clear();
+    covered_pages.clear();
+    n_upserts = 0;
 }

--- a/category/statesync/statesync_client_context.hpp
+++ b/category/statesync/statesync_client_context.hpp
@@ -66,7 +66,15 @@ struct monad_statesync_client_context
     ankerl::unordered_dense::segmented_set<monad::bytes32_t> seen_code;
     Map<monad::bytes32_t, monad::byte_string> code;
     Map<monad::Address, std::optional<StateDelta>> deltas;
+    // pages whose complete contents arrived since the last commit
+    Map<monad::Address,
+        ankerl::unordered_dense::segmented_set<monad::bytes32_t>>
+        covered_pages;
+    // slot deltas applied since the last commit, not records seen: a page
+    // record counts once per slot it carried
     uint64_t n_upserts;
+    // slot deltas held between commits; must be non-zero
+    uint64_t upserts_per_commit{1 << 20};
     monad_statesync_client *sync;
     void (*statesync_send_request)(
         struct monad_statesync_client *, struct monad_sync_request);

--- a/category/statesync/statesync_messages.h
+++ b/category/statesync/statesync_messages.h
@@ -36,6 +36,9 @@ enum monad_sync_type : uint8_t
     SYNC_TYPE_UPSERT_ACCOUNT_DELETE = 6,
     SYNC_TYPE_UPSERT_STORAGE_DELETE = 7,
     SYNC_TYPE_UPSERT_HEADER = 8,
+    // One page-encoded storage leaf: the 20-byte address followed by the page
+    // leaf verbatim, exactly as the server holds it, page key included.
+    SYNC_TYPE_UPSERT_STORAGE_PAGE = 9,
 };
 
 static_assert(sizeof(enum monad_sync_type) == 1);
@@ -49,9 +52,16 @@ struct monad_sync_request
     uint64_t from;
     uint64_t until;
     uint64_t old_target;
+    // protocol version the requester speaks; the server serves the newest wire
+    // this permits. Authoritative only on requests arriving at a server, where
+    // bft sets it from the requesting peer's negotiated version. On a request
+    // the local client generates, bft substitutes its own version before the
+    // request reaches the network, so the value set here reaches only an
+    // in-process server.
+    uint32_t version;
 };
 
-static_assert(sizeof(struct monad_sync_request) == 48);
+static_assert(sizeof(struct monad_sync_request) == 56);
 static_assert(alignof(struct monad_sync_request) == 8);
 
 struct monad_sync_done

--- a/category/statesync/statesync_protocol.cpp
+++ b/category/statesync/statesync_protocol.cpp
@@ -16,13 +16,17 @@
 #include <category/core/assert.h>
 #include <category/core/bytes.hpp>
 #include <category/core/config.hpp>
+#include <category/core/log.hpp>
 #include <category/core/runtime/unaligned.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/rlp/bytes_rlp.hpp>
 #include <category/execution/ethereum/db/util.hpp>
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/statesync/statesync_client.h>
 #include <category/statesync/statesync_client_context.hpp>
 #include <category/statesync/statesync_protocol.hpp>
+
+#include <utility>
 
 using namespace monad;
 using namespace monad::mpt;
@@ -47,6 +51,12 @@ void account_update(
         if (hash != NULL_HASH) {
             ctx.seen_code.emplace(hash);
         }
+    }
+    else {
+        // Deleting the account voids its pending storage, in branches below
+        // that do not commit. Coverage granted against those slots must not
+        // outlive them, or a later partial page would be built from scratch.
+        ctx.covered_pages.erase(addr);
     }
 
     auto const it = ctx.deltas.find(addr);
@@ -77,10 +87,15 @@ void account_update(
             MONAD_ASSERT(ctx.deltas.emplace(addr, std::nullopt).second);
         }
     }
-    // incarnation
+    // The account was deleted earlier in this batch and is now recreated.
+    // Flush the deletion first so the new one starts from an empty subtrie;
+    // after the flush this batch holds nothing for the address.
     else if (acct.has_value() && !it->second.has_value()) {
         ctx.commit();
-        account_update(ctx, addr, acct);
+        MONAD_ASSERT(
+            ctx.deltas
+                .emplace(addr, std::make_pair(acct.value(), StorageDeltas{}))
+                .second);
     }
     else if (acct.has_value()) {
         std::get<Account>(it->second.value()) = acct.value();
@@ -126,10 +141,15 @@ void storage_update(
             if (it->second.has_value()) {
                 std::get<StorageDeltas>(it->second.value())[key] = val;
             }
-            // incarnation
+            // Storage for an account this batch has pending deletion. Flush
+            // the deletion first; the account is then gone from the trie, so
+            // the slot waits in `buffered` for the record that recreates it.
             else if (val != bytes32_t{}) {
                 ctx.commit();
-                storage_update(ctx, addr, key, val);
+                MONAD_ASSERT(!ctx.tdb.read_account(addr).has_value());
+                MONAD_ASSERT(
+                    ctx.buffered.emplace(addr, StorageDeltas{{key, val}})
+                        .second);
             }
         }
         else {
@@ -177,10 +197,11 @@ void StatesyncProtocolV1_2::send_request(
             .target = tgrt,
             .from = from,
             .until = from >= (tgrt * 99 / 100) ? tgrt : tgrt * 99 / 100,
-            .old_target = old_target});
+            .old_target = old_target,
+            .version = version_});
 }
 
-bool StatesyncProtocolV1_2::handle_upsert(
+bool StatesyncProtocolV1_2::apply_upsert(
     monad_statesync_client_context *const ctx, monad_sync_type const type,
     unsigned char const *const val, uint64_t const size) const
 {
@@ -228,7 +249,9 @@ bool StatesyncProtocolV1_2::handle_upsert(
         storage_update(*ctx, unaligned_load<Address>(val), res.value(), {});
     }
     else {
-        MONAD_ASSERT(type == SYNC_TYPE_UPSERT_HEADER);
+        if (type != SYNC_TYPE_UPSERT_HEADER) {
+            return false;
+        }
         auto const res = rlp::decode_block_header(raw);
         if (res.has_error() || !raw.empty()) {
             return false;
@@ -236,10 +259,68 @@ bool StatesyncProtocolV1_2::handle_upsert(
         ctx->hdrs[res.value().number % ctx->hdrs.size()] = res.value();
     }
 
-    if ((++ctx->n_upserts % (1 << 20)) == 0) {
+    return true;
+}
+
+bool StatesyncProtocolV1_2::handle_upsert(
+    monad_statesync_client_context *const ctx, monad_sync_type const type,
+    unsigned char const *const val, uint64_t const size) const
+{
+    if (!apply_upsert(ctx, type, val, size)) {
+        // Rejecting a record aborts the node: bft asserts on this return value
+        // and its release profile aborts on panic. This log is the only place
+        // the offending record is named.
+        LOG_ERROR(
+            "statesync client rejected upsert type={} size={}",
+            std::to_underlying(type),
+            size);
+        return false;
+    }
+    MONAD_ASSERT(ctx->upserts_per_commit != 0);
+    // Threshold rather than modulo: a page record advances the counter by more
+    // than one, so an exact multiple cannot be relied on.
+    if (++ctx->n_upserts >= ctx->upserts_per_commit) {
         ctx->commit();
     }
+    return true;
+}
 
+bool StatesyncProtocolV1_3::apply_upsert(
+    monad_statesync_client_context *const ctx, monad_sync_type const type,
+    unsigned char const *const val, uint64_t const size) const
+{
+    if (type != SYNC_TYPE_UPSERT_STORAGE_PAGE) {
+        return StatesyncProtocolV1_2::apply_upsert(ctx, type, val, size);
+    }
+    if (size < sizeof(Address)) {
+        return false;
+    }
+    byte_string_view leaf{val, size};
+    leaf.remove_prefix(sizeof(Address));
+    auto const decoded = decode_storage_page_leaf(leaf);
+    if (decoded.has_error()) {
+        LOG_ERROR("statesync client could not decode storage page leaf");
+        return false;
+    }
+    auto const &page = decoded.value().page;
+    // An empty page would grant coverage while contributing no slot. A
+    // slot-granular delete arriving for that page in the same commit window
+    // would then build it from empty and delete the whole page entry, losing
+    // every slot the client holds on disk for it.
+    if (page.is_empty()) {
+        LOG_ERROR("statesync client rejected empty storage page record");
+        return false;
+    }
+    auto const addr = unaligned_load<Address>(val);
+    for (auto const [slot_key, slot_val] : decoded.value().slots()) {
+        storage_update(*ctx, addr, slot_key, slot_val);
+    }
+    // Granted after the loop: storage_update can commit on an incarnation
+    // conflict, and that commit clears coverage.
+    ctx->covered_pages[addr].emplace(decoded.value().page_key);
+    // handle_upsert counts this record once; the page's remaining slots are
+    // deltas the commit window has to bound too.
+    ctx->n_upserts += page.size() - 1;
     return true;
 }
 

--- a/category/statesync/statesync_protocol.hpp
+++ b/category/statesync/statesync_protocol.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/config.hpp>
 #include <category/statesync/statesync_messages.h>
+#include <category/statesync/statesync_version.h>
 
 struct monad_statesync_client_context;
 
@@ -36,10 +37,34 @@ struct StatesyncProtocol
 
 struct StatesyncProtocolV1_2 : StatesyncProtocol
 {
+    explicit StatesyncProtocolV1_2(uint32_t const version)
+        : version_{version}
+    {
+    }
+
     virtual void send_request(
         monad_statesync_client_context *, uint64_t prefix) const override;
 
     virtual bool handle_upsert(
+        monad_statesync_client_context *, monad_sync_type,
+        unsigned char const *, uint64_t) const override;
+
+protected:
+    virtual bool apply_upsert(
+        monad_statesync_client_context *, monad_sync_type,
+        unsigned char const *, uint64_t) const;
+
+    // the version this client declared to the peer; a request advertises it so
+    // the server knows which records the client can decode
+    uint32_t const version_;
+};
+
+struct StatesyncProtocolV1_3 : StatesyncProtocolV1_2
+{
+    using StatesyncProtocolV1_2::StatesyncProtocolV1_2;
+
+protected:
+    virtual bool apply_upsert(
         monad_statesync_client_context *, monad_sync_type,
         unsigned char const *, uint64_t) const override;
 };

--- a/category/statesync/statesync_server.cpp
+++ b/category/statesync/statesync_server.cpp
@@ -27,6 +27,7 @@
 #include <category/mpt/traverse.hpp>
 #include <category/statesync/statesync_server.h>
 #include <category/statesync/statesync_server_context.hpp>
+#include <category/statesync/statesync_version.h>
 
 #include <quill/std/Chrono.h>
 
@@ -202,11 +203,14 @@ bool statesync_server_handle_request(
         uint64_t until;
         uint64_t *num_upserts;
         uint64_t *upsert_bytes;
+        // page-encoded server serving a peer that can decode page records
+        bool emit_page_records;
 
         Traverse(
             monad_statesync_server *const sync, NibblesView const prefix,
             uint64_t const from, uint64_t const until,
-            uint64_t *const num_upserts, uint64_t *const upsert_bytes)
+            uint64_t *const num_upserts, uint64_t *const upsert_bytes,
+            bool const emit_page_records)
             : nibble{INVALID_BRANCH}
             , depth{0}
             , sync{sync}
@@ -215,12 +219,12 @@ bool statesync_server_handle_request(
             , until{until}
             , num_upserts{num_upserts}
             , upsert_bytes{upsert_bytes}
+            , emit_page_records{emit_page_records}
         {
         }
 
-        // When the server's primary is page-encoded, storage leaves hold
-        // encoded pages rather than single slots; we expand each page into
-        // slot-format upserts so v1 clients sync unchanged.
+        // Whether this server's storage leaves hold encoded pages rather than
+        // single slots.
         bool server_is_page_encoded() const
         {
             return sync->context->is_page_encoded();
@@ -292,7 +296,13 @@ bool statesync_server_handle_request(
                     }
                     else {
                         MONAD_ASSERT(depth == (HASH_SIZE * 2));
-                        if (server_is_page_encoded()) {
+                        if (emit_page_records) {
+                            send_upsert(
+                                SYNC_TYPE_UPSERT_STORAGE_PAGE,
+                                reinterpret_cast<unsigned char *>(&addr),
+                                sizeof(addr));
+                        }
+                        else if (server_is_page_encoded()) {
                             // Expand the page-encoded leaf into one slot-format
                             // upsert per non-zero slot, so the wire stays
                             // identical to a slot-encoded server.
@@ -439,7 +449,8 @@ bool statesync_server_handle_request(
         rq.from,
         rq.until,
         &num_upserts,
-        &upsert_bytes);
+        &upsert_bytes,
+        ctx->is_page_encoded() && rq.version >= MONAD_STATESYNC_VERSION_1_3);
     if (!db.traverse(finalized_root, traverse, rq.target)) {
         LOG_INFO(
             "Request failed: traverse failed for target={} prefix={} "

--- a/category/statesync/statesync_server_network.hpp
+++ b/category/statesync/statesync_server_network.hpp
@@ -104,6 +104,27 @@ namespace
 {
     constexpr size_t SEND_BATCH_SIZE = 64 * 1024;
 
+    // No `default` label: a new monad_sync_type must be classified here or
+    // the build fails, rather than aborting the serving process at runtime.
+    constexpr bool is_upsert(monad_sync_type const type)
+    {
+        switch (type) {
+        case SYNC_TYPE_UPSERT_CODE:
+        case SYNC_TYPE_UPSERT_ACCOUNT:
+        case SYNC_TYPE_UPSERT_STORAGE:
+        case SYNC_TYPE_UPSERT_ACCOUNT_DELETE:
+        case SYNC_TYPE_UPSERT_STORAGE_DELETE:
+        case SYNC_TYPE_UPSERT_HEADER:
+        case SYNC_TYPE_UPSERT_STORAGE_PAGE:
+            return true;
+        case SYNC_TYPE_REQUEST:
+        case SYNC_TYPE_TARGET:
+        case SYNC_TYPE_DONE:
+            return false;
+        }
+        return false;
+    }
+
     void send(int const fd, byte_string_view const buf)
     {
         size_t nsent = 0;
@@ -206,12 +227,7 @@ inline void statesync_server_send_upsert(
 {
     MONAD_ASSERT(v1 != nullptr || size1 == 0);
     MONAD_ASSERT(v2 != nullptr || size2 == 0);
-    MONAD_ASSERT(
-        type == SYNC_TYPE_UPSERT_CODE || type == SYNC_TYPE_UPSERT_ACCOUNT ||
-        type == SYNC_TYPE_UPSERT_STORAGE ||
-        type == SYNC_TYPE_UPSERT_ACCOUNT_DELETE ||
-        type == SYNC_TYPE_UPSERT_STORAGE_DELETE ||
-        type == SYNC_TYPE_UPSERT_HEADER);
+    MONAD_ASSERT(is_upsert(type));
 
     [[maybe_unused]] auto const start = std::chrono::steady_clock::now();
     net->obuf.push_back(type);

--- a/category/statesync/statesync_version.cpp
+++ b/category/statesync/statesync_version.cpp
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <category/execution/monad/db/storage_page.hpp>
 #include <category/statesync/statesync_version.h>
+
+// Page records put no page-key shift on the wire: both peers agree on it by
+// protocol version, so a shift change needs a new version.
+static_assert(monad::storage_page_t::PAGE_KEY_SHIFT == 7);
 
 uint32_t monad_statesync_version()
 {

--- a/category/statesync/statesync_version.h
+++ b/category/statesync/statesync_version.h
@@ -31,6 +31,9 @@ enum monad_statesync_version_num : uint16_t
     // Client acknowledges each response. Minors 0 and 1 predate that and are no
     // longer spoken; nothing deployed still runs them.
     MONAD_STATESYNC_MINOR_2 = 2,
+    // A page-encoded server sends each storage page leaf verbatim as one
+    // record, so the client need not read the page back to merge into it.
+    MONAD_STATESYNC_MINOR_3 = 3,
 };
 
 // A version as monad-bft's StateSyncVersion encodes it: major << 16 | minor.
@@ -38,9 +41,11 @@ enum monad_statesync_protocol_version : uint32_t
 {
     MONAD_STATESYNC_VERSION_1_2 =
         MONAD_STATESYNC_MAJOR << 16 | MONAD_STATESYNC_MINOR_2,
+    MONAD_STATESYNC_VERSION_1_3 =
+        MONAD_STATESYNC_MAJOR << 16 | MONAD_STATESYNC_MINOR_3,
 
     MONAD_STATESYNC_VERSION_MIN = MONAD_STATESYNC_VERSION_1_2,
-    MONAD_STATESYNC_VERSION = MONAD_STATESYNC_VERSION_1_2,
+    MONAD_STATESYNC_VERSION = MONAD_STATESYNC_VERSION_1_3,
 };
 
 uint32_t monad_statesync_version();

--- a/category/statesync/test/test_network_shutdown.cpp
+++ b/category/statesync/test/test_network_shutdown.cpp
@@ -82,6 +82,61 @@ namespace
             ::close(fd);
         }
     };
+
+    int listen_on(std::filesystem::path const &socket_path)
+    {
+        int const fd = socket(AF_UNIX, SOCK_STREAM, 0);
+        MONAD_ASSERT(fd >= 0);
+        struct sockaddr_un addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sun_family = AF_UNIX;
+        // Truncation would bind a different path, so fail loudly instead.
+        MONAD_ASSERT(socket_path.native().size() < sizeof(addr.sun_path));
+        strncpy(addr.sun_path, socket_path.c_str(), sizeof(addr.sun_path) - 1);
+        MONAD_ASSERT(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+        MONAD_ASSERT(listen(fd, 1) == 0);
+        return fd;
+    }
+}
+
+// The production send path is what statesync_thread.cpp wires in; the other
+// statesync tests substitute their own. An upsert type it does not accept
+// aborts the serving process, in release builds too.
+TEST(StateSyncServerNetwork, send_upsert_accepts_every_upsert_type)
+{
+    std::filesystem::path const socket_path =
+        unique_socket_path("test_statesync_send_upsert");
+    std::filesystem::remove(socket_path);
+    BOOST_SCOPE_EXIT(&socket_path)
+    {
+        std::filesystem::remove(socket_path);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    int const listen_fd = listen_on(socket_path);
+    BOOST_SCOPE_EXIT(&listen_fd)
+    {
+        close(listen_fd);
+    }
+    BOOST_SCOPE_EXIT_END
+
+    monad_statesync_server_network net{socket_path.c_str()};
+
+    constexpr std::array types{
+        SYNC_TYPE_UPSERT_CODE,
+        SYNC_TYPE_UPSERT_ACCOUNT,
+        SYNC_TYPE_UPSERT_STORAGE,
+        SYNC_TYPE_UPSERT_ACCOUNT_DELETE,
+        SYNC_TYPE_UPSERT_STORAGE_DELETE,
+        SYNC_TYPE_UPSERT_HEADER,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE};
+    for (auto const type : types) {
+        monad::statesync_server_send_upsert(&net, type, nullptr, 0, nullptr, 0);
+    }
+
+    // One type byte plus a uint64 length per record, all still buffered:
+    // nothing reaches SEND_BATCH_SIZE.
+    EXPECT_EQ(net.obuf.size(), types.size() * (1 + sizeof(uint64_t)));
 }
 
 TEST(StateSyncThread, shutdown_via_jthread_stop_token)

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -242,7 +242,7 @@ namespace
             MONAD_ASSERT(primary.timeline_active(mpt::timeline_id::secondary));
         }
 
-        void init()
+        void init(uint32_t const peer_version = monad_statesync_version())
         {
             // Production C ABI (monad_statesync_client_context_create) does
             // this; tests that bypass the C ABI and call the C++ ctor
@@ -258,8 +258,7 @@ namespace
                 &statesync_send_request};
             net = {.client = &client, .cctx = cctx};
             for (size_t i = 0; i < monad_statesync_client_prefixes(); ++i) {
-                monad_statesync_client_handle_new_peer(
-                    cctx, i, monad_statesync_version());
+                monad_statesync_client_handle_new_peer(cctx, i, peer_version);
             }
             server = monad_statesync_server_create(
                 &sctx,
@@ -457,6 +456,26 @@ TYPED_TEST(StateSyncTestBothForks, sync_from_latest)
             .number = N});
     EXPECT_TRUE(monad_statesync_client_has_reached_target(this->cctx));
     EXPECT_TRUE(monad_statesync_client_finalize(this->cctx));
+}
+
+// V2 is the version deployed peers run, so it is the one the old-stream gate
+// has to be tested against.
+TEST_F(StateSyncFixture, deployed_peer_selects_v1_protocol)
+{
+    init(MONAD_STATESYNC_VERSION_1_2);
+    handle_target(
+        cctx, BlockHeader{.state_root = stdb.state_root(), .number = 1});
+    ASSERT_FALSE(client.rqs.empty());
+    EXPECT_EQ(client.rqs.front().version, MONAD_STATESYNC_VERSION_1_2);
+}
+
+TEST_F(StateSyncFixture, request_carries_requester_version)
+{
+    init();
+    handle_target(
+        cctx, BlockHeader{.state_root = stdb.state_root(), .number = 1});
+    ASSERT_FALSE(client.rqs.empty());
+    EXPECT_EQ(client.rqs.front().version, MONAD_STATESYNC_VERSION_1_3);
 }
 
 TEST_F(StateSyncFixture, sync_from_empty)
@@ -1006,6 +1025,290 @@ TEST_F(
     stdb.set_block_and_prefix(N);
     cctx->secondary_tdb->set_block_and_prefix(N);
     EXPECT_EQ(stdb.state_root(), cctx->secondary_tdb->state_root());
+}
+
+// A page-encoded server sends each page leaf verbatim, so the client builds
+// the page from the record instead of reading it back to merge into.
+TEST_F(PageServerStateSyncFixture, page_records_skip_page_reads)
+{
+    ASSERT_TRUE(stdb.is_page_encoded());
+
+    init();
+    uint64_t const timestamp = revision_config.timestamp;
+    monad_revision const rev = cctx->chain->get_monad_revision(timestamp);
+    ASSERT_TRUE(mip_8_active(rev));
+
+    // 0x00/0x01/0x7f share one page, 0x80/0x81 a second.
+    constexpr auto slot_a = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_b = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_c = bytes32_t{uint64_t{0x7f}};
+    constexpr auto slot_d = bytes32_t{uint64_t{0x80}};
+    constexpr auto slot_e = bytes32_t{uint64_t{0x81}};
+    constexpr auto val_a =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto val_b =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto val_c =
+        0x00000000000000000000000000000000000000000000000000000000000000cc_bytes32;
+    constexpr auto val_d =
+        0x00000000000000000000000000000000000000000000000000000000000000dd_bytes32;
+    constexpr auto val_e =
+        0x00000000000000000000000000000000000000000000000000000000000000ee_bytes32;
+
+    ASSERT_EQ(compute_page_key(slot_a), compute_page_key(slot_c));
+    ASSERT_NE(compute_page_key(slot_a), compute_page_key(slot_d));
+
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        commit_sequential_revision_aware(
+            stdb,
+            nullptr,
+            rev,
+            {},
+            Code{},
+            BlockHeader{
+                .parent_hash = parent_hash,
+                .number = i,
+                .timestamp = timestamp});
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    StateDeltas const storage_deltas{
+        {ADDR_A,
+         StateDelta{
+             .account = {std::nullopt, Account{.balance = 100}},
+             .storage = {
+                 {slot_a, {bytes32_t{}, val_a}},
+                 {slot_b, {bytes32_t{}, val_b}},
+                 {slot_c, {bytes32_t{}, val_c}},
+                 {slot_d, {bytes32_t{}, val_d}},
+                 {slot_e, {bytes32_t{}, val_e}}}}}};
+
+    commit_sequential_revision_aware(
+        stdb,
+        nullptr,
+        rev,
+        storage_deltas,
+        Code{},
+        BlockHeader{.number = N, .timestamp = timestamp});
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.state_root(),
+            .number = N,
+            .timestamp = timestamp});
+    run();
+
+    uint64_t const page_reads = cctx->secondary_tdb->storage_read_count();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    stdb.set_block_and_prefix(N);
+    cctx->secondary_tdb->set_block_and_prefix(N);
+    EXPECT_EQ(stdb.state_root(), cctx->secondary_tdb->state_root());
+
+    // Both of ADDR_A's pages arrived whole, so neither was read back.
+    EXPECT_EQ(page_reads, 0);
+}
+
+// The mirror of page_records_skip_page_reads: a peer at V2, the version
+// deployed peers run, must get the old stream. A page record on that stream
+// would be an unknown record the client rejects, aborting the syncing node, so
+// the gate being stuck on is the direction that breaks deployed peers.
+TEST_F(PageServerStateSyncFixture, deployed_peer_falls_back_to_page_reads)
+{
+    ASSERT_TRUE(stdb.is_page_encoded());
+
+    init(MONAD_STATESYNC_VERSION_1_2);
+    uint64_t const timestamp = revision_config.timestamp;
+    monad_revision const rev = cctx->chain->get_monad_revision(timestamp);
+    ASSERT_TRUE(mip_8_active(rev));
+
+    constexpr auto slot_a = bytes32_t{uint64_t{0x00}};
+    constexpr auto slot_b = bytes32_t{uint64_t{0x01}};
+    constexpr auto slot_c = bytes32_t{uint64_t{0x7f}};
+    constexpr auto slot_d = bytes32_t{uint64_t{0x80}};
+    constexpr auto slot_e = bytes32_t{uint64_t{0x81}};
+    constexpr auto val_a =
+        0x00000000000000000000000000000000000000000000000000000000000000aa_bytes32;
+    constexpr auto val_b =
+        0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    constexpr auto val_c =
+        0x00000000000000000000000000000000000000000000000000000000000000cc_bytes32;
+    constexpr auto val_d =
+        0x00000000000000000000000000000000000000000000000000000000000000dd_bytes32;
+    constexpr auto val_e =
+        0x00000000000000000000000000000000000000000000000000000000000000ee_bytes32;
+
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        commit_sequential_revision_aware(
+            stdb,
+            nullptr,
+            rev,
+            {},
+            Code{},
+            BlockHeader{
+                .parent_hash = parent_hash,
+                .number = i,
+                .timestamp = timestamp});
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    StateDeltas const storage_deltas{
+        {ADDR_A,
+         StateDelta{
+             .account = {std::nullopt, Account{.balance = 100}},
+             .storage = {
+                 {slot_a, {bytes32_t{}, val_a}},
+                 {slot_b, {bytes32_t{}, val_b}},
+                 {slot_c, {bytes32_t{}, val_c}},
+                 {slot_d, {bytes32_t{}, val_d}},
+                 {slot_e, {bytes32_t{}, val_e}}}}}};
+
+    commit_sequential_revision_aware(
+        stdb,
+        nullptr,
+        rev,
+        storage_deltas,
+        Code{},
+        BlockHeader{.number = N, .timestamp = timestamp});
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.state_root(),
+            .number = N,
+            .timestamp = timestamp});
+    ASSERT_FALSE(client.rqs.empty());
+    EXPECT_EQ(client.rqs.front().version, MONAD_STATESYNC_VERSION_1_2);
+    run();
+
+    uint64_t const page_reads = cctx->secondary_tdb->storage_read_count();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    stdb.set_block_and_prefix(N);
+    cctx->secondary_tdb->set_block_and_prefix(N);
+    EXPECT_EQ(stdb.state_root(), cctx->secondary_tdb->state_root());
+
+    // No coverage without page records: each of ADDR_A's two pages is read
+    // back once to merge into.
+    EXPECT_EQ(page_reads, 2);
+}
+
+// The commit window is the one thing that can interleave with page coverage:
+// with upserts_per_commit lowered, a commit lands between the two page records
+// of one account, so the first page is already on disk when the second is built
+// from an empty page. Nothing else in the tree sets upserts_per_commit, so this
+// interleaving is otherwise unexercised.
+TEST_F(PageServerStateSyncFixture, mid_stream_commits_preserve_pages)
+{
+    ASSERT_TRUE(stdb.is_page_encoded());
+
+    init();
+    // Low enough that a commit lands after every page record.
+    cctx->upserts_per_commit = 2;
+    uint64_t const timestamp = revision_config.timestamp;
+    monad_revision const rev = cctx->chain->get_monad_revision(timestamp);
+    ASSERT_TRUE(mip_8_active(rev));
+
+    constexpr auto N = 1'000'000;
+    bytes32_t parent_hash{NULL_HASH};
+    load_header(
+        sdb.load_root_for_version(N - 257),
+        sdb,
+        BlockHeader{.number = N - 257});
+    for (size_t i = N - 256; i < N; ++i) {
+        stdb.set_block_and_prefix(i - 1);
+        commit_sequential_revision_aware(
+            stdb,
+            nullptr,
+            rev,
+            {},
+            Code{},
+            BlockHeader{
+                .parent_hash = parent_hash,
+                .number = i,
+                .timestamp = timestamp});
+        parent_hash = to_bytes(
+            keccak256(rlp::encode_block_header(stdb.read_eth_header())));
+    }
+
+    // Two pages per account: 0x00/0x01 on one, 0x80/0x81/0x82 on the next.
+    auto const two_page_storage = [](uint8_t const seed) {
+        return StateDelta{
+            .account = {std::nullopt, Account{.balance = 100}},
+            .storage = {
+                {bytes32_t{uint64_t{0x00}},
+                 {bytes32_t{}, bytes32_t{uint64_t{seed + 0u}}}},
+                {bytes32_t{uint64_t{0x01}},
+                 {bytes32_t{}, bytes32_t{uint64_t{seed + 1u}}}},
+                {bytes32_t{uint64_t{0x80}},
+                 {bytes32_t{}, bytes32_t{uint64_t{seed + 2u}}}},
+                {bytes32_t{uint64_t{0x81}},
+                 {bytes32_t{}, bytes32_t{uint64_t{seed + 3u}}}},
+                {bytes32_t{uint64_t{0x82}},
+                 {bytes32_t{}, bytes32_t{uint64_t{seed + 4u}}}}}};
+    };
+
+    ASSERT_EQ(
+        compute_page_key(bytes32_t{uint64_t{0x00}}),
+        compute_page_key(bytes32_t{uint64_t{0x01}}));
+    ASSERT_NE(
+        compute_page_key(bytes32_t{uint64_t{0x01}}),
+        compute_page_key(bytes32_t{uint64_t{0x80}}));
+
+    StateDeltas const storage_deltas{
+        {ADDR_A, two_page_storage(0xa0)},
+        {ADDR_B, two_page_storage(0xb0)},
+        {ADDR_C, two_page_storage(0xc0)}};
+
+    commit_sequential_revision_aware(
+        stdb,
+        nullptr,
+        rev,
+        storage_deltas,
+        Code{},
+        BlockHeader{.number = N, .timestamp = timestamp});
+
+    handle_target(
+        cctx,
+        BlockHeader{
+            .parent_hash = parent_hash,
+            .state_root = stdb.state_root(),
+            .number = N,
+            .timestamp = timestamp});
+    run();
+
+    uint64_t const page_reads = cctx->secondary_tdb->storage_read_count();
+
+    EXPECT_TRUE(monad_statesync_client_finalize(cctx));
+
+    stdb.set_block_and_prefix(N);
+    cctx->secondary_tdb->set_block_and_prefix(N);
+    EXPECT_EQ(stdb.state_root(), cctx->secondary_tdb->state_root());
+
+    // Coverage is granted before the commit that consumes it, so no page is
+    // read back even though commits land between records.
+    EXPECT_EQ(page_reads, 0);
 }
 
 TEST_F(StateSyncFixture, sync_empty)
@@ -1803,7 +2106,7 @@ TEST_F(StateSyncFixture, validation_old_target_greater_than_target)
 
 TEST(ProtocolValidation, storage_deletion_rejects_oversized_key)
 {
-    StatesyncProtocolV1_2 proto;
+    StatesyncProtocolV1_2 proto{MONAD_STATESYNC_VERSION_1_2};
 
     Address a{0xdeadbeef};
     byte_string oversized_key(33, 0xff);
@@ -1818,7 +2121,7 @@ TEST(ProtocolValidation, storage_deletion_rejects_oversized_key)
 
 TEST(ProtocolValidation, upserts_reject_trailing_bytes)
 {
-    StatesyncProtocolV1_2 proto;
+    StatesyncProtocolV1_2 proto{MONAD_STATESYNC_VERSION_1_2};
 
     auto const dbname = tmp_dbname();
     {
@@ -1885,9 +2188,306 @@ TEST(ProtocolValidation, upserts_reject_trailing_bytes)
     std::filesystem::remove(dbname);
 }
 
+namespace
+{
+    // addr followed by the page leaf, as SYNC_TYPE_UPSERT_STORAGE_PAGE carries
+    // it; slots are given as (slot_key, value) so callers name real keys.
+    byte_string page_record(
+        Address const &addr,
+        std::vector<std::pair<bytes32_t, bytes32_t>> const &slots)
+    {
+        MONAD_ASSERT(!slots.empty());
+        auto const page_key = compute_page_key(slots.front().first);
+        storage_page_t page;
+        for (auto const &[slot_key, val] : slots) {
+            MONAD_ASSERT(compute_page_key(slot_key) == page_key);
+            page.set(compute_slot_offset(slot_key), val);
+        }
+        byte_string record{addr.bytes, sizeof(addr.bytes)};
+        record.append(encode_storage_page_db(page_key, page));
+        return record;
+    }
+
+    struct BareClient
+    {
+        std::filesystem::path dbname;
+        monad_statesync_client client;
+        monad_statesync_client_context ctx;
+
+        explicit BareClient(uint32_t const peer_version)
+            : dbname{tmp_dbname()}
+            , client{}
+            , ctx{CHAIN_CONFIG_MONAD_TESTNET,
+                  {dbname},
+                  std::nullopt,
+                  4,
+                  &client,
+                  &statesync_send_request}
+        {
+            monad_statesync_client_handle_new_peer(&ctx, 0, peer_version);
+        }
+
+        ~BareClient()
+        {
+            std::filesystem::remove(dbname);
+        }
+    };
+}
+
+// A peer at V2, the version deployed peers run, has no
+// SYNC_TYPE_UPSERT_STORAGE_PAGE in its vocabulary. A server that sends one
+// anyway -- by mistake, or a hostile/mismatched peer -- must fail the record
+// rather than reach an assert, since this is unauthenticated wire input.
+TEST(ProtocolValidation, page_record_rejected_by_deployed_peer)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{MONAD_STATESYNC_VERSION_1_2};
+
+    auto const record = page_record(
+        ADDR_A, {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}}});
+    EXPECT_FALSE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        record.data(),
+        record.size()));
+}
+
+// The page leaf comes off the wire, so every way it can fail to decode has to
+// fail the record rather than abort: no address, no leaf, a truncated leaf, and
+// trailing bytes past a well-formed one.
+TEST(ProtocolValidation, malformed_page_record_rejected)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    auto const send = [&c](byte_string const &record) {
+        return monad_statesync_client_handle_upsert(
+            &c.ctx,
+            0,
+            SYNC_TYPE_UPSERT_STORAGE_PAGE,
+            record.data(),
+            record.size());
+    };
+
+    auto const record = page_record(
+        ADDR_A,
+        {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}},
+         {bytes32_t{uint64_t{0x01}}, bytes32_t{uint64_t{0xbb}}}});
+    ASSERT_GT(record.size(), sizeof(Address) + 1);
+
+    EXPECT_FALSE(send(byte_string{ADDR_A.bytes, sizeof(ADDR_A.bytes) - 1}));
+    EXPECT_FALSE(send(byte_string{ADDR_A.bytes, sizeof(ADDR_A.bytes)}));
+    EXPECT_FALSE(send(record.substr(0, record.size() - 1)));
+
+    byte_string trailing{record};
+    trailing.push_back(0xff);
+    EXPECT_FALSE(send(trailing));
+
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+    EXPECT_TRUE(send(record));
+    EXPECT_TRUE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
+// Both storage record types name their key with an unbounded RLP string, and
+// the decoder converts it with to_bytes, which asserts on more than 32 bytes.
+// A record built by hand -- page_record() derives its key with
+// compute_page_key and so cannot express this -- must be rejected instead.
+TEST(ProtocolValidation, oversized_storage_key_rejected)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    auto const send =
+        [&c](monad_sync_type const type, byte_string const &record) {
+            return monad_statesync_client_handle_upsert(
+                &c.ctx, 0, type, record.data(), record.size());
+        };
+
+    byte_string const oversized(sizeof(bytes32_t) + 1, 0xff);
+    auto const prefixed = [](byte_string const &leaf) {
+        byte_string record{ADDR_A.bytes, sizeof(ADDR_A.bytes)};
+        record.append(leaf);
+        return record;
+    };
+
+    storage_page_t page;
+    page.set(0, bytes32_t{uint64_t{0xaa}});
+    EXPECT_FALSE(send(
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        prefixed(rlp::encode_list2(
+            rlp::encode_string2(oversized),
+            rlp::encode_string2(encode_storage_page(page))))));
+
+    bytes32_t const val{uint64_t{0xaa}};
+    EXPECT_FALSE(send(
+        SYNC_TYPE_UPSERT_STORAGE,
+        prefixed(rlp::encode_list2(
+            rlp::encode_string2(oversized),
+            rlp::encode_bytes32_compact(val)))));
+    EXPECT_FALSE(send(
+        SYNC_TYPE_UPSERT_STORAGE,
+        prefixed(rlp::encode_list2(
+            rlp::encode_bytes32_compact(val),
+            rlp::encode_string2(oversized)))));
+
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+    EXPECT_TRUE(c.ctx.deltas.empty());
+    EXPECT_TRUE(c.ctx.buffered.empty());
+}
+
+// An empty page decodes fine but carries no slot, so accepting it would grant
+// coverage that no slot backs. A slot-granular delete on that page in the same
+// commit window would then rebuild it from empty and delete the whole page
+// entry, dropping every slot held on disk for it.
+TEST(ProtocolValidation, empty_page_record_rejected)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    byte_string record{ADDR_A.bytes, sizeof(ADDR_A.bytes)};
+    record.append(encode_storage_page_db(bytes32_t{}, storage_page_t{}));
+
+    EXPECT_FALSE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        record.data(),
+        record.size()));
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
+// The commit window bounds slot deltas held, not records seen: a page record
+// carrying n slots advances it by n, and the window closes on reaching the
+// threshold rather than on an exact multiple of it, which a record worth more
+// than one delta can step over.
+TEST(ProtocolValidation, commit_window_counts_page_slots)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    c.ctx.upserts_per_commit = 3;
+
+    auto const send = [&c](byte_string const &record) {
+        return monad_statesync_client_handle_upsert(
+            &c.ctx,
+            0,
+            SYNC_TYPE_UPSERT_STORAGE_PAGE,
+            record.data(),
+            record.size());
+    };
+
+    ASSERT_TRUE(send(page_record(
+        ADDR_A,
+        {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}},
+         {bytes32_t{uint64_t{0x01}}, bytes32_t{uint64_t{0xbb}}}})));
+    EXPECT_EQ(c.ctx.n_upserts, 2);
+    EXPECT_TRUE(c.ctx.covered_pages.contains(ADDR_A));
+
+    ASSERT_TRUE(send(page_record(
+        ADDR_A,
+        {{bytes32_t{uint64_t{0x80}}, bytes32_t{uint64_t{0xcc}}},
+         {bytes32_t{uint64_t{0x81}}, bytes32_t{uint64_t{0xdd}}}})));
+    EXPECT_EQ(c.ctx.n_upserts, 0);
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
+// Coverage is only ever valid for the delta set it was granted against, so it
+// must not survive the commit that flushes those deltas. Without the clear, a
+// later storage delete on a covered page rebuilds it from scratch and drops
+// every slot the delete did not mention.
+TEST(ProtocolValidation, coverage_does_not_survive_commit)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    auto const record = page_record(
+        ADDR_A, {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}}});
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        record.data(),
+        record.size()));
+    ASSERT_TRUE(c.ctx.covered_pages.contains(ADDR_A));
+
+    c.ctx.commit();
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
+// Deleting an account voids its pending storage without committing, so the
+// coverage granted against those slots must go with them -- otherwise a later
+// partial page for the same account is built from scratch and loses the rest.
+TEST(ProtocolValidation, coverage_dropped_when_account_deleted)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    auto const record = page_record(
+        ADDR_A, {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}}});
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        record.data(),
+        record.size()));
+    ASSERT_TRUE(c.ctx.covered_pages.contains(ADDR_A));
+
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_ACCOUNT_DELETE,
+        ADDR_A.bytes,
+        sizeof(ADDR_A.bytes)));
+    EXPECT_FALSE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
+// The one commit that can land inside a page record: storage_update commits on
+// an incarnation conflict, before any of this page's slots are recorded. Since
+// that commit clears covered_pages, coverage has to be granted after the slot
+// loop, not before it.
+TEST(ProtocolValidation, coverage_granted_after_incarnation_commit)
+{
+    monad::register_ethereum_state_machines();
+    BareClient c{monad_statesync_version()};
+
+    auto const account = encode_account_db(ADDR_A, Account{.balance = 100});
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx, 0, SYNC_TYPE_UPSERT_ACCOUNT, account.data(), account.size()));
+    c.ctx.commit();
+
+    // With the account on disk, the delete becomes a pending nullopt delta,
+    // which is what makes the next non-zero slot commit.
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_ACCOUNT_DELETE,
+        ADDR_A.bytes,
+        sizeof(ADDR_A.bytes)));
+    ASSERT_TRUE(c.ctx.deltas.contains(ADDR_A));
+    ASSERT_FALSE(c.ctx.deltas.at(ADDR_A).has_value());
+
+    auto const record = page_record(
+        ADDR_A,
+        {{bytes32_t{uint64_t{0x00}}, bytes32_t{uint64_t{0xaa}}},
+         {bytes32_t{uint64_t{0x01}}, bytes32_t{uint64_t{0xbb}}}});
+    ASSERT_TRUE(monad_statesync_client_handle_upsert(
+        &c.ctx,
+        0,
+        SYNC_TYPE_UPSERT_STORAGE_PAGE,
+        record.data(),
+        record.size()));
+
+    // The commit happened while applying the first slot, so it cleared nothing
+    // this record contributed.
+    EXPECT_FALSE(c.ctx.deltas.contains(ADDR_A));
+    EXPECT_TRUE(c.ctx.covered_pages.contains(ADDR_A));
+}
+
 TEST(StatesyncVersion, wire_encoding)
 {
     EXPECT_EQ(MONAD_STATESYNC_VERSION_1_2, 0x00010002u);
+    EXPECT_EQ(MONAD_STATESYNC_VERSION_1_3, 0x00010003u);
 }
 
 TEST(StatesyncVersion, compatibility_range)
@@ -1895,6 +2495,7 @@ TEST(StatesyncVersion, compatibility_range)
     EXPECT_EQ(monad_statesync_version(), MONAD_STATESYNC_VERSION);
     EXPECT_TRUE(monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_MIN));
     EXPECT_TRUE(monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_1_2));
+    EXPECT_TRUE(monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_1_3));
     // 0x00010001 is v1, which peers no longer speak.
     EXPECT_FALSE(
         monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_MIN - 1));

--- a/rust/crates/monad-statesync-version/src/lib.rs
+++ b/rust/crates/monad-statesync-version/src/lib.rs
@@ -23,6 +23,7 @@ pub use self::bindings::{
     monad_statesync_protocol_version_MONAD_STATESYNC_VERSION_MIN as MONAD_STATESYNC_VERSION_MIN,
     monad_statesync_version_num_MONAD_STATESYNC_MAJOR as MONAD_STATESYNC_MAJOR,
     monad_statesync_version_num_MONAD_STATESYNC_MINOR_2 as MONAD_STATESYNC_MINOR_2,
+    monad_statesync_version_num_MONAD_STATESYNC_MINOR_3 as MONAD_STATESYNC_MINOR_3,
 };
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]

--- a/rust/crates/monad-statesync/src/ffi.rs
+++ b/rust/crates/monad-statesync/src/ffi.rs
@@ -23,7 +23,7 @@ pub use self::bindings::{
     monad_sync_type_SYNC_TYPE_TARGET, monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT,
     monad_sync_type_SYNC_TYPE_UPSERT_ACCOUNT_DELETE, monad_sync_type_SYNC_TYPE_UPSERT_CODE,
     monad_sync_type_SYNC_TYPE_UPSERT_HEADER, monad_sync_type_SYNC_TYPE_UPSERT_STORAGE,
-    monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_DELETE,
+    monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_DELETE, monad_sync_type_SYNC_TYPE_UPSERT_STORAGE_PAGE,
 };
 
 #[allow(dead_code, non_camel_case_types, non_upper_case_globals)]


### PR DESCRIPTION
Stacked on #2487 — that lands first; this PR's own change is the second commit.

A page-encoded statesync client read every touched storage page back out of its
own trie and merged into it, because mpt upsert is set-not-merge and writing a
page twice loses the slots of the earlier write — one blocking trie descent per
page, on every sync.

Protocol 1.3 adds `SYNC_TYPE_UPSERT_STORAGE_PAGE`: for a peer at 1.3 or newer a
page-encoded server emits one record per storage leaf, payload = address
followed by the leaf exactly as stored, with no decode and no re-encode. The
client decodes it, feeds each slot through the existing `storage_update` so the
account, buffered-storage, incarnation and dual-write paths stay untouched, and
records the page as covered; `commit()` then builds a covered page from empty
rather than reading it back. A peer below 1.3 keeps the per-slot expansion loop,
so its wire is unchanged.

The record is peer input, so the shared storage decoder bounds the key it
converts to a bytes32 (an over-long key reached an assert that fires in
release), an empty page is refused rather than granted coverage that no slot
backs, and the commit window counts slot deltas instead of records, so a
128-slot page cannot buffer 128× the deltas its threshold names.

Getting there also required carrying the requesting peer's protocol version to
the C++ server, which bft previously dropped, and routing unrecognized upsert
types through the existing rejection path instead of a bare assert — a client
below 1.3 can now receive a record type it has no case for, and rejecting it
names the record in the log before bft's own assert takes the process down.

Companion monad-bft PR: category-labs/monad-bft#3216
