### PR TITLE
mpt: widen trie update stat counters to 64 bits

### DIFF
--- a/category/mpt/detail/collected_stats.hpp
+++ b/category/mpt/detail/collected_stats.hpp
@@ -17,6 +17,10 @@
 
 #include <category/mpt/config.hpp>
 
+#include <cstdint>
+#include <new>
+#include <type_traits>
+
 MONAD_MPT_NAMESPACE_BEGIN
 
 // Turn on to collect stats
@@ -28,35 +32,34 @@ namespace detail
     {
 #ifdef MONAD_MPT_COLLECT_STATS
         // counters
-        unsigned nodes_created_or_updated{0};
+        uint64_t nodes_created_or_updated{0};
         // reads stats
-        unsigned nreads_compaction{0};
+        uint64_t nreads_compaction{0};
         // [0]: fast, [1]: slow
-        unsigned nreads_before_compact_offset[2] = {0, 0};
-        unsigned nreads_after_compact_offset[2] = {0, 0};
-        unsigned bytes_read_before_compact_offset[2] = {0, 0};
-        unsigned bytes_read_after_compact_offset[2] = {0, 0};
+        uint64_t nreads_before_compact_offset[2] = {0, 0};
+        uint64_t nreads_after_compact_offset[2] = {0, 0};
+        uint64_t bytes_read_before_compact_offset[2] = {0, 0};
+        uint64_t bytes_read_after_compact_offset[2] = {0, 0};
 
         // node copy stats
-        unsigned compacted_nodes_in_fast{0}; // fast to slow
-        unsigned compacted_nodes_in_slow{0}; // slow to slow
-        unsigned nodes_copied_fast_to_fast_for_fast{0};
-        unsigned nodes_copied_fast_to_fast_for_slow{0};
-        unsigned nodes_copied_slow_to_fast_for_slow{0};
+        uint64_t compacted_nodes_in_fast{0}; // fast to slow
+        uint64_t compacted_nodes_in_slow{0}; // slow to slow
+        uint64_t nodes_copied_fast_to_fast_for_fast{0};
+        uint64_t nodes_copied_fast_to_fast_for_slow{0};
+        uint64_t nodes_copied_slow_to_fast_for_slow{0};
 
         // bytes copied stats
         // Sum of the following three equals the current block slow ring
         // growth
-        unsigned compacted_bytes_in_fast{0}; // copied from fast to slow
-        unsigned compacted_bytes_in_slow{0}; // copied from slow to slow
-        unsigned bytes_copied_slow_to_fast_for_slow{0};
+        uint64_t compacted_bytes_in_fast{0}; // copied from fast to slow
+        uint64_t compacted_bytes_in_slow{0}; // copied from slow to slow
+        uint64_t bytes_copied_slow_to_fast_for_slow{0};
 
         // expire stats
-        unsigned nodes_updated_expire{0};
-        unsigned nreads_expire{0};
+        uint64_t nodes_updated_expire{0};
+        uint64_t nreads_expire{0};
 #else
-        unsigned compacted_bytes_in_slow{0};
-        char padding[4];
+        uint64_t compacted_bytes_in_slow{0};
 #endif
 
         void reset()
@@ -67,11 +70,11 @@ namespace detail
     };
 
 #ifdef MONAD_MPT_COLLECT_STATS
-    static_assert(sizeof(TrieUpdateCollectedStats) == 80);
+    static_assert(sizeof(TrieUpdateCollectedStats) == 160);
 #else
     static_assert(sizeof(TrieUpdateCollectedStats) == 8);
 #endif
-    static_assert(alignof(TrieUpdateCollectedStats) == 4);
+    static_assert(alignof(TrieUpdateCollectedStats) == 8);
     static_assert(std::is_trivially_copyable_v<TrieUpdateCollectedStats>);
 }
 

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -65,6 +65,20 @@ namespace
         auto const r = static_cast<double>(rand()) / RAND_MAX;
         return result_floor + static_cast<uint32_t>(r <= fractional);
     }
+
+#if MONAD_MPT_COLLECT_STATS
+    constexpr double percent(uint64_t const num, uint64_t const denom)
+    {
+        return denom == 0 ? 0.0
+                          : 100.0 * static_cast<double>(num) /
+                                static_cast<double>(denom);
+    }
+
+    constexpr double to_kb(uint64_t const bytes)
+    {
+        return static_cast<double>(bytes) / 1024.0;
+    }
+#endif
 }
 
 // Returns a virtual offset on successful translation; returns
@@ -987,14 +1001,16 @@ void UpdateAux::advance_compact_offsets(
         // bytes to determine how aggressively to advance the compaction head.
         if (stats.compacted_bytes_in_slow != 0 &&
             tl(tid).compact_offset_range_slow_ != 0) {
-            uint32_t const gc_efficiency = static_cast<uint32_t>(std::round(
-                double(tl(tid).compact_offset_range_slow_ << 16) /
-                stats.compacted_bytes_in_slow));
+            uint64_t const slow_range_bytes =
+                uint64_t{tl(tid).compact_offset_range_slow_} << 16;
+            auto const gc_efficiency = static_cast<uint64_t>(std::round(
+                static_cast<double>(slow_range_bytes) /
+                static_cast<double>(stats.compacted_bytes_in_slow)));
             // Cap at last block's growth + 1 to avoid advancing too fast
-            uint32_t const new_range = std::min(
-                static_cast<uint32_t>(last_block_disk_growth_slow_ + 1),
-                gc_efficiency);
-            tl(tid).compact_offset_range_slow_.set_value(new_range);
+            uint64_t const growth_cap =
+                uint64_t{last_block_disk_growth_slow_} + 1;
+            tl(tid).compact_offset_range_slow_.set_value(
+                static_cast<uint32_t>(std::min(growth_cap, gc_efficiency)));
         }
         else {
             // No valid data, use minimum progress
@@ -1115,15 +1131,18 @@ void UpdateAux::print_update_stats(
         stats.nreads_expire);
 
     if (tl(tid).compact_offset_range_fast_) {
+        uint64_t const fast_range_bytes =
+            uint64_t{tl(tid).compact_offset_range_fast_} << 16;
+        uint64_t const slow_range_bytes =
+            uint64_t{tl(tid).compact_offset_range_slow_} << 16;
         std::format_to(
             std::back_inserter(buf),
             "   Fast: total growth ~ {} KB, compact range {} KB, "
             "bytes copied fast to slow {:.2f} KB, active data ratio {:.2f}%\n",
             last_block_disk_growth_fast_ << 6,
             tl(tid).compact_offset_range_fast_ << 6,
-            stats.compacted_bytes_in_fast / 1024.0,
-            100.0 * stats.compacted_bytes_in_fast /
-                (tl(tid).compact_offset_range_fast_ << 16));
+            to_kb(stats.compacted_bytes_in_fast),
+            percent(stats.compacted_bytes_in_fast, fast_range_bytes));
         if (tl(tid).compact_offset_range_slow_) {
             // slow list compaction range vs growth
             auto const total_bytes_written_to_slow =
@@ -1133,12 +1152,11 @@ void UpdateAux::print_update_stats(
                 "   Slow: total growth {:.2f} KB, compact range {} "
                 "KB, bytes copied slow to slow {:.2f} KB, active data ratio "
                 "{:.2f}%. other bytes copied slow to fast {:.2f} KB.\n",
-                total_bytes_written_to_slow / 1024.0,
+                to_kb(total_bytes_written_to_slow),
                 tl(tid).compact_offset_range_slow_ << 6,
-                stats.compacted_bytes_in_slow / 1024.0,
-                100.0 * stats.compacted_bytes_in_slow /
-                    (tl(tid).compact_offset_range_slow_ << 16),
-                stats.bytes_copied_slow_to_fast_for_slow / 1024.0);
+                to_kb(stats.compacted_bytes_in_slow),
+                percent(stats.compacted_bytes_in_slow, slow_range_bytes),
+                to_kb(stats.bytes_copied_slow_to_fast_for_slow));
         }
         else {
             std::format_to(
@@ -1147,24 +1165,19 @@ void UpdateAux::print_update_stats(
         }
 
         // num nodes copied:
-        auto const nodes_copied_for_slow =
-            stats.compacted_nodes_in_fast +
-            stats.nodes_copied_fast_to_fast_for_fast;
+        auto const fast_nodes_copied = stats.compacted_nodes_in_fast +
+                                       stats.nodes_copied_fast_to_fast_for_fast;
         std::format_to(
             std::back_inserter(buf),
             "[Nodes Copied]\n"
             "   Fast: fast to slow {} ({:.2f}%), fast to fast {} ({:.2f}%)\n",
             stats.compacted_nodes_in_fast,
-            nodes_copied_for_slow ? (100.0 * stats.compacted_nodes_in_fast /
-                                     (nodes_copied_for_slow))
-                                  : 0,
+            percent(stats.compacted_nodes_in_fast, fast_nodes_copied),
             stats.nodes_copied_fast_to_fast_for_fast,
-            nodes_copied_for_slow
-                ? (100.0 * stats.nodes_copied_fast_to_fast_for_fast /
-                   nodes_copied_for_slow)
-                : 0);
+            percent(
+                stats.nodes_copied_fast_to_fast_for_fast, fast_nodes_copied));
         if (tl(tid).compact_offsets.slow) {
-            auto const nodes_copied_for_slow =
+            auto const slow_nodes_copied =
                 stats.compacted_nodes_in_slow +
                 stats.nodes_copied_fast_to_fast_for_slow +
                 stats.nodes_copied_slow_to_fast_for_slow;
@@ -1173,21 +1186,19 @@ void UpdateAux::print_update_stats(
                 "   Slow: active slow to slow {} ({:.2f}%), fast to fast {} "
                 "({:.2f}%), other slow to fast {} ({:.2f}%)\n",
                 stats.compacted_nodes_in_slow,
-                nodes_copied_for_slow ? (100.0 * stats.compacted_nodes_in_slow /
-                                         nodes_copied_for_slow)
-                                      : 0,
+                percent(stats.compacted_nodes_in_slow, slow_nodes_copied),
                 stats.nodes_copied_fast_to_fast_for_slow,
-                nodes_copied_for_slow
-                    ? (100.0 * stats.nodes_copied_fast_to_fast_for_slow /
-                       nodes_copied_for_slow)
-                    : 0,
+                percent(
+                    stats.nodes_copied_fast_to_fast_for_slow,
+                    slow_nodes_copied),
                 stats.nodes_copied_slow_to_fast_for_slow,
-                nodes_copied_for_slow
-                    ? (100.0 * stats.nodes_copied_slow_to_fast_for_slow /
-                       nodes_copied_for_slow)
-                    : 0);
+                percent(
+                    stats.nodes_copied_slow_to_fast_for_slow,
+                    slow_nodes_copied));
         }
 
+        auto const fast_compact_reads = stats.nreads_before_compact_offset[0] +
+                                        stats.nreads_after_compact_offset[0];
         std::format_to(
             std::back_inserter(buf),
             "[Reads]\n"
@@ -1197,21 +1208,17 @@ void UpdateAux::print_update_stats(
             "compaction range {} KB = {:.2f}%, bytes read out of "
             "compaction range {:.2f} KB\n",
             stats.nreads_before_compact_offset[0],
-            stats.nreads_before_compact_offset[0] +
-                stats.nreads_after_compact_offset[0],
-            stats.nreads_before_compact_offset[0]
-                ? (100.0 * stats.nreads_before_compact_offset[0] /
-                   (stats.nreads_before_compact_offset[0] +
-                    stats.nreads_after_compact_offset[0]))
-                : 0,
-            (double)stats.bytes_read_before_compact_offset[0] / 1024,
+            fast_compact_reads,
+            percent(stats.nreads_before_compact_offset[0], fast_compact_reads),
+            to_kb(stats.bytes_read_before_compact_offset[0]),
             tl(tid).compact_offset_range_fast_ << 6,
-            stats.bytes_read_before_compact_offset[0]
-                ? (100.0 * stats.bytes_read_before_compact_offset[0] /
-                   tl(tid).compact_offset_range_fast_ / 1024 / 64)
-                : 0,
-            (double)stats.bytes_read_after_compact_offset[0] / 1024);
+            percent(
+                stats.bytes_read_before_compact_offset[0], fast_range_bytes),
+            to_kb(stats.bytes_read_after_compact_offset[0]));
         if (tl(tid).compact_offset_range_slow_) {
+            auto const slow_compact_reads =
+                stats.nreads_before_compact_offset[1] +
+                stats.nreads_after_compact_offset[1];
             std::format_to(
                 std::back_inserter(buf),
                 "   Slow: reads within compaction range {} / "
@@ -1220,20 +1227,15 @@ void UpdateAux::print_update_stats(
                 "compaction range {} KB = {:.2f}%, bytes read out of "
                 "compaction range {:.2f} KB\n",
                 stats.nreads_before_compact_offset[1],
-                stats.nreads_before_compact_offset[1] +
-                    stats.nreads_after_compact_offset[1],
-                stats.nreads_before_compact_offset[1]
-                    ? (100.0 * stats.nreads_before_compact_offset[1] /
-                       (stats.nreads_before_compact_offset[1] +
-                        stats.nreads_after_compact_offset[1]))
-                    : 0,
-                (double)stats.bytes_read_before_compact_offset[1] / 1024,
+                slow_compact_reads,
+                percent(
+                    stats.nreads_before_compact_offset[1], slow_compact_reads),
+                to_kb(stats.bytes_read_before_compact_offset[1]),
                 tl(tid).compact_offset_range_slow_ << 6,
-                stats.bytes_read_before_compact_offset[1]
-                    ? (100.0 * stats.bytes_read_before_compact_offset[1] /
-                       tl(tid).compact_offset_range_slow_ / 1024 / 64)
-                    : 0,
-                (double)stats.bytes_read_after_compact_offset[1] / 1024);
+                percent(
+                    stats.bytes_read_before_compact_offset[1],
+                    slow_range_bytes),
+                to_kb(stats.bytes_read_after_compact_offset[1]));
         }
     }
     LOG_INFO("{}", buf);


### PR DESCRIPTION
The per-upsert counters in TrieUpdateCollectedStats were 32-bit, so a sufficiently large upsert could silently wrap a byte total.

Widening them makes uint64_t -> double narrowing under -Wconversion, which every percentage and KB expression in print_update_stats tripped. The percent() and to_kb() helpers replace that open-coded arithmetic along with its guard-on-the-numerator ternaries; the emitted log text is unchanged. The two "bytes read within compaction range" percentages now share the 64-bit range-in-bytes value with the active-data ratios instead of computing (range << 16) in 32 bits.