### PR TITLE
[mpt] count hits, misses and evictions in the trie node cache

### DIFF
--- a/category/core/lru/static_lru_cache.hpp
+++ b/category/core/lru/static_lru_cache.hpp
@@ -17,6 +17,7 @@
 
 #include <category/core/assert.h>
 #include <category/core/config.hpp>
+#include <category/core/lru/cache_stats.hpp>
 
 #include <boost/intrusive/list.hpp>
 
@@ -52,6 +53,8 @@ protected:
     boost::intrusive::list<list_node> active_list_;
     boost::intrusive::list<list_node> free_list_;
     Map map_;
+    // Derived caches evict on their own bound too, so they record here.
+    CacheStats stats_;
 
 public:
     using ConstAccessor = Map::const_iterator;
@@ -93,6 +96,7 @@ public:
         else { // reuse the last node in active_list_
             auto const list_it = std::prev(active_list_.end());
             erased_value = list_it->val;
+            stats_.record_eviction();
             map_.erase(list_it->key);
             node = &*list_it;
             active_list_.erase(list_it);
@@ -111,10 +115,20 @@ public:
     {
         acc = map_.find(key);
         if (acc == map_.end()) {
+            stats_.record_miss();
             return false;
         }
+        stats_.record_hit();
         update_lru(acc->second);
         return true;
+    }
+
+    // Existence check that is not a lookup: it neither counts nor updates the
+    // LRU order. For assertions and invariant checks, where find() would
+    // otherwise record a miss for a read nobody made.
+    bool contains(Key const &key) const noexcept
+    {
+        return map_.find(key) != map_.end();
     }
 
     size_t size() const noexcept
@@ -122,8 +136,24 @@ public:
         return map_.size();
     }
 
+    CacheStatsSnapshot stats() const noexcept
+    {
+        return stats_.snapshot();
+    }
+
     void clear() noexcept
     {
+        // Recycle the nodes, not just the index. Leaving them on the active
+        // list would make the next insert take the reuse path and count an
+        // eviction for an entry this already removed.
+        while (!active_list_.empty()) {
+            auto const list_it = std::prev(active_list_.end());
+            auto &node = *list_it;
+            active_list_.erase(list_it);
+            node.key = Key();
+            node.val = Value();
+            free_list_.push_front(node);
+        }
         map_.clear();
     }
 

--- a/category/core/lru/static_lru_test.cpp
+++ b/category/core/lru/static_lru_test.cpp
@@ -141,3 +141,73 @@ TEST(static_lru_test, clear)
     lru.insert(5, "world");
     EXPECT_EQ(lru.size(), 1);
 }
+
+TEST(static_lru_test, counts_hits_misses_and_evictions)
+{
+    using LruCache = monad::static_lru_cache<int, int>;
+    LruCache lru(2);
+    LruCache::ConstAccessor acc;
+
+    EXPECT_FALSE(lru.find(acc, 1));
+    lru.insert(1, 0x111);
+    lru.insert(2, 0x222);
+    ASSERT_TRUE(lru.find(acc, 1));
+    EXPECT_EQ(lru.stats().evictions, 0u);
+
+    // Capacity is 2, so this reuses the LRU tail.
+    lru.insert(3, 0x333);
+
+    auto const stats = lru.stats();
+    EXPECT_EQ(stats.hits, 1u);
+    EXPECT_EQ(stats.misses, 1u);
+    EXPECT_EQ(stats.evictions, 1u);
+}
+
+// find() is used as an existence predicate in a few places that are not
+// lookups; those must not move the hit rate.
+TEST(static_lru_test, contains_does_not_count_as_a_lookup)
+{
+    using LruCache = monad::static_lru_cache<int, int>;
+    LruCache lru(2);
+
+    lru.insert(1, 0x111);
+
+    EXPECT_TRUE(lru.contains(1));
+    EXPECT_FALSE(lru.contains(2));
+
+    auto const stats = lru.stats();
+    EXPECT_EQ(stats.hits, 0u);
+    EXPECT_EQ(stats.misses, 0u);
+}
+
+TEST(static_lru_test, clear_does_not_leave_a_phantom_eviction)
+{
+    using LruCache = monad::static_lru_cache<int, int>;
+    LruCache lru(2);
+
+    lru.insert(1, 0x111);
+    lru.insert(2, 0x222);
+    ASSERT_EQ(lru.stats().evictions, 0u);
+
+    lru.clear();
+    ASSERT_EQ(lru.size(), 0);
+
+    // The cache is empty, so this insert needs no room and must not report
+    // evicting the entry clear() already removed.
+    lru.insert(3, 0x333);
+
+    EXPECT_EQ(lru.size(), 1);
+    EXPECT_EQ(lru.stats().evictions, 0u);
+}
+
+TEST(static_lru_test, overwriting_an_existing_key_does_not_evict)
+{
+    using LruCache = monad::static_lru_cache<int, int>;
+    LruCache lru(2);
+
+    lru.insert(1, 0x111);
+    lru.insert(1, 0x222);
+
+    EXPECT_EQ(lru.size(), 1);
+    EXPECT_EQ(lru.stats().evictions, 0u);
+}

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -138,10 +138,7 @@ namespace
             // to write new data.
             auto const virtual_offset_after = aux.physical_to_virtual(offset);
             if (virtual_offset_after == virtual_offset) {
-                {
-                    NodeCache::ConstAccessor acc;
-                    MONAD_ASSERT(node_cache.find(acc, virtual_offset) == false);
-                }
+                MONAD_ASSERT(!node_cache.contains(virtual_offset));
                 std::shared_ptr<Node> const node =
                     detail::deserialize_node_from_receiver_result(
                         std::move(buffer_), buffer_off, io_state);

--- a/category/mpt/node_cache.hpp
+++ b/category/mpt/node_cache.hpp
@@ -44,6 +44,7 @@ class NodeCache final
         while (used_bytes_ > max_bytes_ && !active_list_.empty()) {
             auto const list_it = std::prev(active_list_.end());
             auto &node_to_erase = *list_it;
+            stats_.record_eviction();
             map_.erase(list_it->key);
             used_bytes_ -= list_it->val.second;
             // move to empty list
@@ -60,9 +61,19 @@ public:
     using Base::ConstAccessor;
     using Base::list_node;
 
-    using Base::clear;
+    using Base::contains;
     using Base::find;
     using Base::size;
+    using Base::stats;
+
+    // Bytes of cached nodes, against the max_bytes the cache was built with.
+    // Read alongside size() to tell which of the two bounds is binding: the
+    // slot count is max_bytes / AVERAGE_NODE_SIZE, so a cache whose nodes run
+    // larger than that average evicts on bytes with slots to spare.
+    size_t used_bytes() const noexcept
+    {
+        return used_bytes_;
+    }
 
     explicit NodeCache(size_t const max_bytes)
         : Base(
@@ -75,21 +86,23 @@ public:
 
     ~NodeCache() = default;
 
-    Map::iterator insert(
+    void insert(
         virtual_chunk_offset_t const &virt_offset,
         std::shared_ptr<Node> const &sp) noexcept
     {
         MONAD_ASSERT(virt_offset != virtual_chunk_offset_t::invalid_value());
 
-        used_bytes_ += sp->get_mem_size();
-        evict_until_under_limit();
-
-        auto const [it, erased_value] =
-            Base::insert(virt_offset, {sp, sp->get_mem_size()});
+        auto const size = sp->get_mem_size();
+        auto const [_, erased_value] = Base::insert(virt_offset, {sp, size});
+        // Charge the net change. An overwrite replaces an entry already
+        // accounted for, so only the difference needs room; charging the full
+        // size before inserting would evict entries to make room this insert
+        // does not need.
+        used_bytes_ += size;
         if (erased_value.has_value()) {
             used_bytes_ -= erased_value->second;
         }
-        return it;
+        evict_until_under_limit();
     }
 };
 

--- a/category/mpt/test/node_lru_cache_test.cpp
+++ b/category/mpt/test/node_lru_cache_test.cpp
@@ -102,3 +102,76 @@ TEST(NodeCache, works)
     ASSERT_TRUE(node_cache.find(acc, virtual_chunk_offset_t(1, 0, 0)));
     EXPECT_EQ(get_acc_value(), 0xdead);
 }
+
+TEST(NodeCache, counts_hits_misses_and_evictions)
+{
+    NodeCache node_cache(2 * NodeCache::AVERAGE_NODE_SIZE);
+    NodeCache::ConstAccessor acc;
+
+    auto make_node = [] {
+        monad::byte_string value(84, 0);
+        return monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0);
+    };
+
+    EXPECT_FALSE(node_cache.find(acc, virtual_chunk_offset_t(1, 0, 1)));
+    node_cache.insert(virtual_chunk_offset_t(1, 0, 1), make_node());
+    node_cache.insert(virtual_chunk_offset_t(2, 0, 1), make_node());
+    ASSERT_TRUE(node_cache.find(acc, virtual_chunk_offset_t(1, 0, 1)));
+    EXPECT_EQ(node_cache.stats().evictions, 0u);
+
+    // Third node exceeds the byte budget and evicts the LRU tail.
+    node_cache.insert(virtual_chunk_offset_t(3, 0, 1), make_node());
+
+    auto const stats = node_cache.stats();
+    EXPECT_EQ(stats.hits, 1u);
+    EXPECT_EQ(stats.misses, 1u);
+    EXPECT_EQ(stats.evictions, 1u);
+}
+
+// Overwriting a key replaces an entry already counted against the budget, so
+// it must not evict anything to make room it does not need.
+TEST(NodeCache, overwriting_a_key_does_not_evict_to_make_room)
+{
+    NodeCache node_cache(2 * NodeCache::AVERAGE_NODE_SIZE);
+    NodeCache::ConstAccessor acc;
+
+    auto make_node = [] {
+        monad::byte_string value(84, 0);
+        return monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0);
+    };
+
+    node_cache.insert(virtual_chunk_offset_t(1, 0, 1), make_node());
+    node_cache.insert(virtual_chunk_offset_t(2, 0, 1), make_node());
+    auto const full = node_cache.used_bytes();
+    ASSERT_EQ(node_cache.size(), 2);
+    ASSERT_EQ(node_cache.stats().evictions, 0u);
+
+    // Same key, same size: the budget is unchanged, so the other entry stays.
+    node_cache.insert(virtual_chunk_offset_t(1, 0, 1), make_node());
+
+    EXPECT_EQ(node_cache.used_bytes(), full);
+    EXPECT_EQ(node_cache.size(), 2);
+    EXPECT_EQ(node_cache.stats().evictions, 0u);
+    EXPECT_TRUE(node_cache.find(acc, virtual_chunk_offset_t(2, 0, 1)));
+}
+
+TEST(NodeCache, reports_used_bytes_tracking_the_byte_budget)
+{
+    NodeCache node_cache(4 * NodeCache::AVERAGE_NODE_SIZE);
+
+    auto make_node = [] {
+        monad::byte_string value(84, 0);
+        return monad::mpt::make_node(0, {}, {}, std::move(value), 0, 0);
+    };
+
+    EXPECT_EQ(node_cache.used_bytes(), 0u);
+
+    auto const first = make_node();
+    auto const first_size = first->get_mem_size();
+    node_cache.insert(virtual_chunk_offset_t(1, 0, 1), first);
+    EXPECT_EQ(node_cache.used_bytes(), first_size);
+
+    auto const second = make_node();
+    node_cache.insert(virtual_chunk_offset_t(2, 0, 1), second);
+    EXPECT_EQ(node_cache.used_bytes(), first_size + second->get_mem_size());
+}


### PR DESCRIPTION
Wire CacheStats into static_lru_cache and NodeCache. a follow-up exports them over the triedb FFI.

Two related fixes in NodeCache while making its occupancy observable. insert() charged the full size of the incoming node before evicting, so an overwrite -- which replaces an entry already accounted for -- could evict entries to make room it did not need; it now applies the net change. And NodeCache no longer re-exports Base::clear, which left used_bytes_ stale while size() read zero.