### PR TITLE
Add and use code-or-nonce primitive

### DIFF
--- a/category/execution/ethereum/block_hash_history.cpp
+++ b/category/execution/ethereum/block_hash_history.cpp
@@ -54,7 +54,8 @@ void deploy_block_hash_history_contract(State &state)
     }
 
     // happy path: deploy contract if it doesn't exist
-    if (MONAD_UNLIKELY(!state.account_exists(BLOCK_HISTORY_ADDRESS))) {
+    if (MONAD_UNLIKELY(
+            !state.account_has_code_or_nonce(BLOCK_HISTORY_ADDRESS))) {
         state.create_contract(BLOCK_HISTORY_ADDRESS);
         state.set_code(BLOCK_HISTORY_ADDRESS, BLOCK_HISTORY_CODE);
         MONAD_ASSERT(
@@ -95,7 +96,9 @@ void set_block_hash_history(State &state, BlockHeader const &header)
         return;
     }
 
-    if (MONAD_LIKELY(state.account_exists(BLOCK_HISTORY_ADDRESS))) {
+    if (MONAD_LIKELY(
+            state.get_code_hash(BLOCK_HISTORY_ADDRESS) ==
+            BLOCK_HISTORY_CODE_HASH)) {
         uint64_t const parent_number = header.number - 1;
         uint256_t const index{parent_number % BLOCK_HISTORY_LENGTH};
         bytes32_t const key{store_be_as<bytes32_t>(index)};
@@ -110,7 +113,9 @@ EXPLICIT_TRAITS(set_block_hash_history);
 // of this function guarantees that it is always valid.
 bytes32_t get_block_hash_history(State &state, uint64_t const block_number)
 {
-    if (MONAD_UNLIKELY(!state.account_exists(BLOCK_HISTORY_ADDRESS))) {
+    if (MONAD_UNLIKELY(
+            state.get_code_hash(BLOCK_HISTORY_ADDRESS) !=
+            BLOCK_HISTORY_CODE_HASH)) {
         return bytes32_t{};
     }
 

--- a/category/execution/ethereum/execute_message.cpp
+++ b/category/execution/ethereum/execute_message.cpp
@@ -231,8 +231,7 @@ evmc::Result execute_create_message(
     state.access_account(contract_address);
 
     // Prevent overwriting contracts - EIP-684
-    if (state.get_nonce(contract_address) != 0 ||
-        state.get_code_hash(contract_address) != NULL_HASH) {
+    if (state.account_has_code_or_nonce(contract_address)) {
         evmc::Result result{EVMC_INVALID_INSTRUCTION};
         call_tracer.on_exit(result);
         return result;

--- a/category/execution/ethereum/state3/state.cpp
+++ b/category/execution/ethereum/state3/state.cpp
@@ -212,6 +212,17 @@ bool State::account_is_dead(Address const &address)
     return is_dead(recent_account(address));
 }
 
+bool State::account_has_code_or_nonce(Address const &address)
+{
+    auto const &account = recent_account(address);
+    if (!account.has_value()) {
+        return false;
+    }
+
+    auto const &account_val = account.value();
+    return account_val.nonce > 0 || account_val.code_hash != NULL_HASH;
+}
+
 uint64_t State::get_nonce(Address const &address)
 {
     auto const &account = recent_account(address);

--- a/category/execution/ethereum/state3/state.hpp
+++ b/category/execution/ethereum/state3/state.hpp
@@ -131,6 +131,8 @@ public:
 
     bool account_is_dead(Address const &);
 
+    bool account_has_code_or_nonce(Address const &);
+
     uint64_t get_nonce(Address const &);
 
     uint256_t get_balance(Address const &);


### PR DESCRIPTION
While working on https://github.com/category-labs/monad/pull/2493; @0xSqualo pointed out that `account_exists` is not the correct primitive to use when checking for existing deployments of a system contract (e.g. the block hash history contract in EIP-2935, or the factory contract in EIP-7997). If someone were to frontrun the fork that deploys such a contract by (permissionlessly) funding the known address, deployments would fail due to a non-zero balance.

This PR adds a new primitive `account_has_code_or_nonce` that implements the EIP-684 semantics for when an account can be created at an address. Additionally, it cleans up the code in the block hash history contract deployment to better express the required behaviour.

There are no functional changes in this PR for live networks; the block hash history contract has been deployed already on Monad Mainnet and Testnet. The changes here are cleanup and preparation for future PRs.