### PR TITLE
statesync: name protocol versions with enums, drop v0/v1

### DIFF
--- a/category/statesync/statesync_client.cpp
+++ b/category/statesync/statesync_client.cpp
@@ -99,13 +99,7 @@ void monad_statesync_client_handle_new_peer(
     auto &ptr = ctx->protocol.at(prefix);
     // TODO: handle switching peers
     MONAD_ASSERT(!ptr);
-    switch (version) {
-    case 1:
-        ptr = std::make_unique<StatesyncProtocolV1>();
-        break;
-    default:
-        MONAD_ASSERT(false);
-    };
+    ptr = std::make_unique<StatesyncProtocolV1_2>();
 }
 
 void monad_statesync_client_handle_target(

--- a/category/statesync/statesync_protocol.cpp
+++ b/category/statesync/statesync_protocol.cpp
@@ -161,7 +161,7 @@ MONAD_ANONYMOUS_NAMESPACE_END
 
 MONAD_NAMESPACE_BEGIN
 
-void StatesyncProtocolV1::send_request(
+void StatesyncProtocolV1_2::send_request(
     monad_statesync_client_context *const ctx, uint64_t const prefix) const
 {
     auto const tgrt = ctx->tgrt.number;
@@ -180,7 +180,7 @@ void StatesyncProtocolV1::send_request(
             .old_target = old_target});
 }
 
-bool StatesyncProtocolV1::handle_upsert(
+bool StatesyncProtocolV1_2::handle_upsert(
     monad_statesync_client_context *const ctx, monad_sync_type const type,
     unsigned char const *const val, uint64_t const size) const
 {

--- a/category/statesync/statesync_protocol.hpp
+++ b/category/statesync/statesync_protocol.hpp
@@ -34,7 +34,7 @@ struct StatesyncProtocol
         unsigned char const *, uint64_t) const = 0;
 };
 
-struct StatesyncProtocolV1 : StatesyncProtocol
+struct StatesyncProtocolV1_2 : StatesyncProtocol
 {
     virtual void send_request(
         monad_statesync_client_context *, uint64_t prefix) const override;

--- a/category/statesync/statesync_version.h
+++ b/category/statesync/statesync_version.h
@@ -22,6 +22,27 @@ extern "C"
 {
 #endif
 
+// Components of a statesync protocol version. These are the single source of
+// the {major, minor} pairs monad-bft's StateSyncVersion also names, and bindgen
+// exports them to the rust side.
+enum monad_statesync_version_num : uint16_t
+{
+    MONAD_STATESYNC_MAJOR = 1,
+    // Client acknowledges each response. Minors 0 and 1 predate that and are no
+    // longer spoken; nothing deployed still runs them.
+    MONAD_STATESYNC_MINOR_2 = 2,
+};
+
+// A version as monad-bft's StateSyncVersion encodes it: major << 16 | minor.
+enum monad_statesync_protocol_version : uint32_t
+{
+    MONAD_STATESYNC_VERSION_1_2 =
+        MONAD_STATESYNC_MAJOR << 16 | MONAD_STATESYNC_MINOR_2,
+
+    MONAD_STATESYNC_VERSION_MIN = MONAD_STATESYNC_VERSION_1_2,
+    MONAD_STATESYNC_VERSION = MONAD_STATESYNC_VERSION_1_2,
+};
+
 uint32_t monad_statesync_version();
 
 bool monad_statesync_client_compatible(uint32_t version);

--- a/category/statesync/test/test_statesync.cpp
+++ b/category/statesync/test/test_statesync.cpp
@@ -1803,7 +1803,7 @@ TEST_F(StateSyncFixture, validation_old_target_greater_than_target)
 
 TEST(ProtocolValidation, storage_deletion_rejects_oversized_key)
 {
-    StatesyncProtocolV1 proto;
+    StatesyncProtocolV1_2 proto;
 
     Address a{0xdeadbeef};
     byte_string oversized_key(33, 0xff);
@@ -1818,7 +1818,7 @@ TEST(ProtocolValidation, storage_deletion_rejects_oversized_key)
 
 TEST(ProtocolValidation, upserts_reject_trailing_bytes)
 {
-    StatesyncProtocolV1 proto;
+    StatesyncProtocolV1_2 proto;
 
     auto const dbname = tmp_dbname();
     {
@@ -1883,4 +1883,21 @@ TEST(ProtocolValidation, upserts_reject_trailing_bytes)
             header_buf.size()));
     }
     std::filesystem::remove(dbname);
+}
+
+TEST(StatesyncVersion, wire_encoding)
+{
+    EXPECT_EQ(MONAD_STATESYNC_VERSION_1_2, 0x00010002u);
+}
+
+TEST(StatesyncVersion, compatibility_range)
+{
+    EXPECT_EQ(monad_statesync_version(), MONAD_STATESYNC_VERSION);
+    EXPECT_TRUE(monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_MIN));
+    EXPECT_TRUE(monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_1_2));
+    // 0x00010001 is v1, which peers no longer speak.
+    EXPECT_FALSE(
+        monad_statesync_client_compatible(MONAD_STATESYNC_VERSION_MIN - 1));
+    EXPECT_FALSE(
+        monad_statesync_client_compatible(MONAD_STATESYNC_VERSION + 1));
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1537,6 +1537,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "monad-statesync-version"
+version = "0.1.0"
+dependencies = [
+ "monad-build",
+]
+
+[[package]]
 name = "monad-triedb"
 version = "0.1.0"
 dependencies = [

--- a/rust/crates/monad-statesync-version/Cargo.toml
+++ b/rust/crates/monad-statesync-version/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "monad-statesync-version"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+monad-build = { workspace = true, features = ["bindgen"] }

--- a/rust/crates/monad-statesync-version/build.rs
+++ b/rust/crates/monad-statesync-version/build.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,15 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <category/statesync/statesync_version.h>
-
-uint32_t monad_statesync_version()
-{
-    return MONAD_STATESYNC_VERSION;
-}
-
-bool monad_statesync_client_compatible(uint32_t const version)
-{
-    return version >= MONAD_STATESYNC_VERSION_MIN &&
-           version <= MONAD_STATESYNC_VERSION;
+fn main() {
+    monad_build::bindgen::MonadBindgen::default()
+        .header("wrapper.h")
+        .allowlist_files(["category/statesync/statesync_version.h"])
+        .generate();
 }

--- a/rust/crates/monad-statesync-version/src/lib.rs
+++ b/rust/crates/monad-statesync-version/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The statesync protocol version numbers, generated from execution's
+//! `category/statesync/statesync_version.h`. Split out from `monad-statesync`
+//! so that consumers of the constants alone -- monad-bft's message types --
+//! need neither the C++ library nor a libc, and so stay buildable for wasm.
+
+pub use self::bindings::{
+    monad_statesync_protocol_version_MONAD_STATESYNC_VERSION as MONAD_STATESYNC_VERSION,
+    monad_statesync_protocol_version_MONAD_STATESYNC_VERSION_MIN as MONAD_STATESYNC_VERSION_MIN,
+    monad_statesync_version_num_MONAD_STATESYNC_MAJOR as MONAD_STATESYNC_MAJOR,
+    monad_statesync_version_num_MONAD_STATESYNC_MINOR_2 as MONAD_STATESYNC_MINOR_2,
+};
+
+#[allow(dead_code, non_camel_case_types, non_upper_case_globals)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}

--- a/rust/crates/monad-statesync-version/wrapper.h
+++ b/rust/crates/monad-statesync-version/wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Category Labs, Inc.
+// Copyright (C) 2025-26 Category Labs, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,14 +14,3 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <category/statesync/statesync_version.h>
-
-uint32_t monad_statesync_version()
-{
-    return MONAD_STATESYNC_VERSION;
-}
-
-bool monad_statesync_client_compatible(uint32_t const version)
-{
-    return version >= MONAD_STATESYNC_VERSION_MIN &&
-           version <= MONAD_STATESYNC_VERSION;
-}


### PR DESCRIPTION
The C++ side numbered the protocol 1, 2, 3... while monad-bft numbers it
`{major, minor}` and puts `major << 16 | minor` on the wire, so the version
`monad_statesync_version()` reported bore no relation to the version peers
negotiate.

Name the ladder once, in `statesync_version.h`: an enum of the `{major, minor}`
components, and an enum of the packed values built from them. Only v2 is on it —
v0 and v1 predate the client acknowledging each response and nothing deployed
still runs them — so `monad_statesync_client_compatible()` accepts exactly what
monad-bft's `is_compatible()` does. `handle_new_peer`'s switch on the old
numbering goes with it; every version it can be handed speaks the one protocol
we implement.

Per review, monad-bft now defines `StateSyncVersion` from these enums rather
than repeating the numbers. That is why they get their own crate,
`monad-statesync-version`, instead of riding along in `monad-statesync`: the
consumer is `monad-executor-glue`, `monad-debugger` depends on glue, and CI
checks that crate for `wasm32-unknown-unknown`. The FFI crate cannot build for
wasm — `monad-cxx` does not compile for it, and bindgen dies on `assert.h`
reached through `statesync_messages.h` — whereas `statesync_version.h` pulls
only `<stdint.h>`, so it needs neither a libc nor any linkage.

Companion monad-bft PR: category-labs/monad-bft#3211

### Testing

- `StatesyncVersion.wire_encoding` pins the packed value to the number monad-bft
  puts on the wire, so editing a component cannot silently change the encoding.
- `StatesyncVersion.compatibility_range` pins `monad_statesync_version()` to the
  newest rung and checks both boundaries — notably that v1 (`MIN - 1`) is now
  refused.
