### PR TITLE
[execution] Explicit throw on missing requests hash

### DIFF
--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -313,6 +313,9 @@ Result<std::vector<Receipt>> execute_block(
     }
 
     if constexpr (traits::eip_7685_active()) {
+        MONAD_ASSERT_THROW(
+            block.header.requests_hash.has_value(),
+            "block header must have requests hash when EIP-7685 is active");
         BOOST_OUTCOME_TRY(
             auto const computed_requests_hash,
             process_requests<traits>(


### PR DESCRIPTION
This patch adds an explicit `MONAD_ASSERT_THROW` rather than relying on the implicit check done by `.value()`.