### PR TITLE
execution: link the vendored secp256k1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ find_package(Boost REQUIRED COMPONENTS context filesystem json CONFIG)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(brotli REQUIRED IMPORTED_TARGET libbrotlienc libbrotlidec)
 pkg_check_modules(crypto++ REQUIRED IMPORTED_TARGET libcrypto++)
-pkg_check_modules(secp256k1 REQUIRED IMPORTED_TARGET libsecp256k1)
 pkg_check_modules(zstd REQUIRED IMPORTED_TARGET libzstd)
 
 # ankerl

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -351,7 +351,7 @@ target_link_libraries(
   PRIVATE monad_crypto
   PRIVATE PkgConfig::brotli
   PRIVATE PkgConfig::crypto++
-  PUBLIC secp256k1
+  PRIVATE secp256k1
   PUBLIC ethash::keccak
   PUBLIC evmc
   PUBLIC immer

--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -351,7 +351,7 @@ target_link_libraries(
   PRIVATE monad_crypto
   PRIVATE PkgConfig::brotli
   PRIVATE PkgConfig::crypto++
-  PRIVATE PkgConfig::secp256k1
+  PUBLIC secp256k1
   PUBLIC ethash::keccak
   PUBLIC evmc
   PUBLIC immer
@@ -372,7 +372,7 @@ target_link_libraries(
   PUBLIC monad_trie
   PUBLIC evmc
   PUBLIC magic_enum::magic_enum
-  PRIVATE PkgConfig::secp256k1
+  PUBLIC secp256k1
   PUBLIC quill::quill)
 monad_compile_options(monad_execution_native)
 

--- a/scripts/ubuntu-build/install-deps.sh
+++ b/scripts/ubuntu-build/install-deps.sh
@@ -12,7 +12,6 @@ packages=(
   libgmock-dev
   libgmp-dev
   libgtest-dev
-  libsecp256k1-dev
   libtbb-dev
   liburing-dev
   libzstd-dev

--- a/third_party/silkpre_vendor/CMakeLists.txt
+++ b/third_party/silkpre_vendor/CMakeLists.txt
@@ -33,7 +33,7 @@ target_sources(monad_crypto PRIVATE
 )
 
 # ecdsa needs libsecp256k1 and ethash
-target_link_libraries(monad_crypto PUBLIC PkgConfig::secp256k1 ethash::keccak)
+target_link_libraries(monad_crypto PUBLIC secp256k1 ethash::keccak)
 
 # Consumers include the headers via `<silkpre_vendor/sha256.h>` etc.
 target_include_directories(monad_crypto PUBLIC src/)


### PR DESCRIPTION
monad_crypto, monad_execution and monad_execution_native link the secp256k1 target built from third_party/silkpre, so the shared objects resolve against the copy installed alongside them.

The link is PUBLIC because staking/util/secp256k1.hpp and staking/test/input_generation.hpp expose secp256k1_context and secp256k1_pubkey in their interfaces.