### PR TITLE
[execution/vm] Port evmc_status_code to an in-tree Monad type

### DIFF
--- a/category/execution/ethereum/db/test/test_db.cpp
+++ b/category/execution/ethereum/db/test/test_db.cpp
@@ -31,6 +31,7 @@
 #include <category/mpt/test/test_fixtures_gtest.hpp>
 #include <category/mpt/traverse.hpp>
 #include <category/mpt/traverse_util.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <nlohmann/json.hpp>
 
@@ -873,7 +874,7 @@ TYPED_TEST(DBTest, commit_call_frames)
         .gas_used = 21'000u,
         .input = byte_string{0xaa, 0xbb, 0xcc},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
     };
 
@@ -887,7 +888,7 @@ TYPED_TEST(DBTest, commit_call_frames)
         .gas_used = 10'000u,
         .input = byte_string{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01},
         .output = byte_string{0x01, 0x02},
-        .status = EVMC_REVERT,
+        .status = MONAD_STATUS_REVERT,
         .depth = 1,
     };
 

--- a/category/execution/ethereum/execute_block_test.cpp
+++ b/category/execution/ethereum/execute_block_test.cpp
@@ -46,6 +46,7 @@
 #include <category/mpt/util.hpp>
 #include <category/vm/code.hpp>
 #include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/status_code.h>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
 
@@ -697,7 +698,7 @@ TYPED_TEST(TraitsTest, call_frames_refund)
         .value = 0,
         .gas = 0x186a0,
         .gas_used = gas_used,
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
         .logs = std::vector<CallFrame::Log>{},
     };

--- a/category/execution/ethereum/precompiles.cpp
+++ b/category/execution/ethereum/precompiles.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/precompiles.hpp>
 #include <category/execution/ethereum/precompiles_impl.hpp>
 #include <category/vm/evm/explicit_traits.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -166,8 +167,8 @@ std::optional<evmc::Result> check_call_eth_precompile(evmc_message const &msg)
 
     auto const [status_code, output_buffer, output_size] = execute_func(input);
     return evmc::Result{evmc_result{
-        .status_code = status_code,
-        .gas_left = (status_code == EVMC_SUCCESS)
+        .status_code = to_evmc_status_code(status_code),
+        .gas_left = (status_code == MONAD_STATUS_SUCCESS)
                         ? msg.gas - static_cast<int64_t>(cost.value())
                         : 0,
         .gas_refund = 0,
@@ -201,9 +202,9 @@ from_impl_result(PrecompileImplResult result, uint8_t *out)
     }
     if (size == 0) {
         std::free(out);
-        return {EVMC_SUCCESS, nullptr, size};
+        return {MONAD_STATUS_SUCCESS, nullptr, size};
     }
-    return {EVMC_SUCCESS, data, size};
+    return {MONAD_STATUS_SUCCESS, data, size};
 }
 
 PrecompileResult ecrecover_execute(byte_string_view const input)
@@ -218,11 +219,11 @@ PrecompileResult ecrecover_execute(byte_string_view const input)
     auto const s{load_be_unsafe<uint256_t>(&d[96])};
 
     if (!Secp256k1Signature{r, s}.has_valid_range()) {
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
 
     if (v != 27 && v != 28) {
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
 
     uint8_t *out{static_cast<uint8_t *>(std::aligned_alloc(8, 32))};
@@ -235,10 +236,10 @@ PrecompileResult ecrecover_execute(byte_string_view const input)
             std::span<uint8_t const, 64>{&d[64], 64},
             v != 27)) {
         std::free(out);
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
     else {
-        return {EVMC_SUCCESS, out, 32};
+        return {MONAD_STATUS_SUCCESS, out, 32};
     }
 }
 
@@ -277,7 +278,7 @@ PrecompileResult expmod_execute(byte_string_view const input)
     uint64_t const mod_len = load_be_unsafe<uint64_t>(&header[88]);
 
     if (mod_len == 0) {
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
 
     uint64_t const base_len = load_be_unsafe<uint64_t>(&header[24]);
@@ -420,21 +421,21 @@ PrecompileResult p256_verify_execute(byte_string_view const input)
         p256_verify_impl(input, std::span<uint8_t, 32>{out, 32});
     if (result.data == nullptr) {
         std::free(out);
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
-    return {EVMC_SUCCESS, result.data, result.size};
+    return {MONAD_STATUS_SUCCESS, result.data, result.size};
 }
 
 PrecompileResult identity_execute(byte_string_view const input)
 {
     if (input.empty()) {
-        return {EVMC_SUCCESS, nullptr, 0};
+        return {MONAD_STATUS_SUCCESS, nullptr, 0};
     }
     auto *const out = static_cast<uint8_t *>(std::malloc(input.size()));
     MONAD_ASSERT(out != nullptr);
     auto const result =
         identity_impl(input, std::span<uint8_t>{out, input.size()});
-    return {EVMC_SUCCESS, result.data, result.size};
+    return {MONAD_STATUS_SUCCESS, result.data, result.size};
 }
 
 MONAD_NAMESPACE_END

--- a/category/execution/ethereum/precompiles.hpp
+++ b/category/execution/ethereum/precompiles.hpp
@@ -19,6 +19,7 @@
 #include <category/core/byte_string.hpp>
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
+#include <category/vm/evm/status_code.h>
 #include <category/vm/evm/traits.hpp>
 
 #include <evmc/evmc.h>
@@ -123,14 +124,14 @@ uint64_t p256_verify_gas_cost(byte_string_view);
 
 struct PrecompileResult
 {
-    evmc_status_code status_code;
+    monad_status_code status_code;
     uint8_t *obuf;
     size_t output_size;
 
     static constexpr PrecompileResult failure() noexcept
     {
         return {
-            .status_code = EVMC_PRECOMPILE_FAILURE,
+            .status_code = MONAD_STATUS_PRECOMPILE_FAILURE,
             .obuf = nullptr,
             .output_size = 0,
         };

--- a/category/execution/ethereum/test/test_call_frame_rlp.cpp
+++ b/category/execution/ethereum/test/test_call_frame_rlp.cpp
@@ -17,6 +17,7 @@
 #include <category/execution/ethereum/core/block.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/trace/rlp/call_frame_rlp.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <evmc/evmc.hpp>
 
@@ -44,7 +45,7 @@ TEST(Rlp_CallFrame, encode_decode_call_frame)
         .gas_used = 21'000u,
         .input = byte_string{0xaa, 0xbb, 0xcc},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
     };
 
@@ -67,7 +68,7 @@ TEST(Rlp_CallFrame, encode_decode_call_frames)
         .gas_used = 21'000u,
         .input = byte_string{0xaa, 0xbb, 0xcc},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
         .logs = std::nullopt,
     };
@@ -82,7 +83,7 @@ TEST(Rlp_CallFrame, encode_decode_call_frames)
         .gas_used = 10'000u,
         .input = byte_string{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01},
         .output = byte_string{0x01, 0x02},
-        .status = EVMC_REVERT,
+        .status = MONAD_STATUS_REVERT,
         .depth = 1,
         .logs = std::vector{
             CallFrame::Log{

--- a/category/execution/ethereum/test/test_call_trace.cpp
+++ b/category/execution/ethereum/test/test_call_trace.cpp
@@ -37,6 +37,7 @@
 #include <category/execution/ethereum/types/incarnation.hpp>
 #include <category/execution/monad/chain/monad_chain.hpp>
 #include <category/vm/code.hpp>
+#include <category/vm/evm/status_code.h>
 #include <category/vm/utils/evm-as.hpp>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
@@ -81,7 +82,7 @@ TEST(CallFrame, to_json)
         .gas = 100'000u,
         .gas_used = 21'000u,
         .input = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
     };
 
     auto const json_str = R"(
@@ -202,7 +203,7 @@ TYPED_TEST(TraitsTest, execute_success)
         .value = 0x10000,
         .gas = 0x100000,
         .gas_used = 0x5208,
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
         .logs = std::vector<CallFrame::Log>{},
     };
@@ -287,7 +288,7 @@ TYPED_TEST(TraitsTest, execute_reverted_insufficient_balance)
         .value = 0x10000,
         .gas = 0x10000,
         .gas_used = 0x5208,
-        .status = EVMC_INSUFFICIENT_BALANCE,
+        .status = MONAD_STATUS_INSUFFICIENT_BALANCE,
         .depth = 0,
         .logs = std::vector<CallFrame::Log>{},
     };
@@ -380,7 +381,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
     EXPECT_EQ(call_frames[0].value, 0u);
     EXPECT_EQ(call_frames[0].input, byte_string{});
     EXPECT_EQ(call_frames[0].output, byte_string{});
-    EXPECT_EQ(call_frames[0].status, EVMC_SUCCESS);
+    EXPECT_EQ(call_frames[0].status, MONAD_STATUS_SUCCESS);
     EXPECT_EQ(call_frames[0].depth, 0u);
     EXPECT_EQ(call_frames[0].logs, std::vector<CallFrame::Log>{});
 
@@ -391,7 +392,7 @@ TYPED_TEST(TraitsTest, create_call_trace)
     EXPECT_EQ(call_frames[1].value, 0u);
     EXPECT_EQ(call_frames[1].input, 0xFE_bytes);
     EXPECT_EQ(call_frames[1].output, byte_string{});
-    EXPECT_EQ(call_frames[1].status, EVMC_FAILURE);
+    EXPECT_EQ(call_frames[1].status, MONAD_STATUS_FAILURE);
     EXPECT_EQ(call_frames[1].depth, 1u);
     EXPECT_EQ(call_frames[1].logs, std::vector<CallFrame::Log>{});
 }
@@ -773,7 +774,7 @@ TYPED_TEST(TraitsTest, simulate_v1_trace)
         .value = 1'000'000,
         .gas = 1'000'000,
         .gas_used = 21'000,
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
         .logs = std::vector<CallFrame::Log>{{
             {

--- a/category/execution/ethereum/trace/call_frame.cpp
+++ b/category/execution/ethereum/trace/call_frame.cpp
@@ -21,6 +21,7 @@
 #include <category/core/likely.h>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/vm/evm/opcodes.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -79,11 +80,11 @@ nlohmann::json to_json(CallFrame const &f)
     res["input"] = "0x" + to_hex(f.input);
     res["output"] = "0x" + to_hex(f.output);
 
-    // If status == EVMC_SUCCESS, no error field is shown
-    if (f.status == EVMC_REVERT) {
+    // If status == MONAD_STATUS_SUCCESS, no error field is shown
+    if (f.status == MONAD_STATUS_REVERT) {
         res["error"] = "REVERT";
     }
-    else if (f.status != EVMC_SUCCESS) {
+    else if (f.status != MONAD_STATUS_SUCCESS) {
         res["error"] = "ERROR";
     }
 

--- a/category/execution/ethereum/trace/call_frame.hpp
+++ b/category/execution/ethereum/trace/call_frame.hpp
@@ -20,6 +20,7 @@
 #include <category/core/config.hpp>
 #include <category/core/int.hpp>
 #include <category/execution/ethereum/core/receipt.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <evmc/evmc.hpp>
 #include <nlohmann/json_fwd.hpp>
@@ -81,7 +82,7 @@ struct CallFrame
     uint64_t gas_used{};
     byte_string input{};
     byte_string output{};
-    evmc_status_code status{};
+    monad_status_code status{};
     uint64_t depth{};
     std::optional<std::vector<Log>> logs{};
 

--- a/category/execution/ethereum/trace/call_tracer.cpp
+++ b/category/execution/ethereum/trace/call_tracer.cpp
@@ -25,6 +25,7 @@
 #include <category/execution/ethereum/core/transaction.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
 #include <category/execution/ethereum/trace/call_tracer.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
@@ -149,7 +150,7 @@ void CallTracer::on_enter(evmc_message const &msg)
                      ? byte_string{}
                      : byte_string{msg.input_data, msg.input_size},
         .output = {},
-        .status = EVMC_FAILURE,
+        .status = MONAD_STATUS_FAILURE,
         .depth = depth,
         .logs = std::vector<CallFrame::Log>{},
     });
@@ -173,7 +174,7 @@ void CallTracer::on_exit(evmc::Result const &res)
                            ? byte_string{}
                            : byte_string{res.output_data, res.output_size};
     }
-    frame.status = res.status_code;
+    frame.status = from_evmc_status_code(res.status_code);
 
     if (frame.type == CallType::CREATE || frame.type == CallType::CREATE2) {
         frame.to = is_zero(res.create_address)
@@ -217,7 +218,7 @@ void CallTracer::on_self_destruct(
         .gas_used = 0,
         .input = {},
         .output = {},
-        .status = EVMC_SUCCESS, // TODO
+        .status = MONAD_STATUS_SUCCESS, // TODO
         .depth = parent.depth + 1,
         .logs = std::vector<CallFrame::Log>{},
     });

--- a/category/execution/ethereum/trace/rlp/call_frame_rlp.cpp
+++ b/category/execution/ethereum/trace/rlp/call_frame_rlp.cpp
@@ -24,6 +24,7 @@
 #include <category/execution/ethereum/rlp/decode.hpp>
 #include <category/execution/ethereum/rlp/encode2.hpp>
 #include <category/execution/ethereum/trace/call_frame.hpp>
+#include <category/vm/evm/status_code.h>
 
 #include <boost/outcome/try.hpp>
 
@@ -125,7 +126,7 @@ Result<CallFrame> decode_call_frame(byte_string_view &enc)
     BOOST_OUTCOME_TRY(call_frame.output, decode_string(payload));
     BOOST_OUTCOME_TRY(
         auto const status, decode_unsigned<unsigned char>(payload));
-    call_frame.status = static_cast<enum evmc_status_code>(status);
+    call_frame.status = static_cast<enum monad_status_code>(status);
     BOOST_OUTCOME_TRY(call_frame.depth, decode_unsigned<uint64_t>(payload));
 
     if (MONAD_UNLIKELY(payload.empty())) {

--- a/category/rpc/monad_executor.cpp
+++ b/category/rpc/monad_executor.cpp
@@ -71,6 +71,7 @@
 #include <category/rpc/eth_simulate_block_hash_buffer.hpp>
 #include <category/rpc/lazy_block_hash.hpp>
 #include <category/vm/evm/revision.h>
+#include <category/vm/evm/status_code.h>
 #include <category/vm/evm/switch_traits.hpp>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/vm.hpp>
@@ -701,14 +702,14 @@ namespace
 
             call_result["status"] = std::format(
                 "0x{:x}",
-                call_frames[tx_idx][0].status == EVMC_SUCCESS ? 1 : 0);
+                call_frames[tx_idx][0].status == MONAD_STATUS_SUCCESS ? 1 : 0);
             call_result["returnData"] =
                 format_hex(call_frames[tx_idx][0].output);
             call_result["gasUsed"] =
                 std::format("0x{:x}", call_frames[tx_idx][0].gas_used);
 
             size_t log_index = 0;
-            if (call_frames[tx_idx][0].status == EVMC_SUCCESS) {
+            if (call_frames[tx_idx][0].status == MONAD_STATUS_SUCCESS) {
                 call_result["logs"] = nlohmann::json::array();
                 for (auto const &log : receipts[tx_idx].logs) {
                     call_result["logs"].emplace_back(nlohmann::json{

--- a/category/rpc/monad_executor_test.cpp
+++ b/category/rpc/monad_executor_test.cpp
@@ -59,6 +59,7 @@
 #include <category/vm/code.hpp>
 #include <category/vm/evm/delegation.hpp>
 #include <category/vm/evm/monad/revision.h>
+#include <category/vm/evm/status_code.h>
 #include <category/vm/evm/traits.hpp>
 #include <category/vm/interpreter/intercode.hpp>
 #include <category/vm/utils/evm-as.hpp>
@@ -276,7 +277,7 @@ namespace
             .gas = gas_specified ? tx.gas_limit : MONAD_ETH_CALL_LOW_GAS_LIMIT,
             .gas_used =
                 gas_specified ? tx.gas_limit : MONAD_ETH_CALL_LOW_GAS_LIMIT,
-            .status = EVMC_SUCCESS,
+            .status = MONAD_STATUS_SUCCESS,
             .depth = 0,
             .logs = std::vector<CallFrame::Log>{},
         };
@@ -1441,7 +1442,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
         .gas_used = 100'000,
         .input = byte_string{},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 0,
         .logs =
             std::vector{
@@ -1480,7 +1481,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
         .gas_used = 10'115,
         .input = byte_string{},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 1,
         .logs = std::vector<CallFrame::Log>{},
     };
@@ -1497,7 +1498,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
         .gas_used = 0,
         .input = byte_string{},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 2,
         .logs = std::vector<CallFrame::Log>{},
     };
@@ -1513,7 +1514,7 @@ TEST_F(EthCallFixture, call_trace_with_logs)
         .gas_used = 1027,
         .input = byte_string{},
         .output = byte_string{},
-        .status = EVMC_SUCCESS,
+        .status = MONAD_STATUS_SUCCESS,
         .depth = 1,
         .logs = std::vector{CallFrame::Log{
             .log =
@@ -1617,7 +1618,7 @@ TEST_F(EthCallFixture, static_precompile_OOG_with_call_trace)
         .gas = 22000,
         .gas_used = 22000,
         .input = byte_string(data),
-        .status = EVMC_OUT_OF_GAS,
+        .status = MONAD_STATUS_OUT_OF_GAS,
         .depth = 0,
         .logs = std::vector<CallFrame::Log>{},
     };

--- a/category/vm/evm/CMakeLists.txt
+++ b/category/vm/evm/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(monad-vm-evm PRIVATE
     "opcodes_xmacro.hpp"
     "revision.cpp"
     "revision.h"
+    "status_code.cpp"
+    "status_code.h"
     "switch_traits.hpp"
     "traits.hpp"
 

--- a/category/vm/evm/status_code.cpp
+++ b/category/vm/evm/status_code.cpp
@@ -1,0 +1,156 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/core/assert.h>
+#include <category/vm/evm/status_code.h>
+
+#include <evmc/evmc.h>
+
+#include <utility>
+
+#define MONAD_ASSERT_STATUS_EQ(name)                                           \
+    static_assert(                                                             \
+        std::to_underlying(MONAD_STATUS_##name) ==                             \
+        std::to_underlying(EVMC_##name))
+
+MONAD_ASSERT_STATUS_EQ(SUCCESS);
+MONAD_ASSERT_STATUS_EQ(FAILURE);
+MONAD_ASSERT_STATUS_EQ(REVERT);
+MONAD_ASSERT_STATUS_EQ(OUT_OF_GAS);
+MONAD_ASSERT_STATUS_EQ(INVALID_INSTRUCTION);
+MONAD_ASSERT_STATUS_EQ(UNDEFINED_INSTRUCTION);
+MONAD_ASSERT_STATUS_EQ(STACK_OVERFLOW);
+MONAD_ASSERT_STATUS_EQ(STACK_UNDERFLOW);
+MONAD_ASSERT_STATUS_EQ(BAD_JUMP_DESTINATION);
+MONAD_ASSERT_STATUS_EQ(INVALID_MEMORY_ACCESS);
+MONAD_ASSERT_STATUS_EQ(CALL_DEPTH_EXCEEDED);
+MONAD_ASSERT_STATUS_EQ(STATIC_MODE_VIOLATION);
+MONAD_ASSERT_STATUS_EQ(PRECOMPILE_FAILURE);
+MONAD_ASSERT_STATUS_EQ(CONTRACT_VALIDATION_FAILURE);
+MONAD_ASSERT_STATUS_EQ(ARGUMENT_OUT_OF_RANGE);
+MONAD_ASSERT_STATUS_EQ(WASM_UNREACHABLE_INSTRUCTION);
+MONAD_ASSERT_STATUS_EQ(WASM_TRAP);
+MONAD_ASSERT_STATUS_EQ(INSUFFICIENT_BALANCE);
+MONAD_ASSERT_STATUS_EQ(INTERNAL_ERROR);
+MONAD_ASSERT_STATUS_EQ(REJECTED);
+MONAD_ASSERT_STATUS_EQ(OUT_OF_MEMORY);
+
+#undef MONAD_ASSERT_STATUS_EQ
+
+static_assert(
+    std::to_underlying(MONAD_STATUS_RESERVE_BALANCE_VIOLATION) ==
+    std::to_underlying(EVMC_MONAD_RESERVE_BALANCE_VIOLATION));
+
+evmc_status_code to_evmc_status_code(monad_status_code const code)
+{
+    switch (code) {
+    case MONAD_STATUS_SUCCESS:
+        return EVMC_SUCCESS;
+    case MONAD_STATUS_FAILURE:
+        return EVMC_FAILURE;
+    case MONAD_STATUS_REVERT:
+        return EVMC_REVERT;
+    case MONAD_STATUS_OUT_OF_GAS:
+        return EVMC_OUT_OF_GAS;
+    case MONAD_STATUS_INVALID_INSTRUCTION:
+        return EVMC_INVALID_INSTRUCTION;
+    case MONAD_STATUS_UNDEFINED_INSTRUCTION:
+        return EVMC_UNDEFINED_INSTRUCTION;
+    case MONAD_STATUS_STACK_OVERFLOW:
+        return EVMC_STACK_OVERFLOW;
+    case MONAD_STATUS_STACK_UNDERFLOW:
+        return EVMC_STACK_UNDERFLOW;
+    case MONAD_STATUS_BAD_JUMP_DESTINATION:
+        return EVMC_BAD_JUMP_DESTINATION;
+    case MONAD_STATUS_INVALID_MEMORY_ACCESS:
+        return EVMC_INVALID_MEMORY_ACCESS;
+    case MONAD_STATUS_CALL_DEPTH_EXCEEDED:
+        return EVMC_CALL_DEPTH_EXCEEDED;
+    case MONAD_STATUS_STATIC_MODE_VIOLATION:
+        return EVMC_STATIC_MODE_VIOLATION;
+    case MONAD_STATUS_PRECOMPILE_FAILURE:
+        return EVMC_PRECOMPILE_FAILURE;
+    case MONAD_STATUS_CONTRACT_VALIDATION_FAILURE:
+        return EVMC_CONTRACT_VALIDATION_FAILURE;
+    case MONAD_STATUS_ARGUMENT_OUT_OF_RANGE:
+        return EVMC_ARGUMENT_OUT_OF_RANGE;
+    case MONAD_STATUS_WASM_UNREACHABLE_INSTRUCTION:
+        return EVMC_WASM_UNREACHABLE_INSTRUCTION;
+    case MONAD_STATUS_WASM_TRAP:
+        return EVMC_WASM_TRAP;
+    case MONAD_STATUS_INSUFFICIENT_BALANCE:
+        return EVMC_INSUFFICIENT_BALANCE;
+    case MONAD_STATUS_INTERNAL_ERROR:
+        return EVMC_INTERNAL_ERROR;
+    case MONAD_STATUS_REJECTED:
+        return EVMC_REJECTED;
+    case MONAD_STATUS_OUT_OF_MEMORY:
+        return EVMC_OUT_OF_MEMORY;
+    case MONAD_STATUS_RESERVE_BALANCE_VIOLATION:
+        return EVMC_MONAD_RESERVE_BALANCE_VIOLATION;
+    }
+    MONAD_ABORT("unhandled monad_status_code");
+}
+
+monad_status_code from_evmc_status_code(evmc_status_code const code)
+{
+    switch (code) {
+    case EVMC_SUCCESS:
+        return MONAD_STATUS_SUCCESS;
+    case EVMC_FAILURE:
+        return MONAD_STATUS_FAILURE;
+    case EVMC_REVERT:
+        return MONAD_STATUS_REVERT;
+    case EVMC_OUT_OF_GAS:
+        return MONAD_STATUS_OUT_OF_GAS;
+    case EVMC_INVALID_INSTRUCTION:
+        return MONAD_STATUS_INVALID_INSTRUCTION;
+    case EVMC_UNDEFINED_INSTRUCTION:
+        return MONAD_STATUS_UNDEFINED_INSTRUCTION;
+    case EVMC_STACK_OVERFLOW:
+        return MONAD_STATUS_STACK_OVERFLOW;
+    case EVMC_STACK_UNDERFLOW:
+        return MONAD_STATUS_STACK_UNDERFLOW;
+    case EVMC_BAD_JUMP_DESTINATION:
+        return MONAD_STATUS_BAD_JUMP_DESTINATION;
+    case EVMC_INVALID_MEMORY_ACCESS:
+        return MONAD_STATUS_INVALID_MEMORY_ACCESS;
+    case EVMC_CALL_DEPTH_EXCEEDED:
+        return MONAD_STATUS_CALL_DEPTH_EXCEEDED;
+    case EVMC_STATIC_MODE_VIOLATION:
+        return MONAD_STATUS_STATIC_MODE_VIOLATION;
+    case EVMC_PRECOMPILE_FAILURE:
+        return MONAD_STATUS_PRECOMPILE_FAILURE;
+    case EVMC_CONTRACT_VALIDATION_FAILURE:
+        return MONAD_STATUS_CONTRACT_VALIDATION_FAILURE;
+    case EVMC_ARGUMENT_OUT_OF_RANGE:
+        return MONAD_STATUS_ARGUMENT_OUT_OF_RANGE;
+    case EVMC_WASM_UNREACHABLE_INSTRUCTION:
+        return MONAD_STATUS_WASM_UNREACHABLE_INSTRUCTION;
+    case EVMC_WASM_TRAP:
+        return MONAD_STATUS_WASM_TRAP;
+    case EVMC_INSUFFICIENT_BALANCE:
+        return MONAD_STATUS_INSUFFICIENT_BALANCE;
+    case EVMC_MONAD_RESERVE_BALANCE_VIOLATION:
+        return MONAD_STATUS_RESERVE_BALANCE_VIOLATION;
+    case EVMC_INTERNAL_ERROR:
+        return MONAD_STATUS_INTERNAL_ERROR;
+    case EVMC_REJECTED:
+        return MONAD_STATUS_REJECTED;
+    case EVMC_OUT_OF_MEMORY:
+        return MONAD_STATUS_OUT_OF_MEMORY;
+    }
+    MONAD_ABORT("unhandled evmc_status_code");
+}

--- a/category/vm/evm/status_code.h
+++ b/category/vm/evm/status_code.h
@@ -1,0 +1,58 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <evmc/evmc.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+enum monad_status_code : int
+{
+    MONAD_STATUS_SUCCESS = 0,
+    MONAD_STATUS_FAILURE = 1,
+    MONAD_STATUS_REVERT = 2,
+    MONAD_STATUS_OUT_OF_GAS = 3,
+    MONAD_STATUS_INVALID_INSTRUCTION = 4,
+    MONAD_STATUS_UNDEFINED_INSTRUCTION = 5,
+    MONAD_STATUS_STACK_OVERFLOW = 6,
+    MONAD_STATUS_STACK_UNDERFLOW = 7,
+    MONAD_STATUS_BAD_JUMP_DESTINATION = 8,
+    MONAD_STATUS_INVALID_MEMORY_ACCESS = 9,
+    MONAD_STATUS_CALL_DEPTH_EXCEEDED = 10,
+    MONAD_STATUS_STATIC_MODE_VIOLATION = 11,
+    MONAD_STATUS_PRECOMPILE_FAILURE = 12,
+    MONAD_STATUS_CONTRACT_VALIDATION_FAILURE = 13,
+    MONAD_STATUS_ARGUMENT_OUT_OF_RANGE = 14,
+    MONAD_STATUS_WASM_UNREACHABLE_INSTRUCTION = 15,
+    MONAD_STATUS_WASM_TRAP = 16,
+    MONAD_STATUS_INSUFFICIENT_BALANCE = 17,
+    // Fork-only: no upstream evmc counterpart.
+    MONAD_STATUS_RESERVE_BALANCE_VIOLATION = 18,
+
+    MONAD_STATUS_INTERNAL_ERROR = -1,
+    MONAD_STATUS_REJECTED = -2,
+    MONAD_STATUS_OUT_OF_MEMORY = -3
+};
+
+enum evmc_status_code to_evmc_status_code(enum monad_status_code code);
+enum monad_status_code from_evmc_status_code(enum evmc_status_code code);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/test/vm/unit/CMakeLists.txt
+++ b/test/vm/unit/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(vm-unit-tests PRIVATE
     emitter_tests.cpp
     interpreter_tests.cpp
     lru_weight_cache_tests.cpp
+    status_code_tests.cpp
     test_params.cpp
     runtime/fixture.cpp
     runtime/fixture.S

--- a/test/vm/unit/status_code_tests.cpp
+++ b/test/vm/unit/status_code_tests.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2025-26 Category Labs, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <category/vm/evm/status_code.h>
+
+#include <evmc/evmc.h>
+
+#include <gtest/gtest.h>
+// magic_enum probes [-128,127] with static_cast; evmc_status_code has no
+// fixed underlying type, so GCC flags the out-of-range casts.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <magic_enum/magic_enum.hpp>
+#pragma GCC diagnostic pop
+
+#include <utility>
+
+namespace
+{
+    constexpr auto evmc_status_codes =
+        magic_enum::enum_values<evmc_status_code>();
+    constexpr auto monad_status_codes =
+        magic_enum::enum_values<monad_status_code>();
+}
+
+TEST(StatusCode, MirrorsEvmcValues)
+{
+    for (auto const evmc_code : evmc_status_codes) {
+        EXPECT_EQ(
+            std::to_underlying(from_evmc_status_code(evmc_code)),
+            std::to_underlying(evmc_code));
+    }
+}
+
+TEST(StatusCode, RoundTripsThroughEvmc)
+{
+    for (auto const code : monad_status_codes) {
+        EXPECT_EQ(
+            std::to_underlying(
+                from_evmc_status_code(to_evmc_status_code(code))),
+            std::to_underlying(code));
+    }
+}


### PR DESCRIPTION
Closes EXE-160. Unblocks EXE-173 (`evmc::Result` + the `vm::Host` vtable).

Last of the four evmc leaf types, after `bytes32_t` (#2165), `Address` (#2196) and `monad_eth_revision` (#2304). Follows the last of those closely.

## How to review

- **Commit 1** adds the type. Nothing references it yet. Builds and tests green standalone.
- **Commit 2** migrates. Two conversions; every other line is `EVMC_X` → `MONAD_STATUS_X`.

## The issue's three open questions

**The fork.** `d51cc94` on top of the 12.1.0 tag adds `EVMC_MONAD_RESERVE_BALANCE_VIOLATION = 18`; upstream stops at 17. So 22 enumerators, and the one with no upstream reference gets its own test. It also can't go through the `MONAD_STATUS_##name == EVMC_##name` macro, because evmc spells it with a vendor prefix — that assert is longhand.

**The boundary.** A status code changes type exactly where `evmc_result` does. That's forced, not chosen: `vm::Host` derives from `evmc::Host` (`vm/host.hpp:28`), so `call()`'s signature isn't ours until EXE-173.

**Proving the mirror.** Per-code `static_assert` on `std::to_underlying`, as in `revision.cpp`. A wrong value names both numbers: `note: expression evaluates to '19 == 18'`. That's what lets `to_evmc_status_code` be a bare cast.

## Scope

| | |
|---|---|
| `PrecompileResult::status_code`, `CallFrame::status` | **moved** — Monad-owned |
| `evmc::Result::status_code`, all sites | **kept** — layout fixed by `evmc_result`, behind the vtable. EXE-173 |
| variant from `Context::copy_result_data` | **kept** — private carrier for `copy_to_evmc_result`, not storage |
| `Receipt::status` | **untouched** — `uint64_t` R_z, not a status code |
| transitive `<evmc/...>` includes | **left** — separate sweep, per the issue |

Wire and ABI encodings are byte-identical, and the lines that carry them aren't in the diff: `call_frame_rlp.cpp:65` and `record_txn_events.cpp:419` already used width-agnostic conversions. `exec_event_ctypes.h` is untouched, so the bindgen Rust side is unaffected.

Kept flat-C rather than `enum class` because the safety that would buy is already there — mixing the two enums is a hard error under `-Werror` on both compilers, which is also what caught a `CallFrame` initialiser I'd missed.

## Verification

`ctest` 3892/3892 · clang-19 ASAN+UBSAN clean · clang-tidy clean · `check-trait-instantiations` · clang-format · g++-15 and clang++-19 × Debug/RelWithDebInfo · commit 1 green standalone.

TSAN not run: `clang-tsan.cmake` has a hardcoded absolute blacklist path, and this diff adds no concurrency.

## Found in passing — please file

Three, all pre-existing, none fixed here.

**1. Trace RLP can't represent the status domain.** `call_frame_rlp.cpp:65` encodes the status as one byte. Negatives are lossy, and the decoded value is then outside the enum's `[-32,31]` range, so every later read is UB — UBSAN flags it inside `std::to_underlying`, which is what `record_txn_events.cpp:419` calls in production:

```
INTERNAL_ERROR (-1)   in -1 -> out 255  LOSSY
runtime error: load of value 255, which is not a valid value for type 'monad_status_code'
```

Identical for `evmc_status_code` before this PR, so not a regression. I found no live path that persists a negative code, so this is latent. Fixing it needs a compatibility decision for stored traces.

**2. `Receipt{.status = EVMC_SUCCESS}` is 0 — a *failed* receipt.** Six sites in `monad_executor_test.cpp`. R_z is 1 for success (`record_txn_events.cpp:374`). `test_db.cpp` uses plain `.status = 1`.

**3. `precompiles_test.cpp:528` signed overflow** (UBSAN). MONAD_SEVEN's blake2F price-doubling multiplies the `INT64_MAX` default gas by 2, giving `-2`. Line is `d88013808c`, June; not in this diff. Tests still pass, so that gas value isn't checked where the comment above it implies.

---

Review rationale is on the diff lines it applies to, not in the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
