### PR TITLE
Remove inline from constexpr functions

### DIFF
--- a/category/async/detail/scope_polyfill.hpp
+++ b/category/async/detail/scope_polyfill.hpp
@@ -70,19 +70,19 @@ namespace monad
     namespace detail
     {
         template <class T, bool v = noexcept(std::declval<T>()())>
-        inline constexpr bool is_nothrow_invocable_(int) noexcept
+        constexpr bool is_nothrow_invocable_(int) noexcept
         {
             return v;
         }
 
         template <class T>
-        inline constexpr bool is_nothrow_invocable_(...) noexcept
+        constexpr bool is_nothrow_invocable_(...) noexcept
         {
             return false;
         }
 
         template <class T>
-        inline constexpr bool is_nothrow_invocable() noexcept
+        constexpr bool is_nothrow_invocable() noexcept
         {
             return is_nothrow_invocable_<typename std::decay<T>::type>(5);
         }
@@ -198,7 +198,7 @@ namespace monad
         = true
     #endif
         >
-    inline constexpr auto make_scope_exit(T &&v)
+    constexpr auto make_scope_exit(T &&v)
     {
         return scope_exit<typename std::decay<T>::type>(static_cast<T &&>(v));
     }
@@ -212,7 +212,7 @@ namespace monad
         = true
     #endif
         >
-    inline constexpr auto make_scope_fail(T &&v)
+    constexpr auto make_scope_fail(T &&v)
     {
         return scope_fail<typename std::decay<T>::type>(static_cast<T &&>(v));
     }
@@ -223,7 +223,7 @@ namespace monad
         typename = decltype(std::declval<T>()())
     #endif
         >
-    inline constexpr auto make_scope_success(T &&v)
+    constexpr auto make_scope_success(T &&v)
     {
         return scope_success<typename std::decay<T>::type>(
             static_cast<T &&>(v));

--- a/category/async/sender_errc.hpp
+++ b/category/async/sender_errc.hpp
@@ -146,7 +146,7 @@ public:
     operator=(sender_errc_with_payload_code_domain_ &&) = default;
     ~sender_errc_with_payload_code_domain_() = default;
 
-    static inline constexpr sender_errc_with_payload_code_domain_ const &get();
+    static constexpr sender_errc_with_payload_code_domain_ const &get();
 
     virtual string_ref name() const noexcept override
     {
@@ -245,7 +245,7 @@ protected:
 constexpr sender_errc_with_payload_code_domain_
     sender_errc_with_payload_code_domain;
 
-inline constexpr sender_errc_with_payload_code_domain_ const &
+constexpr sender_errc_with_payload_code_domain_ const &
 sender_errc_with_payload_code_domain_::get()
 {
     return sender_errc_with_payload_code_domain;
@@ -359,7 +359,7 @@ inline nested_sender_errc_with_payload_code make_status_code(
 // quick_status_code_from_enum one (the latter is specialized on cv-unqualified
 // `sender_errc`), causing infinite constexpr recursion through ADL back into
 // this function.
-inline constexpr BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::
+constexpr BOOST_OUTCOME_SYSTEM_ERROR2_NAMESPACE::
     quick_status_code_from_enum_code<sender_errc>
     make_status_code(sender_errc c)
 {

--- a/category/async/util.hpp
+++ b/category/async/util.hpp
@@ -29,14 +29,14 @@ concept safely_roundable_type =
     std::unsigned_integral<T> && (__CHAR_BIT__ * sizeof(T)) > bits;
 
 template <unsigned bits, safely_roundable_type<bits> T>
-inline constexpr T round_up_align(T const x) noexcept
+constexpr T round_up_align(T const x) noexcept
 {
     constexpr T mask = (T(1) << bits) - 1;
     return (x + mask) & ~mask;
 }
 
 template <unsigned bits>
-inline constexpr chunk_offset_t round_up_align(chunk_offset_t x) noexcept
+constexpr chunk_offset_t round_up_align(chunk_offset_t x) noexcept
 {
     constexpr file_offset_t mask = (file_offset_t(1) << bits) - 1;
     x.offset = (x.offset + mask) & ~mask;
@@ -44,14 +44,14 @@ inline constexpr chunk_offset_t round_up_align(chunk_offset_t x) noexcept
 }
 
 template <unsigned bits, safely_roundable_type<bits> T>
-inline constexpr T round_down_align(T const x) noexcept
+constexpr T round_down_align(T const x) noexcept
 {
     constexpr T mask = ~((T(1) << bits) - 1);
     return x & mask;
 }
 
 template <unsigned bits>
-inline constexpr chunk_offset_t round_down_align(chunk_offset_t x) noexcept
+constexpr chunk_offset_t round_down_align(chunk_offset_t x) noexcept
 {
     constexpr file_offset_t mask = ~((file_offset_t(1) << bits) - 1);
     x.offset = x.offset & mask & chunk_offset_t::max_offset;

--- a/category/core/int.hpp
+++ b/category/core/int.hpp
@@ -92,7 +92,7 @@ uint8_t const *as_bytes(T const &&) = delete;
 // buffers — they handle the surrounding memcpy / bit_cast. Use bswap
 // directly when the value is already in a register.
 template <typename T>
-[[nodiscard, gnu::always_inline]] inline constexpr T bswap(T const x) noexcept
+[[nodiscard, gnu::always_inline]] constexpr T bswap(T const x) noexcept
 {
     if constexpr (std::same_as<T, uint256_t>) {
         return byteswap(x);
@@ -129,8 +129,7 @@ load_be_unsafe(uint8_t const *src) noexcept
 
 // Load a little-endian encoded integer from a struct with a .bytes member.
 template <typename T, FixedBytes Src>
-[[nodiscard, gnu::always_inline]] inline constexpr T
-load_le(Src const &src) noexcept
+[[nodiscard, gnu::always_inline]] constexpr T load_le(Src const &src) noexcept
 {
     static_assert(sizeof(Src::bytes) == sizeof(T));
     return std::bit_cast<T>(src);
@@ -138,15 +137,14 @@ load_le(Src const &src) noexcept
 
 // Load a big-endian encoded integer from a struct with a .bytes member.
 template <typename T, FixedBytes Src>
-[[nodiscard, gnu::always_inline]] inline constexpr T
-load_be(Src const &src) noexcept
+[[nodiscard, gnu::always_inline]] constexpr T load_be(Src const &src) noexcept
 {
     return bswap(load_le<T>(src));
 }
 
 // Load a little-endian encoded integer from a sized byte array.
 template <typename T, size_t N>
-[[nodiscard, gnu::always_inline]] inline constexpr T
+[[nodiscard, gnu::always_inline]] constexpr T
 load_le(uint8_t const (&src)[N]) noexcept
 {
     static_assert(N == sizeof(T));
@@ -155,7 +153,7 @@ load_le(uint8_t const (&src)[N]) noexcept
 
 // Load a big-endian encoded integer from a sized byte array.
 template <typename T, size_t N>
-[[nodiscard, gnu::always_inline]] inline constexpr T
+[[nodiscard, gnu::always_inline]] constexpr T
 load_be(uint8_t const (&src)[N]) noexcept
 {
     return bswap(load_le<T>(src));
@@ -186,7 +184,7 @@ template <typename T>
 // (which must have a .bytes member of matching size).
 template <FixedBytes DstT, typename SrcT>
     requires(sizeof(SrcT) >= 8)
-[[nodiscard, gnu::always_inline]] inline constexpr DstT
+[[nodiscard, gnu::always_inline]] constexpr DstT
 store_be_as(SrcT const x) noexcept
 {
     static_assert(sizeof(DstT::bytes) == sizeof(SrcT));

--- a/category/core/mem/allocators.hpp
+++ b/category/core/mem/allocators.hpp
@@ -198,7 +198,7 @@ namespace allocators
     //! aware `unique_ptr`.
     template <allocator Alloc, Alloc &(*GetAllocator)(), class... Args>
         requires(std::is_constructible_v<typename Alloc::value_type, Args...>)
-    inline constexpr std::unique_ptr<
+    constexpr std::unique_ptr<
         typename Alloc::value_type,
         unique_ptr_allocator_deleter<Alloc, GetAllocator>>
     allocate_unique(Args &&...args)
@@ -240,7 +240,7 @@ namespace allocators
             std::is_constructible_v<
                 typename decltype(GetAllocator())::type_allocator::value_type,
                 Args...>)
-    inline constexpr std::unique_ptr<
+    constexpr std::unique_ptr<
         typename decltype(GetAllocator())::type_allocator::value_type,
         unique_ptr_aliasing_allocator_deleter<GetAllocator, GetSize>>
     allocate_aliasing_unique(size_t const storagebytes, Args &&...args)

--- a/category/core/runtime/uint256.hpp
+++ b/category/core/runtime/uint256.hpp
@@ -86,7 +86,7 @@ using m256i = words_t<4>;
 struct uint256_t;
 
 [[gnu::always_inline]]
-constexpr inline result_with_carry<uint64_t>
+constexpr result_with_carry<uint64_t>
 addc(uint64_t const lhs, uint64_t const rhs, bool const carry_in) noexcept
 {
     if consteval {
@@ -97,7 +97,7 @@ addc(uint64_t const lhs, uint64_t const rhs, bool const carry_in) noexcept
     }
 }
 
-[[gnu::always_inline]] constexpr inline result_with_carry<uint64_t>
+[[gnu::always_inline]] constexpr result_with_carry<uint64_t>
 subb(uint64_t const lhs, uint64_t const rhs, bool const borrow_in) noexcept
 {
     if consteval {
@@ -109,7 +109,7 @@ subb(uint64_t const lhs, uint64_t const rhs, bool const borrow_in) noexcept
 }
 
 [[gnu::always_inline]]
-inline constexpr uint64_t
+constexpr uint64_t
 shld(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
 {
     if consteval {
@@ -121,7 +121,7 @@ shld(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
 }
 
 [[gnu::always_inline]]
-inline constexpr uint64_t
+constexpr uint64_t
 shrd(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
 {
     if consteval {
@@ -133,7 +133,7 @@ shrd(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
 }
 
 [[gnu::always_inline]]
-constexpr inline div_result<uint64_t>
+constexpr div_result<uint64_t>
 div(uint64_t u_hi, uint64_t u_lo, uint64_t const v) noexcept
 {
     MONAD_DEBUG_ASSERT(u_hi < v);
@@ -145,7 +145,7 @@ div(uint64_t u_hi, uint64_t u_lo, uint64_t const v) noexcept
     }
 }
 
-inline constexpr uint256_t byteswap(uint256_t const &x) noexcept;
+constexpr uint256_t byteswap(uint256_t const &x) noexcept;
 
 struct uint256_t
 {
@@ -201,7 +201,7 @@ public:
     }
 
     [[gnu::always_inline]]
-    inline constexpr explicit operator bool() const noexcept
+    constexpr explicit operator bool() const noexcept
     {
         using namespace monad::uint256::intrinsics;
 
@@ -214,44 +214,44 @@ public:
 
     template <typename Int>
     [[gnu::always_inline]]
-    inline constexpr explicit operator Int() const noexcept
+    constexpr explicit operator Int() const noexcept
         requires(std::is_integral_v<Int> && sizeof(Int) <= sizeof(word_type))
     {
         return static_cast<Int>(words_[0]);
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint64_t &operator[](size_t i) noexcept
+    constexpr uint64_t &operator[](size_t i) noexcept
     {
         return words_[i];
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint64_t const &operator[](size_t i) const noexcept
+    constexpr uint64_t const &operator[](size_t i) const noexcept
     {
         return words_[i];
     }
 
     [[gnu::always_inline]]
-    inline constexpr std::array<uint64_t, 4> &as_words() noexcept
+    constexpr std::array<uint64_t, 4> &as_words() noexcept
     {
         return words_;
     }
 
     [[gnu::always_inline]]
-    inline constexpr std::array<uint64_t, 4> const &as_words() const noexcept
+    constexpr std::array<uint64_t, 4> const &as_words() const noexcept
     {
         return words_;
     }
 
-    friend inline constexpr uint256_t
+    friend constexpr uint256_t
     operator/(uint256_t const &x, uint256_t const &y) noexcept;
 
-    friend inline constexpr uint256_t
+    friend constexpr uint256_t
     operator%(uint256_t const &x, uint256_t const &y) noexcept;
 
     [[gnu::always_inline]]
-    friend inline constexpr result_with_carry<uint256_t>
+    friend constexpr result_with_carry<uint256_t>
     subb(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         auto [w0, b0] = subb(lhs[0], rhs[0], false);
@@ -262,7 +262,7 @@ public:
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr result_with_carry<uint256_t>
+    friend constexpr result_with_carry<uint256_t>
     addc(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         auto [w0, c0] = addc(lhs[0], rhs[0], false);
@@ -273,7 +273,7 @@ public:
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr uint256_t
+    friend constexpr uint256_t
     operator+(uint256_t const &lhs, uint256_t const &rhs) noexcept
 
     {
@@ -281,35 +281,35 @@ public:
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr uint256_t
+    friend constexpr uint256_t
     operator-(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         return subb(lhs, rhs).value;
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr bool
+    friend constexpr bool
     operator<(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         return subb(lhs, rhs).carry;
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr bool
+    friend constexpr bool
     operator<=(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         return !(lhs > rhs);
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr bool
+    friend constexpr bool
     operator>(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         return rhs < lhs;
     }
 
     [[gnu::always_inline]]
-    friend inline constexpr bool
+    friend constexpr bool
     operator>=(uint256_t const &lhs, uint256_t const &rhs) noexcept
     {
         return !(lhs < rhs);
@@ -318,7 +318,7 @@ public:
     // NOLINTBEGIN(bugprone-macro-parentheses)
 
 #define BITWISE_BINOP(return_ty, op_name)                                      \
-    [[gnu::always_inline]] friend inline constexpr return_ty operator op_name( \
+    [[gnu::always_inline]] friend constexpr return_ty operator op_name(        \
         uint256_t const &x, uint256_t const &y) noexcept                       \
     {                                                                          \
         return uint256_t{                                                      \
@@ -334,7 +334,7 @@ public:
 
     // NOLINTEND(bugprone-macro-parentheses)
 
-    [[gnu::always_inline]] friend inline constexpr bool
+    [[gnu::always_inline]] friend constexpr bool
     operator==(uint256_t const &x, uint256_t const &y) noexcept
     {
         using namespace monad::uint256::intrinsics;
@@ -346,20 +346,19 @@ public:
         return !(force(e0 | e1) | force(e2 | e3));
     }
 
-    [[gnu::always_inline]] inline constexpr uint256_t operator-() const noexcept
+    [[gnu::always_inline]] constexpr uint256_t operator-() const noexcept
     {
         return 0 - *this;
     }
 
-    [[gnu::always_inline]] inline constexpr uint256_t operator~() const noexcept
+    [[gnu::always_inline]] constexpr uint256_t operator~() const noexcept
     {
         return uint256_t{~words_[0], ~words_[1], ~words_[2], ~words_[3]};
     }
 
     template <typename T>
     [[gnu::always_inline]]
-    friend inline constexpr uint256_t
-    operator<<(uint256_t const &x, T shift0) noexcept
+    friend constexpr uint256_t operator<<(uint256_t const &x, T shift0) noexcept
         requires std::is_convertible_v<T, uint64_t> &&
                  (sizeof(T) <= sizeof(uint64_t))
     {
@@ -404,12 +403,12 @@ public:
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint256_t &operator<<=(uint256_t const &shift0) noexcept
+    constexpr uint256_t &operator<<=(uint256_t const &shift0) noexcept
     {
         return *this = *this << shift0;
     }
 
-    [[gnu::always_inline]] friend inline constexpr uint256_t
+    [[gnu::always_inline]] friend constexpr uint256_t
     operator<<(uint256_t const &x, uint256_t const &shift) noexcept
     {
         if (MONAD_UNLIKELY(shift[3] | shift[2] | shift[1])) {
@@ -426,7 +425,7 @@ public:
 
     template <RightShiftType type>
     [[gnu::always_inline]]
-    friend inline constexpr uint256_t
+    friend constexpr uint256_t
     shift_right(uint256_t const &x, uint256_t shift0) noexcept
     {
         uint64_t fill;
@@ -480,14 +479,14 @@ public:
         }
     }
 
-    [[gnu::always_inline]] friend inline constexpr uint256_t
+    [[gnu::always_inline]] friend constexpr uint256_t
     operator>>(uint256_t const &x, uint256_t const &shift) noexcept
     {
         return shift_right<RightShiftType::Logical>(x, shift);
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint256_t &operator>>=(uint256_t const &shift) noexcept
+    constexpr uint256_t &operator>>=(uint256_t const &shift) noexcept
     {
         return *this = *this >> shift;
     }
@@ -496,9 +495,9 @@ public:
     // These are not optimized and should never be used in
     // performance-critical code.
     inline std::string to_string(int const base0) const;
-    static inline constexpr uint256_t from_string(char const *s);
+    static constexpr uint256_t from_string(char const *s);
 
-    [[gnu::always_inline]] static inline constexpr uint256_t
+    [[gnu::always_inline]] static constexpr uint256_t
     from_string(std::string const &s)
     {
         return from_string(s.c_str());
@@ -564,7 +563,7 @@ constexpr size_t popcount(uint256_t const &x)
 }
 
 template <size_t N>
-[[gnu::always_inline]] inline constexpr uint32_t
+[[gnu::always_inline]] constexpr uint32_t
 count_significant_words(std::array<uint64_t, N> const &x) noexcept
 {
     for (size_t i = N; i > 0; --i) {
@@ -576,7 +575,7 @@ count_significant_words(std::array<uint64_t, N> const &x) noexcept
 }
 
 [[gnu::always_inline]]
-inline constexpr uint32_t count_significant_bytes(uint256_t const &x) noexcept
+constexpr uint32_t count_significant_bytes(uint256_t const &x) noexcept
 {
     auto const significant_words = count_significant_words(x.as_words());
     if (significant_words == 0) {
@@ -591,7 +590,7 @@ inline constexpr uint32_t count_significant_bytes(uint256_t const &x) noexcept
 }
 
 [[gnu::always_inline]]
-inline constexpr void mulx(
+constexpr void mulx(
     uint64_t const x, uint64_t const y, uint64_t &r_hi, uint64_t &r_lo) noexcept
 {
     if consteval {
@@ -609,7 +608,7 @@ inline constexpr void mulx(
  */
 template <size_t R, size_t M, size_t N>
 MONAD_NO_VECTORIZE [[gnu::always_inline]]
-inline constexpr words_t<R>
+constexpr words_t<R>
 truncating_mul(words_t<M> const &x, words_t<N> const &y) noexcept
     requires(0 < R && 0 < M && 0 < N && R <= M + N)
 {
@@ -622,7 +621,7 @@ truncating_mul(words_t<M> const &x, words_t<N> const &y) noexcept
 }
 
 MONAD_NO_VECTORIZE [[gnu::always_inline]]
-inline constexpr uint256_t
+constexpr uint256_t
 truncating_mul(uint256_t const &x, uint256_t const &y) noexcept
 {
     return uint256_t{
@@ -631,55 +630,55 @@ truncating_mul(uint256_t const &x, uint256_t const &y) noexcept
 
 MONAD_NO_VECTORIZE
 [[gnu::noinline]]
-inline constexpr uint256_t
+constexpr uint256_t
 operator*(uint256_t const &lhs, uint256_t const &rhs) noexcept
 {
     return truncating_mul(lhs, rhs);
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator+=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs + rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator-=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs - rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator*=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs * rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator/=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs / rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator%=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs % rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator^=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs ^ rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator|=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs | rhs;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t &
+[[gnu::always_inline]] constexpr uint256_t &
 operator&=(uint256_t &lhs, uint256_t const &rhs) noexcept
 {
     return lhs = lhs & rhs;
@@ -804,7 +803,7 @@ knuth_div(size_t m, uint64_t *u, size_t n, uint64_t const *v, uint64_t *quot)
 }
 
 template <size_t M, size_t N>
-inline constexpr div_result<words_t<M>, words_t<N>>
+constexpr div_result<words_t<M>, words_t<N>>
 udivrem(words_t<M> const &u, words_t<N> const &v) noexcept
 {
     auto const m = count_significant_words(u);
@@ -865,14 +864,14 @@ udivrem(words_t<M> const &u, words_t<N> const &v) noexcept
     return result;
 }
 
-[[gnu::always_inline]] constexpr inline div_result<uint256_t>
+[[gnu::always_inline]] constexpr div_result<uint256_t>
 udivrem(uint256_t const &u, uint256_t const &v) noexcept
 {
     auto const r = udivrem(u.as_words(), v.as_words());
     return {.quot = uint256_t{r.quot}, .rem = uint256_t{r.rem}};
 }
 
-inline constexpr uint256_t
+constexpr uint256_t
 addmod(uint256_t const &x, uint256_t const &y, uint256_t const &mod) noexcept
 {
     // Fast path when mod >= 2^192 and x, y < 2*mod
@@ -912,7 +911,7 @@ addmod(uint256_t const &x, uint256_t const &y, uint256_t const &mod) noexcept
 
 MONAD_NO_VECTORIZE
 [[gnu::noinline]]
-inline constexpr uint256_t
+constexpr uint256_t
 mulmod(uint256_t const &u, uint256_t const &v, uint256_t const &mod) noexcept
 {
     auto const prod =
@@ -920,20 +919,20 @@ mulmod(uint256_t const &u, uint256_t const &v, uint256_t const &mod) noexcept
     return uint256_t{udivrem(prod, mod.as_words()).rem};
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t
+[[gnu::always_inline]] constexpr uint256_t
 operator/(uint256_t const &x, uint256_t const &y) noexcept
 {
     return udivrem(x, y).quot;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t
+[[gnu::always_inline]] constexpr uint256_t
 operator%(uint256_t const &x, uint256_t const &y) noexcept
 {
     return udivrem(x, y).rem;
 }
 
 [[gnu::always_inline]]
-inline constexpr div_result<uint256_t>
+constexpr div_result<uint256_t>
 sdivrem(uint256_t const &x, uint256_t const &y) noexcept
 {
     auto const sign_bit = uint64_t{1} << 63;
@@ -953,7 +952,7 @@ sdivrem(uint256_t const &x, uint256_t const &y) noexcept
 }
 
 [[gnu::always_inline]]
-inline constexpr bool slt(uint256_t const &x, uint256_t const &y) noexcept
+constexpr bool slt(uint256_t const &x, uint256_t const &y) noexcept
 {
     auto const x_neg = x[uint256_t::num_words - 1] >> 63;
     auto const y_neg = y[uint256_t::num_words - 1] >> 63;
@@ -965,7 +964,7 @@ inline constexpr bool slt(uint256_t const &x, uint256_t const &y) noexcept
 }
 
 MONAD_NO_VECTORIZE
-[[gnu::noinline]] inline constexpr uint256_t
+[[gnu::noinline]] constexpr uint256_t
 exp(uint256_t base, uint256_t const &exponent) noexcept
 {
     uint256_t result{1};
@@ -1006,8 +1005,7 @@ inline uint256_t byte(uint256_t const &byte_index_256, uint256_t const &x)
     return ret;
 }
 
-[[gnu::always_inline]] inline constexpr uint256_t
-byteswap(uint256_t const &x) noexcept
+[[gnu::always_inline]] constexpr uint256_t byteswap(uint256_t const &x) noexcept
 {
     return uint256_t{
         std::byteswap(x[3]),
@@ -1061,7 +1059,7 @@ inline uint256_t from_bytes(size_t const n, uint8_t const *src)
     return from_bytes(n, n, src);
 }
 
-inline constexpr size_t countl_zero(uint256_t const &x)
+constexpr size_t countl_zero(uint256_t const &x)
 {
     size_t cnt = 0;
     for (size_t i = 0; i < uint256_t::num_words; i++) {
@@ -1168,7 +1166,7 @@ inline size_t bit_width(uint256_t const &x)
 }
 
 [[gnu::always_inline]]
-inline constexpr uint8_t from_dec(char const chr)
+constexpr uint8_t from_dec(char const chr)
 {
     if (chr >= '0' && chr <= '9') {
         return static_cast<uint8_t>(chr - '0');
@@ -1177,7 +1175,7 @@ inline constexpr uint8_t from_dec(char const chr)
 }
 
 [[gnu::always_inline]]
-inline constexpr uint8_t from_hex(char const chr)
+constexpr uint8_t from_hex(char const chr)
 {
     char const chr_lower = static_cast<char>(chr | 0b00100000);
     if (chr_lower >= 'a' && chr_lower <= 'f') {
@@ -1207,7 +1205,7 @@ inline std::string uint256_t::to_string(int const base0 = 10) const
     return buffer;
 }
 
-inline constexpr uint256_t uint256_t::from_string(char const *const str)
+constexpr uint256_t uint256_t::from_string(char const *const str)
 {
     MONAD_ASSERT(str != nullptr);
     static constexpr uint256_t MAX_MULTIPLIABLE_BY_10 =

--- a/category/core/runtime/uint256/intrinsics.hpp
+++ b/category/core/runtime/uint256/intrinsics.hpp
@@ -32,8 +32,7 @@
 
 namespace monad::uint256::intrinsics
 {
-    [[gnu::always_inline]] constexpr inline uint64_t
-    force(uint64_t expr) noexcept
+    [[gnu::always_inline]] constexpr uint64_t force(uint64_t expr) noexcept
     {
         if !consteval {
             asm("" : "+r"(expr));

--- a/category/core/runtime/uint256/portable.hpp
+++ b/category/core/runtime/uint256/portable.hpp
@@ -30,7 +30,7 @@ namespace monad::uint256::portable
 {
 
     [[gnu::always_inline]]
-    constexpr inline result_with_carry<uint64_t>
+    constexpr result_with_carry<uint64_t>
     addc(uint64_t const lhs, uint64_t const rhs, bool const carry_in) noexcept
     {
         uint64_t const sum = lhs + rhs;
@@ -40,7 +40,7 @@ namespace monad::uint256::portable
         return result_with_carry{.value = sum_carry, .carry = carry_out};
     }
 
-    [[gnu::always_inline]] constexpr inline result_with_carry<uint64_t>
+    [[gnu::always_inline]] constexpr result_with_carry<uint64_t>
     subb(uint64_t const lhs, uint64_t const rhs, bool const borrow_in) noexcept
     {
         uint64_t const sub = lhs - rhs;
@@ -51,21 +51,21 @@ namespace monad::uint256::portable
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint64_t
+    constexpr uint64_t
     shld(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
     {
         return (high << shift) | ((low >> 1) >> (63 - shift));
     }
 
     [[gnu::always_inline]]
-    inline constexpr uint64_t
+    constexpr uint64_t
     shrd(uint64_t const high, uint64_t const low, uint8_t const shift) noexcept
     {
         return (low >> shift) | ((high << 1) << (63 - shift));
     }
 
     [[gnu::always_inline]]
-    constexpr inline div_result<uint64_t>
+    constexpr div_result<uint64_t>
     div(uint64_t u_hi, uint64_t u_lo, uint64_t const v) noexcept
     {
         using u128 = unsigned __int128;
@@ -76,7 +76,7 @@ namespace monad::uint256::portable
     }
 
     [[gnu::always_inline]]
-    inline constexpr void mulx(
+    constexpr void mulx(
         uint64_t const x, uint64_t const y, uint64_t &r_hi,
         uint64_t &r_lo) noexcept
     {
@@ -88,7 +88,7 @@ namespace monad::uint256::portable
 
     template <size_t R, size_t M, size_t N>
     [[gnu::always_inline]]
-    inline constexpr words_t<R>
+    constexpr words_t<R>
     truncating_mul(words_t<M> const &x, words_t<N> const &y) noexcept
         requires(0 < R && R <= M + N)
     {

--- a/category/execution/ethereum/core/account.hpp
+++ b/category/execution/ethereum/core/account.hpp
@@ -42,14 +42,14 @@ static_assert(sizeof(std::optional<Account>) == 88);
 static_assert(alignof(std::optional<Account>) == 8);
 
 // YP (14)
-inline constexpr bool is_empty(Account const &account)
+constexpr bool is_empty(Account const &account)
 {
     return account.code_hash == NULL_HASH && account.nonce == 0 &&
            account.balance == 0;
 }
 
 // YP (15)
-inline constexpr bool is_dead(std::optional<Account> const &account)
+constexpr bool is_dead(std::optional<Account> const &account)
 {
     return !account.has_value() || is_empty(account.value());
 }

--- a/category/execution/ethereum/transaction_gas.cpp
+++ b/category/execution/ethereum/transaction_gas.cpp
@@ -50,7 +50,7 @@ namespace
 }
 
 // Intrinsic gas related functions
-inline constexpr auto g_txn_create(Transaction const &tx) noexcept
+constexpr auto g_txn_create(Transaction const &tx) noexcept
 {
     if (!tx.to.has_value()) {
         return 32'000u;
@@ -59,7 +59,7 @@ inline constexpr auto g_txn_create(Transaction const &tx) noexcept
 }
 
 // EIP-2930
-inline constexpr auto g_access_and_storage(Transaction const &tx) noexcept
+constexpr auto g_access_and_storage(Transaction const &tx) noexcept
 {
     uint64_t g = tx.access_list.size() * 2'400u;
     for (auto const &i : tx.access_list) {
@@ -70,7 +70,7 @@ inline constexpr auto g_access_and_storage(Transaction const &tx) noexcept
 
 // EIP-7981
 // Without EIP-7976, the 64 per-byte cost specified by EIP-7981 is 40 per-byte
-inline constexpr uint64_t g_access_list_data(Transaction const &tx) noexcept
+constexpr uint64_t g_access_list_data(Transaction const &tx) noexcept
 {
     uint64_t g = tx.access_list.size() * 20u;
     for (auto const &i : tx.access_list) {
@@ -80,13 +80,13 @@ inline constexpr uint64_t g_access_list_data(Transaction const &tx) noexcept
 }
 
 // EIP-7702
-inline constexpr auto g_authorization(Transaction const &tx) noexcept
+constexpr auto g_authorization(Transaction const &tx) noexcept
 {
     constexpr uint64_t per_empty_account_cost = 25'000u;
     return per_empty_account_cost * tx.authorization_list.size();
 }
 
-inline constexpr uint64_t g_extra_cost_init(Transaction const &tx) noexcept
+constexpr uint64_t g_extra_cost_init(Transaction const &tx) noexcept
 {
     if (!tx.to.has_value()) {
         return ((tx.data.length() + 31u) / 32u) * 2u;
@@ -158,7 +158,7 @@ uint64_t floor_data_gas(Transaction const &tx) noexcept
 
 EXPLICIT_TRAITS(floor_data_gas);
 
-inline constexpr uint256_t priority_fee_per_gas(
+constexpr uint256_t priority_fee_per_gas(
     Transaction const &tx, uint256_t const &base_fee_per_gas) noexcept
 {
     MONAD_ASSERT(tx.max_fee_per_gas >= base_fee_per_gas);

--- a/category/execution/ethereum/transaction_gas.hpp
+++ b/category/execution/ethereum/transaction_gas.hpp
@@ -69,7 +69,7 @@ inline constexpr uint64_t GAS_PER_BLOB = 131'072;
 inline constexpr uint64_t BLOB_BASE_COST = 8192;
 
 template <Traits traits>
-inline constexpr BlobSchedule default_blob_schedule() noexcept
+constexpr BlobSchedule default_blob_schedule() noexcept
 {
     // EIP-7691 increases the blob count where active.
     if constexpr (traits::eip_7691_active()) {
@@ -80,13 +80,13 @@ inline constexpr BlobSchedule default_blob_schedule() noexcept
     }
 }
 
-inline constexpr uint64_t
+constexpr uint64_t
 max_blob_gas_per_block(BlobSchedule const &blob_schedule) noexcept
 {
     return blob_schedule.max_blobs_per_block * GAS_PER_BLOB;
 }
 
-inline constexpr uint64_t
+constexpr uint64_t
 target_blob_gas_per_block(BlobSchedule const &blob_schedule) noexcept
 {
     return blob_schedule.target_blobs_per_block * GAS_PER_BLOB;

--- a/category/mpt/merkle/compact_encode.hpp
+++ b/category/mpt/merkle/compact_encode.hpp
@@ -28,8 +28,7 @@
 
 MONAD_MPT_NAMESPACE_BEGIN
 
-inline constexpr unsigned
-compact_encode_len(unsigned const si, unsigned const ei)
+constexpr unsigned compact_encode_len(unsigned const si, unsigned const ei)
 {
     MONAD_ASSERT(ei >= si);
     return (ei - si) / 2 + 1;

--- a/category/mpt/nibbles_view.hpp
+++ b/category/mpt/nibbles_view.hpp
@@ -125,7 +125,7 @@ public:
     // Returns a left-aligned Nibbles containing a subrange of nibbles starting
     // at `pos` and up to `count` nibbles (or to the end if count == npos).
     // The returned Nibbles is always left-aligned (begin_nibble_ == 0).
-    inline constexpr Nibbles substr(unsigned pos, unsigned count = npos) const;
+    constexpr Nibbles substr(unsigned pos, unsigned count = npos) const;
 
     [[nodiscard]] unsigned char get(unsigned const i) const
     {
@@ -345,7 +345,7 @@ constexpr Nibbles concat(Args... args)
     return ret;
 }
 
-inline constexpr Nibbles
+constexpr Nibbles
 Nibbles::substr(unsigned const pos, unsigned const count) const
 {
     auto const ret = concat(NibblesView(*this).substr(pos, count));

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -541,7 +541,7 @@ Node::SharedPtr read_node_blocking(
 
 //////////////////////////////////////////////////////////////////////////////
 // helpers
-inline constexpr unsigned num_pages(file_offset_t const offset, unsigned bytes)
+constexpr unsigned num_pages(file_offset_t const offset, unsigned bytes)
 {
     auto const rd_offset = round_down_align<DISK_PAGE_BITS>(offset);
     bytes += static_cast<unsigned>(offset - rd_offset);

--- a/category/mpt/util.hpp
+++ b/category/mpt/util.hpp
@@ -270,8 +270,7 @@ struct compact_offset_pair
 static_assert(sizeof(compact_offset_pair) == 8);
 static_assert(alignof(compact_offset_pair) == 4);
 
-inline constexpr unsigned
-bitmask_index(uint16_t const mask, unsigned const i) noexcept
+constexpr unsigned bitmask_index(uint16_t const mask, unsigned const i) noexcept
 {
     MONAD_ASSERT(i < 16);
     MONAD_ASSERT(mask & (1u << i));

--- a/category/vm/compiler/ir/basic_blocks.hpp
+++ b/category/vm/compiler/ir/basic_blocks.hpp
@@ -99,7 +99,7 @@ namespace monad::vm::compiler::basic_blocks
     /**
      * Base gas usage for a given terminator.
      */
-    inline constexpr uint16_t terminator_static_gas(Terminator const t)
+    constexpr uint16_t terminator_static_gas(Terminator const t)
     {
         using enum Terminator;
         switch (t) {

--- a/category/vm/runtime/math.hpp
+++ b/category/vm/runtime/math.hpp
@@ -99,7 +99,7 @@ namespace monad::vm::runtime
 
     template <Traits traits>
     [[gnu::always_inline]]
-    inline constexpr uint32_t exp_dynamic_gas_cost_multiplier() noexcept
+    constexpr uint32_t exp_dynamic_gas_cost_multiplier() noexcept
     {
         static_assert(traits::evm_rev() >= MONAD_ETH_SPURIOUS_DRAGON);
         return 50;

--- a/zkvm/category/core/runtime/uint256/intrinsics.hpp
+++ b/zkvm/category/core/runtime/uint256/intrinsics.hpp
@@ -18,7 +18,6 @@
 #include <category/core/runtime/uint256/portable.hpp>
 #include <category/core/runtime/uint256/types.hpp>
 
-#include <cstddef>
 #include <cstdint>
 
 // zkVM (RISC-V) replacement for the AVX2/BMI2 x86 intrinsics. RISC-V has no
@@ -36,7 +35,7 @@ namespace monad::uint256::intrinsics
     using portable::subb;
     using portable::truncating_mul;
 
-    [[gnu::always_inline]] constexpr inline uint64_t
+    [[gnu::always_inline]] constexpr uint64_t
     force(uint64_t const expr) noexcept
     {
         return expr;


### PR DESCRIPTION
`constexpr` implies `inline` on function declarations