### PR TITLE
Implement EIP-7981 to increase access list cost

### DIFF
--- a/category/execution/ethereum/execute_transaction.cpp
+++ b/category/execution/ethereum/execute_transaction.cpp
@@ -391,7 +391,7 @@ Receipt ExecuteTransaction<traits>::execute_final(
 
     // EIP-7623
     if constexpr (traits::evm_rev() >= MONAD_ETH_PRAGUE) {
-        auto const floor_gas = floor_data_gas(tx_);
+        auto const floor_gas = floor_data_gas<traits>(tx_);
         if (gas_used < floor_gas) {
             auto const delta = floor_gas - gas_used;
             state.subtract_from_balance(sender_, gas_cost * delta);

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -68,6 +68,17 @@ inline constexpr auto g_access_and_storage(Transaction const &tx) noexcept
     return g;
 }
 
+// EIP-7981
+// Without EIP-7976, the 64 per-byte cost specified by EIP-7981 is 40 per-byte
+inline constexpr uint64_t g_access_list_data(Transaction const &tx) noexcept
+{
+    uint64_t g = tx.access_list.size() * 20u;
+    for (auto const &i : tx.access_list) {
+        g += i.keys.size() * 32u;
+    }
+    return g * 40u;
+}
+
 // EIP-7702
 inline constexpr auto g_authorization(Transaction const &tx) noexcept
 {
@@ -124,17 +135,28 @@ uint64_t intrinsic_gas(Transaction const &tx) noexcept
     if constexpr (traits::evm_rev() >= MONAD_ETH_PRAGUE) {
         gas += g_authorization(tx);
     }
+    // EIP-7981: increase access-list cost (Amsterdam)
+    if constexpr (traits::eip_7981_active()) {
+        gas += g_access_list_data(tx);
+    }
 
     return gas;
 }
 
 EXPLICIT_TRAITS(intrinsic_gas);
 
+template <Traits traits>
 uint64_t floor_data_gas(Transaction const &tx) noexcept
 {
     auto const [zeros, nonzeros] = tokens_in_calldata(tx);
-    return 21'000 + (zeros * 10u + nonzeros * 40u);
+    uint64_t gas = 21'000 + (zeros * 10u + nonzeros * 40u);
+    if constexpr (traits::eip_7981_active()) {
+        gas += g_access_list_data(tx);
+    }
+    return gas;
 }
+
+EXPLICIT_TRAITS(floor_data_gas);
 
 inline constexpr uint256_t priority_fee_per_gas(
     Transaction const &tx, uint256_t const &base_fee_per_gas) noexcept

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -37,6 +37,7 @@ uint64_t g_data(Transaction const &) noexcept;
 template <Traits traits>
 uint64_t intrinsic_gas(Transaction const &) noexcept;
 
+template <Traits traits>
 uint64_t floor_data_gas(Transaction const &) noexcept;
 
 template <Traits traits>

--- a/category/execution/ethereum/transaction_gas_test.cpp
+++ b/category/execution/ethereum/transaction_gas_test.cpp
@@ -119,6 +119,12 @@ TYPED_TEST(TraitsTest, intrinsic_gas)
     static constexpr auto cost_per_access_list_address = 2'400;
     static constexpr auto cost_per_access_list_key = 1'900;
 
+    // EIP-7981
+    static constexpr uint64_t cost_per_access_list_data_address =
+        TestFixture::Trait::eip_7981_active() ? 20u * 40u : 0u;
+    static constexpr uint64_t cost_per_access_list_data_key =
+        TestFixture::Trait::eip_7981_active() ? 32u * 40u : 0u;
+
     {
         Transaction t{};
         t.to = 0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address;
@@ -131,15 +137,61 @@ TYPED_TEST(TraitsTest, intrinsic_gas)
         EXPECT_EQ(
             intrinsic_gas<typename TestFixture::Trait>(t),
             21'000 + cost_per_access_list_address +
-                2 * cost_per_access_list_key);
+                2 * cost_per_access_list_key +
+                cost_per_access_list_data_address +
+                2 * cost_per_access_list_data_key);
 
         t.data.push_back(0x00);
         t.data.push_back(0xff);
         EXPECT_EQ(
             intrinsic_gas<typename TestFixture::Trait>(t),
             21'000 + cost_per_access_list_address +
-                2 * cost_per_access_list_key + zero_token_cost +
+                2 * cost_per_access_list_key +
+                cost_per_access_list_data_address +
+                2 * cost_per_access_list_data_key + zero_token_cost +
                 non_zero_token_cost);
+    }
+}
+
+TYPED_TEST(TraitsTest, floor_data_gas)
+{
+    static_assert(TestFixture::Trait::evm_rev() >= MONAD_ETH_BERLIN);
+
+    // EIP-7623
+    static constexpr uint64_t zero_floor_token_cost = 10u;
+    static constexpr uint64_t non_zero_floor_token_cost = 40u;
+
+    // EIP-7981
+    static constexpr uint64_t cost_per_access_list_data_address =
+        TestFixture::Trait::eip_7981_active() ? 20u * 40u : 0u;
+    static constexpr uint64_t cost_per_access_list_data_key =
+        TestFixture::Trait::eip_7981_active() ? 32u * 40u : 0u;
+
+    {
+        Transaction t{};
+        t.data.push_back(0x00);
+        t.data.push_back(0xff);
+        EXPECT_EQ(
+            floor_data_gas<typename TestFixture::Trait>(t),
+            21'000 + zero_floor_token_cost + non_zero_floor_token_cost);
+    }
+
+    {
+        Transaction t{};
+        t.to = 0xf8636377b7a998b51a3cf2bd711b870b3ab0ad56_address;
+
+        static constexpr auto key1{
+            0x0000000000000000000000000000000000000000000000000000000000000007_bytes32};
+        static constexpr auto key2{
+            0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
+        t.access_list.push_back({*t.to, {key1, key2}});
+        t.data.push_back(0x00);
+        t.data.push_back(0xff);
+        EXPECT_EQ(
+            floor_data_gas<typename TestFixture::Trait>(t),
+            21'000 + zero_floor_token_cost + non_zero_floor_token_cost +
+                cost_per_access_list_data_address +
+                2 * cost_per_access_list_data_key);
     }
 }
 

--- a/category/execution/ethereum/validate_transaction.cpp
+++ b/category/execution/ethereum/validate_transaction.cpp
@@ -35,7 +35,6 @@
 #include <boost/outcome/success_failure.hpp>
 
 #include <cstdint>
-#include <initializer_list>
 #include <limits>
 #include <optional>
 
@@ -136,7 +135,7 @@ Result<void> static_validate_transaction(
 
     if constexpr (traits::evm_rev() >= MONAD_ETH_PRAGUE) {
         // EIP-7623
-        if (MONAD_UNLIKELY(floor_data_gas(tx) > tx.gas_limit)) {
+        if (MONAD_UNLIKELY(floor_data_gas<traits>(tx) > tx.gas_limit)) {
             return TransactionError::IntrinsicGasGreaterThanLimit;
         }
 

--- a/category/vm/evm/traits.hpp
+++ b/category/vm/evm/traits.hpp
@@ -84,6 +84,7 @@ namespace monad
         { T::eip_7918_active() } -> std::same_as<bool>;
         { T::eip_7939_active() } -> std::same_as<bool>;
         { T::eip_7951_active() } -> std::same_as<bool>;
+        { T::eip_7981_active() } -> std::same_as<bool>;
         { T::mip_3_active() } -> std::same_as<bool>;
         { T::mip_8_active() } -> std::same_as<bool>;
         { T::mip_11_active() } -> std::same_as<bool>;
@@ -182,6 +183,11 @@ namespace monad
             return Rev >= MONAD_ETH_OSAKA;
         }
 
+        static consteval bool eip_7981_active() noexcept
+        {
+            return Rev >= MONAD_ETH_AMSTERDAM;
+        }
+
         static consteval bool mip_3_active() noexcept
         {
             return false;
@@ -266,6 +272,9 @@ namespace monad
     {
         static consteval monad_eth_revision evm_rev() noexcept
         {
+            if constexpr (Rev >= MONAD_NEXT) {
+                return MONAD_ETH_AMSTERDAM;
+            }
             if constexpr (Rev >= MONAD_NINE) {
                 return MONAD_ETH_OSAKA;
             }
@@ -351,6 +360,11 @@ namespace monad
         static consteval bool eip_7951_active() noexcept
         {
             return Rev >= MONAD_FOUR;
+        }
+
+        static consteval bool eip_7981_active() noexcept
+        {
+            return evm_rev() >= MONAD_ETH_AMSTERDAM;
         }
 
         static consteval bool mip_3_active() noexcept

--- a/test/ethereum_test/CMakeLists.txt
+++ b/test/ethereum_test/CMakeLists.txt
@@ -45,6 +45,16 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON)
 
+ExternalProject_Add(
+  MonadEip7981SpecTestFixtures
+  URL "https://github.com/monad-developers/execution-specs/releases/download/tests-monad_eip7981@v0.1.0/fixtures_monad_eip7981.tar.gz"
+  URL_HASH "SHA256=d624ec9c38c945c48f43ffb229c0a963660b8506d5bf4fe8068e13df4fdf0b8d"
+  PREFIX ${CMAKE_BINARY_DIR}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD ON)
+
 add_executable(monad-ethereum-test)
 target_link_libraries(monad-ethereum-test PRIVATE GTest::gtest monad-test-utils)
 target_sources(
@@ -122,6 +132,7 @@ list(JOIN MONAD_NEXT_amsterdam_excluded_tests ":" TESTS_EXCLUDED)
 add_test(NAME MONAD_NEXT_amsterdam_monad_ethereum_test
          COMMAND monad-ethereum-test --fork MONAD_NEXT
                  --blockchain-tests ${CMAKE_BINARY_DIR}/src/MonadAmsterdamSpecTestFixtures/blockchain_tests
+                 --blockchain-tests ${CMAKE_BINARY_DIR}/src/MonadEip7981SpecTestFixtures/blockchain_tests
                  --gtest_filter=-:${TESTS_EXCLUDED})
 if(MONAD_NEXT_amsterdam_excluded_tests STREQUAL "BlockchainTests.*")
   set_tests_properties(MONAD_NEXT_amsterdam_monad_ethereum_test

--- a/test/ethereum_test/exclude/MONAD_NEXT_amsterdam.cmake
+++ b/test/ethereum_test/exclude/MONAD_NEXT_amsterdam.cmake
@@ -15,7 +15,12 @@
 
 # The MONAD_NEXT Amsterdam spec-test fixtures (EIP-7708, EIP-7843, EIP-8024)
 # expect a block header carrying the SLOTNUM field, which the execution layer
-# does not yet emit; every fixture therefore fails the genesis block-hash
-# check. Exclude the whole suite for now and drop entries here to re-enable
-# individual tests as support lands.
-set(MONAD_NEXT_amsterdam_excluded_tests "BlockchainTests.*")
+# does not yet emit.
+# Drop entries here to re-enable individual tests as support lands.
+set(MONAD_NEXT_amsterdam_excluded_tests
+  "BlockchainTests.for_monad_next/amsterdam/eip7843_slotnum/*"
+  "BlockchainTests.for_monad_next/amsterdam/eip7708_eth_transfer_logs/*"
+  "BlockchainTests.for_monad_next/amsterdam/eip8024_dupn_swapn_exchange/*"
+  # Test contains a EIP-4844 blob which is disabled on Monad
+  "BlockchainTests.for_monad_next/amsterdam/eip7981_increase_access_list_cost/transaction_validity/transactions_without_access_list.json"
+)

--- a/test/ethereum_test/src/main.cpp
+++ b/test/ethereum_test/src/main.cpp
@@ -39,12 +39,14 @@
 
 #include <chrono>
 #include <cstddef>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 MONAD_NAMESPACE_BEGIN
 
@@ -65,7 +67,7 @@ int main(int argc, char *argv[])
     std::optional<size_t> txn_index = std::nullopt;
     std::string record_exec_events_path;
     std::unique_ptr<OwnedEventRing> exec_event_ring;
-    std::optional<std::filesystem::path> blockchain_tests_path;
+    std::vector<std::filesystem::path> blockchain_tests_paths;
     std::optional<std::filesystem::path> transaction_tests_path;
     bool trace_calls = false;
     unsigned sleep_seconds = 0;
@@ -92,8 +94,9 @@ int main(int argc, char *argv[])
     app.add_flag("--trace_calls", trace_calls, "Enable call tracing");
     app.add_option(
            "--blockchain-tests",
-           blockchain_tests_path,
-           "Path to blockchain tests, overrides the hard-coded tests path.")
+           blockchain_tests_paths,
+           "Path to blockchain tests, overrides the hard-coded tests path. May "
+           "be given multiple times to register several test directories.")
         ->check(CLI::ExistingPath);
     app.add_option(
            "--transaction-tests",
@@ -129,10 +132,10 @@ int main(int argc, char *argv[])
 
     std::this_thread::sleep_for(std::chrono::seconds{sleep_seconds});
 
-    if (blockchain_tests_path || transaction_tests_path) {
-        if (blockchain_tests_path) {
+    if (!blockchain_tests_paths.empty() || transaction_tests_path) {
+        for (auto const &blockchain_tests_path : blockchain_tests_paths) {
             test::register_blockchain_tests_path(
-                *blockchain_tests_path,
+                blockchain_tests_path,
                 revision,
                 vm_mode,
                 trace_calls,


### PR DESCRIPTION
Additional cost is conditional on feature flag `eip_7981_active` for intrinsic/floor gas calculations.

Feature is active for EVM rev `>= MONAD_ETH_AMSTERDAM`.

Note: the 64 per-byte cost specified by EIP-7981 is actually 40 per-byte since we haven't/aren't going to implement EIP-7976