### PR TITLE
Fix 32-byte over-read of the EVM output buffer in `mce`

### DIFF
--- a/cmd/vm/mce/mce.cpp
+++ b/cmd/vm/mce/mce.cpp
@@ -20,12 +20,11 @@
 #include <instrumentation_device.hpp>
 #include <stopwatch.hpp>
 
-#include <category/core/int.hpp>
+#include <category/core/byte_string.hpp>
+#include <category/core/hex.hpp>
 #include <category/core/log.hpp>
-#include <category/core/runtime/uint256.hpp>
 #include <category/vm/compiler/ir/basic_blocks.hpp>
 #include <category/vm/compiler/ir/x86/types.hpp>
-#include <category/vm/compiler/types.hpp>
 #include <category/vm/evm/traits.hpp>
 
 #include <asmjit/core/jitruntime.h>
@@ -147,13 +146,8 @@ static void dump_result(arguments const &args, evmc::Result const &result)
     }
 
     if (result.status_code == EVMC_SUCCESS) {
-        if (result.output_size == 0) {
-            object["result"] = json("");
-        }
-        else {
-            auto const x = load_be_unsafe<uint256_t>(&result.output_data[0]);
-            object["result"] = json(x.to_string(16));
-        }
+        object["result"] = json(monad::to_hex(
+            monad::byte_string_view{result.output_data, result.output_size}));
     }
     else {
         switch (result.status_code) {


### PR DESCRIPTION
`dump_result` read a fixed 32 bytes out of `result.output_data` whenever `output_size` was non-zero. `Context::copy_result_data` allocates that buffer with `std::malloc(*size)` for exactly the size the executed bytecode passes to `RETURN`, so any `RETURN` of 1..31 bytes over-read the allocation by up to 31 bytes and hex-printed adjacent heap into the tool's JSON. The same load silently truncated results longer than 32 bytes to their first word.

Now hex-encodes exactly `output_size` bytes, which fixes both.

### Before / after

A single returned byte `0x2a`, three consecutive runs on `main`:

```
$ printf '602a60005360016000f3' > ret1.hex
$ mce -r ret1.hex
{"result": "2a00099925560000000000000000000030306633000000006102000000000000"}
{"result": "2a46eb64be600000000000000000000030306633000000006102000000000000"}
{"result": "2a731c3e85600000000000000000000030306633000000006102000000000000"}
```

Only the leading `2a` is the result; the other 31 bytes are live heap, and differ per run. The recurring `30306633` is ASCII `"00f3"` — the tail of the input file's own hex text, sitting next to the output buffer. With this patch that input prints `{"result": "2a"}` on every run.

The truncation is the same defect from the other side — 64 returned bytes rendered as one digit:

```
$ printf '60406000f3' > ret64.hex
$ mce -r ret64.hex
{"result": "0"}          # before
{"result": "0000...."}   # after, all 128 hex digits
```

Under `gcc-asan`, the unmodified binary on the one-byte return:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 32 at 0x72602abe01f0
  #3 dump_result  cmd/vm/mce/mce.cpp:154
0x72602abe01f1 is located 0 bytes after 1-byte region
allocated by:
  #1 Context::copy_result_data  category/vm/runtime/context.cpp:208
```

After the patch: no overflow on returns of 0, 1, 32 or 64 bytes.

### Notes for review

- **Output format changes** for results that are not exactly one word wide: a 32-byte `RETURN` of 42 renders as 64 zero-padded hex digits rather than `"2a"`. Nothing consumes this output — the only references to `mce` outside its own sources are `cmd/vm/mce/CMakeLists.txt` and `cmd/CMakeLists.txt`.
- `category/vm/compiler/types.hpp` is dropped alongside the two integer headers; it was included only for its `uint256_t` alias, used solely on the removed line.
- A **pre-existing** heap-use-after-free at `mce_main` scope exit — `Binary bin` is declared before `asmjit::JitRuntime rt`, so `rt` is destroyed first and `bin`'s `shared_ptr<Nativecode>` releases into the freed `JitAllocator` — is left untouched for a separate change.

Raised as EXEC-063 in the mythos-review audit batch (EXE-150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
