### PR TITLE
[core] add a shared cache statistics counter

### DIFF
--- a/category/core/CMakeLists.txt
+++ b/category/core/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(
   "tl_tid.c"
   "tl_tid.h"
   "detail/start_lifetime_as_polyfill.hpp"
+  "lru/cache_stats.hpp"
   "lru/lru_cache.hpp"
   "lru/static_lru_cache.hpp"
   "mem/batch_mem_pool.hpp"

--- a/category/core/lru/cache_stats.hpp
+++ b/category/core/lru/cache_stats.hpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+
+#include <atomic>
+#include <cstdint>
+
+MONAD_NAMESPACE_BEGIN
+
+struct CacheStatsSnapshot
+{
+    uint64_t hits{0};
+    uint64_t misses{0};
+    uint64_t evictions{0}; // entries dropped to stay within the cache's bound
+};
+
+// Hit/miss/eviction counts for the life of the cache object.
+class CacheStats
+{
+    std::atomic<uint64_t> hits_{0};
+    std::atomic<uint64_t> misses_{0};
+    std::atomic<uint64_t> evictions_{0};
+
+public:
+    void record_hit() noexcept
+    {
+        hits_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void record_miss() noexcept
+    {
+        misses_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void record_eviction() noexcept
+    {
+        evictions_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] CacheStatsSnapshot snapshot() const noexcept
+    {
+        return {
+            .hits = hits_.load(std::memory_order_relaxed),
+            .misses = misses_.load(std::memory_order_relaxed),
+            .evictions = evictions_.load(std::memory_order_relaxed)};
+    }
+};
+
+MONAD_NAMESPACE_END

--- a/category/core/lru/cache_stats_test.cpp
+++ b/category/core/lru/cache_stats_test.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/lru/cache_stats.hpp>
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+using monad::CacheStats;
+using monad::CacheStatsSnapshot;
+
+TEST(cache_stats_test, counts_each_event_independently)
+{
+    CacheStats stats;
+    stats.record_hit();
+    stats.record_hit();
+    stats.record_miss();
+    stats.record_eviction();
+
+    auto const s = stats.snapshot();
+    EXPECT_EQ(s.hits, 2u);
+    EXPECT_EQ(s.misses, 1u);
+    EXPECT_EQ(s.evictions, 1u);
+}
+
+// The facility this replaces cleared its counters when read, so two readers
+// stole counts from each other and totals could not be scraped.
+TEST(cache_stats_test, reading_does_not_consume_counts)
+{
+    CacheStats stats;
+    stats.record_hit();
+
+    auto const first = stats.snapshot();
+    auto const second = stats.snapshot();
+
+    EXPECT_EQ(first.hits, 1u);
+    EXPECT_EQ(second.hits, 1u);
+}
+
+TEST(cache_stats_test, a_fresh_snapshot_is_zeroed)
+{
+    CacheStatsSnapshot const s;
+    EXPECT_EQ(s.hits, 0u);
+    EXPECT_EQ(s.misses, 0u);
+    EXPECT_EQ(s.evictions, 0u);
+    EXPECT_EQ(CacheStats{}.snapshot().hits, 0u);
+}
+
+// Atomic counters make the type non-copyable, which is what keeps an embedding
+// cache from being silently copied or moved along with its statistics.
+static_assert(!std::is_copy_constructible_v<CacheStats>);
+static_assert(!std::is_move_constructible_v<CacheStats>);


### PR DESCRIPTION
Introduce CacheStats, a small always-on counter for hits, misses and evictions, plus the plain snapshot type callers read it through.