### PR TITLE
Compile the shared gtest main.cpp once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,22 +207,24 @@ configure_file(cmake/test_resource_data.h.in test/test_resource_data.h @ONLY)
 set(TOP_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 function(monad_add_test target)
   cmake_parse_arguments(AT "NO_CUSTOM_MAIN" "" "PROPERTIES" ${ARGN})
+  # Exactly one main provider per branch: gtest's main for NO_CUSTOM_MAIN,
+  # otherwise monad_gtest_main. Linking both would make the resolution of
+  # main order-dependent between the two archives.
   if(AT_NO_CUSTOM_MAIN)
     add_executable(${target} ${AT_UNPARSED_ARGUMENTS})
+    target_link_libraries(${target} GTest::Main)
   else()
-    add_executable(
-      ${target}
-      "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test/unit/common/src/test/main.cpp"
-      ${AT_UNPARSED_ARGUMENTS})
+    add_executable(${target} ${AT_UNPARSED_ARGUMENTS})
     target_include_directories(
       ${target}
       PRIVATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/test/unit/common/include")
+    target_link_libraries(${target} monad_gtest_main)
   endif()
   monad_compile_options(${target})
   target_compile_options(${target} PUBLIC "-Wno-missing-field-initializers"
   )# TODO
   target_include_directories(${target} PRIVATE "${TOP_CURRENT_BINARY_DIR}/test")
-  target_link_libraries(${target} monad_execution GTest::GTest GTest::Main)
+  target_link_libraries(${target} monad_execution GTest::GTest)
   gtest_discover_tests(
     ${target} DISCOVERY_MODE PRE_TEST
     PROPERTIES ENVIRONMENT ASAN_OPTIONS=abort_on_error=1 ENVIRONMENT

--- a/category/mpt/CMakeLists.txt
+++ b/category/mpt/CMakeLists.txt
@@ -92,15 +92,12 @@ function(add_trie_test)
   cmake_parse_arguments(ADD_TRIE_TEST "" "${ONE_VALUE_ARGS}"
                         "${MULTI_VALUE_ARGS}" ${ARGN})
 
-  add_executable(
-    ${ADD_TRIE_TEST_TARGET}
-    "${PROJECT_SOURCE_DIR}/../../test/unit/common/src/test/main.cpp"
-    ${ADD_TRIE_TEST_SOURCES})
+  add_executable(${ADD_TRIE_TEST_TARGET} ${ADD_TRIE_TEST_SOURCES})
   monad_compile_options(${ADD_TRIE_TEST_TARGET})
   target_link_libraries(
     ${ADD_TRIE_TEST_TARGET}
-    PUBLIC monad_execution GTest::GTest monad_unit_test_common
-           ${ADD_TRIE_TEST_LINK_LIBRARIES})
+    PUBLIC monad_execution GTest::GTest monad_gtest_main
+           monad_unit_test_common ${ADD_TRIE_TEST_LINK_LIBRARIES})
   gtest_discover_tests(
     ${ADD_TRIE_TEST_TARGET}
     TEST_PREFIX ${PROJECT_NAME}/ TEST_FILTER ${ADD_TRIE_TEST_TEST_FILTER}

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -25,3 +25,12 @@ target_include_directories(
 set_target_properties(monad_unit_test_common PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(monad_unit_test_common PUBLIC monad_execution_native)
 monad_compile_options(monad_unit_test_common)
+
+# The shared gtest main for monad_add_test executables, compiled once here
+# instead of once per test target.
+add_library(monad_gtest_main STATIC
+            ${PROJECT_SOURCE_DIR}/test/unit/common/src/test/main.cpp)
+target_include_directories(monad_gtest_main
+                           PRIVATE ${PROJECT_SOURCE_DIR}/test/unit/common/include)
+target_link_libraries(monad_gtest_main PUBLIC monad_execution GTest::GTest)
+monad_compile_options(monad_gtest_main)


### PR DESCRIPTION
## Summary

Every `monad_add_test` executable (and `category/mpt`'s `add_trie_test`) compiled `test/unit/common/src/test/main.cpp` as its own source, so the same ~2.4s TU built ~140 times per clean build (~340 CPU-s). This moves it into a new `monad_gtest_main` static library, linked instead of compiled per target.

`GTest::Main` moves into the `NO_CUSTOM_MAIN` branch: with `main` now provided by an archive rather than a direct object, linking both `monad_gtest_main` and `GTest::Main` would make `main` resolution order-dependent between the two archives. Each branch now links exactly one `main` provider (sole `NO_CUSTOM_MAIN` user is `log_ffi_test`, which relies on gtest's main).

## Measured effect (16-core workstation, g++-15 RelWithDebInfo)

hyperfine, 2 clean builds per side (`ninja clean` + reconfigure between runs):

| | wall (mean ± σ) | CPU (user+sys) |
|---|---|---|
| `origin/main` | 222.64 s ± 0.02 | 3037 s |
| this branch | 206.55 s ± 0.55 | 2753 s |

**−16.1 s wall (−7.2%), −284 CPU-s.** Touching `monad/test/environment.hpp` now recompiles 2 TUs instead of 141 (the shared main + vm-unit-tests' own extended main, which is intentionally untouched).

## Testing

- Full rebuild from a clean reconfigure: `main.cpp` compiles exactly once
- `log_ffi_test` (gtest-provided main), `test_call_trace` (230 tests, confirms the custom main's `Environment` registration still runs), `state_machine_test`, `cli_tool_test` (36 tests) all pass
- Full ctest suite run locally (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ddXySwncygSTPNmQF4LiD