### PR TITLE
[test/vm] Use the OCaml spec VM as the unit-test differential oracle

### DIFF
--- a/scripts/vm/lsan.supp
+++ b/scripts/vm/lsan.supp
@@ -1,0 +1,5 @@
+# The OCaml runtime keeps its heap in its own mmap'd regions, which
+# LeakSanitizer does not scan as roots, so allocations owned by the spec VM
+# (libmonadml_evm.so and its statically linked ctypes/secp256k1 dependencies)
+# are reported as leaked at exit even though they are still reachable.
+leak:libmonadml_evm.so

--- a/scripts/vm/test.sh
+++ b/scripts/vm/test.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 export UBSAN_OPTIONS="halt_on_error=1"
+export LSAN_OPTIONS="suppressions=$(dirname "$0")/lsan.supp"
 ulimit -s 131072
 
 ./build/test/vm/unit/vm-unit-tests

--- a/test/vm/unit/CMakeLists.txt
+++ b/test/vm/unit/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(vm-unit-tests
 
 if(MONAD_COMPILER_TESTING)
     target_link_libraries(vm-unit-tests
-        PRIVATE evmone
+        PRIVATE monadml-evm
     )
 endif()
 

--- a/test/vm/unit/evm_fixture.hpp
+++ b/test/vm/unit/evm_fixture.hpp
@@ -18,21 +18,20 @@
 #include <category/core/address.hpp>
 #include <category/core/bytes.hpp>
 #include <category/core/int.hpp>
+#include <category/vm/evm/monad/revision.h>
 #include <category/vm/evm/revision.h>
 #include <category/vm/evm/switch_traits.hpp>
+#include <category/vm/evm/traits.hpp>
 #include <category/vm/runtime/allocator.hpp>
 #include <category/vm/runtime/types.hpp>
 #include <category/vm/vm.hpp>
 #include <monad/test/traits_test.hpp>
 #include <test/vm/utils/test_message.hpp>
 
+#include <monadml_evm/monadml_evm.hpp>
+
 #include <evmc/evmc.hpp>
 #include <evmc/mocked_host.hpp>
-
-#include <evmone/baseline.hpp>
-#include <evmone/constants.hpp>
-#include <evmone/evmone.h>
-#include <evmone/vm.hpp>
 
 #include <gtest/gtest.h>
 
@@ -55,8 +54,13 @@ namespace monad::vm::compiler::test
         {
             Compiler,
             Interpreter,
-            Evmone,
+            Spec,
         };
+
+        // The OCaml spec VM ignores the evmc_revision it is handed and is
+        // pinned to this Monad revision; execute_and_compare skips for any
+        // other trait.
+        static constexpr monad_revision spec_revision = MONAD_EIGHT;
 
         static constexpr auto get_trait()
         {
@@ -146,16 +150,16 @@ namespace monad::vm::compiler::test
                         rt_ctx, icode);
             }
             else {
-                MONAD_ASSERT(impl == Evmone);
-                evmc::VM const evmone_vm{evmc_create_evmone()};
+                MONAD_ASSERT(impl == Spec);
+                evmc::VM spec_vm{evmc_create_monadml_evm()};
 
-                result_ = evmc::Result{::evmone::baseline::execute(
-                    *static_cast<::evmone::VM *>(evmone_vm.get_raw_pointer()),
+                result_ = spec_vm.execute(
                     host_.get_interface(),
                     host_.to_context(),
                     to_evmc_revision(TraitsTest<T>::Trait::evm_rev()),
                     msg_,
-                    evmone::baseline::analyze(evmc::bytes_view(code)))};
+                    code.data(),
+                    code.size());
             }
         }
 
@@ -199,6 +203,11 @@ namespace monad::vm::compiler::test
             std::int64_t gas_limit, std::span<std::uint8_t const> code,
             std::span<std::uint8_t const> calldata = {}) noexcept
         {
+            if constexpr (!std::same_as<Trait, MonadTraits<spec_revision>>) {
+                GTEST_SKIP() << "spec oracle is pinned to "
+                             << monad_revision_to_string(spec_revision);
+            }
+
             // This comparison shouldn't be called multiple times in one test;
             // if any state has been recorded on this host before we begin a
             // test, the test should fail and stop us from trying to make
@@ -214,7 +223,7 @@ namespace monad::vm::compiler::test
             // second one).
             host_ = {};
 
-            execute(gas_limit, code, calldata, Evmone);
+            execute(gas_limit, code, calldata, Spec);
             auto expected = std::move(result_);
 
             switch (expected.status_code) {

--- a/test/vm/unit/evm_tests.cpp
+++ b/test/vm/unit/evm_tests.cpp
@@ -306,9 +306,6 @@ TEST_P(VMFileTest, RegressionFile)
 {
     auto const [entry, rev] = GetParam();
 
-    if (std::holds_alternative<monad_revision>(rev)) {
-        GTEST_SKIP() << "evmone only executes evm revisions";
-    }
     auto file = std::ifstream{entry.path(), std::ifstream::binary};
 
     ASSERT_TRUE(file.good());
@@ -404,10 +401,6 @@ TYPED_TEST(VMTraitsTest, MissingDischargeInJumpiKeepFallthroughStack)
         0x60, 0x08, 0x86, 0x90, 0x1c, 0x90, 0x50, 0x80, 0x60, 0x04, 0x1a, 0x90,
         0x50, 0x5f, 0x60, 0x10};
 
-    if constexpr (TestFixture::is_monad_trait()) {
-        GTEST_SKIP() << "evmone only executes evm revisions";
-    }
-
     TestFixture::execute_and_compare(1'000'000, bytecode, {});
 }
 
@@ -430,10 +423,6 @@ TYPED_TEST(VMTraitsTest, WrongGasCheckConditionalJump)
         0x26, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-
-    if constexpr (TestFixture::is_monad_trait()) {
-        GTEST_SKIP() << "evmone only executes evm revisions";
-    }
 
     TestFixture::execute_and_compare(1'000'000, bytecode, calldata);
 }
@@ -460,10 +449,6 @@ TYPED_TEST(VMTraitsTest, MissingRemoveStackOffsetInFallthroughStack)
                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-
-    if constexpr (TestFixture::is_monad_trait()) {
-        GTEST_SKIP() << "evmone only executes evm revisions";
-    }
 
     TestFixture::execute_and_compare(1'000'000, bytecode, calldata);
 }


### PR DESCRIPTION
This PR switches a handful of regression tests that previously compared against evmone to instead use the OCaml spec. There are some changes to what revisions get tested via `execute_and_compare` as a result (previously: evmone didn't test Monad revisions, now: OCaml spec only tests `MONAD_EIGHT`), but we don't meaningfully change coverage as a result. There is also an LSAN exclude added to avoid trying to sanitise the OCaml runtime.