### PR TITLE
offset trie improvments

### DIFF
--- a/category/execution/ethereum/db/offset_trie.cpp
+++ b/category/execution/ethereum/db/offset_trie.cpp
@@ -35,7 +35,6 @@
 #include <bit>
 #include <cstdint>
 #include <cstring>
-#include <limits>
 #include <span>
 #include <utility>
 #include <vector>
@@ -61,6 +60,22 @@ NodeId OffsetTrie::read_root(byte_string_view const blob)
     return root;
 }
 
+namespace
+{
+    // Set (val = true) or clear (val = false) the bit for byte offset `off`
+    template <bool val>
+    void set_offset_value(std::span<uint64_t> const offsets, uint64_t const off)
+    {
+        uint64_t const bit = uint64_t{1} << (off & 63);
+        if constexpr (val) {
+            offsets[off >> 6] |= bit;
+        }
+        else {
+            offsets[off >> 6] &= ~bit;
+        }
+    }
+}
+
 OffsetTrie::OffsetTrie(byte_string_view const blob)
     : blob_(blob)
     , root{read_root(blob_)}
@@ -79,12 +94,20 @@ OffsetTrie::OffsetTrie(byte_string_view const blob)
     MONAD_ASSERT(node.bytes() == region_end || node.tag() != EMPTY);
     std::vector<uint64_t> node_offsets((blob_.size() + 63) / 64, 0);
 
+    // A node's bit is set when the walk reaches it and cleared when a parent
+    // claims it as a child.
+    // A child whose bit is clear is either previously unseen/invalid or already
+    // claimed by a different parent.
     auto const is_valid_offset = [&](NodeId c) {
+        if (c == NULL_ID) {
+            return;
+        }
         uint64_t child_offset = static_cast<uint64_t>(c);
         MONAD_ASSERT(
-            c == NULL_ID ||
-            (child_offset < node_offset && child_offset < blob_.size() &&
-             ((node_offsets[child_offset >> 6] >> (child_offset & 63)) & 1)));
+            child_offset < blob_.size() &&
+            (node_offsets[child_offset >> 6] &
+             (uint64_t{1} << (child_offset & 63))));
+        set_offset_value<false>(node_offsets, child_offset);
     };
     unsigned char rlp_buf[MAX_NODE_RLP];
 
@@ -137,12 +160,17 @@ OffsetTrie::OffsetTrie(byte_string_view const blob)
                     }
                 }});
 
-        node_offsets[node_offset >> 6] |= 1ull << (node_offset & 63);
+        set_offset_value<true>(node_offsets, node_offset);
         node = NodeViewBase{base + next_offset};
         node_offset = next_offset;
     }
     MONAD_ASSERT(node.bytes() == region_end); // nodes tile exactly
     is_valid_offset(root);
+
+    // Every node was claimed exactly once, a leftover bit is a node not
+    // reachable from root.
+    MONAD_ASSERT(std::ranges::all_of(
+        node_offsets, [](uint64_t const w) { return w == 0; }));
 }
 
 NodeViewBase OffsetTrie::find_original(NodeId id, NibblesView key) const
@@ -209,6 +237,7 @@ bytes32_t OffsetTrie::hash(NodeId const id)
 
                 unsigned char buf[MAX_NODE_RLP];
                 node_rlp_span const rem = encode_rlp(node, node_rlp_span{buf});
+                MONAD_ASSERT(rem.rlp_size() >= 32);
                 bytes32_t h;
                 // RLP occupies the tail: [rem.end(), buf_end).
                 monad_keccak256(rem.rlp_data(), rem.rlp_size(), h.bytes);
@@ -284,10 +313,10 @@ OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
         std::memcpy(s.last(hdr_len).data(), hdr, hdr_len);
         return s.shrink(hdr_len);
     };
-    return node_rlp_span{match(
+    return match(
         node,
         Cases{
-            [&, wrap](BranchView b) -> std::span<unsigned char> {
+            [&, wrap](BranchView b) -> node_rlp_span {
                 dest.back() = 0x80; // empty branch value — last list element
                 dest = dest.shrink(1);
                 std::array<node_id_wire_t, 16> const children = b.children();
@@ -337,14 +366,13 @@ OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
                 }
                 return wrap(dest);
             },
-            [&, encode_path, wrap](ExtView e) -> std::span<unsigned char> {
+            [&, encode_path, wrap](ExtView e) -> node_rlp_span {
                 // child ref — last element
                 dest = child_ref<priming_pass>(e.child(), dest);
                 dest = encode_path(dest, e.path(), /*terminating=*/false);
                 return wrap(dest);
             },
-            [&, encode_path, wrap](
-                AccountLeafView l) -> std::span<unsigned char> {
+            [&, encode_path, wrap](AccountLeafView l) -> node_rlp_span {
                 // The leaf's value is the account's canonical RLP, which the
                 // node no longer holds whole: rebuild it straight into dest's
                 // tail — last field first, like everything else here —
@@ -353,17 +381,8 @@ OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
                 // through hash() is what ties the account to its storage — a
                 // leaf can only claim the root its subtree actually hashes to,
                 // and NULL_ID resolves to NULL_ROOT, i.e. no storage at all.
-                bytes32_t const storage_root = hash(l.storage());
-                byte_string_view const code_hash = l.code_hash_rlp();
-                std::memcpy(
-                    dest.last(HASH_RLP_LEN).data(),
-                    code_hash.data(),
-                    HASH_RLP_LEN);
-                dest = dest.shrink(HASH_RLP_LEN);
-                rlp::encode_string(
-                    dest.last(HASH_RLP_LEN),
-                    byte_string_view{storage_root.bytes, 32});
-                dest = dest.shrink(HASH_RLP_LEN);
+                dest = encode_rlp(l.code_hash_rlp(), dest);
+                dest = encode_rlp(hash(l.storage()), dest);
                 byte_string_view const nonce_balance = l.nonce_balance_rlp();
                 std::memcpy(
                     dest.last(nonce_balance.size()).data(),
@@ -387,8 +406,7 @@ OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
                 dest = encode_path(dest, l.path(), /*terminating=*/true);
                 return wrap(dest);
             },
-            [&, encode_path, wrap](
-                StorageLeafView l) -> std::span<unsigned char> {
+            [&, encode_path, wrap](StorageLeafView l) -> node_rlp_span {
                 bytes32_t const v = l.value();
                 // storage value = rlp(zeroless(slot)), itself wrapped again
                 // as the leaf's value string: write the inner rlp(zl) into
@@ -408,9 +426,9 @@ OffsetTrie::encode_rlp(NodeViewBase const node, OffsetTrie::node_rlp_span dest)
                 dest = encode_path(dest, l.path(), /*terminating=*/true);
                 return wrap(dest);
             },
-            [](DigestView) -> std::span<unsigned char> { std::unreachable(); },
-            [](NullView) -> std::span<unsigned char> { std::unreachable(); },
-        })};
+            [](DigestView) -> node_rlp_span { std::unreachable(); },
+            [](NullView) -> node_rlp_span { std::unreachable(); },
+        });
 }
 
 namespace
@@ -444,7 +462,7 @@ namespace
     void append_path(byte_string &b, NibblesView const path)
     {
         unsigned const nlen = path.nibble_size();
-        MONAD_ASSERT(nlen <= std::numeric_limits<unsigned char>::max());
+        MONAD_ASSERT(nlen <= MAX_PATH_NIBBLES);
         b.push_back(static_cast<unsigned char>(nlen));
         size_t const start = b.size();
         b.resize(start + (nlen + 1) / 2, 0);
@@ -562,7 +580,8 @@ NodeId OffsetTrie::clone_acct(
 {
     // Everything up to the path — tag, storage edge and both field runs — is
     // copied verbatim, so re-pathing neither decodes nor re-encodes it.
-    byte_string node{acc.bytes(), rlp_end(child_end(acc.payload()))};
+    byte_string node{
+        acc.bytes(), rlp_end(code_hash_end(child_end(acc.payload())))};
     append_path(node, new_path);
     return put_node(id, std::move(node));
 }

--- a/category/execution/ethereum/db/offset_trie.hpp
+++ b/category/execution/ethereum/db/offset_trie.hpp
@@ -62,6 +62,9 @@ inline constexpr uint32_t HEADER_LEN = 8; // magic(4) root_offset(4)
 // + value slot + list header. 700 leaves margin.
 inline constexpr size_t MAX_NODE_RLP = 700;
 
+// Longest path a node may carry.
+inline constexpr unsigned MAX_PATH_NIBBLES = 64;
+
 // A node's stable id. 0 = null; `n` in the [HEADER_LEN, blob_len) range is
 // a blob offset (unless shadowed by an overlay); n >= OVERLAY_BASE is a
 // fresh overlay node.
@@ -76,7 +79,8 @@ inline constexpr NodeId NULL_ID{0};
 // Width of a child/root field in the node encoding
 using node_id_wire_t = uint32_t;
 
-inline constexpr size_t HASH_RLP_LEN = 33; // 0xa0 ‖ 32 B
+inline constexpr size_t HASH_RLP_LEN = KECCAK256_SIZE + 1; // 0xa0 ‖ 32 B
+using hash_rlp_view = std::span<unsigned char const, HASH_RLP_LEN>;
 // Widest that run can get: 1 + 8 for the nonce, 1 + 32 for the balance. Both
 // are RLP-zeroless, so real accounts sit far below this.
 inline constexpr size_t MAX_NONCE_BALANCE_RLP_LEN = 42;
@@ -172,9 +176,9 @@ inline unsigned path_length(unsigned char const *const p)
 }
 
 // Packed size of the path in bytes — half the nibble count, rounded up.
-inline unsigned path_byte_length(unsigned char const *const p)
+inline unsigned path_byte_length(unsigned n)
 {
-    return (path_length(p) + 1) / 2;
+    return (n + 1) / 2;
 }
 
 inline NibblesView path_view(unsigned char const *const p)
@@ -182,25 +186,41 @@ inline NibblesView path_view(unsigned char const *const p)
     return NibblesView{0u, path_length(p), p + 1};
 }
 
+template <typename C>
+inline C path_view_end(C const p, unsigned nlen)
+{
+    return p + 1 + path_byte_length(nlen);
+}
+
 inline unsigned char const *path_view_end(unsigned char const *const p)
 {
-    return p + 1 + path_byte_length(p);
+    return path_view_end(p, path_length(p));
 }
 
 // LEAF_ACCT and EXT keep their child id at a fixed position right after the
 // tag, so storage()/child() is a constant-offset read instead of a walk
 // over a path or account RLP. The rest of the node follows that field.
-inline unsigned char const *child_end(unsigned char const *const p)
+template <typename C>
+inline C child_end(C const p)
 {
     return p + sizeof(node_id_wire_t);
 }
 
-// One past a LEAF_ACCT's field runs, from the start of its code hash: the
-// fixed-width hash, then the length byte and the nonce ‖ balance run it
-// counts.
+template <typename C>
+inline C code_hash_end(C const p)
+{
+    return p + HASH_RLP_LEN;
+}
+
+template <typename C>
+inline C rlp_end(C const p, unsigned nlen)
+{
+    return p + 1 + nlen;
+}
+
 inline unsigned char const *rlp_end(unsigned char const *const p)
 {
-    return p + HASH_RLP_LEN + 1 + p[HASH_RLP_LEN];
+    return rlp_end(p, p[0]);
 }
 
 inline unsigned char const *
@@ -208,41 +228,55 @@ NodeViewBase::checked_end(unsigned char const *const region_end) const
 {
     MONAD_DEBUG_ASSERT(bytes() < region_end);
 
-    auto const path_view_end_checked =
-        [region_end](unsigned char const *const p) {
-            MONAD_ASSERT(p < region_end);
-            return path_view_end(p);
-        };
+    size_t const avail = static_cast<size_t>(region_end - bytes());
 
-    auto const rlp_end_checked = [region_end](unsigned char const *const p) {
-        MONAD_ASSERT(static_cast<size_t>(region_end - p) > HASH_RLP_LEN);
-        return rlp_end(p);
+    auto const fits = [avail](size_t const off) {
+        MONAD_ASSERT(off <= avail);
+        return off;
     };
 
-    unsigned char const *end_ptr{nullptr};
+    auto const at = [this, avail](size_t const off) -> unsigned {
+        MONAD_ASSERT(off < avail);
+        return bytes()[off];
+    };
+
+    auto const path_view_end_checked = [&](size_t const off) {
+        unsigned const nlen = at(off);
+        MONAD_ASSERT(nlen <= MAX_PATH_NIBBLES);
+        return fits(path_view_end(off, nlen));
+    };
+
+    auto const rlp_end_checked = [&](size_t const off) {
+        unsigned const rlp_len = at(off);
+        return fits(rlp_end(off, rlp_len));
+    };
+
+    constexpr size_t PAYLOAD_OFF = 1;
+
+    size_t end_off{0};
 
     switch (tag()) {
-    case BRANCH: // 16 child offsets
-        end_ptr = payload() + 16 * sizeof(node_id_wire_t);
+    case BRANCH: // tag + 16 child offsets
+        end_off = fits(PAYLOAD_OFF + 16 * sizeof(node_id_wire_t));
         break;
     case EXT: // child offset + path
-        end_ptr = path_view_end_checked(child_end(payload()));
+        end_off = path_view_end_checked(child_end(PAYLOAD_OFF));
         break;
     case LEAF_ACCT: // storage offset + code hash + nonce & balance length +
                     // nonce & balance + path
-        end_ptr = path_view_end_checked(rlp_end_checked(child_end(payload())));
+        end_off = path_view_end_checked(
+            rlp_end_checked(code_hash_end(child_end(PAYLOAD_OFF))));
         break;
     case LEAF_STORAGE: // 32-byte value + path
-        end_ptr = path_view_end_checked(payload() + 32);
+        end_off = path_view_end_checked(PAYLOAD_OFF + 32);
         break;
     case DIGEST: // 32-byte hash
-        end_ptr = payload() + 32;
+        end_off = fits(PAYLOAD_OFF + 32);
         break;
     default:
         MONAD_ABORT("offset trie: invalid node tag");
     }
-    MONAD_ASSERT(end_ptr <= region_end);
-    return end_ptr;
+    return bytes() + end_off;
 }
 
 class NullView : public NodeViewBase
@@ -316,9 +350,9 @@ public:
     }
 
     // code_hash as an RLP string
-    byte_string_view code_hash_rlp() const
+    hash_rlp_view code_hash_rlp() const
     {
-        return byte_string_view{child_end(payload()), HASH_RLP_LEN};
+        return hash_rlp_view{child_end(payload()), HASH_RLP_LEN};
     }
 
     // nonce ‖ balance as RLP strings
@@ -332,7 +366,7 @@ public:
 
     NibblesView path() const
     {
-        return path_view(rlp_end(child_end(payload())));
+        return path_view(rlp_end(code_hash_end(child_end(payload()))));
     }
 
     // lazily RLP-decode the account (fields for read_account)
@@ -341,7 +375,9 @@ public:
         Account acct;
         // Decoded through the accessors, so the stored length is bounded here
         // as well and not only on the extent walk.
-        byte_string_view code_hash = code_hash_rlp();
+        auto const code_hash_bytes = code_hash_rlp();
+        byte_string_view code_hash{
+            code_hash_bytes.data(), code_hash_bytes.size()};
         auto const hash = rlp::decode_bytes32(code_hash);
         MONAD_ASSERT(hash.has_value());
         acct.code_hash = hash.value();
@@ -391,6 +427,13 @@ public:
         bytes32_t h;
         std::memcpy(h.bytes, payload(), 32);
         return h;
+    }
+
+    // Since the DIGEST byte is 0x80 + KECCAK256_SIZE, a digest node is also a
+    // valid RLP encoded string
+    hash_rlp_view hash_rlp() const
+    {
+        return hash_rlp_view{bytes(), HASH_RLP_LEN};
     }
 };
 
@@ -517,8 +560,11 @@ private:
     //   rlp_data() = data() + size(),  rlp_size() = MAX_NODE_RLP - size().
     struct node_rlp_span : std::span<unsigned char>
     {
-        explicit node_rlp_span(std::span<unsigned char> const s)
-            : std::span<unsigned char>(s)
+        // rlp_size() computes the written tail as MAX_NODE_RLP - size(),
+        // which is only right when the span starts out covering exactly
+        // MAX_NODE_RLP bytes — so that is the only buffer accepted here.
+        explicit node_rlp_span(unsigned char (&buf)[MAX_NODE_RLP])
+            : std::span<unsigned char>(buf)
         {
         }
 
@@ -528,6 +574,13 @@ private:
         // accidental writes to the unwritten head being mistaken for the
         // payload.
         unsigned char *data() const = delete;
+
+        // The remaining unchecked accessors are deleted too: bytes are
+        // reachable only through the asserting back()/last() below.
+        unsigned char &operator[](size_t) const = delete;
+        unsigned char &front() const = delete;
+        std::span<unsigned char> first(size_t) const = delete;
+        std::span<unsigned char> subspan(size_t, size_t) const = delete;
 
         unsigned char const *rlp_data() const
         {
@@ -539,9 +592,28 @@ private:
             return MAX_NODE_RLP - size();
         }
 
+        unsigned char &back() const
+        {
+            MONAD_ASSERT(!empty());
+            return std::span<unsigned char>::back();
+        }
+
+        std::span<unsigned char> last(size_t const n) const
+        {
+            MONAD_ASSERT(n <= size());
+            return std::span<unsigned char>::last(n);
+        }
+
         node_rlp_span shrink(size_t const n) const
         {
-            return node_rlp_span{first(size() - n)};
+            MONAD_ASSERT(n <= size());
+            return node_rlp_span{std::span<unsigned char>::first(size() - n)};
+        }
+
+    private:
+        explicit node_rlp_span(std::span<unsigned char> const s)
+            : std::span<unsigned char>(s)
+        {
         }
     };
 
@@ -574,21 +646,30 @@ private:
                 },
                 [&](DigestView d) {
                     static_assert(DIGEST == 0x80 + KECCAK256_SIZE);
-                    std::memcpy(
-                        dest.last(HASH_RLP_LEN).data(),
-                        d.bytes(),
-                        HASH_RLP_LEN);
-                    return dest.shrink(HASH_RLP_LEN);
+                    return encode_rlp(d.hash_rlp(), dest);
                 },
                 [&](auto) {
                     if (auto const it = hashes_.find(id); it != hashes_.end()) {
                         bytes32_t const &hash = it->second;
-                        rlp::encode_string(
-                            dest.last(33), byte_string_view{hash.bytes, 32});
-                        return dest.shrink(33);
+                        return encode_rlp(hash, dest);
                     }
                     return child_ref_compute<priming_pass>(id, node, dest);
                 }});
+    }
+
+    node_rlp_span encode_rlp(bytes32_t const &hash32, node_rlp_span dest)
+    {
+        static_assert(HASH_RLP_LEN == KECCAK256_SIZE + 1);
+        auto const hash_span = dest.last(HASH_RLP_LEN);
+        hash_span[0] = 0xa0;
+        std::memcpy(hash_span.data() + 1, hash32.bytes, KECCAK256_SIZE);
+        return dest.shrink(HASH_RLP_LEN);
+    }
+
+    node_rlp_span encode_rlp(hash_rlp_view const hash, node_rlp_span dest)
+    {
+        std::memcpy(dest.last(hash.size()).data(), hash.data(), hash.size());
+        return dest.shrink(hash.size());
     }
 
     // The node's full canonical Ethereum RLP. Reads `node`'s fields and

--- a/category/execution/ethereum/db/test/test_offset_trie.cpp
+++ b/category/execution/ethereum/db/test/test_offset_trie.cpp
@@ -258,11 +258,69 @@ TEST(OffsetTrieDeathTest, OutOfRangeChildAborts)
     EXPECT_DEATH((void)OffsetTrie{blob}, "");
 }
 
+// A LEAF_ACCT tag in the last byte of the blob: its storage field alone runs
+// past the end, so validation has to reject the node rather than go on to read
+// the nonce/balance length byte another 34 bytes out.
+TEST(OffsetTrieDeathTest, TruncatedAccountLeafAborts)
+{
+    BlobBuilder bb;
+    bb.buf.push_back(static_cast<unsigned char>(LEAF_ACCT)); // nothing follows
+    byte_string const blob = bb.finalize(HEADER_LEN);
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
+// The encoder never dedupes identical subtries, so a node reached from two
+// parents is malformed. Priming clears a child's bit when a parent claims it,
+// leaving the second claim to find it already clear.
+TEST(OffsetTrieDeathTest, SharedChildAborts)
+{
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, bytes32_t{});
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    ch[7] = leaf; // one leaf claimed by two branch slots
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
+// A node no parent references is unreachable from the root, which priming
+// catches as a bit still set once the walk has consumed the whole blob.
+TEST(OffsetTrieDeathTest, UnreachableNodeAborts)
+{
+    BlobBuilder bb;
+    uint32_t const leaf = bb.storage_leaf({0xa}, bytes32_t{});
+    (void)bb.storage_leaf({0xb}, bytes32_t{}); // nothing references this
+    std::array<uint32_t, 16> ch{};
+    ch[3] = leaf;
+    uint32_t const br = bb.branch(ch);
+    byte_string const blob = bb.finalize(br);
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
+// The count byte can spell 255 nibbles, but encode_path only emits a
+// short-string RLP prefix
+TEST(OffsetTrieDeathTest, OverlongPathAborts)
+{
+    BlobBuilder bb;
+    // Start from the longest supported path, a whole key, so that bumping the
+    // count leaves the node tiling the blob exactly: only the path length is
+    // wrong, not the node's extent.
+    std::vector<uint8_t> const nibs(MAX_PATH_NIBBLES, 0xa);
+    uint32_t const leaf = bb.storage_leaf(nibs, bytes32_t{});
+    // LEAF_STORAGE layout: tag, 32-byte value, then the path's count byte.
+    bb.buf[leaf + 1 + 32] = MAX_PATH_NIBBLES + 1;
+    bb.buf.push_back(0); // the extra packed byte one more nibble implies
+    byte_string const blob = bb.finalize(leaf);
+    EXPECT_DEATH((void)OffsetTrie{blob}, "");
+}
+
 TEST(OffsetTrie, HashSingleStorageLeaf)
 {
     bytes32_t v{};
     v.bytes[31] = 0x11;
-    std::vector<uint8_t> const nibs = {1, 2, 3};
+    // A leaf that is its own root must have a full bytes32_t as a path
+    std::vector<uint8_t> const nibs = key_nibbles(make_key(0x12, 0x34));
 
     BlobBuilder bb;
     uint32_t const leaf = bb.storage_leaf(nibs, v);


### PR DESCRIPTION
offset trie fixes/improvements:
- constructor validates the data forms a tree, i.e. each child has
  exactly one parent and no nodes are unreachable
- Bound path length at MAX_PATH_NIBBLES as the decoder assumes the
  encoding is always a short string
- Rework checked_end onto offsets, fixing an out-of-bounds read
- hashes_ insert is now guarded on the RLP length, enforcing the
  invariant that only hash-referenced nodes get cached in the map