### PR TITLE
[dual-db] Historical nodes only commit the page timeline past mip-8; reads route per version

### DIFF
--- a/category/execution/monad/db/commit_block_migration.cpp
+++ b/category/execution/monad/db/commit_block_migration.cpp
@@ -78,36 +78,29 @@ void commit_block(
         return;
     }
 
-    // Dual-write migration path. The primary and secondary dbs write the same
-    // data to every table; the only difference is state encoding. state_deltas
-    // is added separately to each builder so the page builder's override can
-    // kick in; everything else goes through the shared helper.
+    // Dual-write path: one slot db and one page db, in either role order
+    // (the offline promote swaps them). The db whose encoding matches the
+    // block's revision is canonical; it commits first so its roots are live
+    // when the other db's populate_header runs.
     MONAD_ASSERT(
-        !primary_db.is_page_encoded() && secondary_db->is_page_encoded());
-    auto builder = make_commit_builder(header.number, primary_db);
-    builder->add_state_deltas(state);
-    add_common_deltas(*builder);
+        primary_db.is_page_encoded() != secondary_db->is_page_encoded());
+    canonical_db = traits::mip_8_active() == primary_db.is_page_encoded()
+                       ? &primary_db
+                       : secondary_db;
+    Db *const other_db =
+        canonical_db == &primary_db ? secondary_db : &primary_db;
 
-    auto builder2 = make_commit_builder(header.number, *secondary_db);
-    builder2->add_state_deltas(state);
-    add_common_deltas(*builder2);
+    auto canonical_builder = make_commit_builder(header.number, *canonical_db);
+    canonical_builder->add_state_deltas(state);
+    add_common_deltas(*canonical_builder);
 
-    // The canonical db owns the state_root stamped into the header: pre-fork
-    // the slot-encoded primary, post-fork (mip-8 active) the page-encoded
-    // secondary. The canonical db commits first so its roots are live when the
-    // other db's populate_header runs.
-    bool const primary_is_canonical = !traits::mip_8_active();
-    canonical_db = primary_is_canonical ? &primary_db : secondary_db;
-    if (primary_is_canonical) {
-        primary_db.commit(block_id, *builder, header, state, populate_header);
-        secondary_db->commit(
-            block_id, *builder2, header, state, populate_header);
-    }
-    else {
-        secondary_db->commit(
-            block_id, *builder2, header, state, populate_header);
-        primary_db.commit(block_id, *builder, header, state, populate_header);
-    }
+    auto other_builder = make_commit_builder(header.number, *other_db);
+    other_builder->add_state_deltas(state);
+    add_common_deltas(*other_builder);
+
+    canonical_db->commit(
+        block_id, *canonical_builder, header, state, populate_header);
+    other_db->commit(block_id, *other_builder, header, state, populate_header);
 }
 
 EXPLICIT_MONAD_TRAITS(commit_block);

--- a/category/execution/monad/db/commit_block_migration.hpp
+++ b/category/execution/monad/db/commit_block_migration.hpp
@@ -55,4 +55,14 @@ void commit_block(
     BlockHeader const &header, StateDeltas const &state,
     BlockCommitAncillaries const &anc);
 
+// apply f to both dbs that are present
+template <typename F>
+void for_each_db(Db &db, Db *const secondary_db, F &&f)
+{
+    f(db);
+    if (secondary_db != nullptr) {
+        f(*secondary_db);
+    }
+}
+
 MONAD_NAMESPACE_END

--- a/category/execution/runloop/runloop_interface_monad.cpp
+++ b/category/execution/runloop/runloop_interface_monad.cpp
@@ -406,6 +406,7 @@ try {
         runloop->ledger_dir,
         runloop->raw_db,
         runloop->runloop_db,
+        &runloop->secondary_runloop_db,
         runloop->vm,
         runloop->block_hash_buffer,
         runloop->priority_pool,
@@ -414,7 +415,6 @@ try {
         stop,
         /* enable_tracing = */ false,
         /* exec_recorder = */ nullptr,
-        &runloop->secondary_runloop_db,
         runloop_override);
 
     auto const block_num_after = runloop->block_num;

--- a/category/execution/runloop/runloop_monad.cpp
+++ b/category/execution/runloop/runloop_monad.cpp
@@ -282,14 +282,11 @@ Result<BlockExecOutput> propose_block(
 
     // Core execution: transaction-level EVM execution that tracks state
     // changes but does not commit them
-    db.set_block_and_prefix(
-        block.header.number - 1,
-        is_first_block ? bytes32_t{} : consensus_header.parent_id());
-    if (secondary_db != nullptr) {
-        secondary_db->set_block_and_prefix(
+    for_each_db(db, secondary_db, [&](Db &d) {
+        d.set_block_and_prefix(
             block.header.number - 1,
             is_first_block ? bytes32_t{} : consensus_header.parent_id());
-    }
+    });
     block.header.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(db.read_eth_header())));
 
@@ -368,21 +365,14 @@ Result<BlockExecOutput> propose_block(
 
     // Dual-db migration: log both timelines' state roots (slot primary vs
     // page secondary) so a divergence is visible per block.
-    if (secondary_db != nullptr) {
-        LOG_INFO(
-            "block={}, block_id={} state_root primary={} secondary={}",
-            block.header.number,
-            block_id,
-            db.state_root(),
-            secondary_db->state_root());
-    }
-    else {
-        LOG_INFO(
-            "block={}, block_id={} state_root primary={}",
-            block.header.number,
-            block_id,
-            db.state_root());
-    }
+    LOG_INFO(
+        "block={}, block_id={} state_root primary={}{}",
+        block.header.number,
+        block_id,
+        db.state_root(),
+        secondary_db != nullptr
+            ? fmt::format(" secondary={}", secondary_db->state_root())
+            : std::string{});
 
     // Emit the block metrics log line
     [[maybe_unused]] auto const block_time =
@@ -503,12 +493,12 @@ MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &chain, std::filesystem::path const &ledger_dir,
-    mpt::Db &raw_db, Db &db, vm::VM &vm,
+    mpt::Db &raw_db, Db &db, Db *secondary_db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
     bool const enable_tracing, ExecutionEventRecorder *const exec_recorder,
-    Db *secondary_db, RunloopMonadOverride const runloop_override)
+    RunloopMonadOverride const runloop_override)
 {
     constexpr auto SLEEP_TIME = std::chrono::microseconds(100);
     uint64_t const start_block_num =
@@ -668,11 +658,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 auto const &header) -> Result<std::pair<uint64_t, uint64_t>> {
             auto const block_time_start = std::chrono::steady_clock::now();
 
-            db.update_voted_metadata(header.seqno - 1, header.parent_id());
-            if (secondary_db != nullptr) {
-                secondary_db->update_voted_metadata(
-                    header.seqno - 1, header.parent_id());
-            }
+            for_each_db(db, secondary_db, [&](Db &d) {
+                d.update_voted_metadata(header.seqno - 1, header.parent_id());
+            });
             record_block_qc(exec_recorder, header, last_finalized_block_number);
 
             uint64_t const block_number = header.execution_inputs.number;
@@ -733,10 +721,9 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 BlockExecOutput const exec_output,
                 record_block_result(exec_recorder, propose_dispatch()));
 
-            db.update_proposed_metadata(header.seqno, block_id);
-            if (secondary_db != nullptr) {
-                secondary_db->update_proposed_metadata(header.seqno, block_id);
-            }
+            for_each_db(db, secondary_db, [&](Db &d) {
+                d.update_proposed_metadata(header.seqno, block_id);
+            });
 
             log_tps(
                 block_number,
@@ -761,20 +748,17 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad(
                 "Processing finalization for block {} with block_id {}",
                 block,
                 block_id);
-            db.finalize(block, block_id);
-            if (secondary_db != nullptr) {
-                secondary_db->finalize(block, block_id);
-            }
+            for_each_db(
+                db, secondary_db, [&](Db &d) { d.finalize(block, block_id); });
             block_hash_chain.finalize(block_id);
             record_block_finalized(exec_recorder, block_id, block);
             finalized_block_num = block;
 
             if (!verified_blocks.empty() &&
                 verified_blocks.back() != mpt::INVALID_BLOCK_NUM) {
-                db.update_verified_block(verified_blocks.back());
-                if (secondary_db != nullptr) {
-                    secondary_db->update_verified_block(verified_blocks.back());
-                }
+                for_each_db(db, secondary_db, [&](Db &d) {
+                    d.update_verified_block(verified_blocks.back());
+                });
             }
             record_block_verified(exec_recorder, verified_blocks);
         }

--- a/category/execution/runloop/runloop_monad.hpp
+++ b/category/execution/runloop/runloop_monad.hpp
@@ -45,9 +45,9 @@ namespace fiber
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad(
     MonadChain const &, std::filesystem::path const &, mpt::Db &, Db &,
-    vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
-    uint64_t, sig_atomic_t const volatile &, bool enable_tracing,
-    ExecutionEventRecorder *, Db *secondary_db,
+    Db *secondary_db, vm::VM &, BlockHashBufferFinalized &,
+    fiber::PriorityPool &, uint64_t &, uint64_t, sig_atomic_t const volatile &,
+    bool enable_tracing, ExecutionEventRecorder *,
     RunloopMonadOverride runloop_override = {});
 
 MONAD_NAMESPACE_END

--- a/category/execution/runloop/runloop_monad_ethblocks.cpp
+++ b/category/execution/runloop/runloop_monad_ethblocks.cpp
@@ -119,7 +119,7 @@ void get_block_with_retry(
 template <Traits traits>
     requires is_monad_trait_v<traits>
 Result<void> process_monad_block(
-    MonadChain const &chain, Db &db, vm::VM &vm,
+    MonadChain const &chain, Db &db, Db *const mirror_db, vm::VM &vm,
     BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, Block &block, bytes32_t const &block_id,
     bytes32_t const &parent_block_id, bool const enable_tracing,
@@ -209,12 +209,14 @@ Result<void> process_monad_block(
 
     // Core execution: transaction-level EVM execution that tracks state
     // changes but does not commit them
-    db.set_block_and_prefix(block.header.number - 1, parent_block_id);
+    for_each_db(db, mirror_db, [&](Db &d) {
+        d.set_block_and_prefix(block.header.number - 1, parent_block_id);
+    });
     block.header.parent_hash =
         to_bytes(keccak256(rlp::encode_block_header(db.read_eth_header())));
 
     BlockMetrics block_metrics;
-    BlockState block_state(db, vm);
+    BlockState block_state(db, vm, mirror_db);
     record_block_marker_event(exec_recorder, MONAD_EXEC_BLOCK_PERF_EVM_ENTER);
     BOOST_OUTCOME_TRY(
         auto const receipts,
@@ -247,7 +249,7 @@ Result<void> process_monad_block(
         .call_frames = call_frames,
         .ommers = block.ommers,
         .withdrawals = block.withdrawals};
-    commit_block<traits>(db, nullptr, block_id, block.header, *state, anc);
+    commit_block<traits>(db, mirror_db, block_id, block.header, *state, anc);
 
     [[maybe_unused]] auto const commit_time =
         std::chrono::duration_cast<std::chrono::microseconds>(
@@ -266,13 +268,28 @@ Result<void> process_monad_block(
 
     // Commit prologue: database finalization, computation of the Ethereum
     // block hash to append to the circular hash buffer
-    db.finalize(block.header.number, block_id);
-    db.update_verified_block(block.header.number);
+    for_each_db(db, mirror_db, [&](Db &d) {
+        d.finalize(block.header.number, block_id);
+        d.update_verified_block(block.header.number);
+    });
     exec_output.eth_block_hash =
         to_bytes(keccak256(rlp::encode_block_header(exec_output.eth_header)));
     block_hash_buffer.set(
         exec_output.eth_header.number, exec_output.eth_block_hash);
     (void)record_block_result(exec_recorder, exec_output);
+
+    LOG_INFO(
+        "block={}, block_id={} state_root {}={}{}",
+        block.header.number,
+        block_id,
+        db.is_page_encoded() ? "page" : "slot",
+        db.state_root(),
+        mirror_db != nullptr
+            ? fmt::format(
+                  " mirror_{}={}",
+                  mirror_db->is_page_encoded() ? "page" : "slot",
+                  mirror_db->state_root())
+            : std::string{});
 
     // Emit the block metrics log line
     [[maybe_unused]] auto const block_time =
@@ -317,7 +334,8 @@ MONAD_NAMESPACE_BEGIN
 
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
     MonadChain const &chain, std::filesystem::path const &ledger_dir, Db &db,
-    vm::VM &vm, BlockHashBufferFinalized &block_hash_buffer,
+    Db *const secondary_db, vm::VM &vm,
+    BlockHashBufferFinalized &block_hash_buffer,
     fiber::PriorityPool &priority_pool, uint64_t &finalized_block_num,
     uint64_t const end_block_num, sig_atomic_t const volatile &stop,
     bool const enable_tracing, std::chrono::seconds const block_db_timeout,
@@ -410,18 +428,25 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
         monad_revision const rev =
             chain.get_monad_revision(block.header.timestamp);
 
-        // Storage encoding is fixed for the lifetime of the runloop (it
-        // matches the TrieDbImpl<page_encoded> backing `db`). If the
-        // replay crosses the mip-8 cutoff in either direction, the
-        // encoding the caller picked at startup no longer matches what
-        // this block's revision expects.
+        // Blocks always execute on and commit to the primary; the primary's
+        // encoding must match the block's revision. Before the mip-8 cutoff
+        // the primary is the slot db and a page-encoded secondary, when
+        // open, is mirrored so it can be promoted at the cutoff (offline,
+        // via monad-mpt). After the promote the primary is the page db and
+        // the slot secondary is frozen history that takes no writes.
         MONAD_ASSERT_PRINTF(
-            mip_8_active(rev) == db.is_page_encoded(),
-            "monad revision %d at block %lu crosses mip-8 cutoff "
-            "but db was opened with page_encoded=%d",
+            db.is_page_encoded() == mip_8_active(rev),
+            "monad revision %d at block %lu needs a %s-encoded primary "
+            "(found %s); %s",
             rev,
             block.header.number,
-            db.is_page_encoded());
+            mip_8_active(rev) ? "page" : "slot",
+            db.is_page_encoded() ? "page" : "slot",
+            mip_8_active(rev)
+                ? "run monad-mpt --promote-secondary offline"
+                : "pre MIP-8 blocks cannot replay on a promoted db");
+
+        Db *const mirror_db = !mip_8_active(rev) ? secondary_db : nullptr;
 
         ankerl::unordered_dense::segmented_set<Address> senders_and_authorities;
         BOOST_OUTCOME_TRY([&] {
@@ -429,6 +454,7 @@ Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
                 process_monad_block,
                 chain,
                 db,
+                mirror_db,
                 vm,
                 block_hash_buffer,
                 priority_pool,

--- a/category/execution/runloop/runloop_monad_ethblocks.hpp
+++ b/category/execution/runloop/runloop_monad_ethblocks.hpp
@@ -39,10 +39,15 @@ namespace fiber
     class PriorityPool;
 }
 
+// Blocks always execute on and commit to the primary `db`, whose encoding
+// must match the block's revision. A page-encoded `secondary_db`, when
+// non-null, is the pre-promote migration backfill and is mirrored on every
+// commit; a slot-encoded secondary is post-promote frozen history and takes no
+// writes.
 Result<std::pair<uint64_t, uint64_t>> runloop_monad_ethblocks(
-    MonadChain const &, std::filesystem::path const &, Db &, vm::VM &,
-    BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &, uint64_t,
-    sig_atomic_t const volatile &, bool enable_tracing,
+    MonadChain const &, std::filesystem::path const &, Db &, Db *secondary_db,
+    vm::VM &, BlockHashBufferFinalized &, fiber::PriorityPool &, uint64_t &,
+    uint64_t, sig_atomic_t const volatile &, bool enable_tracing,
     std::chrono::seconds block_db_timeout, ExecutionEventRecorder *);
 
 MONAD_NAMESPACE_END

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -1015,13 +1015,30 @@ struct RODb::Impl final
     }
 };
 
-RODb::RODb(ReadOnlyOnDiskDbConfig const &options, timeline_id const tid)
+RODb::RODb(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl))
+{
+}
+
+RODb::RODb(ReadOnlyOnDiskDbConfig const &options)
     : impl_(std::make_unique<Impl>(
-          std::make_shared<OnDiskDbServiceThread>(options), tid))
+          std::make_shared<OnDiskDbServiceThread>(options),
+          timeline_id::primary))
 {
 }
 
 RODb::~RODb() = default;
+
+std::unique_ptr<RODb> RODb::open_secondary_timeline() const
+{
+    MONAD_ASSERT(impl_);
+    MONAD_ASSERT(impl_->tid_ == timeline_id::primary);
+    if (!impl_->aux().metadata_ctx().timeline_active(timeline_id::secondary)) {
+        return nullptr;
+    }
+    return std::unique_ptr<RODb>(new RODb(
+        std::make_unique<Impl>(impl_->worker_thread_, timeline_id::secondary)));
+}
 
 uint64_t RODb::get_latest_version() const
 {

--- a/category/mpt/db.cpp
+++ b/category/mpt/db.cpp
@@ -420,6 +420,7 @@ public:
         NodeCursor start;
         NibblesView key;
         uint64_t version;
+        timeline_id tid;
     };
 
     using Comms = std::variant<
@@ -486,7 +487,8 @@ private:
                                 std::move(req->promise),
                                 req->start,
                                 req->key,
-                                req->version);
+                                req->version,
+                                req->tid);
                         }
                         else {
                             MONAD_ASSERT(req->key.empty());
@@ -495,7 +497,8 @@ private:
                                 node_cache,
                                 inflight,
                                 std::move(req->promise),
-                                req->version);
+                                req->version,
+                                req->tid);
                         }
                     }
                     else if (auto *req = std::get_if<4>(&request);
@@ -946,11 +949,18 @@ public:
 struct RODb::Impl final
 {
     std::shared_ptr<OnDiskDbServiceThread> worker_thread_;
+    timeline_id const tid_;
 
-    explicit Impl(std::shared_ptr<OnDiskDbServiceThread> worker_thread)
+    explicit Impl(
+        std::shared_ptr<OnDiskDbServiceThread> worker_thread,
+        timeline_id const tid)
         : worker_thread_(std::move(worker_thread))
+        , tid_(tid)
     {
         MONAD_ASSERT(worker_thread_ != nullptr);
+        MONAD_ASSERT(
+            worker_thread_->aux().metadata_ctx().timeline_active(tid_),
+            "RODb opened on an inactive timeline");
     }
 
     UpdateAux &aux()
@@ -968,14 +978,15 @@ struct RODb::Impl final
                 .promise = std::move(promise),
                 .start = start,
                 .key = key,
-                .version = version});
+                .version = version,
+                .tid = tid_});
         return fut.get();
     }
 
     NodeCursor load_root_fiber_blocking(uint64_t const version)
     {
         auto const root_offset =
-            aux().metadata_ctx().get_root_offset_at_version(version);
+            aux().metadata_ctx().get_root_offset_at_version(version, tid_);
         if (root_offset == INVALID_OFFSET) {
             return {};
         }
@@ -998,14 +1009,15 @@ struct RODb::Impl final
             .root = std::move(node),
             .machine = machine,
             .version = version,
-            .concurrency_limit = concurrency_limit});
+            .concurrency_limit = concurrency_limit,
+            .tid = tid_});
         return fut.get();
     }
 };
 
-RODb::RODb(ReadOnlyOnDiskDbConfig const &options)
+RODb::RODb(ReadOnlyOnDiskDbConfig const &options, timeline_id const tid)
     : impl_(std::make_unique<Impl>(
-          std::make_shared<OnDiskDbServiceThread>(options)))
+          std::make_shared<OnDiskDbServiceThread>(options), tid))
 {
 }
 
@@ -1014,20 +1026,33 @@ RODb::~RODb() = default;
 uint64_t RODb::get_latest_version() const
 {
     MONAD_ASSERT(impl_);
-    return impl_->aux().metadata_ctx().db_history_max_version();
+    return impl_->aux().metadata_ctx().db_history_max_version(impl_->tid_);
 }
 
 uint64_t RODb::get_earliest_version() const
 {
     MONAD_ASSERT(impl_);
-    return impl_->aux().metadata_ctx().db_history_min_valid_version();
+    return impl_->aux().metadata_ctx().db_history_min_valid_version(
+        impl_->tid_);
+}
+
+bool RODb::timeline_active(timeline_id const tid) const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux().metadata_ctx().timeline_active(tid);
+}
+
+bool RODb::version_is_valid_ondisk(uint64_t const version) const
+{
+    MONAD_ASSERT(impl_);
+    return impl_->aux().metadata_ctx().version_is_valid_ondisk(
+        version, impl_->tid_);
 }
 
 state_machine_kind RODb::state_machine_type() const
 {
     MONAD_ASSERT(impl_);
-    return impl_->aux().metadata_ctx().get_state_machine_kind(
-        timeline_id::primary);
+    return impl_->aux().metadata_ctx().get_state_machine_kind(impl_->tid_);
 }
 
 DbError find_result_to_db_error(find_result const result) noexcept
@@ -1477,6 +1502,7 @@ uint64_t Db::get_history_length() const
 
 AsyncContext::AsyncContext(Db &db, size_t const node_lru_max_mem)
     : aux(db.impl_->aux())
+    , tid(db.impl_->tid())
     , node_cache(node_lru_max_mem)
 {
 }
@@ -1536,7 +1562,7 @@ namespace detail
             std::shared_ptr<Node> root{};
             bool const block_alive_after_read =
                 sender->context.aux.metadata_ctx().version_is_valid_ondisk(
-                    sender->block_id);
+                    sender->block_id, sender->context.tid);
             if (block_alive_after_read) {
                 sender->root = detail::deserialize_node_from_receiver_result(
                     std::move(buffer_), buffer_off, io_state);
@@ -1567,6 +1593,7 @@ namespace detail
         async::erased_connected_operation *const io_state;
         uint64_t const version;
         UpdateAux &aux;
+        timeline_id const tid;
 
         static constexpr bool lifetime_managed_internally = true;
 
@@ -1580,10 +1607,11 @@ namespace detail
                 delete this_io_state;
                 return;
             }
-            get_result = aux.metadata_ctx().version_is_valid_ondisk(version)
-                             ? std::move(res).assume_value()
-                             : find_result_type<T>{
-                                   T{}, find_result::version_no_longer_exist};
+            get_result =
+                aux.metadata_ctx().version_is_valid_ondisk(version, tid)
+                    ? std::move(res).assume_value()
+                    : find_result_type<T>{
+                          T{}, find_result::version_no_longer_exist};
 
             io_state->completed(async::success());
             delete this_io_state;
@@ -1599,7 +1627,8 @@ namespace detail
         case op_t::op_get_data1:
         case op_t::op_get_node1: {
             chunk_offset_t const offset =
-                context.aux.metadata_ctx().get_root_offset_at_version(block_id);
+                context.aux.metadata_ctx().get_root_offset_at_version(
+                    block_id, context.tid);
             auto const virt_offset = context.aux.physical_to_virtual(offset);
             NodeCache::ConstAccessor acc;
             if (context.node_cache.find(acc, virt_offset)) {
@@ -1642,7 +1671,8 @@ namespace detail
         case op_t::op_get_data2:
         case op_t::op_get_node2: {
             // verify version is valid in db history before doing anything
-            if (!context.aux.metadata_ctx().version_is_valid_ondisk(block_id)) {
+            if (!context.aux.metadata_ctx().version_is_valid_ondisk(
+                    block_id, context.tid)) {
                 get_result = {T{}, find_result::version_no_longer_exist};
                 io_state->completed(async::success());
                 return async::success();
@@ -1656,9 +1686,10 @@ namespace detail
                     cur,
                     block_id,
                     nv,
-                    op_type == op_t::op_get2),
+                    op_type == op_t::op_get2,
+                    context.tid),
                 find_request_receiver_t<T>{
-                    get_result, io_state, block_id, context.aux}));
+                    get_result, io_state, block_id, context.aux, context.tid}));
             state->initiate();
             return async::success();
         }

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -61,18 +61,20 @@ struct AsyncIOContext
     explicit AsyncIOContext(OnDiskDbConfig const &options);
 };
 
-// A read-only db handle bound to one timeline (primary by default). During
-// the dual-timeline migration the timelines differ in encoding and, once
-// post-fork commits go to the page-encoded timeline only, in which versions
-// they have on file.
+// A read-only db handle bound to one timeline. The constructor opens the
+// primary; a secondary handle comes from open_secondary_timeline and shares
+// the primary's service thread and node cache. During the dual-timeline
+// migration the timelines differ in encoding and, once post-fork commits go
+// to the page-encoded timeline only, in which versions they have on file.
 class RODb
 {
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
+    explicit RODb(std::unique_ptr<Impl>);
+
 public:
-    explicit RODb(
-        ReadOnlyOnDiskDbConfig const &, timeline_id tid = timeline_id::primary);
+    explicit RODb(ReadOnlyOnDiskDbConfig const &);
     ~RODb();
 
     RODb(RODb const &) = delete;
@@ -93,6 +95,10 @@ public:
         size_t concurrency_limit = 4096);
 
     state_machine_kind state_machine_type() const;
+
+    // Handle on the secondary timeline sharing this (primary) handle's
+    // service thread and node cache; nullptr when no secondary is active.
+    [[nodiscard]] std::unique_ptr<RODb> open_secondary_timeline() const;
 };
 
 struct DbStorageStats

--- a/category/mpt/db.hpp
+++ b/category/mpt/db.hpp
@@ -61,15 +61,18 @@ struct AsyncIOContext
     explicit AsyncIOContext(OnDiskDbConfig const &options);
 };
 
-// Hardcode it to open the primary timeline. All timelines are always in sync
-// and store the canonical state.
+// A read-only db handle bound to one timeline (primary by default). During
+// the dual-timeline migration the timelines differ in encoding and, once
+// post-fork commits go to the page-encoded timeline only, in which versions
+// they have on file.
 class RODb
 {
     struct Impl;
     std::unique_ptr<Impl> impl_;
 
 public:
-    explicit RODb(ReadOnlyOnDiskDbConfig const &);
+    explicit RODb(
+        ReadOnlyOnDiskDbConfig const &, timeline_id tid = timeline_id::primary);
     ~RODb();
 
     RODb(RODb const &) = delete;
@@ -83,6 +86,8 @@ public:
 
     uint64_t get_latest_version() const;
     uint64_t get_earliest_version() const;
+    bool timeline_active(timeline_id) const;
+    bool version_is_valid_ondisk(uint64_t version) const;
     bool traverse(
         NodeCursor const &, TraverseMachine &, uint64_t block_id,
         size_t concurrency_limit = 4096);
@@ -279,6 +284,9 @@ struct AsyncContext
         uint64_t, std::vector<std::function<void(std::shared_ptr<Node>)>>>;
 
     UpdateAux &aux;
+    // Timeline of the Db this context was created from; the async senders
+    // route root lookups and version-validity checks through it.
+    timeline_id const tid;
     NodeCache node_cache;
     inflight_root_t inflight_roots;
     AsyncInflightNodes inflight_nodes;
@@ -357,8 +365,7 @@ namespace detail
 inline detail::TraverseSender make_traverse_sender(
     AsyncContext *const context, Node::SharedPtr traverse_root,
     std::unique_ptr<TraverseMachine> machine, uint64_t const block_id,
-    size_t const concurrency_limit = 4096,
-    timeline_id const tid = timeline_id::primary)
+    size_t const concurrency_limit = 4096)
 {
     MONAD_ASSERT(context);
     return {
@@ -366,7 +373,7 @@ inline detail::TraverseSender make_traverse_sender(
         std::move(traverse_root),
         std::move(machine),
         block_id,
-        tid,
+        context->tid,
         concurrency_limit};
 }
 

--- a/category/mpt/find_notify_fiber.cpp
+++ b/category/mpt/find_notify_fiber.cpp
@@ -20,6 +20,7 @@
 #include <category/core/assert.h>
 #include <category/core/tl_tid.h>
 #include <category/mpt/config.hpp>
+#include <category/mpt/detail/timeline.hpp>
 #include <category/mpt/nibbles_view.hpp>
 #include <category/mpt/node.hpp>
 #include <category/mpt/node_cache.hpp>
@@ -251,9 +252,10 @@ void find_notify_fiber_future(
 void find_owning_notify_fiber_future(
     UpdateAux &aux, NodeCache &node_cache, inflight_map_owning_t &inflights,
     ::boost::fibers::promise<find_owning_cursor_result_type> promise,
-    NodeCursor const &start, NibblesView const key, uint64_t const version)
+    NodeCursor const &start, NibblesView const key, uint64_t const version,
+    timeline_id const tid)
 {
-    if (!aux.metadata_ctx().version_is_valid_ondisk(version)) {
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version, tid)) {
         promise.set_value({start, find_result::version_no_longer_exist});
         return;
     }
@@ -296,7 +298,7 @@ void find_owning_notify_fiber_future(
         auto const next_virtual_offset =
             aux.physical_to_virtual(next_node_offset);
         // version validity check must be after the virtual offset translation
-        if (!aux.metadata_ctx().version_is_valid_ondisk(version) ||
+        if (!aux.metadata_ctx().version_is_valid_ondisk(version, tid) ||
             next_virtual_offset == INVALID_VIRTUAL_OFFSET) {
             promise.set_value({start, find_result::version_no_longer_exist});
             return;
@@ -312,7 +314,8 @@ void find_owning_notify_fiber_future(
                 std::move(promise),
                 next_cursor,
                 next_key,
-                version);
+                version,
+                tid);
             return;
         }
         if (aux.io->owning_thread_id() != get_tl_tid()) {
@@ -326,7 +329,8 @@ void find_owning_notify_fiber_future(
              &inflights,
              p = std::move(promise),
              next_key,
-             version](NodeCursor const &node_cursor) mutable -> result<void> {
+             version,
+             tid](NodeCursor const &node_cursor) mutable -> result<void> {
             if (!node_cursor.is_valid()) {
                 p.set_value(
                     {NodeCursor{}, find_result::version_no_longer_exist});
@@ -339,7 +343,8 @@ void find_owning_notify_fiber_future(
                 std::move(p),
                 node_cursor,
                 next_key,
-                version);
+                version,
+                tid);
             return success();
         };
         async_read_with_continuation(
@@ -360,13 +365,13 @@ void find_owning_notify_fiber_future(
 void load_root_notify_fiber_future(
     UpdateAux &aux, NodeCache &node_cache, inflight_map_owning_t &inflights,
     ::boost::fibers::promise<find_owning_cursor_result_type> promise,
-    uint64_t const version)
+    uint64_t const version, timeline_id const tid)
 {
     auto const root_offset =
-        aux.metadata_ctx().get_root_offset_at_version(version);
+        aux.metadata_ctx().get_root_offset_at_version(version, tid);
     auto const root_virtual_offset = aux.physical_to_virtual(root_offset);
     // version validity check must be after the virtual offset translation
-    if (!aux.metadata_ctx().version_is_valid_ondisk(version) ||
+    if (!aux.metadata_ctx().version_is_valid_ondisk(version, tid) ||
         root_virtual_offset == INVALID_VIRTUAL_OFFSET) {
         promise.set_value({NodeCursor{}, find_result::version_no_longer_exist});
         return;

--- a/category/mpt/find_request_sender.hpp
+++ b/category/mpt/find_request_sender.hpp
@@ -69,6 +69,7 @@ private:
     NibblesView key_;
     AsyncInflightNodes &inflights_;
     std::optional<find_result_type<T>> res_{std::nullopt};
+    timeline_id timeline_;
     bool tid_checked_{false};
     bool return_value_{true};
 
@@ -93,13 +94,14 @@ public:
     constexpr find_request_sender(
         UpdateAux &aux, NodeCache &node_cache, AsyncInflightNodes &inflights,
         NodeCursor const root, uint64_t const version, NibblesView const key,
-        bool const return_value)
+        bool const return_value, timeline_id const timeline)
         : aux_(aux)
         , node_cache_(node_cache)
         , root_(root)
         , version_(version)
         , key_(key)
         , inflights_(inflights)
+        , timeline_(timeline)
         , return_value_(return_value)
     {
         MONAD_ASSERT(root_.is_valid());
@@ -250,7 +252,8 @@ inline MONAD_ASYNC_NAMESPACE::result<void> find_request_sender<T>::operator()(
             virtual_chunk_offset_t const virt_offset =
                 aux_.physical_to_virtual(offset);
             // Verify version after translating address
-            if (!aux_.metadata_ctx().version_is_valid_ondisk(version_)) {
+            if (!aux_.metadata_ctx().version_is_valid_ondisk(
+                    version_, timeline_)) {
                 res_ = {T{}, find_result::version_no_longer_exist};
                 io_state->completed(success());
                 return success();

--- a/category/mpt/test/dual_timeline_test.cpp
+++ b/category/mpt/test/dual_timeline_test.cpp
@@ -16,6 +16,9 @@
 #include "test_fixtures_base.hpp"
 #include "test_fixtures_gtest.hpp"
 
+#include <category/async/concepts.hpp>
+#include <category/async/connected_operation.hpp>
+#include <category/async/erased_connected_operation.hpp>
 #include <category/core/assert.h>
 #include <category/core/byte_string.hpp>
 #include <category/core/hex.hpp>
@@ -31,6 +34,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -417,6 +421,209 @@ namespace
                                     uint64_t const version) {
             return db.traverse(root, machine, version);
         });
+    }
+
+    // -------------------------------------------------------------------
+    // Test: reopening with rewind_to_latest_finalized after the offline
+    // promote, when the old slot primary is a frozen secondary behind the
+    // page primary (the archive shape past the mip-8 cutoff). The rewind
+    // must trim the primary's unfinalized tail and leave the frozen
+    // secondary untouched.
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, rewind_to_finalized_with_frozen_secondary)
+    {
+        auto const pk = 0x1111111111111111_bytes;
+        for (uint64_t v = 0; v <= 4; v++) {
+            primary_root = upsert_kv(primary_root, pk, pk, v);
+        }
+
+        // The secondary advances to 7 while the old primary stays at 4; 6
+        // is the last finalized version. Promote swaps the roles, so the
+        // frozen timeline becomes the secondary.
+        activate_secondary();
+        auto const sk = 0xAAAAAAAAAAAAAAAA_bytes;
+        for (uint64_t v = 5; v <= 7; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, sk, sk, v, timeline_id::secondary);
+        }
+        db.update_finalized_version(6);
+        promote_secondary();
+
+        // Reopen the primary with rewind_to_latest_finalized, as production
+        // does on restart.
+        {
+            Db const expired = std::move(db);
+        }
+        OnDiskDbConfig reopen_config = config;
+        reopen_config.append = true;
+        reopen_config.rewind_to_latest_finalized = true;
+        db = Db{std::make_unique<StateMachineAlwaysMerkle>(), reopen_config};
+        secondary_db.emplace(*db.open_secondary_timeline(
+            std::make_unique<StateMachineAlwaysMerkle>()));
+
+        EXPECT_EQ(db.get_latest_finalized_version(), 6);
+        // The primary's unfinalized version 7 is rewound away; the frozen
+        // secondary keeps its tip.
+        EXPECT_EQ(db.get_latest_version(), 6);
+        EXPECT_EQ(secondary_db->get_latest_version(), 4);
+
+        // Data on both timelines stays readable at their tips.
+        auto root = db.load_root_for_version(6);
+        ASSERT_NE(root, nullptr);
+        auto const pres = db_get(db, root, NibblesView{sk}, 6);
+        ASSERT_TRUE(pres.has_value());
+        EXPECT_EQ(pres.value(), monad::byte_string{sk});
+
+        root = secondary_db->load_root_for_version(4);
+        ASSERT_NE(root, nullptr);
+        auto const sres = db_get(*secondary_db, root, NibblesView{pk}, 4);
+        ASSERT_TRUE(sres.has_value());
+        EXPECT_EQ(sres.value(), monad::byte_string{pk});
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: async senders route root lookups and version checks by the
+    // timeline their AsyncContext's Db is bound to
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, async_context_reads_secondary_timeline)
+    {
+        auto const pk = 0x1111111111111111_bytes;
+        for (uint64_t v = 0; v <= 4; v++) {
+            primary_root = upsert_kv(primary_root, pk, pk, v);
+        }
+
+        // The secondary diverges with its own key at versions 5-6 while the
+        // primary stays frozen at 4.
+        activate_secondary();
+        auto const sk = 0xAAAAAAAAAAAAAAAA_bytes;
+        for (uint64_t v = 5; v <= 6; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, sk, sk, v, timeline_id::secondary);
+        }
+
+        // One AsyncIOContext for both timelines: an AsyncIO is
+        // one-per-thread, and two RO-blocking Dbs can share one.
+        AsyncIOContext io_ctx{ReadOnlyOnDiskDbConfig{.dbname_paths = {dbname}}};
+        Db ro_primary{io_ctx};
+        Db ro_secondary{io_ctx, timeline_id::secondary};
+        auto const primary_ctx = async_context_create(ro_primary);
+        auto const secondary_ctx = async_context_create(ro_secondary);
+
+        // Async completions run on the polling thread (this one).
+        size_t callbacks = 0;
+        std::optional<monad::byte_string> last_value;
+
+        struct GetReceiver
+        {
+            size_t *callbacks;
+            std::optional<monad::byte_string> *last_value;
+
+            void set_value(
+                monad::async::erased_connected_operation *const state,
+                monad::async::result<monad::byte_string> res)
+            {
+                if (res.has_value()) {
+                    *last_value = std::move(res).assume_value();
+                }
+                else {
+                    last_value->reset();
+                }
+                ++*callbacks;
+                delete state;
+            }
+        };
+
+        // The expected-failure lookups need no IO and complete synchronously
+        // inside initiate(), so the target must be computed before it.
+        auto const async_get = [&](AsyncContext *const ctx,
+                                   Db &ro,
+                                   monad::byte_string const &key,
+                                   uint64_t const version) {
+            size_t const target = callbacks + 1;
+            auto *state = new auto(monad::async::connect(
+                make_get_sender(ctx, NibblesView{key}, version),
+                GetReceiver{&callbacks, &last_value}));
+            state->initiate();
+            while (callbacks < target) {
+                ro.poll(false);
+            }
+        };
+
+        // A version only the secondary has resolves through the
+        // secondary-bound context and fails through the primary-bound one.
+        async_get(secondary_ctx.get(), ro_secondary, sk, 6);
+        ASSERT_TRUE(last_value.has_value());
+        EXPECT_EQ(*last_value, monad::byte_string{sk});
+        async_get(primary_ctx.get(), ro_primary, sk, 6);
+        EXPECT_FALSE(last_value.has_value());
+
+        // And symmetrically for a version only the primary has.
+        async_get(primary_ctx.get(), ro_primary, pk, 4);
+        ASSERT_TRUE(last_value.has_value());
+        EXPECT_EQ(*last_value, monad::byte_string{pk});
+        async_get(secondary_ctx.get(), ro_secondary, pk, 4);
+        EXPECT_FALSE(last_value.has_value());
+
+        deactivate_secondary();
+    }
+
+    // -------------------------------------------------------------------
+    // Test: RODb bound to the secondary timeline serves versions the
+    // primary does not have (the archive shape where the primary stops
+    // committing at the mip-8 cutoff)
+    // -------------------------------------------------------------------
+    TEST_F(DualTimelineFixture, rodb_reads_secondary_timeline)
+    {
+        auto const pk = 0x1111111111111111_bytes;
+        for (uint64_t v = 0; v <= 4; v++) {
+            primary_root = upsert_kv(primary_root, pk, pk, v);
+        }
+
+        // The secondary diverges with its own key at versions 5-6 while the
+        // primary stays frozen at 4.
+        activate_secondary();
+        auto const sk = 0xAAAAAAAAAAAAAAAA_bytes;
+        for (uint64_t v = 5; v <= 6; v++) {
+            secondary_root =
+                upsert_kv(secondary_root, sk, sk, v, timeline_id::secondary);
+        }
+
+        {
+            ReadOnlyOnDiskDbConfig const ro_config{.dbname_paths = {dbname}};
+            RODb const ro_primary{ro_config};
+            RODb const ro_secondary{ro_config, timeline_id::secondary};
+
+            EXPECT_TRUE(ro_primary.timeline_active(timeline_id::secondary));
+
+            // Each handle reports its own timeline's version range.
+            EXPECT_EQ(ro_primary.get_latest_version(), 4);
+            EXPECT_EQ(ro_secondary.get_latest_version(), 6);
+            EXPECT_TRUE(ro_primary.version_is_valid_ondisk(4));
+            EXPECT_FALSE(ro_primary.version_is_valid_ondisk(6));
+            EXPECT_TRUE(ro_secondary.version_is_valid_ondisk(6));
+
+            // A version only the secondary has is readable through the
+            // secondary-bound handle and rejected by the primary-bound one.
+            auto const sres = ro_secondary.find(NibblesView{sk}, 6);
+            ASSERT_TRUE(sres.has_value());
+            EXPECT_EQ(
+                monad::byte_string{sres.value().node->value()},
+                monad::byte_string{sk});
+            EXPECT_FALSE(ro_primary.find(NibblesView{sk}, 6).has_value());
+
+            // The primary keys stay readable at the primary's frozen tip
+            // and are absent from the secondary's trie.
+            auto const pres = ro_primary.find(NibblesView{pk}, 4);
+            ASSERT_TRUE(pres.has_value());
+            EXPECT_EQ(
+                monad::byte_string{pres.value().node->value()},
+                monad::byte_string{pk});
+            EXPECT_FALSE(ro_secondary.find(NibblesView{pk}, 6).has_value());
+        }
+
+        deactivate_secondary();
     }
 
     // -------------------------------------------------------------------

--- a/category/mpt/test/dual_timeline_test.cpp
+++ b/category/mpt/test/dual_timeline_test.cpp
@@ -593,20 +593,20 @@ namespace
         {
             ReadOnlyOnDiskDbConfig const ro_config{.dbname_paths = {dbname}};
             RODb const ro_primary{ro_config};
-            RODb const ro_secondary{ro_config, timeline_id::secondary};
-
             EXPECT_TRUE(ro_primary.timeline_active(timeline_id::secondary));
+            auto const ro_secondary = ro_primary.open_secondary_timeline();
+            ASSERT_NE(ro_secondary, nullptr);
 
             // Each handle reports its own timeline's version range.
             EXPECT_EQ(ro_primary.get_latest_version(), 4);
-            EXPECT_EQ(ro_secondary.get_latest_version(), 6);
+            EXPECT_EQ(ro_secondary->get_latest_version(), 6);
             EXPECT_TRUE(ro_primary.version_is_valid_ondisk(4));
             EXPECT_FALSE(ro_primary.version_is_valid_ondisk(6));
-            EXPECT_TRUE(ro_secondary.version_is_valid_ondisk(6));
+            EXPECT_TRUE(ro_secondary->version_is_valid_ondisk(6));
 
             // A version only the secondary has is readable through the
             // secondary-bound handle and rejected by the primary-bound one.
-            auto const sres = ro_secondary.find(NibblesView{sk}, 6);
+            auto const sres = ro_secondary->find(NibblesView{sk}, 6);
             ASSERT_TRUE(sres.has_value());
             EXPECT_EQ(
                 monad::byte_string{sres.value().node->value()},
@@ -620,7 +620,7 @@ namespace
             EXPECT_EQ(
                 monad::byte_string{pres.value().node->value()},
                 monad::byte_string{pk});
-            EXPECT_FALSE(ro_secondary.find(NibblesView{pk}, 6).has_value());
+            EXPECT_FALSE(ro_secondary->find(NibblesView{pk}, 6).has_value());
         }
 
         deactivate_secondary();

--- a/category/mpt/test/mixed_async_sync_loads_test.cpp
+++ b/category/mpt/test/mixed_async_sync_loads_test.cpp
@@ -86,7 +86,8 @@ TEST_F(MixedAsyncSyncLoadsTest, works)
             NodeCursor{root},
             latest_version,
             key,
-            true),
+            true,
+            timeline_id::primary),
         receiver_t{});
     state.initiate();
 

--- a/category/mpt/test/monad_trie_test.cpp
+++ b/category/mpt/test/monad_trie_test.cpp
@@ -818,7 +818,8 @@ int main(int const argc, char *argv[])
                                 NodeCursor{start_node},
                                 aux.metadata_ctx().db_history_max_version(),
                                 NibblesView{},
-                                true},
+                                true,
+                                timeline_id::primary},
                             receiver_t(
                                 ops,
                                 signal_done,

--- a/category/mpt/trie.hpp
+++ b/category/mpt/trie.hpp
@@ -528,13 +528,13 @@ void find_notify_fiber_future(
 void find_owning_notify_fiber_future(
     UpdateAux &, NodeCache &, inflight_map_owning_t &,
     ::boost::fibers::promise<find_owning_cursor_result_type> promise,
-    NodeCursor const &start, NibblesView, uint64_t version);
+    NodeCursor const &start, NibblesView, uint64_t version, timeline_id tid);
 
 // rodb load root
 void load_root_notify_fiber_future(
     UpdateAux &, NodeCache &, inflight_map_owning_t &,
     ::boost::fibers::promise<find_owning_cursor_result_type> promise,
-    uint64_t version);
+    uint64_t version, timeline_id tid);
 
 /*! \brief blocking find node indexed by key from root, It works for both
 on-disk and in-memory trie. When node along key is not yet in memory, it loads

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -299,7 +299,10 @@ static std::optional<chunk_offset_t> post_root_fast_offset_(
 void UpdateAux::rewind_to_version(uint64_t const version)
 {
     MONAD_ASSERT(is_on_disk());
-    MONAD_ASSERT(metadata_ctx_->version_is_valid_ondisk(version));
+    MONAD_ASSERT(
+        metadata_ctx_->version_is_valid_ondisk(version, timeline_id::primary) ||
+        metadata_ctx_->version_is_valid_ondisk(
+            version, timeline_id::secondary));
 
     bool const secondary_active =
         metadata_ctx_->timeline_active(timeline_id::secondary);
@@ -310,8 +313,9 @@ void UpdateAux::rewind_to_version(uint64_t const version)
     bool const secondary_needs_rewind =
         secondary_active && secondary_max_before != INVALID_BLOCK_NUM &&
         secondary_max_before > version;
+    auto const primary_max_before = metadata_ctx_->db_history_max_version();
     bool const primary_needs_rewind =
-        metadata_ctx_->db_history_max_version() > version;
+        primary_max_before != INVALID_BLOCK_NUM && primary_max_before > version;
     if (!primary_needs_rewind && !secondary_needs_rewind) {
         return;
     }
@@ -353,8 +357,10 @@ void UpdateAux::rewind_to_version(uint64_t const version)
             cutoff_fast = candidate;
         }
     };
-    consider(
-        post_root_fast_offset_(main, metadata_ctx_->root_offsets()[version]));
+    // Range-checked lookup: a `version` outside the primary's range yields
+    // INVALID_OFFSET (raw ring indexing would return a stale slot).
+    consider(post_root_fast_offset_(
+        main, metadata_ctx_->get_root_offset_at_version(version)));
     if (secondary_active) {
         auto const secondary_ro =
             metadata_ctx_->root_offsets(timeline_id::secondary);

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -1243,10 +1243,47 @@ struct monad_executor
 
     mpt::RODb db_;
 
+    // Page-encoded secondary timeline, opened when active. On archive nodes
+    // the slot-encoded primary stops committing after the mip-8 cutoff, so
+    // post-fork versions are only on file here.
+    std::optional<mpt::RODb> secondary_db_;
+
     // The VM for executing eth calls needs to unconditionally use the
     // interpreter rather than the compiler. If it uses the compiler, then
     // out-of-gas errors can be misreported as generic failures.
     vm::VM vm_{vm::VM::InterpreterOnly};
+
+    static mpt::ReadOnlyOnDiskDbConfig make_db_config(
+        std::string const &triedb_path, uint64_t const node_lru_max_mem)
+    {
+        std::vector<std::filesystem::path> paths;
+        if (std::filesystem::is_directory(triedb_path)) {
+            for (auto const &file :
+                 std::filesystem::directory_iterator(triedb_path)) {
+                paths.emplace_back(file.path());
+            }
+        }
+        else {
+            paths.emplace_back(triedb_path);
+        }
+        return mpt::ReadOnlyOnDiskDbConfig{
+            .dbname_paths = std::move(paths),
+            .node_lru_max_mem = node_lru_max_mem};
+    }
+
+    // The primary owns everything from its earliest version upward; only
+    // versions below that floor fall through to the secondary (the strictly
+    // older history). Availability is re-validated inside the read path, so
+    // a version trimmed between here and the read fails the same way it
+    // always has.
+    mpt::RODb &select_db(uint64_t const block_number)
+    {
+        if (block_number >= db_.get_earliest_version() ||
+            !secondary_db_.has_value()) {
+            return db_;
+        }
+        return *secondary_db_;
+    }
 
     monad_executor(
         monad_executor_pool_config const &low_pool_config,
@@ -1265,26 +1302,16 @@ struct monad_executor
               block_pool_config.queue_limit,
               std::chrono::seconds(block_pool_config.timeout_sec),
               trace_thread_pool_.create_fiber_group(tx_exec_num_fibers)}
-        , db_{[&] {
-            std::vector<std::filesystem::path> paths;
-            if (std::filesystem::is_directory(triedb_path)) {
-                for (auto const &file :
-                     std::filesystem::directory_iterator(triedb_path)) {
-                    paths.emplace_back(file.path());
-                }
-            }
-            else {
-                paths.emplace_back(triedb_path);
-            }
-
-            // create the db instances on the PriorityPool thread so all the
-            // thread local storage gets instantiated on the one thread its
-            // used
-            auto const config = mpt::ReadOnlyOnDiskDbConfig{
-                .dbname_paths = paths, .node_lru_max_mem = node_lru_max_mem};
-            return mpt::RODb{config};
-        }()}
+        // create the db instances on the PriorityPool thread so all the
+        // thread local storage gets instantiated on the one thread its
+        // used
+        , db_{make_db_config(triedb_path, node_lru_max_mem)}
     {
+        if (db_.timeline_active(mpt::timeline_id::secondary)) {
+            secondary_db_.emplace(
+                make_db_config(triedb_path, node_lru_max_mem),
+                mpt::timeline_id::secondary);
+        }
     }
 
     monad_executor(monad_executor const &) = delete;
@@ -1352,7 +1379,7 @@ struct monad_executor
              block_header = block_header,
              block_number = block_number,
              block_id = block_id,
-             &db = db_,
+             &db = select_db(block_number),
              sender = sender,
              result = result,
              complete = complete,
@@ -1663,7 +1690,7 @@ struct monad_executor
              block_number = block_number,
              chain_config = chain_config,
              complete = complete,
-             &db = db_,
+             &db = select_db(block_number),
              fiber_group = &trace_block_group_,
              tx_exec_group = &trace_tx_exec_group_,
              grandparent_id = grandparent_id,
@@ -1886,7 +1913,7 @@ struct monad_executor
              block_id = block_id,
              grandparent_id = grandparent_id,
              chain_config = chain_config,
-             &db = db_,
+             &db = select_db(block_number),
              gas_limit = gas_limit,
              max_calls = max_calls,
              emit_native_transfer_logs = emit_native_transfer_logs,

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -1243,10 +1243,11 @@ struct monad_executor
 
     mpt::RODb db_;
 
-    // Page-encoded secondary timeline, opened when active. On archive nodes
-    // the slot-encoded primary stops committing after the mip-8 cutoff, so
-    // post-fork versions are only on file here.
-    std::optional<mpt::RODb> secondary_db_;
+    // Secondary timeline, opened when active; shares db_'s service thread
+    // and node cache. On archive nodes after the offline promote this is the
+    // frozen slot-encoded history that serves pre-cutoff versions the
+    // page-encoded primary does not have.
+    std::unique_ptr<mpt::RODb> secondary_db_;
 
     // The VM for executing eth calls needs to unconditionally use the
     // interpreter rather than the compiler. If it uses the compiler, then
@@ -1279,7 +1280,7 @@ struct monad_executor
     mpt::RODb &select_db(uint64_t const block_number)
     {
         if (block_number >= db_.get_earliest_version() ||
-            !secondary_db_.has_value()) {
+            secondary_db_ == nullptr) {
             return db_;
         }
         return *secondary_db_;
@@ -1306,12 +1307,8 @@ struct monad_executor
         // thread local storage gets instantiated on the one thread its
         // used
         , db_{make_db_config(triedb_path, node_lru_max_mem)}
+        , secondary_db_{db_.open_secondary_timeline()}
     {
-        if (db_.timeline_active(mpt::timeline_id::secondary)) {
-            secondary_db_.emplace(
-                make_db_config(triedb_path, node_lru_max_mem),
-                mpt::timeline_id::secondary);
-        }
     }
 
     monad_executor(monad_executor const &) = delete;

--- a/cmd/monad/main.cpp
+++ b/cmd/monad/main.cpp
@@ -344,6 +344,27 @@ try {
     TrieDb triedb{
         raw_db,
         /*enable_multiblock_cache=*/true};
+
+    // Dual-timeline: open the secondary alongside the primary. The primary
+    // always owns the latest state; a secondary is optional.
+    // runloop_monad: writes every block to every open db.
+    // runloop_monad_ethblocks:
+    //             before mip8 fork: writes every block to every open db
+    //             after mip8 fork: asserts primary db must be page-encoded,
+    //             writes to primary db only, freeze secondary slot db if
+    //             secondary db is active.
+    std::optional<mpt::Db> secondary_raw_db;
+    std::optional<TrieDb> secondary_db;
+    if (!db_in_memory &&
+        raw_db.timeline_active(monad::mpt::timeline_id::secondary)) {
+        secondary_raw_db = raw_db.open_secondary_timeline();
+        MONAD_ASSERT(secondary_raw_db.has_value());
+        secondary_db.emplace(*secondary_raw_db);
+        MONAD_ASSERT(
+            secondary_db->is_page_encoded() != triedb.is_page_encoded(),
+            "dual-timeline dbs must pair one slot and one page encoding");
+    }
+
     // Note: in memory db block number is always zero
     uint64_t const init_block_num = [&] {
         if (!snapshot.empty()) {
@@ -415,7 +436,7 @@ try {
     if (!db_in_memory) {
         mpt::AsyncIOContext io_ctx{mpt::ReadOnlyOnDiskDbConfig{
             .sq_thread_cpu = ro_sq_thread_cpu, .dbname_paths = dbname_paths}};
-        mpt::Db rodb{io_ctx};
+        mpt::Db rodb{io_ctx, monad::mpt::timeline_id::primary};
         initialized_headers_from_triedb = init_block_hash_buffer_from_triedb(
             rodb, start_block_num, block_hash_buffer);
     }
@@ -479,12 +500,13 @@ try {
                 chain_rlp_path);
         case CHAIN_CONFIG_MONAD_DEVNET:
         case CHAIN_CONFIG_MONAD_TESTNET:
-        case CHAIN_CONFIG_MONAD_MAINNET:
+        case CHAIN_CONFIG_MONAD_MAINNET: {
             if (as_eth_blocks) {
                 return runloop_monad_ethblocks(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
                     db,
+                    secondary_db.has_value() ? &*secondary_db : nullptr,
                     vm,
                     block_hash_buffer,
                     priority_pool,
@@ -502,8 +524,7 @@ try {
                 if (chain_config == CHAIN_CONFIG_MONAD_TESTNET ||
                     chain_config == CHAIN_CONFIG_MONAD_MAINNET) {
                     bool const primary_is_page = db.is_page_encoded();
-                    bool const secondary_active = raw_db.timeline_active(
-                        monad::mpt::timeline_id::secondary);
+                    bool const secondary_active = secondary_db.has_value();
                     MONAD_ASSERT_PRINTF(
                         primary_is_page || secondary_active,
                         "live monad requires a page-encoded timeline "
@@ -516,22 +537,12 @@ try {
                         secondary_active);
                 }
 
-                std::optional<mpt::Db> secondary_db;
-                std::optional<TrieDb> secondary_triedb;
-                if (raw_db.timeline_active(
-                        monad::mpt::timeline_id::secondary)) {
-                    secondary_db = raw_db.open_secondary_timeline();
-                    MONAD_ASSERT(secondary_db.has_value());
-                    secondary_triedb.emplace(*secondary_db);
-                    MONAD_ASSERT(
-                        secondary_triedb->is_page_encoded(),
-                        "secondary timeline must be page-encoded");
-                }
                 return runloop_monad(
                     dynamic_cast<MonadChain const &>(*chain),
                     block_db_path,
                     raw_db,
                     db,
+                    secondary_db.has_value() ? &*secondary_db : nullptr,
                     vm,
                     block_hash_buffer,
                     priority_pool,
@@ -539,10 +550,9 @@ try {
                     end_block_num,
                     stop,
                     trace_calls,
-                    exec_recorder,
-                    secondary_triedb.has_value() ? &*secondary_triedb
-                                                 : nullptr);
+                    exec_recorder);
             }
+        }
         }
         MONAD_ABORT_PRINTF("Unsupported chain");
     }();

--- a/rust/crates/monad-triedb/include/ffi.h
+++ b/rust/crates/monad-triedb/include/ffi.h
@@ -43,13 +43,15 @@ int triedb_read(
 // is an encoded page; otherwise storage is slot-encoded.
 bool triedb_is_page_encoded(TriedbRoInner *);
 
-// Dual-DB migration phase of the on-disk triedb, derived from the primary
-// timeline's state-machine kind and secondary-timeline presence (the same
-// pair monad-mpt reports). Read racily from the mmap'd metadata; safe on a
-// read-only handle while the writer is live.
+// Dual-DB migration phase. Fully determines each timeline's encoding, so
+// readers derive both from it. Safe on a read-only handle while the writer
+// is live.
 //   0 = legacy        (primary ethereum, no secondary)
-//   1 = dual-timeline (primary ethereum, secondary active — migrating)
-//   2 = page-encoded  (primary monad — migration complete)
+//   1 = dual-timeline (primary ethereum, page secondary backfilling)
+//   2 = page-encoded  (primary monad, no secondary)
+//   3 = promoted      (primary monad, slot secondary kept as history)
+// Phases only change offline via monad-mpt with every reader and the daemon
+// stopped; a handle observes one phase for its lifetime.
 uint8_t triedb_migration_phase(TriedbRoInner *);
 
 // Storage-pool disk capacity and usage, in bytes. Zeros for in-memory /
@@ -135,9 +137,15 @@ uint64_t triedb_latest_finalized_version(TriedbRoInner *);
 uint64_t triedb_latest_verified_version(TriedbRoInner *);
 
 // returns MAX if doesn't exist
+// Earliest version available on any timeline.
 uint64_t triedb_earliest_version(TriedbRoInner *);
 // returns MAX if doesn't exist
+// Latest version available on any timeline.
 uint64_t triedb_latest_version(TriedbRoInner *);
+// Earliest version on file in the primary timeline. Versions below it are
+// only on file in the secondary (when one is active); on an archive node
+// after the offline promote that is the frozen slot-encoded history.
+uint64_t triedb_primary_earliest_version(TriedbRoInner *);
 
 #pragma pack(push, 1)
 

--- a/rust/crates/monad-triedb/src/ffi.cpp
+++ b/rust/crates/monad-triedb/src/ffi.cpp
@@ -25,9 +25,11 @@
 #include <category/mpt/ondisk_db_config.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/traverse_util.hpp>
+#include <category/mpt/util.hpp>
 
 #include <quill/std/SystemError.h>
 
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <iostream>
@@ -43,6 +45,15 @@ struct TriedbRoInner
     monad::mpt::Db db;
     monad::mpt::AsyncContext async_ctx;
 
+    // Secondary timeline, opened when active. Both timelines share the one
+    // AsyncIOContext (an AsyncIO is one-per-thread). During the migration the
+    // secondary is the page-encoded backfill target; after page db gets
+    // promoted to primary, secondary becomes the frozen slot-encoded history
+    // that serves pre-cutoff versions the primary doesn't have. Versioned
+    // reads route primary first, then secondary (see db_for).
+    std::optional<monad::mpt::Db> secondary_db;
+    std::optional<monad::mpt::AsyncContext> secondary_async_ctx;
+
     explicit TriedbRoInner(
         std::vector<std::filesystem::path> dbname_paths,
         uint64_t const node_lru_max_mem)
@@ -52,6 +63,27 @@ struct TriedbRoInner
         , db{io_ctx}
         , async_ctx{db, node_lru_max_mem}
     {
+        if (db.timeline_active(monad::mpt::timeline_id::secondary)) {
+            secondary_db.emplace(io_ctx, monad::mpt::timeline_id::secondary);
+            secondary_async_ctx.emplace(*secondary_db, node_lru_max_mem);
+        }
+    }
+
+    // The primary owns everything from its earliest version upward; only
+    // versions below that floor fall through to the secondary (the strictly
+    // older history). An empty primary reports INVALID_BLOCK_NUM (u64 max)
+    // as its earliest, which routes every version to the secondary.
+    monad::mpt::Db &db_for(uint64_t const version)
+    {
+        if (version >= db.get_earliest_version() || !secondary_db.has_value()) {
+            return db;
+        }
+        return *secondary_db;
+    }
+
+    monad::mpt::AsyncContext &async_ctx_for(uint64_t const version)
+    {
+        return (&db_for(version) == &db) ? async_ctx : *secondary_async_ctx;
     }
 };
 
@@ -127,8 +159,8 @@ int triedb_read(
 
     *value = nullptr;
 
-    auto result =
-        db->db.find(key_to_nibbles_view(key, key_len_nibbles), block_id);
+    auto result = db->db_for(block_id).find(
+        key_to_nibbles_view(key, key_len_nibbles), block_id);
     if (!result.has_value()) {
         return -1;
     }
@@ -159,23 +191,25 @@ bool triedb_is_page_encoded(TriedbRoInner *const db)
 uint8_t triedb_migration_phase(TriedbRoInner *const db)
 {
     // Phase codes; must stay in sync with the contract in ffi.h and the Rust
-    // MigrationPhase mapping in lib.rs.
+    // MigrationPhase mapping in lib.rs. The phase fully determines each
+    // timeline's encoding (see ffi.h), so readers derive both from it.
     enum phase : uint8_t
     {
         legacy = 0,
         dual_timeline = 1,
         page_encoded = 2,
+        promoted = 3,
     };
 
     if (db == nullptr) {
         return legacy;
     }
+    bool const secondary_active =
+        db->db.timeline_active(monad::mpt::timeline_id::secondary);
     if (db->db.state_machine_type() == monad::mpt::state_machine_kind::monad) {
-        return page_encoded;
+        return secondary_active ? promoted : page_encoded;
     }
-    return db->db.timeline_active(monad::mpt::timeline_id::secondary)
-               ? dual_timeline
-               : legacy;
+    return secondary_active ? dual_timeline : legacy;
 }
 
 void triedb_storage_stats_read(
@@ -286,7 +320,7 @@ void triedb_async_read(
 {
     auto *state = new auto(monad::async::connect(
         monad::mpt::make_get_sender(
-            &db->async_ctx,
+            &db->async_ctx_for(block_id),
             key_to_nibbles_view(key, key_len_nibbles),
             block_id),
         AsyncReadReceiver{callback, user}));
@@ -436,7 +470,8 @@ bool triedb_traverse(
     triedb_async_traverse_callback_fn callback)
 {
     monad::mpt::NibblesView const prefix{0, key_len_nibbles, key};
-    auto cursor = db->db.find(prefix, block_id);
+    monad::mpt::Db &routed_db = db->db_for(block_id);
+    auto cursor = routed_db.find(prefix, block_id);
     if (!cursor.has_value()) {
         callback(
             triedb_async_traverse_callback_finished_early,
@@ -451,7 +486,8 @@ bool triedb_traverse(
     TraverseMachineWithCallback machine(
         context, callback, monad::mpt::NibblesView{});
 
-    bool const completed = db->db.traverse(cursor.value(), machine, block_id);
+    bool const completed =
+        routed_db.traverse(cursor.value(), machine, block_id);
 
     callback(
         completed ? triedb_async_traverse_callback_finished_normally
@@ -498,13 +534,14 @@ void triedb_async_ranged_get(
                 value.data(),
                 value.size());
         });
+    monad::mpt::AsyncContext &ctx = db->async_ctx_for(block_id);
     (new auto(monad::async::connect(
-         monad::mpt::make_get_node_sender(&db->async_ctx, prefix, block_id),
+         monad::mpt::make_get_node_sender(&ctx, prefix, block_id),
          GetRootForTraverseReceiver(
              context,
              callback,
              monad::mpt::make_traverse_sender(
-                 &db->async_ctx, {}, std::move(machine), block_id)))))
+                 &ctx, {}, std::move(machine), block_id)))))
         ->initiate();
 }
 
@@ -516,18 +553,21 @@ void triedb_async_traverse(
     monad::mpt::NibblesView const prefix{0, key_len_nibbles, key};
     auto machine = std::make_unique<TraverseMachineWithCallback>(
         context, callback, monad::mpt::NibblesView{});
+    monad::mpt::AsyncContext &ctx = db->async_ctx_for(block_id);
     (new auto(monad::async::connect(
-         monad::mpt::make_get_node_sender(&db->async_ctx, prefix, block_id),
+         monad::mpt::make_get_node_sender(&ctx, prefix, block_id),
          GetRootForTraverseReceiver(
              context,
              callback,
              monad::mpt::make_traverse_sender(
-                 &db->async_ctx, {}, std::move(machine), block_id)))))
+                 &ctx, {}, std::move(machine), block_id)))))
         ->initiate();
 }
 
 size_t triedb_poll(TriedbRoInner *db, bool const blocking, size_t const count)
 {
+    // Both timelines share one AsyncIO, so polling the primary handle pumps
+    // the secondary's reads too.
     return db->db.poll(blocking, count);
 }
 
@@ -569,12 +609,31 @@ uint64_t triedb_latest_verified_version(TriedbRoInner *db)
 
 uint64_t triedb_earliest_version(TriedbRoInner *db)
 {
-    return db->db.get_earliest_version();
+    uint64_t earliest = db->db.get_earliest_version();
+    if (db->secondary_db.has_value()) {
+        earliest = std::min(earliest, db->secondary_db->get_earliest_version());
+    }
+    return earliest;
 }
 
 uint64_t triedb_latest_version(TriedbRoInner *db)
 {
-    return db->db.get_latest_version();
+    uint64_t latest = db->db.get_latest_version();
+    if (db->secondary_db.has_value()) {
+        uint64_t const secondary_latest =
+            db->secondary_db->get_latest_version();
+        if (latest == monad::mpt::INVALID_BLOCK_NUM ||
+            (secondary_latest != monad::mpt::INVALID_BLOCK_NUM &&
+             secondary_latest > latest)) {
+            latest = secondary_latest;
+        }
+    }
+    return latest;
+}
+
+uint64_t triedb_primary_earliest_version(TriedbRoInner *db)
+{
+    return db->db.get_earliest_version();
 }
 
 namespace
@@ -595,7 +654,8 @@ void triedb_free_valset(validator_set *valset)
 validator_set *triedb_read_valset(
     TriedbRoInner *db, size_t const block_num, uint64_t const requested_epoch)
 {
-    auto ret = monad::staking::read_valset(db->db, block_num, requested_epoch);
+    auto ret = monad::staking::read_valset(
+        db->db_for(block_num), block_num, requested_epoch);
     if (!ret.has_value()) {
         return nullptr;
     }

--- a/rust/crates/monad-triedb/src/ffi.rs
+++ b/rust/crates/monad-triedb/src/ffi.rs
@@ -23,9 +23,9 @@ pub(crate) use self::bindings::{
     triedb_earliest_version, triedb_finalize, triedb_free_valset, triedb_is_page_encoded,
     triedb_latest_finalized_version, triedb_latest_proposed_block_id,
     triedb_latest_proposed_version, triedb_latest_verified_version, triedb_latest_voted_block_id,
-    triedb_latest_voted_version, triedb_migration_phase, triedb_open, triedb_poll, triedb_read,
-    triedb_read_valset, triedb_storage_stats, triedb_storage_stats_read, triedb_traverse,
-    TriedbRoInner,
+    triedb_latest_voted_version, triedb_migration_phase, triedb_open, triedb_poll,
+    triedb_primary_earliest_version, triedb_read, triedb_read_valset, triedb_storage_stats,
+    triedb_storage_stats_read, triedb_traverse, TriedbRoInner,
 };
 pub use self::bindings::{validator_data, validator_set};
 

--- a/rust/crates/monad-triedb/src/lib.rs
+++ b/rust/crates/monad-triedb/src/lib.rs
@@ -41,17 +41,21 @@ pub struct TriedbHandle {
 }
 
 /// Dual-DB migration phase read from the triedb metadata, mirroring what
-/// `monad-mpt` reports. Cheap and safe on a read-only handle while execution
-/// is writing.
+/// `monad-mpt` reports. Fully determines each timeline's encoding, so
+/// readers derive both from it. Cheap and safe on a read-only handle while
+/// execution is writing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum MigrationPhase {
-    /// Primary ethereum, no secondary timeline — migration not started.
+    /// Primary ethereum, no secondary timeline: migration not started.
     Legacy = 0,
-    /// Primary ethereum with an active secondary — migration in progress.
+    /// Primary ethereum, page secondary backfilling: migration in progress.
     DualTimeline = 1,
-    /// Primary monad — migration complete.
+    /// Primary monad, no secondary: migration complete.
     PageEncoded = 2,
+    /// Primary monad, slot secondary kept as pre-cutoff history (archive
+    /// nodes after the offline promote).
+    Promoted = 3,
 }
 
 impl MigrationPhase {
@@ -59,6 +63,7 @@ impl MigrationPhase {
         match code {
             1 => Self::DualTimeline,
             2 => Self::PageEncoded,
+            3 => Self::Promoted,
             _ => Self::Legacy,
         }
     }
@@ -283,8 +288,10 @@ impl TriedbHandle {
         unsafe { ffi::triedb_is_page_encoded(self.db_ptr) }
     }
 
-    /// The on-disk dual-DB migration phase. Cheap (a couple of loads from the
-    /// mmap'd metadata) and safe on a read-only handle while execution writes.
+    /// The on-disk dual-DB migration phase. Phases only change offline
+    /// (monad-mpt with readers and the daemon stopped), so the answer is
+    /// fixed for the lifetime of the handle. Cheap and safe on a read-only
+    /// handle while execution writes.
     pub fn migration_phase(&self) -> MigrationPhase {
         MigrationPhase::from_code(unsafe { ffi::triedb_migration_phase(self.db_ptr) })
     }
@@ -518,6 +525,13 @@ impl TriedbHandle {
         parse_triedb_block_num(unsafe { ffi::triedb_earliest_version(self.db_ptr) })
     }
 
+    /// Earliest version on file in the primary timeline. Versions below it
+    /// are only on file in the secondary (when one is active); on an archive
+    /// node after the offline promote that is the frozen slot history.
+    pub fn primary_earliest_version(&self) -> Option<u64> {
+        parse_triedb_block_num(unsafe { ffi::triedb_primary_earliest_version(self.db_ptr) })
+    }
+
     pub fn validator_set_at_block(
         &self,
         block_num: usize,
@@ -575,9 +589,10 @@ mod migration_phase_tests {
         assert_eq!(MigrationPhase::from_code(0), MigrationPhase::Legacy);
         assert_eq!(MigrationPhase::from_code(1), MigrationPhase::DualTimeline);
         assert_eq!(MigrationPhase::from_code(2), MigrationPhase::PageEncoded);
+        assert_eq!(MigrationPhase::from_code(3), MigrationPhase::Promoted);
         // Unexpected codes fall back to Legacy rather than panicking in a
         // monitoring path.
-        assert_eq!(MigrationPhase::from_code(3), MigrationPhase::Legacy);
+        assert_eq!(MigrationPhase::from_code(4), MigrationPhase::Legacy);
         assert_eq!(MigrationPhase::from_code(255), MigrationPhase::Legacy);
     }
 }


### PR DESCRIPTION
The context is that historical archive nodes have to keep both timelines alive after MIP8 fork. Our 0.16.1 release includes PR 2845 that commit to both timelines, 2x the disk growth rate. Goal here is to save them from that 2x write speed with dual timeline setup, by only committing to page-encoded timeline post fork in `runloop_monad_ethblocks`.

### **Important Notes to Operator:**
Historical archive nodes must run `monad-mpt --promote-secondary` after the mip 8 fork when running the release with this change (but do not run promote if running with previous release <= 0.16.1). The change asserts if primary db's encoding type doesn't match the block's revision.

Recap on replaying the whole monad history: First, set up the disk with `monad-mpt --state-machine ethereum` and start replay from genesis. Expect to hit an assertion when cross the MONAD_TEN (Mip8 fork), then do migration phase A & B to mirror state to page based secondary db, and run `monad-mpt --promote-secondary` before resuming the replay.