### PR TITLE
[rpc] Propagate insufficient balance error

### DIFF
--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -1504,7 +1504,10 @@ struct monad_executor
                         return;
                     }
                     if (MONAD_UNLIKELY(res.has_error())) {
-                        result->status_code = EVMC_REJECTED;
+                        result->status_code =
+                            res.error() == TransactionError::InsufficientBalance
+                                ? EVMC_INSUFFICIENT_BALANCE
+                                : EVMC_REJECTED;
                         result->message = strdup(res.error().message().c_str());
                         MONAD_ASSERT(result->message);
                         complete(result, user);

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -412,7 +412,7 @@ TEST_F(EthCallFixture, insufficient_balance)
         true);
     f.get();
 
-    EXPECT_TRUE(ctx.result->status_code == EVMC_REJECTED);
+    EXPECT_TRUE(ctx.result->status_code == EVMC_INSUFFICIENT_BALANCE);
     EXPECT_TRUE(std::strcmp(ctx.result->message, "insufficient balance") == 0);
     EXPECT_TRUE(ctx.result->encoded_trace_len == 0);
     EXPECT_EQ(ctx.result->gas_refund, 0);

--- a/rust/crates/monad-ethcall/src/executor/call.rs
+++ b/rust/crates/monad-ethcall/src/executor/call.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::f32::consts::E;
+
 use alloy_consensus::{Header, Transaction as _, TxEnvelope};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::Address;
@@ -22,7 +24,8 @@ use tracing::warn;
 
 use super::{
     decode_revert_message, EthCallResult, MessageError, MonadExecutor, MonadExecutorResult,
-    ETH_CALL_SUCCESS, EVMC_MONAD_RESERVE_BALANCE_VIOLATION, EVMC_OUT_OF_GAS,
+    ETH_CALL_SUCCESS, EVMC_INSUFFICIENT_BALANCE, EVMC_MONAD_RESERVE_BALANCE_VIOLATION,
+    EVMC_OUT_OF_GAS,
 };
 use crate::{
     ffi,
@@ -77,6 +80,10 @@ pub enum EthCallError {
     },
     GasLimitTooHigh,
     InternalError,
+    InsufficientBalance {
+        gas_used: u64,
+        gas_refund: u64,
+    },
     Other {
         message: String,
     },
@@ -278,6 +285,20 @@ impl MonadExecutor {
             EVMC_MONAD_RESERVE_BALANCE_VIOLATION => {
                 if tracer_cval == ffi::monad_tracer_config_NOOP_TRACER {
                     Err(EthCallError::ReserveBalanceViolation {
+                        gas_used: result.gas_used(),
+                        gas_refund: result.gas_refund(),
+                    })
+                } else {
+                    let trace = result.encoded_trace().map_err(|_| {
+                        warn!("execution error `eth_call` failed: encoded trace pointer is null");
+                        EthCallError::InternalError
+                    })?;
+                    Err(EthCallError::Trace { trace })
+                }
+            }
+            EVMC_INSUFFICIENT_BALANCE => {
+                if tracer_cval == ffi::monad_tracer_config_NOOP_TRACER {
+                    Err(EthCallError::InsufficientBalance {
                         gas_used: result.gas_used(),
                         gas_refund: result.gas_refund(),
                     })

--- a/rust/crates/monad-ethcall/src/executor/mod.rs
+++ b/rust/crates/monad-ethcall/src/executor/mod.rs
@@ -34,6 +34,7 @@ mod trace;
 
 pub(super) const ETH_CALL_SUCCESS: i32 = 0;
 pub(super) const EVMC_OUT_OF_GAS: i32 = 3;
+pub(super) const EVMC_INSUFFICIENT_BALANCE: i32 = 4;
 pub(super) const EVMC_MONAD_RESERVE_BALANCE_VIOLATION: i32 = 18;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This patch propagates the insufficient balance error through the rpc stack rather than rewriting it to a generic "other" error type with a custom message.

BFT companion patch: https://github.com/category-labs/monad-bft/pull/3234