### PR TITLE
Compile via ccache when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,33 @@ option(MONAD_COMPILER_DUMP_ASM "Dump assembly files into build/asm" OFF)
 option(MONAD_COMPILER_STATS "Print statistics about the compiler" OFF)
 option(MONAD_COMPILER_HOT_PATH_STATS "Print statistics about the vm" OFF)
 
+find_program(CCACHE_EXECUTABLE ccache)
+if(CCACHE_EXECUTABLE)
+  set(MONAD_CCACHE_DEFAULT ON)
+else()
+  set(MONAD_CCACHE_DEFAULT OFF)
+endif()
+option(MONAD_CCACHE "Compile via ccache" ${MONAD_CCACHE_DEFAULT})
+
+if(MONAD_CCACHE)
+  if(NOT CCACHE_EXECUTABLE)
+    message(FATAL_ERROR "MONAD_CCACHE is ON but ccache was not found")
+  endif()
+  if(NOT CMAKE_C_COMPILER_LAUNCHER)
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
+  endif()
+  if(NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
+  endif()
+  # Make __FILE__ and debug info checkout-relative so that object files are
+  # byte-identical no matter which checkout (main tree or worktree) compiled
+  # them, allowing ccache hits to be shared between checkouts. ccache excludes
+  # -f*-prefix-map options from its hash, so the per-checkout flag value does
+  # not itself cause misses.
+  add_compile_options("-ffile-prefix-map=${PROJECT_SOURCE_DIR}=."
+                      "-ffile-prefix-map=${CMAKE_BINARY_DIR}=.")
+endif()
+
 include(cmake/test.cmake)
 
 # ##############################################################################


### PR DESCRIPTION
Adds a `MONAD_CCACHE` option (default ON when `ccache` is found; `-DMONAD_CCACHE=OFF` to disable) that sets `CMAKE_{C,CXX}_COMPILER_LAUNCHER` unless one is already configured.

Alongside it, passes `-ffile-prefix-map=<srcdir>=.` and `-ffile-prefix-map=<builddir>=.` so `__FILE__` and debug info are checkout-relative. Object files are then byte-identical regardless of which checkout (main tree or worktree) compiled them, so a single ccache can be shared between checkouts deterministically rather than handing one checkout objects with another checkout's absolute paths baked in. ccache excludes `-f*-prefix-map` from its hash, so the per-checkout flag value does not itself cause misses.

Cross-worktree sharing additionally needs a machine-local `~/.config/ccache/ccache.conf` with `base_dir` set to the parent of the checkouts and `hash_dir = false`; that is not part of this change.

Notes:
- `DW_AT_comp_dir` becomes `.`, so gdb resolves sources when launched from `build/` (where ctest runs); from elsewhere use `set substitute-path`.
- Test TUs that include the generated `test/test_resource_data.h` still miss across worktrees, since that header embeds absolute paths. Accepted as-is.
- CI is unaffected: the Docker build has no ccache installed, so the option defaults to OFF there.

Verified: full RelWithDebInfo build with gcc-15, all TUs compiled through the launcher; spot-checked object contains no absolute paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KRCiuj7RDLJgotA8auRvG
