### PR TITLE
vm: widen the JUMPDEST scan index to 64-bit

### DIFF
--- a/category/vm/interpreter/intercode.cpp
+++ b/category/vm/interpreter/intercode.cpp
@@ -18,6 +18,7 @@
 #include <category/vm/interpreter/intercode.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <span>
 
@@ -60,7 +61,7 @@ namespace monad::vm::interpreter
     {
         auto jumpdests = JumpdestMap(code.size(), false);
 
-        for (auto i = 0u; i < code.size(); ++i) {
+        for (size_t i = 0; i < code.size(); ++i) {
             auto const op = code[i];
 
             if (op == EvmOpCode::JUMPDEST) {


### PR DESCRIPTION
find_jumpdests scans every contract byte. Its loop variable was `auto i = 0u` — 32-bit, on a 64-bit target, used as an index — so the compiler re-zero-extended it every iteration on riscv: the emitted body was 10 instructions per byte and two were slli/srli by 32.

(cherry picked from commit 0d1eb843a87c049783d7a1d3783f0ecbb886a4c7)