### PR TITLE
Add monad-mpt --rescan-devices

### DIFF
--- a/category/async/storage_pool.cpp
+++ b/category/async/storage_pool.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -35,6 +36,7 @@
 #include <filesystem>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <utility>
 #include <variant>
@@ -58,6 +60,841 @@ MONAD_ASYNC_NAMESPACE_BEGIN
 // such pools were always carved with this many conventional chunks.
 static constexpr uint32_t legacy_default_num_cnv_chunks = 3;
 
+uint64_t storage_pool::compute_unique_hash_(
+    device_t::type_t_ const type, uint64_t const dev_no,
+    file_offset_t const size)
+{
+    auto hash = fnv1a_hash<uint32_t>::begin();
+    fnv1a_hash<uint32_t>::add(hash, uint32_t(type));
+    fnv1a_hash<uint32_t>::add(hash, uint32_t(dev_no));
+    fnv1a_hash<uint32_t>::add(hash, uint32_t(dev_no >> 32));
+    fnv1a_hash<uint32_t>::add(hash, uint32_t(size));
+    return hash;
+}
+
+storage_pool::device_info_ storage_pool::read_device_identity_(
+    int const fd, std::filesystem::path const &source)
+{
+    struct stat stat;
+    memset(&stat, 0, sizeof(stat));
+    MONAD_ASSERT_PRINTF(
+        -1 != ::fstat(fd, &stat),
+        "fstat failed due to %s",
+        std::strerror(errno));
+    device_info_ ret{};
+    uint64_t dev_no = 0;
+    uint64_t rdev = 0;
+    if ((stat.st_mode & S_IFMT) == S_IFBLK) {
+        ret.type = device_t::type_t_::block_device;
+        MONAD_ASSERT_PRINTF(
+            !ioctl(fd, _IOR(0x12, 114, size_t) /*BLKGETSIZE64*/, &ret.size),
+            "ioctl failed due to %s",
+            std::strerror(errno));
+        rdev = static_cast<uint64_t>(stat.st_rdev);
+        unsigned int logical_block_size = 0;
+        // Asserted, not tolerated: absent would read as "not a block device"
+        // at the addressability check, so a failure here would let a 4Kn
+        // device join a database that requires 512 byte addressing.
+        MONAD_ASSERT_PRINTF(
+            0 == ioctl(fd, _IO(0x12, 104) /*BLKSSZGET*/, &logical_block_size),
+            "ioctl failed due to %s",
+            std::strerror(errno));
+        ret.logical_block_size = logical_block_size;
+    }
+    else if ((stat.st_mode & S_IFMT) == S_IFREG) {
+        ret.type = device_t::type_t_::file;
+        dev_no = stat.st_ino;
+        ret.size = static_cast<file_offset_t>(stat.st_size);
+    }
+    else {
+        MONAD_ABORT_PRINTF(
+            "Storage pool source %s has unknown file entry type = %u",
+            source.string().c_str(),
+            stat.st_mode & S_IFMT);
+    }
+    MONAD_ASSERT_PRINTF(
+        ret.size >= CPU_PAGE_SIZE,
+        "Storage pool source %s must be at least 4Kb long",
+        source.string().c_str());
+    ret.unique_hash = compute_unique_hash_(ret.type, dev_no, ret.size);
+    ret.identity = device_identity_{
+        .dev = static_cast<uint64_t>(stat.st_dev),
+        .ino = static_cast<uint64_t>(stat.st_ino),
+        .rdev = rdev,
+        .hash_dev_no = dev_no};
+    return ret;
+}
+
+storage_pool::device_info_
+storage_pool::read_device_info_(std::filesystem::path const &source)
+{
+    int const fd = ::open(source.c_str(), O_RDONLY | O_CLOEXEC);
+    MONAD_ASSERT_PRINTF(
+        fd != -1,
+        "open of %s failed due to %s",
+        source.string().c_str(),
+        std::strerror(errno));
+    auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+    device_info_ ret = read_device_identity_(fd, source);
+
+    auto *const buffer = reinterpret_cast<std::byte *>(
+        aligned_alloc(DISK_PAGE_SIZE, DISK_PAGE_SIZE * 2));
+    MONAD_ASSERT(buffer != nullptr);
+    auto const unbuffer = make_scope_exit([&]() noexcept { ::free(buffer); });
+    auto const offset = round_down_align<DISK_PAGE_BITS>(
+        ret.size - sizeof(device_t::metadata_t));
+    auto const bytesread = ::pread(
+        fd,
+        buffer,
+        static_cast<size_t>(ret.size - offset),
+        static_cast<off_t>(offset));
+    MONAD_ASSERT_PRINTF(
+        bytesread != -1, "pread failed due to %s", std::strerror(errno));
+    // The footer is located from the byte count, so a short read would point
+    // it at the wrong bytes -- and at zero bytes, before the buffer entirely.
+    // What those bytes say is whether this device belongs to a pool.
+    MONAD_ASSERT_PRINTF(
+        static_cast<file_offset_t>(bytesread) == ret.size - offset,
+        "read %zd of %llu bytes of %s's pool footer",
+        bytesread,
+        static_cast<unsigned long long>(ret.size - offset),
+        source.string().c_str());
+    auto const *const footer = start_lifetime_as<device_t::metadata_t>(
+        buffer + bytesread - sizeof(device_t::metadata_t));
+    if (memcmp(footer->magic, "MND0", 4) == 0) {
+        ret.pool_metadata = device_pool_metadata_{
+            .chunk_capacity = footer->chunk_capacity,
+            .num_cnv_chunks = footer->num_cnv_chunks == 0
+                                  ? legacy_default_num_cnv_chunks
+                                  : footer->num_cnv_chunks,
+            .config_hash = footer->config_hash,
+            .chunks = footer->chunks(ret.size)};
+    }
+    return ret;
+}
+
+bool storage_pool::has_pool_metadata(std::filesystem::path const &source)
+{
+    return read_device_info_(source).pool_metadata.has_value();
+}
+
+void storage_pool::refuse_duplicate_sources_(
+    std::span<std::filesystem::path const> const sources)
+{
+    std::vector<device_info_> identities;
+    identities.reserve(sources.size());
+    for (auto const &source : sources) {
+        int const fd = ::open(source.c_str(), O_RDONLY | O_CLOEXEC);
+        MONAD_ASSERT_PRINTF(
+            fd != -1,
+            "open of %s failed due to %s",
+            source.string().c_str(),
+            std::strerror(errno));
+        auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+        identities.push_back(read_device_identity_(fd, source));
+    }
+    for (size_t i = 0; i < identities.size(); i++) {
+        for (size_t j = i + 1; j < identities.size(); j++) {
+            MONAD_ASSERT_PRINTF(
+                !same_device_identity_(identities[i], identities[j]),
+                "Storage pool source %s and %s name the same underlying "
+                "device; each device may be given only once.",
+                sources[i].string().c_str(),
+                sources[j].string().c_str());
+        }
+    }
+}
+
+storage_pool::rescan_preview storage_pool::preview_rescan(
+    std::span<std::filesystem::path const> const sources,
+    std::optional<file_offset_t> const recorded_size,
+    std::optional<db_metadata_budget> const &budget)
+{
+    MONAD_ASSERT(!sources.empty());
+    refuse_duplicate_sources_(sources);
+    std::vector<device_info_> infos;
+    infos.reserve(sources.size());
+    for (auto const &source : sources) {
+        infos.push_back(read_device_info_(source));
+    }
+    auto const plan =
+        validate_devices_to_add_(sources, infos, recorded_size, budget);
+    rescan_preview ret{};
+    ret.existing = plan.members;
+    ret.first_initialised = plan.members;
+    if (plan.grown.has_value()) {
+        ret.grown_previous_size = plan.grown->previous_size;
+        ret.grown_previous_chunks = plan.grown->previous_chunks;
+        ret.first_initialised = plan.grown->index + 1;
+    }
+    return ret;
+}
+
+uint32_t
+storage_pool::compute_config_hash_(std::span<device_info_ const> const devices)
+{
+    auto hash = fnv1a_hash<uint32_t>::begin();
+    for (auto const &device : devices) {
+        fnv1a_hash<uint32_t>::add(hash, uint32_t(device.unique_hash));
+        fnv1a_hash<uint32_t>::add(hash, uint32_t(device.unique_hash >> 32));
+    }
+    for (auto const &device : devices) {
+        auto const &metadata = device.pool_metadata.value();
+        fnv1a_hash<uint32_t>::add(hash, static_cast<uint32_t>(metadata.chunks));
+        fnv1a_hash<uint32_t>::add(hash, metadata.chunk_capacity);
+    }
+    return uint32_t(hash);
+}
+
+storage_pool::device_info_ storage_pool::device_info_of_(device_t const &device)
+{
+    MONAD_ASSERT(
+        device.is_file() || device.is_block_device(),
+        "zonefs support isn't implemented yet");
+    device_info_ ret{};
+    ret.type = device.type_;
+    ret.unique_hash = device.unique_hash_;
+    ret.size = device.size_of_file_;
+    // A live device always carries its footer; only the path it was opened
+    // from is no longer available.
+    ret.pool_metadata = device_pool_metadata_{
+        .chunk_capacity = device.metadata_->chunk_capacity,
+        .num_cnv_chunks = static_cast<uint32_t>(device.cnv_chunks()),
+        .config_hash = device.metadata_->config_hash,
+        .chunks = device.chunks()};
+    return ret;
+}
+
+bool storage_pool::same_device_identity_(
+    device_info_ const &a, device_info_ const &b)
+{
+    MONAD_ASSERT(a.identity.has_value() && b.identity.has_value());
+    auto const &x = *a.identity;
+    auto const &y = *b.identity;
+    if (x.dev == y.dev && x.ino == y.ino) {
+        return true;
+    }
+    // Two distinct special files can still name the same underlying block
+    // device.
+    return a.type == device_t::type_t_::block_device &&
+           b.type == device_t::type_t_::block_device && x.rdev == y.rdev;
+}
+
+// A device grown in place after joining a pool (LVM extend, or a backing
+// file resized larger) strands its footer mid-device, so read_device_info_
+// finds no MND0 at the new end and cannot tell it from a blank device. Chunks
+// are written append-only from their own offset 0, so a chunk holding any data
+// always has a non-zero first page; checking every chunk's first page, rather
+// than trusting the absent footer, is what separates the two.
+static bool device_is_blank(
+    std::filesystem::path const &source, uint32_t const chunk_capacity,
+    size_t const chunks)
+{
+    int const fd = ::open(source.c_str(), O_RDONLY | O_CLOEXEC);
+    MONAD_ASSERT_PRINTF(
+        fd != -1,
+        "open of %s failed due to %s",
+        source.string().c_str(),
+        std::strerror(errno));
+    auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+    auto *const buffer = reinterpret_cast<std::byte *>(
+        aligned_alloc(DISK_PAGE_SIZE, CPU_PAGE_SIZE));
+    MONAD_ASSERT(buffer != nullptr);
+    auto const unbuffer = make_scope_exit([&]() noexcept { ::free(buffer); });
+    for (size_t i = 0; i < chunks; i++) {
+        auto const offset = file_offset_t(i) * chunk_capacity;
+        auto const bytesread =
+            ::pread(fd, buffer, CPU_PAGE_SIZE, static_cast<off_t>(offset));
+        MONAD_ASSERT_PRINTF(
+            bytesread != -1, "pread failed due to %s", std::strerror(errno));
+        // A short read must never be treated as a blank page: this cannot
+        // happen for a real device, since chunks is derived from the
+        // device's own size, so every probed offset is well inside it.
+        MONAD_ASSERT_PRINTF(
+            bytesread == CPU_PAGE_SIZE,
+            "Storage pool source %s could not be fully read at offset %llu "
+            "while checking it is blank; refusing to treat it as blank.",
+            source.string().c_str(),
+            static_cast<unsigned long long>(offset));
+        if (!std::all_of(buffer, buffer + bytesread, [](std::byte const b) {
+                return b == std::byte{0};
+            })) {
+            return false;
+        }
+    }
+    return true;
+}
+
+auto storage_pool::read_footer_for_size_(int const fd, file_offset_t const size)
+    -> std::optional<device_t::metadata_t>
+{
+    if (size < sizeof(device_t::metadata_t)) {
+        return std::nullopt;
+    }
+    device_t::metadata_t footer{};
+    auto const bytesread = ::pread(
+        fd, &footer, sizeof(footer), static_cast<off_t>(size - sizeof(footer)));
+    MONAD_ASSERT_PRINTF(
+        bytesread != -1, "pread failed due to %s", std::strerror(errno));
+    if (static_cast<size_t>(bytesread) != sizeof(footer) ||
+        memcmp(footer.magic, "MND0", 4) != 0) {
+        return std::nullopt;
+    }
+    return footer;
+}
+
+storage_pool::device_info_ storage_pool::device_info_at_previous_size_(
+    device_info_ const &now, grown_device_ const &grown)
+{
+    device_info_ ret = now;
+    ret.size = grown.previous_size;
+    ret.pool_metadata = device_pool_metadata_{
+        .chunk_capacity = grown.chunk_capacity,
+        .num_cnv_chunks = grown.num_cnv_chunks,
+        // The stranded footer's own config_hash is what the caller compares
+        // against, so it is deliberately not carried over here.
+        .config_hash = 0,
+        .chunks = grown.previous_chunks};
+    ret.unique_hash = compute_unique_hash_(
+        now.type, now.identity.value().hash_dev_no, grown.previous_size);
+    return ret;
+}
+
+auto storage_pool::validate_grown_device_(
+    std::filesystem::path const &source, device_info_ const &current,
+    std::span<device_info_ const> const members,
+    std::optional<file_offset_t> const recorded_size, bool &footer_found)
+    -> std::optional<grown_device_>
+{
+    footer_found = false;
+    if (!recorded_size.has_value() || *recorded_size >= current.size ||
+        *recorded_size < CPU_PAGE_SIZE) {
+        return std::nullopt;
+    }
+    int const fd = ::open(source.c_str(), O_RDONLY | O_CLOEXEC);
+    MONAD_ASSERT_PRINTF(
+        fd != -1,
+        "open of %s failed due to %s",
+        source.string().c_str(),
+        std::strerror(errno));
+    auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+    auto const footer = read_footer_for_size_(fd, *recorded_size);
+    if (!footer.has_value()) {
+        return std::nullopt;
+    }
+    footer_found = true;
+    auto const capacity = footer->chunk_capacity;
+    if (capacity == 0 || (capacity & (capacity - 1)) != 0) {
+        return std::nullopt;
+    }
+    auto const cnv_chunks = footer->num_cnv_chunks == 0
+                                ? legacy_default_num_cnv_chunks
+                                : footer->num_cnv_chunks;
+    if (!members.empty()) {
+        auto const &first = members[0].pool_metadata.value();
+        if (capacity != first.chunk_capacity ||
+            cnv_chunks != first.num_cnv_chunks) {
+            return std::nullopt;
+        }
+    }
+    auto const previous_chunks = footer->chunks(*recorded_size);
+    if (previous_chunks < cnv_chunks + 1u) {
+        return std::nullopt;
+    }
+    grown_device_ const candidate{
+        .index = members.size(),
+        .previous_size = *recorded_size,
+        .previous_chunks = previous_chunks,
+        .chunk_capacity = capacity,
+        .num_cnv_chunks = cnv_chunks};
+    // The recorded size implies a whole pre-grow device set, and the hash that
+    // set must produce is the one the stranded footer itself stores.
+    // unique_hash folds each device's size, so the recomputed hash depends on
+    // the recorded size to the byte: this pins the previous size rather than
+    // merely narrowing it, and four bytes spelling MND0 in trie data cannot
+    // pass it. The footer predates the grow and this operation never rewrites
+    // it, so it stays a fixed point to check against even across an
+    // interrupted run.
+    std::vector<device_info_> before(members.begin(), members.end());
+    before.push_back(device_info_at_previous_size_(current, candidate));
+    if (compute_config_hash_(before) != footer->config_hash) {
+        return std::nullopt;
+    }
+    return candidate;
+}
+
+auto storage_pool::validate_devices_to_add_(
+    std::span<std::filesystem::path const> const sources,
+    std::span<device_info_ const> const infos,
+    std::optional<file_offset_t> const recorded_size,
+    std::optional<db_metadata_budget> const &budget) -> add_devices_plan_
+{
+    MONAD_ASSERT(sources.size() == infos.size());
+    size_t prefix = 0;
+    while (prefix < infos.size() && infos[prefix].pool_metadata.has_value()) {
+        prefix++;
+    }
+
+    // A device extended in place presents no footer at its new end, so the
+    // footer test alone cannot tell it from a blank one, and it can only sit
+    // where the first footerless source does. Telling the two apart costs
+    // I/O, so it waits until every arithmetic check below has had its chance
+    // to refuse the set for free -- except when device 0 is itself the
+    // footerless source, since then nothing else knows the pool's geometry and
+    // none of those checks can run at all.
+    std::optional<grown_device_> grown;
+    bool tail_probed_blank = false;
+    auto const classify_tail = [&] {
+        // The recorded size settles the tail for one 64 byte read, where the
+        // blankness probe below costs a page per chunk, so it goes first. It
+        // also decides the one case the probe cannot: a device the pool already
+        // owns can be empty as well as extended, since new chunks splice onto
+        // the tail of the free list and one added recently stays cold for a
+        // long time, and every chunk on it then reads as blank exactly like a
+        // device being joined.
+        bool footer_at_recorded_size = false;
+        grown = validate_grown_device_(
+            sources[prefix],
+            infos[prefix],
+            infos.subspan(0, prefix),
+            recorded_size,
+            footer_at_recorded_size);
+        if (grown.has_value()) {
+            return;
+        }
+        device_t::metadata_t probe{};
+        // A grown device carries its own geometry in the footer the extend
+        // stranded, so the probe only needs a stride to sample chunk starts
+        // with. The pool's capacity is that stride whenever it is known; when
+        // device 0 is itself the footerless source nothing knows it yet, and
+        // the smallest capacity a pool can have divides every real one, so it
+        // steps over no chunk that holds data.
+        probe.chunk_capacity = infos[0].pool_metadata.has_value()
+                                   ? infos[0].pool_metadata->chunk_capacity
+                                   : min_chunk_capacity;
+        tail_probed_blank = device_is_blank(
+            sources[prefix],
+            probe.chunk_capacity,
+            probe.chunks(infos[prefix].size));
+        if (tail_probed_blank) {
+            // Reading as blank is not enough to initialise it: a footer at the
+            // recorded size means this database has owned this device, so
+            // whatever stopped that footer validating, joining it as new would
+            // destroy the bytes-used array stranded with it.
+            MONAD_ASSERT_PRINTF(
+                !footer_at_recorded_size,
+                "Storage pool source %s reads as blank, but pool metadata is "
+                "stranded at the %llu bytes the database recorded for it and "
+                "does not describe this pool. This database has owned this "
+                "device, so it will not be re-initialised as a new one. "
+                "Restore the device the database was last opened with, or "
+                "clear this one (with blkdiscard, for example) to offer it as "
+                "a genuinely new device.",
+                sources[prefix].string().c_str(),
+                static_cast<unsigned long long>(*recorded_size));
+            return;
+        }
+        // A device with data but no footer at its end was extended in place.
+        // Deciding that here keeps the diagnosis right: the recorded size
+        // fails against a pre-grow set which is not the one the operator
+        // described, so reporting that failure would name a foreign device
+        // rather than a misplaced one.
+        for (size_t n = prefix + 1; n < infos.size(); n++) {
+            MONAD_ASSERT_PRINTF(
+                !infos[n].pool_metadata.has_value(),
+                "Storage pool source %s is not blank and carries no pool "
+                "metadata at its end, so it was extended in place, but %s "
+                "after it still belongs to the pool. Only the last device the "
+                "pool already owns may be extended: growing an earlier one "
+                "renumbers every chunk on the devices behind it.",
+                sources[prefix].string().c_str(),
+                sources[n].string().c_str());
+        }
+        MONAD_ASSERT_PRINTF(
+            recorded_size.has_value(),
+            "Storage pool source %s is not blank and carries no pool metadata "
+            "at its end. If it was extended in place, the database holds no "
+            "record of the size it had beforehand, which is the only thing "
+            "that can locate the metadata the extend stranded; that size is "
+            "recorded on every writable open, so a database last written by a "
+            "release which did not record it must be opened writable once "
+            "before its devices are extended. Return the device to its former "
+            "size to reopen the database, or restore from a monad-mpt "
+            "--archive. If the device is instead meant to join as a new one, "
+            "clear it first (with blkdiscard, for example).",
+            sources[prefix].string().c_str());
+        MONAD_ASSERT_PRINTF(
+            !footer_at_recorded_size,
+            "Storage pool source %s was extended in place from the %llu bytes "
+            "the database recorded for it, but the pool metadata stranded "
+            "there describes a different pool, so this is not the device the "
+            "database was last opened with. Restore the original device, or "
+            "clear this one (with blkdiscard, for example) to offer it as a "
+            "new device.",
+            sources[prefix].string().c_str(),
+            static_cast<unsigned long long>(*recorded_size));
+        MONAD_ABORT_PRINTF(
+            "Storage pool source %s is not blank and carries no pool metadata "
+            "at its end, nor any at the %llu bytes the database recorded for "
+            "it. If it was extended in place, it is not the device the "
+            "database was last opened with; if it is meant to join as a new "
+            "device, clear it first (with blkdiscard, for example).",
+            sources[prefix].string().c_str(),
+            static_cast<unsigned long long>(*recorded_size));
+    };
+    if (prefix == 0) {
+        classify_tail();
+        MONAD_ASSERT_PRINTF(
+            grown.has_value(),
+            "Storage pool source %s carries no pool metadata, so it cannot be "
+            "the first source of an existing pool. The first source holds the "
+            "database metadata and must be one the pool was created with.",
+            sources[0].string().c_str());
+    }
+
+    uint32_t const chunk_capacity = infos[0].pool_metadata.has_value()
+                                        ? infos[0].pool_metadata->chunk_capacity
+                                        : grown->chunk_capacity;
+    uint32_t const cnv_chunks = infos[0].pool_metadata.has_value()
+                                    ? infos[0].pool_metadata->num_cnv_chunks
+                                    : grown->num_cnv_chunks;
+    MONAD_ASSERT_PRINTF(
+        chunk_capacity != 0 && (chunk_capacity & (chunk_capacity - 1)) == 0,
+        "Storage pool source %s stores chunk capacity %u, which is not a "
+        "power of two, so its pool metadata is corrupt.",
+        sources[0].string().c_str(),
+        chunk_capacity);
+
+    // Each source as it will be once make_device_ has carved the joining ones
+    // at the pool's geometry and the grown one has taken its new size, which
+    // is what the pool's new config_hash covers. Both are counted the same
+    // way, so this does not depend on the classification above.
+    std::vector<device_info_> joined(infos.begin(), infos.end());
+    size_t total_seq_chunks = 0;
+    for (size_t n = 0; n < joined.size(); n++) {
+        if (n >= prefix) {
+            device_t::metadata_t probe{};
+            probe.chunk_capacity = chunk_capacity;
+            joined[n].pool_metadata = device_pool_metadata_{
+                .chunk_capacity = chunk_capacity,
+                .num_cnv_chunks = cnv_chunks,
+                .config_hash = 0,
+                .chunks = probe.chunks(infos[n].size)};
+            MONAD_ASSERT_PRINTF(
+                joined[n].pool_metadata->chunks >= cnv_chunks + 1,
+                "Storage pool source %s would have only %zu chunks once joined "
+                "at the pool's chunk capacity; the minimum allowed is %u. Use "
+                "a larger device.",
+                sources[n].string().c_str(),
+                joined[n].pool_metadata->chunks,
+                cnv_chunks + 1);
+        }
+        else {
+            MONAD_ASSERT_PRINTF(
+                joined[n].pool_metadata->chunks >= cnv_chunks + 1,
+                "Storage pool source %s has only %zu chunks, fewer than the "
+                "%u this pool needs per device (%u conventional plus at least "
+                "one sequential), so its pool metadata is corrupt.",
+                sources[n].string().c_str(),
+                joined[n].pool_metadata->chunks,
+                cnv_chunks + 1,
+                cnv_chunks);
+        }
+        total_seq_chunks += joined[n].pool_metadata->chunks - cnv_chunks;
+    }
+
+    // Both budgets are checked here so an over-large device set is refused
+    // before a footer is written; the layer that owns the metadata layout
+    // cannot do it for itself, because by the time it opens the footers are
+    // already committed.
+    //
+    // chunk_info_count is a 20 bit field, and its top value is the sentinel
+    // the database's free list terminates on, so a count of 0x100000 would
+    // both overflow the field and produce an id indistinguishable from an
+    // absent link.
+    MONAD_ASSERT_PRINTF(
+        total_seq_chunks <= chunk_offset_t::max_id,
+        "Adding these devices would give the pool %zu sequential chunks, "
+        "beyond the %llu the 20 bit chunk id space allows. Use fewer or "
+        "smaller devices.",
+        total_seq_chunks,
+        static_cast<unsigned long long>(chunk_offset_t::max_id));
+    size_t const metadata_bytes_needed =
+        budget.has_value()
+            ? budget->header_bytes + total_seq_chunks * budget->bytes_per_chunk
+            : 0;
+    size_t const metadata_bytes_available = chunk_capacity / 2;
+    MONAD_ASSERT_PRINTF(
+        !budget.has_value() ||
+            metadata_bytes_available >= metadata_bytes_needed,
+        "Adding these devices would give the pool %zu sequential chunks, "
+        "needing %zu bytes of database metadata, but conventional chunk 0 on "
+        "%s only provides %zu. This pool's chunk capacity is too small to "
+        "describe that many chunks; use fewer or smaller devices.",
+        total_seq_chunks,
+        metadata_bytes_needed,
+        sources[0].string().c_str(),
+        metadata_bytes_available);
+
+    // The set this operation produces, and so the hash every device ends up
+    // carrying. It does not depend on how the tail source is classified: a
+    // grown device and a joining one are both carved at the pool's geometry
+    // and both hash at their current size.
+    uint32_t const target_hash = compute_config_hash_(joined);
+
+    if (prefix > 0 && prefix < infos.size()) {
+        classify_tail();
+    }
+    size_t const joining = prefix + (grown.has_value() ? 1 : 0);
+
+    for (size_t n = joining; n < infos.size(); n++) {
+        MONAD_ASSERT_PRINTF(
+            !infos[n].pool_metadata.has_value(),
+            "Storage pool source %s already carries storage pool metadata but "
+            "follows source %s, which does not. Devices being added must come "
+            "last and must be blank: clear the final 4Kb of %s (with "
+            "blkdiscard, for example) before adding it.",
+            sources[n].string().c_str(),
+            sources[prefix].string().c_str(),
+            sources[n].string().c_str());
+        // The one moment a joining device's addressability can be checked;
+        // update_aux.cpp only ever reads the ioctls from device 0. A device
+        // which grew was already a member, so it is not re-checked: its
+        // block size changing under the pool is out of scope.
+        MONAD_ASSERT_PRINTF(
+            !infos[n].logical_block_size.has_value() ||
+                *infos[n].logical_block_size == 512,
+            "Storage pool source %s is addressable in %u byte units, but this "
+            "database requires 512 byte addressable storage.",
+            sources[n].string().c_str(),
+            infos[n].logical_block_size.value_or(0));
+    }
+
+    // The relocation writes the grown device's new metadata region before the
+    // old one is superseded, so the two must not overlap: writing the new
+    // bytes-used array over the old one would destroy the only record of how
+    // full each existing chunk is while the new footer is not yet durable.
+    // Refusing a growth too small to clear the old region turns that crash
+    // window into an input check, and rejects nothing useful, since a growth
+    // that small yields no new chunks anyway.
+    if (grown.has_value()) {
+        auto const &g = *grown;
+        size_t const region =
+            sizeof(device_t::metadata_t) +
+            joined[g.index].pool_metadata->chunks * sizeof(uint32_t);
+        MONAD_ASSERT_PRINTF(
+            infos[g.index].size >= g.previous_size + region,
+            "Storage pool source %s grew from %llu to %llu bytes, but its new "
+            "metadata occupies %zu bytes and would overwrite the metadata "
+            "being recovered. Extend it by at least %llu more bytes and "
+            "re-run.",
+            sources[g.index].string().c_str(),
+            static_cast<unsigned long long>(g.previous_size),
+            static_cast<unsigned long long>(infos[g.index].size),
+            region,
+            static_cast<unsigned long long>(
+                g.previous_size + region - infos[g.index].size));
+    }
+
+    // A source storing the hash of the *whole* set is one an earlier
+    // interrupted run already joined, so accepting it makes re-running the
+    // same list finish an add interrupted after the footers were stamped.
+    // Where a device grew, the relocation stamps that same hash on the intact
+    // members before it commits, so a member carrying it may equally be a
+    // grow interrupted before its own commit; either way re-running is the
+    // recovery. The hash proves membership of a set with this geometry, not
+    // identity: unique_hash folds a literal zero for a block device's device
+    // number, so same-sized block devices are indistinguishable to it.
+    std::vector<device_info_> before(
+        infos.begin(), infos.begin() + static_cast<ptrdiff_t>(prefix));
+    if (grown.has_value()) {
+        before.push_back(
+            device_info_at_previous_size_(infos[grown->index], *grown));
+    }
+    uint32_t const prefix_hash = compute_config_hash_(before);
+    for (size_t n = 0; n < prefix; n++) {
+        MONAD_ASSERT_PRINTF(
+            infos[n].pool_metadata->config_hash != 0,
+            "Storage pool source %s carries a pool footer but no pool identity "
+            "(config hash zero), so an earlier operation initialised it and "
+            "stopped before joining it to a pool. If it is one of the devices "
+            "being added, clear its final 4Kb (with blkdiscard, for example) "
+            "and re-run the same command.",
+            sources[n].string().c_str());
+        MONAD_ASSERT_PRINTF(
+            infos[n].pool_metadata->config_hash == prefix_hash ||
+                infos[n].pool_metadata->config_hash == target_hash,
+            "Storage pool source %s stores config hash %u, which is neither "
+            "the hash of the sources listed as already belonging to the pool "
+            "(%u) nor the hash of the pool this operation would produce (%u). "
+            "The existing sources must be listed first, in the exact order the "
+            "pool was created with, followed by the sources being added. A "
+            "source which belongs to a different pool must have its final 4Kb "
+            "cleared (with blkdiscard, for example) before it can be added to "
+            "this one.",
+            sources[n].string().c_str(),
+            infos[n].pool_metadata->config_hash,
+            prefix_hash,
+            target_hash);
+        MONAD_ASSERT_PRINTF(
+            infos[n].pool_metadata->chunk_capacity == chunk_capacity,
+            "Storage pool source %s has chunk capacity %u but source %s has "
+            "%u; the pool is inconsistent.",
+            sources[n].string().c_str(),
+            infos[n].pool_metadata->chunk_capacity,
+            sources[0].string().c_str(),
+            chunk_capacity);
+    }
+
+    // Last, because it is the only remaining check that costs real I/O: every
+    // cheaper arithmetic check above has already had the chance to refuse
+    // this device set first. The source classify_tail already probed is not
+    // probed again.
+    for (size_t n = joining; n < joined.size(); n++) {
+        if (n == prefix && tail_probed_blank) {
+            continue;
+        }
+        MONAD_ASSERT_PRINTF(
+            device_is_blank(
+                sources[n], chunk_capacity, joined[n].pool_metadata->chunks),
+            "Storage pool source %s is not blank. It may already have been "
+            "part of a storage pool, or it may have been resized in place so "
+            "its pool metadata no longer sits at the end of the device. If "
+            "you are certain you want to use it, clear it first (with "
+            "blkdiscard, for example).",
+            sources[n].string().c_str());
+    }
+    return add_devices_plan_{
+        .members = prefix,
+        .grown = grown,
+        .target_hash = target_hash,
+        .chunk_capacity = chunk_capacity,
+        .num_cnv_chunks = cnv_chunks};
+}
+
+void storage_pool::stamp_config_hash_(
+    std::filesystem::path const &source, file_offset_t const size,
+    uint32_t const hash)
+{
+    int const fd = ::open(source.c_str(), O_RDWR | O_CLOEXEC);
+    MONAD_ASSERT_PRINTF(
+        fd != -1,
+        "open of %s failed due to %s",
+        source.string().c_str(),
+        std::strerror(errno));
+    auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+    auto footer = read_footer_for_size_(fd, size);
+    MONAD_ASSERT_PRINTF(
+        footer.has_value(),
+        "Storage pool source %s no longer carries a pool footer",
+        source.string().c_str());
+    if (footer->config_hash == hash) {
+        // The read came through the page cache, so a match is not proof of
+        // durability -- and making the members durable before the grown
+        // device's footer commits is this function's whole purpose.
+        MONAD_ASSERT_PRINTF(
+            0 == ::fdatasync(fd),
+            "fdatasync failed due to %s",
+            std::strerror(errno));
+        return;
+    }
+    footer->config_hash = hash;
+    MONAD_ASSERT_PRINTF(
+        ::pwrite(
+            fd,
+            &*footer,
+            sizeof(*footer),
+            static_cast<off_t>(size - sizeof(*footer))) ==
+            ssize_t(sizeof(*footer)),
+        "pwrite failed due to %s",
+        std::strerror(errno));
+    MONAD_ASSERT_PRINTF(
+        0 == ::fdatasync(fd),
+        "fdatasync failed due to %s",
+        std::strerror(errno));
+}
+
+void storage_pool::relocate_device_metadata_(
+    std::filesystem::path const &source, file_offset_t const current_size,
+    grown_device_ const &grown, uint32_t const new_config_hash)
+{
+    int const fd = ::open(source.c_str(), O_RDWR | O_CLOEXEC);
+    MONAD_ASSERT_PRINTF(
+        fd != -1,
+        "open of %s failed due to %s",
+        source.string().c_str(),
+        std::strerror(errno));
+    auto const unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
+
+    device_t::metadata_t footer{};
+    footer.chunk_capacity = grown.chunk_capacity;
+    footer.num_cnv_chunks = grown.num_cnv_chunks;
+    footer.config_hash = new_config_hash;
+    // chunks() carries a correction which drops the last chunk when the
+    // metadata region would otherwise collide with it, so it must be called
+    // rather than reimplemented.
+    auto const new_chunks = footer.chunks(current_size);
+    MONAD_ASSERT(new_chunks >= grown.previous_chunks);
+    auto const array_bytes = new_chunks * sizeof(uint32_t);
+    auto const array_base = current_size - sizeof(footer) - array_bytes;
+    MONAD_ASSERT(array_base >= grown.previous_size);
+
+    // The array is anchored to the footer and indexed upward from its base,
+    // so a larger chunk count shifts every existing entry as well as the
+    // array as a whole. It is therefore rebuilt and written whole; a
+    // byte-for-byte copy of the old region would land every entry at the
+    // wrong index.
+    std::vector<uint32_t> bytes_used(new_chunks, 0);
+    auto const old_array_bytes = grown.previous_chunks * sizeof(uint32_t);
+    auto const old_array_base =
+        grown.previous_size - sizeof(footer) - old_array_bytes;
+    auto const bytesread = ::pread(
+        fd,
+        bytes_used.data(),
+        old_array_bytes,
+        static_cast<off_t>(old_array_base));
+    MONAD_ASSERT_PRINTF(
+        bytesread != -1, "pread failed due to %s", std::strerror(errno));
+    MONAD_ASSERT_PRINTF(
+        static_cast<size_t>(bytesread) == old_array_bytes,
+        "read %zd of %zu bytes of the stranded per-chunk bytes-used array "
+        "on %s",
+        bytesread,
+        old_array_bytes,
+        source.string().c_str());
+
+    MONAD_ASSERT_PRINTF(
+        ::pwrite(
+            fd,
+            bytes_used.data(),
+            array_bytes,
+            static_cast<off_t>(array_base)) == ssize_t(array_bytes),
+        "pwrite failed due to %s",
+        std::strerror(errno));
+    MONAD_ASSERT_PRINTF(
+        0 == ::fdatasync(fd),
+        "fdatasync failed due to %s",
+        std::strerror(errno));
+
+    // The footer at the new end is what makes the device valid, so it commits
+    // the relocation. A crash before it is durable leaves the device still
+    // classified as grown, and re-running simply redoes the whole operation.
+    memcpy(footer.magic, "MND0", sizeof(footer.magic));
+    MONAD_ASSERT_PRINTF(
+        ::pwrite(
+            fd,
+            &footer,
+            sizeof(footer),
+            static_cast<off_t>(current_size - sizeof(footer))) ==
+            ssize_t(sizeof(footer)),
+        "pwrite failed due to %s",
+        std::strerror(errno));
+    MONAD_ASSERT_PRINTF(
+        0 == ::fdatasync(fd),
+        "fdatasync failed due to %s",
+        std::strerror(errno));
+}
+
 std::filesystem::path storage_pool::device_t::current_path() const
 {
     std::filesystem::path::string_type ret;
@@ -77,6 +914,37 @@ std::filesystem::path storage_pool::device_t::current_path() const
         ret.clear();
     }
     return ret;
+}
+
+std::pair<void *, size_t>
+storage_pool::device_t::metadata_mapping_() const noexcept
+{
+    auto const total_size = metadata_->total_size(size_of_file_);
+    auto const offset =
+        round_down_align<CPU_PAGE_BITS>(size_of_file_ - total_size);
+    auto const mapped_bytes =
+        round_up_align<CPU_PAGE_BITS>(size_of_file_ - offset);
+    auto const metadata_from_base =
+        static_cast<size_t>(size_of_file_ - offset) - sizeof(metadata_t);
+    return {
+        reinterpret_cast<std::byte *>(metadata_) - metadata_from_base,
+        static_cast<size_t>(mapped_bytes)};
+}
+
+void storage_pool::device_t::flush_metadata_() const
+{
+    auto const mapping = metadata_mapping_();
+    MONAD_ASSERT_PRINTF(
+        0 == ::msync(mapping.first, mapping.second, MS_SYNC),
+        "msync failed due to %s",
+        std::strerror(errno));
+    // msync covers the mapped stores; the fd also carries the footer written
+    // before the mapping existed, and any file size change made to initialise
+    // the device.
+    MONAD_ASSERT_PRINTF(
+        0 == ::fdatasync(readwritefd_),
+        "fdatasync failed due to %s",
+        std::strerror(errno));
 }
 
 size_t storage_pool::device_t::chunks() const
@@ -343,12 +1211,8 @@ storage_pool::device_t storage_pool::make_device_(
 {
     int readwritefd = fd;
     uint64_t const chunk_capacity = 1ULL << flags.chunk_capacity;
-    auto unique_hash = fnv1a_hash<uint32_t>::begin();
-    if (auto const *dev_no = std::get_if<0>(&dev_no_or_dev)) {
-        fnv1a_hash<uint32_t>::add(unique_hash, uint32_t(type));
-        fnv1a_hash<uint32_t>::add(unique_hash, uint32_t(*dev_no));
-        fnv1a_hash<uint32_t>::add(unique_hash, uint32_t(*dev_no >> 32));
-    }
+    uint64_t unique_hash = 0;
+    auto const *const dev_no = std::get_if<0>(&dev_no_or_dev);
     if (!path.empty()) {
         readwritefd = ::open(
             path.c_str(),
@@ -388,8 +1252,12 @@ storage_pool::device_t storage_pool::make_device_(
             "storage pool",
             path.string().c_str());
     }
-    fnv1a_hash<uint32_t>::add(unique_hash, uint32_t(stat.st_size));
+    if (dev_no != nullptr) {
+        unique_hash = compute_unique_hash_(
+            type, *dev_no, static_cast<file_offset_t>(stat.st_size));
+    }
     size_t total_size = 0;
+    bool freshly_initialised = false;
     {
         auto *const buffer = reinterpret_cast<std::byte *>(
             aligned_alloc(DISK_PAGE_SIZE, DISK_PAGE_SIZE * 2));
@@ -410,6 +1278,7 @@ storage_pool::device_t storage_pool::make_device_(
             buffer + bytesread - sizeof(device_t::metadata_t));
         if (memcmp(metadata_footer->magic, "MND0", 4) != 0 ||
             op == mode::truncate) {
+            freshly_initialised = true;
             // Uninitialised
             if (op == mode::open_existing) {
                 MONAD_ABORT_PRINTF(
@@ -519,17 +1388,18 @@ storage_pool::device_t storage_pool::make_device_(
         type,
         unique_hash,
         static_cast<size_t>(stat.st_size),
-        metadata);
+        metadata,
+        freshly_initialised);
 }
 
-void storage_pool::fill_chunks_(creation_flags const &flags)
+void storage_pool::fill_chunks_(mode const op, creation_flags const &flags)
 {
-    auto hashshouldbe = fnv1a_hash<uint32_t>::begin();
+    std::vector<device_info_> infos;
+    infos.reserve(devices_.size());
     for (auto const &device : devices_) {
-        fnv1a_hash<uint32_t>::add(hashshouldbe, uint32_t(device.unique_hash_));
-        fnv1a_hash<uint32_t>::add(
-            hashshouldbe, uint32_t(device.unique_hash_ >> 32));
+        infos.push_back(device_info_of_(device));
     }
+    uint32_t const hashshouldbe = compute_config_hash_(infos);
     uint32_t const cnv_chunks_count =
         static_cast<uint32_t>(devices_[0].cnv_chunks());
     std::vector<size_t> chunks;
@@ -548,20 +1418,23 @@ void storage_pool::fill_chunks_(creation_flags const &flags)
             // Take off cnv_chunks_count for the cnv chunks
             chunks.push_back(devicechunks - cnv_chunks_count);
             total += devicechunks - cnv_chunks_count;
-            fnv1a_hash<uint32_t>::add(
-                hashshouldbe, static_cast<uint32_t>(devicechunks));
-            fnv1a_hash<uint32_t>::add(
-                hashshouldbe, device.metadata_->chunk_capacity);
         }
         else {
             MONAD_ABORT("zonefs support isn't implemented yet");
         }
     }
     for (auto const &device : devices_) {
-        if (device.metadata_->config_hash == 0) {
-            device.metadata_->config_hash = uint32_t(hashshouldbe);
+        if (op == mode::add_devices) {
+            // The prefix was validated against its own hash before anything
+            // was written; the whole set now adopts the new hash. Devices
+            // joined by an earlier interrupted run already carry it.
+            device.metadata_->config_hash = hashshouldbe;
+            continue;
         }
-        else if (device.metadata_->config_hash != uint32_t(hashshouldbe)) {
+        if (device.metadata_->config_hash == 0) {
+            device.metadata_->config_hash = hashshouldbe;
+        }
+        else if (device.metadata_->config_hash != hashshouldbe) {
             if (!flags.disable_mismatching_storage_pool_check) {
                 MONAD_ABORT_PRINTF(
                     "Storage pool source %s was initialised with a "
@@ -584,6 +1457,16 @@ void storage_pool::fill_chunks_(creation_flags const &flags)
                     "no longer needed and has been disabled.",
                     device.current_path().c_str());
             }
+        }
+    }
+    if (op == mode::add_devices) {
+        MONAD_ASSERT(!is_read_only_);
+        // The footers and their new config_hash must reach the storage before
+        // DbMetadataContext makes the grown chunk_info[] durable, or a power
+        // loss can leave the database describing chunks the devices do not
+        // carry.
+        for (auto const &device : devices_) {
+            device.flush_metadata_();
         }
     }
     auto const zone_id = [this](int const chunk_type) {
@@ -660,6 +1543,7 @@ storage_pool::storage_pool(
     , is_read_only_allow_dirty_(false)
     , is_migration_allowed_(false)
     , is_newly_truncated_(false)
+    , is_adding_devices_(false)
 {
     devices_.reserve(src->devices_.size());
     creation_flags flags;
@@ -705,19 +1589,87 @@ storage_pool::storage_pool(
             MONAD_ABORT();
         }());
     }
-    fill_chunks_(flags);
+    fill_chunks_(mode::open_existing, flags);
 }
 
 storage_pool::storage_pool(
-    std::span<std::filesystem::path const> const sources, mode const mode,
+    std::span<std::filesystem::path const> const sources, mode const mode_,
     creation_flags const flags)
     : is_read_only_(flags.open_read_only || flags.open_read_only_allow_dirty)
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
     , is_migration_allowed_(flags.allow_migration)
-    , is_newly_truncated_(mode == mode::truncate)
+    // mode::add_devices must never set this, however much of the device set it
+    // initialises: DbMetadataContext zeroes both metadata magics when it is
+    // set, which would destroy the database it is meant to be growing.
+    , is_newly_truncated_(mode_ == mode::truncate)
+    , is_adding_devices_(mode_ == mode::add_devices)
 {
+    MONAD_ASSERT(!sources.empty());
+    refuse_duplicate_sources_(sources);
+    // Classify and validate before writing anything, the interleaving refusal
+    // included. Diagnosing a bad prefix after make_device_ had already stamped
+    // a footer onto the joining device would make every retry fail as "already
+    // carries pool metadata", so one mistyped path would wedge the operation
+    // permanently.
+    size_t existing_devices = sources.size();
+    add_devices_plan_ plan{};
+    std::vector<device_info_> infos;
+    if (mode_ == mode::add_devices) {
+        MONAD_ASSERT(
+            !flags.interleave_chunks_evenly,
+            "Devices cannot be added to an evenly interleaved pool: chunk ids "
+            "are assigned round-robin across devices, so appending a device "
+            "renumbers every existing chunk.");
+        MONAD_ASSERT(
+            !flags.open_read_only && !flags.open_read_only_allow_dirty,
+            "mode::add_devices initialises joining devices and relocates the "
+            "metadata of a grown one, so it cannot be opened read only.");
+        infos.reserve(sources.size());
+        for (auto const &source : sources) {
+            infos.push_back(read_device_info_(source));
+        }
+        plan = validate_devices_to_add_(
+            sources,
+            infos,
+            flags.recorded_size_of_grown_device,
+            flags.metadata_budget);
+        existing_devices = plan.members;
+        if (plan.grown.has_value()) {
+            // Every intact member must already agree on the hash of the set
+            // this operation produces before the grown device's footer lands,
+            // or a crash in between would leave the grown device holding a
+            // hash no other device shares and the pool unopenable. Once that
+            // footer is durable the whole set agrees, which is the state the
+            // append path already knows how to finish.
+            for (size_t n = 0; n < plan.members; n++) {
+                stamp_config_hash_(sources[n], infos[n].size, plan.target_hash);
+            }
+            auto const index = plan.grown->index;
+            relocate_device_metadata_(
+                sources[index],
+                infos[index].size,
+                *plan.grown,
+                plan.target_hash);
+            existing_devices = index + 1;
+        }
+    }
+
     devices_.reserve(sources.size());
-    for (auto const &source : sources) {
+    creation_flags device_flags = flags;
+    for (size_t n = 0; n < sources.size(); n++) {
+        auto const &source = sources[n];
+        auto const device_mode = [&] {
+            if (mode_ != mode::add_devices) {
+                return mode_;
+            }
+            return n < existing_devices ? mode::open_existing : mode::truncate;
+        }();
+        if (mode_ == mode::add_devices && n == existing_devices) {
+            // Joining devices take the pool's geometry, never the caller's.
+            device_flags.set_chunk_capacity(
+                static_cast<uint32_t>(std::countr_zero(plan.chunk_capacity)));
+            device_flags.num_cnv_chunks = plan.num_cnv_chunks;
+        }
         devices_.push_back([&] {
             int const fd = ::open(source.c_str(), O_PATH | O_CLOEXEC);
             MONAD_ASSERT_PRINTF(
@@ -738,21 +1690,21 @@ storage_pool::storage_pool(
                 std::strerror(errno));
             if ((stat.st_mode & S_IFMT) == S_IFBLK) {
                 return make_device_(
-                    mode,
+                    device_mode,
                     device_t::type_t_::block_device,
                     source.c_str(),
                     fd,
                     0ULL,
-                    flags);
+                    device_flags);
             }
             if ((stat.st_mode & S_IFMT) == S_IFREG) {
                 return make_device_(
-                    mode,
+                    device_mode,
                     device_t::type_t_::file,
                     source.c_str(),
                     fd,
                     stat.st_ino,
-                    flags);
+                    device_flags);
             }
             MONAD_ABORT_PRINTF(
                 "Storage pool source %s has unknown file entry type = %u",
@@ -760,7 +1712,7 @@ storage_pool::storage_pool(
                 stat.st_mode & S_IFMT);
         }());
     }
-    fill_chunks_(flags);
+    fill_chunks_(mode_, flags);
 }
 
 storage_pool::storage_pool(use_anonymous_inode_tag, creation_flags const flags)
@@ -776,6 +1728,7 @@ storage_pool::storage_pool(
     , is_read_only_allow_dirty_(flags.open_read_only_allow_dirty)
     , is_migration_allowed_(flags.allow_migration)
     , is_newly_truncated_(false)
+    , is_adding_devices_(false)
 {
     int const fd = make_temporary_inode();
     auto unfd = make_scope_exit([fd]() noexcept { ::close(fd); });
@@ -784,7 +1737,7 @@ storage_pool::storage_pool(
     devices_.push_back(make_device_(
         mode::truncate, device_t::type_t_::file, {}, fd, uint64_t(0), flags));
     unfd.release();
-    fill_chunks_(flags);
+    fill_chunks_(mode::truncate, flags);
 }
 
 storage_pool::~storage_pool()
@@ -812,13 +1765,8 @@ storage_pool::~storage_pool()
     cleanupchunks_(seq);
     for (auto const &device : devices_) {
         if (device.metadata_ != nullptr) {
-            auto const total_size =
-                device.metadata_->total_size(device.size_of_file_);
-            ::munmap(
-                reinterpret_cast<void *>(round_down_align<CPU_PAGE_BITS>(
-                    (uintptr_t)device.metadata_ + sizeof(device_t::metadata_t) -
-                    total_size)),
-                total_size);
+            auto const mapping = device.metadata_mapping_();
+            ::munmap(mapping.first, mapping.second);
         }
         if (device.readwritefd_ != -1) {
             (void)::fsync(device.readwritefd_);

--- a/category/async/storage_pool.hpp
+++ b/category/async/storage_pool.hpp
@@ -23,11 +23,17 @@
 #include <atomic>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <variant>
 #include <vector>
 
 MONAD_ASYNC_NAMESPACE_BEGIN
+
+namespace test
+{
+    struct StoragePoolTestAccess; // test-only access to the hash formulae
+}
 
 /* \brief Makes available the lowest possible latency zoned storage, if `zonefs`
 is available. Otherwise falls back to an emulation which can use a file on a
@@ -68,6 +74,8 @@ pathological i/o performance loss at usually the most inconvenient times.
 */
 class storage_pool
 {
+    friend struct test::StoragePoolTestAccess;
+
 public:
     //! \brief Type of chunk, conventional or sequential
     enum chunk_type
@@ -146,21 +154,50 @@ public:
             }
         } *const metadata_;
 
+        // True if this open wrote the device's footer, i.e. it was blank
+        // beforehand.
+        bool const is_freshly_initialised_;
+
         static_assert(sizeof(metadata_t) == 64);
+
+        // Base address and length of the mapping make_device_ established over
+        // this device's metadata. The base is CPU page aligned.
+        std::pair<void *, size_t> metadata_mapping_() const noexcept;
+
+        // Writes back this device's footer and per-chunk bytes-used array,
+        // returning once the storage reports them durable.
+        void flush_metadata_() const;
 
         constexpr device_t(
             int const readwritefd, type_t_ const type,
             uint64_t const unique_hash, file_offset_t const size_of_file,
-            metadata_t *const metadata)
+            metadata_t *const metadata, bool const is_freshly_initialised)
             : readwritefd_(readwritefd)
             , type_(type)
             , unique_hash_(unique_hash)
             , size_of_file_(size_of_file)
             , metadata_(metadata)
+            , is_freshly_initialised_(is_freshly_initialised)
         {
         }
 
     public:
+        //! Returns whether this open wrote the device's footer, i.e. whether
+        //! the device was blank before this pool was constructed
+        bool is_freshly_initialised() const noexcept
+        {
+            return is_freshly_initialised_;
+        }
+
+        //! The size of the device in bytes, as of when this pool opened it.
+        //! This is the quantity chunks() and the device's unique_hash are
+        //! derived from, so it is what has to be recorded to later recover
+        //! the geometry of a device grown in place.
+        file_offset_t size_bytes() const noexcept
+        {
+            return size_of_file_;
+        }
+
         //! The current filesystem path of the device (it can change over time)
         std::filesystem::path current_path() const;
 
@@ -307,10 +344,41 @@ public:
     //! \brief What to do when opening the pool for use.
     enum class mode
     {
+        //! Every source must already carry pool metadata; abort if one does
+        //! not.
         open_existing,
+        //! Initialise any source which does not, and open the rest as they are.
         create_if_needed,
-        truncate
+        //! Discard every source's contents and initialise all of them.
+        truncate,
+        //! Take up storage the sources now offer but the pool does not yet
+        //! use: initialise and join a blank suffix, and relocate the metadata
+        //! of a last device extended in place. Existing data is kept, and
+        //! re-running the same list resumes an interrupted run.
+        add_devices
     };
+
+    //! \brief How much space a database's metadata needs in the first half of
+    //! conventional chunk 0, supplied by the caller that owns that layout so
+    //! this layer needs no knowledge of it.
+    struct db_metadata_budget
+    {
+        //! Fixed header, ahead of the per-chunk array. Should be the largest
+        //! of any on-disk format the caller can still read, so a pool stays
+        //! migratable without remapping.
+        size_t header_bytes;
+        //! Cost of each sequential chunk in the per-chunk array.
+        size_t bytes_per_chunk;
+    };
+
+    //! Smallest chunk capacity any pool carrying a database can have been
+    //! created with. This layer enforces no minimum of its own; the floor
+    //! comes from the database metadata having to fit in half of conventional
+    //! chunk 0, which the owning layer enforces on open. Every chunk therefore
+    //! starts at a multiple of this, and it is a power of two, which makes it a
+    //! safe stride for sampling chunk starts on a device whose own geometry is
+    //! not known yet.
+    static constexpr uint32_t min_chunk_capacity = 1u << 21;
 
     //! \brief Flags for storage pool creation
     struct creation_flags
@@ -341,6 +409,15 @@ public:
         //! Number of conventional chunks to allocate per device. Default is 3.
         uint32_t num_cnv_chunks;
 
+        //! What db_metadata recorded as the size of the device which grew:
+        //! its size before the extend. Only one device can have grown, the
+        //! last the pool already owns, so this needs no device index.
+        std::optional<file_offset_t> recorded_size_of_grown_device;
+
+        //! Space the database's metadata needs, from the caller that owns that
+        //! layout. Nothing if there is no database.
+        std::optional<db_metadata_budget> metadata_budget;
+
         constexpr creation_flags()
             : chunk_capacity(28)
             , interleave_chunks_evenly(false)
@@ -349,6 +426,8 @@ public:
             , disable_mismatching_storage_pool_check(false)
             , allow_migration(false)
             , num_cnv_chunks(3)
+            , recorded_size_of_grown_device(std::nullopt)
+            , metadata_budget(std::nullopt)
         {
         }
 
@@ -363,7 +442,7 @@ public:
 
 private:
     bool const is_read_only_, is_read_only_allow_dirty_, is_migration_allowed_,
-        is_newly_truncated_;
+        is_newly_truncated_, is_adding_devices_;
     std::vector<device_t> devices_;
 
     // Lock protects everything below this
@@ -371,12 +450,173 @@ private:
 
     std::vector<chunk_t> chunks_[2];
 
+    // The pool metadata a device carries in its final sizeof(metadata_t)
+    // bytes, as read back. Absent on a blank device, and on one extended in
+    // place, which strands the footer mid-device.
+    struct device_pool_metadata_
+    {
+        uint32_t chunk_capacity;
+        uint32_t num_cnv_chunks;
+        uint32_t config_hash;
+        size_t chunks;
+    };
+
+    // How the filesystem identifies the path a device was read from. Used to
+    // reject a source listed twice, which unique_hash cannot do: block devices
+    // fold a constant dev_no, so two distinct same-sized ones collide by
+    // construction.
+    struct device_identity_
+    {
+        uint64_t dev;
+        uint64_t ino;
+        // Target device number for a block device special file, so that two
+        // distinct special files naming the same device also compare equal;
+        // 0 (never a valid rdev) otherwise.
+        uint64_t rdev;
+        // The device number compute_unique_hash_ was given, so that the hash
+        // can be recomputed at a different size -- which is what validating a
+        // grown device's previous size needs.
+        uint64_t hash_dev_no;
+    };
+
+    // Read-only description of a candidate source, gathered before anything is
+    // written. Everything mode::add_devices validates is derivable from this,
+    // so a rejected device set is never modified. unique_hash is stored
+    // already-computed rather than as its inputs, so this can equally describe
+    // a live device_t, which keeps only the finished hash.
+    struct device_info_
+    {
+        device_t::type_t_ type;
+        uint64_t unique_hash;
+        // Current size: BLKGETSIZE64 for a block device, st_size for a file.
+        file_offset_t size;
+        std::optional<device_pool_metadata_> pool_metadata;
+        // Absent when this describes a live device_t, which keeps no record of
+        // the path it was opened from.
+        std::optional<device_identity_> identity;
+        // BLKSSZGET for a block device, in bytes. Nothing for a file, or if
+        // the ioctl fails.
+        std::optional<uint32_t> logical_block_size;
+    };
+
+    // Everything about `source` that needs no read of its contents. `fd` must
+    // be open on it.
+    static device_info_
+    read_device_identity_(int fd, std::filesystem::path const &source);
+
+    // The above, plus the pool metadata read back from the device's end.
+    static device_info_ read_device_info_(std::filesystem::path const &source);
+
+    // Both must carry an identity, so both must have come from a path.
+    static bool
+    same_device_identity_(device_info_ const &a, device_info_ const &b);
+
+    // Aborts if two sources name the same underlying device, which would
+    // otherwise alias the same storage under two chunk id ranges. A pass of
+    // its own ahead of every mode, because make_device_ initialises as it
+    // goes: by the time the duplicate is reached, the first copy has been
+    // written to.
+    static void
+    refuse_duplicate_sources_(std::span<std::filesystem::path const> sources);
+
+    // The per-device and whole-pool hash formulae, each in one place so the
+    // validating pre-pass and fill_chunks_ cannot drift apart. Members rather
+    // than file-local statics because device_t::type_t_ is private to device_t
+    // and only storage_pool is its friend.
+    static uint64_t compute_unique_hash_(
+        device_t::type_t_ type, uint64_t dev_no, file_offset_t size);
+
+    static uint32_t compute_config_hash_(std::span<device_info_ const>);
+
+    static device_info_ device_info_of_(device_t const &);
+
+    // A source which grew in place: it presents no footer at the end its
+    // current size gives it, because extending strands the footer mid-device,
+    // but carries a stranded one below which validates against the pool's own
+    // hash.
+    struct grown_device_
+    {
+        size_t index; // position within the source list
+        // The recorded size, once validated: the size this device had when it
+        // was last part of this pool, exact to the byte.
+        file_offset_t previous_size;
+        size_t previous_chunks; // chunks() at previous_size
+        uint32_t chunk_capacity; // read back from the stranded footer
+        uint32_t num_cnv_chunks;
+    };
+
+    // What a validated mode::add_devices open is going to do. Everything here
+    // is decided before a byte is written, so a refused device set is left
+    // untouched.
+    struct add_devices_plan_
+    {
+        // Sources [0, members) already carry a footer at their end. Sources
+        // from members on are initialised and joined, except for a grown one,
+        // which sits at index `members` and keeps its contents.
+        size_t members;
+        std::optional<grown_device_> grown;
+        // config_hash of the set this operation produces.
+        uint32_t target_hash;
+        // Geometry every joining device is carved at. Taken from device 0's
+        // footer, or from the grown device's stranded footer when device 0
+        // is itself the one that grew.
+        uint32_t chunk_capacity;
+        uint32_t num_cnv_chunks;
+    };
+
+    // Validates the mode::add_devices preconditions and returns the plan.
+    // Aborts, having written nothing, if the joining devices are not a
+    // contiguous suffix, if a joining device is not verifiably blank, if a
+    // source other than the last the pool owns grew, if a source grew but
+    // `recorded_size` does not describe the pool it grew out of, if a
+    // pre-existing source hashes to none of the sets this operation can
+    // legitimately see, or if the result would exceed the chunk id space or
+    // `budget`.
+    static add_devices_plan_ validate_devices_to_add_(
+        std::span<std::filesystem::path const> sources,
+        std::span<device_info_ const> infos,
+        std::optional<file_offset_t> recorded_size,
+        std::optional<db_metadata_budget> const &budget);
+
+    // Reads the sizeof(metadata_t) bytes a footer would occupy if the device
+    // were exactly `size` bytes long, and returns it if it carries the magic.
+    static std::optional<device_t::metadata_t>
+    read_footer_for_size_(int fd, file_offset_t size);
+
+    // The device as it was before it grew, which is what the pool's pre-grow
+    // config_hash covers.
+    static device_info_ device_info_at_previous_size_(
+        device_info_ const &now, grown_device_ const &grown);
+
+    // Checks `recorded_size` against the footer stranded there by the extend
+    // which grew `source`, for a source presenting no footer at its end.
+    // `members` are the sources ahead of it, all of which do carry one.
+    // Returns nothing unless that footer describes the pool as it was at
+    // `recorded_size`; `footer_found` then distinguishes a size with no footer
+    // at all from one whose footer belongs elsewhere. Reads only.
+    static std::optional<grown_device_> validate_grown_device_(
+        std::filesystem::path const &source, device_info_ const &current,
+        std::span<device_info_ const> members,
+        std::optional<file_offset_t> recorded_size, bool &footer_found);
+
+    // Writes the grown device's metadata region at the end its current size
+    // gives it: the bytes-used array carried over from the region stranded at
+    // `grown.previous_size` with the new chunks zeroed, then the footer. The
+    // footer is written and made durable last, so it is the commit record.
+    static void relocate_device_metadata_(
+        std::filesystem::path const &source, file_offset_t current_size,
+        grown_device_ const &grown, uint32_t new_config_hash);
+
+    // Rewrites the config_hash of the footer already at the end of `source`.
+    static void stamp_config_hash_(
+        std::filesystem::path const &source, file_offset_t size, uint32_t hash);
+
     device_t make_device_(
         mode op, device_t::type_t_ type, std::filesystem::path const &path,
         int fd, std::variant<uint64_t, device_t const *> dev_no_or_dev,
         creation_flags flags);
 
-    void fill_chunks_(creation_flags const &flags);
+    void fill_chunks_(mode op, creation_flags const &flags);
 
     struct clone_as_read_only_tag_
     {
@@ -431,11 +671,54 @@ public:
         return is_newly_truncated_;
     }
 
+    //! \brief True if the storage pool was opened with mode::add_devices.
+    //! Consulted by DbMetadataContext to decide whether a pool reporting more
+    //! chunks than the metadata describes should be grown or rejected with a
+    //! "run monad-mpt --rescan-devices" message.
+    bool is_adding_devices() const noexcept
+    {
+        return is_adding_devices_;
+    }
+
     //! \brief Returns a list of the backing storage devices
     std::span<device_t const> devices() const noexcept
     {
         return {devices_};
     }
+
+    //! \brief Returns whether `source` already carries storage pool metadata.
+    //! Read-only. Lets tooling tell a device already belonging to a pool from
+    //! a blank one before attempting a mode::add_devices open.
+    static bool has_pool_metadata(std::filesystem::path const &source);
+
+    //! \brief What a mode::add_devices open of `sources` would do, decided
+    //! without writing anything.
+    struct rescan_preview
+    {
+        //! Leading sources which already carry a footer at their end.
+        size_t existing;
+        //! The validated previous size of the source at index `existing`: the
+        //! size it had before it was extended in place, zero if none was. A
+        //! source which grew keeps its contents.
+        file_offset_t grown_previous_size;
+        //! Total chunks, cnv and seq, that source offered at its previous
+        //! size.
+        size_t grown_previous_chunks;
+        //! First source which will be initialised, destroying whatever is on
+        //! it. Equal to sources.size() when there is none.
+        size_t first_initialised;
+    };
+
+    //! \brief Classifies `sources` as a mode::add_devices open would, writing
+    //! nothing. It applies the same refusals, so a caller can put an accurate
+    //! confirmation prompt in front of the operation and know the operation
+    //! will not then refuse it. `recorded_size` is what db_metadata holds for
+    //! the source which grew; the validated previous size it yields comes back
+    //! in `grown_previous_size`.
+    static rescan_preview preview_rescan(
+        std::span<std::filesystem::path const> sources,
+        std::optional<file_offset_t> recorded_size = std::nullopt,
+        std::optional<db_metadata_budget> const &budget = std::nullopt);
 
     //! \brief Returns the number of chunks for the specified type
     size_t chunks(chunk_type const which) const noexcept

--- a/category/async/test/storage_pool.cpp
+++ b/category/async/test/storage_pool.cpp
@@ -19,8 +19,10 @@
 #include <category/async/config.hpp>
 #include <category/async/detail/scope_polyfill.hpp>
 #include <category/async/storage_pool.hpp>
+#include <category/async/test/storage_pool_test_access.hpp>
 #include <category/async/util.hpp>
 #include <category/core/assert.h>
+#include <category/core/log.hpp>
 #include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
 #include <category/core/test_util/temp_file_cleanup.hpp>
 
@@ -36,6 +38,7 @@
 #include <utility>
 #include <vector>
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -243,13 +246,16 @@ namespace
 
     TEST(StoragePool, raw_partitions)
     {
+        // The duplicate-source pass is the first thing to open each source, so
+        // it is what reports a path that cannot be opened -- naming it, and
+        // before any device has been touched.
         ASSERT_DEATH(
             ({
                 std::filesystem::path const devs[] = {
                     "/dev/mapper/raid0-rawblk0", "/dev/mapper/raid0-rawblk1"};
                 storage_pool const pool(devs, storage_pool::mode::truncate);
             }),
-            "open failed");
+            "open of /dev/mapper/raid0-rawblk0 failed");
     }
 
     TEST(StoragePool, device_interleaving)
@@ -407,6 +413,1054 @@ namespace
             "was initialised with a configuration different to this storage "
             "pool");
         storage_pool{devs2, storage_pool::mode::truncate};
+    }
+
+    TEST(StoragePool, config_hash_formula_is_pinned)
+    {
+        using monad::async::test::StoragePoolConfigHashInput;
+        using monad::async::test::StoragePoolTestAccess;
+
+        // Fixed, hardcoded inputs -- not read from a real device, whose
+        // unique_hash varies by inode and filesystem -- so this test isolates
+        // compute_config_hash_ itself. This value pins the on-disk format:
+        // changing it means every existing pool becomes unopenable.
+        StoragePoolConfigHashInput const devices[] = {
+            {0x1122334455667788ULL, 4091, 1u << 28},
+            {0xaabbccddeeff0011ULL, 39, 1u << 26},
+        };
+        EXPECT_EQ(
+            StoragePoolTestAccess::compute_config_hash(devices), 0xbc17f0ecu);
+    }
+
+    TEST(StoragePool, add_devices_preserves_chunk_ids)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE),
+            create_temp_file(10 * BLKSIZE),
+            create_temp_file(5 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+
+        // A chunk's physical identity, independent of the pool object that
+        // produced it.
+        struct chunk_identity
+        {
+            size_t device_idx;
+            file_offset_t read_offset;
+            file_offset_t capacity;
+
+            bool operator==(chunk_identity const &) const = default;
+        };
+
+        auto sample_chunks = [](storage_pool &pool,
+                                storage_pool::chunk_type which) {
+            std::vector<chunk_identity> ret;
+            for (size_t n = 0; n < pool.chunks(which); n++) {
+                auto &c = pool.chunk(which, static_cast<uint32_t>(n));
+                ret.push_back(chunk_identity{
+                    static_cast<size_t>(&c.device() - pool.devices().data()),
+                    c.read_fd().second,
+                    c.capacity()});
+            }
+            return ret;
+        };
+
+        std::vector<chunk_identity> seq_before;
+        std::vector<chunk_identity> cnv_before;
+        std::filesystem::path const two[] = {devs[0], devs[1]};
+        {
+            storage_pool pool{two};
+            seq_before = sample_chunks(pool, storage_pool::seq);
+            cnv_before = sample_chunks(pool, storage_pool::cnv);
+        }
+        ASSERT_GT(seq_before.size(), 0u);
+
+        storage_pool pool{devs, storage_pool::mode::add_devices};
+        EXPECT_TRUE(pool.is_adding_devices());
+        EXPECT_FALSE(pool.is_newly_truncated());
+        auto const seq_after = sample_chunks(pool, storage_pool::seq);
+        auto const cnv_after = sample_chunks(pool, storage_pool::cnv);
+
+        // Every pre-existing id keeps its exact physical meaning.
+        ASSERT_GT(seq_after.size(), seq_before.size());
+        ASSERT_GT(cnv_after.size(), cnv_before.size());
+        for (size_t n = 0; n < seq_before.size(); n++) {
+            EXPECT_EQ(seq_before[n], seq_after[n]) << "seq id " << n;
+        }
+        for (size_t n = 0; n < cnv_before.size(); n++) {
+            EXPECT_EQ(cnv_before[n], cnv_after[n]) << "cnv id " << n;
+        }
+        // The added ids all live on the joining device.
+        for (size_t n = seq_before.size(); n < seq_after.size(); n++) {
+            EXPECT_EQ(seq_after[n].device_idx, 2u);
+        }
+        EXPECT_FALSE(pool.devices()[0].is_freshly_initialised());
+        EXPECT_FALSE(pool.devices()[1].is_freshly_initialised());
+        EXPECT_TRUE(pool.devices()[2].is_freshly_initialised());
+    }
+
+    TEST(StoragePool, add_devices_refusals)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE),
+            create_temp_file(10 * BLKSIZE),
+            create_temp_file(5 * BLKSIZE),
+            create_temp_file(4 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        std::filesystem::path const two[] = {devs[0], devs[1]};
+        {
+            storage_pool const _{two};
+        }
+
+        EXPECT_TRUE(storage_pool::has_pool_metadata(devs[0]));
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[2]));
+
+        {
+            std::filesystem::path const reordered[] = {
+                devs[1], devs[0], devs[2]};
+            ASSERT_DEATH(
+                storage_pool(reordered, storage_pool::mode::add_devices),
+                "must be listed first, in the exact order");
+        }
+        {
+            std::filesystem::path const missing[] = {devs[0], devs[2]};
+            ASSERT_DEATH(
+                storage_pool(missing, storage_pool::mode::add_devices),
+                "must be listed first, in the exact order");
+        }
+        {
+            std::filesystem::path const joining_first[] = {
+                devs[0], devs[2], devs[1]};
+            ASSERT_DEATH(
+                storage_pool(joining_first, storage_pool::mode::add_devices),
+                "Devices being added must come last");
+        }
+        {
+            std::filesystem::path const blank_first[] = {
+                devs[2], devs[0], devs[1]};
+            ASSERT_DEATH(
+                storage_pool(blank_first, storage_pool::mode::add_devices),
+                "cannot be the first source");
+        }
+        {
+            storage_pool::creation_flags interleaved;
+            interleaved.interleave_chunks_evenly = true;
+            std::filesystem::path const three[] = {devs[0], devs[1], devs[2]};
+            ASSERT_DEATH(
+                storage_pool(
+                    three, storage_pool::mode::add_devices, interleaved),
+                "evenly interleaved pool");
+        }
+
+        // Every rejection above must have left devs[2] untouched, so a real
+        // add still works afterwards.
+        std::filesystem::path const three[] = {devs[0], devs[1], devs[2]};
+        {
+            storage_pool const pool{three, storage_pool::mode::add_devices};
+            EXPECT_TRUE(pool.devices()[2].is_freshly_initialised());
+        }
+        // The grown pool now demands all three devices.
+        {
+            storage_pool const _{three};
+        }
+        ASSERT_DEATH(
+            storage_pool{two},
+            "was initialised with a configuration different");
+        // A device carrying another pool's footer is refused: it classifies as
+        // pre-existing, and its stored hash is neither this pool's nor the one
+        // the add would produce.
+        {
+            std::filesystem::path const other[] = {devs[3]};
+            {
+                storage_pool const _{other};
+            }
+            std::filesystem::path const four[] = {
+                devs[0], devs[1], devs[2], devs[3]};
+            ASSERT_DEATH(
+                storage_pool(four, storage_pool::mode::add_devices),
+                "which is neither the hash of the sources listed");
+        }
+    }
+
+    TEST(StoragePool, add_devices_rerun_completes_an_interrupted_add)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE), create_temp_file(10 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        std::filesystem::path const one[] = {devs[0]};
+        {
+            storage_pool const _{one};
+        }
+
+        size_t chunks_after_add = 0;
+        {
+            storage_pool const pool{devs, storage_pool::mode::add_devices};
+            chunks_after_add = pool.chunks(storage_pool::seq);
+            EXPECT_TRUE(pool.devices()[1].is_freshly_initialised());
+        }
+
+        // The same command again, as an operator would run it to finish an add
+        // interrupted after this point: the join is recognised, nothing is
+        // reinitialised, and the pool is unchanged.
+        storage_pool const pool{devs, storage_pool::mode::add_devices};
+        EXPECT_EQ(pool.chunks(storage_pool::seq), chunks_after_add);
+        EXPECT_FALSE(pool.devices()[0].is_freshly_initialised());
+        EXPECT_FALSE(pool.devices()[1].is_freshly_initialised());
+    }
+
+    TEST(StoragePool, add_devices_refuses_a_set_the_metadata_cannot_describe)
+    {
+        using monad::async::test::StoragePoolAddDevicesInput;
+        using monad::async::test::StoragePoolTestAccess;
+
+        std::filesystem::path const sources[] = {
+            "existing-device", "joining-device"};
+
+        // A budget the size of MONAD008's, which the pool only does
+        // arithmetic with: a 2Mb chunk capacity leaves 1Mb of database
+        // metadata, which this header and 8 bytes per chunk exhaust at about
+        // 65000 chunks.
+        static constexpr storage_pool::db_metadata_budget budget{
+            .header_bytes = 528512, .bytes_per_chunk = 8};
+        static constexpr file_offset_t TWO_MB = 2 * 1024 * 1024;
+        StoragePoolAddDevicesInput const beyond_metadata[] = {
+            {.has_pool_metadata = true,
+             .size = 100 * TWO_MB,
+             .chunk_capacity = uint32_t(TWO_MB),
+             .num_cnv_chunks = 3,
+             .config_hash = 1,
+             .chunks = 100},
+            {.has_pool_metadata = false,
+             .size = 70000 * TWO_MB,
+             .chunk_capacity = 0,
+             .num_cnv_chunks = 0,
+             .config_hash = 0,
+             .chunks = 0}};
+        ASSERT_DEATH(
+            StoragePoolTestAccess::validate_devices_to_add(
+                sources, beyond_metadata, budget),
+            "chunk capacity is too small");
+
+        // At the 256Mb default the metadata budget is ample, so the 20 bit
+        // chunk id space binds first.
+        static constexpr file_offset_t CHUNK = 256 * 1024 * 1024;
+        StoragePoolAddDevicesInput const beyond_id_space[] = {
+            {.has_pool_metadata = true,
+             .size = 100 * CHUNK,
+             .chunk_capacity = uint32_t(CHUNK),
+             .num_cnv_chunks = 3,
+             .config_hash = 1,
+             .chunks = 100},
+            {.has_pool_metadata = false,
+             .size = 1100000 * CHUNK,
+             .chunk_capacity = 0,
+             .num_cnv_chunks = 0,
+             .config_hash = 0,
+             .chunks = 0}};
+        ASSERT_DEATH(
+            StoragePoolTestAccess::validate_devices_to_add(
+                sources, beyond_id_space, budget),
+            "20 bit chunk id space");
+    }
+
+    TEST(StoragePool, add_devices_rejects_undersized_joining_device)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE),
+            create_temp_file(10 * BLKSIZE),
+            // 3 chunks at the default 256Mb chunk capacity; the default pool
+            // needs num_cnv_chunks(3) + 1 = 4.
+            create_temp_file(3 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        std::filesystem::path const two[] = {devs[0], devs[1]};
+        {
+            storage_pool const _{two};
+        }
+
+        std::filesystem::path const three[] = {devs[0], devs[1], devs[2]};
+        ASSERT_DEATH(
+            storage_pool(three, storage_pool::mode::add_devices),
+            "would have only");
+
+        // Left byte-for-byte untouched by the rejected attempt: still
+        // classifies as blank, so the exact same path can be retried once it
+        // is large enough.
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[2]));
+        MONAD_ASSERT(
+            -1 !=
+            ::truncate(
+                devs[2].c_str(), static_cast<off_t>(5 * BLKSIZE + 16384)));
+
+        storage_pool const pool{three, storage_pool::mode::add_devices};
+        EXPECT_TRUE(pool.devices()[2].is_freshly_initialised());
+    }
+
+    TEST(StoragePool, add_devices_rejects_a_grown_device_with_data)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE),
+            create_temp_file(10 * BLKSIZE),
+            create_temp_file(20 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        std::filesystem::path const two[] = {devs[0], devs[1]};
+        {
+            storage_pool const _{two};
+        }
+
+        // Models an LVM-grown device: real data sits well past chunk 0 (the
+        // one chunk on a non-first device that is never written, so probing
+        // only it would miss this), yet the device's footer no longer sits
+        // at the end, so it still classifies as blank.
+        static constexpr size_t mid_chunk = 10;
+        std::vector<std::byte> const marker(64, std::byte{0x5a});
+        {
+            int const fd = ::open(devs[2].c_str(), O_WRONLY);
+            ASSERT_NE(fd, -1);
+            auto const unfd =
+                monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+            ASSERT_EQ(
+                ssize_t(marker.size()),
+                ::pwrite(
+                    fd,
+                    marker.data(),
+                    marker.size(),
+                    static_cast<off_t>(mid_chunk * BLKSIZE)));
+        }
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[2]));
+
+        std::filesystem::path const three[] = {devs[0], devs[1], devs[2]};
+        ASSERT_DEATH(
+            storage_pool(three, storage_pool::mode::add_devices),
+            "is not blank");
+
+        // Left untouched by the rejection: still blank by the footer test,
+        // and the data planted mid-device is still there.
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[2]));
+        std::vector<std::byte> readback(marker.size());
+        int const fd = ::open(devs[2].c_str(), O_RDONLY);
+        ASSERT_NE(fd, -1);
+        auto const unfd =
+            monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+        ASSERT_EQ(
+            ssize_t(readback.size()),
+            ::pread(
+                fd,
+                readback.data(),
+                readback.size(),
+                static_cast<off_t>(mid_chunk * BLKSIZE)));
+        EXPECT_EQ(0, memcmp(marker.data(), readback.data(), marker.size()));
+    }
+
+    TEST(StoragePool, rejects_duplicate_path)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE), create_temp_file(10 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        std::filesystem::path const one[] = {devs[0]};
+        {
+            storage_pool const _{one};
+        }
+
+        std::filesystem::path const duplicated[] = {devs[0], devs[1], devs[1]};
+        ASSERT_DEATH(
+            storage_pool(duplicated, storage_pool::mode::add_devices),
+            "name the same underlying device");
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[1]));
+
+        // A hard link to the same file: identical (dev, ino), different path
+        // spelling, and no on-disk footer to distinguish them either.
+        std::filesystem::path const linked = devs[1].string() + "_hardlink";
+        std::filesystem::create_hard_link(devs[1], linked);
+        auto const unlinked = monad::make_scope_exit(
+            [&]() noexcept { ::unlink(linked.c_str()); });
+        std::filesystem::path const via_link[] = {devs[0], devs[1], linked};
+        ASSERT_DEATH(
+            storage_pool(via_link, storage_pool::mode::add_devices),
+            "name the same underlying device");
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[1]));
+
+        // The refusal is not particular to mode::add_devices: two sources
+        // naming one device would alias the same storage under two chunk id
+        // ranges whichever mode reached them, and creating is where an
+        // operator is most likely to mistype a list.
+        std::filesystem::path const twice[] = {devs[1], devs[1]};
+        for (auto const mode :
+             {storage_pool::mode::create_if_needed,
+              storage_pool::mode::truncate,
+              storage_pool::mode::open_existing}) {
+            ASSERT_DEATH(
+                storage_pool(twice, mode), "name the same underlying device");
+        }
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[1]))
+            << "a refused create initialised the device anyway";
+        ASSERT_DEATH(
+            storage_pool(via_link, storage_pool::mode::create_if_needed),
+            "name the same underlying device");
+
+        // Left untouched by every rejection: a real add with a single,
+        // genuinely distinct joining device still works afterwards.
+        std::filesystem::path const two[] = {devs[0], devs[1]};
+        storage_pool const pool{two, storage_pool::mode::add_devices};
+        EXPECT_TRUE(pool.devices()[1].is_freshly_initialised());
+    }
+
+    TEST(StoragePool, add_devices_inherits_pool_geometry)
+    {
+        // This test's flag mismatch on an existing device reaches the
+        // num_cnv_chunks LOG_WARNING in make_device_, which dereferences the
+        // global root logger; this test binary's plain gtest_main never
+        // initialises it.
+        monad::start_logger_minimal();
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 64 * 1024 * 1024;
+        std::filesystem::path devs[] = {
+            create_temp_file(20 * BLKSIZE), create_temp_file(10 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+        storage_pool::creation_flags created;
+        created.set_chunk_capacity(26); // 64Mb, not the 256Mb default
+        created.num_cnv_chunks = 4;
+        std::filesystem::path const one[] = {devs[0]};
+        {
+            storage_pool const _{
+                one, storage_pool::mode::create_if_needed, created};
+        }
+
+        // Deliberately disagree with the pool on both geometry values.
+        storage_pool::creation_flags wrong;
+        wrong.set_chunk_capacity(28);
+        wrong.num_cnv_chunks = 9;
+        storage_pool const pool{devs, storage_pool::mode::add_devices, wrong};
+        EXPECT_EQ(pool.devices()[1].cnv_chunks(), 4u);
+        // 64Mb chunks, so a 10 * 64Mb device yields about 10 chunks, not 2.
+        EXPECT_GE(pool.devices()[1].chunks(), 9u);
+    }
+
+    // Reproduces exactly what lvextend leaves behind: a pool built on a
+    // device, closed, then the device made larger. Its footer is stranded
+    // mid-device and its per-chunk bytes-used array, the only on-disk record
+    // of how full each existing chunk is, has to survive the move.
+    TEST(StoragePool, grow_last_device_preserves_chunks_and_bytes_used)
+    {
+        auto create_temp_file =
+            [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        std::filesystem::path const devs[] = {
+            create_temp_file(20 * BLKSIZE), create_temp_file(10 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+
+        // seq chunk id -> bytes written into it, and where that chunk lives.
+        std::vector<std::pair<uint32_t, uint32_t>> written;
+        std::vector<std::pair<size_t, file_offset_t>> placement;
+        size_t chunks_before = 0;
+        {
+            storage_pool pool{devs};
+            chunks_before = pool.chunks(storage_pool::seq);
+            ASSERT_GT(chunks_before, 20u);
+            // Spanning both devices, and including chunks on the device about
+            // to grow so that it is not blank.
+            for (uint32_t const id : {0u, 5u, 17u, 20u}) {
+                ASSERT_LT(id, chunks_before);
+                auto const bytes = static_cast<uint32_t>(4096 * (id + 1));
+                std::vector<std::byte> buffer(bytes, std::byte{0xa5});
+                auto &chunk = pool.chunk(storage_pool::seq, id);
+                auto const fd = chunk.write_fd(bytes);
+                ASSERT_EQ(
+                    ssize_t(bytes),
+                    ::pwrite(
+                        fd.first,
+                        buffer.data(),
+                        bytes,
+                        static_cast<off_t>(fd.second)));
+                written.emplace_back(id, bytes);
+            }
+            for (uint32_t id = 0; id < chunks_before; id++) {
+                auto const &chunk = pool.chunk(storage_pool::seq, id);
+                size_t device_index = 0;
+                for (size_t n = 0; n < pool.devices().size(); n++) {
+                    if (&pool.devices()[n] == &chunk.device()) {
+                        device_index = n;
+                    }
+                }
+                placement.emplace_back(device_index, chunk.read_fd().second);
+            }
+        }
+
+        // The extend itself. Nothing writes pool metadata at the new end, so
+        // the pool now presents no footer there at all.
+        auto const recorded =
+            static_cast<file_offset_t>(std::filesystem::file_size(devs[1]));
+        {
+            int const fd = ::open(devs[1].c_str(), O_RDWR);
+            ASSERT_NE(fd, -1);
+            auto const unfd =
+                monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+            ASSERT_NE(
+                -1, ::ftruncate(fd, static_cast<off_t>(14 * BLKSIZE + 16384)));
+        }
+        EXPECT_FALSE(storage_pool::has_pool_metadata(devs[1]));
+        storage_pool::creation_flags flags;
+        flags.recorded_size_of_grown_device = recorded;
+
+        auto const check = [&](storage_pool &pool) {
+            EXPECT_GT(pool.chunks(storage_pool::seq), chunks_before);
+            for (uint32_t id = 0; id < chunks_before; id++) {
+                auto const &chunk = pool.chunk(storage_pool::seq, id);
+                size_t device_index = 0;
+                for (size_t n = 0; n < pool.devices().size(); n++) {
+                    if (&pool.devices()[n] == &chunk.device()) {
+                        device_index = n;
+                    }
+                }
+                EXPECT_EQ(device_index, placement[id].first) << "chunk " << id;
+                EXPECT_EQ(chunk.read_fd().second, placement[id].second)
+                    << "chunk " << id;
+            }
+            for (auto const &[id, bytes] : written) {
+                EXPECT_EQ(pool.chunk(storage_pool::seq, id).size(), bytes)
+                    << "chunk " << id;
+            }
+            for (auto id = static_cast<uint32_t>(chunks_before);
+                 id < pool.chunks(storage_pool::seq);
+                 id++) {
+                EXPECT_EQ(pool.chunk(storage_pool::seq, id).size(), 0u)
+                    << "new chunk " << id;
+            }
+        };
+
+        {
+            storage_pool pool{devs, storage_pool::mode::add_devices, flags};
+            EXPECT_FALSE(pool.devices()[1].is_freshly_initialised())
+                << "the grown device was wiped rather than relocated";
+            check(pool);
+        }
+        // And the relocation is durable: a plain open sees the same pool.
+        storage_pool pool{devs, storage_pool::mode::open_existing};
+        check(pool);
+    }
+
+    // Fixture for the grow tests: builds a pool, writes a known amount into
+    // one seq chunk of the last device so it is not blank, and can then
+    // extend that device in place.
+    struct growable_pool
+    {
+        static constexpr file_offset_t BLKSIZE = 256 * 1024 * 1024;
+        static constexpr uint32_t MARKED_BYTES = 40960;
+
+        std::vector<std::filesystem::path> devs;
+        uint32_t marked_chunk{0};
+        size_t chunks_before{0};
+        // What db_metadata recorded for the device these tests grow, i.e. its
+        // size as of the pool open the constructor performed.
+        file_offset_t recorded_last_size{0};
+
+        explicit growable_pool(std::vector<file_offset_t> const &lengths)
+        {
+            for (auto const length : lengths) {
+                monad::test::remove_stale_temp_files_once(
+                    working_temporary_directory(), "monad_storage_pool_test_");
+                std::filesystem::path path(
+                    working_temporary_directory() /
+                    "monad_storage_pool_test_XXXXXX");
+                int const fd = ::mkstemp((char *)path.native().data());
+                MONAD_ASSERT(fd != -1);
+                MONAD_ASSERT(
+                    -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+                ::close(fd);
+                devs.push_back(std::move(path));
+            }
+            storage_pool pool{devs};
+            chunks_before = pool.chunks(storage_pool::seq);
+            // The last seq chunk always lives on the last device, which is
+            // the one these tests grow. Chunk 0 is written too: a live pool
+            // always carries db_metadata on device 0, so a device 0 reading
+            // as entirely blank is not a state worth modelling.
+            marked_chunk = static_cast<uint32_t>(chunks_before - 1);
+            for (uint32_t const id : {0u, marked_chunk}) {
+                std::vector<std::byte> buffer(MARKED_BYTES, std::byte{0xa5});
+                auto &chunk = pool.chunk(storage_pool::seq, id);
+                auto const fd = chunk.write_fd(MARKED_BYTES);
+                MONAD_ASSERT(
+                    ssize_t(MARKED_BYTES) ==
+                    ::pwrite(
+                        fd.first,
+                        buffer.data(),
+                        MARKED_BYTES,
+                        static_cast<off_t>(fd.second)));
+            }
+            recorded_last_size = last_size();
+        }
+
+        growable_pool(growable_pool const &) = delete;
+        growable_pool &operator=(growable_pool const &) = delete;
+
+        ~growable_pool()
+        {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        }
+
+        void extend_last_to(file_offset_t const size) const
+        {
+            int const fd = ::open(devs.back().c_str(), O_RDWR);
+            MONAD_ASSERT(fd != -1);
+            auto const unfd =
+                monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+            MONAD_ASSERT(-1 != ::ftruncate(fd, static_cast<off_t>(size)));
+        }
+
+        file_offset_t last_size() const
+        {
+            return static_cast<file_offset_t>(
+                std::filesystem::file_size(devs.back()));
+        }
+
+        // What monad-mpt hands the pool: only the recorded size can locate the
+        // metadata an extend stranded, so a grow is refused without it.
+        storage_pool::creation_flags recorded_flags() const
+        {
+            storage_pool::creation_flags flags;
+            flags.recorded_size_of_grown_device = recorded_last_size;
+            return flags;
+        }
+    };
+
+    // The motivating case: one logical volume, extended in place. There is no
+    // sibling to cross-check the recorded previous size against, so it is
+    // validated against the stranded footer's own config_hash.
+    TEST(StoragePool, grow_single_device_pool)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(14 * growable_pool::BLKSIZE + 16384);
+
+        storage_pool pool{
+            fixture.devs,
+            storage_pool::mode::add_devices,
+            fixture.recorded_flags()};
+        EXPECT_GT(pool.chunks(storage_pool::seq), fixture.chunks_before);
+        EXPECT_FALSE(pool.devices()[0].is_freshly_initialised());
+        EXPECT_EQ(
+            pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+            growable_pool::MARKED_BYTES);
+    }
+
+    // New chunks splice onto the tail of the free list, so a device the pool
+    // already owns can still have nothing on it at all. Every chunk then
+    // reads as blank, exactly like a device being joined, and only the
+    // recorded previous size tells the two apart.
+    TEST(StoragePool, grow_an_empty_member_device)
+    {
+        static constexpr file_offset_t BLKSIZE = growable_pool::BLKSIZE;
+        auto make = [](file_offset_t length) -> std::filesystem::path {
+            monad::test::remove_stale_temp_files_once(
+                working_temporary_directory(), "monad_storage_pool_test_");
+            std::filesystem::path ret(
+                working_temporary_directory() /
+                "monad_storage_pool_test_XXXXXX");
+            int const fd = ::mkstemp((char *)ret.native().data());
+            MONAD_ASSERT(fd != -1);
+            MONAD_ASSERT(
+                -1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+            ::close(fd);
+            return ret;
+        };
+        std::filesystem::path const devs[] = {
+            make(20 * BLKSIZE), make(10 * BLKSIZE)};
+        auto const undevs = monad::make_scope_exit([&]() noexcept {
+            for (auto const &p : devs) {
+                std::filesystem::remove(p);
+            }
+        });
+
+        size_t chunks_before = 0;
+        {
+            storage_pool pool{devs};
+            chunks_before = pool.chunks(storage_pool::seq);
+            // Device 0 only; device 1 is left with not one byte written.
+            std::vector<std::byte> buffer(40960, std::byte{0xa5});
+            auto &chunk = pool.chunk(storage_pool::seq, 0);
+            auto const fd =
+                chunk.write_fd(static_cast<uint32_t>(buffer.size()));
+            ASSERT_EQ(
+                ssize_t(buffer.size()),
+                ::pwrite(
+                    fd.first,
+                    buffer.data(),
+                    buffer.size(),
+                    static_cast<off_t>(fd.second)));
+        }
+        auto const recorded =
+            static_cast<file_offset_t>(std::filesystem::file_size(devs[1]));
+        {
+            int const fd = ::open(devs[1].c_str(), O_RDWR);
+            ASSERT_NE(fd, -1);
+            auto const unfd =
+                monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+            ASSERT_NE(-1, ::ftruncate(fd, static_cast<off_t>(14 * BLKSIZE)));
+        }
+
+        storage_pool::creation_flags flags;
+        flags.recorded_size_of_grown_device = recorded;
+        {
+            storage_pool const pool{
+                devs, storage_pool::mode::add_devices, flags};
+            EXPECT_FALSE(pool.devices()[1].is_freshly_initialised())
+                << "an empty member device was rejoined as a new one";
+            EXPECT_GT(pool.chunks(storage_pool::seq), chunks_before);
+        }
+        storage_pool const pool{devs, storage_pool::mode::open_existing};
+        EXPECT_GT(pool.chunks(storage_pool::seq), chunks_before);
+    }
+
+    // The footer at the new end is the relocation's commit record, so a crash
+    // before it is durable must leave the device re-runnable with its
+    // bytes-used accounting intact. Reproduced by clearing that footer's
+    // magic after a completed relocation: the new array is in place, the
+    // commit is not, which is exactly the window. The recorded size is still
+    // the pre-grow one there, since a crash this early is a crash before the
+    // metadata layer ran at all.
+    TEST(StoragePool, grow_interrupted_before_the_footer_reruns)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(14 * growable_pool::BLKSIZE + 16384);
+        {
+            storage_pool pool{
+                fixture.devs,
+                storage_pool::mode::add_devices,
+                fixture.recorded_flags()};
+            ASSERT_EQ(
+                pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+                growable_pool::MARKED_BYTES);
+        }
+
+        auto const size = fixture.last_size();
+        {
+            int const fd = ::open(fixture.devs[0].c_str(), O_RDWR);
+            ASSERT_NE(fd, -1);
+            auto const unfd =
+                monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+            std::array<char, 4> const cleared{};
+            ASSERT_EQ(
+                ssize_t(cleared.size()),
+                ::pwrite(
+                    fd,
+                    cleared.data(),
+                    cleared.size(),
+                    static_cast<off_t>(size - cleared.size())));
+            ASSERT_EQ(0, ::fsync(fd));
+        }
+        ASSERT_FALSE(storage_pool::has_pool_metadata(fixture.devs[0]))
+            << "the crash window was not built";
+
+        // Re-running redoes the whole operation from the stranded footer,
+        // which this never touched.
+        storage_pool pool{
+            fixture.devs,
+            storage_pool::mode::add_devices,
+            fixture.recorded_flags()};
+        EXPECT_GT(pool.chunks(storage_pool::seq), fixture.chunks_before);
+        EXPECT_EQ(
+            pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+            growable_pool::MARKED_BYTES);
+    }
+
+    // A device can be extended again after a completed grow, and what the
+    // second run must be given is the size the first one left it at.
+    TEST(StoragePool, grow_twice_in_succession)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(12 * growable_pool::BLKSIZE + 16384);
+        size_t after_first = 0;
+        {
+            storage_pool const pool{
+                fixture.devs,
+                storage_pool::mode::add_devices,
+                fixture.recorded_flags()};
+            after_first = pool.chunks(storage_pool::seq);
+        }
+        ASSERT_GT(after_first, fixture.chunks_before);
+
+        // That run was a writable open, so this is what the database now
+        // records for the device.
+        auto const recorded = fixture.last_size();
+        fixture.extend_last_to(15 * growable_pool::BLKSIZE + 16384);
+        storage_pool::creation_flags flags;
+        flags.recorded_size_of_grown_device = recorded;
+        storage_pool pool{fixture.devs, storage_pool::mode::add_devices, flags};
+        EXPECT_GT(pool.chunks(storage_pool::seq), after_first);
+        EXPECT_EQ(
+            pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+            growable_pool::MARKED_BYTES);
+    }
+
+    // The new metadata region must clear the old one, or writing it would
+    // destroy the bytes-used array before the new footer is durable.
+    TEST(StoragePool, grow_too_small_to_clear_the_old_metadata_is_refused)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        // The region is only 64 bytes plus four per chunk, so this refusal
+        // takes a growth far below anything an operator would ask for; it
+        // exists to keep the crash window closed, not to reject real input.
+        auto const before = fixture.last_size();
+        fixture.extend_last_to(before + 64);
+
+        ASSERT_DEATH(
+            storage_pool(
+                fixture.devs,
+                storage_pool::mode::add_devices,
+                fixture.recorded_flags()),
+            "would overwrite the metadata being recovered");
+        // Refused before anything was written: the stranded footer is still
+        // the only one on the device.
+        EXPECT_FALSE(storage_pool::has_pool_metadata(fixture.devs[0]));
+    }
+
+    // The recorded size is checked against the pool's own hash before it is
+    // acted on, so a wrong one is refused rather than used. Four bytes
+    // spelling MND0 turn up in trie data eventually, and this is what stops
+    // one of them being taken for a footer.
+    TEST(StoragePool, grow_with_a_wrong_recorded_size_is_refused)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(14 * growable_pool::BLKSIZE + 16384);
+
+        storage_pool::creation_flags flags;
+        flags.recorded_size_of_grown_device = fixture.recorded_last_size - 8192;
+        ASSERT_DEATH(
+            storage_pool(fixture.devs, storage_pool::mode::add_devices, flags),
+            "nor any at the");
+        EXPECT_FALSE(storage_pool::has_pool_metadata(fixture.devs[0]));
+    }
+
+    // Without the recorded size nothing can say where the extend left the
+    // metadata, and the refusal has to say how to get one.
+    TEST(StoragePool, grow_without_a_recorded_size_is_refused)
+    {
+        growable_pool fixture{{10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(14 * growable_pool::BLKSIZE + 16384);
+
+        ASSERT_DEATH(
+            storage_pool(fixture.devs, storage_pool::mode::add_devices),
+            "must be opened writable once before its devices are extended");
+        EXPECT_FALSE(storage_pool::has_pool_metadata(fixture.devs[0]));
+    }
+
+    // One operation reconciling the pool with everything the hardware now
+    // offers: the last device the pool owns has grown, and a blank device
+    // follows it. Both land under a single metadata growth.
+    TEST(StoragePool, grow_and_append_in_one_operation)
+    {
+        growable_pool const fixture{
+            {20 * growable_pool::BLKSIZE, 10 * growable_pool::BLKSIZE}};
+        fixture.extend_last_to(14 * growable_pool::BLKSIZE + 16384);
+
+        monad::test::remove_stale_temp_files_once(
+            working_temporary_directory(), "monad_storage_pool_test_");
+        std::filesystem::path joining(
+            working_temporary_directory() / "monad_storage_pool_test_XXXXXX");
+        int const fd = ::mkstemp((char *)joining.native().data());
+        ASSERT_NE(fd, -1);
+        ASSERT_NE(
+            -1,
+            ::ftruncate(
+                fd, static_cast<off_t>(5 * growable_pool::BLKSIZE + 16384)));
+        ::close(fd);
+        auto const unjoining = monad::make_scope_exit(
+            [&]() noexcept { std::filesystem::remove(joining); });
+
+        std::vector<std::filesystem::path> all = fixture.devs;
+        all.push_back(joining);
+        {
+            storage_pool pool{
+                all, storage_pool::mode::add_devices, fixture.recorded_flags()};
+            EXPECT_EQ(pool.devices().size(), 3u);
+            EXPECT_FALSE(pool.devices()[1].is_freshly_initialised())
+                << "the grown device was wiped rather than relocated";
+            EXPECT_TRUE(pool.devices()[2].is_freshly_initialised());
+            EXPECT_GT(pool.chunks(storage_pool::seq), fixture.chunks_before);
+            EXPECT_EQ(
+                pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+                growable_pool::MARKED_BYTES);
+        }
+        // Every device now agrees on the new hash, so a plain open succeeds.
+        storage_pool pool{all, storage_pool::mode::open_existing};
+        EXPECT_EQ(
+            pool.chunk(storage_pool::seq, fixture.marked_chunk).size(),
+            growable_pool::MARKED_BYTES);
+    }
+
+    // Growing device i renumbers every chunk on the devices after it, so only
+    // the last device the pool owns may grow. The recorded size cannot
+    // validate for such a device -- the hash it would have to match covers the
+    // devices behind it too -- so the misplaced-device diagnosis has to be
+    // reached before that failure is reported as a foreign device.
+    TEST(StoragePool, grow_a_device_which_is_not_the_last_is_refused)
+    {
+        growable_pool fixture{
+            {20 * growable_pool::BLKSIZE, 10 * growable_pool::BLKSIZE}};
+        auto const recorded = static_cast<file_offset_t>(
+            std::filesystem::file_size(fixture.devs[0]));
+        // Extend device 0, which still has device 1 behind it.
+        int const fd = ::open(fixture.devs[0].c_str(), O_RDWR);
+        ASSERT_NE(fd, -1);
+        auto const unfd =
+            monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+        ASSERT_NE(
+            -1,
+            ::ftruncate(
+                fd, static_cast<off_t>(24 * growable_pool::BLKSIZE + 16384)));
+
+        storage_pool::creation_flags flags;
+        flags.recorded_size_of_grown_device = recorded;
+        ASSERT_DEATH(
+            storage_pool(fixture.devs, storage_pool::mode::add_devices, flags),
+            "Only the last device the pool already owns may be extended");
     }
 
     TEST(StoragePool, clone_content)

--- a/category/async/test/storage_pool_test_access.hpp
+++ b/category/async/test/storage_pool_test_access.hpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/async/config.hpp>
+#include <category/async/storage_pool.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <vector>
+
+MONAD_ASYNC_NAMESPACE_BEGIN
+
+namespace test
+{
+    // The device_info_ fields compute_config_hash_ reads. A standalone
+    // type rather than storage_pool::device_info_ itself, so this header
+    // does not also need friend access to device_t::type_t_.
+    struct StoragePoolConfigHashInput
+    {
+        uint64_t unique_hash;
+        size_t chunks;
+        uint32_t chunk_capacity;
+    };
+
+    // The device_info_ fields validate_devices_to_add_ reads. Lets a unit
+    // test reach refusals whose real trigger is a device set far larger than
+    // any test machine can provision.
+    struct StoragePoolAddDevicesInput
+    {
+        bool has_pool_metadata;
+        MONAD_ASYNC_NAMESPACE::file_offset_t size;
+        uint32_t chunk_capacity;
+        uint32_t num_cnv_chunks;
+        uint32_t config_hash;
+        size_t chunks;
+    };
+
+    // Test-only access to storage_pool's private on-disk hash formula, so a
+    // unit test can pin a golden value against the real implementation
+    // without a live device_t.
+    struct StoragePoolTestAccess
+    {
+        static size_t validate_devices_to_add(
+            std::span<std::filesystem::path const> const sources,
+            std::span<StoragePoolAddDevicesInput const> const devices,
+            std::optional<storage_pool::db_metadata_budget> const &budget =
+                std::nullopt)
+        {
+            std::vector<storage_pool::device_info_> infos;
+            infos.reserve(devices.size());
+            for (size_t n = 0; n < devices.size(); n++) {
+                storage_pool::device_info_ info{};
+                info.size = devices[n].size;
+                if (devices[n].has_pool_metadata) {
+                    info.pool_metadata = storage_pool::device_pool_metadata_{
+                        .chunk_capacity = devices[n].chunk_capacity,
+                        .num_cnv_chunks = devices[n].num_cnv_chunks,
+                        .config_hash = devices[n].config_hash,
+                        .chunks = devices[n].chunks};
+                }
+                // Present so that a caller reaching the grown-device path,
+                // which recomputes a hash from it, does not fault on an
+                // absent identity. Duplicate sources are refused before
+                // validate_devices_to_add_ is ever called.
+                info.identity = storage_pool::device_identity_{
+                    .dev = 0, .ino = n + 1, .rdev = 0, .hash_dev_no = 0};
+                infos.push_back(info);
+            }
+            return storage_pool::validate_devices_to_add_(
+                       sources, infos, std::nullopt, budget)
+                .members;
+        }
+
+        static uint32_t compute_config_hash(
+            std::span<StoragePoolConfigHashInput const> const devices)
+        {
+            std::vector<storage_pool::device_info_> infos;
+            infos.reserve(devices.size());
+            for (auto const &d : devices) {
+                storage_pool::device_info_ info{};
+                info.unique_hash = d.unique_hash;
+                info.pool_metadata = storage_pool::device_pool_metadata_{
+                    .chunk_capacity = d.chunk_capacity,
+                    .num_cnv_chunks = 0,
+                    .config_hash = 0,
+                    .chunks = d.chunks};
+                infos.push_back(info);
+            }
+            return storage_pool::compute_config_hash_(infos);
+        }
+    };
+}
+
+MONAD_ASYNC_NAMESPACE_END

--- a/category/mpt/cli_tool_impl.cpp
+++ b/category/mpt/cli_tool_impl.cpp
@@ -39,6 +39,7 @@
 #include <CLI/CLI.hpp>
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cctype>
 #include <cerrno>
@@ -79,6 +80,49 @@
 #include <time.h>
 #include <unistd.h>
 #include <zstd.h>
+
+// The recorded size of the device at `index`: what it reported at the last
+// writable open, which is no longer its current size if it has since been
+// extended. Nothing if none was recorded -- a pool created before the field
+// existed, or a device at or beyond MAX_RECORDED_DEVICES.
+//
+// db_metadata's first copy is read straight off device 0 without opening the
+// pool, which is the only way round the circularity: the device whose previous
+// size is being recovered has no footer at its end until this has answered.
+//
+// Only that copy is read, so a corrupt one reads as nothing recorded even when
+// the second still holds the record. The second sits at half the conventional
+// chunk capacity, which only device 0's footer states, and in a single-device
+// pool device 0 is the extended device whose footer is the very thing missing.
+// Nor is there a pool open to heal one copy from the other, since a pool with
+// an extended device cannot be opened at all.
+std::optional<MONAD_ASYNC_NAMESPACE::file_offset_t>
+recorded_device_size(std::filesystem::path const &device0, size_t const index)
+{
+    using MONAD_MPT_NAMESPACE::detail::db_metadata;
+    if (index >= db_metadata::MAX_RECORDED_DEVICES) {
+        return std::nullopt;
+    }
+    int const fd = ::open(device0.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd == -1) {
+        return std::nullopt;
+    }
+    auto const unfd = monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+    alignas(db_metadata) std::array<std::byte, sizeof(db_metadata)> buffer{};
+    if (::pread(fd, buffer.data(), buffer.size(), 0) !=
+        ssize_t(buffer.size())) {
+        return std::nullopt;
+    }
+    auto const *const m = monad::start_lifetime_as<db_metadata>(buffer.data());
+    if (0 !=
+        memcmp(m->magic, db_metadata::MAGIC, db_metadata::MAGIC_STRING_LEN)) {
+        return std::nullopt;
+    }
+    if (m->device_sizes[index] == 0) {
+        return std::nullopt;
+    }
+    return m->device_sizes[index];
+}
 
 std::string print_bytes(MONAD_ASYNC_NAMESPACE::file_offset_t const bytes_)
 {
@@ -435,6 +479,11 @@ struct impl_t
     std::filesystem::path archive_database;
     std::filesystem::path restore_database;
     std::vector<std::filesystem::path> storage_paths;
+    bool rescan_devices = false;
+    // What --rescan-devices classified the storage as, kept so the summary
+    // after the pool is open can attribute the new chunks to the device that
+    // grew and to the devices that joined.
+    MONAD_ASYNC_NAMESPACE::storage_pool::rescan_preview rescan{};
     int compression_level = 3;
 
     std::optional<MONAD_ASYNC_NAMESPACE::storage_pool> pool;
@@ -1510,7 +1559,10 @@ set it to the desired size beforehand).
 
 The storage source order must be identical to database creation, as must be
 the source type, size and device id, otherwise the database cannot be
-opened.
+opened. An existing database can take up more storage with --rescan-devices,
+either from devices appended to the end of the list or from its last device
+having been extended in place. Every later open must list the devices in that
+same order.
 )");
     try {
         impl_t impl(cout, cerr);
@@ -1580,6 +1632,22 @@ opened.
                 "sentinel, which would make a later --activate-secondary wipe "
                 "the metadata. Normalises it so activation is safe. Run with "
                 "the daemon stopped.");
+            cli_ops_group->add_flag(
+                "--rescan-devices",
+                impl.rescan_devices,
+                "reconcile an existing database with the storage it is now "
+                "given: join any new, blank device listed after the ones it "
+                "already has, and take up the space of its last device if that "
+                "was extended in place. --storage must list every device the "
+                "database should contain, in its original order, with any new "
+                "ones appended. All data on a new device is destroyed; an "
+                "extended device keeps its contents. Taking up an extended "
+                "device needs the size the database recorded for it, which "
+                "every writable open writes, so only extend a device of a "
+                "database this release has already opened. Run with the daemon "
+                "stopped. An interrupted run is finished by re-running the "
+                "identical command, which resumes it from wherever it "
+                "stopped.");
             cli_ops_group->add_option(
                 "--reset-history-length",
                 impl.reset_history_length,
@@ -1698,6 +1766,27 @@ opened.
             impl.flags.num_cnv_chunks =
                 impl.root_offsets_chunk_count +
                 monad::mpt::UpdateAux::cnv_chunks_for_db_metadata;
+            // What db_metadata costs, so the pool can refuse a device set the
+            // database could not describe before it writes any footer.
+            impl.flags.metadata_budget =
+                MONAD_ASYNC_NAMESPACE::storage_pool::db_metadata_budget{
+                    .header_bytes =
+                        monad::mpt::detail::db_metadata::MONAD007_HEADER_BYTES,
+                    .bytes_per_chunk =
+                        sizeof(monad::mpt::detail::db_metadata::chunk_info_t)};
+            // --restore sets truncate_database below, so this must run first:
+            // otherwise --rescan-devices --restore would fall into the truncate
+            // branch further down and destroy the pool before this guard is
+            // ever reached.
+            bool const restore_or_archive_requested =
+                !impl.restore_database.empty() ||
+                !impl.archive_database.empty();
+            if (impl.rescan_devices && restore_or_archive_requested) {
+                cerr << "FATAL: --rescan-devices cannot be combined with "
+                        "--restore or --archive. Take up the storage first, "
+                        "then run the archive or restore separately.\n";
+                return 1;
+            }
             if (!impl.restore_database.empty()) {
                 if (!impl.archive_database.empty()) {
                     impl.cli_ask_question(
@@ -1748,6 +1837,125 @@ opened.
                 impl.flags.open_read_only_allow_dirty = false;
                 impl.flags.allow_migration = true;
             }
+            else if (impl.rescan_devices) {
+                // has_pool_metadata and the pool constructor both abort on a
+                // path they cannot open, so a mistyped argument has to be
+                // caught here to be reported rather than dumped as a crash.
+                for (auto const &p : impl.storage_paths) {
+                    std::error_code ec;
+                    auto const status = std::filesystem::status(p, ec);
+                    if (ec) {
+                        cerr << "FATAL: cannot examine " << p << ": "
+                             << ec.message() << "\n";
+                        return 1;
+                    }
+                    if (status.type() != std::filesystem::file_type::regular &&
+                        status.type() != std::filesystem::file_type::block) {
+                        cerr << "FATAL: " << p
+                             << " is neither a file nor a block device, so it "
+                                "cannot be a source of block storage.\n";
+                        return 1;
+                    }
+                    if (-1 == ::access(p.c_str(), R_OK | W_OK)) {
+                        cerr << "FATAL: " << p << " is not readable and "
+                             << "writable: " << strerror(errno) << "\n";
+                        return 1;
+                    }
+                }
+                // Whether a device already belongs to this pool needs the
+                // config hash, so the pool layer decides it. Listing one
+                // device twice is decidable here, and reads as a typo.
+                for (size_t i = 0; i < impl.storage_paths.size(); i++) {
+                    for (size_t j = i + 1; j < impl.storage_paths.size(); j++) {
+                        std::error_code ec;
+                        if (std::filesystem::equivalent(
+                                impl.storage_paths[i],
+                                impl.storage_paths[j],
+                                ec) &&
+                            !ec) {
+                            cerr << "FATAL: " << impl.storage_paths[i]
+                                 << " and " << impl.storage_paths[j]
+                                 << " name the same device; each device may be "
+                                    "given only once.\n";
+                            return 1;
+                        }
+                    }
+                }
+                // Classify before prompting, so the operator is told exactly
+                // which devices lose their contents and which keep them, and
+                // so every refusal is raised before they are asked to confirm
+                // anything.
+                //
+                // A device extended in place is the first source with no
+                // footer at its end, and the size db_metadata recorded for it
+                // is the only thing which can locate the metadata that extend
+                // stranded. The pool checks it against its own hash, and
+                // refuses rather than guessing where it does not hold up.
+                size_t with_footer = 0;
+                while (with_footer < impl.storage_paths.size() &&
+                       MONAD_ASYNC_NAMESPACE::storage_pool::has_pool_metadata(
+                           impl.storage_paths[with_footer])) {
+                    with_footer++;
+                }
+                std::optional<MONAD_ASYNC_NAMESPACE::file_offset_t>
+                    recorded_size;
+                if (with_footer < impl.storage_paths.size()) {
+                    recorded_size = recorded_device_size(
+                        impl.storage_paths[0], with_footer);
+                }
+                auto const preview =
+                    MONAD_ASYNC_NAMESPACE::storage_pool::preview_rescan(
+                        impl.storage_paths,
+                        recorded_size,
+                        impl.flags.metadata_budget);
+                bool const joins =
+                    preview.first_initialised < impl.storage_paths.size();
+                bool const grows = preview.grown_previous_size != 0;
+                if (!joins && !grows) {
+                    cout << "Nothing to do: the database already spans every "
+                            "device given, at its current size.\n";
+                }
+                std::stringstream ss;
+                ss << "WARNING: --rescan-devices";
+                if (joins) {
+                    ss << " will destroy all existing data on";
+                    for (size_t n = preview.first_initialised;
+                         n < impl.storage_paths.size();
+                         n++) {
+                        ss << " " << impl.storage_paths[n];
+                    }
+                    ss << " and permanently join "
+                       << (impl.storage_paths.size() -
+                                       preview.first_initialised >
+                                   1
+                               ? "them"
+                               : "it")
+                       << " to the database";
+                }
+                if (grows) {
+                    ss << (joins ? ", and" : " will")
+                       << " relocate the pool metadata of "
+                       << impl.storage_paths[preview.existing]
+                       << ", which was extended in place; its contents are "
+                          "kept";
+                }
+                if (!joins && !grows) {
+                    ss << " will destroy nothing; it will only finish work an "
+                          "earlier run left incomplete";
+                }
+                ss << ". This cannot be undone without a full --archive and "
+                      "--restore. Are you sure?\n";
+                impl.cli_ask_question(ss.str().c_str());
+                mode = MONAD_ASYNC_NAMESPACE::storage_pool::mode::add_devices;
+                impl.flags.open_read_only = false;
+                impl.flags.open_read_only_allow_dirty = false;
+                // The recorded size, not the preview's validated one: the
+                // open re-validates from scratch, and flattening "nothing
+                // grew" to zero here would re-engage the optional the pool
+                // uses to tell a missing record from a bad one.
+                impl.flags.recorded_size_of_grown_device = recorded_size;
+                impl.rescan = preview;
+            }
             else if (
                 impl.activate_secondary || impl.deactivate_secondary ||
                 impl.promote_secondary || impl.repair_database) {
@@ -1772,7 +1980,8 @@ opened.
         bool const needs_write_ring =
             impl.rewind_database_to || impl.reset_history_length ||
             impl.activate_secondary || impl.deactivate_secondary ||
-            impl.promote_secondary || impl.repair_database;
+            impl.promote_secondary || impl.repair_database ||
+            impl.rescan_devices;
         auto wr_ring(
             needs_write_ring
                 ? std::optional<monad::io::Ring>(monad::io::RingConfig{4})
@@ -1825,6 +2034,56 @@ opened.
                      << " to discard its contents and restamp it.\n";
                 return 1;
             }
+        }
+
+        if (impl.rescan_devices) {
+            auto const cnv_capacity =
+                impl.pool->chunk(MONAD_ASYNC_NAMESPACE::storage_pool::cnv, 0)
+                    .capacity();
+            auto const devices = impl.pool->devices();
+            // Counted from the pool's own device list rather than from what
+            // this run initialised, so the totals stay right when the run was
+            // a resume, which initialises nothing.
+            size_t from_growth = 0;
+            if (impl.rescan.grown_previous_size != 0) {
+                from_growth = devices[impl.rescan.existing].chunks() -
+                              impl.rescan.grown_previous_chunks;
+            }
+            size_t from_new_devices = 0;
+            MONAD_ASYNC_NAMESPACE::file_offset_t reserved_cnv = 0;
+            for (size_t n = impl.rescan.first_initialised; n < devices.size();
+                 n++) {
+                from_new_devices +=
+                    devices[n].chunks() - devices[n].cnv_chunks();
+                reserved_cnv += devices[n].cnv_chunks() * cnv_capacity;
+            }
+            cout << "Rescan complete.\n";
+            if (from_growth > 0) {
+                cout << "  " << impl.storage_paths[impl.rescan.existing]
+                     << " was extended in place, from "
+                     << impl.rescan.grown_previous_size
+                     << " bytes: " << from_growth
+                     << " more sequential chunks.\n";
+            }
+            if (from_new_devices > 0) {
+                cout << "  " << (devices.size() - impl.rescan.first_initialised)
+                     << " device(s) joined: " << from_new_devices
+                     << " sequential chunks.\n";
+            }
+            cout << "  "
+                 << impl.pool->chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq)
+                 << " sequential chunks in total. Free space is now "
+                 << aux.metadata_ctx().get_lower_bound_free_space()
+                 << " bytes.\n";
+            if (reserved_cnv > 0) {
+                cout << "  " << reserved_cnv
+                     << " bytes of conventional chunks are reserved on the new "
+                        "device(s) and will not be used; only the first "
+                        "device's conventional chunks are live.\n";
+            }
+            cout << "  New chunks join the tail of the free list, so they are "
+                    "allocated after all currently free chunks. Existing data "
+                    "is not redistributed.\n";
         }
 
         // Secondary timeline lifecycle. These execute against the open

--- a/category/mpt/db_metadata_context.cpp
+++ b/category/mpt/db_metadata_context.cpp
@@ -58,11 +58,26 @@ using namespace MONAD_ASYNC_NAMESPACE;
 // root_offsets_ring_t::SIZE_ = 65536; MONAD008 dropped it to 32, shrinking
 // sizeof(db_metadata) from 528512 to 4480 bytes and shifting chunk_info[]
 // and the db_offsets/consensus block accordingly.
-static constexpr size_t MONAD007_DB_METADATA_SIZE = 528512;
+static constexpr size_t MONAD007_DB_METADATA_SIZE =
+    detail::db_metadata::MONAD007_HEADER_BYTES;
 static constexpr size_t MONAD007_DB_OFFSETS_OFFSET = 524328;
 static constexpr size_t MONAD007_DB_OFFSETS_THROUGH_BLOCK_IDS_BYTES = 128;
 static constexpr size_t MONAD007_LIST_TRIPLE_OFFSET = 528488;
 static constexpr size_t DB_METADATA_LIST_TRIPLE_BYTES = 24;
+
+// storage_pool documents min_chunk_capacity as the smallest capacity a pool
+// carrying a database can have, and samples chunk starts at that stride when a
+// device's own geometry is unknown. check_chunk_info_fits_ below is what makes
+// that true at open time, by refusing a pool whose conventional chunk 0 cannot
+// hold the header; these two bounds keep min_chunk_capacity the smallest
+// power of two that survives it, so that it divides every real capacity and
+// the stride skips no chunk.
+static_assert(
+    storage_pool::min_chunk_capacity / 2 >=
+    detail::db_metadata::MONAD007_HEADER_BYTES);
+static_assert(
+    storage_pool::min_chunk_capacity / 4 <
+    detail::db_metadata::MONAD007_HEADER_BYTES);
 
 namespace detail
 {
@@ -194,12 +209,7 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
     metadata_mmap_size_ = cnv_chunk.capacity() / 2;
     db_map_size_ = sizeof(detail::db_metadata) +
                    chunk_count * sizeof(detail::db_metadata::chunk_info_t);
-    MONAD_ASSERT(
-        metadata_mmap_size_ >=
-            MONAD007_DB_METADATA_SIZE +
-                chunk_count * sizeof(detail::db_metadata::chunk_info_t),
-        "cnv chunk 0 is too small to hold a MONAD007 metadata header plus "
-        "chunk_info[]; pool configuration is incompatible with this build");
+    check_chunk_info_fits_(chunk_count, metadata_mmap_size_);
 
     // mmap both metadata copies
     copies_[0].main = start_lifetime_as<detail::db_metadata>(::mmap(
@@ -238,7 +248,10 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
                 can_write_to_map_,
                 "First copy of metadata corrupted, but not opened for "
                 "healing");
-            db_copy(copies_[0].main, copies_[1].main, db_map_size_);
+            db_copy(
+                copies_[0].main,
+                copies_[1].main,
+                db_map_size_of_(copies_[1].main));
         }
     }
 
@@ -355,11 +368,17 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
                  detail::db_metadata::MAGIC_STRING_LEN)) {
         if (can_write_to_map_) {
             if (copies_[0].main->is_dirty().load(std::memory_order_acquire)) {
-                db_copy(copies_[0].main, copies_[1].main, db_map_size_);
+                db_copy(
+                    copies_[0].main,
+                    copies_[1].main,
+                    db_map_size_of_(copies_[1].main));
             }
             else if (copies_[1].main->is_dirty().load(
                          std::memory_order_acquire)) {
-                db_copy(copies_[1].main, copies_[0].main, db_map_size_);
+                db_copy(
+                    copies_[1].main,
+                    copies_[0].main,
+                    db_map_size_of_(copies_[0].main));
             }
         }
         else {
@@ -457,6 +476,8 @@ DbMetadataContext::DbMetadataContext(AsyncIO &io)
         map_ring_a_storage();
         map_ring_b_storage();
         replay_pending_shrink_grow_();
+        reconcile_chunk_count_();
+        record_device_sizes_();
     }
 }
 #if defined(__GNUC__) && !defined(__clang__)
@@ -505,6 +526,129 @@ uint32_t DbMetadataContext::ring_max_chunks_() const noexcept
 size_t DbMetadataContext::map_bytes_per_chunk_() const noexcept
 {
     return io_->storage_pool().chunk(storage_pool::cnv, 0).capacity() / 2;
+}
+
+void DbMetadataContext::check_chunk_info_fits_(
+    size_t const target, size_t const metadata_mmap_size)
+{
+    MONAD_ASSERT_PRINTF(
+        target <= MONAD_ASYNC_NAMESPACE::chunk_offset_t::max_id,
+        "The storage pool provides %zu sequential chunks, beyond the %llu the "
+        "20 bit chunk id space allows. If devices were just added, they are "
+        "too many for this pool; use fewer or larger ones.",
+        target,
+        static_cast<unsigned long long>(
+            MONAD_ASYNC_NAMESPACE::chunk_offset_t::max_id));
+    auto const needed = MONAD007_DB_METADATA_SIZE +
+                        target * sizeof(detail::db_metadata::chunk_info_t);
+    MONAD_ASSERT_PRINTF(
+        metadata_mmap_size >= needed,
+        "The storage pool provides %zu sequential chunks, needing %zu bytes "
+        "of metadata, but conventional chunk 0 only provides %zu. If devices "
+        "were just added, this pool's chunk capacity is too small to describe "
+        "that many chunks.",
+        target,
+        needed,
+        metadata_mmap_size);
+}
+
+size_t DbMetadataContext::db_map_size_of_(
+    detail::db_metadata const *const m) const noexcept
+{
+    auto const ret =
+        sizeof(detail::db_metadata) +
+        size_t(m->chunk_info_count) * sizeof(detail::db_metadata::chunk_info_t);
+    MONAD_ASSERT(ret <= metadata_mmap_size_);
+    return ret;
+}
+
+void DbMetadataContext::do_add_devices_body_(uint32_t const target_chunk_count)
+{
+    for (auto const &copy : copies_) {
+        auto *const m = copy.main;
+        auto const from = static_cast<uint32_t>(m->chunk_info_count);
+        if (from == target_chunk_count) {
+            continue;
+        }
+        MONAD_ASSERT(from < target_chunk_count);
+        uint64_t added = 0;
+        for (uint32_t n = from; n < target_chunk_count; n++) {
+            auto const &chunk = io_->storage_pool().chunk(storage_pool::seq, n);
+            MONAD_ASSERT_PRINTF(
+                chunk.size() == 0,
+                "sequential chunk %u on a joining device already holds %zu "
+                "bytes; refusing to add a device which is not blank",
+                n,
+                size_t(chunk.size()));
+            added += chunk.capacity();
+        }
+        m->extend_chunk_info_(target_chunk_count, added);
+    }
+}
+
+void DbMetadataContext::record_device_sizes_()
+{
+    if (io_->storage_pool().is_read_only()) {
+        return;
+    }
+    auto const devices = io_->storage_pool().devices();
+    auto const recorded = std::min(
+        devices.size(), size_t(detail::db_metadata::MAX_RECORDED_DEVICES));
+    for (auto const &copy : copies_) {
+        auto *const m = copy.main;
+        auto const g = m->hold_dirty();
+        for (size_t n = 0; n < recorded; n++) {
+            m->device_sizes[n] = devices[n].size_bytes();
+        }
+    }
+    // Synced like every other mutation here, and for a sharper reason: this is
+    // the only record of a device's pre-extend size, and losing it refuses the
+    // next extend outright.
+    sync_metadata_to_disk_();
+}
+
+void DbMetadataContext::reconcile_chunk_count_()
+{
+    auto const pool_chunks = io_->chunk_count();
+    auto const described =
+        static_cast<size_t>(copies_[0].main->chunk_info_count);
+    if (described == pool_chunks) {
+        if (io_->storage_pool().is_adding_devices()) {
+            LOG_INFO(
+                "DB metadata already describes all {} sequential chunks; the "
+                "device add was already completed by an earlier run.",
+                described);
+        }
+        return;
+    }
+    MONAD_ASSERT_PRINTF(
+        described < pool_chunks,
+        "DB metadata describes %zu sequential chunks but the storage pool "
+        "only provides %zu. A storage device appears to be missing.",
+        described,
+        pool_chunks);
+    MONAD_ASSERT_PRINTF(
+        io_->storage_pool().is_adding_devices(),
+        "The storage pool provides %zu sequential chunks but the DB metadata "
+        "describes only %zu. If storage was added, by attaching a device or by "
+        "extending one in place, run 'monad-mpt --rescan-devices' with the "
+        "daemon stopped to take it up.",
+        pool_chunks,
+        described);
+    MONAD_ASSERT(can_write_to_map_);
+    auto const target = static_cast<uint32_t>(pool_chunks);
+    LOG_INFO(
+        "Growing DB metadata from {} to {} sequential chunks after a device "
+        "add",
+        described,
+        target);
+    set_pending_shrink_grow_(
+        detail::db_metadata::PENDING_OP_ADD_DEVICES, target);
+    sync_metadata_to_disk_();
+    do_add_devices_body_(target);
+    sync_metadata_to_disk_();
+    clear_pending_shrink_grow_();
+    sync_metadata_to_disk_();
 }
 
 // Version metadata getters
@@ -1002,6 +1146,20 @@ void DbMetadataContext::replay_pending_shrink_grow_()
             "primary_ring_idx = {}) after unclean shutdown",
             op_param);
         do_promote_secondary_to_primary_body_(static_cast<uint8_t>(op_param));
+    }
+    else if (op_kind == detail::db_metadata::PENDING_OP_ADD_DEVICES) {
+        MONAD_ASSERT_PRINTF(
+            op_param == io_->chunk_count(),
+            "An interrupted device add targeted %u sequential chunks but the "
+            "storage pool provides %zu. Re-attach the devices which were "
+            "being added and reopen to let the operation complete.",
+            op_param,
+            io_->chunk_count());
+        LOG_INFO(
+            "Replaying in-flight chunk_info growth (target {} sequential "
+            "chunks) after unclean shutdown",
+            op_param);
+        do_add_devices_body_(op_param);
     }
     else {
         MONAD_ABORT_PRINTF(
@@ -1733,6 +1891,7 @@ void DbMetadataContext::init_new_pool(
         memset(
             m->future_variables_unused, 0, sizeof(m->future_variables_unused));
     }
+    record_device_sizes_();
 
     std::atomic_signal_fence(
         std::memory_order_seq_cst); // no compiler reordering here

--- a/category/mpt/db_metadata_context.hpp
+++ b/category/mpt/db_metadata_context.hpp
@@ -45,6 +45,7 @@ MONAD_MPT_NAMESPACE_BEGIN
 class DbMetadataContext
 {
     friend class UpdateAux;
+    friend struct test::AddDevicesTestAccess;
 
 public:
     // Each metadata_copy describes one of the two redundant db_metadata
@@ -592,6 +593,36 @@ private:
     // operation to completion before the constructor returns.
     void replay_pending_shrink_grow_();
 
+    // Inner body of the chunk_info[] growth which follows a device add.
+    // Idempotent under replay: a copy already at `target` is left alone.
+    // Expects the pending flag to already be stamped.
+    void do_add_devices_body_(uint32_t target_chunk_count);
+
+    // Called from the constructor after replay_pending_shrink_grow_. Compares
+    // chunk_info_count against the pool's seq chunk count and either does
+    // nothing, grows, or aborts naming monad-mpt --rescan-devices.
+    void reconcile_chunk_count_();
+
+    // Aborts if chunk_info[] cannot describe `target` chunks. Split out from
+    // the constructor so the limits can be unit tested without provisioning a
+    // multi-terabyte pool.
+    static void
+    check_chunk_info_fits_(size_t target, size_t metadata_mmap_size);
+
+    // Stamps each device's current size into db_metadata::device_sizes, making
+    // that the device's recorded size, which monad-mpt later reads back as the
+    // previous size of a device grown in place. A no-op on a read-only open. On
+    // the open which performs a grow, the storage layer has already relocated
+    // the metadata by the time this runs, so the recorded size it advances past
+    // has served its purpose.
+    void record_device_sizes_();
+
+    // Logical metadata bytes described by `m` itself, as opposed to
+    // db_map_size_, which is derived from the pool. The two differ while a
+    // device add is in flight, so healing must be sized from the clean source
+    // copy or it reads or writes past what that copy describes.
+    size_t db_map_size_of_(detail::db_metadata const *m) const noexcept;
+
     MONAD_ASYNC_NAMESPACE::AsyncIO *io_{nullptr};
     metadata_copy copies_[2];
     // db_map_size_ is the logical bytes of live metadata (header +
@@ -599,9 +630,10 @@ private:
     // (cnv chunk 0 half-capacity). The latter is always >= the former
     // and >= MONAD007_DB_METADATA_SIZE + chunk_info[], so migration
     // from a MONAD007 pool can read and relocate chunk_info[] without
-    // remapping. Use metadata_mmap_size_ for mmap/munmap and
-    // db_map_size_ for msync/db_copy to avoid syncing megabytes of
-    // dead bytes beyond the logical metadata.
+    // remapping. Use metadata_mmap_size_ for mmap/munmap and db_map_size_
+    // for msync, to avoid syncing megabytes of dead bytes beyond the logical
+    // metadata; a copy-to-copy db_copy is sized by db_map_size_of_ instead,
+    // as a copy can describe fewer chunks than the pool does mid-grow.
     size_t db_map_size_{0};
     size_t metadata_mmap_size_{0};
     bool is_new_pool_{false};

--- a/category/mpt/detail/db_metadata.hpp
+++ b/category/mpt/detail/db_metadata.hpp
@@ -27,6 +27,7 @@
 #include "unsigned_20.hpp"
 
 #include <atomic>
+#include <cstddef>
 #include <type_traits>
 
 MONAD_MPT_NAMESPACE_BEGIN
@@ -36,6 +37,7 @@ class UpdateAux;
 namespace test
 {
     struct DbMetadataTestAccess; // test-only access to ring internals
+    struct AddDevicesTestAccess; // test-only access to growth internals
 }
 
 namespace detail
@@ -82,6 +84,14 @@ namespace detail
         // Previous magic supported via on-the-fly migration (see
         // DbMetadataContext constructor).
         static constexpr char const *PREVIOUS_MAGIC = "MONAD007";
+
+        // Fixed header of the MONAD007 layout, whose root_offsets_ring_t held
+        // 65536 slots. Still the largest of any format this code can read, so
+        // every pool must reserve it: migration relocates chunk_info[] in
+        // place rather than remapping. It is therefore also the header half of
+        // the budget storage_pool checks a device set against, which is why it
+        // is public rather than local to db_metadata_context.cpp.
+        static constexpr size_t MONAD007_HEADER_BYTES = 528512;
 
         friend class MONAD_MPT_NAMESPACE::DbMetadataContext;
         friend class MONAD_MPT_NAMESPACE::UpdateAux;
@@ -258,24 +268,46 @@ namespace detail
             PENDING_OP_ACTIVATE = 1, // activate_secondary_header
             PENDING_OP_DEACTIVATE = 2, // deactivate_secondary_header
             PENDING_OP_PROMOTE = 3, // promote_secondary_to_primary_header
+            PENDING_OP_ADD_DEVICES = 4 // chunk_info[] growth after a device add
         };
 
         struct pending_shrink_grow_t
         {
             uint32_t op_kind; // pending_op_kind
             // op-specific param: target primary cnv_chunks_len for
-            // ACTIVATE/DEACTIVATE; target primary_ring_idx for PROMOTE.
+            // ACTIVATE/DEACTIVATE; target primary_ring_idx for PROMOTE;
+            // target chunk_info_count for ADD_DEVICES.
             uint32_t op_param;
         } pending_shrink_grow;
 
         static_assert(sizeof(pending_shrink_grow_t) == 8);
+
+        // How many devices device_sizes below can describe. A pool with more
+        // devices than this records nothing for those past the end, so
+        // monad-mpt --rescan-devices refuses to take one of them up extended
+        // in place.
+        static constexpr size_t MAX_RECORDED_DEVICES = 64;
+
+        // The *recorded* size in bytes of each storage pool device, indexed by
+        // its position in the device list: what the device reported at the last
+        // writable open, which is no longer its current size once it has been
+        // extended in place. Zero means not recorded: a pool predating this
+        // field, or a device at or beyond MAX_RECORDED_DEVICES. An extend
+        // strands the device's footer mid-device, so the device stops reporting
+        // its own former geometry and this becomes the only record of it;
+        // monad-mpt --rescan-devices refuses to take up an extended device
+        // without it. Carved from the padding below, which both a fresh pool
+        // and the MONAD007 migration zero, so the sentinel holds on every pool
+        // that already exists.
+        uint64_t device_sizes[MAX_RECORDED_DEVICES];
 
         // padding for adding future atomics without requiring DB reset.
         // Sized so sizeof(db_metadata) stays at 4480 regardless of how
         // timeline_state_t grows in subsequent PRs.
         uint8_t future_variables_unused
             [4040 - sizeof(root_offsets_ring_t) - 2 * sizeof(timeline_state_t) -
-             16 - sizeof(pending_shrink_grow_t)];
+             16 - sizeof(pending_shrink_grow_t) -
+             MAX_RECORDED_DEVICES * sizeof(uint64_t)];
 
         // used to know if the metadata was being
         // updated when the process suddenly exited
@@ -305,7 +337,14 @@ namespace detail
 
         struct chunk_info_t
         {
-            static constexpr uint32_t INVALID_CHUNK_ID = 0xfffff;
+            // The links below carry chunk_offset_t's own chunk id, whose top
+            // value can never be a real chunk id, so it marks an absent link.
+            static constexpr uint32_t INVALID_CHUNK_ID = static_cast<uint32_t>(
+                MONAD_ASYNC_NAMESPACE::chunk_offset_t::max_id);
+            // Frozen by the on-disk format: every existing pool's free list
+            // terminates on this value, so widening chunk_offset_t's id field
+            // would reinterpret those terminators rather than migrate them.
+            static_assert(INVALID_CHUNK_ID == 0xfffff);
             uint64_t prev_chunk_id : 20; // same bits as from chunk_offset_t
             uint64_t in_fast_list : 1;
             uint64_t in_slow_list : 1;
@@ -586,6 +625,56 @@ namespace detail
             capacity_in_free_list -= bytes;
         }
 
+        // Grow chunk_info[] to `to` entries, append every new entry to the
+        // free list continuing insertion counts from the current tail, and
+        // fold in the new chunks' capacity. All of it in one dirty scope, so
+        // a crash part-way through is caught by dirty-bit recovery rather
+        // than leaving a half-linked list or an understated capacity.
+        void extend_chunk_info_(
+            uint32_t const to, uint64_t const added_capacity_bytes) noexcept
+        {
+            auto const g = hold_dirty();
+            auto const from = uint32_t(chunk_info_count);
+            MONAD_ASSERT(to >= from);
+            MONAD_ASSERT((to & ~0xfffffU) == 0);
+            chunk_info_count = to & 0xfffffU;
+            for (uint32_t n = from; n < to; n++) {
+                chunk_info_t info;
+                info.in_fast_list = 0;
+                info.in_slow_list = 0;
+                info.unused0_ = 0;
+                info.next_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
+                if (free_list.end == NULL_CHUNK) {
+                    MONAD_ASSERT(free_list.begin == NULL_CHUNK);
+                    info.prev_chunk_id = chunk_info_t::INVALID_CHUNK_ID;
+                    info.insertion_count0_ = 0;
+                    info.insertion_count1_ = 0;
+                    free_list.begin = free_list.end = n;
+                }
+                else {
+                    MONAD_ASSERT((free_list.end & ~0xfffffU) == 0);
+                    auto *const tail = at_(free_list.end);
+                    uint32_t const insertion_count =
+                        uint32_t(tail->insertion_count()) + 1;
+                    MONAD_ASSERT(
+                        insertion_count < virtual_chunk_offset_t::MAX_COUNT,
+                        "Chunk count overflow detected. The 20-bit address "
+                        "space for chunk count has been exhausted. Please "
+                        "perform a database reset.");
+                    info.insertion_count0_ = insertion_count & 0x3ff;
+                    info.insertion_count1_ = insertion_count >> 10 & 0x3ff;
+                    info.prev_chunk_id = free_list.end & 0xfffffU;
+                    MONAD_ASSERT(
+                        tail->next_chunk_id == chunk_info_t::INVALID_CHUNK_ID);
+                    tail->next_chunk_id = n & 0xfffffU;
+                    free_list.end = n;
+                }
+                std::atomic_ref<chunk_info_t>(chunk_info[n])
+                    .store(info, std::memory_order_release);
+            }
+            capacity_in_free_list += added_capacity_bytes;
+        }
+
         void advance_db_offsets_to_(
             db_offsets_info_t const &offsets_to_apply) noexcept
         {
@@ -604,6 +693,13 @@ namespace detail
     // chunk_info[] budget for any given chunk_count.
     static_assert(sizeof(db_metadata) == 4480);
     static_assert(alignof(db_metadata) == 8);
+    // device_sizes reads zero on a pool that predates it only while it stays
+    // inside the window the MONAD007 migration zeroes.
+    static_assert(
+        offsetof(db_metadata, device_sizes) >
+        offsetof(db_metadata, secondary_timeline));
+    static_assert(
+        offsetof(db_metadata, device_sizes) < offsetof(db_metadata, free_list));
 
     inline void atomic_memcpy(
         void *__restrict__ const dest_, void const *__restrict__ const src_,

--- a/category/mpt/test/CMakeLists.txt
+++ b/category/mpt/test/CMakeLists.txt
@@ -13,6 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+monad_add_test_death(
+  add_devices_death_no_mode_test
+  SOURCES
+  "add_devices_death_no_mode.cpp"
+  LINK_LIBRARIES
+  monad_execution
+  FAIL_REGEX
+  ".*run 'monad-mpt --rescan-devices.*")
+add_trie_test(TARGET add_devices_test SOURCES "add_devices_test.cpp")
 add_trie_test(TARGET append_test SOURCES "append_test.cpp")
 add_trie_test(TARGET big_endian_serialization_test SOURCES
               "big_endian_serialization_test.cpp")
@@ -35,6 +44,7 @@ add_trie_test(TARGET db_test SOURCES "db_test.cpp")
 add_trie_test(TARGET encode_branch_test SOURCES "encode_branch_test.cpp")
 add_trie_test(TARGET encode_two_pieces_test SOURCES
               "encode_two_pieces_test.cpp")
+add_trie_test(TARGET device_resize_test SOURCES "device_resize_test.cpp")
 add_trie_test(TARGET dual_timeline_test SOURCES "dual_timeline_test.cpp")
 add_trie_test(TARGET load_all_test SOURCES "load_all_test.cpp")
 add_trie_test(TARGET many_nested_updates SOURCES "many_nested_updates.cpp"

--- a/category/mpt/test/add_devices_death_no_mode.cpp
+++ b/category/mpt/test/add_devices_death_no_mode.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "add_devices_test_util.hpp"
+
+#include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/core/log.hpp>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <iostream>
+
+using namespace MONAD_ASYNC_NAMESPACE;
+using add_devices_test::BLKSIZE;
+using add_devices_test::create_temp_file;
+using add_devices_test::opened_db;
+
+// A pool grown at the storage layer but opened without mode::add_devices must
+// abort telling the operator to run monad-mpt --rescan-devices. Its own
+// executable because it aborts while holding io_uring rings, which in-process
+// death tests handle poorly.
+TEST(add_devices_death, growth_refused_without_add_devices_mode)
+{
+    monad::start_logger_minimal();
+
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const one[] = {dev0};
+    std::filesystem::path const both[] = {dev0, dev1};
+    {
+        opened_db const db{one, storage_pool::mode::create_if_needed};
+    }
+    {
+        storage_pool const pool{both, storage_pool::mode::add_devices};
+    }
+    std::cout << "Must fail after this:" << std::endl;
+    opened_db const db{both, storage_pool::mode::open_existing};
+}

--- a/category/mpt/test/add_devices_test.cpp
+++ b/category/mpt/test/add_devices_test.cpp
@@ -1,0 +1,347 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "add_devices_test_util.hpp"
+#include "db_metadata_test_access.hpp"
+
+#include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/config.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace MONAD_ASYNC_NAMESPACE;
+using namespace MONAD_MPT_NAMESPACE;
+using add_devices_test::BLKSIZE;
+using add_devices_test::create_temp_file;
+using add_devices_test::free_list_ids;
+using add_devices_test::opened_db;
+
+TEST(add_devices, grows_chunk_info_and_free_list)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const one[] = {dev0};
+    std::filesystem::path const both[] = {dev0, dev1};
+
+    uint32_t before_count = 0;
+    uint64_t before_capacity = 0;
+    std::vector<uint32_t> before_free;
+    {
+        opened_db db{one, storage_pool::mode::create_if_needed};
+        auto const *m = db.aux.metadata_ctx().main();
+        before_count = static_cast<uint32_t>(m->chunk_info_count);
+        before_capacity = m->capacity_in_free_list;
+        before_free = free_list_ids(m);
+    }
+    ASSERT_GT(before_count, 0u);
+
+    opened_db db{both, storage_pool::mode::add_devices};
+    auto const *m0 = db.aux.metadata_ctx().main(0);
+    auto const *m1 = db.aux.metadata_ctx().main(1);
+    auto const after_count = static_cast<uint32_t>(m0->chunk_info_count);
+    EXPECT_EQ(after_count, db.io.chunk_count());
+    EXPECT_GT(after_count, before_count);
+    EXPECT_EQ(uint32_t(m1->chunk_info_count), after_count);
+
+    // The old free-list order is preserved and the new ids follow it, in
+    // ascending order, at the tail.
+    auto const after_free = free_list_ids(m0);
+    ASSERT_EQ(
+        after_free.size(), before_free.size() + (after_count - before_count));
+    for (size_t n = 0; n < before_free.size(); n++) {
+        EXPECT_EQ(after_free[n], before_free[n]) << "free slot " << n;
+    }
+    for (uint32_t n = before_count; n < after_count; n++) {
+        EXPECT_EQ(after_free[before_free.size() + (n - before_count)], n);
+    }
+    EXPECT_EQ(free_list_ids(m1), after_free);
+
+    // Insertion counts stay monotone across the splice point, which is what
+    // chunk_list_and_age relies on.
+    for (size_t n = 1; n < after_free.size(); n++) {
+        EXPECT_EQ(
+            uint32_t(m0->at(after_free[n])->insertion_count()),
+            uint32_t(m0->at(after_free[n - 1])->insertion_count()) + 1)
+            << "free slot " << n;
+    }
+
+    // Free capacity grew by exactly the new chunks' capacity.
+    uint64_t added = 0;
+    for (uint32_t n = before_count; n < after_count; n++) {
+        added += db.pool.chunk(storage_pool::seq, n).capacity();
+    }
+    EXPECT_EQ(m0->capacity_in_free_list, before_capacity + added);
+    EXPECT_EQ(m1->capacity_in_free_list, before_capacity + added);
+    EXPECT_EQ(
+        m0->pending_shrink_grow.op_kind,
+        MONAD_MPT_NAMESPACE::detail::db_metadata::PENDING_OP_NONE);
+}
+
+TEST(add_devices, reopening_a_grown_pool_changes_nothing)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const one[] = {dev0};
+    std::filesystem::path const both[] = {dev0, dev1};
+    {
+        opened_db const db{one, storage_pool::mode::create_if_needed};
+    }
+
+    uint32_t count = 0;
+    uint64_t capacity = 0;
+    std::vector<uint32_t> free_ids;
+    {
+        opened_db db{both, storage_pool::mode::add_devices};
+        auto const *m = db.aux.metadata_ctx().main();
+        count = static_cast<uint32_t>(m->chunk_info_count);
+        capacity = m->capacity_in_free_list;
+        free_ids = free_list_ids(m);
+    }
+    opened_db db{both, storage_pool::mode::open_existing};
+    auto const *m = db.aux.metadata_ctx().main();
+    EXPECT_EQ(uint32_t(m->chunk_info_count), count);
+    EXPECT_EQ(m->capacity_in_free_list, capacity);
+    EXPECT_EQ(free_list_ids(m), free_ids);
+}
+
+// Reproduces the crash window between do_add_devices_body_'s two per-copy
+// scopes: pending record stamped, copy 0 grown, copy 1 not, neither copy
+// dirty. Built by raw file I/O on cnv chunk 0 rather than by driving
+// DbMetadataContext, whose constructor always leaves the two copies agreeing.
+// Same technique as provision_monad007_pool in cli_tool_test.cpp.
+TEST(add_devices, interrupted_growth_replays_on_reopen)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const one[] = {dev0};
+    std::filesystem::path const both[] = {dev0, dev1};
+
+    // cnv chunk 0 geometry, and copy 1's pre-growth bytes.
+    file_offset_t base_offset = 0;
+    file_offset_t half_capacity = 0;
+    std::vector<std::byte> saved_copy1;
+    size_t pre_growth_count = 0;
+    {
+        opened_db db{one, storage_pool::mode::create_if_needed};
+        auto &cnv = db.pool.chunk(storage_pool::cnv, 0);
+        auto const fdr = cnv.read_fd();
+        auto const fdw = cnv.write_fd(0);
+        ASSERT_EQ(fdr.second, fdw.second)
+            << "read/write fds disagree on cnv chunk 0's base offset; the "
+               "pread/pwrite geometry below would be silently wrong";
+        base_offset = fdr.second;
+        half_capacity = cnv.capacity() / 2;
+        ASSERT_GT(half_capacity, 0u);
+        pre_growth_count = db.aux.metadata_ctx().main()->chunk_info_count;
+        saved_copy1.resize(static_cast<size_t>(half_capacity));
+        auto const got = ::pread(
+            fdr.first,
+            saved_copy1.data(),
+            saved_copy1.size(),
+            static_cast<off_t>(base_offset + half_capacity));
+        ASSERT_EQ(got, ssize_t(saved_copy1.size()));
+    }
+
+    // Complete the add so copy 0 is fully grown and the pool is joined.
+    size_t grown_count = 0;
+    {
+        opened_db db{both, storage_pool::mode::add_devices};
+        grown_count = db.aux.metadata_ctx().main()->chunk_info_count;
+    }
+    ASSERT_GT(grown_count, pre_growth_count);
+
+    // Roll copy 1 back to its pre-growth bytes and stamp the pending record
+    // into both copies, clean.
+    {
+        storage_pool pool{both, storage_pool::mode::open_existing};
+        auto &cnv = pool.chunk(storage_pool::cnv, 0);
+        auto const fdw = cnv.write_fd(0);
+        ASSERT_EQ(
+            ssize_t(saved_copy1.size()),
+            ::pwrite(
+                fdw.first,
+                saved_copy1.data(),
+                saved_copy1.size(),
+                static_cast<off_t>(base_offset + half_capacity)));
+        MONAD_MPT_NAMESPACE::detail::db_metadata::pending_shrink_grow_t const
+            pending{
+                MONAD_MPT_NAMESPACE::detail::db_metadata::
+                    PENDING_OP_ADD_DEVICES,
+                static_cast<uint32_t>(grown_count)};
+        for (unsigned which = 0; which < 2; which++) {
+            ASSERT_EQ(
+                ssize_t(sizeof(pending)),
+                ::pwrite(
+                    fdw.first,
+                    &pending,
+                    sizeof(pending),
+                    static_cast<off_t>(
+                        base_offset + which * half_capacity +
+                        offsetof(
+                            MONAD_MPT_NAMESPACE::detail::db_metadata,
+                            pending_shrink_grow))));
+        }
+        ASSERT_EQ(0, ::fsync(fdw.first));
+
+        // Confirm the crash window was actually built, by reading back what
+        // is genuinely on disk rather than through a mapped
+        // DbMetadataContext. If this doesn't hold, the reopen below would
+        // converge trivially (or not exercise replay at all) and the
+        // assertions past it would pass vacuously.
+        uint64_t copy1_header_word = 0;
+        ASSERT_EQ(
+            ssize_t(sizeof(copy1_header_word)),
+            ::pread(
+                fdw.first,
+                &copy1_header_word,
+                sizeof(copy1_header_word),
+                static_cast<off_t>(
+                    base_offset + half_capacity +
+                    MONAD_MPT_NAMESPACE::detail::db_metadata::
+                        MAGIC_STRING_LEN)));
+        ASSERT_EQ(copy1_header_word & 0xfffffU, uint64_t(pre_growth_count))
+            << "copy 1's chunk_info_count was not rolled back; the crash "
+               "window was not built";
+        for (unsigned which = 0; which < 2; which++) {
+            MONAD_MPT_NAMESPACE::detail::db_metadata::pending_shrink_grow_t
+                readback_pending{};
+            ASSERT_EQ(
+                ssize_t(sizeof(readback_pending)),
+                ::pread(
+                    fdw.first,
+                    &readback_pending,
+                    sizeof(readback_pending),
+                    static_cast<off_t>(
+                        base_offset + which * half_capacity +
+                        offsetof(
+                            MONAD_MPT_NAMESPACE::detail::db_metadata,
+                            pending_shrink_grow))));
+            ASSERT_EQ(
+                readback_pending.op_kind,
+                uint32_t(MONAD_MPT_NAMESPACE::detail::db_metadata::
+                             PENDING_OP_ADD_DEVICES))
+                << "copy " << which << " does not carry the pending record";
+
+            uint8_t dirty_byte = 0xff;
+            ASSERT_EQ(
+                ssize_t(sizeof(dirty_byte)),
+                ::pread(
+                    fdw.first,
+                    &dirty_byte,
+                    sizeof(dirty_byte),
+                    static_cast<off_t>(
+                        base_offset + which * half_capacity +
+                        offsetof(
+                            MONAD_MPT_NAMESPACE::detail::db_metadata,
+                            capacity_in_free_list) -
+                        1)));
+            ASSERT_EQ(dirty_byte, 0u)
+                << "copy " << which
+                << " is dirty; dirty-bit recovery (not replay) would "
+                   "resolve this window, defeating the point of the test";
+        }
+    }
+
+    // Reopening must replay and converge both copies.
+    opened_db db{both, storage_pool::mode::open_existing};
+    auto const *m0 = db.aux.metadata_ctx().main(0);
+    auto const *m1 = db.aux.metadata_ctx().main(1);
+    EXPECT_EQ(uint32_t(m0->chunk_info_count), db.io.chunk_count());
+    EXPECT_EQ(uint32_t(m1->chunk_info_count), db.io.chunk_count());
+    EXPECT_EQ(m0->capacity_in_free_list, m1->capacity_in_free_list);
+    EXPECT_EQ(free_list_ids(m0), free_list_ids(m1));
+    EXPECT_EQ(
+        m0->pending_shrink_grow.op_kind,
+        MONAD_MPT_NAMESPACE::detail::db_metadata::PENDING_OP_NONE);
+    EXPECT_EQ(
+        m1->pending_shrink_grow.op_kind,
+        MONAD_MPT_NAMESPACE::detail::db_metadata::PENDING_OP_NONE);
+}
+
+// An add interrupted between the storage layer's commit and the metadata
+// growth -- the state add_devices_death_no_mode leaves behind -- is finished by
+// re-running the same operation.
+TEST(add_devices, rerun_finishes_a_pool_layer_only_join)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const one[] = {dev0};
+    std::filesystem::path const both[] = {dev0, dev1};
+
+    size_t pre_growth_count = 0;
+    {
+        opened_db db{one, storage_pool::mode::create_if_needed};
+        pre_growth_count = db.aux.metadata_ctx().main()->chunk_info_count;
+    }
+    {
+        storage_pool const pool{both, storage_pool::mode::add_devices};
+    }
+
+    opened_db db{both, storage_pool::mode::add_devices};
+    auto const *m0 = db.aux.metadata_ctx().main(0);
+    auto const *m1 = db.aux.metadata_ctx().main(1);
+    EXPECT_GT(uint32_t(m0->chunk_info_count), pre_growth_count);
+    EXPECT_EQ(uint32_t(m0->chunk_info_count), db.io.chunk_count());
+    EXPECT_EQ(uint32_t(m1->chunk_info_count), db.io.chunk_count());
+    EXPECT_EQ(free_list_ids(m0), free_list_ids(m1));
+    EXPECT_EQ(m0->capacity_in_free_list, m1->capacity_in_free_list);
+    EXPECT_EQ(
+        m0->pending_shrink_grow.op_kind,
+        MONAD_MPT_NAMESPACE::detail::db_metadata::PENDING_OP_NONE);
+}
+
+// The bounds are unit tested directly rather than by provisioning a pool of
+// hundreds of gigabytes.
+TEST(add_devices, chunk_info_bounds)
+{
+    // 4096 chunks at 8 bytes each on top of the MONAD007 header, inside a 1Mb
+    // half-chunk: fits.
+    MONAD_MPT_NAMESPACE::test::AddDevicesTestAccess::check_chunk_info_fits(
+        4096, 1024 * 1024);
+    ASSERT_DEATH(
+        MONAD_MPT_NAMESPACE::test::AddDevicesTestAccess::check_chunk_info_fits(
+            0x100000, 1 << 30),
+        "20 bit chunk id space");
+    ASSERT_DEATH(
+        MONAD_MPT_NAMESPACE::test::AddDevicesTestAccess::check_chunk_info_fits(
+            100000, 1024 * 1024),
+        "conventional chunk 0 only provides");
+}

--- a/category/mpt/test/add_devices_test_util.hpp
+++ b/category/mpt/test/add_devices_test_util.hpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <category/async/io.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/core/assert.h>
+#include <category/core/io/buffers.hpp>
+#include <category/core/io/ring.hpp>
+#include <category/core/test_util/temp_file_cleanup.hpp>
+#include <category/mpt/db_metadata_context.hpp>
+#include <category/mpt/detail/db_metadata.hpp>
+#include <category/mpt/trie.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <vector>
+
+#include <stdlib.h>
+#include <unistd.h>
+
+namespace add_devices_test
+{
+    inline constexpr MONAD_ASYNC_NAMESPACE::file_offset_t BLKSIZE =
+        256 * 1024 * 1024;
+
+    inline std::filesystem::path
+    create_temp_file(MONAD_ASYNC_NAMESPACE::file_offset_t const length)
+    {
+        monad::test::remove_stale_temp_files_once(
+            MONAD_ASYNC_NAMESPACE::working_temporary_directory(),
+            "monad_add_devices_test_");
+        std::filesystem::path ret(
+            MONAD_ASYNC_NAMESPACE::working_temporary_directory() /
+            "monad_add_devices_test_XXXXXX");
+        int const fd = ::mkstemp((char *)ret.native().data());
+        MONAD_ASSERT(fd != -1);
+        MONAD_ASSERT(-1 != ::ftruncate(fd, static_cast<off_t>(length + 16384)));
+        ::close(fd);
+        return ret;
+    }
+
+    inline monad::io::Buffers make_buffers(
+        bool const read_only, monad::io::Ring &rd_ring,
+        monad::io::Ring &wr_ring)
+    {
+        constexpr size_t rd_size =
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE;
+        constexpr size_t wr_size =
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_WRITE_SIZE;
+        if (read_only) {
+            return monad::io::make_buffers_for_read_only(rd_ring, 2, rd_size);
+        }
+        return monad::io::make_buffers_for_segregated_read_write(
+            rd_ring, wr_ring, 2, 4, rd_size, wr_size);
+    }
+
+    // Opens the pool through a full AsyncIO and UpdateAux so the metadata
+    // constructor runs exactly as it does in production.
+    struct opened_db
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool;
+        monad::io::Ring rd_ring;
+        monad::io::Ring wr_ring;
+        monad::io::Buffers buffers;
+        MONAD_ASYNC_NAMESPACE::AsyncIO io;
+        MONAD_MPT_NAMESPACE::UpdateAux aux;
+
+        opened_db(
+            std::span<std::filesystem::path const> const devs,
+            MONAD_ASYNC_NAMESPACE::storage_pool::mode const mode,
+            MONAD_ASYNC_NAMESPACE::storage_pool::creation_flags const flags =
+                {})
+            : pool{devs, mode, flags}
+            , rd_ring{monad::io::RingConfig{2}}
+            , wr_ring{monad::io::RingConfig{4}}
+            , buffers{make_buffers(pool.is_read_only(), rd_ring, wr_ring)}
+            , io{pool, buffers}
+            , aux{io}
+        {
+        }
+    };
+
+    // The free list in list order.
+    inline std::vector<uint32_t>
+    free_list_ids(MONAD_MPT_NAMESPACE::detail::db_metadata const *const m)
+    {
+        std::vector<uint32_t> ret;
+        for (auto const *i = m->free_list_begin(); i != nullptr;
+             i = i->next(m)) {
+            ret.push_back(i->index(m));
+        }
+        return ret;
+    }
+}

--- a/category/mpt/test/cli_tool_test.cpp
+++ b/category/mpt/test/cli_tool_test.cpp
@@ -41,7 +41,9 @@
 #include <category/mpt/update.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cctype>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -56,6 +58,7 @@
 #include <utility>
 #include <vector>
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -2336,4 +2339,590 @@ TEST(cli_tool, upgrade_requires_storage)
     int const retcode = main_impl(cout, cerr, args);
     ASSERT_NE(0, retcode);
     EXPECT_TRUE(cerr.str().starts_with("FATAL:"));
+}
+
+TEST(cli_tool, rescan_devices_joins_devices_and_preserves_data)
+{
+    char path0[] = "cli_tool_tmp_add0_XXXXXX";
+    char path1[] = "cli_tool_tmp_add1_XXXXXX";
+    make_temp_pool(path0);
+    make_temp_pool(path1);
+    auto const untempfiles = monad::make_scope_exit([&]() noexcept {
+        unlink(path0);
+        unlink(path1);
+    });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "--create",
+            "--root-offsets-chunk-count",
+            "2"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    monad::byte_string const key =
+        monad::byte_string(32, static_cast<uint8_t>(0xa5));
+    monad::byte_string const value =
+        monad::byte_string(64, static_cast<uint8_t>(0x5a));
+    {
+        monad::mpt::OnDiskDbConfig const config{
+            .dbname_paths = {path0},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        monad::mpt::Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+        upsert_one(db, key, value, nullptr);
+    }
+
+    uint64_t free_before = 0;
+    size_t chunks_before = 0;
+    std::array<std::filesystem::path, 1> const one{path0};
+    std::array<std::filesystem::path, 2> const both{path0, path1};
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{one};
+        chunks_before = pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+        free_before = aux.metadata_ctx().get_lower_bound_free_space();
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            "--rescan-devices",
+            "--yes"};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(0, retcode) << cerr.str();
+        EXPECT_NE(std::string::npos, cout.str().find("1 device(s) joined"));
+    }
+
+    std::async(std::launch::async, [&] {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{both};
+        EXPECT_GT(
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq),
+            chunks_before);
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+        EXPECT_GT(aux.metadata_ctx().get_lower_bound_free_space(), free_before);
+
+        monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
+            aux,
+            aux.metadata_ctx().get_latest_root_offset(),
+            aux.metadata_ctx().db_history_max_version(),
+            monad::mpt::timeline_id::primary)};
+        monad::mpt::NodeCursor const root(root_ptr);
+        auto const ret = monad::mpt::find_blocking(
+            aux,
+            root,
+            monad::mpt::NibblesView{key},
+            aux.metadata_ctx().db_history_max_version(),
+            monad::mpt::timeline_id::primary);
+        EXPECT_EQ(ret.second, monad::mpt::find_result::success);
+    }).get();
+
+    // Joining more than one device at once: the plural "device(s)" wording,
+    // the cross-device from_new_devices/reserved_cnv summation, and the join
+    // order of a multi-device list are otherwise unexercised.
+    char path2[] = "cli_tool_tmp_add2_XXXXXX";
+    char path3[] = "cli_tool_tmp_add3_XXXXXX";
+    make_temp_pool(path2);
+    make_temp_pool(path3);
+    auto const untempfiles23 = monad::make_scope_exit([&]() noexcept {
+        unlink(path2);
+        unlink(path3);
+    });
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            path2,
+            path3,
+            "--rescan-devices",
+            "--yes"};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(0, retcode) << cerr.str();
+        EXPECT_NE(std::string::npos, cout.str().find("2 device(s) joined"));
+    }
+
+    // A read cannot see a mis-spliced free list or a wrong insertion_count --
+    // the pre-rescan nodes are still where they were. Only allocating again
+    // can, so upsert through a writable Db onto the grown metadata and then
+    // require both keys back.
+    monad::byte_string const key_after =
+        monad::byte_string(32, static_cast<uint8_t>(0x7e));
+    monad::byte_string const value_after =
+        monad::byte_string(96, static_cast<uint8_t>(0xe7));
+    {
+        // append, or the open resets the database it is meant to extend.
+        monad::mpt::OnDiskDbConfig const config{
+            .append = true,
+            .dbname_paths = {path0, path1, path2, path3},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        monad::mpt::Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+        auto v0_root = db.load_root_for_version(0);
+        ASSERT_NE(v0_root, nullptr)
+            << "version 0's root is unreachable after the rescan; history ["
+            << db.get_earliest_version() << ", " << db.get_latest_version()
+            << "]";
+        monad::mpt::UpdateList ul;
+        auto u = monad::mpt::make_update(
+            monad::mpt::NibblesView{key_after},
+            monad::byte_string_view{value_after});
+        ul.push_front(u);
+        db.upsert(std::move(v0_root), std::move(ul), 1);
+    }
+
+    std::async(std::launch::async, [&] {
+        std::array<std::filesystem::path, 4> const all{
+            path0, path1, path2, path3};
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{all};
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+
+        monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
+            aux,
+            aux.metadata_ctx().get_latest_root_offset(),
+            aux.metadata_ctx().db_history_max_version(),
+            monad::mpt::timeline_id::primary)};
+        monad::mpt::NodeCursor const root(root_ptr);
+        EXPECT_EQ(aux.metadata_ctx().db_history_max_version(), 1u)
+            << "the post-rescan upsert did not become the newest version";
+        for (auto const &[label, k] :
+             {std::pair{"pre-rescan", key},
+              std::pair{"post-rescan", key_after}}) {
+            auto const ret = monad::mpt::find_blocking(
+                aux,
+                root,
+                monad::mpt::NibblesView{k},
+                aux.metadata_ctx().db_history_max_version(),
+                monad::mpt::timeline_id::primary);
+            EXPECT_EQ(ret.second, monad::mpt::find_result::success) << label;
+        }
+    }).get();
+}
+
+// The whole feature through the tool, on exactly the state lvextend leaves:
+// a database written, closed, and its only device made larger.
+TEST(cli_tool, rescan_devices_takes_up_an_extended_device)
+{
+    char path0[] = "cli_tool_tmp_ext0_XXXXXX";
+    make_temp_pool(path0);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(path0); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "--create",
+            "--root-offsets-chunk-count",
+            "2"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    monad::byte_string const key =
+        monad::byte_string(32, static_cast<uint8_t>(0x3c));
+    monad::byte_string const value =
+        monad::byte_string(64, static_cast<uint8_t>(0xc3));
+    {
+        monad::mpt::OnDiskDbConfig const config{
+            .dbname_paths = {path0},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        monad::mpt::Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+        upsert_one(db, key, value, nullptr);
+    }
+
+    uint64_t free_before = 0;
+    size_t chunks_before = 0;
+    std::array<std::filesystem::path, 1> const one{path0};
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{one};
+        chunks_before = pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+        free_before = aux.metadata_ctx().get_lower_bound_free_space();
+    }
+
+    ASSERT_EQ(0, ::truncate(path0, 10ULL * 1024 * 1024 * 1024));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", path0, "--rescan-devices", "--yes"};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(0, retcode) << cerr.str();
+        EXPECT_NE(std::string::npos, cout.str().find("was extended in place"));
+    }
+
+    // The relocation moved the bytes-used array; a read of a pre-grow key
+    // cannot tell whether the entries survived, because the nodes have not
+    // moved. Allocating again is what would land on a chunk the pool wrongly
+    // believes empty, so upsert onto the grown metadata first.
+    monad::byte_string const key_after =
+        monad::byte_string(32, static_cast<uint8_t>(0x5a));
+    monad::byte_string const value_after =
+        monad::byte_string(96, static_cast<uint8_t>(0xa5));
+    {
+        // append, or the open resets the database it is meant to extend.
+        monad::mpt::OnDiskDbConfig const config{
+            .append = true,
+            .dbname_paths = {path0},
+            .fixed_history_length = MPT_TEST_HISTORY_LENGTH};
+        monad::mpt::Db db{std::make_unique<StateMachineAlwaysMerkle>(), config};
+        auto v0_root = db.load_root_for_version(0);
+        ASSERT_NE(v0_root, nullptr)
+            << "version 0's root is unreachable after the grow";
+        monad::mpt::UpdateList ul;
+        auto u = monad::mpt::make_update(
+            monad::mpt::NibblesView{key_after},
+            monad::byte_string_view{value_after});
+        ul.push_front(u);
+        db.upsert(std::move(v0_root), std::move(ul), 1);
+    }
+
+    std::async(std::launch::async, [&] {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{one};
+        EXPECT_GT(
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq),
+            chunks_before);
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+        EXPECT_GT(aux.metadata_ctx().get_lower_bound_free_space(), free_before);
+
+        monad::mpt::Node::SharedPtr const root_ptr{read_node_blocking(
+            aux,
+            aux.metadata_ctx().get_latest_root_offset(),
+            aux.metadata_ctx().db_history_max_version(),
+            monad::mpt::timeline_id::primary)};
+        monad::mpt::NodeCursor const root(root_ptr);
+        for (auto const &[label, k] :
+             {std::pair{"pre-grow", key}, std::pair{"post-grow", key_after}}) {
+            auto const ret = monad::mpt::find_blocking(
+                aux,
+                root,
+                monad::mpt::NibblesView{k},
+                aux.metadata_ctx().db_history_max_version(),
+                monad::mpt::timeline_id::primary);
+            EXPECT_EQ(ret.second, monad::mpt::find_result::success) << label;
+        }
+    }).get();
+}
+
+// A pool laid down before db_metadata carried device sizes records none, and
+// nothing else can say where an extend left the metadata, so the extend cannot
+// be taken up. Zeroing the array reproduces that pool exactly, since zero is
+// the not-recorded sentinel.
+TEST(cli_tool, rescan_devices_refuses_without_a_recorded_size)
+{
+    char path0[] = "cli_tool_tmp_der0_XXXXXX";
+    make_temp_pool(path0);
+    auto const untempfile =
+        monad::make_scope_exit([&]() noexcept { unlink(path0); });
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "--create",
+            "--root-offsets-chunk-count",
+            "2"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    MONAD_ASYNC_NAMESPACE::file_offset_t size_before = 0;
+    MONAD_ASYNC_NAMESPACE::file_offset_t half_capacity = 0;
+    size_t chunks_before = 0;
+    std::array<std::filesystem::path, 1> const one{path0};
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{one};
+        chunks_before = pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+        size_before = pool.devices()[0].size_bytes();
+        half_capacity =
+            pool.chunk(MONAD_ASYNC_NAMESPACE::storage_pool::cnv, 0).capacity() /
+            2;
+    }
+
+    // Both metadata copies, so nothing heals the sentinel back.
+    {
+        int const fd = ::open(path0, O_RDWR);
+        ASSERT_NE(fd, -1);
+        auto const unfd =
+            monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+        uint64_t const zero = 0;
+        for (unsigned which = 0; which < 2; which++) {
+            ASSERT_EQ(
+                ssize_t(sizeof(zero)),
+                ::pwrite(
+                    fd,
+                    &zero,
+                    sizeof(zero),
+                    static_cast<off_t>(
+                        which * half_capacity +
+                        offsetof(
+                            monad::mpt::detail::db_metadata, device_sizes))));
+        }
+        ASSERT_EQ(0, ::fsync(fd));
+
+        // Read back what is genuinely on disk: if the offset arithmetic were
+        // wrong the recorded size would survive and answer for itself, and the
+        // refusal below would never be reached.
+        for (unsigned which = 0; which < 2; which++) {
+            uint64_t readback = ~uint64_t{0};
+            ASSERT_EQ(
+                ssize_t(sizeof(readback)),
+                ::pread(
+                    fd,
+                    &readback,
+                    sizeof(readback),
+                    static_cast<off_t>(
+                        which * half_capacity +
+                        offsetof(
+                            monad::mpt::detail::db_metadata, device_sizes))));
+            ASSERT_EQ(readback, 0u)
+                << "copy " << which << " still records a device size";
+        }
+    }
+
+    ASSERT_EQ(0, ::truncate(path0, 10ULL * 1024 * 1024 * 1024));
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt", "--storage", path0, "--rescan-devices", "--yes"};
+        ASSERT_DEATH(
+            { (void)main_impl(cout, cerr, args); },
+            "must be opened writable once before its devices are extended");
+    }
+
+    // Refused before anything was written, so the extend can still be undone.
+    ASSERT_EQ(0, ::truncate(path0, static_cast<off_t>(size_before)));
+    std::async(std::launch::async, [&] {
+        MONAD_ASYNC_NAMESPACE::storage_pool const pool{one};
+        EXPECT_EQ(
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq),
+            chunks_before);
+    }).get();
+}
+
+// An add interrupted after the storage layer committed leaves every device
+// carrying the joined pool's config hash. Re-running the identical command is
+// the documented recovery, and must finish the metadata growth rather than
+// refuse the devices it already stamped.
+TEST(cli_tool, rescan_devices_rerun_finishes_an_interrupted_join)
+{
+    char path0[] = "cli_tool_tmp_arf0_XXXXXX";
+    char path1[] = "cli_tool_tmp_arf1_XXXXXX";
+    make_temp_pool(path0);
+    make_temp_pool(path1);
+    auto const untempfiles = monad::make_scope_exit([&]() noexcept {
+        unlink(path0);
+        unlink(path1);
+    });
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "--create",
+            "--root-offsets-chunk-count",
+            "2"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+
+    size_t chunks_before = 0;
+    std::array<std::filesystem::path, 2> const both{path0, path1};
+    {
+        MONAD_ASYNC_NAMESPACE::storage_pool const pool{
+            both, MONAD_ASYNC_NAMESPACE::storage_pool::mode::add_devices};
+        chunks_before = pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq);
+    }
+
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            "--rescan-devices",
+            "--yes"};
+        int const retcode = std::async(std::launch::async, [&] {
+                                return main_impl(cout, cerr, args);
+                            }).get();
+        ASSERT_EQ(0, retcode) << cerr.str();
+    }
+
+    std::async(std::launch::async, [&] {
+        MONAD_ASYNC_NAMESPACE::storage_pool pool{both};
+        EXPECT_EQ(
+            pool.chunks(MONAD_ASYNC_NAMESPACE::storage_pool::seq),
+            chunks_before);
+        monad::io::Ring ring;
+        auto buffers = monad::io::make_buffers_for_read_only(
+            ring,
+            1,
+            MONAD_ASYNC_NAMESPACE::AsyncIO::MONAD_IO_BUFFERS_READ_SIZE);
+        MONAD_ASYNC_NAMESPACE::AsyncIO io{pool, buffers};
+        monad::mpt::UpdateAux const aux{io};
+        EXPECT_EQ(
+            static_cast<size_t>(aux.metadata_ctx().main()->chunk_info_count),
+            io.chunk_count());
+    }).get();
+}
+
+TEST(cli_tool, rescan_devices_argument_cross_checks)
+{
+    char path0[] = "cli_tool_tmp_axc0_XXXXXX";
+    char path1[] = "cli_tool_tmp_axc1_XXXXXX";
+    make_temp_pool(path0);
+    make_temp_pool(path1);
+    auto const untempfiles = monad::make_scope_exit([&]() noexcept {
+        unlink(path0);
+        unlink(path1);
+    });
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "--create",
+            "--root-offsets-chunk-count",
+            "2"};
+        ASSERT_EQ(0, main_impl(cout, cerr, args));
+    }
+    // A device listed twice reads as a typo, and is decidable here.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path0,
+            "--rescan-devices",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(std::string::npos, cerr.str().find("name the same device"));
+    }
+    // A mistyped path is reported, not turned into an abort inside the pool.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            "/nonexistent-joining-device",
+            "--rescan-devices",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(std::string::npos, cerr.str().find("cannot examine"));
+    }
+    // Mutually exclusive with the other mutating operations.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            "--rescan-devices",
+            "--truncate",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+    }
+    // --restore sits outside the exclusive group and sets truncate_database,
+    // so it needs its own refusal or it would destroy the pool.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            "--rescan-devices",
+            "--restore",
+            "/nonexistent-archive",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos,
+            cerr.str().find("cannot be combined with --restore"));
+    }
+    // --archive sits outside the exclusive group too and shares the guard.
+    {
+        std::stringstream cout;
+        std::stringstream cerr;
+        std::string_view args[] = {
+            "monad-mpt",
+            "--storage",
+            path0,
+            path1,
+            "--rescan-devices",
+            "--archive",
+            "/nonexistent-archive-dest",
+            "--yes"};
+        EXPECT_NE(0, main_impl(cout, cerr, args));
+        EXPECT_NE(
+            std::string::npos,
+            cerr.str().find("cannot be combined with --restore"));
+    }
 }

--- a/category/mpt/test/db_metadata_test.cpp
+++ b/category/mpt/test/db_metadata_test.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -129,13 +130,14 @@ TEST(db_metadata, ring_b_layout_matches_ring_a)
     // Layout order: root_offsets → root_offsets_state → ... →
     // secondary_timeline → secondary_timeline_state → primary_ring_idx →
     // secondary_timeline_active_ → reserved_timeline_[14] →
-    // pending_shrink_grow → future_variables_unused.
+    // pending_shrink_grow → device_sizes → future_variables_unused.
     auto const offset_secondary = offsetof(md, secondary_timeline);
     auto const offset_secondary_state = offsetof(md, secondary_timeline_state);
     auto const offset_primary_ring_idx = offsetof(md, primary_ring_idx);
     auto const offset_active = offsetof(md, secondary_timeline_active_);
     auto const offset_reserved = offsetof(md, reserved_timeline_);
     auto const offset_pending = offsetof(md, pending_shrink_grow);
+    auto const offset_device_sizes = offsetof(md, device_sizes);
     auto const offset_future = offsetof(md, future_variables_unused);
     EXPECT_EQ(
         offset_secondary_state - offset_secondary,
@@ -147,7 +149,15 @@ TEST(db_metadata, ring_b_layout_matches_ring_a)
     EXPECT_EQ(offset_reserved, offset_active + 1);
     EXPECT_EQ(offset_pending, offset_reserved + 14);
     EXPECT_EQ(
-        offset_future, offset_pending + sizeof(md::pending_shrink_grow_t));
+        offset_device_sizes,
+        offset_pending + sizeof(md::pending_shrink_grow_t));
+    EXPECT_EQ(
+        offset_future,
+        offset_device_sizes + md::MAX_RECORDED_DEVICES * sizeof(uint64_t));
+    // device_sizes reads as not-recorded on a pool that predates it only
+    // while it stays inside the window the MONAD007 migration zeroes.
+    EXPECT_GT(offset_device_sizes, offset_secondary);
+    EXPECT_LT(offset_device_sizes, offsetof(md, free_list));
 }
 
 TEST(db_metadata, role_bytes_zero_initialized)

--- a/category/mpt/test/db_metadata_test_access.hpp
+++ b/category/mpt/test/db_metadata_test_access.hpp
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <category/mpt/config.hpp>
+#include <category/mpt/db_metadata_context.hpp>
 #include <category/mpt/detail/db_metadata.hpp>
 
+#include <cstddef>
 #include <cstdint>
 
 MONAD_MPT_NAMESPACE_BEGIN
@@ -58,6 +60,17 @@ namespace test
         static auto const &storage(ring const &r) noexcept
         {
             return r.storage_;
+        }
+    };
+
+    // Test-only access to the device-add growth internals. Offline,
+    // single-threaded use only.
+    struct AddDevicesTestAccess
+    {
+        static void
+        check_chunk_info_fits(size_t const target, size_t const mmap_size)
+        {
+            DbMetadataContext::check_chunk_info_fits_(target, mmap_size);
         }
     };
 }

--- a/category/mpt/test/device_resize_test.cpp
+++ b/category/mpt/test/device_resize_test.cpp
@@ -1,0 +1,242 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "add_devices_test_util.hpp"
+
+#include <category/async/config.hpp>
+#include <category/async/detail/scope_polyfill.hpp>
+#include <category/async/storage_pool.hpp>
+#include <category/core/assert.h>
+#include <category/core/test_util/gtest_signal_stacktrace_printer.hpp> // NOLINT
+#include <category/mpt/config.hpp>
+#include <category/mpt/detail/db_metadata.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace MONAD_ASYNC_NAMESPACE;
+using namespace MONAD_MPT_NAMESPACE;
+using add_devices_test::BLKSIZE;
+using add_devices_test::create_temp_file;
+using add_devices_test::opened_db;
+
+namespace
+{
+    // Byte offset of device_sizes[index] within metadata copy `which`, from
+    // the base of cnv chunk 0.
+    off_t device_size_offset(
+        file_offset_t const base_offset, file_offset_t const half_capacity,
+        unsigned const which, size_t const index)
+    {
+        return static_cast<off_t>(
+            base_offset + which * half_capacity +
+            offsetof(MONAD_MPT_NAMESPACE::detail::db_metadata, device_sizes) +
+            index * sizeof(uint64_t));
+    }
+
+    struct cnv0_geometry
+    {
+        file_offset_t base_offset;
+        file_offset_t half_capacity;
+    };
+
+    cnv0_geometry geometry_of(storage_pool &pool)
+    {
+        auto &cnv = pool.chunk(storage_pool::cnv, 0);
+        auto const fdr = cnv.read_fd();
+        auto const fdw = cnv.write_fd(0);
+        MONAD_ASSERT(fdr.second == fdw.second);
+        return {fdr.second, cnv.capacity() / 2};
+    }
+}
+
+TEST(device_resize, records_device_sizes_on_writable_open)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const dev1 = create_temp_file(10 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit([&]() noexcept {
+        std::filesystem::remove(dev0);
+        std::filesystem::remove(dev1);
+    });
+    std::filesystem::path const both[] = {dev0, dev1};
+
+    opened_db db{both, storage_pool::mode::create_if_needed};
+    auto const devices = db.pool.devices();
+    ASSERT_EQ(devices.size(), 2u);
+    EXPECT_NE(devices[0].size_bytes(), devices[1].size_bytes())
+        << "the two devices must differ in size, or a transposed recording "
+           "would pass";
+
+    for (unsigned which = 0; which < 2; which++) {
+        auto const *const m = db.aux.metadata_ctx().main(which);
+        EXPECT_EQ(m->device_sizes[0], devices[0].size_bytes())
+            << "copy " << which;
+        EXPECT_EQ(m->device_sizes[1], devices[1].size_bytes())
+            << "copy " << which;
+        // Slots past the device list stay at the not-recorded sentinel.
+        for (size_t n = devices.size();
+             n < MONAD_MPT_NAMESPACE::detail::db_metadata::MAX_RECORDED_DEVICES;
+             n++) {
+            EXPECT_EQ(m->device_sizes[n], 0u)
+                << "copy " << which << " slot " << n;
+        }
+    }
+}
+
+// The recorded size is what a grow reads back, so an open which is not
+// allowed to mutate the database must not touch it, and the next writable
+// open must repair whatever it finds.
+TEST(device_resize, read_only_open_leaves_recorded_device_sizes_alone)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit(
+        [&]() noexcept { std::filesystem::remove(dev0); });
+    std::filesystem::path const one[] = {dev0};
+
+    file_offset_t real_size = 0;
+    file_offset_t base_offset = 0;
+    file_offset_t half_capacity = 0;
+    {
+        opened_db db{one, storage_pool::mode::create_if_needed};
+        real_size = db.pool.devices()[0].size_bytes();
+        auto const g = geometry_of(db.pool);
+        base_offset = g.base_offset;
+        half_capacity = g.half_capacity;
+    }
+    ASSERT_GT(real_size, 0u);
+
+    // Poison both copies behind the pool's back, leaving the dirty flag
+    // clear so the next open is a plain one.
+    constexpr uint64_t poison = 0xdeadbeefdeadbeefULL;
+    {
+        storage_pool pool{one, storage_pool::mode::open_existing};
+        auto const fdw = pool.chunk(storage_pool::cnv, 0).write_fd(0);
+        for (unsigned which = 0; which < 2; which++) {
+            ASSERT_EQ(
+                ssize_t(sizeof(poison)),
+                ::pwrite(
+                    fdw.first,
+                    &poison,
+                    sizeof(poison),
+                    device_size_offset(base_offset, half_capacity, which, 0)));
+        }
+        ASSERT_EQ(0, ::fsync(fdw.first));
+    }
+
+    {
+        storage_pool::creation_flags flags;
+        flags.open_read_only = true;
+        opened_db db{one, storage_pool::mode::open_existing, flags};
+        for (unsigned which = 0; which < 2; which++) {
+            EXPECT_EQ(
+                db.aux.metadata_ctx().main(which)->device_sizes[0], poison)
+                << "a read-only open rewrote the recorded size on copy "
+                << which;
+        }
+    }
+
+    opened_db db{one, storage_pool::mode::open_existing};
+    for (unsigned which = 0; which < 2; which++) {
+        EXPECT_EQ(db.aux.metadata_ctx().main(which)->device_sizes[0], real_size)
+            << "copy " << which;
+    }
+}
+
+namespace
+{
+    // Extends a pool device in place, exactly as lvextend would.
+    void
+    extend_in_place(std::filesystem::path const &path, file_offset_t const size)
+    {
+        int const fd = ::open(path.c_str(), O_RDWR);
+        ASSERT_NE(fd, -1);
+        auto const unfd =
+            monad::make_scope_exit([fd]() noexcept { ::close(fd); });
+        ASSERT_NE(-1, ::ftruncate(fd, static_cast<off_t>(size)));
+    }
+}
+
+// The whole operation, storage layer through metadata layer: the pool sees
+// more sequential chunks than chunk_info[] describes, and grows it onto the
+// free list under the same intent record a device add uses.
+TEST(device_resize, growing_a_device_grows_chunk_info_and_free_list)
+{
+    auto const dev0 = create_temp_file(20 * BLKSIZE);
+    auto const undevs = monad::make_scope_exit(
+        [&]() noexcept { std::filesystem::remove(dev0); });
+    std::filesystem::path const one[] = {dev0};
+
+    uint32_t before_count = 0;
+    uint64_t before_capacity = 0;
+    std::vector<uint32_t> before_free;
+    file_offset_t recorded_size = 0;
+    {
+        opened_db db{one, storage_pool::mode::create_if_needed};
+        auto const *m = db.aux.metadata_ctx().main();
+        before_count = static_cast<uint32_t>(m->chunk_info_count);
+        before_capacity = m->capacity_in_free_list;
+        before_free = add_devices_test::free_list_ids(m);
+        recorded_size = m->device_sizes[0];
+    }
+    ASSERT_GT(before_count, 0u);
+    ASSERT_GT(recorded_size, 0u);
+
+    extend_in_place(dev0, 26 * BLKSIZE + 16384);
+
+    // What monad-mpt reads out of db_metadata and hands to the pool; the
+    // storage layer has no way to consult the database itself.
+    storage_pool::creation_flags flags;
+    flags.recorded_size_of_grown_device = recorded_size;
+    opened_db db{one, storage_pool::mode::add_devices, flags};
+    auto const *m0 = db.aux.metadata_ctx().main(0);
+    auto const *m1 = db.aux.metadata_ctx().main(1);
+    auto const after_count = static_cast<uint32_t>(m0->chunk_info_count);
+    EXPECT_EQ(after_count, db.io.chunk_count());
+    EXPECT_GT(after_count, before_count);
+    EXPECT_EQ(uint32_t(m1->chunk_info_count), after_count);
+
+    // The old free-list order is preserved and the chunks the extend
+    // uncovered follow it, in ascending order, at the tail.
+    auto const after_free = add_devices_test::free_list_ids(m0);
+    ASSERT_EQ(
+        after_free.size(), before_free.size() + (after_count - before_count));
+    for (size_t n = 0; n < before_free.size(); n++) {
+        EXPECT_EQ(after_free[n], before_free[n]) << "free slot " << n;
+    }
+    for (uint32_t n = before_count; n < after_count; n++) {
+        EXPECT_EQ(after_free[before_free.size() + (n - before_count)], n);
+    }
+
+    uint64_t added = 0;
+    for (uint32_t n = before_count; n < after_count; n++) {
+        added += db.pool.chunk(storage_pool::seq, n).capacity();
+    }
+    EXPECT_EQ(m0->capacity_in_free_list, before_capacity + added);
+    EXPECT_EQ(
+        m0->pending_shrink_grow.op_kind,
+        MONAD_MPT_NAMESPACE::detail::db_metadata::PENDING_OP_NONE);
+
+    // The grow recorded the device's new size, so a second extend has a
+    // previous size to be taken up from.
+    EXPECT_EQ(m0->device_sizes[0], db.pool.devices()[0].size_bytes());
+    EXPECT_EQ(m1->device_sizes[0], db.pool.devices()[0].size_bytes());
+}

--- a/category/mpt/test/update_aux_test.cpp
+++ b/category/mpt/test/update_aux_test.cpp
@@ -514,9 +514,12 @@ TEST(update_aux_test, migrates_monad007_layout_to_monad008)
     uint32_t const test_cnv_chunk_id_1 = 2;
     uint32_t const test_free_list_begin = 5;
     uint32_t const test_free_list_end = 7;
-    uint32_t const test_chunk_count = static_cast<uint32_t>(
-        pool.chunks(monad::async::storage_pool::seq) +
-        pool.chunks(monad::async::storage_pool::cnv));
+    // chunk_info[] indexes sequential chunks only (see
+    // DbMetadataContext::reconcile_chunk_count_), so the synthetic buffer's
+    // chunk_info_count must match the pool's seq chunk count exactly, not
+    // seq + cnv.
+    uint32_t const test_chunk_count =
+        static_cast<uint32_t>(pool.chunks(monad::async::storage_pool::seq));
 
     auto &cnv_chunk = pool.chunk(monad::async::storage_pool::cnv, 0);
     auto const [write_fd, base_offset] = cnv_chunk.write_fd(0);

--- a/category/mpt/update_aux.cpp
+++ b/category/mpt/update_aux.cpp
@@ -482,9 +482,14 @@ void UpdateAux::init(AsyncIO &io_, std::optional<uint64_t> const history_len)
             }
         }
     }
-    // If the pool has changed since we configured the metadata, this will
-    // fail
-    MONAD_ASSERT(metadata_ctx_->main()->chunk_info_count == io->chunk_count());
+    // If the pool has changed since we configured the metadata, this will fail
+    MONAD_ASSERT_PRINTF(
+        metadata_ctx_->main()->chunk_info_count == io->chunk_count(),
+        "DB metadata describes %u sequential chunks but the storage pool "
+        "provides %zu. If storage was added, by attaching a device or by "
+        "extending one in place, run 'monad-mpt --rescan-devices'.",
+        unsigned(metadata_ctx_->main()->chunk_info_count),
+        io->chunk_count());
 }
 
 void UpdateAux::reset_node_writers()


### PR DESCRIPTION
Growing a node's database meant --archive then --restore into a freshly created larger pool: scratch space, plus a full dump and restore. Extending a device the pool already owned was worse than unsupported -- the metadata saying a device belongs to a pool lives at its very end, so lvextend left it unopenable, with no resize2fs step to follow.

--rescan-devices reconciles a database with whatever storage it is now given: --storage lists every device it should contain, and one offline run joins any blank suffix and takes up the space of an extended last device, under one confirmation and one metadata growth.

Taking up an extend needs the previous size of the device, which the extend itself strands mid-device, so db_metadata now records every device's size on each writable open, in padding it already reserves -- no magic bump, no migration. That recording is the only source, and is acted on only where the stranded footer's config_hash confirms it, so an extend must be preceded by a writable open under a release carrying this code.

Refusing two sources that name one device is needed here, but the hole is not new: creating a pool with a device listed twice was silently accepted, and no later open could detect it. That check goes in the constructor, for every mode.