### PR TITLE
Cache P-256 curve parameters per thread in p256_verify_impl

### DIFF
--- a/category/execution/ethereum/precompiles_impl.hpp
+++ b/category/execution/ethereum/precompiles_impl.hpp
@@ -22,6 +22,7 @@
 #include <category/core/hex.hpp>
 #include <category/core/int.hpp>
 #include <category/core/likely.h>
+#include <category/core/thread_local.h>
 #include <category/crypto/silkpre_vendor/blake2b.h>
 #include <category/crypto/silkpre_vendor/ecdsa.h>
 #include <category/crypto/silkpre_vendor/rmd160.h>
@@ -383,7 +384,8 @@ p256_verify_impl(byte_string_view const input, std::span<uint8_t, 32> const out)
     Integer qx(input.data() + 96, 32);
     Integer qy(input.data() + 128, 32);
 
-    DL_GroupParameters_EC<ECP> params(ASN1::secp256r1());
+    MONAD_THREAD_LOCAL DL_GroupParameters_EC<ECP> const params(
+        ASN1::secp256r1());
     auto const &ec = params.GetCurve();
     auto const &n = params.GetSubgroupOrder();
     auto const p_mod = ec.FieldSize();
@@ -407,13 +409,14 @@ p256_verify_impl(byte_string_view const input, std::span<uint8_t, 32> const out)
         return PrecompileImplResult::failure();
     }
 
-    // if qy^2 ≢ qx^3 + a*qx + b (mod p): return
-    if (!ec.VerifyPoint({qx, qy})) {
+    // if (qx, qy) == (0, 0): return
+    // (cheaper, check first)
+    if (qx.IsZero() && qy.IsZero()) {
         return PrecompileImplResult::failure();
     }
 
-    // if (qx, qy) == (0, 0): return
-    if (qx.IsZero() && qy.IsZero()) {
+    // if qy^2 ≢ qx^3 + a*qx + b (mod p): return
+    if (!ec.VerifyPoint({qx, qy})) {
         return PrecompileImplResult::failure();
     }
 


### PR DESCRIPTION
Fixes #1646.

- **Cache the secp256r1 curve parameters per thread.** `DL_GroupParameters_EC<ECP>` was constructed on every call; it now lives in a function-local `thread_local`. Not a shared global: Crypto++'s `ECP` writes mutable scratch state under `Add`/`Multiply`, so one object shared across execution threads would be a data race. This matches the `thread_local secp256k1_context` pattern in `ecrecover_impl`.
- **Check the (0, 0) infinity public key before the curve equation.** Both orders reject identically — (0, 0) is not on the curve since b ≠ 0 for P-256 — so the cheap check runs first.

The issue's remaining suggestion (`constexpr empty_result`) was already resolved by the zkvm precompiles refactor (1ce42ff76).

No consensus-visible behavior change; all 19 `p256_verify` test instantiations pass (782 geth/wycheproof vectors each). The zkvm build shadows this header and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
