### PR TITLE
Add shared wei/gwei/ether unit constants header

### DIFF
--- a/category/execution/CMakeLists.txt
+++ b/category/execution/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(
   "ethereum/core/signature.hpp"
   "ethereum/core/transaction.cpp"
   "ethereum/core/transaction.hpp"
+  "ethereum/core/units.hpp"
   "ethereum/core/withdrawal.hpp"
   # ethereum/db
   "ethereum/db/block_db.cpp"

--- a/category/execution/ethereum/core/units.hpp
+++ b/category/execution/ethereum/core/units.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/core/config.hpp>
+#include <category/core/int.hpp>
+
+MONAD_NAMESPACE_BEGIN
+
+inline constexpr uint256_t WEI{1};
+inline constexpr uint256_t GWEI{1'000'000'000};
+inline constexpr uint256_t ETHER{1'000'000'000'000'000'000};
+
+namespace literals
+{
+    consteval uint256_t operator""_wei(unsigned long long const x) noexcept
+    {
+        return uint256_t{x};
+    }
+
+    consteval uint256_t operator""_gwei(unsigned long long const x) noexcept
+    {
+        return uint256_t{x} * GWEI;
+    }
+
+    consteval uint256_t operator""_ether(unsigned long long const x) noexcept
+    {
+        return uint256_t{x} * ETHER;
+    }
+}
+
+using literals::operator""_wei;
+using literals::operator""_gwei;
+using literals::operator""_ether;
+
+MONAD_NAMESPACE_END

--- a/category/execution/ethereum/execute_block.cpp
+++ b/category/execution/ethereum/execute_block.cpp
@@ -30,6 +30,7 @@
 #include <category/execution/ethereum/core/fmt/transaction_fmt.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/core/withdrawal.hpp>
 #include <category/execution/ethereum/dispatch_transaction.hpp>
 #include <category/execution/ethereum/event/exec_event_ctypes.h>
@@ -78,8 +79,7 @@ void process_withdrawal(
     if (withdrawals.has_value()) {
         for (auto const &withdrawal : withdrawals.value()) {
             state.add_to_balance(
-                withdrawal.recipient,
-                uint256_t{withdrawal.amount} * uint256_t{1'000'000'000u});
+                withdrawal.recipient, uint256_t{withdrawal.amount} * GWEI);
         }
     }
 }

--- a/category/execution/ethereum/execute_transaction_test.cpp
+++ b/category/execution/ethereum/execute_transaction_test.cpp
@@ -21,6 +21,7 @@
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/execute_transaction.hpp>
@@ -184,9 +185,8 @@ TYPED_TEST(TraitsTest, TopLevelCreate)
     BlockMetrics metrics;
 
     {
-        constexpr uint256_t WEI_PER_MON{1000000000000000000};
         State state{bs, Incarnation{0, 0}};
-        state.add_to_balance(from, 20 * WEI_PER_MON);
+        state.add_to_balance(from, 20_ether);
         state.set_nonce(from, 25);
         bs.merge(state);
     }

--- a/category/execution/ethereum/test/test_monad_chain.cpp
+++ b/category/execution/ethereum/test/test_monad_chain.cpp
@@ -21,6 +21,7 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/core/rlp/block_rlp.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/reserve_balance.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
@@ -199,7 +200,7 @@ void run_revert_transaction_test(
     {
         State state{bs, Incarnation{0, 0}};
         uint256_t const initial_balance =
-            uint256_t{initial_balance_mon} * 1000000000000000000ULL;
+            uint256_t{initial_balance_mon} * ETHER;
         state.add_to_balance(SENDER, initial_balance);
         if (prevent_dip_bitset & (1 << IsDelegated)) {
             byte_string const code{
@@ -213,7 +214,7 @@ void run_revert_transaction_test(
         bs.merge(state);
     }
 
-    uint256_t const gas_fee = uint256_t{gas_fee_mon} * 1000000000000000000ULL;
+    uint256_t const gas_fee = uint256_t{gas_fee_mon} * ETHER;
     uint256_t const gas_limit = gas_fee / BASE_FEE_PER_GAS;
     MONAD_ASSERT(
         (gas_fee % BASE_FEE_PER_GAS) == 0 &&
@@ -282,7 +283,7 @@ void run_revert_transaction_test(
             noop_state_tracer,
             chain_context);
         state.subtract_from_balance(SENDER, gas_fee);
-        uint256_t const value = uint256_t{value_mon} * 1000000000000000000ULL;
+        uint256_t const value = uint256_t{value_mon} * ETHER;
         state.subtract_from_balance(SENDER, value);
         bool should_revert = revert_transaction<traits>(
             SENDER,
@@ -395,9 +396,6 @@ TYPED_TEST(
 
     static constexpr Address SENDER{1};
     static constexpr uint256_t BASE_FEE_PER_GAS = 10;
-    auto const to_wei = [](uint64_t mon) {
-        return uint256_t{mon} * 1000000000000000000ULL;
-    };
 
     mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
@@ -406,12 +404,12 @@ TYPED_TEST(
 
     {
         State init_state{bs, Incarnation{0, 0}};
-        init_state.add_to_balance(SENDER, to_wei(20));
+        init_state.add_to_balance(SENDER, 20_ether);
         MONAD_ASSERT(bs.can_merge(init_state));
         bs.merge(init_state);
     }
 
-    uint256_t const sender_gas_fee = to_wei(11); // reserve is capped at 10 MON
+    uint256_t const sender_gas_fee = 11_ether; // reserve is capped at 10 MON
     uint256_t const gas_limit_u256 = sender_gas_fee / BASE_FEE_PER_GAS;
     MONAD_ASSERT(
         (sender_gas_fee % BASE_FEE_PER_GAS) == 0 &&
@@ -471,10 +469,6 @@ TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
     constexpr Address sender{1};
     constexpr uint256_t base_fee_per_gas = 10;
 
-    auto const to_wei = [](uint64_t mon) {
-        return uint256_t{mon} * staking::MON;
-    };
-
     mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
     vm::VM vm;
@@ -482,13 +476,13 @@ TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
 
     {
         State state{bs, Incarnation{0, 0}};
-        state.add_to_balance(sender, to_wei(20));
-        state.add_to_balance(staking::STAKING_CA, to_wei(10));
+        state.add_to_balance(sender, 20_ether);
+        state.add_to_balance(staking::STAKING_CA, 10_ether);
         MONAD_ASSERT(bs.can_merge(state));
         bs.merge(state);
     }
 
-    uint256_t const sender_gas_fee = to_wei(1);
+    uint256_t const sender_gas_fee = 1_ether;
     uint256_t const gas_limit_u256 = sender_gas_fee / base_fee_per_gas;
     MONAD_ASSERT(
         (sender_gas_fee % base_fee_per_gas) == 0 &&
@@ -520,7 +514,7 @@ TYPED_TEST(MonadTraitsTest, staking_contract_balance_drop_does_not_revert)
         noop_state_tracer,
         chain_context);
     state.subtract_from_balance(sender, sender_gas_fee);
-    state.subtract_from_balance(staking::STAKING_CA, to_wei(1));
+    state.subtract_from_balance(staking::STAKING_CA, 1_ether);
 
     EXPECT_FALSE(revert_transaction<traits>(
         sender,
@@ -609,9 +603,6 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
     static constexpr Address SENDER{1};
     static constexpr Address NEW_CONTRACT{2};
     static constexpr uint64_t BASE_FEE_PER_GAS = 10;
-    auto const to_wei = [](uint64_t mon) {
-        return uint256_t{mon} * 1000000000000000000ULL;
-    };
 
     mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
@@ -620,8 +611,8 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
 
     {
         State init_state{bs, Incarnation{0, 0}};
-        init_state.add_to_balance(SENDER, to_wei(20));
-        init_state.add_to_balance(NEW_CONTRACT, to_wei(3));
+        init_state.add_to_balance(SENDER, 20_ether);
+        init_state.add_to_balance(NEW_CONTRACT, 3_ether);
         MONAD_ASSERT(bs.can_merge(init_state));
         bs.merge(init_state);
     }
@@ -656,7 +647,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_code_hash)
         init_reserve_balance_context<traits>(
             state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
         state.subtract_from_balance(SENDER, gas_cost);
-        state.subtract_from_balance(NEW_CONTRACT, to_wei(3));
+        state.subtract_from_balance(NEW_CONTRACT, 3_ether);
         byte_string const contract_code{0x60, 0x00};
         state.set_code(NEW_CONTRACT, contract_code);
     };
@@ -688,9 +679,6 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
     static constexpr Address SENDER{1};
     static constexpr Address NEW_CONTRACT{2};
     static constexpr uint64_t BASE_FEE_PER_GAS = 10;
-    auto const to_wei = [](uint64_t mon) {
-        return uint256_t{mon} * 1000000000000000000ULL;
-    };
 
     mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
@@ -699,8 +687,8 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
 
     {
         State init_state{bs, Incarnation{0, 0}};
-        init_state.add_to_balance(SENDER, to_wei(20));
-        init_state.add_to_balance(NEW_CONTRACT, to_wei(3));
+        init_state.add_to_balance(SENDER, 20_ether);
+        init_state.add_to_balance(NEW_CONTRACT, 3_ether);
         MONAD_ASSERT(bs.can_merge(init_state));
         bs.merge(init_state);
     }
@@ -735,7 +723,7 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_empty_code_hash)
     init_reserve_balance_context<traits>(
         state, SENDER, tx, BASE_FEE_PER_GAS, 0, noop_state_tracer, context);
     state.subtract_from_balance(SENDER, gas_cost);
-    state.subtract_from_balance(NEW_CONTRACT, to_wei(3));
+    state.subtract_from_balance(NEW_CONTRACT, 3_ether);
     state.set_code(NEW_CONTRACT, {});
 
     bool const should_revert = revert_transaction<traits>(
@@ -759,9 +747,6 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
     constexpr Address NEW_CONTRACT{2};
     constexpr Address BENEFICIARY{3};
     constexpr uint64_t BASE_FEE_PER_GAS = 10;
-    auto const to_wei = [](uint64_t mon) {
-        return uint256_t{mon} * 1000000000000000000ULL;
-    };
 
     mpt::Db db{std::make_unique<InMemoryMachine>()};
     TrieDb tdb{db};
@@ -770,8 +755,8 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
 
     {
         State init_state{bs, Incarnation{0, 0}};
-        init_state.add_to_balance(SENDER, to_wei(20));
-        init_state.add_to_balance(NEW_CONTRACT, to_wei(3));
+        init_state.add_to_balance(SENDER, 20_ether);
+        init_state.add_to_balance(NEW_CONTRACT, 3_ether);
         MONAD_ASSERT(bs.can_merge(init_state));
         bs.merge(init_state);
     }
@@ -814,9 +799,9 @@ TYPED_TEST(MonadTraitsTest, reserve_checks_prefunded_init_selfdestruct)
     auto const [inserted, initial_balance] =
         state.selfdestruct<traits>(NEW_CONTRACT, BENEFICIARY);
     EXPECT_TRUE(inserted);
-    EXPECT_EQ(initial_balance, to_wei(3));
+    EXPECT_EQ(initial_balance, 3_ether);
     EXPECT_EQ(state.get_balance(NEW_CONTRACT), 0);
-    EXPECT_EQ(state.get_balance(BENEFICIARY), to_wei(3));
+    EXPECT_EQ(state.get_balance(BENEFICIARY), 3_ether);
 
     bool const should_revert = revert_transaction<traits>(
         SENDER, tx, BASE_FEE_PER_GAS, 0, state, noop_state_tracer, context);

--- a/category/execution/monad/reserve_balance.cpp
+++ b/category/execution/monad/reserve_balance.cpp
@@ -21,6 +21,7 @@
 #include <category/core/monad_exception.hpp>
 #include <category/execution/ethereum/chain/chain.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/reserve_balance.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
 #include <category/execution/ethereum/transaction_gas.hpp>
@@ -453,10 +454,9 @@ template <Traits traits>
 uint256_t get_max_reserve(Address const &)
 {
     // TODO: implement precompile (support reading from orig)
-    constexpr uint256_t WEI_PER_MON{1000000000000000000};
     return uint256_t{
                monad_default_max_reserve_balance_mon(traits::monad_rev())} *
-           WEI_PER_MON;
+           ETHER;
 }
 
 EXPLICIT_MONAD_TRAITS(get_max_reserve);

--- a/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
+++ b/category/execution/monad/reserve_balance/reserve_balance_contract_test.cpp
@@ -25,6 +25,7 @@
 #include <category/execution/ethereum/core/contract/abi_signatures.hpp>
 #include <category/execution/ethereum/core/contract/big_endian.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
 #include <category/execution/ethereum/db/util.hpp>
 #include <category/execution/ethereum/evmc_host.hpp>
@@ -213,7 +214,7 @@ void add_revert_check(std::vector<uint8_t> &code)
 
 void add_spend_code(uint64_t const value_mon, std::vector<uint8_t> &code)
 {
-    uint256_t const value = uint256_t{value_mon} * 1000000000000000000ULL;
+    uint256_t const value = uint256_t{value_mon} * ETHER;
     auto const *v = as_bytes(value);
     code.append_range(std::initializer_list<uint8_t>{
         PUSH0, PUSH0, PUSH0, PUSH0, PUSH32, v[31], v[30], v[29], v[28], v[27],
@@ -244,7 +245,7 @@ void run_dipped_into_reserve_test(
     uint64_t const initial_balance_mon, uint64_t const value_mon,
     Outcome outcome)
 {
-    static constexpr uint256_t GAS_FEE = 4 * 1000000000000000000ULL;
+    static constexpr uint256_t GAS_FEE = 4_ether;
     static constexpr uint256_t BASE_FEE_PER_GAS = 10;
     static constexpr uint256_t GAS_LIMIT = GAS_FEE / BASE_FEE_PER_GAS;
     static constexpr Address BUNDLER{0xbbbbbbbb};
@@ -276,7 +277,7 @@ void run_dipped_into_reserve_test(
     {
         State state{bs, Incarnation{0, 0}};
         uint256_t const initial_balance =
-            uint256_t{initial_balance_mon} * 1000000000000000000ULL;
+            uint256_t{initial_balance_mon} * ETHER;
         state.add_to_balance(EOA, initial_balance);
 
         // set EOA to delegate to SCW

--- a/category/execution/monad/staking/priority_fee_routing_test.cpp
+++ b/category/execution/monad/staking/priority_fee_routing_test.cpp
@@ -54,7 +54,7 @@ TYPED_TEST(MonadTraitsTest, mip11_fork)
 
     {
         State state{bs, Incarnation{0, 0}};
-        state.add_to_balance(from, 1'000'000'000'000'000'000);
+        state.add_to_balance(from, 1_ether);
         bs.merge(state);
     }
 

--- a/category/execution/monad/staking/util/constants.hpp
+++ b/category/execution/monad/staking/util/constants.hpp
@@ -18,6 +18,7 @@
 #include <category/core/address.hpp>
 #include <category/execution/ethereum/core/contract/big_endian.hpp>
 #include <category/execution/ethereum/core/contract/storage_variable.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/monad/staking/config.hpp>
 #include <category/vm/evm/traits.hpp>
 
@@ -37,8 +38,8 @@ inline constexpr Address STAKING_CA{0x1000};
 inline constexpr Address PRIORITY_FEE_DIST_ADDRESS{
     0xfee5fee5fee5fee5fee5fee5fee5fee5fee5fee5_address};
 
-// 1e18 constant
-inline constexpr uint256_t MON{1000000000000000000_u256};
+// MON has the same 18-decimal denomination as ether
+inline constexpr uint256_t MON{ETHER};
 
 // accumulator precision
 inline constexpr uint256_t UNIT_BIAS{
@@ -49,7 +50,7 @@ namespace limits
 {
     constexpr uint256_t dust_threshold()
     {
-        return 1000000000; // 1e9
+        return 1_gwei;
     }
 
     constexpr uint256_t max_commission()

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -33,6 +33,7 @@
 #include <category/execution/ethereum/core/rlp/transaction_rlp.hpp>
 #include <category/execution/ethereum/core/signature.hpp>
 #include <category/execution/ethereum/core/transaction.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/create_contract_address.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/db/trie_db.hpp>
@@ -2464,8 +2465,8 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
     uint64_t const initial_balance_mon = 10;
     uint64_t const gas_fee_mon = 2;
     uint64_t const value_mon = 1;
-    uint256_t const value = uint256_t{value_mon} * 1000000000000000000ULL;
-    uint256_t const gas_fee = uint256_t{gas_fee_mon} * 1000000000000000000ULL;
+    uint256_t const value = uint256_t{value_mon} * ETHER;
+    uint256_t const gas_fee = uint256_t{gas_fee_mon} * ETHER;
     uint256_t const gas_limit_ = gas_fee / BASE_FEE_PER_GAS;
     ASSERT_TRUE((gas_fee % BASE_FEE_PER_GAS) == 0);
     ASSERT_TRUE(gas_limit_ <= std::numeric_limits<uint64_t>::max());
@@ -2492,8 +2493,7 @@ TEST_F(EthCallFixture, monad_executor_run_reserve_balance)
 
     Address const sender = recover_sender(tx).value();
     Account const sender_acc{
-        .balance = uint256_t{initial_balance_mon} * 1000000000000000000ULL,
-        .nonce = 1};
+        .balance = uint256_t{initial_balance_mon} * ETHER, .nonce = 1};
     {
         // Initial state.
         StateDeltas deltas{
@@ -4010,7 +4010,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = uint256_t{1'000'000'000'000'000'000} * 100,
+                          .balance = 100_ether,
                           .code_hash = NULL_HASH,
                           .nonce = 0}}}},
             {delegated_eoa,
@@ -4018,7 +4018,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = uint256_t{1'000'000'000'000'000'000} * 7,
+                          .balance = 7_ether,
                           .code_hash = delegated_eoa_code_hash,
                           .nonce = 0}}}},
             {contract,
@@ -4044,7 +4044,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance)
 
     Transaction const tx{
         .gas_limit = 200000u,
-        .value = uint256_t{1'000'000'000'000'000'000} * 3,
+        .value = 3_ether,
         .to = delegated_eoa,
     };
 
@@ -4110,7 +4110,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = uint256_t{1'000'000'000'000'000'000} * 12,
+                          .balance = 12_ether,
                           .code_hash = NULL_HASH,
                           .nonce = 0}}}},
             {recipient,
@@ -4125,7 +4125,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_emptying)
 
     Transaction const tx{
         .gas_limit = 200000u,
-        .value = uint256_t{1'000'000'000'000'000'000} * 5,
+        .value = 5_ether,
         .to = recipient,
     };
 
@@ -4210,7 +4210,7 @@ TEST_F(EthCallFixture, eth_call_reserve_balance_assertion)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = uint256_t{1'000'000'000'000'000'000} * 12,
+                          .balance = 12_ether,
                           .code_hash = delegated_eoa_code_hash,
                           .nonce = 0}}}},
             {contract,
@@ -5035,10 +5035,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} *
-                                     uint256_t{1'000'000'000'000'000'000ULL},
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -5134,9 +5131,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_simple_transfers_multiple_blocks)
     // should remain unchanged.
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);
@@ -5159,7 +5154,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_single_call_block_255)
     // One simple EIP-1559 transfer: send 1 ETH to 0xdeadbeef...
     Transaction const tx{
         .gas_limit = 200'000'000,
-        .value = uint256_t{1'000'000'000'000'000'000ULL}, // 1 ETH
+        .value = 1_ether,
         .to = 0xdeadbeef00000000000000000000000000000000_address,
         .type = TransactionType::eip1559,
     };
@@ -5286,7 +5281,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_block_override_synthetic_gap)
     // One simple EIP-1559 transfer: send 1 ETH to 0xdeadbeef...
     Transaction const tx{
         .gas_limit = 200'000'000,
-        .value = uint256_t{1'000'000'000'000'000'000ULL}, // 1 ETH
+        .value = 1_ether,
         .to = 0xdeadbeef00000000000000000000000000000000_address,
         .type = TransactionType::eip1559,
     };
@@ -5484,7 +5479,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_stress_queue_rejection)
 
     Transaction const tx{
         .gas_limit = 200'000'000,
-        .value = uint256_t{1'000'000'000'000'000'000ULL},
+        .value = 1_ether,
         .to = 0xdeadbeef00000000000000000000000000000000_address,
         .type = TransactionType::eip1559,
     };
@@ -5600,8 +5595,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_stress_queue_rejection)
 //          sender_a, cannot dip)
 TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender_a =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address sender_b =
@@ -5615,17 +5608,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
             {sender_a,
              StateDelta{
                  .account =
-                     {std::nullopt,
-                      Account{
-                          .balance = uint256_t{11} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                     {std::nullopt, Account{.balance = 11_ether, .nonce = 0}}}},
             {sender_b,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -5650,7 +5638,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
     // tx0: sender_a sends 2 MON (dips into reserve, allowed as first tx)
     Transaction const tx_dip{
         .gas_limit = 200'000'000,
-        .value = uint256_t{2} * WEI_PER_MON,
+        .value = 2_ether,
         .to = recipient,
     };
     // tx1: sender_b sends 1 wei (plenty of balance, no dipping)
@@ -5663,7 +5651,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
     // reverts)
     Transaction const tx_repeat{
         .gas_limit = 200'000'000,
-        .value = uint256_t{1} * WEI_PER_MON,
+        .value = 1_ether,
         .to = recipient,
     };
 
@@ -5762,8 +5750,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance)
 //              parent/grandparent contexts)
 TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     // sender_x is the address recovered from the known test AuthorizationEntry
     // (see test_transaction.cpp). Using this address lets us also test the
     // authority path without needing to generate new ECDSA signatures.
@@ -5782,7 +5768,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
                  .account =
                      {std::nullopt,
                       Account{
-                          .balance = uint256_t{11} * WEI_PER_MON,
+                          .balance = 11_ether,
                           // Nonce starts at 1 so the EIP-7702 auth entry
                           // (nonce=0) won't match during execution, preventing
                           // the delegation designation from being set on
@@ -5794,9 +5780,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -5826,7 +5810,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
 
         Transaction const tx_dip{
             .gas_limit = 200'000'000,
-            .value = uint256_t{2} * WEI_PER_MON,
+            .value = 2_ether,
             .to = recipient,
         };
         auto const encoded_tx_dip =
@@ -5954,7 +5938,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_reserve_balance_chain_context_buffer)
         };
         Transaction const tx_dip{
             .gas_limit = 200'000'000,
-            .value = uint256_t{2} * WEI_PER_MON,
+            .value = 2_ether,
             .to = recipient,
         };
 
@@ -6288,8 +6272,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_call_types)
 //            refund)
 TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address account_a =
         0x00000000000000000000000000000000aaaaaa01_address;
     static constexpr Address account_b =
@@ -6304,16 +6286,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {account_b,
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -6330,12 +6308,12 @@ TEST_F(EthCallFixture, eth_simulate_v1_state_changes_across_blocks)
     // Transactions.
     Transaction const tx_a_sends_60{
         .gas_limit = 200'000'000,
-        .value = uint256_t{60} * WEI_PER_MON,
+        .value = 60_ether,
         .to = recipient,
     };
     Transaction const tx_b_refunds_a{
         .gas_limit = 200'000'000,
-        .value = uint256_t{50} * WEI_PER_MON,
+        .value = 50_ether,
         .to = account_a,
     };
 
@@ -6444,8 +6422,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
 {
     using namespace monad::vm::utils;
 
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address beneficiary =
@@ -6510,9 +6486,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {beneficiary,
              StateDelta{
                  .account =
@@ -6536,7 +6510,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
     // Block 2: call deployed contract with 10 MON.
     Transaction const call_tx{
         .gas_limit = 200'000'000,
-        .value = uint256_t{10} * WEI_PER_MON,
+        .value = 10_ether,
         .to = deployed,
     };
 
@@ -6638,7 +6612,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
     ASSERT_EQ(output[1]["calls"].size(), 1);
     EXPECT_EQ(output[1]["calls"][0]["status"], "0x1");
 
-    auto const expected_half = uint256_t{5} * WEI_PER_MON;
+    auto const expected_half = 5_ether;
     auto const expected_bytes = store_be_as<bytes32_t>(expected_half);
     auto const expected_return_data =
         std::format("0x{}", to_hex(expected_bytes));
@@ -6671,8 +6645,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_deploy_and_call)
 TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
 {
     using namespace monad::vm::utils;
-
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
 
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
@@ -6731,9 +6703,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {sink,
              StateDelta{
                  .account =
@@ -6765,7 +6735,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
     // Single tx: sender calls forwarder with 10 MON.
     Transaction const tx{
         .gas_limit = 200'000'000,
-        .value = uint256_t{10} * WEI_PER_MON,
+        .value = 10_ether,
         .to = forwarder_addr,
     };
 
@@ -6842,7 +6812,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
     EXPECT_EQ(logs[0]["topics"][0], std::format("0x{}", to_hex(transfer_sig)));
     EXPECT_EQ(logs[0]["topics"][1], format_address_topic(sender));
     EXPECT_EQ(logs[0]["topics"][2], format_address_topic(forwarder_addr));
-    auto const ten_mon = store_be_as<bytes32_t>(uint256_t{10} * WEI_PER_MON);
+    auto const ten_mon = store_be_as<bytes32_t>(10_ether);
     EXPECT_EQ(logs[0]["data"], std::format("0x{}", to_hex(ten_mon)));
 
     // Log 1: forwarder -> sink (5 MON)
@@ -6852,7 +6822,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
     EXPECT_EQ(logs[1]["topics"][0], std::format("0x{}", to_hex(transfer_sig)));
     EXPECT_EQ(logs[1]["topics"][1], format_address_topic(forwarder_addr));
     EXPECT_EQ(logs[1]["topics"][2], format_address_topic(sink));
-    auto const five_mon = store_be_as<bytes32_t>(uint256_t{5} * WEI_PER_MON);
+    auto const five_mon = store_be_as<bytes32_t>(5_ether);
     EXPECT_EQ(logs[1]["data"], std::format("0x{}", to_hex(five_mon)));
 
     monad_block_override_vec_destroy(bo);
@@ -6864,8 +6834,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_native_transfer_logs)
 TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
 {
     using namespace monad::vm::utils;
-
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
 
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
@@ -6891,9 +6859,7 @@ TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {time_contract,
              StateDelta{
                  .account =
@@ -6989,8 +6955,6 @@ TYPED_TEST(EthCallEncodingFixture, eth_simulate_v1_time_travel)
 // during an eth_simulateV1 call.
 TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address blockhash_contract =
@@ -7023,9 +6987,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {blockhash_contract,
              StateDelta{
                  .account =
@@ -7147,8 +7109,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_blockhash_reads)
 // execute successfully when encoded in mixed envelope formats.
 TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address recipient =
@@ -7161,9 +7121,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -7253,9 +7211,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
 
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);
@@ -7266,8 +7222,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_legacy_transactions)
 // type-1 (EIP-2930) and type-2 (EIP-1559) both execute successfully.
 TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address recipient =
@@ -7280,9 +7234,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -7371,9 +7323,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
 
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);
@@ -7384,8 +7334,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transactions_2930_and_1559)
 // checks that it executes successfully.
 TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address recipient =
@@ -7398,9 +7346,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -7502,9 +7448,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
 
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);
@@ -7515,8 +7459,6 @@ TEST_F(EthCallFixture, eth_simulate_v1_typed_transaction_7702)
 // supported format: legacy, EIP-2930, EIP-1559, and EIP-7702.
 TEST_F(EthCallFixture, eth_simulate_v1_all_transaction_formats_single_block)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address recipient =
@@ -7529,9 +7471,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_all_transaction_formats_single_block)
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -7665,9 +7605,7 @@ TEST_F(EthCallFixture, eth_simulate_v1_all_transaction_formats_single_block)
 
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);
@@ -7681,8 +7619,6 @@ TEST_F(
     EthCallFixture,
     eth_simulate_v1_typed_transactions_2930_and_1559_across_blocks)
 {
-    static constexpr auto WEI_PER_MON = uint256_t{1'000'000'000'000'000'000ULL};
-
     static constexpr Address sender =
         0x00000000000000000000000000000000deadbeef_address;
     static constexpr Address recipient =
@@ -7695,9 +7631,7 @@ TEST_F(
              StateDelta{
                  .account =
                      {std::nullopt,
-                      Account{
-                          .balance = uint256_t{100} * WEI_PER_MON,
-                          .nonce = 0}}}},
+                      Account{.balance = 100_ether, .nonce = 0}}}},
             {recipient,
              StateDelta{
                  .account =
@@ -7787,9 +7721,7 @@ TEST_F(
 
     auto sender_account = tdb.read_account(sender);
     ASSERT_TRUE(sender_account.has_value());
-    EXPECT_EQ(
-        sender_account->balance,
-        uint256_t{100} * uint256_t{1'000'000'000'000'000'000ULL});
+    EXPECT_EQ(sender_account->balance, 100_ether);
 
     monad_block_override_vec_destroy(block_overrides);
     monad_state_override_vec_destroy(state_overrides);

--- a/test/vm/micro_benchmarks/main.cpp
+++ b/test/vm/micro_benchmarks/main.cpp
@@ -19,6 +19,7 @@
 #include <category/core/int.hpp>
 #include <category/core/keccak.hpp>
 #include <category/execution/ethereum/chain/ethereum_mainnet.hpp>
+#include <category/execution/ethereum/core/units.hpp>
 #include <category/execution/ethereum/db/test/commit_simple.hpp>
 #include <category/execution/ethereum/state2/block_state.hpp>
 #include <category/execution/ethereum/state3/state.hpp>
@@ -340,7 +341,7 @@ static void init_execute_state(
     auto icode = make_shared_intercode(raw_code);
     Code code{{code_hash, std::move(icode)}};
 
-    static constexpr uint256_t BALANCE = exp(uint256_t{10}, uint256_t{18});
+    static constexpr uint256_t BALANCE = 1_ether;
     Account code_account{
         .balance = BALANCE,
         .code_hash = code_hash,


### PR DESCRIPTION
Adds `category/execution/ethereum/core/units.hpp` exposing `WEI`/`GWEI`/`ETHER` as `inline constexpr uint256_t`, and migrates the ad-hoc 1e9/1e18 literals to it: the EIP-4895 withdrawal gwei conversion, `get_max_reserve`, `staking::MON` (now `MON{ETHER}`), `dust_threshold()` (now `GWEI`), and test literals.

No behavior change — all substitutions are value-identical. Nanosecond 1e9 timestamp conversions are untouched.

Closes EXE-69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)